### PR TITLE
chore(deps): bump codeql-action to v4, cosign-installer to v4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
           fi
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: results.sarif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           path: dist/
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Sign wheels and sdist
         run: |


### PR DESCRIPTION
## Summary
- Bump `github/codeql-action/upload-sarif` from v3 to v4 in ci.yml
- Bump `sigstore/cosign-installer` from v3.10.1 to v4.0.0 in release.yml (SHA pinned)

Supersedes Dependabot PRs #1-#4 (checkout and setup-python were already at v6)