### PR TITLE
feat: PermissionProfile + privilege detection + registry expansion (427 servers)

### DIFF
--- a/scripts/expand_registry.py
+++ b/scripts/expand_registry.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Expand the bundled MCP registry with servers from the Official MCP Registry.
+
+Usage:
+    python scripts/expand_registry.py                   # Fetch and add new servers
+    python scripts/expand_registry.py --dry-run          # Preview without writing
+    python scripts/expand_registry.py --max-pages 20     # Fetch more pages
+
+Servers are auto-classified with risk_level based on tool names and credential
+exposure. Entries are flagged with "auto_enriched": true for manual review.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+REGISTRY_PATH = ROOT / "src" / "agent_bom" / "mcp_registry.json"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Expand bundled MCP registry")
+    parser.add_argument(
+        "--max-pages", type=int, default=10,
+        help="Maximum pages to fetch (default: 10, ~100 servers/page)",
+    )
+    parser.add_argument(
+        "--page-size", type=int, default=100,
+        help="Servers per page (default: 100)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Show what would change without writing",
+    )
+    args = parser.parse_args()
+
+    # Load current registry for before/after count
+    data = json.loads(REGISTRY_PATH.read_text())
+    before = len(data.get("servers", {}))
+
+    print(f"Current registry: {before} servers")
+    print(f"Fetching from Official MCP Registry (max {args.max_pages} pages)...")
+
+    from agent_bom.mcp_official_registry import sync_from_official_registry_sync
+
+    result = sync_from_official_registry_sync(
+        max_pages=args.max_pages,
+        page_size=args.page_size,
+        dry_run=args.dry_run,
+    )
+
+    print(f"Fetched: {result.total_fetched}")
+    print(f"Added: {result.added}")
+    print(f"Skipped (already exists): {result.skipped}")
+
+    if result.added > 0:
+        # Reload to get new count
+        if not args.dry_run:
+            after_data = json.loads(REGISTRY_PATH.read_text())
+            after = len(after_data.get("servers", {}))
+            # Update _total_servers
+            after_data["_total_servers"] = after
+            REGISTRY_PATH.write_text(json.dumps(after_data, indent=2) + "\n")
+            print(f"Registry updated: {before} → {after} servers")
+        else:
+            print(f"Would add {result.added} servers (dry run)")
+
+    if result.details:
+        print("\nNew entries:")
+        for d in result.details[:20]:
+            print(f"  + {d['server']} (v{d.get('version', '?')})")
+        if len(result.details) > 20:
+            print(f"  ... and {len(result.details) - 20} more")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent_bom/mcp_registry.json
+++ b/src/agent_bom/mcp_registry.json
@@ -1,8 +1,8 @@
 {
   "_comment": "agent-bom MCP Server Registry \u2014 threat intelligence database for known MCP servers",
   "_schema_version": "2.0",
-  "_updated": "2026-02-23",
-  "_total_servers": 112,
+  "_updated": "2026-02-24",
+  "_total_servers": 427,
   "_differentiator": "Threat intelligence database \u2014 not just a catalog. Each entry has risk_level, tools, credential_env_vars for blast radius pre-computation.",
   "_source": "https://github.com/msaad00/agent-bom/blob/main/data/mcp-registry.yaml",
   "servers": {
@@ -3046,6 +3046,5657 @@
         "HF_TOKEN"
       ],
       "source_url": "https://github.com/Snowflake-Labs/agent-world-model"
+    },
+    "agency.lona/trading": {
+      "package": "agency.lona/trading",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.0.0",
+      "description": "AI-powered trading strategy development: backtesting, market data, and portfolio analysis",
+      "name": "agency.lona/trading",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "agency.lona/trading",
+        "trading"
+      ],
+      "source_url": "https://github.com/mindsightventures/lona",
+      "auto_enriched": true
+    },
+    "ai.aliengiraffe/spotdb": {
+      "package": "ai.aliengiraffe/spotdb",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.0",
+      "description": "Ephemeral data sandbox for AI workflows with guardrails and security",
+      "name": "ai.aliengiraffe/spotdb",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.aliengiraffe/spotdb",
+        "spotdb"
+      ],
+      "source_url": "https://github.com/aliengiraffe/spotdb",
+      "auto_enriched": true
+    },
+    "ai.alpic.mcp/alpic-mcp": {
+      "package": "ai.alpic.mcp/alpic-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.1",
+      "description": "Manage your projects, debug deployment, and check analytics for any MCP server you host with Alpic",
+      "name": "ai.alpic.mcp/alpic-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.alpic.mcp/alpic-mcp",
+        "alpic-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.alpic.test/test-mcp-server": {
+      "package": "ai.alpic.test/test-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.1",
+      "description": "Alpic Test MCP Server - great server!",
+      "name": "ai.alpic.test/test-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.alpic.test/test-mcp-server",
+        "test-mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.anzenna/anzenna": {
+      "package": "ai.anzenna/anzenna",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1",
+      "description": "MCP server for Anzenna",
+      "name": "ai.anzenna/anzenna",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.anzenna/anzenna",
+        "anzenna"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.appdeploy/deploy-app": {
+      "package": "ai.appdeploy/deploy-app",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "AppDeploy turns app ideas described in AI chat into live full-stack web applications",
+      "name": "ai.appdeploy/deploy-app",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.appdeploy/deploy-app",
+        "deploy-app"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.auteng/docs": {
+      "package": "ai.auteng/docs",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.1.0",
+      "description": "Publish markdown documents as public share links with mermaid diagram support. Built by AutEng.ai",
+      "name": "ai.auteng/docs",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.auteng/docs",
+        "docs"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.auteng/mcp": {
+      "package": "ai.auteng/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Publish markdown documents as public share links with mermaid diagrams. Built by AutEng.ai",
+      "name": "ai.auteng/mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.auteng/mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.autoblocks/contextlayer-mcp": {
+      "package": "ai.autoblocks/contextlayer-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.3",
+      "description": "Personal context management for AI assistants",
+      "name": "ai.autoblocks/contextlayer-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.autoblocks/contextlayer-mcp",
+        "contextlayer-mcp"
+      ],
+      "source_url": "https://github.com/autoblocksai/ctxl",
+      "auto_enriched": true
+    },
+    "ai.autoblocks/ctxl": {
+      "package": "ai.autoblocks/ctxl",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.2",
+      "description": "Personal context management for AI assistants",
+      "name": "ai.autoblocks/ctxl",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.autoblocks/ctxl",
+        "ctxl"
+      ],
+      "source_url": "https://github.com/autoblocksai/ctxl",
+      "auto_enriched": true
+    },
+    "ai.autoblocks/ctxl-mcp": {
+      "package": "ai.autoblocks/ctxl-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.2",
+      "description": "Personal context management for AI assistants",
+      "name": "ai.autoblocks/ctxl-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.autoblocks/ctxl-mcp",
+        "ctxl-mcp"
+      ],
+      "source_url": "https://github.com/autoblocksai/ctxl",
+      "auto_enriched": true
+    },
+    "ai.cirra/salesforce-mcp": {
+      "package": "ai.cirra/salesforce-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Comprehensive Salesforce administration and data management capabilities",
+      "name": "ai.cirra/salesforce-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.cirra/salesforce-mcp",
+        "salesforce-mcp"
+      ],
+      "source_url": "https://github.com/cirra-ai/mcp-server",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/contabo": {
+      "package": "ai.com.mcp/contabo",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.6.0",
+      "description": "Contabo API (v1.0.0) as MCP tools for cloud provisioning, and management. Powered by HAPI MCP server",
+      "name": "ai.com.mcp/contabo",
+      "category": "cloud",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/contabo",
+        "contabo"
+      ],
+      "source_url": "https://github.com/la-rebelion/hapimcp",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/hapi-mcp": {
+      "package": "ai.com.mcp/hapi-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.6.0",
+      "description": "HAPI MCP server: Dynamically exposes OpenAPI REST APIs as MCP tools for AI assistants",
+      "name": "ai.com.mcp/hapi-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/hapi-mcp",
+        "hapi-mcp"
+      ],
+      "source_url": "https://github.com/larebelion/hapimcp",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/lenny-rachitsky-podcast": {
+      "package": "ai.com.mcp/lenny-rachitsky-podcast",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.6.0",
+      "description": "MCP server for structured access to Lenny Rachitsky podcast transcripts. For content creators.",
+      "name": "ai.com.mcp/lenny-rachitsky-podcast",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/lenny-rachitsky-podcast",
+        "lenny-rachitsky-podcast"
+      ],
+      "source_url": "https://github.com/la-rebelion/hapimcp",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/linkedin": {
+      "package": "ai.com.mcp/linkedin",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0+0.7.1",
+      "description": "LinkedIn API as MCP tools to retrieve profile data and publish content. Powered by HAPI MCP.",
+      "name": "ai.com.mcp/linkedin",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/linkedin",
+        "linkedin"
+      ],
+      "source_url": "https://github.com/la-rebelion/hapimcp",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/openai-tools": {
+      "package": "ai.com.mcp/openai-tools",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.6.0",
+      "description": "Focused MCP server for OpenAI image/audio generation (v2.0.0). Wraps endpoints via HAPI CLI.",
+      "name": "ai.com.mcp/openai-tools",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/openai-tools",
+        "openai-tools"
+      ],
+      "source_url": "https://github.com/la-rebelion/hapimcp",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/petstore": {
+      "package": "ai.com.mcp/petstore",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.6.0",
+      "description": "Swagger Petstore API (v1.0.27) as MCP for testing and prototyping powered by the HAPI MCP server",
+      "name": "ai.com.mcp/petstore",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/petstore",
+        "petstore"
+      ],
+      "source_url": "https://github.com/la-rebelion/hapimcp",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/registry": {
+      "package": "ai.com.mcp/registry",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Publish and discover MCP servers via the official MCP Registry. Powered by HAPI MCP server.",
+      "name": "ai.com.mcp/registry",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/registry",
+        "registry"
+      ],
+      "source_url": "https://github.com/modelcontextprotocol/registry",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/skills-search": {
+      "package": "ai.com.mcp/skills-search",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Search and discover Agent Skills from the skills.sh registry. Powered by HAPI MCP server.",
+      "name": "ai.com.mcp/skills-search",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/skills-search",
+        "skills-search"
+      ],
+      "source_url": "https://github.com/agentskills/agentskills",
+      "auto_enriched": true
+    },
+    "ai.com.mcp/strava": {
+      "package": "ai.com.mcp/strava",
+      "ecosystem": "mcp-registry",
+      "latest_version": "3.0.0+0.7.1",
+      "description": "Strava MCP tools for AI: athletes, activities, segments, clubs, routes. Powered by HAPI MCP server.",
+      "name": "ai.com.mcp/strava",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.com.mcp/strava",
+        "strava"
+      ],
+      "source_url": "https://github.com/la-rebelion/hapimcp",
+      "auto_enriched": true
+    },
+    "ai.exa/exa": {
+      "package": "ai.exa/exa",
+      "ecosystem": "mcp-registry",
+      "latest_version": "3.1.3",
+      "description": "Fast, intelligent web search and web crawling.\n\nNew mcp tool: Exa-code is a context tool for coding ",
+      "name": "ai.exa/exa",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.exa/exa"
+      ],
+      "source_url": "https://github.com/exa-labs/exa-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.explorium/mcp-explorium": {
+      "package": "ai.explorium/mcp-explorium",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Access live company and contact data from Explorium's AgentSource B2B platform.",
+      "name": "ai.explorium/mcp-explorium",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.explorium/mcp-explorium",
+        "mcp-explorium"
+      ],
+      "source_url": "https://github.com/explorium-ai/mcp-explorium",
+      "auto_enriched": true
+    },
+    "ai.filegraph/document-processing": {
+      "package": "ai.filegraph/document-processing",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Extract text from documents, manipulate PDFs, and perform OCR on images.",
+      "name": "ai.filegraph/document-processing",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.filegraph/document-processing",
+        "document-processing"
+      ],
+      "source_url": "https://github.com/filegraph/docconvert",
+      "auto_enriched": true
+    },
+    "ai.fodda/mcp-server": {
+      "package": "ai.fodda/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.3.0",
+      "description": "Expert-curated knowledge graphs for AI agents \u2014 PSFK Retail, Beauty, Sports and more.",
+      "name": "ai.fodda/mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.fodda/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "https://github.com/fodda/mcp-server",
+      "auto_enriched": true
+    },
+    "ai.gomarble/mcp-api": {
+      "package": "ai.gomarble/mcp-api",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "GoMarble MCP API Server",
+      "name": "ai.gomarble/mcp-api",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.gomarble/mcp-api",
+        "mcp-api"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.gossiper/shopify-admin-mcp": {
+      "package": "ai.gossiper/shopify-admin-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Control Shopify Admin tasks with agents or via prompt. Ultra slim integration, fast and secure.",
+      "name": "ai.gossiper/shopify-admin-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.gossiper/shopify-admin-mcp",
+        "shopify-admin-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.klavis/strata": {
+      "package": "ai.klavis/strata",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "MCP server for progressive tool usage at any scale (see https://klavis.ai)",
+      "name": "ai.klavis/strata",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.klavis/strata",
+        "strata"
+      ],
+      "source_url": "https://github.com/Klavis-AI/klavis",
+      "auto_enriched": true
+    },
+    "ai.kubit/mcp-server": {
+      "package": "ai.kubit/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Bring Kubit into your AI workflow \u2014 query your warehouse with natural language",
+      "name": "ai.kubit/mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.kubit/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "https://github.com/Kubit-AI/mcp-server",
+      "auto_enriched": true
+    },
+    "ai.llmse/mcp": {
+      "package": "ai.llmse/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.3.12",
+      "description": "Public MCP server for the LLM Search Engine",
+      "name": "ai.llmse/mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.llmse/mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.ludo/game-assets": {
+      "package": "ai.ludo/game-assets",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.9.0",
+      "description": "Generate game assets with AI: sprites, 3D models, animations, sound effects, music, and voices.",
+      "name": "ai.ludo/game-assets",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.ludo/game-assets",
+        "game-assets"
+      ],
+      "source_url": "https://github.com/Ludo-AI/ludo-mcp",
+      "auto_enriched": true
+    },
+    "ai.mailjunky/mcp": {
+      "package": "ai.mailjunky/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.0",
+      "description": "Send emails, track events, and manage contacts with MailJunky.",
+      "name": "ai.mailjunky/mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.mailjunky/mcp"
+      ],
+      "source_url": "https://github.com/TheNightProject/tnp.web.mailjunky.ai",
+      "auto_enriched": true
+    },
+    "ai.mcpanalytics/analytics": {
+      "package": "ai.mcpanalytics/analytics",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.3",
+      "description": "MCP Analytics, searchable tools and reports with interactive HTML visualization",
+      "name": "ai.mcpanalytics/analytics",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.mcpanalytics/analytics",
+        "analytics"
+      ],
+      "source_url": "https://github.com/embeddedlayers/mcp-analytics",
+      "auto_enriched": true
+    },
+    "ai.mcpcap/mcpcap": {
+      "package": "ai.mcpcap/mcpcap",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.6.0",
+      "description": "An MCP server for analyzing PCAP files.",
+      "name": "ai.mcpcap/mcpcap",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.mcpcap/mcpcap",
+        "mcpcap"
+      ],
+      "source_url": "https://github.com/mcpcap/mcpcap",
+      "auto_enriched": true
+    },
+    "ai.meetlark/mcp-server": {
+      "package": "ai.meetlark/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.3",
+      "description": "Agent-first meeting schedule polls for humans and agents. Create polls, vote, find times.",
+      "name": "ai.meetlark/mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.meetlark/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.meetsquad/squad": {
+      "package": "ai.meetsquad/squad",
+      "ecosystem": "mcp-registry",
+      "latest_version": "3.0.1",
+      "description": "Your AI Product Manager. Surface insights, build roadmaps, and plan strategy with 30+ tools.",
+      "name": "ai.meetsquad/squad",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.meetsquad/squad",
+        "squad"
+      ],
+      "source_url": "https://github.com/the-basilisk-ai/squad-mcp",
+      "auto_enriched": true
+    },
+    "ai.meminal/meminal": {
+      "package": "ai.meminal/meminal",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Memory for deep conversational context across any platform",
+      "name": "ai.meminal/meminal",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.meminal/meminal",
+        "meminal"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.mino/web-agent": {
+      "package": "ai.mino/web-agent",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "AI-powered web automation. Navigate websites using AI agents for one page or a thousand",
+      "name": "ai.mino/web-agent",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.mino/web-agent",
+        "web-agent"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.packmind/mcp-server": {
+      "package": "ai.packmind/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Packmind captures, scales, and enforces your organization's technical decisions.",
+      "name": "ai.packmind/mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.packmind/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "https://github.com/PackmindHub/packmind",
+      "auto_enriched": true
+    },
+    "ai.parallel/search-mcp": {
+      "package": "ai.parallel/search-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "The best web search for your AI Agent",
+      "name": "ai.parallel/search-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.parallel/search-mcp",
+        "search-mcp"
+      ],
+      "source_url": "https://github.com/parallel-web/search-mcp",
+      "auto_enriched": true
+    },
+    "ai.parallel/task-mcp": {
+      "package": "ai.parallel/task-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "An MCP server for deep research or task groups",
+      "name": "ai.parallel/task-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.parallel/task-mcp",
+        "task-mcp"
+      ],
+      "source_url": "https://github.com/parallel-web/task-mcp",
+      "auto_enriched": true
+    },
+    "ai.perplexity/mcp-server": {
+      "package": "ai.perplexity/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.8.2",
+      "description": "Real-time web search, reasoning, and research through Perplexity's API",
+      "name": "ai.perplexity/mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.perplexity/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.rapay/mcp-server": {
+      "package": "ai.rapay/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.2.5",
+      "description": "Send fiat payments via MCP with two-step confirmation and Stripe Connect.",
+      "name": "ai.rapay/mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.rapay/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "https://github.com/Ra-Pay-AI/rapay",
+      "auto_enriched": true
+    },
+    "ai.seltz/seltz-ai-seltz-mcp": {
+      "package": "ai.seltz/seltz-ai-seltz-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Provides AI assistants with access to Seltz's powerful Web Search capabilities.\n",
+      "name": "ai.seltz/seltz-ai-seltz-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.seltz/seltz-ai-seltz-mcp",
+        "seltz-ai-seltz-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.shawndurrani/mcp-merchant": {
+      "package": "ai.shawndurrani/mcp-merchant",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.3",
+      "description": "Search-only commerce MCP server backed by Stripe (test)",
+      "name": "ai.shawndurrani/mcp-merchant",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.shawndurrani/mcp-merchant",
+        "mcp-merchant"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.shawndurrani/mcp-registry": {
+      "package": "ai.shawndurrani/mcp-registry",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.3",
+      "description": "Search the public MCP Registry; discover servers and copy SSE URLs.",
+      "name": "ai.shawndurrani/mcp-registry",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.shawndurrani/mcp-registry",
+        "mcp-registry"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/222wcnm-bilistalkermcp": {
+      "package": "ai.smithery/222wcnm-bilistalkermcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Track Bilibili creators and get the latest updates on videos, dynamics, and articles. Fetch user p\u2026",
+      "name": "ai.smithery/222wcnm-bilistalkermcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/222wcnm-bilistalkermcp",
+        "222wcnm-bilistalkermcp"
+      ],
+      "source_url": "https://github.com/222wcnm/BiliStalkerMCP",
+      "auto_enriched": true
+    },
+    "ai.smithery/Aman-Amith-Shastry-scientific_computation_mcp": {
+      "package": "ai.smithery/Aman-Amith-Shastry-scientific_computation_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "This MCP server enables users to perform scientific computations regarding linear algebra and vect\u2026",
+      "name": "ai.smithery/Aman-Amith-Shastry-scientific_computation_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Aman-Amith-Shastry-scientific_computation_mcp",
+        "Aman-Amith-Shastry-scientific_computation_mcp"
+      ],
+      "source_url": "https://github.com/Aman-Amith-Shastry/scientific_computation_mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/Artin0123-gemini-image-mcp-server": {
+      "package": "ai.smithery/Artin0123-gemini-image-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.4.3",
+      "description": "Analyze images and videos with Gemini to get fast, reliable visual insights. Handle content from U\u2026",
+      "name": "ai.smithery/Artin0123-gemini-image-mcp-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Artin0123-gemini-image-mcp-server",
+        "Artin0123-gemini-image-mcp-server"
+      ],
+      "source_url": "https://github.com/Artin0123/gemini-vision-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/BadRooBot-my_test_mcp": {
+      "package": "ai.smithery/BadRooBot-my_test_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Get current weather for any city and create images from your prompts. Streamline planning, reports\u2026",
+      "name": "ai.smithery/BadRooBot-my_test_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/BadRooBot-my_test_mcp",
+        "BadRooBot-my_test_mcp"
+      ],
+      "source_url": "https://github.com/BadRooBot/python_mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/BadRooBot-test_m": {
+      "package": "ai.smithery/BadRooBot-test_m",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Send quick greetings, scrape website content, and generate text or images on demand. Perform web s\u2026",
+      "name": "ai.smithery/BadRooBot-test_m",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/BadRooBot-test_m",
+        "BadRooBot-test_m"
+      ],
+      "source_url": "https://github.com/BadRooBot/test_m",
+      "auto_enriched": true
+    },
+    "ai.smithery/BigVik193-reddit-ads-mcp": {
+      "package": "ai.smithery/BigVik193-reddit-ads-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Manage Reddit advertising across accounts, campaigns, ad groups, posts, and ads. List accounts, fu\u2026",
+      "name": "ai.smithery/BigVik193-reddit-ads-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/BigVik193-reddit-ads-mcp",
+        "BigVik193-reddit-ads-mcp"
+      ],
+      "source_url": "https://github.com/BigVik193/reddit-ads-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/BigVik193-reddit-ads-mcp-api": {
+      "package": "ai.smithery/BigVik193-reddit-ads-mcp-api",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Manage Reddit advertising end to end across accounts, funding methods, campaigns, ad groups, and a\u2026",
+      "name": "ai.smithery/BigVik193-reddit-ads-mcp-api",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/BigVik193-reddit-ads-mcp-api",
+        "BigVik193-reddit-ads-mcp-api"
+      ],
+      "source_url": "https://github.com/BigVik193/reddit-ads-mcp-api",
+      "auto_enriched": true
+    },
+    "ai.smithery/BigVik193-reddit-ads-mcp-test": {
+      "package": "ai.smithery/BigVik193-reddit-ads-mcp-test",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Manage Reddit advertising end-to-end: browse ad accounts and payment methods, and organize campaig\u2026",
+      "name": "ai.smithery/BigVik193-reddit-ads-mcp-test",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/BigVik193-reddit-ads-mcp-test",
+        "BigVik193-reddit-ads-mcp-test"
+      ],
+      "source_url": "https://github.com/BigVik193/reddit-ads-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/BigVik193-reddit-user-mcp": {
+      "package": "ai.smithery/BigVik193-reddit-user-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Browse and manage Reddit posts, comments, and threads. Fetch user activity, explore hot/new/rising\u2026",
+      "name": "ai.smithery/BigVik193-reddit-user-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/BigVik193-reddit-user-mcp",
+        "BigVik193-reddit-user-mcp"
+      ],
+      "source_url": "https://github.com/BigVik193/reddit-user-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/BowenXU0126-aistudio_hw3": {
+      "package": "ai.smithery/BowenXU0126-aistudio_hw3",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Send personalized greetings with optional pirate flair. Compose friendly salutations for any name\u2026",
+      "name": "ai.smithery/BowenXU0126-aistudio_hw3",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/BowenXU0126-aistudio_hw3",
+        "BowenXU0126-aistudio_hw3"
+      ],
+      "source_url": "https://github.com/BowenXU0126/aistudio_hw3",
+      "auto_enriched": true
+    },
+    "ai.smithery/ChiR24-unreal_mcp": {
+      "package": "ai.smithery/ChiR24-unreal_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.4.6",
+      "description": "Control Unreal Engine to browse assets, import content, and manage levels and sequences. Automate\u2026",
+      "name": "ai.smithery/ChiR24-unreal_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ChiR24-unreal_mcp",
+        "ChiR24-unreal_mcp"
+      ],
+      "source_url": "https://github.com/ChiR24/Unreal_mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/ChiR24-unreal_mcp_server": {
+      "package": "ai.smithery/ChiR24-unreal_mcp_server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.4.4",
+      "description": "A comprehensive Model Context Protocol (MCP) server that enables AI assistants to control Unreal E\u2026",
+      "name": "ai.smithery/ChiR24-unreal_mcp_server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ChiR24-unreal_mcp_server",
+        "ChiR24-unreal_mcp_server"
+      ],
+      "source_url": "https://github.com/ChiR24/Unreal_mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/CollectiveSpend-collectivespend-smithery-mcp": {
+      "package": "ai.smithery/CollectiveSpend-collectivespend-smithery-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Connect CollectiveSpend with Xero to manage contacts. Retrieve, create, and update contact records\u2026",
+      "name": "ai.smithery/CollectiveSpend-collectivespend-smithery-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/CollectiveSpend-collectivespend-smithery-mcp",
+        "CollectiveSpend-collectivespend-smithery-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/CryptoCultCurt-appfolio-mcp-server": {
+      "package": "ai.smithery/CryptoCultCurt-appfolio-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Provide seamless access to Appfolio Property Manager Reporting API through a standardized MCP serv\u2026",
+      "name": "ai.smithery/CryptoCultCurt-appfolio-mcp-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/CryptoCultCurt-appfolio-mcp-server",
+        "CryptoCultCurt-appfolio-mcp-server"
+      ],
+      "source_url": "https://github.com/CryptoCultCurt/appfolio-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/Danushkumar-V-mcp-discord": {
+      "package": "ai.smithery/Danushkumar-V-mcp-discord",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.2.0",
+      "description": "An MCP server that integrates with Discord to provide AI-powered features.",
+      "name": "ai.smithery/Danushkumar-V-mcp-discord",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Danushkumar-V-mcp-discord",
+        "Danushkumar-V-mcp-discord"
+      ],
+      "source_url": "https://github.com/Danushkumar-V/mcp-discord",
+      "auto_enriched": true
+    },
+    "ai.smithery/DynamicEndpoints-autogen_mcp": {
+      "package": "ai.smithery/DynamicEndpoints-autogen_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.0",
+      "description": "Create and manage AI agents that collaborate and solve problems through natural language interacti\u2026",
+      "name": "ai.smithery/DynamicEndpoints-autogen_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/DynamicEndpoints-autogen_mcp",
+        "DynamicEndpoints-autogen_mcp"
+      ],
+      "source_url": "https://github.com/DynamicEndpoints/Autogen_MCP",
+      "auto_enriched": true
+    },
+    "ai.smithery/DynamicEndpoints-m365-core-mcp": {
+      "package": "ai.smithery/DynamicEndpoints-m365-core-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.1.0",
+      "description": "*Updated June 17th 2025** Manage your Microsoft 365 services effortlessly. Create and manage distr\u2026",
+      "name": "ai.smithery/DynamicEndpoints-m365-core-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/DynamicEndpoints-m365-core-mcp",
+        "DynamicEndpoints-m365-core-mcp"
+      ],
+      "source_url": "https://github.com/DynamicEndpoints/m365-core-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/DynamicEndpoints-powershell-exec-mcp-server": {
+      "package": "ai.smithery/DynamicEndpoints-powershell-exec-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Execute PowerShell commands securely with controlled timeouts and input validation. Retrieve syste\u2026",
+      "name": "ai.smithery/DynamicEndpoints-powershell-exec-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/DynamicEndpoints-powershell-exec-mcp-server",
+        "DynamicEndpoints-powershell-exec-mcp-server"
+      ],
+      "source_url": "https://github.com/DynamicEndpoints/PowerShell-Exec-MCP-Server",
+      "auto_enriched": true
+    },
+    "ai.smithery/FelixYifeiWang-felix-mcp-smithery": {
+      "package": "ai.smithery/FelixYifeiWang-felix-mcp-smithery",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Streamline your workflow with Felix. Integrate it into your workspace and tailor its behavior to y\u2026",
+      "name": "ai.smithery/FelixYifeiWang-felix-mcp-smithery",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/FelixYifeiWang-felix-mcp-smithery",
+        "FelixYifeiWang-felix-mcp-smithery"
+      ],
+      "source_url": "https://github.com/FelixYifeiWang/felix-mcp-smithery",
+      "auto_enriched": true
+    },
+    "ai.smithery/Funding-Machine-ghl-mcp-fundingmachine": {
+      "package": "ai.smithery/Funding-Machine-ghl-mcp-fundingmachine",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Automate GoHighLevel across CRM, messaging, calendars, marketing, e-commerce, and billing. Manage\u2026",
+      "name": "ai.smithery/Funding-Machine-ghl-mcp-fundingmachine",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Funding-Machine-ghl-mcp-fundingmachine",
+        "Funding-Machine-ghl-mcp-fundingmachine"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/HARJAP-SINGH-3105-splitwise_mcp": {
+      "package": "ai.smithery/HARJAP-SINGH-3105-splitwise_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Manage Splitwise balances, expenses, and groups from your workspace. Fetch friends and recent acti\u2026",
+      "name": "ai.smithery/HARJAP-SINGH-3105-splitwise_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/HARJAP-SINGH-3105-splitwise_mcp",
+        "HARJAP-SINGH-3105-splitwise_mcp"
+      ],
+      "source_url": "https://github.com/HARJAP-SINGH-3105/Splitwise_MCP",
+      "auto_enriched": true
+    },
+    "ai.smithery/Hint-Services-obsidian-github-mcp": {
+      "package": "ai.smithery/Hint-Services-obsidian-github-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.4.0",
+      "description": "Connect AI assistants to your GitHub-hosted Obsidian vault to seamlessly access, search, and analy\u2026",
+      "name": "ai.smithery/Hint-Services-obsidian-github-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Hint-Services-obsidian-github-mcp",
+        "Hint-Services-obsidian-github-mcp"
+      ],
+      "source_url": "https://github.com/Hint-Services/obsidian-github-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/IlyaGusev-academia_mcp": {
+      "package": "ai.smithery/IlyaGusev-academia_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Search arXiv and ACL Anthology, retrieve citations and references, and browse web sources to accel\u2026",
+      "name": "ai.smithery/IlyaGusev-academia_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/IlyaGusev-academia_mcp",
+        "IlyaGusev-academia_mcp"
+      ],
+      "source_url": "https://github.com/IlyaGusev/academia_mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/ImRonAI-mcp-server-browserbase": {
+      "package": "ai.smithery/ImRonAI-mcp-server-browserbase",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.0.0",
+      "description": "Automate cloud browsers to navigate websites, interact with elements, and extract structured data.\u2026",
+      "name": "ai.smithery/ImRonAI-mcp-server-browserbase",
+      "category": "cloud",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ImRonAI-mcp-server-browserbase",
+        "ImRonAI-mcp-server-browserbase"
+      ],
+      "source_url": "https://github.com/ImRonAI/mcp-server-browserbase",
+      "auto_enriched": true
+    },
+    "ai.smithery/IndianAppGuy-magicslide-mcp": {
+      "package": "ai.smithery/IndianAppGuy-magicslide-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Generate professional PowerPoint presentations from text, YouTube videos, or structured JSON data.\u2026",
+      "name": "ai.smithery/IndianAppGuy-magicslide-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/IndianAppGuy-magicslide-mcp",
+        "IndianAppGuy-magicslide-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/IndianAppGuy-magicslide-mcp-actual-test": {
+      "package": "ai.smithery/IndianAppGuy-magicslide-mcp-actual-test",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Generate polished PowerPoint presentations from text prompts, YouTube videos, or structured outlin\u2026",
+      "name": "ai.smithery/IndianAppGuy-magicslide-mcp-actual-test",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/IndianAppGuy-magicslide-mcp-actual-test",
+        "IndianAppGuy-magicslide-mcp-actual-test"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/JMoak-chrono-mcp": {
+      "package": "ai.smithery/JMoak-chrono-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.0",
+      "description": "Convert and compare dates and times across any timezone with flexible, locale-aware formatting. Ad\u2026",
+      "name": "ai.smithery/JMoak-chrono-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/JMoak-chrono-mcp",
+        "JMoak-chrono-mcp"
+      ],
+      "source_url": "https://github.com/JMoak/chrono-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/JunoJunHyun-festival-finder-mcp": {
+      "package": "ai.smithery/JunoJunHyun-festival-finder-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Discover festivals worldwide by location, date, and genre. Compare options with key details like d\u2026",
+      "name": "ai.smithery/JunoJunHyun-festival-finder-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/JunoJunHyun-festival-finder-mcp",
+        "JunoJunHyun-festival-finder-mcp"
+      ],
+      "source_url": "https://github.com/JunoJunHyun/Festival-Finder-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/Kim-soung-won-mcp-smithery-exam": {
+      "package": "ai.smithery/Kim-soung-won-mcp-smithery-exam",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Craft quick, personalized greetings by name. Generate ready-to-use greeting prompts for a consiste\u2026",
+      "name": "ai.smithery/Kim-soung-won-mcp-smithery-exam",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Kim-soung-won-mcp-smithery-exam",
+        "Kim-soung-won-mcp-smithery-exam"
+      ],
+      "source_url": "https://github.com/Kim-soung-won/mcp-smithery-exam",
+      "auto_enriched": true
+    },
+    "ai.smithery/Kryptoskatt-mcp-server": {
+      "package": "ai.smithery/Kryptoskatt-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Enable AI assistants to interact seamlessly with the DefiLlama API by translating MCP tool calls i\u2026",
+      "name": "ai.smithery/Kryptoskatt-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Kryptoskatt-mcp-server",
+        "Kryptoskatt-mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/Leghis-smart-thinking": {
+      "package": "ai.smithery/Leghis-smart-thinking",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.0",
+      "description": "Find relevant Smart\u2011Thinking memories fast. Fetch full entries by ID to get complete context. Spee\u2026",
+      "name": "ai.smithery/Leghis-smart-thinking",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Leghis-smart-thinking",
+        "Leghis-smart-thinking"
+      ],
+      "source_url": "https://github.com/Leghis/Smart-Thinking",
+      "auto_enriched": true
+    },
+    "ai.smithery/LinkupPlatform-linkup-mcp-server": {
+      "package": "ai.smithery/LinkupPlatform-linkup-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Search the web in real time to get trustworthy, source-backed answers. Find the latest news and co\u2026",
+      "name": "ai.smithery/LinkupPlatform-linkup-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/LinkupPlatform-linkup-mcp-server",
+        "LinkupPlatform-linkup-mcp-server"
+      ],
+      "source_url": "https://github.com/LinkupPlatform/linkup-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/MetehanGZL-pokemcp": {
+      "package": "ai.smithery/MetehanGZL-pokemcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Provide detailed Pok\u00e9mon data and information through a standardized MCP interface. Enable LLMs an\u2026",
+      "name": "ai.smithery/MetehanGZL-pokemcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/MetehanGZL-pokemcp",
+        "MetehanGZL-pokemcp"
+      ],
+      "source_url": "https://github.com/MetehanGZL/PokeMCP",
+      "auto_enriched": true
+    },
+    "ai.smithery/MisterSandFR-supabase-mcp-selfhosted": {
+      "package": "ai.smithery/MisterSandFR-supabase-mcp-selfhosted",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.1",
+      "description": "Manage Supabase projects end to end across database, auth, storage, realtime, and migrations. Moni\u2026",
+      "name": "ai.smithery/MisterSandFR-supabase-mcp-selfhosted",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/MisterSandFR-supabase-mcp-selfhosted",
+        "MisterSandFR-supabase-mcp-selfhosted"
+      ],
+      "source_url": "https://github.com/MisterSandFR/Supabase-MCP-SelfHosted",
+      "auto_enriched": true
+    },
+    "ai.smithery/Nekzus-npm-sentinel-mcp": {
+      "package": "ai.smithery/Nekzus-npm-sentinel-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "{{VERSION}}",
+      "description": "Provide AI-powered real-time analysis and intelligence on NPM packages, including security, depend\u2026",
+      "name": "ai.smithery/Nekzus-npm-sentinel-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Nekzus-npm-sentinel-mcp",
+        "Nekzus-npm-sentinel-mcp"
+      ],
+      "source_url": "https://github.com/Nekzus/npm-sentinel-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/Open-Scout-mcp": {
+      "package": "ai.smithery/Open-Scout-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.0",
+      "description": "Create and publish one-pagers and boards for your organization. Upload images from the web, update\u2026",
+      "name": "ai.smithery/Open-Scout-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Open-Scout-mcp",
+        "Open-Scout-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/PabloLec-keyprobe-mcp": {
+      "package": "ai.smithery/PabloLec-keyprobe-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Audit certificates and keystores to surface expiry risks, weak algorithms, and misconfigurations.\u2026",
+      "name": "ai.smithery/PabloLec-keyprobe-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/PabloLec-keyprobe-mcp",
+        "PabloLec-keyprobe-mcp"
+      ],
+      "source_url": "https://github.com/PabloLec/KeyProbe-MCP",
+      "auto_enriched": true
+    },
+    "ai.smithery/Parc-Dev-task-breakdown-server": {
+      "package": "ai.smithery/Parc-Dev-task-breakdown-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Break down complex problems into clear, actionable steps. Adapt on the fly by iterating, revising,\u2026",
+      "name": "ai.smithery/Parc-Dev-task-breakdown-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Parc-Dev-task-breakdown-server",
+        "Parc-Dev-task-breakdown-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/Phionx-mcp-hello-server": {
+      "package": "ai.smithery/Phionx-mcp-hello-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Send personalized greetings to anyone. Enable Pirate Mode for swashbuckling salutations. Explore t\u2026",
+      "name": "ai.smithery/Phionx-mcp-hello-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Phionx-mcp-hello-server",
+        "Phionx-mcp-hello-server"
+      ],
+      "source_url": "https://github.com/Phionx/mcp-hello-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/PixdataOrg-coderide": {
+      "package": "ai.smithery/PixdataOrg-coderide",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.9.1",
+      "description": "CodeRide eliminates the context reset cycle once and for all. Through MCP integration, it seamless\u2026",
+      "name": "ai.smithery/PixdataOrg-coderide",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/PixdataOrg-coderide",
+        "PixdataOrg-coderide"
+      ],
+      "source_url": "https://github.com/PixdataOrg/coderide-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/Pratiksha-Kanoja-magicslide-mcp-test": {
+      "package": "ai.smithery/Pratiksha-Kanoja-magicslide-mcp-test",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Create polished slide decks from text or YouTube links in seconds. Fetch video transcripts to tran\u2026",
+      "name": "ai.smithery/Pratiksha-Kanoja-magicslide-mcp-test",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/Pratiksha-Kanoja-magicslide-mcp-test",
+        "Pratiksha-Kanoja-magicslide-mcp-test"
+      ],
+      "source_url": "https://github.com/Pratiksha-Kanoja/magicslide-mcp-test",
+      "auto_enriched": true
+    },
+    "ai.smithery/ProfessionalWiki-mediawiki-mcp-server": {
+      "package": "ai.smithery/ProfessionalWiki-mediawiki-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.1",
+      "description": "Enable Large Language Model clients to interact seamlessly with any MediaWiki wiki. Perform action\u2026",
+      "name": "ai.smithery/ProfessionalWiki-mediawiki-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ProfessionalWiki-mediawiki-mcp-server",
+        "ProfessionalWiki-mediawiki-mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/RectiFlex-centerassist-mcp": {
+      "package": "ai.smithery/RectiFlex-centerassist-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Streamline field service and construction operations with CenterPoint Connect. Manage companies, o\u2026",
+      "name": "ai.smithery/RectiFlex-centerassist-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/RectiFlex-centerassist-mcp",
+        "RectiFlex-centerassist-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/RectiFlex-centerassist-mcp-cp": {
+      "package": "ai.smithery/RectiFlex-centerassist-mcp-cp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Streamline property management, construction, and service workflows with CenterPoint Connect. Sear\u2026",
+      "name": "ai.smithery/RectiFlex-centerassist-mcp-cp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/RectiFlex-centerassist-mcp-cp",
+        "RectiFlex-centerassist-mcp-cp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/RectiFlex-centerassist-mcp-cp1": {
+      "package": "ai.smithery/RectiFlex-centerassist-mcp-cp1",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Access and manage CenterPoint Connect data for property management, construction, and service oper\u2026",
+      "name": "ai.smithery/RectiFlex-centerassist-mcp-cp1",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/RectiFlex-centerassist-mcp-cp1",
+        "RectiFlex-centerassist-mcp-cp1"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/RectiFlex-centerassist-mcp1": {
+      "package": "ai.smithery/RectiFlex-centerassist-mcp1",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Manage CenterPoint Connect data across properties, companies, employees, invoices, materials, and\u2026",
+      "name": "ai.smithery/RectiFlex-centerassist-mcp1",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/RectiFlex-centerassist-mcp1",
+        "RectiFlex-centerassist-mcp1"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/STUzhy-py_execute_mcp": {
+      "package": "ai.smithery/STUzhy-py_execute_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Run Python code in a secure sandbox without local setup. Declare inline dependencies and execute s\u2026",
+      "name": "ai.smithery/STUzhy-py_execute_mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/STUzhy-py_execute_mcp",
+        "STUzhy-py_execute_mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/ScrapeGraphAI-scrapegraph-mcp": {
+      "package": "ai.smithery/ScrapeGraphAI-scrapegraph-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Enable language models to perform advanced AI-powered web scraping with enterprise-grade reliabili\u2026",
+      "name": "ai.smithery/ScrapeGraphAI-scrapegraph-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ScrapeGraphAI-scrapegraph-mcp",
+        "ScrapeGraphAI-scrapegraph-mcp"
+      ],
+      "source_url": "https://github.com/ScrapeGraphAI/scrapegraph-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/TakoData-tako-mcp": {
+      "package": "ai.smithery/TakoData-tako-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Provide real-time data querying and visualization by integrating Tako with your agents. Generate o\u2026",
+      "name": "ai.smithery/TakoData-tako-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/TakoData-tako-mcp",
+        "TakoData-tako-mcp"
+      ],
+      "source_url": "https://github.com/TakoData/tako-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/a-ariff-canvas-instant-mcp": {
+      "package": "ai.smithery/a-ariff-canvas-instant-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.0.0",
+      "description": "Manage your Canvas coursework with quick access to courses, assignments, and grades. Track upcomin\u2026",
+      "name": "ai.smithery/a-ariff-canvas-instant-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/a-ariff-canvas-instant-mcp",
+        "a-ariff-canvas-instant-mcp"
+      ],
+      "source_url": "https://github.com/a-ariff/canvas-instant-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/aamangeldi-dad-jokes-mcp": {
+      "package": "ai.smithery/aamangeldi-dad-jokes-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Get a random dad joke or search by keyword to fit any moment. Retrieve specific jokes by ID for re\u2026",
+      "name": "ai.smithery/aamangeldi-dad-jokes-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/aamangeldi-dad-jokes-mcp",
+        "aamangeldi-dad-jokes-mcp"
+      ],
+      "source_url": "https://github.com/aamangeldi/dad-jokes-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/adamamer20-paper-search-mcp-openai": {
+      "package": "ai.smithery/adamamer20-paper-search-mcp-openai",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Search and download academic papers from arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, Semantic\u2026",
+      "name": "ai.smithery/adamamer20-paper-search-mcp-openai",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/adamamer20-paper-search-mcp-openai",
+        "adamamer20-paper-search-mcp-openai"
+      ],
+      "source_url": "https://github.com/adamamer20/paper-search-mcp-openai",
+      "auto_enriched": true
+    },
+    "ai.smithery/afgong-sqlite-mcp-server": {
+      "package": "ai.smithery/afgong-sqlite-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Explore your Messages SQLite database to browse tables and inspect schemas with ease. Run flexible\u2026",
+      "name": "ai.smithery/afgong-sqlite-mcp-server",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/afgong-sqlite-mcp-server",
+        "afgong-sqlite-mcp-server"
+      ],
+      "source_url": "https://github.com/afgong/sqlite-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/agentmail": {
+      "package": "ai.smithery/agentmail",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "AgentMail is the email inbox API for AI agents. It gives agents their own email inboxes, like Gmail",
+      "name": "ai.smithery/agentmail",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/agentmail",
+        "agentmail"
+      ],
+      "source_url": "https://github.com/agentmail-to/agentmail-smithery-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/aicastle-school-openai-api-agent-project": {
+      "package": "ai.smithery/aicastle-school-openai-api-agent-project",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Fetch current stock prices and key data for symbols across global markets. Look up companies like\u2026",
+      "name": "ai.smithery/aicastle-school-openai-api-agent-project",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/aicastle-school-openai-api-agent-project",
+        "aicastle-school-openai-api-agent-project"
+      ],
+      "source_url": "https://github.com/aicastle-school/openai-api-agent-project",
+      "auto_enriched": true
+    },
+    "ai.smithery/aicastle-school-openai-api-agent-project11": {
+      "package": "ai.smithery/aicastle-school-openai-api-agent-project11",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Fetch the latest available stock quotes by ticker symbol across international markets. Check price\u2026",
+      "name": "ai.smithery/aicastle-school-openai-api-agent-project11",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/aicastle-school-openai-api-agent-project11",
+        "aicastle-school-openai-api-agent-project11"
+      ],
+      "source_url": "https://github.com/aicastle-school/openai-api-agent-project",
+      "auto_enriched": true
+    },
+    "ai.smithery/airmang-hwpx-mcp": {
+      "package": "ai.smithery/airmang-hwpx-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "\uc790\ub3d9\ud654\ud558\uc5ec HWPX \ubb38\uc11c\uc758 \ub85c\ub529, \ud0d0\uc0c9, \ud3b8\uc9d1, \uac80\uc99d\uc744 \ud55c \ubc88\uc5d0 \ucc98\ub9ac\ud569\ub2c8\ub2e4. \ubb38\ub2e8\u00b7\ud45c\u00b7\uc8fc\uc11d \ucd94\uac00, \ud14d\uc2a4\ud2b8 \uc77c\uad04 \uce58\ud658, \uba38\ub9ac\ub9d0\u00b7\uaf2c\ub9ac\ub9d0 \uc124\uc815 \ub4f1 \ubc18\ubcf5 \uc791\uc5c5\uc744 \uc2e0\uc18d\ud788 \uc218\ud589\ud569\ub2c8\ub2e4. \uae30\u2026",
+      "name": "ai.smithery/airmang-hwpx-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/airmang-hwpx-mcp",
+        "airmang-hwpx-mcp"
+      ],
+      "source_url": "https://github.com/airmang/hwpx-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/akilat-spec-leave-manager-mcp": {
+      "package": "ai.smithery/akilat-spec-leave-manager-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Track and manage employee time off with quick balance lookups and streamlined applications. Find t\u2026",
+      "name": "ai.smithery/akilat-spec-leave-manager-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/akilat-spec-leave-manager-mcp",
+        "akilat-spec-leave-manager-mcp"
+      ],
+      "source_url": "https://github.com/akilat-spec/leave-manager-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/alex-llm-attack-mcp-server": {
+      "package": "ai.smithery/alex-llm-attack-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.1",
+      "description": "Query and retrieve information about various adversarial tactics and techniques used in cyber atta\u2026",
+      "name": "ai.smithery/alex-llm-attack-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/alex-llm-attack-mcp-server",
+        "alex-llm-attack-mcp-server"
+      ],
+      "source_url": "https://github.com/alex-llm/attAck-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/alphago2580-naramarketmcp": {
+      "package": "ai.smithery/alphago2580-naramarketmcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.1",
+      "description": "Access Korea\u2019s G2B procurement and Nara Market data for bid notices, awards, contracts, statistics\u2026",
+      "name": "ai.smithery/alphago2580-naramarketmcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/alphago2580-naramarketmcp",
+        "alphago2580-naramarketmcp"
+      ],
+      "source_url": "https://github.com/alphago2580/naramarketmcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/anirbanbasu-frankfurtermcp": {
+      "package": "ai.smithery/anirbanbasu-frankfurtermcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "A MCP server for the Frankfurter API for currency exchange rates.",
+      "name": "ai.smithery/anirbanbasu-frankfurtermcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/anirbanbasu-frankfurtermcp",
+        "anirbanbasu-frankfurtermcp"
+      ],
+      "source_url": "https://github.com/anirbanbasu/frankfurtermcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/anirbanbasu-pymcp": {
+      "package": "ai.smithery/anirbanbasu-pymcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.7",
+      "description": "Primarily to be used as a template repository for developing MCP servers with FastMCP in Python, P\u2026",
+      "name": "ai.smithery/anirbanbasu-pymcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/anirbanbasu-pymcp",
+        "anirbanbasu-pymcp"
+      ],
+      "source_url": "https://github.com/anirbanbasu/pymcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-ahoy": {
+      "package": "ai.smithery/arjunkmrm-ahoy",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Send friendly, personalized greetings by name. Switch to a playful pirate voice for themed salutat\u2026",
+      "name": "ai.smithery/arjunkmrm-ahoy",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-ahoy",
+        "arjunkmrm-ahoy"
+      ],
+      "source_url": "https://github.com/arjunkmrm/ahoy",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-ahoy2": {
+      "package": "ai.smithery/arjunkmrm-ahoy2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Create friendly greetings by name, with an optional pirate tone. Explore the origin of 'Hello, Wor\u2026",
+      "name": "ai.smithery/arjunkmrm-ahoy2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-ahoy2",
+        "arjunkmrm-ahoy2"
+      ],
+      "source_url": "https://github.com/arjunkmrm/ahoy",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-boba-tea": {
+      "package": "ai.smithery/arjunkmrm-boba-tea",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Send friendly greetings to people by name. Discover the origin story behind 'Hello, World' for qui\u2026",
+      "name": "ai.smithery/arjunkmrm-boba-tea",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-boba-tea",
+        "arjunkmrm-boba-tea"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-bobo": {
+      "package": "ai.smithery/arjunkmrm-bobo",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Send friendly, personalized greetings on command. Explore the origin of 'Hello, World' for quick c\u2026",
+      "name": "ai.smithery/arjunkmrm-bobo",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-bobo",
+        "arjunkmrm-bobo"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-brave-search-mcp-server": {
+      "package": "ai.smithery/arjunkmrm-brave-search-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.0.25",
+      "description": "Search the web, images, videos, news, and local businesses with robust filters, freshness controls\u2026",
+      "name": "ai.smithery/arjunkmrm-brave-search-mcp-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-brave-search-mcp-server",
+        "arjunkmrm-brave-search-mcp-server"
+      ],
+      "source_url": "https://github.com/arjunkmrm/brave-search-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-clock": {
+      "package": "ai.smithery/arjunkmrm-clock",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.1",
+      "description": "Check the current time instantly and explore world timezones by region. Browse available continent\u2026",
+      "name": "ai.smithery/arjunkmrm-clock",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-clock",
+        "arjunkmrm-clock"
+      ],
+      "source_url": "https://github.com/arjunkmrm/clock",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-fetch": {
+      "package": "ai.smithery/arjunkmrm-fetch",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Fetch web pages and extract exactly the content you need. Select elements with CSS and retrieve co\u2026",
+      "name": "ai.smithery/arjunkmrm-fetch",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-fetch",
+        "arjunkmrm-fetch"
+      ],
+      "source_url": "https://github.com/arjunkmrm/fetch",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-http-test": {
+      "package": "ai.smithery/arjunkmrm-http-test",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.2",
+      "description": "Kickstart your setup with ready-to-run greetings and the 'Hello, World' origin story. Learn the inte",
+      "name": "ai.smithery/arjunkmrm-http-test",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-http-test",
+        "arjunkmrm-http-test"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-local-test2": {
+      "package": "ai.smithery/arjunkmrm-local-test2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Send friendly greetings instantly. Learn the origin of 'Hello, World' to add a fun fact to your me\u2026",
+      "name": "ai.smithery/arjunkmrm-local-test2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-local-test2",
+        "arjunkmrm-local-test2"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-local001": {
+      "package": "ai.smithery/arjunkmrm-local001",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Get the current time in your preferred timezone or any region you specify. Browse concise informat\u2026",
+      "name": "ai.smithery/arjunkmrm-local001",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-local001",
+        "arjunkmrm-local001"
+      ],
+      "source_url": "https://github.com/arjunkmrm/time",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-local01": {
+      "package": "ai.smithery/arjunkmrm-local01",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Greet people warmly or roast them with playful banter. Explore the origin of 'Hello, World' for qu\u2026",
+      "name": "ai.smithery/arjunkmrm-local01",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-local01",
+        "arjunkmrm-local01"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-local02": {
+      "package": "ai.smithery/arjunkmrm-local02",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Get the current time in your chosen timezone and view common timezone information. Simplify schedu\u2026",
+      "name": "ai.smithery/arjunkmrm-local02",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-local02",
+        "arjunkmrm-local02"
+      ],
+      "source_url": "https://github.com/arjunkmrm/time",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-lta-mcp": {
+      "package": "ai.smithery/arjunkmrm-lta-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.0",
+      "description": "Provide real-time transportation data including bus arrivals, train service alerts, carpark availa\u2026",
+      "name": "ai.smithery/arjunkmrm-lta-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-lta-mcp",
+        "arjunkmrm-lta-mcp"
+      ],
+      "source_url": "https://github.com/arjunkmrm/lta-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-mango-sago": {
+      "package": "ai.smithery/arjunkmrm-mango-sago",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Create cheerful, personalized greetings in seconds. Switch to playful pirate-speak for extra flair\u2026",
+      "name": "ai.smithery/arjunkmrm-mango-sago",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-mango-sago",
+        "arjunkmrm-mango-sago"
+      ],
+      "source_url": "https://github.com/arjunkmrm/mango-sago",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-perplexity-search": {
+      "package": "ai.smithery/arjunkmrm-perplexity-search",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Enable AI assistants to perform web searches using Perplexity's Sonar Pro.",
+      "name": "ai.smithery/arjunkmrm-perplexity-search",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-perplexity-search",
+        "arjunkmrm-perplexity-search"
+      ],
+      "source_url": "https://github.com/arjunkmrm/perplexity-search",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-py-test-0": {
+      "package": "ai.smithery/arjunkmrm-py-test-0",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Send personalized greetings by name, with an optional pirate tone. Generate greeting prompts and e\u2026",
+      "name": "ai.smithery/arjunkmrm-py-test-0",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-py-test-0",
+        "arjunkmrm-py-test-0"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-py-test-2": {
+      "package": "ai.smithery/arjunkmrm-py-test-2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Greet people by name with friendly, customizable messages. Toggle Pirate Mode to speak like a swas\u2026",
+      "name": "ai.smithery/arjunkmrm-py-test-2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-py-test-2",
+        "arjunkmrm-py-test-2"
+      ],
+      "source_url": "https://github.com/arjunkmrm/mango-sago",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-scrapermcp_el": {
+      "package": "ai.smithery/arjunkmrm-scrapermcp_el",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Extract and parse web pages into clean HTML, links, or Markdown. Handle dynamic, complex, or block\u2026",
+      "name": "ai.smithery/arjunkmrm-scrapermcp_el",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-scrapermcp_el",
+        "arjunkmrm-scrapermcp_el"
+      ],
+      "source_url": "https://github.com/arjunkmrm/ScraperMcp_el",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-sg-bus-test": {
+      "package": "ai.smithery/arjunkmrm-sg-bus-test",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Get real-time bus arrival times for any Singapore bus stop by code, with optional service filterin\u2026",
+      "name": "ai.smithery/arjunkmrm-sg-bus-test",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-sg-bus-test",
+        "arjunkmrm-sg-bus-test"
+      ],
+      "source_url": "https://github.com/arjunkmrm/sg-bus-test",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-test0": {
+      "package": "ai.smithery/arjunkmrm-test0",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Get the current time in any timezone and quickly look up common timezone info. Set a default timez\u2026",
+      "name": "ai.smithery/arjunkmrm-test0",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-test0",
+        "arjunkmrm-test0"
+      ],
+      "source_url": "https://github.com/arjunkmrm/time",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-test01": {
+      "package": "ai.smithery/arjunkmrm-test01",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Get the current time in any timezone. Explore concise timezone info to pick the right region. Simp\u2026",
+      "name": "ai.smithery/arjunkmrm-test01",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-test01",
+        "arjunkmrm-test01"
+      ],
+      "source_url": "https://github.com/arjunkmrm/time",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-test2": {
+      "package": "ai.smithery/arjunkmrm-test2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Greet anyone by name with a friendly message. Explore the origin of 'Hello, World' to add context\u2026",
+      "name": "ai.smithery/arjunkmrm-test2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-test2",
+        "arjunkmrm-test2"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-time": {
+      "package": "ai.smithery/arjunkmrm-time",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Get the current time anywhere and access concise timezone information. Set your preferred timezone\u2026",
+      "name": "ai.smithery/arjunkmrm-time",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-time",
+        "arjunkmrm-time"
+      ],
+      "source_url": "https://github.com/arjunkmrm/time",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-ts-test-2": {
+      "package": "ai.smithery/arjunkmrm-ts-test-2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Greet anyone with a friendly, personalized hello. Explore the origin story of 'Hello, World.' Jump\u2026",
+      "name": "ai.smithery/arjunkmrm-ts-test-2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-ts-test-2",
+        "arjunkmrm-ts-test-2"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-tutorials": {
+      "package": "ai.smithery/arjunkmrm-tutorials",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Analyze stocks and SEC filings to surface key insights, from price and volume to insider activity\u2026",
+      "name": "ai.smithery/arjunkmrm-tutorials",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-tutorials",
+        "arjunkmrm-tutorials"
+      ],
+      "source_url": "https://github.com/arjunkmrm/tutorials",
+      "auto_enriched": true
+    },
+    "ai.smithery/arjunkmrm-watch2": {
+      "package": "ai.smithery/arjunkmrm-watch2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.1",
+      "description": "Get the current time in your chosen timezone. Browse available continents and regions to pick the\u2026",
+      "name": "ai.smithery/arjunkmrm-watch2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/arjunkmrm-watch2",
+        "arjunkmrm-watch2"
+      ],
+      "source_url": "https://github.com/arjunkmrm/clock",
+      "auto_enriched": true
+    },
+    "ai.smithery/aryankeluskar-poke-video-mcp": {
+      "package": "ai.smithery/aryankeluskar-poke-video-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Search your Flashback video library with natural language to instantly find relevant moments. Get\u2026",
+      "name": "ai.smithery/aryankeluskar-poke-video-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/aryankeluskar-poke-video-mcp",
+        "aryankeluskar-poke-video-mcp"
+      ],
+      "source_url": "https://github.com/aryankeluskar/poke-video-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/bergeramit-bergeramit-hw3-tech": {
+      "package": "ai.smithery/bergeramit-bergeramit-hw3-tech",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Create friendly greetings and add two numbers instantly. Speed up simple tasks and streamline ligh\u2026",
+      "name": "ai.smithery/bergeramit-bergeramit-hw3-tech",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/bergeramit-bergeramit-hw3-tech",
+        "bergeramit-bergeramit-hw3-tech"
+      ],
+      "source_url": "https://github.com/bergeramit/bergeramit-hw3-tech",
+      "auto_enriched": true
+    },
+    "ai.smithery/bergeramit-bergeramit-hw3-tech-1": {
+      "package": "ai.smithery/bergeramit-bergeramit-hw3-tech-1",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Add two numbers instantly and generate friendly greetings on demand. Speed up quick math and perso\u2026",
+      "name": "ai.smithery/bergeramit-bergeramit-hw3-tech-1",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/bergeramit-bergeramit-hw3-tech-1",
+        "bergeramit-bergeramit-hw3-tech-1"
+      ],
+      "source_url": "https://github.com/bergeramit/bergeramit-hw3-tech",
+      "auto_enriched": true
+    },
+    "ai.smithery/bhushangitfull-file-mcp-smith": {
+      "package": "ai.smithery/bhushangitfull-file-mcp-smith",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Manage files and folders directly from your workspace. Read and write files, list directories, cre\u2026",
+      "name": "ai.smithery/bhushangitfull-file-mcp-smith",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/bhushangitfull-file-mcp-smith",
+        "bhushangitfull-file-mcp-smith"
+      ],
+      "source_url": "https://github.com/bhushangitfull/file-mcp-smith",
+      "auto_enriched": true
+    },
+    "ai.smithery/bielacki-igdb-mcp-server": {
+      "package": "ai.smithery/bielacki-igdb-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Explore and discover video games from the Internet Game Database. Search titles, view detailed inf\u2026",
+      "name": "ai.smithery/bielacki-igdb-mcp-server",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/bielacki-igdb-mcp-server",
+        "bielacki-igdb-mcp-server"
+      ],
+      "source_url": "https://github.com/bielacki/igdb-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/blacklotusdev8-test_m": {
+      "package": "ai.smithery/blacklotusdev8-test_m",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Greet anyone by name with a friendly hello. Scrape webpages to extract content for quick reference\u2026",
+      "name": "ai.smithery/blacklotusdev8-test_m",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/blacklotusdev8-test_m",
+        "blacklotusdev8-test_m"
+      ],
+      "source_url": "https://github.com/blacklotusdev8/test_m",
+      "auto_enriched": true
+    },
+    "ai.smithery/blbl147-xhs-mcp": {
+      "package": "ai.smithery/blbl147-xhs-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.6.0",
+      "description": "\u641c\u7d22\u7b14\u8bb0\u3001\u6d4f\u89c8\u9996\u9875\u63a8\u8350\u3001\u67e5\u770b\u7b14\u8bb0\u5185\u5bb9\u4e0e\u8bc4\u8bba\uff0c\u5e76\u53d1\u8868\u4f60\u7684\u8bc4\u8bba\u3002\u76f4\u63a5\u5728\u5de5\u4f5c\u6d41\u4e2d\u4e0e\u5c0f\u7ea2\u4e66\u5185\u5bb9\u4e92\u52a8\uff0c\u9ad8\u6548\u8ddf\u8fdb\u8bdd\u9898\u3002",
+      "name": "ai.smithery/blbl147-xhs-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/blbl147-xhs-mcp",
+        "blbl147-xhs-mcp"
+      ],
+      "source_url": "https://github.com/blbl147/xhs-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/blockscout-mcp-server": {
+      "package": "ai.smithery/blockscout-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Provide AI agents and automation tools with contextual access to blockchain data including balance\u2026",
+      "name": "ai.smithery/blockscout-mcp-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/blockscout-mcp-server",
+        "blockscout-mcp-server"
+      ],
+      "source_url": "https://github.com/blockscout/mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/brandonbosco-sigao-scf-mcp": {
+      "package": "ai.smithery/brandonbosco-sigao-scf-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Provides access to Civic Plus - See Click Fix, allowing you to interact with your data via an LLM.\u2026",
+      "name": "ai.smithery/brandonbosco-sigao-scf-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/brandonbosco-sigao-scf-mcp",
+        "brandonbosco-sigao-scf-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/brave": {
+      "package": "ai.smithery/brave",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.0.9",
+      "description": "Visit https://brave.com/search/api/ for a free API key. Search the web, local businesses, images,\u2026",
+      "name": "ai.smithery/brave",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/brave",
+        "brave"
+      ],
+      "source_url": "https://github.com/brave/brave-search-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/browserbasehq-mcp-browserbase": {
+      "package": "ai.smithery/browserbasehq-mcp-browserbase",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.2.0",
+      "description": "Provides cloud browser automation capabilities using Stagehand and Browserbase, enabling LLMs to i\u2026",
+      "name": "ai.smithery/browserbasehq-mcp-browserbase",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/browserbasehq-mcp-browserbase",
+        "browserbasehq-mcp-browserbase"
+      ],
+      "source_url": "https://github.com/browserbase/mcp-server-browserbase",
+      "auto_enriched": true
+    },
+    "ai.smithery/callmybot-cookbook-mcp-server": {
+      "package": "ai.smithery/callmybot-cookbook-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Count occurrences of any character in your text instantly. Specify the character and get precise c\u2026",
+      "name": "ai.smithery/callmybot-cookbook-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/callmybot-cookbook-mcp-server",
+        "callmybot-cookbook-mcp-server"
+      ],
+      "source_url": "https://github.com/callmybot/cookbook-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/callmybot-domoticz": {
+      "package": "ai.smithery/callmybot-domoticz",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Greet anyone by name with a friendly hello. Explore the origin of 'Hello, World' for context in de\u2026",
+      "name": "ai.smithery/callmybot-domoticz",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/callmybot-domoticz",
+        "callmybot-domoticz"
+      ],
+      "source_url": "https://github.com/callmybot/domoticz",
+      "auto_enriched": true
+    },
+    "ai.smithery/callmybot-hello-mcp-server": {
+      "package": "ai.smithery/callmybot-hello-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Generate quick, friendly greetings by name. Personalize salutations for any context. Explore the o\u2026",
+      "name": "ai.smithery/callmybot-hello-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/callmybot-hello-mcp-server",
+        "callmybot-hello-mcp-server"
+      ],
+      "source_url": "https://github.com/callmybot/hello-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/cc25a-openai-api-agent-project123123123": {
+      "package": "ai.smithery/cc25a-openai-api-agent-project123123123",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Look up the latest stock prices by ticker symbol across global markets. Get current price and esse\u2026",
+      "name": "ai.smithery/cc25a-openai-api-agent-project123123123",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/cc25a-openai-api-agent-project123123123",
+        "cc25a-openai-api-agent-project123123123"
+      ],
+      "source_url": "https://github.com/cc25a/openai-api-agent-project",
+      "auto_enriched": true
+    },
+    "ai.smithery/cindyloo-dropbox-mcp-server": {
+      "package": "ai.smithery/cindyloo-dropbox-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Search, browse, and read your Dropbox files. Find documents by name or content, list folders, and\u2026",
+      "name": "ai.smithery/cindyloo-dropbox-mcp-server",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/cindyloo-dropbox-mcp-server",
+        "cindyloo-dropbox-mcp-server"
+      ],
+      "source_url": "https://github.com/cindyloo/dropbox-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/clpi-clp-mcp": {
+      "package": "ai.smithery/clpi-clp-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.1",
+      "description": "Manage simple context workflows with quick init and add actions. Access the 'Hello, World' origin\u2026",
+      "name": "ai.smithery/clpi-clp-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/clpi-clp-mcp",
+        "clpi-clp-mcp"
+      ],
+      "source_url": "https://github.com/clpi/clp-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/cpretzinger-ai-assistant-simple": {
+      "package": "ai.smithery/cpretzinger-ai-assistant-simple",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "UPDATED 9/1/2025! NEW TOOLS! Use the Redis Stream tools with n8n MCP Client Node for use anywhere!\u2026",
+      "name": "ai.smithery/cpretzinger-ai-assistant-simple",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/cpretzinger-ai-assistant-simple",
+        "cpretzinger-ai-assistant-simple"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/cristianoaredes-mcp-dadosbr": {
+      "package": "ai.smithery/cristianoaredes-mcp-dadosbr",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "# MCP DadosBR Servidor MCP focado em dados p\u00fablicos do Brasil. Oferece duas ferramentas simples e\u2026",
+      "name": "ai.smithery/cristianoaredes-mcp-dadosbr",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/cristianoaredes-mcp-dadosbr",
+        "cristianoaredes-mcp-dadosbr"
+      ],
+      "source_url": "https://github.com/cristianoaredes/mcp-dadosbr",
+      "auto_enriched": true
+    },
+    "ai.smithery/ctaylor86-mcp-video-download-server": {
+      "package": "ai.smithery/ctaylor86-mcp-video-download-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Connect your video workflows to cloud storage. Organize and access video assets across projects wi\u2026",
+      "name": "ai.smithery/ctaylor86-mcp-video-download-server",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ctaylor86-mcp-video-download-server",
+        "ctaylor86-mcp-video-download-server"
+      ],
+      "source_url": "https://github.com/ctaylor86/mcp-video-download-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/cuongpo-coti-mcp": {
+      "package": "ai.smithery/cuongpo-coti-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.1",
+      "description": "Connect to the COTI blockchain to manage accounts, transfer native tokens, and deploy and operate\u2026",
+      "name": "ai.smithery/cuongpo-coti-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/cuongpo-coti-mcp",
+        "cuongpo-coti-mcp"
+      ],
+      "source_url": "https://github.com/cuongpo/coti-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/cuongpo-coti-mcp-1": {
+      "package": "ai.smithery/cuongpo-coti-mcp-1",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.1",
+      "description": "Manage COTI accounts, deploy private ERC20 and ERC721 contracts, and transfer tokens and NFTs with\u2026",
+      "name": "ai.smithery/cuongpo-coti-mcp-1",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/cuongpo-coti-mcp-1",
+        "cuongpo-coti-mcp-1"
+      ],
+      "source_url": "https://github.com/cuongpo/coti-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/data-mindset-sts-google-forms-mcp": {
+      "package": "ai.smithery/data-mindset-sts-google-forms-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Create and manage Google Forms to run surveys and collect data. Add text and multiple-choice quest\u2026",
+      "name": "ai.smithery/data-mindset-sts-google-forms-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/data-mindset-sts-google-forms-mcp",
+        "data-mindset-sts-google-forms-mcp"
+      ],
+      "source_url": "https://github.com/data-mindset/sts-google-forms-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/demomagic-duckchain-mcp": {
+      "package": "ai.smithery/demomagic-duckchain-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Explore blockchain data across addresses, tokens, blocks, and transactions. Investigate any transa\u2026",
+      "name": "ai.smithery/demomagic-duckchain-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/demomagic-duckchain-mcp",
+        "demomagic-duckchain-mcp"
+      ],
+      "source_url": "https://github.com/demomagic/duckchain-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/devbrother2024-typescript-mcp-server-boilerplate": {
+      "package": "ai.smithery/devbrother2024-typescript-mcp-server-boilerplate",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Kickstart development with a customizable TypeScript template featuring sample tools for greeting,\u2026",
+      "name": "ai.smithery/devbrother2024-typescript-mcp-server-boilerplate",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/devbrother2024-typescript-mcp-server-boilerplate",
+        "devbrother2024-typescript-mcp-server-boilerplate"
+      ],
+      "source_url": "https://github.com/devbrother2024/typescript-mcp-server-boilerplate",
+      "auto_enriched": true
+    },
+    "ai.smithery/docfork-mcp": {
+      "package": "ai.smithery/docfork-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.7.0",
+      "description": "@latest documentation and code examples to 9000+ libraries for LLMs and AI code editors in a singl\u2026",
+      "name": "ai.smithery/docfork-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/docfork-mcp",
+        "docfork-mcp"
+      ],
+      "source_url": "https://github.com/docfork/docfork-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/dsharipova-mcp-hw": {
+      "package": "ai.smithery/dsharipova-mcp-hw",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Create personalized greetings by name in the tone you choose. Get quick suggestions for friendly i\u2026",
+      "name": "ai.smithery/dsharipova-mcp-hw",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/dsharipova-mcp-hw",
+        "dsharipova-mcp-hw"
+      ],
+      "source_url": "https://github.com/dsharipova/mcp-hw",
+      "auto_enriched": true
+    },
+    "ai.smithery/duvomike-mcp": {
+      "package": "ai.smithery/duvomike-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Transform numbers by doubling them and adding 5. Get instant results with a clear breakdown of the\u2026",
+      "name": "ai.smithery/duvomike-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/duvomike-mcp",
+        "duvomike-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/eliu243-oura-mcp-server": {
+      "package": "ai.smithery/eliu243-oura-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Connect your Oura Ring account and enable access to your wellness data in apps and automations. In\u2026",
+      "name": "ai.smithery/eliu243-oura-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/eliu243-oura-mcp-server",
+        "eliu243-oura-mcp-server"
+      ],
+      "source_url": "https://github.com/eliu243/oura-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/eliu243-oura-mcp-server-2": {
+      "package": "ai.smithery/eliu243-oura-mcp-server-2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Connect your Oura Ring account to enable secure, authenticated access in your workflows. Generate\u2026",
+      "name": "ai.smithery/eliu243-oura-mcp-server-2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/eliu243-oura-mcp-server-2",
+        "eliu243-oura-mcp-server-2"
+      ],
+      "source_url": "https://github.com/eliu243/oura-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/eliu243-oura-mcp-server-eliu": {
+      "package": "ai.smithery/eliu243-oura-mcp-server-eliu",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Connect your Oura Ring account securely in minutes. Enable authorized access to your sleep, activi\u2026",
+      "name": "ai.smithery/eliu243-oura-mcp-server-eliu",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/eliu243-oura-mcp-server-eliu",
+        "eliu243-oura-mcp-server-eliu"
+      ],
+      "source_url": "https://github.com/eliu243/oura-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/exa-labs-exa-code-mcp": {
+      "package": "ai.smithery/exa-labs-exa-code-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.1",
+      "description": "Find open-source libraries and fetch contextual code snippets by version to accelerate development\u2026",
+      "name": "ai.smithery/exa-labs-exa-code-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/exa-labs-exa-code-mcp",
+        "exa-labs-exa-code-mcp"
+      ],
+      "source_url": "https://github.com/exa-labs/exa-code-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/faithk7-gmail-mcp": {
+      "package": "ai.smithery/faithk7-gmail-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.7.4",
+      "description": "Manage Gmail messages, threads, labels, drafts, and settings from your workflows. Send and organiz\u2026",
+      "name": "ai.smithery/faithk7-gmail-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/faithk7-gmail-mcp",
+        "faithk7-gmail-mcp"
+      ],
+      "source_url": "https://github.com/faithk7/gmail-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/feeefapp-mcp": {
+      "package": "ai.smithery/feeefapp-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Enable AI assistants to interact seamlessly with Feeef e-commerce stores, products, and orders usi\u2026",
+      "name": "ai.smithery/feeefapp-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/feeefapp-mcp",
+        "feeefapp-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/fengyinxia-jimeng-mcp": {
+      "package": "ai.smithery/fengyinxia-jimeng-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Create images and videos from prompts, with options for image mixing, reference images, and start/\u2026",
+      "name": "ai.smithery/fengyinxia-jimeng-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/fengyinxia-jimeng-mcp",
+        "fengyinxia-jimeng-mcp"
+      ],
+      "source_url": "https://github.com/fengyinxia/jimeng-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/fitaf-ai-fitaf-ai-mcp": {
+      "package": "ai.smithery/fitaf-ai-fitaf-ai-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Manage workouts, nutrition, goals, and progress across the FitAF platform. Connect wearables, sync\u2026",
+      "name": "ai.smithery/fitaf-ai-fitaf-ai-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/fitaf-ai-fitaf-ai-mcp",
+        "fitaf-ai-fitaf-ai-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/fitaf-ai-fitaf-mcp": {
+      "package": "ai.smithery/fitaf-ai-fitaf-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Track workouts, nutrition, body metrics, habits, and SMART goals with insights and trends. Connect\u2026",
+      "name": "ai.smithery/fitaf-ai-fitaf-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/fitaf-ai-fitaf-mcp",
+        "fitaf-ai-fitaf-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/flight505-mcp_dincoder": {
+      "package": "ai.smithery/flight505-mcp_dincoder",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.15",
+      "description": "Driven Intent Negotiation \u2014 Contract-Oriented Deterministic Executable Runtime DinCoder brings the\u2026",
+      "name": "ai.smithery/flight505-mcp_dincoder",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/flight505-mcp_dincoder",
+        "flight505-mcp_dincoder"
+      ],
+      "source_url": "https://github.com/flight505/MCP_DinCoder",
+      "auto_enriched": true
+    },
+    "ai.smithery/hithereiamaliff-mcp-datagovmy": {
+      "package": "ai.smithery/hithereiamaliff-mcp-datagovmy",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "This MCP server provides seamless access to Malaysia's government open data, including datasets, w\u2026",
+      "name": "ai.smithery/hithereiamaliff-mcp-datagovmy",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/hithereiamaliff-mcp-datagovmy",
+        "hithereiamaliff-mcp-datagovmy"
+      ],
+      "source_url": "https://github.com/hithereiamaliff/mcp-datagovmy",
+      "auto_enriched": true
+    },
+    "ai.smithery/hithereiamaliff-mcp-nextcloud": {
+      "package": "ai.smithery/hithereiamaliff-mcp-nextcloud",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "A comprehensive Model Context Protocol (MCP) server that enables AI assistants to interact with yo\u2026",
+      "name": "ai.smithery/hithereiamaliff-mcp-nextcloud",
+      "category": "cloud",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/hithereiamaliff-mcp-nextcloud",
+        "hithereiamaliff-mcp-nextcloud"
+      ],
+      "source_url": "https://github.com/hithereiamaliff/mcp-nextcloud",
+      "auto_enriched": true
+    },
+    "ai.smithery/hjsh200219-pharminfo-mcp": {
+      "package": "ai.smithery/hjsh200219-pharminfo-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Look up Korean drug ingredient and product data by HIRA component and product codes via Pilldoc. V\u2026",
+      "name": "ai.smithery/hjsh200219-pharminfo-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/hjsh200219-pharminfo-mcp",
+        "hjsh200219-pharminfo-mcp"
+      ],
+      "source_url": "https://github.com/hjsh200219/pharminfo-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/hollaugo-financial-research-mcp-server": {
+      "package": "ai.smithery/hollaugo-financial-research-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Analyze stocks with summaries, price targets, and analyst recommendations. Track SEC filings, divi\u2026",
+      "name": "ai.smithery/hollaugo-financial-research-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/hollaugo-financial-research-mcp-server",
+        "hollaugo-financial-research-mcp-server"
+      ],
+      "source_url": "https://github.com/hollaugo/tutorials",
+      "auto_enriched": true
+    },
+    "ai.smithery/hustcc-mcp-mermaid": {
+      "package": "ai.smithery/hustcc-mcp-mermaid",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.3",
+      "description": "Generate dynamic Mermaid diagrams and charts with AI assistance. Customize styles and export diagr\u2026",
+      "name": "ai.smithery/hustcc-mcp-mermaid",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/hustcc-mcp-mermaid",
+        "hustcc-mcp-mermaid"
+      ],
+      "source_url": "https://github.com/hustcc/mcp-mermaid",
+      "auto_enriched": true
+    },
+    "ai.smithery/huuthangntk-claude-vision-mcp-server": {
+      "package": "ai.smithery/huuthangntk-claude-vision-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Analyze images from multiple angles to extract detailed insights or quick summaries. Describe visu\u2026",
+      "name": "ai.smithery/huuthangntk-claude-vision-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/huuthangntk-claude-vision-mcp-server",
+        "huuthangntk-claude-vision-mcp-server"
+      ],
+      "source_url": "https://github.com/huuthangntk/claude-vision-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/infranodus-mcp-server-infranodus": {
+      "package": "ai.smithery/infranodus-mcp-server-infranodus",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Map text into knowledge graphs to create a structured representation of conceptual relations and t\u2026",
+      "name": "ai.smithery/infranodus-mcp-server-infranodus",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/infranodus-mcp-server-infranodus",
+        "infranodus-mcp-server-infranodus"
+      ],
+      "source_url": "https://github.com/infranodus/mcp-server-infranodus",
+      "auto_enriched": true
+    },
+    "ai.smithery/isnow890-data4library-mcp": {
+      "package": "ai.smithery/isnow890-data4library-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.5",
+      "description": "\ucc45 \uc2eb\uc5b4\ud558\ub294 \uc81c\uac00 \ucc45\uc5d0 \ub300\ud574 \uc544\ub294\ucc99\ud558\uace0 \uc2f6\uc5b4\uc11c \ub9cc\ub4e4\uc5c8\uc2b5\ub2c8\ub2e4.. \ub0b4 \uc8fc\ubcc0 \ub3c4\uc11c\uad00 \uc2e4\uc2dc\uac04 \ub300\ucd9c \ud655\uc778 \uc77d\uace0 \uc2f6\uc740 \ucc45\uc744 \uac80\uc0c9\ud558\uba74 \uc8fc\ubcc0 \ub3c4\uc11c\uad00 \ub300\ucd9c \uac00\ub2a5 \uc5ec\ubd80\ub97c \uc989\uc2dc \ud655\uc778 \uad73\uc774 \ub3c4\uc11c\uad00\u2026",
+      "name": "ai.smithery/isnow890-data4library-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/isnow890-data4library-mcp",
+        "isnow890-data4library-mcp"
+      ],
+      "source_url": "https://github.com/isnow890/data4library-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/jekakos-mcp-user-data-enrichment": {
+      "package": "ai.smithery/jekakos-mcp-user-data-enrichment",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Enrich user data by adding social network links based on provided personal information. Integrate\u2026",
+      "name": "ai.smithery/jekakos-mcp-user-data-enrichment",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/jekakos-mcp-user-data-enrichment",
+        "jekakos-mcp-user-data-enrichment"
+      ],
+      "source_url": "https://github.com/jekakos/mcp-user-data-enrichment",
+      "auto_enriched": true
+    },
+    "ai.smithery/jenniferjiang0511-mit-ai-studio-hw3": {
+      "package": "ai.smithery/jenniferjiang0511-mit-ai-studio-hw3",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Greet people by name and check local forecasts and weather alerts across the U.S. Switch to a play\u2026",
+      "name": "ai.smithery/jenniferjiang0511-mit-ai-studio-hw3",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/jenniferjiang0511-mit-ai-studio-hw3",
+        "jenniferjiang0511-mit-ai-studio-hw3"
+      ],
+      "source_url": "https://github.com/jenniferjiang0511/MIT-AI-studio-HW3",
+      "auto_enriched": true
+    },
+    "ai.smithery/jessicayanwang-test": {
+      "package": "ai.smithery/jessicayanwang-test",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Fetch latest and historical currency exchange rates from Frankfurter. Convert amounts between curr\u2026",
+      "name": "ai.smithery/jessicayanwang-test",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/jessicayanwang-test",
+        "jessicayanwang-test"
+      ],
+      "source_url": "https://github.com/jessicayanwang/frankfurtermcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/jirispilka-actors-mcp-server": {
+      "package": "ai.smithery/jirispilka-actors-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Greet anyone by name with friendly, personalized messages. Explore the origin of Hello, World thro\u2026",
+      "name": "ai.smithery/jirispilka-actors-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/jirispilka-actors-mcp-server",
+        "jirispilka-actors-mcp-server"
+      ],
+      "source_url": "https://github.com/jirispilka/actors-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/jjlabsio-korea-stock-mcp": {
+      "package": "ai.smithery/jjlabsio-korea-stock-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Search company disclosures and financial statements from the Korean market. Retrieve stock profile\u2026",
+      "name": "ai.smithery/jjlabsio-korea-stock-mcp",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/jjlabsio-korea-stock-mcp",
+        "jjlabsio-korea-stock-mcp"
+      ],
+      "source_url": "https://github.com/jjlabsio/korea-stock-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/jweingardt12-mlb_mcp": {
+      "package": "ai.smithery/jweingardt12-mlb_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Provides easy access to MLB, Baseball Savant, Statcast, and Fangraphs baseball data. Query detaile\u2026",
+      "name": "ai.smithery/jweingardt12-mlb_mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/jweingardt12-mlb_mcp",
+        "jweingardt12-mlb_mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/kaszek-kaszek-attio-mcp": {
+      "package": "ai.smithery/kaszek-kaszek-attio-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.0",
+      "description": "Automate Attio CRM workflows with fast search and bulk operations across companies, people, deals,\u2026",
+      "name": "ai.smithery/kaszek-kaszek-attio-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kaszek-kaszek-attio-mcp",
+        "kaszek-kaszek-attio-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/keithah-hostex-mcp": {
+      "package": "ai.smithery/keithah-hostex-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.0",
+      "description": "Manage your Hostex vacation rentals\u2014properties, reservations, availability, listings, and guest me\u2026",
+      "name": "ai.smithery/keithah-hostex-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/keithah-hostex-mcp",
+        "keithah-hostex-mcp"
+      ],
+      "source_url": "https://github.com/keithah/hostex-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/keithah-tessie-mcp": {
+      "package": "ai.smithery/keithah-tessie-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.1.1",
+      "description": "Unofficial integration! ## \u2728 Key Features ### \ud83d\udcb0 Financial Intelligence - **Smart Charging Cost An\u2026",
+      "name": "ai.smithery/keithah-tessie-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/keithah-tessie-mcp",
+        "keithah-tessie-mcp"
+      ],
+      "source_url": "https://github.com/keithah/tessie-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/keremurat-json": {
+      "package": "ai.smithery/keremurat-json",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Compare two JSON files deeply without worrying about key or array order. Detect missing, extra, an\u2026",
+      "name": "ai.smithery/keremurat-json",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/keremurat-json",
+        "keremurat-json"
+      ],
+      "source_url": "https://github.com/keremurat/mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/keremurat-jsonmcp": {
+      "package": "ai.smithery/keremurat-jsonmcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Compare two JSON files deeply, ignoring order, to surface every difference. Get a clear, structure\u2026",
+      "name": "ai.smithery/keremurat-jsonmcp",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/keremurat-jsonmcp",
+        "keremurat-jsonmcp"
+      ],
+      "source_url": "https://github.com/keremurat/mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/keremurat-mcp": {
+      "package": "ai.smithery/keremurat-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Compare two JSON files deeply, regardless of order. Get a detailed difference report highlighting\u2026",
+      "name": "ai.smithery/keremurat-mcp",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/keremurat-mcp",
+        "keremurat-mcp"
+      ],
+      "source_url": "https://github.com/keremurat/mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/kesslerio-attio-mcp-server": {
+      "package": "ai.smithery/kesslerio-attio-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.1.1-fallback",
+      "description": "Connect AI to your Attio CRM. Manage contacts, companies, deals, and sales pipelines. Create tasks\u2026",
+      "name": "ai.smithery/kesslerio-attio-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kesslerio-attio-mcp-server",
+        "kesslerio-attio-mcp-server"
+      ],
+      "source_url": "https://github.com/kesslerio/attio-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/kesslerio-attio-mcp-server-beta": {
+      "package": "ai.smithery/kesslerio-attio-mcp-server-beta",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.1.1",
+      "description": "Streamline your Attio workflows using natural language to search, create, update, and organize com\u2026",
+      "name": "ai.smithery/kesslerio-attio-mcp-server-beta",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kesslerio-attio-mcp-server-beta",
+        "kesslerio-attio-mcp-server-beta"
+      ],
+      "source_url": "https://github.com/kesslerio/attio-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/kirbah-mcp-youtube": {
+      "package": "ai.smithery/kirbah-mcp-youtube",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.6",
+      "description": "Provide token-optimized, structured YouTube data to enhance your LLM applications. Access efficien\u2026",
+      "name": "ai.smithery/kirbah-mcp-youtube",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kirbah-mcp-youtube",
+        "kirbah-mcp-youtube"
+      ],
+      "source_url": "https://github.com/kirbah/mcp-youtube",
+      "auto_enriched": true
+    },
+    "ai.smithery/kkjdaniel-bgg-mcp": {
+      "package": "ai.smithery/kkjdaniel-bgg-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.3.2",
+      "description": "BGG MCP provides access to the BoardGameGeek API through the Model Context Protocol, enabling retr\u2026",
+      "name": "ai.smithery/kkjdaniel-bgg-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kkjdaniel-bgg-mcp",
+        "kkjdaniel-bgg-mcp"
+      ],
+      "source_url": "https://github.com/kkjdaniel/bgg-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/kodey-ai-mapwise-mcp": {
+      "package": "ai.smithery/kodey-ai-mapwise-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Send friendly, personalized greetings on demand. Generate quick salutations with a simple prompt.\u2026",
+      "name": "ai.smithery/kodey-ai-mapwise-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kodey-ai-mapwise-mcp",
+        "kodey-ai-mapwise-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/kodey-ai-salesforce-mcp": {
+      "package": "ai.smithery/kodey-ai-salesforce-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Run SOQL queries to explore and retrieve Salesforce data. Inspect records, fields, and relationshi\u2026",
+      "name": "ai.smithery/kodey-ai-salesforce-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kodey-ai-salesforce-mcp",
+        "kodey-ai-salesforce-mcp"
+      ],
+      "source_url": "https://github.com/kodey-ai/salesforce-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/kodey-ai-salesforce-mcp-kodey": {
+      "package": "ai.smithery/kodey-ai-salesforce-mcp-kodey",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Run SOQL queries against your Salesforce org to explore and retrieve data. Quickly iterate on filt\u2026",
+      "name": "ai.smithery/kodey-ai-salesforce-mcp-kodey",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kodey-ai-salesforce-mcp-kodey",
+        "kodey-ai-salesforce-mcp-kodey"
+      ],
+      "source_url": "https://github.com/kodey-ai/salesforce-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/kodey-ai-salesforce-mcp-minimal": {
+      "package": "ai.smithery/kodey-ai-salesforce-mcp-minimal",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Run SOQL queries to explore and retrieve Salesforce data. Access accounts, contacts, opportunities\u2026",
+      "name": "ai.smithery/kodey-ai-salesforce-mcp-minimal",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kodey-ai-salesforce-mcp-minimal",
+        "kodey-ai-salesforce-mcp-minimal"
+      ],
+      "source_url": "https://github.com/kodey-ai/salesforce-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/kodey-ai-salesforce-mcp-server": {
+      "package": "ai.smithery/kodey-ai-salesforce-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Run SOQL queries against your Salesforce org to retrieve records and insights. Explore objects, fi\u2026",
+      "name": "ai.smithery/kodey-ai-salesforce-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kodey-ai-salesforce-mcp-server",
+        "kodey-ai-salesforce-mcp-server"
+      ],
+      "source_url": "https://github.com/kodey-ai/salesforce-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/kwp-lab-rss-reader-mcp": {
+      "package": "ai.smithery/kwp-lab-rss-reader-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Track and browse RSS feeds with ease. Fetch the latest entries from any feed URL and extract full\u2026",
+      "name": "ai.smithery/kwp-lab-rss-reader-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/kwp-lab-rss-reader-mcp",
+        "kwp-lab-rss-reader-mcp"
+      ],
+      "source_url": "https://github.com/kwp-lab/rss-reader-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/leandrogavidia-vechain-mcp-server": {
+      "package": "ai.smithery/leandrogavidia-vechain-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Search VeChain documentation, query on-chain data, and fetch fee suggestions with direct links to\u2026",
+      "name": "ai.smithery/leandrogavidia-vechain-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/leandrogavidia-vechain-mcp-server",
+        "leandrogavidia-vechain-mcp-server"
+      ],
+      "source_url": "https://github.com/leandrogavidia/vechain-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/lineex-pubmed-mcp-smithery": {
+      "package": "ai.smithery/lineex-pubmed-mcp-smithery",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Search PubMed with precision using keyword and journal filters and smart sorting. Uncover MeSH ter\u2026",
+      "name": "ai.smithery/lineex-pubmed-mcp-smithery",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/lineex-pubmed-mcp-smithery",
+        "lineex-pubmed-mcp-smithery"
+      ],
+      "source_url": "https://github.com/lineex/pubmed-mcp-smithery",
+      "auto_enriched": true
+    },
+    "ai.smithery/lukaskostka99-marketing-miner-mcp": {
+      "package": "ai.smithery/lukaskostka99-marketing-miner-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Discover high-impact keyword ideas across Central and Eastern European and English markets. Analyz\u2026",
+      "name": "ai.smithery/lukaskostka99-marketing-miner-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/lukaskostka99-marketing-miner-mcp",
+        "lukaskostka99-marketing-miner-mcp"
+      ],
+      "source_url": "https://github.com/lukaskostka99/marketing-miner-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/luminati-io-brightdata-mcp": {
+      "package": "ai.smithery/luminati-io-brightdata-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "One MCP for the Web. Easily search, crawl, navigate, and extract websites without getting blocked.\u2026",
+      "name": "ai.smithery/luminati-io-brightdata-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/luminati-io-brightdata-mcp",
+        "luminati-io-brightdata-mcp"
+      ],
+      "source_url": "https://github.com/brightdata/brightdata-mcp-sse",
+      "auto_enriched": true
+    },
+    "ai.smithery/magenie33-quality-dimension-generator": {
+      "package": "ai.smithery/magenie33-quality-dimension-generator",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Generate tailored quality criteria and scoring guides from your task descriptions. Refine objectiv\u2026",
+      "name": "ai.smithery/magenie33-quality-dimension-generator",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/magenie33-quality-dimension-generator",
+        "magenie33-quality-dimension-generator"
+      ],
+      "source_url": "https://github.com/magenie33/quality-dimension-generator",
+      "auto_enriched": true
+    },
+    "ai.smithery/mayla-debug-mcp-google-calendar2": {
+      "package": "ai.smithery/mayla-debug-mcp-google-calendar2",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Schedule and manage Google Calendar events directly from your workspace. Check availability, view\u2026",
+      "name": "ai.smithery/mayla-debug-mcp-google-calendar2",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/mayla-debug-mcp-google-calendar2",
+        "mayla-debug-mcp-google-calendar2"
+      ],
+      "source_url": "https://github.com/mayla-debug/mcp-google-calendar2",
+      "auto_enriched": true
+    },
+    "ai.smithery/mfukushim-map-traveler-mcp": {
+      "package": "ai.smithery/mfukushim-map-traveler-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.0",
+      "description": "Create immersive travel experiences by instructing an avatar to navigate Google Maps. Report on th\u2026",
+      "name": "ai.smithery/mfukushim-map-traveler-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/mfukushim-map-traveler-mcp",
+        "mfukushim-map-traveler-mcp"
+      ],
+      "source_url": "https://github.com/mfukushim/map-traveler-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/miguelgarzons-mcp-cun": {
+      "package": "ai.smithery/miguelgarzons-mcp-cun",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Greet people by name with friendly, personalized messages. Add a warm touch to onboarding, demos,\u2026",
+      "name": "ai.smithery/miguelgarzons-mcp-cun",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/miguelgarzons-mcp-cun",
+        "miguelgarzons-mcp-cun"
+      ],
+      "source_url": "https://github.com/miguelgarzons/mcp-cun",
+      "auto_enriched": true
+    },
+    "ai.smithery/minionszyw-bazi": {
+      "package": "ai.smithery/minionszyw-bazi",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Generate BaZi charts from birth details. Explore Four Pillars, solar terms, and Luck Pillars for d\u2026",
+      "name": "ai.smithery/minionszyw-bazi",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/minionszyw-bazi",
+        "minionszyw-bazi"
+      ],
+      "source_url": "https://github.com/minionszyw/bazi",
+      "auto_enriched": true
+    },
+    "ai.smithery/mjucius-cozi_mcp": {
+      "package": "ai.smithery/mjucius-cozi_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Manage your family's calendars and lists in Cozi. View, create, and update appointments; organize\u2026",
+      "name": "ai.smithery/mjucius-cozi_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/mjucius-cozi_mcp",
+        "mjucius-cozi_mcp"
+      ],
+      "source_url": "https://github.com/mjucius/cozi_mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/morosss-sdfsdf": {
+      "package": "ai.smithery/morosss-sdfsdf",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Find academic papers across major sources like arXiv, PubMed, bioRxiv, and more. Download PDFs whe\u2026",
+      "name": "ai.smithery/morosss-sdfsdf",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/morosss-sdfsdf",
+        "morosss-sdfsdf"
+      ],
+      "source_url": "https://github.com/morosss/sdfsdf",
+      "auto_enriched": true
+    },
+    "ai.smithery/motorboy1-my-mcp-server": {
+      "package": "ai.smithery/motorboy1-my-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Send friendly greetings by name. Discover the origin story of 'Hello, World' for quick context.",
+      "name": "ai.smithery/motorboy1-my-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/motorboy1-my-mcp-server",
+        "motorboy1-my-mcp-server"
+      ],
+      "source_url": "https://github.com/motorboy1/my-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/mrugankpednekar-bill_splitter_mcp": {
+      "package": "ai.smithery/mrugankpednekar-bill_splitter_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Track and split shared expenses across trips, events, and groups. Create groups, add expenses, and\u2026",
+      "name": "ai.smithery/mrugankpednekar-bill_splitter_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/mrugankpednekar-bill_splitter_mcp",
+        "mrugankpednekar-bill_splitter_mcp"
+      ],
+      "source_url": "https://github.com/mrugankpednekar/bill_splitter_mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/mrugankpednekar-mcp-optimizer": {
+      "package": "ai.smithery/mrugankpednekar-mcp-optimizer",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Optimize crew and workforce schedules, resource allocation, and routing with linear and mixed-inte\u2026",
+      "name": "ai.smithery/mrugankpednekar-mcp-optimizer",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/mrugankpednekar-mcp-optimizer",
+        "mrugankpednekar-mcp-optimizer"
+      ],
+      "source_url": "https://github.com/mrugankpednekar/mcp-optimizer",
+      "auto_enriched": true
+    },
+    "ai.smithery/neverinfamous-memory-journal-mcp": {
+      "package": "ai.smithery/neverinfamous-memory-journal-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "A MCP server built for developers enabling Git based project management with project and personal\u2026",
+      "name": "ai.smithery/neverinfamous-memory-journal-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/neverinfamous-memory-journal-mcp",
+        "neverinfamous-memory-journal-mcp"
+      ],
+      "source_url": "https://github.com/neverinfamous/memory-journal-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/nickthelegend-test-mcp": {
+      "package": "ai.smithery/nickthelegend-test-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Create friendly, personalized greetings in seconds. Toggle Pirate Mode to speak like a pirate for\u2026",
+      "name": "ai.smithery/nickthelegend-test-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/nickthelegend-test-mcp",
+        "nickthelegend-test-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/oxylabs-oxylabs-mcp": {
+      "package": "ai.smithery/oxylabs-oxylabs-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "Fetch and process content from specified URLs using the Oxylabs Web Scraper API.",
+      "name": "ai.smithery/oxylabs-oxylabs-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/oxylabs-oxylabs-mcp",
+        "oxylabs-oxylabs-mcp"
+      ],
+      "source_url": "https://github.com/oxylabs/oxylabs-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/pinion05-supabase-mcp-lite": {
+      "package": "ai.smithery/pinion05-supabase-mcp-lite",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Same functionality, consuming only 1/20 of the context window tokens.",
+      "name": "ai.smithery/pinion05-supabase-mcp-lite",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/pinion05-supabase-mcp-lite",
+        "pinion05-supabase-mcp-lite"
+      ],
+      "source_url": "https://github.com/pinion05/supabase-mcp-lite",
+      "auto_enriched": true
+    },
+    "ai.smithery/pinkpixel-dev-web-scout-mcp": {
+      "package": "ai.smithery/pinkpixel-dev-web-scout-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.5.5",
+      "description": "Search the web and extract clean, readable text from webpages. Process multiple URLs at once to sp\u2026",
+      "name": "ai.smithery/pinkpixel-dev-web-scout-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/pinkpixel-dev-web-scout-mcp",
+        "pinkpixel-dev-web-scout-mcp"
+      ],
+      "source_url": "https://github.com/pinkpixel-dev/web-scout-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/plainyogurt21-clintrials-mcp": {
+      "package": "ai.smithery/plainyogurt21-clintrials-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Provide structured access to ClinicalTrials.gov data for searching, retrieving, and analyzing clin\u2026",
+      "name": "ai.smithery/plainyogurt21-clintrials-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/plainyogurt21-clintrials-mcp",
+        "plainyogurt21-clintrials-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/plainyogurt21-sec-edgar-mcp": {
+      "package": "ai.smithery/plainyogurt21-sec-edgar-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Provide AI assistants with real-time access to official SEC EDGAR filings and financial data. Enab\u2026",
+      "name": "ai.smithery/plainyogurt21-sec-edgar-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/plainyogurt21-sec-edgar-mcp",
+        "plainyogurt21-sec-edgar-mcp"
+      ],
+      "source_url": "https://github.com/plainyogurt21/sec-edgar-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/proflulab-documentassistant": {
+      "package": "ai.smithery/proflulab-documentassistant",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.1",
+      "description": "Convert files between formats without quality loss. Speed up your workflow with fast, reliable con\u2026",
+      "name": "ai.smithery/proflulab-documentassistant",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/proflulab-documentassistant",
+        "proflulab-documentassistant"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/pythondev-pro-egw_writings_mcp_server": {
+      "package": "ai.smithery/pythondev-pro-egw_writings_mcp_server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.12.4",
+      "description": "Search Ellen G. White\u2019s writings by keyword to surface relevant quotations. Retrieve exact passage\u2026",
+      "name": "ai.smithery/pythondev-pro-egw_writings_mcp_server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/pythondev-pro-egw_writings_mcp_server",
+        "pythondev-pro-egw_writings_mcp_server"
+      ],
+      "source_url": "https://github.com/pythondev-pro/egw_writings_mcp_server",
+      "auto_enriched": true
+    },
+    "ai.smithery/rainbowgore-stealthee-mcp-tools": {
+      "package": "ai.smithery/rainbowgore-stealthee-mcp-tools",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Spot pre-launch products before they trend. Search the web and tech sites, extract and parse pages\u2026",
+      "name": "ai.smithery/rainbowgore-stealthee-mcp-tools",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/rainbowgore-stealthee-mcp-tools",
+        "rainbowgore-stealthee-mcp-tools"
+      ],
+      "source_url": "https://github.com/rainbowgore/stealthee-MCP-tools",
+      "auto_enriched": true
+    },
+    "ai.smithery/ramadasmr-networkcalc-mcp": {
+      "package": "ai.smithery/ramadasmr-networkcalc-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.0",
+      "description": "Look up DNS information for any domain to troubleshoot issues and gather insights. Get fast, relia\u2026",
+      "name": "ai.smithery/ramadasmr-networkcalc-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ramadasmr-networkcalc-mcp",
+        "ramadasmr-networkcalc-mcp"
+      ],
+      "source_url": "https://github.com/ramadasmr/networkcalc-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/ref-tools-ref-tools-mcp": {
+      "package": "ai.smithery/ref-tools-ref-tools-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "3.0.0",
+      "description": "Provide your AI coding tools with token-efficient access to up-to-date technical documentation for\u2026",
+      "name": "ai.smithery/ref-tools-ref-tools-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/ref-tools-ref-tools-mcp",
+        "ref-tools-ref-tools-mcp"
+      ],
+      "source_url": "https://github.com/ref-tools/ref-tools-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/renCosta2025-context7fork": {
+      "package": "ai.smithery/renCosta2025-context7fork",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.13",
+      "description": "Get up-to-date, version-specific documentation and code examples from official sources directly in\u2026",
+      "name": "ai.smithery/renCosta2025-context7fork",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/renCosta2025-context7fork",
+        "renCosta2025-context7fork"
+      ],
+      "source_url": "https://github.com/renCosta2025/context7fork",
+      "auto_enriched": true
+    },
+    "ai.smithery/rfdez-pvpc-mcp-server": {
+      "package": "ai.smithery/rfdez-pvpc-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "3.2.3",
+      "description": "Retrieve daily PVPC electricity tariffs for 2.0 TD consumers, published by Red El\u00e9ctrica.",
+      "name": "ai.smithery/rfdez-pvpc-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/rfdez-pvpc-mcp-server",
+        "rfdez-pvpc-mcp-server"
+      ],
+      "source_url": "https://github.com/rfdez/pvpc-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/sachicali-discordmcp-suite": {
+      "package": "ai.smithery/sachicali-discordmcp-suite",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.2.0",
+      "description": "Control your Discord community: send/read messages, manage channels and forums, and handle webhook\u2026",
+      "name": "ai.smithery/sachicali-discordmcp-suite",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/sachicali-discordmcp-suite",
+        "sachicali-discordmcp-suite"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/saidsef-mcp-github-pr-issue-analyser": {
+      "package": "ai.smithery/saidsef-mcp-github-pr-issue-analyser",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "A Model Context Protocol (MCP) application for automated GitHub PR analysis and issue management.\u2026",
+      "name": "ai.smithery/saidsef-mcp-github-pr-issue-analyser",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/saidsef-mcp-github-pr-issue-analyser",
+        "saidsef-mcp-github-pr-issue-analyser"
+      ],
+      "source_url": "https://github.com/saidsef/mcp-github-pr-issue-analyser",
+      "auto_enriched": true
+    },
+    "ai.smithery/samihalawa-whatsapp-go-mcp": {
+      "package": "ai.smithery/samihalawa-whatsapp-go-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "v7.5.0",
+      "description": "Scan QR codes and go! No more troublesome autos or APIs! Send text messages, images, links, locati\u2026",
+      "name": "ai.smithery/samihalawa-whatsapp-go-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/samihalawa-whatsapp-go-mcp",
+        "samihalawa-whatsapp-go-mcp"
+      ],
+      "source_url": "https://github.com/samihalawa/whatsapp-go-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/sasabasara-where_is_my_bus_mcp": {
+      "package": "ai.smithery/sasabasara-where_is_my_bus_mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.0.0",
+      "description": "Get real-time NYC bus arrivals, live vehicle locations, and service alerts. Plan trips between any\u2026",
+      "name": "ai.smithery/sasabasara-where_is_my_bus_mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/sasabasara-where_is_my_bus_mcp",
+        "sasabasara-where_is_my_bus_mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/sebastianall1977-gmail-mcp": {
+      "package": "ai.smithery/sebastianall1977-gmail-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.7.4",
+      "description": "Manage Gmail end-to-end: search, read, send, draft, label, and organize threads. Automate workflow\u2026",
+      "name": "ai.smithery/sebastianall1977-gmail-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/sebastianall1977-gmail-mcp",
+        "sebastianall1977-gmail-mcp"
+      ],
+      "source_url": "https://github.com/sebastianall1977/gmail-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/serkan-ozal-driflyte-mcp-server": {
+      "package": "ai.smithery/serkan-ozal-driflyte-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.15",
+      "description": "Discover available topics and explore up-to-date, topic-tagged web content. Search to surface the\u2026",
+      "name": "ai.smithery/serkan-ozal-driflyte-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/serkan-ozal-driflyte-mcp-server",
+        "serkan-ozal-driflyte-mcp-server"
+      ],
+      "source_url": "https://github.com/serkan-ozal/driflyte-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/shoumikdc-arxiv-mcp": {
+      "package": "ai.smithery/shoumikdc-arxiv-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Discover the latest arXiv papers by category and keyword. Control how many results you get to spee\u2026",
+      "name": "ai.smithery/shoumikdc-arxiv-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/shoumikdc-arxiv-mcp",
+        "shoumikdc-arxiv-mcp"
+      ],
+      "source_url": "https://github.com/shoumikdc/arXiv-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/skr-cloudify-clickup-mcp-server-new": {
+      "package": "ai.smithery/skr-cloudify-clickup-mcp-server-new",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.8.5",
+      "description": "Manage your ClickUp workspace by creating, updating, and organizing tasks, lists, folders, and tag\u2026",
+      "name": "ai.smithery/skr-cloudify-clickup-mcp-server-new",
+      "category": "cloud",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/skr-cloudify-clickup-mcp-server-new",
+        "skr-cloudify-clickup-mcp-server-new"
+      ],
+      "source_url": "https://github.com/skr-cloudify/clickup-mcp-server-new",
+      "auto_enriched": true
+    },
+    "ai.smithery/slhad-aha-mcp": {
+      "package": "ai.smithery/slhad-aha-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.0",
+      "description": "A TypeScript MCP server for Home Assistant, enabling programmatic management of entities, automati\u2026",
+      "name": "ai.smithery/slhad-aha-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/slhad-aha-mcp",
+        "slhad-aha-mcp"
+      ],
+      "source_url": "https://github.com/slhad/aha-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-ai-cookbook-python-quickstart": {
+      "package": "ai.smithery/smithery-ai-cookbook-python-quickstart",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.13.1",
+      "description": "A simple MCP server built with FastMCP and python",
+      "name": "ai.smithery/smithery-ai-cookbook-python-quickstart",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-ai-cookbook-python-quickstart",
+        "smithery-ai-cookbook-python-quickstart"
+      ],
+      "source_url": "https://github.com/smithery-ai/smithery-cookbook",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-ai-cookbook-ts-smithery-cli": {
+      "package": "ai.smithery/smithery-ai-cookbook-ts-smithery-cli",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "A simple Typescript MCP server built using the official MCP Typescript SDK and smithery/cli. This\u2026",
+      "name": "ai.smithery/smithery-ai-cookbook-ts-smithery-cli",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-ai-cookbook-ts-smithery-cli",
+        "smithery-ai-cookbook-ts-smithery-cli"
+      ],
+      "source_url": "https://github.com/smithery-ai/smithery-cookbook",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-ai-fetch": {
+      "package": "ai.smithery/smithery-ai-fetch",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "A simple tool that performs a fetch request to a webpage.",
+      "name": "ai.smithery/smithery-ai-fetch",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-ai-fetch",
+        "smithery-ai-fetch"
+      ],
+      "source_url": "https://github.com/smithery-ai/mcp-servers",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-ai-github": {
+      "package": "ai.smithery/smithery-ai-github",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Access the GitHub API, enabling file operations, repository management, search functionality, and\u2026",
+      "name": "ai.smithery/smithery-ai-github",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-ai-github",
+        "smithery-ai-github"
+      ],
+      "source_url": "https://github.com/smithery-ai/mcp-servers",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-ai-national-weather-service": {
+      "package": "ai.smithery/smithery-ai-national-weather-service",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Provide real-time and forecast weather information for locations in the United States using natura\u2026",
+      "name": "ai.smithery/smithery-ai-national-weather-service",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-ai-national-weather-service",
+        "smithery-ai-national-weather-service"
+      ],
+      "source_url": "https://github.com/smithery-ai/mcp-servers",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-ai-slack": {
+      "package": "ai.smithery/smithery-ai-slack",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Enable interaction with Slack workspaces. Supports subscribing to Slack events through Resources.",
+      "name": "ai.smithery/smithery-ai-slack",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-ai-slack",
+        "smithery-ai-slack"
+      ],
+      "source_url": "https://github.com/smithery-ai/mcp-servers",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-notion": {
+      "package": "ai.smithery/smithery-notion",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "A Notion workspace is a collaborative environment where teams can organize work, manage projects,\u2026",
+      "name": "ai.smithery/smithery-notion",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-notion",
+        "smithery-notion"
+      ],
+      "source_url": "https://github.com/smithery-ai/mcp-servers",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-toolbox": {
+      "package": "ai.smithery/smithery-toolbox",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Toolbox dynamically routes to all MCPs in the Smithery registry based on your agent's need. When a\u2026",
+      "name": "ai.smithery/smithery-toolbox",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-toolbox",
+        "smithery-toolbox"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/smithery-unicorn": {
+      "package": "ai.smithery/smithery-unicorn",
+      "ecosystem": "mcp-registry",
+      "latest_version": "3.0.0",
+      "description": "A choose your own adventure game where you play as a startup founder trying to build a unicorn again",
+      "name": "ai.smithery/smithery-unicorn",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/smithery-unicorn",
+        "smithery-unicorn"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/sunub-obsidian-mcp-server": {
+      "package": "ai.smithery/sunub-obsidian-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Search your Obsidian vault to quickly find notes by title or keyword, summarize related content, a\u2026",
+      "name": "ai.smithery/sunub-obsidian-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/sunub-obsidian-mcp-server",
+        "sunub-obsidian-mcp-server"
+      ],
+      "source_url": "https://github.com/sunub/obsidian-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/szge-lolwiki-mcp": {
+      "package": "ai.smithery/szge-lolwiki-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Generate friendly greetings for any audience. Toggle Pirate Mode for a playful, swashbuckling styl\u2026",
+      "name": "ai.smithery/szge-lolwiki-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/szge-lolwiki-mcp",
+        "szge-lolwiki-mcp"
+      ],
+      "source_url": "https://github.com/szge/lolwiki-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/truss44-mcp-crypto-price": {
+      "package": "ai.smithery/truss44-mcp-crypto-price",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.1.0",
+      "description": "Provide real-time cryptocurrency price data and market analysis.",
+      "name": "ai.smithery/truss44-mcp-crypto-price",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/truss44-mcp-crypto-price",
+        "truss44-mcp-crypto-price"
+      ],
+      "source_url": "https://github.com/truss44/mcp-crypto-price",
+      "auto_enriched": true
+    },
+    "ai.smithery/turnono-datacommons-mcp-server": {
+      "package": "ai.smithery/turnono-datacommons-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Discover statistical indicators and topics in Data Commons. Retrieve observations for specific var\u2026",
+      "name": "ai.smithery/turnono-datacommons-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/turnono-datacommons-mcp-server",
+        "turnono-datacommons-mcp-server"
+      ],
+      "source_url": "https://github.com/turnono/datacommons-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/wgong-sqlite-mcp-server": {
+      "package": "ai.smithery/wgong-sqlite-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.16.0",
+      "description": "Explore, query, and inspect SQLite databases with ease. List tables, preview results, and view det\u2026",
+      "name": "ai.smithery/wgong-sqlite-mcp-server",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/wgong-sqlite-mcp-server",
+        "wgong-sqlite-mcp-server"
+      ],
+      "source_url": "https://github.com/wgong/sqlite-mcp-server",
+      "auto_enriched": true
+    },
+    "ai.smithery/xinkuang-china-stock-mcp": {
+      "package": "ai.smithery/xinkuang-china-stock-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.15.0",
+      "description": "Access real-time and historical market data for China A-shares and Hong Kong stocks, along with ne\u2026",
+      "name": "ai.smithery/xinkuang-china-stock-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/xinkuang-china-stock-mcp",
+        "xinkuang-china-stock-mcp"
+      ],
+      "source_url": "https://github.com/xinkuang/china-stock-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/yuhuison-mediawiki-mcp-server-auth": {
+      "package": "ai.smithery/yuhuison-mediawiki-mcp-server-auth",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Connect to your MediaWiki using simple credentials and manage content without OAuth. Search, read,\u2026",
+      "name": "ai.smithery/yuhuison-mediawiki-mcp-server-auth",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/yuhuison-mediawiki-mcp-server-auth",
+        "yuhuison-mediawiki-mcp-server-auth"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.smithery/yuna0x0-anilist-mcp": {
+      "package": "ai.smithery/yuna0x0-anilist-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.3.7",
+      "description": "Access and interact with anime and manga data seamlessly. Retrieve detailed information about your\u2026",
+      "name": "ai.smithery/yuna0x0-anilist-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/yuna0x0-anilist-mcp",
+        "yuna0x0-anilist-mcp"
+      ],
+      "source_url": "https://github.com/yuna0x0/anilist-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/yuna0x0-hackmd-mcp": {
+      "package": "ai.smithery/yuna0x0-hackmd-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.5.3",
+      "description": "Interact with your HackMD notes and teams seamlessly. Manage your notes, view reading history, and\u2026",
+      "name": "ai.smithery/yuna0x0-hackmd-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/yuna0x0-hackmd-mcp",
+        "yuna0x0-hackmd-mcp"
+      ],
+      "source_url": "https://github.com/yuna0x0/hackmd-mcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/zeta-chain-cli": {
+      "package": "ai.smithery/zeta-chain-cli",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Create friendly, customizable greetings for any name or audience. Break the ice in demos, onboardi\u2026",
+      "name": "ai.smithery/zeta-chain-cli",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/zeta-chain-cli",
+        "zeta-chain-cli"
+      ],
+      "source_url": "https://github.com/zeta-chain/cli",
+      "auto_enriched": true
+    },
+    "ai.smithery/zhaoganghao-hellomcp": {
+      "package": "ai.smithery/zhaoganghao-hellomcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Greet people by name with friendly, concise messages. Explore the origin of 'Hello, World' for fun\u2026",
+      "name": "ai.smithery/zhaoganghao-hellomcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/zhaoganghao-hellomcp",
+        "zhaoganghao-hellomcp"
+      ],
+      "source_url": "https://github.com/zhaoganghao/hellomcp",
+      "auto_enriched": true
+    },
+    "ai.smithery/zwldarren-akshare-one-mcp": {
+      "package": "ai.smithery/zwldarren-akshare-one-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.14.0",
+      "description": "Provide access to Chinese stock market data including historical prices, real-time data, news, and\u2026",
+      "name": "ai.smithery/zwldarren-akshare-one-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.smithery/zwldarren-akshare-one-mcp",
+        "zwldarren-akshare-one-mcp"
+      ],
+      "source_url": "https://github.com/zwldarren/akshare-one-mcp",
+      "auto_enriched": true
+    },
+    "ai.specproof/specproof-mcp": {
+      "package": "ai.specproof/specproof-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "SpecProof: Search standards specs with MCP-ready precision.",
+      "name": "ai.specproof/specproof-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.specproof/specproof-mcp",
+        "specproof-mcp"
+      ],
+      "source_url": "https://github.com/ibouazizi/specproof.git",
+      "auto_enriched": true
+    },
+    "ai.spritecook/generate": {
+      "package": "ai.spritecook/generate",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.8",
+      "description": "Generate game sprites and assets from text prompts for game development.",
+      "name": "ai.spritecook/generate",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.spritecook/generate",
+        "generate"
+      ],
+      "source_url": "https://github.com/SpriteCook/skills",
+      "auto_enriched": true
+    },
+    "ai.stumpy/agents": {
+      "package": "ai.stumpy/agents",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Persistent AI agents that run 24/7 in your Slack, Telegram, SMS, or email.",
+      "name": "ai.stumpy/agents",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.stumpy/agents",
+        "agents"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.telbase/deploy": {
+      "package": "ai.telbase/deploy",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.14.0-beta.2",
+      "description": "Deploy any web project with one command. AI-native platform with self-healing feedback.",
+      "name": "ai.telbase/deploy",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.telbase/deploy",
+        "deploy"
+      ],
+      "source_url": "https://github.com/Victor-EU/telbase",
+      "auto_enriched": true
+    },
+    "ai.tickettailor/mcp": {
+      "package": "ai.tickettailor/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Provides event organisers with tools to interact with a Ticket Tailor box office account.",
+      "name": "ai.tickettailor/mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.tickettailor/mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.tinyfish.agent/web-agent": {
+      "package": "ai.tinyfish.agent/web-agent",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "AI-powered web automation. Navigate websites using AI agents for one page or a thousand",
+      "name": "ai.tinyfish.agent/web-agent",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.tinyfish.agent/web-agent",
+        "web-agent"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ai.toolprint/hypertool-mcp": {
+      "package": "ai.toolprint/hypertool-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.42",
+      "description": "Dynamically expose tools from proxied servers based on an Agent Persona",
+      "name": "ai.toolprint/hypertool-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.toolprint/hypertool-mcp",
+        "hypertool-mcp"
+      ],
+      "source_url": "https://github.com/toolprint/hypertool-mcp",
+      "auto_enriched": true
+    },
+    "ai.urlcheck/urlcheck-mcp": {
+      "package": "ai.urlcheck/urlcheck-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.3",
+      "description": "Scans links for threats and confirms intent alignment with high accuracy.",
+      "name": "ai.urlcheck/urlcheck-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.urlcheck/urlcheck-mcp",
+        "urlcheck-mcp"
+      ],
+      "source_url": "https://github.com/cybrlab-ai/urlcheck-mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/airtable": {
+      "package": "ai.waystation/airtable",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Access and manage your Airtable bases, tables, and records seamlessly",
+      "name": "ai.waystation/airtable",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/airtable",
+        "airtable"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/gmail": {
+      "package": "ai.waystation/gmail",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Read emails, send messages, and manage labels in your Gmail account.",
+      "name": "ai.waystation/gmail",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/gmail",
+        "gmail"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/jira": {
+      "package": "ai.waystation/jira",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Track issues, manage projects, and streamline workflows in Jira.",
+      "name": "ai.waystation/jira",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/jira",
+        "jira"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/mcp": {
+      "package": "ai.waystation/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Ultimate toolbox to connect your LLM to popular productivity tools such as Monday, AirTable, Slack",
+      "name": "ai.waystation/mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/mcp"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/miro": {
+      "package": "ai.waystation/miro",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Collaborate on visual boards with your team using Miro integration.",
+      "name": "ai.waystation/miro",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/miro",
+        "miro"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/monday": {
+      "package": "ai.waystation/monday",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Access and manage your Monday.com boards, items, and updates seamlessly",
+      "name": "ai.waystation/monday",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/monday",
+        "monday"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/office": {
+      "package": "ai.waystation/office",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Create, edit, and collaborate on Office documents and spreadsheets.",
+      "name": "ai.waystation/office",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/office",
+        "office"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/postgres": {
+      "package": "ai.waystation/postgres",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Connect to your PostgreSQL database to query data and schemas.",
+      "name": "ai.waystation/postgres",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/postgres",
+        "postgres"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/slack": {
+      "package": "ai.waystation/slack",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Send messages, access channels, and manage files in your Slack workspace.",
+      "name": "ai.waystation/slack",
+      "category": "filesystem",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/slack",
+        "slack"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/supabase": {
+      "package": "ai.waystation/supabase",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Connect to your Supabase database to query data and schemas.",
+      "name": "ai.waystation/supabase",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/supabase",
+        "supabase"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/teams": {
+      "package": "ai.waystation/teams",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Collaborate, chat, and manage meetings in Microsoft Teams.",
+      "name": "ai.waystation/teams",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/teams",
+        "teams"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.waystation/wrike": {
+      "package": "ai.waystation/wrike",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.3.1",
+      "description": "Manage projects, tasks, and workflows with Wrike project management.",
+      "name": "ai.waystation/wrike",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.waystation/wrike",
+        "wrike"
+      ],
+      "source_url": "https://github.com/waystation-ai/mcp",
+      "auto_enriched": true
+    },
+    "ai.websitepublisher/mcp": {
+      "package": "ai.websitepublisher/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.4.0",
+      "description": "Build and publish websites through AI conversation.",
+      "name": "ai.websitepublisher/mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.websitepublisher/mcp"
+      ],
+      "source_url": "https://github.com/megberts/mcp-websitepublisher-ai",
+      "auto_enriched": true
+    },
+    "ai.wild-card/deepcontext": {
+      "package": "ai.wild-card/deepcontext",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.15",
+      "description": "Advanced codebase indexing and semantic search MCP server",
+      "name": "ai.wild-card/deepcontext",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.wild-card/deepcontext",
+        "deepcontext"
+      ],
+      "source_url": "https://github.com/Wildcard-Official/deepcontext",
+      "auto_enriched": true
+    },
+    "ai.xpoz/social-insights": {
+      "package": "ai.xpoz/social-insights",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.4.0",
+      "description": "Twitter/X, Instagram, Reddit & TikTok data for AI agents. 1.5B+ posts. No API keys.",
+      "name": "ai.xpoz/social-insights",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.xpoz/social-insights",
+        "social-insights"
+      ],
+      "source_url": "https://github.com/xpozpublic/xpoz-mcp",
+      "auto_enriched": true
+    },
+    "ai.zine/mcp": {
+      "package": "ai.zine/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Your memory, everywhere AI goes. Build knowledge once, access it via MCP anywhere.",
+      "name": "ai.zine/mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ai.zine/mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "app.certman/server": {
+      "package": "app.certman/server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "Create and manage your own Certificate Authority for internal HTTPS.",
+      "name": "app.certman/server",
+      "category": "web",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.certman/server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "app.flaim/mcp": {
+      "package": "app.flaim/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Connect ESPN & Yahoo fantasy leagues to Claude, ChatGPT, and Gemini via MCP",
+      "name": "app.flaim/mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.flaim/mcp"
+      ],
+      "source_url": "https://github.com/jdguggs10/flaim",
+      "auto_enriched": true
+    },
+    "app.getdialer/dialer": {
+      "package": "app.getdialer/dialer",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "An MCP server that provides lets you make outbound phone calls using your own phone number",
+      "name": "app.getdialer/dialer",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.getdialer/dialer",
+        "dialer"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "app.linear/linear": {
+      "package": "app.linear/linear",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "MCP server for Linear project management and issue tracking",
+      "name": "app.linear/linear",
+      "category": "general",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.linear/linear",
+        "linear"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "app.qwady/borough": {
+      "package": "app.qwady/borough",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.1.0",
+      "description": "Search NYC rentals and sales, property details, building data, and market analytics",
+      "name": "app.qwady/borough",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.qwady/borough",
+        "borough"
+      ],
+      "source_url": "https://github.com/jdmay2/borough",
+      "auto_enriched": true
+    },
+    "app.recordo.api/calories-club": {
+      "package": "app.recordo.api/calories-club",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "AI-powered calorie tracking with photo recognition, barcode scanning, and voice logging",
+      "name": "app.recordo.api/calories-club",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.recordo.api/calories-club",
+        "calories-club"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "app.recordo.api/recordo": {
+      "package": "app.recordo.api/recordo",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Brain dump, routines, task planning, focus, and instant thought retrieval",
+      "name": "app.recordo.api/recordo",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.recordo.api/recordo",
+        "recordo"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "app.thoughtspot/mcp-server": {
+      "package": "app.thoughtspot/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.1",
+      "description": "MCP Server for ThoughtSpot - provides OAuth authentication and tools for querying data",
+      "name": "app.thoughtspot/mcp-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.thoughtspot/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "https://github.com/thoughtspot/mcp-server",
+      "auto_enriched": true
+    },
+    "app.tradeit/mcp": {
+      "package": "app.tradeit/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Trade stock, crypto, and options on Robinhood, ETrade, Webull, Charles Schwab, Coinbase, or Kraken.",
+      "name": "app.tradeit/mcp",
+      "category": "web",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.tradeit/mcp"
+      ],
+      "source_url": "https://github.com/trade-it-inc/trade-it-mcp",
+      "auto_enriched": true
+    },
+    "app.trustrails/server": {
+      "package": "app.trustrails/server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.7",
+      "description": "Search UK electronics products across retailers. Real-time prices, stock, and specs.",
+      "name": "app.trustrails/server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.trustrails/server"
+      ],
+      "source_url": "https://github.com/james-webdev/trustrails-mcp-server",
+      "auto_enriched": true
+    },
+    "app.zenable/zenable": {
+      "package": "app.zenable/zenable",
+      "ecosystem": "mcp-registry",
+      "latest_version": "2.0.0",
+      "description": "Zenable cleans up sloppy AI code and prevents vulnerabilities with deterministic guardrails",
+      "name": "app.zenable/zenable",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "app.zenable/zenable",
+        "zenable"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "aws.api.us-east-1.ecs-mcp/server": {
+      "package": "aws.api.us-east-1.ecs-mcp/server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "AI-powered Amazon ECS workload management",
+      "name": "aws.api.us-east-1.ecs-mcp/server",
+      "category": "cloud",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "aws.api.us-east-1.ecs-mcp/server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "aws.api.us-east-1.eks-mcp/server": {
+      "package": "aws.api.us-east-1.eks-mcp/server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "AI-powered Amazon EKS cluster management and troubleshooting",
+      "name": "aws.api.us-east-1.eks-mcp/server",
+      "category": "cloud",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "aws.api.us-east-1.eks-mcp/server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "biz.icecat/mcp": {
+      "package": "biz.icecat/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.3",
+      "description": "Retrieve product specifications and technical details from Icecat's database",
+      "name": "biz.icecat/mcp",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "biz.icecat/mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "build.arca.mcp/arca-mcp-server": {
+      "package": "build.arca.mcp/arca-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.1",
+      "description": "Arca is a private data vault where your AI stores your structured data, semantic memory and skills. ",
+      "name": "build.arca.mcp/arca-mcp-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "build.arca.mcp/arca-mcp-server",
+        "arca-mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "capital.hove/read-only-local-mysql-mcp-server": {
+      "package": "capital.hove/read-only-local-mysql-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.1",
+      "description": "MCP server for read-only MySQL database queries in Claude Desktop",
+      "name": "capital.hove/read-only-local-mysql-mcp-server",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "capital.hove/read-only-local-mysql-mcp-server",
+        "read-only-local-mysql-mcp-server"
+      ],
+      "source_url": "https://github.com/hovecapital/read-only-local-mysql-mcp-server",
+      "auto_enriched": true
+    },
+    "capital.hove/read-only-local-postgres-mcp-server": {
+      "package": "capital.hove/read-only-local-postgres-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.0",
+      "description": "MCP server for read-only PostgreSQL database queries in Claude Desktop",
+      "name": "capital.hove/read-only-local-postgres-mcp-server",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "capital.hove/read-only-local-postgres-mcp-server",
+        "read-only-local-postgres-mcp-server"
+      ],
+      "source_url": "https://github.com/hovecapital/read-only-local-postgres-mcp-server",
+      "auto_enriched": true
+    },
+    "capital.hove/read-only-mysql-mcp-server": {
+      "package": "capital.hove/read-only-mysql-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.0",
+      "description": "MCP server for read-only MySQL database queries in Claude Desktop",
+      "name": "capital.hove/read-only-mysql-mcp-server",
+      "category": "database",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "capital.hove/read-only-mysql-mcp-server",
+        "read-only-mysql-mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "casa.find-me.sub1/send-email-mcp": {
+      "package": "casa.find-me.sub1/send-email-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.0.9",
+      "description": "Non functional server (yet)",
+      "name": "casa.find-me.sub1/send-email-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "casa.find-me.sub1/send-email-mcp",
+        "send-email-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "ch.martinelli/jooq-mcp": {
+      "package": "ch.martinelli/jooq-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "An MCP server that provides access to the jOOQ documentation",
+      "name": "ch.martinelli/jooq-mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ch.martinelli/jooq-mcp",
+        "jooq-mcp"
+      ],
+      "source_url": "https://github.com/martinellich/jooq-mcp",
+      "auto_enriched": true
+    },
+    "ch.pfx/mcp-server": {
+      "package": "ch.pfx/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.1.9",
+      "description": "MCP Server f\u00fcr Forterro Proffix Px5 ERP",
+      "name": "ch.pfx/mcp-server",
+      "category": "general",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ch.pfx/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "https://github.com/pitwch/pfx-mcp-server",
+      "auto_enriched": true
+    },
+    "ci.git/mymlh-mcp-server": {
+      "package": "ci.git/mymlh-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "OAuth-enabled MyMLH MCP server for accessing MyMLH data.",
+      "name": "ci.git/mymlh-mcp-server",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "ci.git/mymlh-mcp-server",
+        "mymlh-mcp-server"
+      ],
+      "source_url": "https://github.com/wei/mymlh-mcp-server",
+      "auto_enriched": true
+    },
+    "co.axiom/mcp": {
+      "package": "co.axiom/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
+      "name": "co.axiom/mcp",
+      "category": "monitoring",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.axiom/mcp"
+      ],
+      "source_url": "https://github.com/axiomhq/mcp",
+      "auto_enriched": true
+    },
+    "co.contraption/mcp": {
+      "package": "co.contraption/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "An MCP server that provides [describe what your server does]",
+      "name": "co.contraption/mcp",
+      "category": "developer-tools",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.contraption/mcp"
+      ],
+      "source_url": "https://github.com/contraptionco/mcp",
+      "auto_enriched": true
+    },
+    "co.dockai/mcp": {
+      "package": "co.dockai/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Discover MCP endpoints for real-world entities by resolving business domains.",
+      "name": "co.dockai/mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.dockai/mcp"
+      ],
+      "source_url": "https://github.com/dock-ai/mcp",
+      "auto_enriched": true
+    },
+    "co.flyweel/mcp-server": {
+      "package": "co.flyweel/mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Access Google & Meta Ads data via AI. Analyse campaign performance in seconds.",
+      "name": "co.flyweel/mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.flyweel/mcp-server",
+        "mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "co.heyspark.mcp/server": {
+      "package": "co.heyspark.mcp/server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.0",
+      "description": "Search and discover local businesses. 30+ categories with verified contact info, hours, and reviews.",
+      "name": "co.heyspark.mcp/server",
+      "category": "general",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.heyspark.mcp/server"
+      ],
+      "source_url": "https://github.com/jhibird/HeySpark-MCP",
+      "auto_enriched": true
+    },
+    "co.huggingface/hf-mcp-server": {
+      "package": "co.huggingface/hf-mcp-server",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.2.33",
+      "description": "Connect to Hugging Face Hub and thousands of Gradio AI Applications",
+      "name": "co.huggingface/hf-mcp-server",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.huggingface/hf-mcp-server",
+        "hf-mcp-server"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "co.okahu.mcp-registry/okahu": {
+      "package": "co.okahu.mcp-registry/okahu",
+      "ecosystem": "mcp-registry",
+      "latest_version": "0.1.1",
+      "description": "Cloud hosted Okahu MCP server that helps you manage genAI trace data",
+      "name": "co.okahu.mcp-registry/okahu",
+      "category": "cloud",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.okahu.mcp-registry/okahu",
+        "okahu"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "co.pipeboard/meta-ads-mcp": {
+      "package": "co.pipeboard/meta-ads-mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.0.45",
+      "description": "Facebook / Meta Ads automation with AI: analyze performance, test creatives, optimize spend.",
+      "name": "co.pipeboard/meta-ads-mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.pipeboard/meta-ads-mcp",
+        "meta-ads-mcp"
+      ],
+      "source_url": "",
+      "auto_enriched": true
+    },
+    "co.thisdot.docusign-navigator/mcp": {
+      "package": "co.thisdot.docusign-navigator/mcp",
+      "ecosystem": "mcp-registry",
+      "latest_version": "1.2.1",
+      "description": "Secure Docusign Navigator integration for AI assistants to access and analyze agreement data.",
+      "name": "co.thisdot.docusign-navigator/mcp",
+      "category": "ai-ml",
+      "risk_level": "low",
+      "verified": true,
+      "tools": [],
+      "credential_env_vars": [],
+      "command_patterns": [
+        "co.thisdot.docusign-navigator/mcp"
+      ],
+      "source_url": "https://github.com/thisdot/docusign-navigator-mcp",
+      "auto_enriched": true
     }
-  }
+  },
+  "_mcp_registry_sync": "2026-02-24T01:46:59Z"
 }

--- a/src/agent_bom/permissions.py
+++ b/src/agent_bom/permissions.py
@@ -1,0 +1,152 @@
+"""Tool permission classification and PermissionProfile construction.
+
+Centralizes keyword-based classification of MCP tool permissions, risk level
+inference, and PermissionProfile building. Used by:
+- discovery/__init__.py (sudo/shell detection at discovery time)
+- parsers/__init__.py (tool_permissions from registry data)
+- scripts/expand_registry.py (auto-enrich new registry entries)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_bom.models import PermissionProfile
+
+# ── Keyword sets for tool classification ─────────────────────────────────────
+
+_DESTRUCTIVE_KEYWORDS = frozenset({
+    "delete", "remove", "drop", "destroy", "purge", "truncate", "wipe", "erase",
+    "uninstall", "terminate", "kill",
+})
+
+_EXECUTE_KEYWORDS = frozenset({
+    "exec", "execute", "run", "shell", "eval", "command", "invoke", "spawn",
+    "call", "launch", "start_process",
+})
+
+_WRITE_KEYWORDS = frozenset({
+    "write", "create", "update", "modify", "set", "put", "push", "post",
+    "insert", "upload", "move", "rename", "copy", "send", "publish", "deploy",
+    "scale", "restart", "apply", "patch", "merge", "commit",
+})
+
+_READ_KEYWORDS = frozenset({
+    "read", "get", "list", "search", "query", "fetch", "find", "describe",
+    "show", "download", "view", "inspect", "check", "count", "browse",
+    "lookup", "resolve", "ping",
+})
+
+_SHELL_COMMANDS = frozenset({"sh", "bash", "zsh", "cmd", "powershell", "pwsh"})
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def classify_tool(tool_name: str, tool_description: str = "") -> str:
+    """Classify a tool's permission level from its name and description.
+
+    Returns one of: ``"read"``, ``"write"``, ``"execute"``, ``"destructive"``.
+    """
+    combined = f"{tool_name} {tool_description}".lower()
+
+    if any(kw in combined for kw in _DESTRUCTIVE_KEYWORDS):
+        return "destructive"
+    if any(kw in combined for kw in _EXECUTE_KEYWORDS):
+        return "execute"
+    if any(kw in combined for kw in _WRITE_KEYWORDS):
+        return "write"
+    return "read"
+
+
+def classify_risk_level(tools: list[str], credential_env_vars: list[str]) -> str:
+    """Classify risk_level for a registry entry based on tools and credentials.
+
+    Returns ``"high"``, ``"medium"``, or ``"low"``.
+    """
+    has_creds = bool(credential_env_vars)
+    tool_text = " ".join(tools).lower()
+
+    has_dangerous = any(kw in tool_text for kw in _DESTRUCTIVE_KEYWORDS | _EXECUTE_KEYWORDS)
+    has_write = any(kw in tool_text for kw in _WRITE_KEYWORDS)
+
+    if (has_dangerous or has_write) and has_creds:
+        return "high"
+    if has_write or has_creds or has_dangerous:
+        return "medium"
+    return "low"
+
+
+def build_tool_permissions(tools: list) -> dict[str, str]:
+    """Build tool_permissions dict from a list of tool names or MCPTool objects."""
+    result: dict[str, str] = {}
+    for tool in tools:
+        name = tool.name if hasattr(tool, "name") else str(tool)
+        desc = tool.description if hasattr(tool, "description") else ""
+        result[name] = classify_tool(name, desc)
+    return result
+
+
+def build_permission_profile(
+    tools: list | None = None,
+    credential_env_vars: list[str] | None = None,
+    command: str = "",
+    args: list[str] | None = None,
+) -> "PermissionProfile":
+    """Construct a PermissionProfile from tool list and command info."""
+    from agent_bom.models import PermissionProfile
+
+    tool_perms = build_tool_permissions(tools or [])
+
+    has_write = any(v in ("write", "destructive") for v in tool_perms.values())
+    has_exec = any(v == "execute" for v in tool_perms.values())
+    has_shell = has_exec or command_is_shell(command, args or [])
+
+    return PermissionProfile(
+        tool_permissions=tool_perms,
+        filesystem_write=has_write,
+        shell_access=has_shell,
+        network_access=bool(credential_env_vars),
+        runs_as_root=command_runs_as_root(command, args or []),
+    )
+
+
+def _infer_category(qualified_name: str, description: str) -> str:
+    """Infer registry category from server name and description."""
+    combined = f"{qualified_name} {description}".lower()
+
+    _category_keywords: dict[str, list[str]] = {
+        "filesystem": ["filesystem", "file", "directory", "disk", "storage"],
+        "database": ["database", "sql", "postgres", "mysql", "mongo", "redis", "sqlite", "supabase", "clickhouse"],
+        "developer-tools": ["github", "gitlab", "git", "code", "ide", "dev", "build", "npm", "docker"],
+        "cloud": ["aws", "gcp", "azure", "cloud", "s3", "lambda", "kubernetes", "k8s"],
+        "ai-ml": ["openai", "anthropic", "llm", "ai", "ml", "model", "embedding", "ollama", "huggingface"],
+        "communication": ["slack", "email", "discord", "teams", "notification", "twilio"],
+        "web": ["browser", "http", "fetch", "web", "scrape", "puppeteer", "playwright"],
+        "security": ["security", "vault", "secret", "encrypt", "auth", "sso"],
+        "monitoring": ["monitor", "log", "metric", "alert", "grafana", "datadog", "sentry"],
+        "data": ["data", "etl", "csv", "json", "transform", "analytics"],
+    }
+
+    for category, keywords in _category_keywords.items():
+        if any(kw in combined for kw in keywords):
+            return category
+    return "general"
+
+
+def command_runs_as_root(command: str, args: list[str]) -> bool:
+    """Check if command uses sudo or runs explicitly as root."""
+    if command == "sudo":
+        return True
+    if "sudo" in args:
+        return True
+    return False
+
+
+def command_is_shell(command: str, args: list[str]) -> bool:
+    """Check if command is a shell interpreter."""
+    cmd_base = command.rsplit("/", 1)[-1] if "/" in command else command
+    return cmd_base in _SHELL_COMMANDS or any(
+        a.rsplit("/", 1)[-1] in _SHELL_COMMANDS for a in args
+    )

--- a/tests/test_expand_registry.py
+++ b/tests/test_expand_registry.py
@@ -1,0 +1,233 @@
+"""Tests for registry expansion and Official MCP Registry sync with auto-classification."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from agent_bom.mcp_official_registry import (
+    sync_from_official_registry_sync,
+)
+
+
+def _make_response(data, status=200):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json.return_value = data
+    return resp
+
+
+def _mock_server_entry(name, desc="", version="1.0.0", tools=None, creds=None):
+    return {
+        "server": {
+            "name": name,
+            "description": desc,
+            "version": version,
+            "repository": {"url": f"https://github.com/{name}"},
+            "packages": [],
+            "tools": tools or [],
+            "credential_env_vars": creds or [],
+        },
+        "_meta": {"status": "active"},
+    }
+
+
+class TestSyncAutoClassification:
+    """Verify that sync_from_official_registry uses classify_risk_level and _infer_category."""
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_new_entries_get_auto_enriched_flag(self, mock_path, mock_client, mock_request):
+        """Auto-enriched entries should have auto_enriched=True."""
+        mock_path.read_text.return_value = json.dumps({"servers": {}})
+        mock_path.write_text = MagicMock()
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        api_response = {
+            "servers": [_mock_server_entry("test/new-server", "A test server")],
+            "metadata": {"count": 1, "nextCursor": None},
+        }
+        mock_request.return_value = _make_response(api_response)
+
+        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+
+        assert result.added == 1
+        assert result.total_fetched == 1
+
+        # Check written data
+        written = json.loads(mock_path.write_text.call_args[0][0])
+        entry = written["servers"]["test/new-server"]
+        assert entry["auto_enriched"] is True
+        assert entry["verified"] is True
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_risk_level_classification(self, mock_path, mock_client, mock_request):
+        """Entries with dangerous tools + creds should get high risk."""
+        mock_path.read_text.return_value = json.dumps({"servers": {}})
+        mock_path.write_text = MagicMock()
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        api_response = {
+            "servers": [
+                _mock_server_entry(
+                    "test/dangerous-server",
+                    "File management",
+                    tools=["delete_file", "exec_command"],
+                    creds=["API_KEY"],
+                ),
+            ],
+            "metadata": {"count": 1, "nextCursor": None},
+        }
+        mock_request.return_value = _make_response(api_response)
+
+        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+
+        written = json.loads(mock_path.write_text.call_args[0][0])
+        entry = written["servers"]["test/dangerous-server"]
+        assert entry["risk_level"] == "high"
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_category_inference(self, mock_path, mock_client, mock_request):
+        """Category should be inferred from name/description."""
+        mock_path.read_text.return_value = json.dumps({"servers": {}})
+        mock_path.write_text = MagicMock()
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        api_response = {
+            "servers": [
+                _mock_server_entry("github-actions", "GitHub CI/CD integration"),
+                _mock_server_entry("postgres-query", "PostgreSQL database tools"),
+            ],
+            "metadata": {"count": 2, "nextCursor": None},
+        }
+        mock_request.return_value = _make_response(api_response)
+
+        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+
+        written = json.loads(mock_path.write_text.call_args[0][0])
+        assert written["servers"]["github-actions"]["category"] == "developer-tools"
+        assert written["servers"]["postgres-query"]["category"] == "database"
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_skip_existing_entries(self, mock_path, mock_client, mock_request):
+        """Existing entries should be skipped."""
+        existing = {"servers": {"existing/server": {"package": "existing/server"}}}
+        mock_path.read_text.return_value = json.dumps(existing)
+        mock_path.write_text = MagicMock()
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        api_response = {
+            "servers": [_mock_server_entry("existing/server", "Already here")],
+            "metadata": {"count": 1, "nextCursor": None},
+        }
+        mock_request.return_value = _make_response(api_response)
+
+        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+
+        assert result.added == 0
+        assert result.skipped == 1
+        mock_path.write_text.assert_not_called()
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_dry_run_no_write(self, mock_path, mock_client, mock_request):
+        """Dry run should not write to registry."""
+        mock_path.read_text.return_value = json.dumps({"servers": {}})
+        mock_path.write_text = MagicMock()
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        api_response = {
+            "servers": [_mock_server_entry("test/new-server")],
+            "metadata": {"count": 1, "nextCursor": None},
+        }
+        mock_request.return_value = _make_response(api_response)
+
+        result = sync_from_official_registry_sync(max_pages=1, page_size=10, dry_run=True)
+
+        assert result.added == 1
+        mock_path.write_text.assert_not_called()
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_low_risk_read_only_no_creds(self, mock_path, mock_client, mock_request):
+        """Read-only tools with no creds should be low risk."""
+        mock_path.read_text.return_value = json.dumps({"servers": {}})
+        mock_path.write_text = MagicMock()
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        api_response = {
+            "servers": [
+                _mock_server_entry("test/reader", "Read data", tools=["get_data", "list_items"]),
+            ],
+            "metadata": {"count": 1, "nextCursor": None},
+        }
+        mock_request.return_value = _make_response(api_response)
+
+        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+
+        written = json.loads(mock_path.write_text.call_args[0][0])
+        assert written["servers"]["test/reader"]["risk_level"] == "low"
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_pagination(self, mock_path, mock_client, mock_request):
+        """Pagination via nextCursor should fetch multiple pages."""
+        mock_path.read_text.return_value = json.dumps({"servers": {}})
+        mock_path.write_text = MagicMock()
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        page1 = {
+            "servers": [_mock_server_entry("server/one")],
+            "metadata": {"count": 2, "nextCursor": "cursor_abc"},
+        }
+        page2 = {
+            "servers": [_mock_server_entry("server/two")],
+            "metadata": {"count": 2, "nextCursor": None},
+        }
+        mock_request.side_effect = [_make_response(page1), _make_response(page2)]
+
+        result = sync_from_official_registry_sync(max_pages=5, page_size=1)
+
+        assert result.added == 2
+        assert result.total_fetched == 2
+
+    @patch("agent_bom.mcp_official_registry.request_with_retry")
+    @patch("agent_bom.mcp_official_registry.create_client")
+    @patch("agent_bom.mcp_official_registry._REGISTRY_PATH")
+    def test_api_failure_graceful(self, mock_path, mock_client, mock_request):
+        """API returning None should stop gracefully."""
+        mock_path.read_text.return_value = json.dumps({"servers": {}})
+
+        mock_client.return_value.__aenter__ = AsyncMock()
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        mock_request.return_value = None
+
+        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+
+        assert result.added == 0
+        assert result.total_fetched == 0

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,246 @@
+"""Tests for tool permission classification and PermissionProfile building."""
+
+
+from agent_bom.models import PermissionProfile
+from agent_bom.permissions import (
+    _infer_category,
+    build_permission_profile,
+    build_tool_permissions,
+    classify_risk_level,
+    classify_tool,
+    command_is_shell,
+    command_runs_as_root,
+)
+
+# ─── classify_tool ───────────────────────────────────────────────────────────
+
+
+class TestClassifyTool:
+    def test_destructive_by_name(self):
+        assert classify_tool("delete_file") == "destructive"
+        assert classify_tool("remove_user") == "destructive"
+        assert classify_tool("drop_table") == "destructive"
+        assert classify_tool("purge_cache") == "destructive"
+
+    def test_destructive_by_description(self):
+        assert classify_tool("cleanup", "destroy all temp files") == "destructive"
+
+    def test_execute_by_name(self):
+        assert classify_tool("exec_command") == "execute"
+        assert classify_tool("run_script") == "execute"
+        assert classify_tool("shell_exec") == "execute"
+        assert classify_tool("eval_code") == "execute"
+
+    def test_write_by_name(self):
+        assert classify_tool("create_file") == "write"
+        assert classify_tool("update_record") == "write"
+        assert classify_tool("upload_data") == "write"
+        assert classify_tool("push_commit") == "write"
+        assert classify_tool("deploy_app") == "write"
+
+    def test_read_by_default(self):
+        assert classify_tool("get_status") == "read"
+        assert classify_tool("list_files") == "read"
+        assert classify_tool("search_logs") == "read"
+        assert classify_tool("fetch_data") == "read"
+
+    def test_unknown_defaults_to_read(self):
+        assert classify_tool("foobar") == "read"
+        assert classify_tool("xyz_unknown_tool") == "read"
+
+    def test_destructive_takes_precedence_over_write(self):
+        # "remove" is destructive even though combined text might match write
+        assert classify_tool("remove_and_create") == "destructive"
+
+    def test_execute_takes_precedence_over_write(self):
+        assert classify_tool("run_deploy") == "execute"
+
+    def test_description_contributes(self):
+        assert classify_tool("process", "execute a shell command") == "execute"
+        assert classify_tool("manage", "create new resources") == "write"
+
+
+# ─── classify_risk_level ─────────────────────────────────────────────────────
+
+
+class TestClassifyRiskLevel:
+    def test_high_dangerous_with_creds(self):
+        assert classify_risk_level(["delete_record"], ["API_KEY"]) == "high"
+        assert classify_risk_level(["exec_command"], ["TOKEN"]) == "high"
+
+    def test_high_write_with_creds(self):
+        assert classify_risk_level(["create_file", "upload"], ["SECRET"]) == "high"
+
+    def test_medium_write_no_creds(self):
+        assert classify_risk_level(["create_file", "update_record"], []) == "medium"
+
+    def test_medium_creds_only(self):
+        assert classify_risk_level(["list_items"], ["API_KEY"]) == "medium"
+
+    def test_medium_dangerous_no_creds(self):
+        assert classify_risk_level(["delete_file"], []) == "medium"
+
+    def test_low_read_only_no_creds(self):
+        assert classify_risk_level(["get_status", "list_files"], []) == "low"
+
+    def test_low_empty(self):
+        assert classify_risk_level([], []) == "low"
+
+
+# ─── build_tool_permissions ──────────────────────────────────────────────────
+
+
+class TestBuildToolPermissions:
+    def test_string_tools(self):
+        result = build_tool_permissions(["read_file", "delete_record", "exec_cmd"])
+        assert result["read_file"] == "read"
+        assert result["delete_record"] == "destructive"
+        assert result["exec_cmd"] == "execute"
+
+    def test_empty_list(self):
+        assert build_tool_permissions([]) == {}
+
+    def test_object_tools(self):
+        class FakeTool:
+            def __init__(self, name, description=""):
+                self.name = name
+                self.description = description
+
+        tools = [FakeTool("create_item"), FakeTool("get_info")]
+        result = build_tool_permissions(tools)
+        assert result["create_item"] == "write"
+        assert result["get_info"] == "read"
+
+
+# ─── build_permission_profile ────────────────────────────────────────────────
+
+
+class TestBuildPermissionProfile:
+    def test_read_only_tools(self):
+        profile = build_permission_profile(tools=["get_data", "list_items"])
+        assert isinstance(profile, PermissionProfile)
+        assert not profile.filesystem_write
+        assert not profile.shell_access
+        assert not profile.runs_as_root
+        assert profile.privilege_level == "low"
+
+    def test_write_tools_sets_filesystem_write(self):
+        profile = build_permission_profile(tools=["create_file", "get_data"])
+        assert profile.filesystem_write
+        assert profile.privilege_level == "medium"
+
+    def test_exec_tools_sets_shell_access(self):
+        profile = build_permission_profile(tools=["exec_command"])
+        assert profile.shell_access
+        assert profile.privilege_level == "high"
+
+    def test_sudo_command_sets_root(self):
+        profile = build_permission_profile(
+            tools=["get_data"], command="sudo", args=["node", "server.js"],
+        )
+        assert profile.runs_as_root
+        assert profile.privilege_level == "high"
+
+    def test_shell_command_sets_shell_access(self):
+        profile = build_permission_profile(
+            tools=[], command="bash", args=["-c", "echo hello"],
+        )
+        assert profile.shell_access
+        assert profile.privilege_level == "high"
+
+    def test_credentials_set_network_access(self):
+        profile = build_permission_profile(
+            tools=["get_data"], credential_env_vars=["API_KEY"],
+        )
+        assert profile.network_access
+        assert profile.privilege_level == "medium"
+
+    def test_no_args_defaults(self):
+        profile = build_permission_profile()
+        assert not profile.runs_as_root
+        assert not profile.shell_access
+        assert not profile.filesystem_write
+        assert not profile.network_access
+
+
+# ─── command_runs_as_root ────────────────────────────────────────────────────
+
+
+class TestCommandRunsAsRoot:
+    def test_sudo_command(self):
+        assert command_runs_as_root("sudo", ["node", "server.js"])
+
+    def test_sudo_in_args(self):
+        assert command_runs_as_root("node", ["sudo", "server.js"])
+
+    def test_normal_command(self):
+        assert not command_runs_as_root("node", ["server.js"])
+        assert not command_runs_as_root("npx", ["-y", "@some/package"])
+
+    def test_empty(self):
+        assert not command_runs_as_root("", [])
+
+
+# ─── command_is_shell ────────────────────────────────────────────────────────
+
+
+class TestCommandIsShell:
+    def test_bash(self):
+        assert command_is_shell("bash", ["-c", "echo hi"])
+
+    def test_sh(self):
+        assert command_is_shell("sh", [])
+
+    def test_zsh(self):
+        assert command_is_shell("zsh", [])
+
+    def test_powershell(self):
+        assert command_is_shell("powershell", ["-Command", "Get-Process"])
+
+    def test_full_path(self):
+        assert command_is_shell("/bin/bash", ["-c", "ls"])
+        assert command_is_shell("/usr/bin/zsh", [])
+
+    def test_shell_in_args(self):
+        assert command_is_shell("env", ["bash", "-c", "echo hi"])
+
+    def test_not_shell(self):
+        assert not command_is_shell("node", ["server.js"])
+        assert not command_is_shell("npx", ["-y", "something"])
+        assert not command_is_shell("python", ["-m", "mcp_server"])
+
+
+# ─── _infer_category ─────────────────────────────────────────────────────────
+
+
+class TestInferCategory:
+    def test_filesystem(self):
+        assert _infer_category("local-fs", "filesystem access") == "filesystem"
+
+    def test_database(self):
+        assert _infer_category("postgres-mcp", "PostgreSQL server") == "database"
+        assert _infer_category("redis-tools", "Redis cache") == "database"
+
+    def test_developer_tools(self):
+        assert _infer_category("github-mcp", "GitHub integration") == "developer-tools"
+
+    def test_cloud(self):
+        assert _infer_category("aws-mcp", "AWS services") == "cloud"
+
+    def test_ai_ml(self):
+        assert _infer_category("openai-tools", "LLM integration") == "ai-ml"
+
+    def test_communication(self):
+        assert _infer_category("slack-mcp", "Slack messaging") == "communication"
+
+    def test_web(self):
+        assert _infer_category("browser-tools", "web scraping") == "web"
+
+    def test_security(self):
+        assert _infer_category("vault-mcp", "secret management") == "security"
+
+    def test_monitoring(self):
+        assert _infer_category("datadog-mcp", "monitoring metrics") == "monitoring"
+
+    def test_general_fallback(self):
+        assert _infer_category("xyz-unknown", "something random") == "general"

--- a/tests/test_privilege_detection.py
+++ b/tests/test_privilege_detection.py
@@ -1,0 +1,251 @@
+"""Tests for Docker privilege detection and PermissionProfile model."""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from agent_bom.image import detect_container_privileges, detect_image_privileges
+from agent_bom.models import PermissionProfile
+
+# ─── PermissionProfile model tests ───────────────────────────────────────────
+
+
+class TestPermissionProfile:
+    def test_defaults(self):
+        p = PermissionProfile()
+        assert not p.runs_as_root
+        assert not p.container_privileged
+        assert not p.shell_access
+        assert not p.network_access
+        assert not p.filesystem_write
+        assert p.tool_permissions == {}
+        assert p.capabilities == []
+        assert p.security_opt == []
+
+    def test_is_elevated_false_default(self):
+        assert not PermissionProfile().is_elevated
+
+    def test_is_elevated_root(self):
+        assert PermissionProfile(runs_as_root=True).is_elevated
+
+    def test_is_elevated_privileged(self):
+        assert PermissionProfile(container_privileged=True).is_elevated
+
+    def test_is_elevated_shell(self):
+        assert PermissionProfile(shell_access=True).is_elevated
+
+    def test_is_elevated_capabilities(self):
+        assert PermissionProfile(capabilities=["CAP_NET_RAW"]).is_elevated
+
+    def test_is_elevated_network_only_not_elevated(self):
+        assert not PermissionProfile(network_access=True).is_elevated
+
+    def test_is_elevated_fs_write_only_not_elevated(self):
+        assert not PermissionProfile(filesystem_write=True).is_elevated
+
+    def test_privilege_level_critical_privileged(self):
+        assert PermissionProfile(container_privileged=True).privilege_level == "critical"
+
+    def test_privilege_level_critical_sys_admin(self):
+        assert PermissionProfile(capabilities=["CAP_SYS_ADMIN"]).privilege_level == "critical"
+
+    def test_privilege_level_high_root(self):
+        assert PermissionProfile(runs_as_root=True).privilege_level == "high"
+
+    def test_privilege_level_high_shell(self):
+        assert PermissionProfile(shell_access=True).privilege_level == "high"
+
+    def test_privilege_level_medium_fs_write(self):
+        assert PermissionProfile(filesystem_write=True).privilege_level == "medium"
+
+    def test_privilege_level_medium_network(self):
+        assert PermissionProfile(network_access=True).privilege_level == "medium"
+
+    def test_privilege_level_medium_other_caps(self):
+        assert PermissionProfile(capabilities=["CAP_NET_RAW"]).privilege_level == "medium"
+
+    def test_privilege_level_low(self):
+        assert PermissionProfile().privilege_level == "low"
+
+
+# ─── detect_image_privileges ─────────────────────────────────────────────────
+
+
+class TestDetectImagePrivileges:
+    def _mock_inspect(self, config):
+        """Helper: patch _docker_inspect to return given config."""
+        return patch(
+            "agent_bom.image._docker_inspect",
+            return_value={"Config": config},
+        )
+
+    def test_root_user_empty(self):
+        with self._mock_inspect({"User": "", "ExposedPorts": None, "Volumes": None}):
+            p = detect_image_privileges("test:latest")
+        assert p.runs_as_root
+
+    def test_root_user_zero(self):
+        with self._mock_inspect({"User": "0", "ExposedPorts": None, "Volumes": None}):
+            p = detect_image_privileges("test:latest")
+        assert p.runs_as_root
+
+    def test_root_user_explicit(self):
+        with self._mock_inspect({"User": "root", "ExposedPorts": None, "Volumes": None}):
+            p = detect_image_privileges("test:latest")
+        assert p.runs_as_root
+
+    def test_nonroot_user(self):
+        with self._mock_inspect({"User": "app", "ExposedPorts": None, "Volumes": None}):
+            p = detect_image_privileges("test:latest")
+        assert not p.runs_as_root
+
+    def test_exposed_ports(self):
+        with self._mock_inspect({"User": "app", "ExposedPorts": {"80/tcp": {}}, "Volumes": None}):
+            p = detect_image_privileges("test:latest")
+        assert p.network_access
+
+    def test_no_exposed_ports(self):
+        with self._mock_inspect({"User": "app", "ExposedPorts": None, "Volumes": None}):
+            p = detect_image_privileges("test:latest")
+        assert not p.network_access
+
+    def test_volumes(self):
+        with self._mock_inspect({"User": "app", "ExposedPorts": None, "Volumes": {"/data": {}}}):
+            p = detect_image_privileges("test:latest")
+        assert p.filesystem_write
+
+    def test_no_volumes(self):
+        with self._mock_inspect({"User": "app", "ExposedPorts": None, "Volumes": None}):
+            p = detect_image_privileges("test:latest")
+        assert not p.filesystem_write
+
+    def test_inspect_failure_returns_empty_profile(self):
+        from agent_bom.image import ImageScanError
+        with patch("agent_bom.image._docker_inspect", side_effect=ImageScanError("nope")):
+            p = detect_image_privileges("bad:image")
+        assert not p.runs_as_root
+        assert not p.network_access
+        assert p.privilege_level == "low"
+
+
+# ─── detect_container_privileges ─────────────────────────────────────────────
+
+
+class TestDetectContainerPrivileges:
+    def _mock_subprocess(self, data, returncode=0):
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = json.dumps([data])
+        return patch("agent_bom.image.subprocess.run", return_value=result)
+
+    def test_privileged_container(self):
+        data = {
+            "Config": {"User": ""},
+            "HostConfig": {
+                "Privileged": True,
+                "CapAdd": None,
+                "CapDrop": None,
+                "SecurityOpt": [],
+                "NetworkMode": "bridge",
+            },
+        }
+        with self._mock_subprocess(data):
+            p = detect_container_privileges("abc123")
+        assert p.container_privileged
+        assert p.runs_as_root
+        assert p.privilege_level == "critical"
+
+    def test_cap_add(self):
+        data = {
+            "Config": {"User": "app"},
+            "HostConfig": {
+                "Privileged": False,
+                "CapAdd": ["CAP_SYS_ADMIN", "CAP_NET_RAW"],
+                "CapDrop": None,
+                "SecurityOpt": [],
+                "NetworkMode": "bridge",
+            },
+        }
+        with self._mock_subprocess(data):
+            p = detect_container_privileges("abc123")
+        assert "CAP_SYS_ADMIN" in p.capabilities
+        assert "CAP_NET_RAW" in p.capabilities
+        assert p.privilege_level == "critical"
+
+    def test_cap_drop_filters(self):
+        data = {
+            "Config": {"User": "app"},
+            "HostConfig": {
+                "Privileged": False,
+                "CapAdd": ["CAP_NET_RAW", "CAP_SYS_PTRACE"],
+                "CapDrop": ["CAP_NET_RAW"],
+                "SecurityOpt": [],
+                "NetworkMode": "bridge",
+            },
+        }
+        with self._mock_subprocess(data):
+            p = detect_container_privileges("abc123")
+        assert "CAP_NET_RAW" not in p.capabilities
+        assert "CAP_SYS_PTRACE" in p.capabilities
+
+    def test_host_network(self):
+        data = {
+            "Config": {"User": "app"},
+            "HostConfig": {
+                "Privileged": False,
+                "CapAdd": None,
+                "CapDrop": None,
+                "SecurityOpt": [],
+                "NetworkMode": "host",
+            },
+        }
+        with self._mock_subprocess(data):
+            p = detect_container_privileges("abc123")
+        assert p.network_access
+
+    def test_security_opts(self):
+        data = {
+            "Config": {"User": "app"},
+            "HostConfig": {
+                "Privileged": False,
+                "CapAdd": None,
+                "CapDrop": None,
+                "SecurityOpt": ["no-new-privileges", "seccomp=unconfined"],
+                "NetworkMode": "none",
+            },
+        }
+        with self._mock_subprocess(data):
+            p = detect_container_privileges("abc123")
+        assert "seccomp=unconfined" in p.security_opt
+
+    def test_subprocess_failure_returns_empty(self):
+        result = MagicMock()
+        result.returncode = 1
+        with patch("agent_bom.image.subprocess.run", return_value=result):
+            p = detect_container_privileges("bad_container")
+        assert not p.container_privileged
+        assert p.privilege_level == "low"
+
+    def test_subprocess_timeout_returns_empty(self):
+        with patch(
+            "agent_bom.image.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("docker", 30),
+        ):
+            p = detect_container_privileges("slow_container")
+        assert p.privilege_level == "low"
+
+    def test_nonroot_user(self):
+        data = {
+            "Config": {"User": "nonroot"},
+            "HostConfig": {
+                "Privileged": False,
+                "CapAdd": None,
+                "CapDrop": None,
+                "SecurityOpt": [],
+                "NetworkMode": "none",
+            },
+        }
+        with self._mock_subprocess(data):
+            p = detect_container_privileges("abc123")
+        assert not p.runs_as_root
+        assert not p.network_access


### PR DESCRIPTION
## Summary

- **PermissionProfile model** — new dataclass modeling server privilege levels: `runs_as_root`, `container_privileged`, `shell_access`, `tool_permissions` (read/write/execute/destructive per tool), `capabilities` (Linux caps), with computed `is_elevated` and `privilege_level` (critical/high/medium/low)
- **Tool permission classifier** (`permissions.py`) — keyword-based classification of MCP tool names into read/write/execute/destructive categories, risk level inference, and profile building
- **Docker privilege detection** — `detect_image_privileges()` and `detect_container_privileges()` extract privilege info from Docker inspect (User, Privileged, CapAdd/CapDrop, SecurityOpt, NetworkMode)
- **Discovery-time detection** — sudo/shell detection when MCP servers are discovered from 13 config sources
- **Registry enrichment** — tool permissions auto-populated from registry data during parsing, merged with discovery-time profiles
- **Console + JSON output** — privilege indicators (🛡 PRIVILEGED/root/shell/elevated) in console tree, full `permission_profile` in JSON output, elevated server count in posture summary
- **Registry expansion** — 112 → 427 bundled MCP servers via Official MCP Registry sync with auto-classification of risk level and category
- **Expansion script** (`scripts/expand_registry.py`) — standalone script with `--dry-run`, `--max-pages`, `--page-size` flags

## Test plan

- [x] 88 new tests across 3 test files (test_permissions.py, test_privilege_detection.py, test_expand_registry.py)
- [x] Full suite: 949 tests passing
- [x] Ruff clean
- [ ] CI passes