### PR TITLE
release: v0.31.0 — privilege detection, registry expansion, clean README

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim
 
-ARG VERSION=0.30.0
+ARG VERSION=0.31.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center">
-  <b>Generate AI Bills of Materials. Scan AI agents and MCP servers for CVEs. Map blast radius. Enterprise remediation with named assets and risk narratives. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
+  <b>AI Bill of Materials generator. CVE scanning for AI agents and MCP servers. Blast radius mapping. Privilege detection. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
 </p>
 
 <p align="center">
@@ -40,12 +40,10 @@
 > **Grype tells you a package has a CVE.**
 > **agent-bom tells you which AI agents are compromised, which credentials leak, which tools an attacker reaches, and what the business impact is.**
 
-Traditional scanners stop at the package boundary. agent-bom maps the full blast radius through your AI infrastructure:
-
 ```
 CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
   └─ better-sqlite3@9.0.0  (npm)
-       └─ sqlite-mcp  (MCP Server · unverified)
+       └─ sqlite-mcp  (MCP Server · unverified · 🛡 root)
             ├─ Cursor IDE  (Agent · 4 servers · 12 tools)
             ├─ ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credentials exposed)
             └─ query_db, read_file, write_file, run_shell  (Tools at risk)
@@ -55,19 +53,17 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 
 | | Grype / Syft / Trivy | agent-bom |
 |---|---|---|
-| Package CVE detection | Yes | Yes — OSV batch + NVD CVSS v4 + FIRST EPSS + CISA KEV |
+| Package CVE detection | Yes | Yes — OSV + NVD CVSS v4 + EPSS + CISA KEV |
 | SBOM generation | Yes (Syft) | Yes — CycloneDX 1.6, SPDX 3.0, SARIF |
-| **AI agent discovery** | — | 12 MCP clients + Docker Compose auto-discovered |
+| **AI agent discovery** | — | 13 MCP clients + Docker Compose auto-discovered |
 | **Blast radius mapping** | — | CVE → package → server → agent → credentials → tools |
 | **Credential exposure** | — | Which secrets leak per vulnerability, per agent |
-| **MCP tool reachability** | — | Which tools (read_file, run_shell) an attacker reaches post-exploit |
-| **Enterprise remediation** | — | Named assets, impact percentages, risk narratives per fix |
-| **OWASP LLM + MITRE ATLAS + NIST AI RMF** | — | Triple-framework tagging on every finding |
-| **AI-powered enrichment** | — | LLM-generated threat chains and executive summaries |
-| **Policy-as-code for AI** | — | Block unverified servers, enforce thresholds in CI/CD |
-| **112-server MCP registry** | — | Risk levels, provenance, tool inventories per server |
-
-**Ecosystem:** Ships as a [ToolHive](integrations/toolhive/) container, an [MCP Registry](integrations/mcp-registry/server.json) entry for any MCP client, an [OpenClaw](integrations/openclaw/SKILL.md) skill, and a [GitHub Action](action.yml) for CI/CD.
+| **MCP tool reachability** | — | Which tools an attacker reaches post-exploit |
+| **Privilege detection** | — | runs_as_root, shell_access, container_privileged, per-tool permissions |
+| **Enterprise remediation** | — | Named assets, impact percentages, risk narratives |
+| **Triple-framework tagging** | — | OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF |
+| **Policy-as-code** | — | Block unverified servers, enforce thresholds in CI/CD |
+| **427+ server MCP registry** | — | Risk levels, tool inventories, auto-synced weekly |
 
 <table>
 <tr>
@@ -77,17 +73,17 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 
 | Source | How |
 |--------|-----|
-| MCP configs | Auto-discover (12 clients + Docker Compose) |
-| Docker images | Grype / Syft if available, else Docker CLI |
+| MCP configs | Auto-discover (13 clients + Docker Compose) |
+| Docker images | Grype / Syft / Docker CLI fallback |
 | Kubernetes | kubectl across namespaces |
-| Terraform | Bedrock, Vertex AI, Azure |
-| GitHub Actions | AI env vars + SDK steps |
-| Python agents | 10 frameworks detected |
 | Cloud providers | AWS, Azure, GCP, Databricks, Snowflake, Nebius |
+| Terraform / GitHub Actions | AI resources + env vars |
 | AI platforms | HuggingFace, W&B, MLflow, OpenAI |
 | Jupyter notebooks | AI library imports + model refs |
-| Model files | 13 formats (.gguf, .safetensors, .onnx, .pt, .pkl, ...) |
-| Skill files | CLAUDE.md, .cursorrules, skills.md, AGENTS.md |
+| Model files | 13 formats (.gguf, .safetensors, .pkl, ...) |
+| Skill files | CLAUDE.md, .cursorrules, AGENTS.md |
+| Prompt templates | .prompt, .promptfile, prompt.yaml |
+| Ollama models | Local inventory via API + manifests |
 | Existing SBOMs | CycloneDX / SPDX import |
 
 </td>
@@ -97,7 +93,20 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 
 Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON, REST API
 
-**Read-only guarantee:** Never writes configs, never runs servers, never stores secrets. All API calls (OSV, NVD, EPSS) are read-only queries. `--dry-run` shows every file and API URL before access.
+**Read-only guarantee:** Never writes configs, never runs servers, never stores secrets. All API calls are read-only. See [PERMISSIONS.md](PERMISSIONS.md).
+
+**Ecosystem:**
+
+| Platform | Link |
+|----------|------|
+| PyPI | `pip install agent-bom` |
+| Docker | `docker run agentbom/agent-bom scan` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.0` |
+| MCP Registry | [server.json](integrations/mcp-registry/server.json) |
+| ToolHive | [registry entry](integrations/toolhive/server.json) |
+| OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
+| Smithery | [smithery.yaml](smithery.yaml) |
+| Railway | [Dockerfile.sse](Dockerfile.sse) |
 
 </td>
 </tr>
@@ -112,55 +121,41 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 
 ---
 
-## Quick links
-
-- **[Install](#install)** — `pip install agent-bom` or Docker
-- **[Get started](#get-started)** — scan in 30 seconds
-- **[AI-BOM export](#ai-bom-export)** — CycloneDX, SPDX, JSON, SARIF, HTML
-- **[Remediation plan](#enterprise-remediation-plan)** — named assets, risk narratives
-- **[Cloud UI](#cloud-ui)** — enterprise aggregate dashboard
-- **[CI integration](#ci-integration)** — GitHub Actions + SARIF upload
-- **[REST API](#rest-api)** — FastAPI on port 8422
-- **[Skills](skills/)** — downloadable workflow playbooks (AI-BOM, cloud audit, OWASP, incident response)
-- **[MCP Registry](src/agent_bom/mcp_registry.json)** — 112 known servers with metadata
-- **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract
-- **[Roadmap](#roadmap)** — what's coming next
-
----
-
 ## Get started
 
 ```bash
 pip install agent-bom
 
-# Auto-discover and scan local AI agents
-agent-bom scan
-
-# HTML dashboard with severity donut + blast radius chart
-agent-bom scan -f html -o report.html && open report.html
-
-# CI gate — fail on critical/high CVEs
-agent-bom scan --fail-on-severity high -q
+agent-bom scan                                     # auto-discover + scan
+agent-bom scan --enrich                            # + NVD CVSS + EPSS + CISA KEV
+agent-bom scan -f html -o report.html              # HTML dashboard
+agent-bom scan --fail-on-severity high -q          # CI gate
+agent-bom scan --image myapp:latest                # Docker image scanning
+agent-bom scan --k8s --all-namespaces              # K8s cluster
+agent-bom scan --aws --snowflake --databricks      # Multi-cloud
 ```
 
-No config needed. Auto-discovers Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Copilot, Continue, Zed, Cortex Code, and OpenClaw on macOS, Linux, and Windows.
+Auto-discovers Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Copilot, Continue, Zed, Cortex Code, OpenClaw, ToolHive, Docker MCP Toolkit, and VS Code native MCP.
 
----
-
-## Install
+<details>
+<summary><b>Install extras</b></summary>
 
 | Mode | Command |
 |------|---------|
 | Core CLI | `pip install agent-bom` |
-| AWS discovery | `pip install 'agent-bom[aws]'` |
-| Databricks | `pip install 'agent-bom[databricks]'` |
+| Cloud (all) | `pip install 'agent-bom[cloud]'` |
+| AWS | `pip install 'agent-bom[aws]'` |
 | Snowflake | `pip install 'agent-bom[snowflake]'` |
+| Databricks | `pip install 'agent-bom[databricks]'` |
 | Nebius GPU cloud | `pip install 'agent-bom[nebius]'` |
-| All cloud | `pip install 'agent-bom[cloud]'` |
 | REST API | `pip install 'agent-bom[api]'` |
 | Dashboard | `pip install 'agent-bom[ui]'` |
+| AI enrichment | `pip install 'agent-bom[ai-enrich]'` |
+| MCP server | `pip install 'agent-bom[mcp-server]'` |
 | OpenTelemetry | `pip install 'agent-bom[otel]'` |
 | Docker | `docker run --rm -v ~/.config:/root/.config:ro agentbom/agent-bom scan` |
+
+</details>
 
 ---
 
@@ -168,144 +163,44 @@ No config needed. Auto-discovers Claude Desktop, Claude Code, Cursor, Windsurf, 
 
 ### CVE scanning + blast radius
 
-```bash
-agent-bom scan --enrich                    # OSV + NVD CVSS + EPSS + CISA KEV
-agent-bom scan --image myapp:latest        # Docker image (Grype/Syft if available, else Docker CLI)
-agent-bom scan --k8s --all-namespaces      # Every pod in the cluster
-agent-bom scan --sbom syft-output.cdx.json # Pipe in existing SBOMs
-```
+Every vulnerability is mapped through your AI stack: **which agents** are affected, **which credentials** are exposed, **which MCP tools** an attacker can reach, and **what to fix first**.
 
-Every vulnerability is mapped to: **which agents** are affected, **which credentials** are exposed, **which MCP tools** an attacker can reach.
+Enrichment sources: OSV batch (primary), NVD CVSS v4, FIRST EPSS exploit probability, CISA KEV active exploitation catalog.
 
-### OWASP LLM Top 10 tagging
+### Privilege detection
 
-| Code | Triggered when |
-|------|---------------|
-| **LLM05** | Any package CVE (always) |
-| **LLM06** | Credential env var exposed alongside CVE |
-| **LLM08** | Server with >5 tools + CRITICAL/HIGH CVE |
-| **LLM02** | Tool with shell/exec semantics |
-| **LLM07** | Tool that reads files or prompts |
-| **LLM04** | AI framework + HIGH+ CVE |
+Every MCP server is assessed for privilege escalation risk:
 
-### MITRE ATLAS threat mapping
+| Signal | Detection |
+|--------|-----------|
+| **runs_as_root** | `sudo` in command/args, Docker `Config.User` empty/"0"/"root" |
+| **shell_access** | bash/sh/zsh/powershell command, exec/shell tools |
+| **container_privileged** | Docker `HostConfig.Privileged`, CapAdd/CapDrop |
+| **tool_permissions** | Per-tool read/write/execute/destructive classification |
 
-Every finding is also mapped to [MITRE ATLAS](https://atlas.mitre.org/) adversarial ML techniques:
+Privilege levels: **critical** (privileged container, CAP_SYS_ADMIN) → **high** (root, shell) → **medium** (fs write, network) → **low** (read-only).
 
-| Technique | Triggered when |
-|-----------|---------------|
-| **AML.T0010** | Any package CVE (always — supply chain compromise) |
-| **AML.T0062** | Credentials exposed alongside vulnerability |
-| **AML.T0061** | >3 tools reachable through compromised path |
-| **AML.T0051** | Tools can access prompts/context (injection surface) |
-| **AML.T0056** | Tools can read files (meta prompt extraction) |
-| **AML.T0043** | Tools with shell/exec capability (adversarial data) |
-| **AML.T0020** | AI framework + HIGH+ CVE (training data poisoning) |
-| **AML.T0058** | AI framework + creds + HIGH+ (agent context poisoning) |
+### Triple-framework threat mapping
 
-### NIST AI RMF compliance mapping
+Every finding is tagged against three frameworks simultaneously:
 
-Every finding is also mapped to the [NIST AI Risk Management Framework](https://www.nist.gov/artificial-intelligence/ai-risk-management-framework) (AI RMF 1.0) — covering all four functions:
+- **OWASP LLM Top 10** — LLM01 through LLM10 (6 categories triggered)
+- **MITRE ATLAS** — AML.T0010, AML.T0043, AML.T0051, etc. (8 techniques mapped)
+- **NIST AI RMF 1.0** — Govern, Map, Measure, Manage (12 subcategories mapped)
 
-| Subcategory | Triggered when |
-|-------------|---------------|
-| **GOVERN-1.7** | Any package CVE (always — third-party component risk) |
-| **MAP-3.5** | Any package CVE (always — supply chain risk assessed) |
-| **GOVERN-6.1** | Shell/exec tools reachable (third-party assessment) |
-| **GOVERN-6.2** | AI framework + creds + HIGH+ (contingency planning) |
-| **MAP-1.6** | >3 tools reachable (interface mapping) |
-| **MAP-5.2** | Data/file access tools reachable (deployment impact) |
-| **MEASURE-2.5** | AI framework + HIGH+ CVE (security testing) |
-| **MEASURE-2.9** | Fix available (mitigation effectiveness) |
-| **MANAGE-1.3** | CISA KEV finding (documented risk response) |
-| **MANAGE-2.2** | Credentials exposed (anomalous event detection) |
-| **MANAGE-2.4** | AI framework + creds + HIGH+ (remediation) |
-| **MANAGE-4.1** | Credentials + tools exposed (post-deployment monitoring) |
+### Enterprise remediation
 
-### MCP runtime introspection
-
-Connect to live MCP servers to discover their actual runtime capabilities:
-
-```bash
-agent-bom scan --introspect                 # introspect all discovered servers
-agent-bom scan --introspect --introspect-timeout 15  # custom timeout per server
-```
-
-Introspection is **read-only** — it only calls `tools/list` and `resources/list` (never `tools/call`). It enables:
-
-- **Runtime tool discovery** — see actual tools exposed by running servers
-- **Drift detection** — compare config-declared tools vs runtime reality
-- **Hidden capability discovery** — find tools not declared in configs
-- **Server enrichment** — merge runtime data into the AI-BOM inventory
-
-Requires the MCP SDK: `pip install mcp`
-
-### Threat framework coverage matrix
-
-After every scan, agent-bom shows which OWASP + ATLAS + NIST AI RMF categories were triggered — and how many findings per category:
-
-**CLI** — `print_threat_frameworks()` renders three Rich tables with bar charts:
-
-```
-┌───────────── OWASP LLM Top 10 ──────────────┐    ┌─────── NIST AI RMF 1.0 ────────┐
-│ LLM05  Supply Chain Vulnerabilities    12 ████│    │ GOVERN-1.7  Third-party risk 12 ████│
-│ LLM06  Sensitive Information Disclosure 4 ██  │    │ MAP-3.5     Supply chain    12 ████│
-│ LLM08  Excessive Agency                2 █   │    │ MANAGE-2.2  Event detection  4 ██  │
-│ LLM01  Prompt Injection                —     │    │ MEASURE-2.5 Security test    2 █   │
-│ ...                                          │    │ ...                               │
-└──────────────────────────────────────────────┘    └─────────────────────────────────┘
-```
-
-**JSON** — `threat_framework_summary` section with per-category counts:
-
-```json
-{
-  "threat_framework_summary": {
-    "owasp_llm_top10": [{"code": "LLM05", "name": "Supply Chain Vulnerabilities", "findings": 12, "triggered": true}],
-    "mitre_atlas": [{"technique_id": "AML.T0010", "name": "ML Supply Chain Compromise", "findings": 12, "triggered": true}],
-    "nist_ai_rmf": [{"subcategory_id": "MAP-3.5", "name": "AI supply chain risks assessed", "findings": 12, "triggered": true}],
-    "total_owasp_triggered": 4,
-    "total_atlas_triggered": 5,
-    "total_nist_triggered": 6
-  }
-}
-```
-
-**Cloud UI** — three-column threat matrix grid with hit/miss indicators and finding counts per category.
+Each fix tells you exactly what will be protected — named agents, credentials, tools, percentages, threat tags, and risk narratives.
 
 ### AI-BOM export
-
-Every scan produces a complete **AI Bill of Materials** — a structured document listing all agents, MCP servers, packages, credentials, tools, and vulnerabilities. Export in any standard format:
 
 ```bash
 agent-bom scan -f cyclonedx -o ai-bom.cdx.json   # CycloneDX 1.6
 agent-bom scan -f spdx -o ai-bom.spdx.json       # SPDX 3.0
-agent-bom scan -f json -o ai-bom.json             # Full AI-BOM (document_type: "AI-BOM")
 agent-bom scan -f sarif -o results.sarif           # GitHub Security tab
-agent-bom scan -f html -o report.html              # Interactive HTML dashboard
+agent-bom scan -f json -o ai-bom.json             # Full AI-BOM
+agent-bom scan -f html -o report.html              # Interactive dashboard
 ```
-
-The JSON output includes `"document_type": "AI-BOM"` and `"spec_version": "1.0"` at the top level for programmatic identification. Console output shows an export hint panel after every scan.
-
-### Enterprise remediation plan
-
-Each remediation tells you exactly **what will be protected** when you fix it:
-
-```
- 3. upgrade python 3.11.14 → 3.13.10
-    clears 2 vuln(s) • impact score: 14
-    agents:       claude-desktop-agent (100%)
-    credentials:  YOUTUBE_API_KEY (100%)
-    tools:        read_file, execute_command, web_search (3 of 8 — 38%)
-    mitigates:    LLM05 LLM06 AML.T0010 AML.T0062
-    ⚠ if not fixed: attacker exploiting CVE-2025-1234 can reach
-      claude-desktop-agent → YOUTUBE_API_KEY → execute_command
-```
-
-- **Named assets** — which specific agents, credentials, and tools are at risk
-- **Percentages** — what fraction of your total inventory each fix protects
-- **Threat tags** — which OWASP LLM + MITRE ATLAS + NIST AI RMF categories are mitigated
-- **Risk narratives** — plain-text explanation of what happens if you don't remediate
 
 ### Policy-as-code
 
@@ -313,539 +208,205 @@ Each remediation tells you exactly **what will be protected** when you fix it:
 agent-bom scan --policy policy.json --fail-on-severity high
 ```
 
-```json
-[
-  {"id": "no-unverified-high", "unverified_server": true, "severity_gte": "HIGH", "action": "fail"},
-  {"id": "warn-excessive-agency", "min_tools": 6, "action": "warn"},
-  {"id": "block-kev", "severity_gte": "CRITICAL", "action": "fail"}
-]
-```
-
 ### Cloud provider discovery
 
-Discover AI agents directly from cloud provider APIs — no manual inventory files needed. Customer pays for compute; scans run in your environment with your credentials.
-
 ```bash
-# AWS — Bedrock agents + Lambda + EKS + Step Functions + EC2
-agent-bom scan --aws --aws-region us-east-1
-agent-bom scan --aws --aws-include-lambda --aws-include-eks --aws-include-step-functions
-
-# Snowflake — Cortex Agents, MCP Servers, Search, Snowpark, Streamlit, query history
-agent-bom scan --snowflake
-
-# Databricks — cluster libraries, model serving endpoints
-agent-bom scan --databricks
-
-# Nebius — GPU cloud K8s clusters + container services
-agent-bom scan --nebius --nebius-project-id my-project
-
-# CoreWeave — K8s-native, use the --k8s flag with your cluster context
-agent-bom scan --k8s --context=coreweave-cluster --all-namespaces
-
-# Combine with local scans
-agent-bom scan --aws --databricks --snowflake --image myapp:latest --enrich
+agent-bom scan --aws --aws-region us-east-1       # Bedrock, Lambda, EKS, ECS, SageMaker, EC2
+agent-bom scan --snowflake                         # Cortex Agents, MCP Servers, Search, Snowpark
+agent-bom scan --databricks                        # Cluster libraries, model serving
+agent-bom scan --nebius --nebius-project-id proj   # GPU cloud K8s + containers
+agent-bom scan --k8s --context=coreweave-cluster   # CoreWeave / any K8s
 ```
+
+<details>
+<summary><b>Cloud provider details</b></summary>
 
 | Provider | What's discovered | Install |
 |----------|------------------|---------|
-| **AWS** | Bedrock agents, Lambda functions, EKS clusters, Step Functions workflows, EC2 instances, ECS images, SageMaker endpoints | `pip install 'agent-bom[aws]'` |
-| **Snowflake** | Cortex Agents, native MCP Servers (with tool specs), Cortex Search Services, Snowpark packages, Streamlit apps, query history audit trail, custom functions/procedures | `pip install 'agent-bom[snowflake]'` |
-| **Databricks** | Cluster PyPI/Maven packages, model serving endpoints | `pip install 'agent-bom[databricks]'` |
+| **AWS** | Bedrock agents, Lambda, EKS, Step Functions, EC2, ECS, SageMaker | `pip install 'agent-bom[aws]'` |
+| **Snowflake** | Cortex Agents, native MCP Servers, Search, Snowpark, Streamlit, query history | `pip install 'agent-bom[snowflake]'` |
+| **Databricks** | Cluster packages, model serving endpoints | `pip install 'agent-bom[databricks]'` |
 | **Azure** | AI Foundry agents, Container Apps | `pip install 'agent-bom[azure]'` |
-| **GCP** | Vertex AI endpoints, Cloud Run services | `pip install 'agent-bom[gcp]'` |
-| **Nebius** | Managed K8s clusters, container services + images | `pip install 'agent-bom[nebius]'` |
-| **CoreWeave** | K8s-native — use `--k8s --context=coreweave-cluster` | (core CLI) |
-
-<details>
-<summary><b>AWS deep discovery flags</b></summary>
-
-| Flag | Discovers |
-|------|-----------|
-| `--aws` | Bedrock agents, ECS images, SageMaker endpoints (default) |
-| `--aws-include-lambda` | Standalone Lambda functions (filtered by AI runtimes) |
-| `--aws-include-eks` | EKS clusters → reuses `--k8s` pod image scanning per cluster |
-| `--aws-include-step-functions` | Step Functions workflows → extracts Lambda/SageMaker/Bedrock ARNs |
-| `--aws-include-ec2` | EC2 instances (requires `--aws-ec2-tag KEY=VALUE` for safety) |
+| **GCP** | Vertex AI endpoints, Cloud Run | `pip install 'agent-bom[gcp]'` |
+| **Nebius** | Managed K8s, container services | `pip install 'agent-bom[nebius]'` |
+| **CoreWeave** | K8s-native — `--k8s --context=coreweave-cluster` | (core CLI) |
+| **Ollama** | Local model inventory via API + manifests | (core CLI) |
 
 </details>
 
+### Additional capabilities
+
 <details>
-<summary><b>Snowflake deep discovery</b></summary>
+<summary><b>MCP runtime introspection</b></summary>
 
-Snowflake discovery covers the full Cortex AI stack:
-
-- **Cortex Agents** — `SHOW AGENTS IN ACCOUNT` discovers agentic orchestration systems
-- **Native MCP Servers** — `SHOW MCP SERVERS IN ACCOUNT` + `DESCRIBE MCP SERVER` parses YAML tool specs. `SYSTEM_EXECUTE_SQL` tools are flagged as **[HIGH-RISK]**
-- **Query History Audit** — scans `INFORMATION_SCHEMA.QUERY_HISTORY()` for `CREATE MCP SERVER` and `CREATE AGENT` statements to catch objects created outside standard flows
-- **Custom Tools** — inventories `INFORMATION_SCHEMA.FUNCTIONS` and `INFORMATION_SCHEMA.PROCEDURES` with language annotation (Python/Java/JavaScript) for attack surface analysis
-- **Cortex Search + Snowpark + Streamlit** — existing discovery for search services, packages, and apps
-
-</details>
-
-Cloud SDKs are optional extras — install only what you need. Authentication uses each provider's standard credential chain (env vars, config files, IAM roles).
-
-### Attack flow diagrams
-
-Drill into any CVE with an interactive per-CVE blast radius diagram — showing the exact attack chain from vulnerability through packages, MCP servers, agents, credentials, and tools:
+Connect to live servers to discover runtime tools/resources and detect drift from configs. Read-only — only calls `tools/list` and `resources/list`.
 
 ```bash
-# Via the REST API
-GET /v1/scan/{job_id}/attack-flow?cve=CVE-2024-1234&severity=critical
-```
-
-- **Interactive React Flow canvas** — zoom, pan, minimap, click-to-inspect detail panel
-- **Filter by CVE, severity, framework tag, or agent** — isolate specific attack chains
-- **Color-coded nodes** — red (CVE), gray (package), blue (server), green (agent), yellow (credential), purple (tool)
-- **Export** — download graph data as JSON for audit evidence
-- **Linked from scan results** — "View Attack Flow" button in every blast radius section
-
-### Skill file scanning
-
-Scan AI coding assistant instruction files (CLAUDE.md, .cursorrules, skill.md, AGENTS.md, etc.) for embedded MCP server references, package dependencies, and credential env vars:
-
-```bash
-# Explicit file
-agent-bom scan --skill CLAUDE.md --skill .cursorrules
-
-# Auto-discovery — scans all well-known skill files in the project
-agent-bom scan
-
-# Skip skill scanning entirely
-agent-bom scan --no-skill
-
-# Scan ONLY skill/instruction files (skip agent/package/CVE scanning)
-agent-bom scan --skill-only
-```
-
-Auto-discovers: `CLAUDE.md`, `.claude/CLAUDE.md`, `.cursorrules`, `.cursor/rules/*.md`, `skill.md`, `skills/*.md`, `.github/copilot-instructions.md`, `.windsurfrules`, `AGENTS.md`
-
-Extracts:
-- `npx`/`bunx` package references → npm ecosystem
-- `uvx`/`uv run`/`uv tool run` package references → pypi ecosystem
-- `pip install` and `npm install` commands
-- MCP server JSON config blocks (`mcpServers`)
-- Credential env var names (API keys, tokens, secrets)
-
-### Skill security audit
-
-Skill files are a supply chain attack vector — a malicious CLAUDE.md or .cursorrules could contain typosquatted packages, unverified MCP servers, or credential-harvesting env vars. agent-bom audits skill scan results with 7 security checks:
-
-| Check | Severity | What it detects |
-|-------|----------|-----------------|
-| Typosquat detection | HIGH | Package name within edit distance of a known registry entry (fuzzy match ≥80%) |
-| Shell/exec access | HIGH | Server command is `bash`/`sh`/`cmd`/`powershell`, or args contain `--allow-exec` |
-| Dangerous server names | HIGH | Server names containing `exec`, `shell`, `terminal`, `command` |
-| Unverified MCP server | MEDIUM | Server not found in registry or marked as unverified |
-| Excessive credentials | MEDIUM | Server with ≥5 env vars, or skill files referencing ≥8 credential vars total |
-| External URL | MEDIUM | SSE/HTTP server pointing to a non-localhost URL (data exfiltration risk) |
-| Unknown package | LOW | Package not found in any registry entry |
-
-Findings are shown inline during the scan and included in JSON output (`skill_audit` key) and the REST API (`GET /v1/scan/{id}/skill-audit`).
-
-### AI skill analysis
-
-When `--ai-enrich` is active, agent-bom sends raw skill file content alongside static findings to an LLM for context-aware security analysis. The AI distinguishes between safety warnings and dangerous directives — a line saying "never bind to 0.0.0.0" is recognized as a safety instruction, not flagged as a risk.
-
-```bash
-agent-bom scan --skill CLAUDE.md --ai-enrich
-```
-
-What the AI adds:
-- **False positive detection** — marks static findings that are actually safety warnings (e.g., "don't use bash" flagged as shell access)
-- **Severity adjustments** — raises or lowers severity based on context understanding
-- **New threat detection** — finds threats static rules can't catch: prompt injection, social engineering, credential harvesting, data exfiltration, obfuscation patterns
-- **Overall risk narrative** — 2-3 sentence summary with risk level (critical/high/medium/low/safe)
-
-AI results appear in console output, JSON (`skill_audit.ai_skill_summary`, `ai_overall_risk_level`), and per-finding annotations (`ai_analysis`, `ai_adjusted_severity`). Works with local Ollama (free, all data stays local) or any litellm-supported provider.
-
-### Jupyter notebook scanning
-
-Scan Jupyter notebooks for AI/ML library usage, pip install commands, model references, and credential environment variables:
-
-```bash
-agent-bom scan --jupyter ./notebooks
-```
-
-Detects 29+ AI libraries (openai, anthropic, langchain, transformers, torch, tensorflow, crewai, etc.), `!pip install` / `%pip install` commands with version pinning, `os.environ["API_KEY"]` credential access, and hardcoded API key patterns. Each notebook with findings produces a separate agent entry in the AI-BOM.
-
-### Model binary file detection
-
-Scan directories for ML model artifacts and flag security risks:
-
-```bash
-agent-bom scan --model-files ./models
-```
-
-| Format | Extensions | Security |
-|--------|-----------|----------|
-| GGUF (Ollama/llama.cpp) | `.gguf` | — |
-| SafeTensors (HuggingFace) | `.safetensors` | — |
-| ONNX | `.onnx` | — |
-| PyTorch | `.pt`, `.pth` | — |
-| TensorFlow | `.pb`, `.tflite` | — |
-| Keras | `.h5`, `.keras` | — |
-| Core ML | `.mlmodel` | — |
-| Pickle | `.pkl` | **HIGH** — arbitrary code execution |
-| Joblib | `.joblib` | **MEDIUM** — uses pickle internally |
-| Generic Binary | `.bin` | Size-filtered (≥10 MB) |
-
-Pickle-based model files (`.pkl`, `.joblib`) are flagged as security risks because they can execute arbitrary code on load via Python's `__reduce__` protocol. Results appear in JSON output (`model_files` key) and console summary.
-
-### CLI attack flow tree
-
-Visualize the full CVE → Package → Server → Agent → Credentials → Tools attack chain directly in your terminal:
-
-```
-💥 Attack Flow Chains
-
-CVE-2024-1234 [CRITICAL] CVSS 9.8 · EPSS 72% · KEV
- └─ express@4.18.2 (npm)
-      └─ github-mcp (MCP Server)
-           ├─ claude-desktop (Agent)
-           ├─ cursor (Agent)
-           ├─ 🔑 GITHUB_TOKEN
-           └─ 🔧 create_issue, push_code
-```
-
-- Severity-colored output (red for CRITICAL/HIGH, yellow for MEDIUM)
-- Top 15 findings by risk score
-- Shows exposed credentials and MCP tools per chain
-- Disable with `--no-tree`
-
-### Graph visualization
-
-The HTML dashboard includes two interactive Cytoscape.js graphs with dagre hierarchical layout:
-
-- **Supply Chain Graph** — Provider → Agent → Server → Package → CVE flow showing your full dependency tree
-- **CVE Attack Flow** — Reverse propagation: CVE → Package → MCP Server → Credentials / Tools / Agents, showing blast radius impact paths
-
-Both graphs support zoom, fit-to-view, fullscreen, node tooltips, and click-to-highlight neighborhood isolation.
-
-Export the raw graph for use in Cytoscape, Sigma.js, or other tools:
-
-```bash
-agent-bom scan --aws -f graph -o agent-graph.json
-```
-
-### OpenClaw scanning
-
-[OpenClaw](https://github.com/openclaw/openclaw) (214k+ stars) is the most popular open-source personal AI assistant. agent-bom auto-discovers OpenClaw configs and scans them for vulnerabilities — including 12 known CVEs (CWD injection, container escape, SSRF, XSS, secret leakage) from OpenClaw's published security advisories.
-
-```bash
-# Auto-discovers ~/.openclaw/openclaw.json and project-level .openclaw/openclaw.json
-agent-bom scan
-
-# Combine with live introspection
 agent-bom scan --introspect
 ```
 
-### AI-powered enrichment
+</details>
 
-Use LLMs to generate contextual risk analysis beyond template-based output. Supports 100+ LLM providers via [litellm](https://github.com/BerriAI/litellm) — OpenAI, Anthropic, Ollama (local), and more.
+<details>
+<summary><b>Skill file scanning + security audit</b></summary>
+
+Scan CLAUDE.md, .cursorrules, AGENTS.md for embedded MCP servers, packages, and credentials. 7 security checks: typosquat detection, shell access, dangerous server names, unverified servers, excessive credentials, external URLs, unknown packages.
 
 ```bash
-pip install 'agent-bom[ai-enrich]'
-
-# Enrich with GPT-4o-mini (default)
-agent-bom scan --ai-enrich
-
-# Use a different model
-agent-bom scan --ai-enrich --ai-model anthropic/claude-3-haiku-20240307
-
-# Use local Ollama
-agent-bom scan --ai-enrich --ai-model ollama/llama3
+agent-bom scan --skill CLAUDE.md    # explicit
+agent-bom scan --skill-only         # skills only
+agent-bom scan --no-skill           # skip skills
 ```
 
-What `--ai-enrich` generates:
-- **Risk narratives** — contextual 2-3 sentence analysis per finding (why this CVE matters in your agent's tool chain)
-- **Executive summary** — one-paragraph CISO brief with risk rating and actions
-- **Threat chains** — red-team-style attack chain analysis through MCP tools
-- **Skill file analysis** — context-aware review of skill files with false positive detection, severity adjustments, and new threat discovery
+</details>
 
-### MCP Server Registry (112 servers)
+<details>
+<summary><b>Prompt template scanning</b></summary>
 
-Ships with a curated registry of 112 known MCP servers — including OpenClaw, ClickHouse, Figma, Prisma, Browserbase, and E2B. Each entry includes: package name + version pin, ecosystem, risk level, **risk justification** (why this server has its risk level), tool names, credential env vars, license, category, latest version, known CVEs, and source URL.
+Scan .prompt, .promptfile, system_prompt.*, prompt.yaml/json files for hardcoded secrets, prompt injection patterns, unsafe instructions, and sensitive data exposure.
 
-The Cloud UI provides a full **registry browser** with search, risk/category filters, and drill-down detail pages showing tools, credentials, CVEs, and risk justification for each server.
+```bash
+agent-bom scan --scan-prompts
+```
 
-Unverified servers in your configs trigger a warning. Policy rules can block them in CI.
+</details>
+
+<details>
+<summary><b>AI-powered enrichment</b></summary>
+
+LLM-generated risk narratives, executive summaries, and threat chain analysis. Works with local Ollama (free) or 100+ providers via litellm.
+
+```bash
+agent-bom scan --ai-enrich                              # auto-detect Ollama
+agent-bom scan --ai-enrich --ai-model ollama/llama3      # specific model
+agent-bom scan --ai-enrich --ai-model openai/gpt-4o-mini # cloud LLM
+```
+
+</details>
+
+<details>
+<summary><b>Jupyter notebook + model file scanning</b></summary>
+
+Detect 29+ AI libraries, pip installs, credentials in notebooks. Scan 13 model file formats with security flags for pickle-based formats.
+
+```bash
+agent-bom scan --jupyter ./notebooks
+agent-bom scan --model-files ./models
+```
+
+</details>
+
+<details>
+<summary><b>Attack flow visualization</b></summary>
+
+CLI attack flow tree, interactive HTML graphs (Cytoscape.js), per-CVE React Flow diagrams via REST API.
+
+```bash
+agent-bom scan --aws -f graph -o graph.json   # export graph data
+```
+
+</details>
 
 ---
 
-## Deployment models
+## Deployment
 
 | Mode | Command | Best for |
 |------|---------|----------|
-| Developer CLI | `agent-bom scan` | Local audit, pre-commit checks |
-| Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running any MCP server |
-| GitHub Action | `uses: msaad00/agent-bom@v0.30.0 | CI/CD gate + Security tab |
-| Docker | `docker run agentbom/agent-bom scan` | Isolated, reproducible scans |
-| REST API | `agent-bom api` | Dashboards, SIEM, scripting |
-| Dashboard | `agent-bom serve` | Team-visible security dashboard |
-| Prometheus | `--push-gateway` or `--otel-endpoint` | Continuous monitoring |
-| K8s CronJob | `kubectl apply` CronJob manifest | Cluster-wide auditing |
+| CLI | `agent-bom scan` | Local audit |
+| Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.0` | CI/CD + SARIF |
+| Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
+| REST API | `agent-bom api` | Dashboards, SIEM |
+| MCP Server | `agent-bom mcp-server` | Inside any MCP client |
+| Dashboard | `agent-bom serve` | Team UI |
+| Prometheus | `--push-gateway` / `--otel-endpoint` | Monitoring |
 
----
-
-## GitHub Action
-
-Use agent-bom directly in your CI/CD pipeline:
+### GitHub Action
 
 ```yaml
-- name: AI supply chain scan
-  uses: msaad00/agent-bom@v0.30.0
+- uses: msaad00/agent-bom@v0.31.0
   with:
     severity-threshold: high
     upload-sarif: true
+    enrich: true
+    fail-on-kev: true
 ```
 
-Full options:
-
-```yaml
-- uses: msaad00/agent-bom@v0.30.0
-  with:
-    severity-threshold: high        # fail on high+ CVEs
-    policy: policy.json             # policy-as-code gates
-    enrich: true                    # NVD CVSS + EPSS + CISA KEV
-    upload-sarif: true              # results in GitHub Security tab
-    fail-on-kev: true               # block actively exploited CVEs
-```
-
-Outputs: `sarif-file`, `exit-code`, `vulnerability-count` for downstream steps.
-
-SARIF output includes OWASP LLM tags, MITRE ATLAS techniques, and NIST AI RMF subcategories in `result.properties` — visible directly in GitHub Advanced Security.
-
----
-
-## AI enrichment (Ollama)
-
-Generate risk narratives, executive summaries, and threat chain analysis using local open-source LLMs — no API keys, no cost:
-
-```bash
-# Install and start Ollama (one-time)
-curl -fsSL https://ollama.com/install.sh | sh
-ollama pull llama3.2
-
-# Scan with AI enrichment (auto-detects Ollama)
-agent-bom scan --ai-enrich
-```
-
-agent-bom auto-detects Ollama at `localhost:11434`. No extra Python dependencies needed — uses httpx (already included).
-
-For cloud LLMs (OpenAI, Anthropic, Mistral, etc.), install litellm:
-
-```bash
-pip install agent-bom[ai-enrich]
-export OPENAI_API_KEY=sk-...
-agent-bom scan --ai-enrich --ai-model openai/gpt-4o-mini
-```
-
----
-
-## REST API
+### REST API
 
 ```bash
 pip install agent-bom[api]
-agent-bom api   # http://127.0.0.1:8422  →  /docs for Swagger UI
-
-# Production hardening
-agent-bom api --api-key $SECRET --cors-origins "https://myui.example.com" --rate-limit 30
+agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 ```
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /health` | Liveness + `X-Agent-Bom-Read-Only: true` header |
-| `POST /v1/scan` | Start async scan (returns `job_id`) |
-| `GET /v1/scan/{job_id}` | Poll status + results |
-| `GET /v1/scan/{job_id}/stream` | SSE real-time progress |
-| `GET /v1/scan/{job_id}/attack-flow` | Per-CVE attack flow graph (filterable) |
-| `GET /v1/scan/{job_id}/skill-audit` | Skill file security audit findings |
-| `GET /v1/registry` | Full MCP server registry (112 servers) |
-| `GET /v1/registry/{id}` | Single registry entry |
+| `POST /v1/scan` | Start async scan |
+| `GET /v1/scan/{id}` | Results + status |
+| `GET /v1/scan/{id}/attack-flow` | Per-CVE blast radius graph |
+| `GET /v1/registry` | 427+ server registry |
 
-**API hardening options:**
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--api-key KEY` | None | Require Bearer token or X-API-Key authentication |
-| `--cors-origins` | localhost:3000 | Comma-separated allowed origins |
-| `--cors-allow-all` | off | Allow all origins (dev mode) |
-| `--rate-limit RPM` | 60 | Scan endpoint requests/minute per IP |
-
-Max 10 concurrent scan jobs. Completed jobs auto-expire after 1 hour. Request body limited to 10MB.
-
----
-
-## MCP Server
-
-agent-bom runs as an MCP server, making security scanning available inside any MCP client (Claude Desktop, ChatGPT, Cursor, Windsurf, VS Code Copilot, and more).
+### MCP Server
 
 ```bash
 pip install agent-bom[mcp-server]
-agent-bom mcp-server                    # stdio (local clients)
-agent-bom mcp-server --transport sse    # SSE (remote clients)
+agent-bom mcp-server                    # stdio
+agent-bom mcp-server --transport sse    # remote
 ```
 
-**Claude Desktop config** (`~/.claude/claude_desktop_config.json`):
-```json
-{"mcpServers": {"agent-bom": {"command": "agent-bom", "args": ["mcp-server"]}}}
-```
+8 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`
 
-**Cursor config** (`~/.cursor/mcp.json`):
-```json
-{"mcpServers": {"agent-bom": {"command": "agent-bom", "args": ["mcp-server"]}}}
-```
-
-| MCP Tool | Description |
-|----------|-------------|
-| `scan` | Full discovery, CVE scanning, blast radius analysis |
-| `blast_radius` | Look up attack chain for a specific CVE |
-| `policy_check` | Evaluate security policy rules against findings |
-| `registry_lookup` | Query 112-server threat intelligence registry |
-| `generate_sbom` | Generate CycloneDX 1.6 or SPDX 3.0 SBOM |
-
----
-
-## Integrations
-
-| Platform | How to use | Details |
-|----------|-----------|---------|
-| **ToolHive** | `thv run agent-bom` | [ToolHive registry entry](integrations/toolhive/server.json) — runs in isolated container |
-| **OpenClaw** | `clawhub install agent-bom` | [OpenClaw skill](integrations/openclaw/SKILL.md) — teaches agents to run security scans |
-| **MCP Registry** | `uvx agent-bom mcp-server` | [Registry entry](integrations/mcp-registry/server.json) — official MCP Registry |
-| **GitHub Actions** | `uses: msaad00/agent-bom@v0.30.0 | SARIF upload to Security tab, policy gating |
-
----
-
-## Cloud UI
-
-The Next.js dashboard (`ui/`) provides an enterprise-grade web interface on top of the REST API:
-
-- **Security posture dashboard** — fleet-wide severity distribution, scan source breakdown, top vulnerable packages across all scans
-- **Vulnerability explorer** — group by severity, package, or agent with full-text search
-- **Scan detail** — per-job blast radius table, threat framework matrix, remediation plan with impact bars, collapsible sections
-- **Attack flow diagrams** — per-CVE interactive blast radius chain: CVE → Package → Server → Agent → Credentials/Tools, filterable by CVE, severity, framework tag, or agent, with exportable JSON for audit evidence
-- **Supply chain graph** — interactive React Flow visualization: Agent → MCP Server → Package → CVE with color-coded nodes, click-to-inspect detail panel, hover tooltips, zoom/pan, minimap, and job selector
-- **Registry browser** — searchable 112-server catalog with risk/category filters, drill-down detail pages (risk justification, tools, credentials, CVEs, versions), verified badges
-- **Agent discovery** — auto-discovered agents with stats bar (servers, packages, credentials, ecosystems), collapsible agent cards
-- **Enterprise scan form** — bulk Docker image input (one-at-a-time, bulk paste, .txt file upload), K8s, Terraform, GitHub Actions, Python agents
-- **Severity chart** — stacked bar chart with critical/high/medium/low percentage breakdown
-- **Source tracking** — each finding tagged by source (MCP agents, container images, K8s pods, SBOMs)
-- **Live API health check** — nav bar shows real-time backend status with version display
+### Cloud UI
 
 ```bash
 cd ui && npm install && npm run dev   # http://localhost:3000
 ```
 
-Requires the REST API backend running on port 8422.
+Security posture dashboard, vulnerability explorer, attack flow diagrams, supply chain graph, registry browser, enterprise scan form.
 
 ---
 
-## Skills
+## MCP Server Registry (427+ servers)
 
-Downloadable workflow playbooks in [`skills/`](skills/) — structured instructions for common security workflows. Each skill is a self-contained markdown document with goals, steps, decision points, and output artifacts.
+Curated registry of 427+ known MCP servers with risk levels, tool inventories, credential env vars, categories, and version pins. Auto-synced weekly from the [Official MCP Registry](https://registry.modelcontextprotocol.io). Unverified servers trigger warnings. Policy rules can block them in CI.
 
-| Skill | What it does |
-|-------|-------------|
-| [**AI-BOM Generator**](skills/ai-bom-generator.md) | Full asset discovery + scan + enrich + AI Bill of Materials generation across all sources |
-| [**Cloud Security Audit**](skills/cloud-security-audit.md) | Multi-cloud AI asset discovery and vulnerability assessment (AWS, Azure, GCP, Snowflake, Databricks, Nebius, CoreWeave) |
-| [**OWASP LLM Assessment**](skills/owasp-llm-assessment.md) | Systematic OWASP LLM Top 10 + MITRE ATLAS threat assessment with per-category remediation |
-| [**Incident Response**](skills/incident-response.md) | Given a CVE, find all affected agents, map blast radius, triage, and remediate |
-| [**Pre-Deploy Gate**](skills/pre-deploy-gate.md) | CI/CD security gate — block deployments with critical CVEs or policy violations |
-| [**MCP Server Review**](skills/mcp-server-review.md) | Evaluate an MCP server before adopting — registry lookup, CVE scan, tool risk analysis |
-| [**Compliance Export**](skills/compliance-export.md) | Generate audit-ready CycloneDX, SPDX, SARIF with threat framework coverage reports |
+Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python scripts/expand_registry.py`
 
 ---
 
 ## AI supply chain coverage
 
-agent-bom covers the AI infrastructure landscape through multiple scanning strategies:
-
-| Layer | How agent-bom covers it | Examples |
-|-------|------------------------|----------|
-| **GPU clouds** | `--k8s --context=<cluster>` | CoreWeave, Lambda Labs, Paperspace, DGX Cloud |
-| **AI platforms** | Cloud provider modules | AWS Bedrock/SageMaker, Azure AI Foundry, GCP Vertex AI, Databricks, Snowflake Cortex, HuggingFace Hub, W&B, MLflow, OpenAI |
-| **Container workloads** | `--image` (Grype/Syft optional, Docker CLI fallback) | NVIDIA Triton, NIM, vLLM, TGI, Ollama, any OCI image |
-| **K8s-native inference** | `--k8s` discovers pods | KServe, Seldon Core, Kubeflow, Ray Serve, BentoML |
-| **AI frameworks** | Dependency scanning (PyPI/npm) | LangChain, LlamaIndex, AutoGen, CrewAI, PyTorch, Transformers, NeMo |
-| **Vector databases** | `--image` for self-hosted | Weaviate, Qdrant, Milvus, ChromaDB, pgvector |
-| **LLM providers** | API key detection + SDK scanning | OpenAI, Anthropic, Cohere, Mistral, Gemini |
-| **MCP ecosystem** | Auto-discovery (12 clients + Docker Compose) + registry (112 servers) | Claude Desktop, Cursor, Windsurf, Cline, OpenClaw |
-| **IaC + CI/CD** | `--tf-dir` and `--gha` | Terraform AI resources, GitHub Actions AI workflows |
-
----
-
-## agent-bom vs ToolHive
-
-These tools solve different problems and are **complementary**.
-
-| | agent-bom | ToolHive |
-|---|---|---|
-| **Purpose** | Scan + audit AI supply chain | Deploy + manage MCP servers |
-| **CVE scanning** | OSV, NVD, EPSS, CISA KEV (+ optional Grype for images) | No |
-| **Blast radius** | Agents, credentials, tools | No |
-| **OWASP + ATLAS + NIST** | Triple-framework tagging on every finding | No |
-| **MCP server isolation** | No (scanner only) | Yes (containers + seccomp) |
-| **Secret injection** | No | Yes (Vault, AWS SM) |
-| **Read-only** | Yes | No (manages processes) |
-
-**Together:** ToolHive runs your MCP servers securely. agent-bom audits whether the packages they depend on have known CVEs and what the blast radius would be.
+| Layer | Coverage | Examples |
+|-------|----------|----------|
+| **GPU clouds** | `--k8s` | CoreWeave, Lambda Labs, Paperspace |
+| **AI platforms** | Cloud modules | Bedrock, Vertex AI, Snowflake Cortex, Databricks |
+| **Containers** | `--image` | NVIDIA NIM, vLLM, Ollama, any OCI image |
+| **AI frameworks** | Dependency scan | LangChain, LlamaIndex, AutoGen, PyTorch |
+| **MCP ecosystem** | Auto-discovery + registry | 13 clients, 427+ servers |
+| **LLM providers** | API key + SDK detection | OpenAI, Anthropic, Cohere, Mistral |
+| **IaC + CI/CD** | `--tf-dir`, `--gha` | Terraform AI resources, GitHub Actions |
 
 ---
 
 ## Trust & permissions
 
-- **`--dry-run`** — shows every file and API URL that would be accessed, then exits
-- **[PERMISSIONS.md](PERMISSIONS.md)** — auditable contract: what is read, what APIs are called, what is never done
-- **API headers** — every response includes `X-Agent-Bom-Read-Only: true`
-- **Sigstore signing** — releases v0.7.0+ signed via [cosign](https://www.sigstore.dev/)
-- **Credential redaction** — only env var **names** appear in reports as `***REDACTED***`
+- **`--dry-run`** — preview every file and API URL before access
+- **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract
+- **Read-only** — never writes configs, runs servers, or stores secrets
+- **Sigstore signed** — releases v0.7.0+ signed via cosign
+- **Credential redaction** — only env var **names** in reports
 
 ---
 
 ## Roadmap
 
-- [x] MITRE ATLAS adversarial ML threat mapping
-- [x] SLSA provenance + SHA256 integrity verification
-- [x] Threat framework coverage matrix (CLI + JSON + UI)
-- [x] Enterprise remediation plan with named assets + risk narratives
-- [x] Enterprise aggregate dashboard (Cloud UI)
-- [x] AI-BOM export identity (CycloneDX, SPDX, JSON, SARIF)
-- [x] Cloud provider discovery (AWS, Azure, GCP, Databricks, Snowflake, Nebius, CoreWeave)
-- [x] Deep cloud scanning — Snowflake Cortex Agents/MCP Servers, AWS Lambda/EKS/Step Functions/EC2
-- [x] Graph visualization (provider → agent → server → package → CVE)
-- [x] Security skills — downloadable workflow playbooks for AI-BOM, cloud audit, OWASP, incident response
-- [x] AI platform discovery — HuggingFace Hub, Weights & Biases, MLflow, OpenAI
-- [x] NIST AI RMF compliance mapping (Govern, Map, Measure, Manage)
-- [x] MCP runtime introspection — connect to live servers for tool/resource discovery + drift detection
-- [x] OpenClaw discovery — auto-scan OpenClaw configs, 12 known CVEs from published security advisories
-- [x] AI-powered enrichment — LLM-generated risk narratives, executive summaries, and threat chains via litellm
-- [x] CLI posture summary — aggregate security posture panel with ecosystem breakdown and credential exposure
-- [x] Interactive supply chain graph — click-to-inspect detail panel, hover tooltips, pane click dismiss
-- [x] Registry enrichment — 112 servers with risk justifications, drill-down detail pages, category filters
-- [x] Enterprise scan form — bulk Docker image input (paste, file upload) for fleet-scale scanning
-- [x] Collapsible UI — agents, blast radius, remediation, and inventory sections collapse/expand
-- [x] Attack flow diagrams — per-CVE interactive blast radius chain with filters and audit export
-- [x] Skill file scanning — CLAUDE.md, .cursorrules, AGENTS.md parsing for packages, MCP servers, credentials
-- [x] Skill security audit — 7 checks: typosquat detection, shell access, unverified servers, excessive credentials, external URLs
-- [x] CLI attack flow tree — terminal-native CVE → Package → Server → Agent → Credentials/Tools chain visualization
-- [x] AI skill file analysis — LLM-powered context-aware review of skill files with false positive detection, severity adjustments, and new threat discovery
-- [x] Jupyter notebook AI library scanning — detect 29+ AI/ML imports, pip installs, credentials, hardcoded keys
-- [x] Skill scanning control — `--no-skill` to skip, `--skill-only` for skill-only mode
-- [x] Model binary file detection — .gguf, .safetensors, .onnx, .pt, .pkl security flags, 13 formats
-- [x] API server hardening — API key authentication, per-IP rate limiting, CORS tightening, job cleanup
-- [x] CLI tree labels — explicit 🤖 Agent / 🔌 MCP Server / 📦 Package prefixes with summary stats
-- [x] MCP server — 8 tools: scan, check, blast_radius, policy_check, registry_lookup, generate_sbom, compliance, remediate
-- [x] ToolHive integration — registry entry + MCP container for enterprise deployment
-- [x] OpenClaw skill — ClawHub-compatible skill for AI agent security scanning
-- [x] GitHub Action enhancements — image, config-dir, sbom, remediate inputs
-- [ ] CIS AI benchmarks — integrate CIS AI/agent security benchmarks when published
-- [ ] Agent guardrails engine — runtime policy enforcement for agent actions and tool calls
-- [ ] AI-powered discovery — use LLMs to identify AI components in unstructured codebases
-- [ ] EU AI Act compliance — risk classification and documentation requirements mapping
-- [ ] Multi-language SDK detection — Go, Rust, Java AI library scanning beyond Python/Node
-- [ ] n8n / workflow engine scanning — detect AI nodes in n8n, Zapier, Make automation flows
-- [ ] License compliance engine (SPDX license detection + copyleft chain analysis)
+- [ ] CIS AI benchmarks
+- [ ] Agent guardrails engine — runtime policy enforcement
+- [ ] EU AI Act compliance mapping
+- [ ] Multi-language SDK detection (Go, Rust, Java)
+- [ ] Workflow engine scanning (n8n, Zapier, Make)
+- [ ] License compliance engine
 
 ---
 
@@ -857,16 +418,8 @@ pip install -e ".[dev]"
 pytest && ruff check src/
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) | [SECURITY.md](SECURITY.md)
+See [CONTRIBUTING.md](CONTRIBUTING.md) | [SECURITY.md](SECURITY.md) | [Skills](skills/)
 
 ---
 
 Apache 2.0 — [LICENSE](LICENSE)
-
-<!-- Badge reference links -->
-[release-img]: https://img.shields.io/pypi/v/agent-bom?style=flat&label=Latest%20version
-[ci-img]: https://img.shields.io/github/actions/workflow/status/msaad00/agent-bom/ci.yml?style=flat&logo=github&label=Build
-[license-img]: https://img.shields.io/badge/License-Apache%202.0-blue?style=flat
-[docker-img]: https://img.shields.io/docker/pulls/agentbom/agent-bom?style=flat&label=Docker%20pulls
-[stars-img]: https://img.shields.io/github/stars/msaad00/agent-bom?style=flat&logo=github&label=Stars
-[ossf-img]: https://api.securityscorecards.dev/projects/github.com/msaad00/agent-bom/badge

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius, policy enforcement, SBOM generation",
   "title": "agent-bom",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: Scan AI agents and MCP servers for CVEs, generate SBOMs, map blast radius, enforce security policies
-version: 0.30.0
+version: 0.31.0
 metadata:
   openclaw:
     requires:
@@ -48,7 +48,7 @@ and tools are exposed if a package is compromised), generates SBOMs, and evaluat
 - Blast radius mapping: CVE → package → server → agent → credentials/tools
 - SBOM generation: CycloneDX 1.6, SPDX 3.0, SARIF 2.1.0
 - Policy-as-code engine for CI/CD security gates
-- Threat intelligence registry of 112+ known MCP servers with risk metadata
+- Threat intelligence registry of 427+ known MCP servers with risk metadata
 - Docker image scanning (requires `docker` binary, optional)
 
 ## Installation
@@ -71,7 +71,7 @@ pipx install agent-bom
 ### Verify installation
 ```bash
 agent-bom --version
-# Should print: agent-bom 0.30.0
+# Should print: agent-bom 0.31.0
 ```
 
 ### Verify source

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG VERSION=0.30.0
+ARG VERSION=0.31.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius analysis, policy enforcement, and SBOM generation for MCP servers and AI agents",
   "title": "agent-bom",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.30.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.30.0": {
+        "ghcr.io/msaad00/agent-bom:v0.31.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.30.0"
+version = "0.31.0"
 description = "AI Bill of Materials (AI-BOM) generator — CVE scanning, blast radius, enterprise remediation plans, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF threat mapping, LLM-powered enrichment, OpenClaw discovery, MCP runtime introspection, and MCP registry for AI agents."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -78,7 +78,7 @@ def bump(new_version: str, *, dry_run: bool = False) -> int:
     print(f"\n{'Would update' if dry_run else 'Updated'} {changed} occurrence(s)")
 
     if not dry_run and changed > 0:
-        print(f"\nNext steps:")
+        print("\nNext steps:")
         print(f"  git add -A && git commit -m 'chore: bump version to {new_version}'")
         print(f"  git tag v{new_version}")
         print(f"  git push origin main v{new_version}")

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.30.0"
+    __version__ = "0.31.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,7 +255,7 @@ def empty_report():
 
 def test_version_sync():
     from agent_bom import __version__
-    assert __version__ == "0.30.0"
+    assert __version__ == "0.31.0"
 
 
 def test_report_version_matches():
@@ -2795,7 +2795,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.30.0"
+    assert data["version"] == "0.31.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 

--- a/tests/test_prompt_scanner.py
+++ b/tests/test_prompt_scanner.py
@@ -1,18 +1,13 @@
 """Tests for prompt template security scanner."""
 
-from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from agent_bom.cli import main
 from agent_bom.parsers.prompt_scanner import (
-    PromptFinding,
-    PromptScanResult,
     discover_prompt_files,
     scan_prompt_files,
 )
-
 
 # ── Discovery tests ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump version 0.30.0 → 0.31.0 across all files (pyproject.toml, Dockerfiles, integrations, tests)
- Rewrite README: 873 → ~280 lines — concise, diagrams kept, detailed docs in collapsible sections
- Update all counts: 427+ servers, 13 MCP clients, privilege detection featured
- Fix pre-existing ruff issues

## What's new in v0.31.0

- **PermissionProfile** — runs_as_root, shell_access, container_privileged, per-tool permissions
- **Docker privilege detection** — image + container inspect for escalation risks
- **Registry expansion** — 112 → 427+ servers via Official MCP Registry auto-sync
- **Ollama local model discovery** — API + manifest fallback
- **Prompt template scanning** — detect hardcoded secrets, injection patterns
- **949 tests** passing

## Test plan

- [x] 949 tests passing
- [x] Ruff clean
- [ ] CI passes
- [ ] After merge: `git tag v0.31.0 && git push --tags` to trigger PyPI + Docker release