### PR TITLE
fix: update Railway URL + clean PUBLISHING.md

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -47,7 +47,7 @@ jobs:
             exit 0
           fi
 
-          QUALIFIED_NAME="agentbom%2Fagent-bom"
+          QUALIFIED_NAME="agent-bom%2Fagent-bom"
           MCP_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app/mcp}"
 
           echo "Publishing agent-bom v${{ steps.meta.outputs.version }} to Smithery..."

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -22,7 +22,7 @@ The SSE server is deployed on Railway at `https://agent-bom-mcp.up.railway.app` 
 
 **Option A — Web UI**:
 1. Go to https://smithery.ai/servers/new
-2. Namespace: `msaad00`
+2. Namespace: `agent-bom`
 3. Server ID: `agent-bom`
 4. MCP Server URL: `https://agent-bom-mcp.up.railway.app/mcp`
 5. Click **Continue**
@@ -32,7 +32,7 @@ The `publish-registries.yml` workflow auto-publishes to Smithery on each release
 
 ### Verification
 
-After publishing, check: https://smithery.ai/server/msaad00/agent-bom
+After publishing, check: https://smithery.ai/server/agent-bom/agent-bom
 
 ---
 


### PR DESCRIPTION
## Summary
- Update Railway fallback URL from old `web-production-c0852` to `agent-bom-mcp.up.railway.app`
- Clean up PUBLISHING.md to reflect fully automated release pipeline
- All platforms now documented with correct trigger chain