### PR TITLE
feat: full path transparency + where --json + v0.31.1

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim
 
-ARG VERSION=0.31.0
+ARG VERSION=0.31.1
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.31.0" --no-input --force
+  --version "0.31.1" --no-input --force
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.31.0
-git push origin v0.31.0
+git tag v0.31.1
+git push origin v0.31.1
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.1` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -315,7 +315,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.1` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` | Inside any MCP client |
@@ -325,7 +325,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.31.0
+- uses: msaad00/agent-bom@v0.31.1
   with:
     severity-threshold: high
     upload-sarif: true

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius, policy enforcement, SBOM generation",
   "title": "agent-bom",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: Scan AI agents and MCP servers for CVEs, generate SBOMs, map blast radius, enforce security policies
-version: 0.31.0
+version: 0.31.1
 metadata:
   openclaw:
     requires:
@@ -71,7 +71,7 @@ pipx install agent-bom
 ### Verify installation
 ```bash
 agent-bom --version
-# Should print: agent-bom 0.31.0
+# Should print: agent-bom 0.31.1
 ```
 
 ### Verify source

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG VERSION=0.31.0
+ARG VERSION=0.31.1
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius analysis, policy enforcement, and SBOM generation for MCP servers and AI agents",
   "title": "agent-bom",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.1",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.31.0": {
+        "ghcr.io/msaad00/agent-bom:v0.31.1": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.31.0"
+version = "0.31.1"
 description = "AI Bill of Materials (AI-BOM) generator — CVE scanning, blast radius, enterprise remediation plans, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF threat mapping, LLM-powered enrichment, OpenClaw discovery, MCP runtime introspection, and MCP registry for AI agents."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.31.0"
+    __version__ = "0.31.1"

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -134,6 +134,29 @@ def expand_path(path_str: str) -> Path:
     return Path(os.path.expanduser(path_str)).resolve()
 
 
+def get_all_discovery_paths(plat: Optional[str] = None) -> list[tuple[str, str]]:
+    """Return all config paths that would be checked during discovery.
+
+    Returns a list of (client_name, path_string) tuples for the given platform.
+    Used by --dry-run and ``agent-bom paths`` for full transparency.
+    """
+    plat = plat or get_platform()
+    paths: list[tuple[str, str]] = []
+    for agent_type, platforms in CONFIG_LOCATIONS.items():
+        for p in platforms.get(plat, []):
+            paths.append((agent_type.value, p))
+    # Docker MCP Toolkit paths (not in CONFIG_LOCATIONS)
+    paths.append(("Docker MCP Toolkit", "~/.docker/mcp/registry.yaml"))
+    paths.append(("Docker MCP Toolkit", "~/.docker/mcp/catalogs/docker-mcp.yaml"))
+    # Project-level configs (relative to CWD)
+    for pf in PROJECT_CONFIG_FILES:
+        paths.append(("Project config", pf))
+    # Docker Compose files (relative to CWD)
+    for cf in COMPOSE_FILE_NAMES:
+        paths.append(("Docker Compose", cf))
+    return paths
+
+
 def parse_mcp_config(config_data: dict, config_path: str) -> list[MCPServer]:
     """Parse MCP server definitions from a config file.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,7 +255,7 @@ def empty_report():
 
 def test_version_sync():
     from agent_bom import __version__
-    assert __version__ == "0.31.0"
+    assert __version__ == "0.31.1"
 
 
 def test_report_version_matches():
@@ -2795,7 +2795,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.31.0"
+    assert data["version"] == "0.31.1"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary

- **Fix dry-run path enumeration**: Replace hardcoded 3-path sample (one was wrong — `~/.codeium/windsurf/mcp_config.json` never existed) with full enumeration of all 25 discovery paths from `CONFIG_LOCATIONS`
- **New `get_all_discovery_paths()`**: Centralized function returning all (client, path) tuples for the current platform — reused by `--dry-run` and `where`
- **Enhanced `where` command**: Shows Docker MCP Toolkit paths, Docker Compose files, totals summary, and `--json` flag for machine-readable audit output
- **Version bump to 0.31.1** across all 10 files (pyproject.toml, __init__.py, README, Dockerfiles, integration JSONs, SKILL.md, PUBLISHING.md)
- **4 new tests** (953 total): path enumeration, Linux platform paths, where --json schema, where totals

Driven by ClawHub OpenClaw scanner Instruction Scope feedback — makes the fixed discovery scope fully transparent and auditable.

## Test plan

- [x] 953 tests pass
- [x] `agent-bom where` shows all 25 paths with exists/missing indicators + totals
- [x] `agent-bom where --json` outputs valid JSON with client/path/expanded/exists fields
- [x] `agent-bom scan --dry-run` lists all discovery paths instead of 3 hardcoded samples
- [ ] After merge: tag v0.31.1, push to trigger full release pipeline
- [ ] Re-upload SKILL.md to ClawHub for re-scan