### PR TITLE
fix: ClawHub trust — optional_env, source evidence, file_reads justification (v0.31.4)

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim
 
-ARG VERSION=0.31.3
+ARG VERSION=0.31.4
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.31.3"
+  --version "0.31.4"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.31.3
-git push origin v0.31.3
+git tag v0.31.4
+git push origin v0.31.4
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.3` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.4` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -315,7 +315,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.3` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.4` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` | Inside any MCP client |
@@ -325,7 +325,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.31.3
+- uses: msaad00/agent-bom@v0.31.4
   with:
     severity-threshold: high
     upload-sarif: true

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius, policy enforcement, SBOM generation",
   "title": "agent-bom",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG VERSION=0.31.3
+ARG VERSION=0.31.4
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius analysis, policy enforcement, and SBOM generation for MCP servers and AI agents",
   "title": "agent-bom",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.3",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.4",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.31.3": {
+        "ghcr.io/msaad00/agent-bom:v0.31.4": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.31.3"
+version = "0.31.4"
 description = "AI Bill of Materials (AI-BOM) generator — CVE scanning, blast radius, enterprise remediation plans, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF threat mapping, LLM-powered enrichment, OpenClaw discovery, MCP runtime introspection, and MCP registry for AI agents."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.31.3"
+    __version__ = "0.31.4"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,7 +255,7 @@ def empty_report():
 
 def test_version_sync():
     from agent_bom import __version__
-    assert __version__ == "0.31.3"
+    assert __version__ == "0.31.4"
 
 
 def test_report_version_matches():
@@ -2795,7 +2795,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.31.3"
+    assert data["version"] == "0.31.4"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 
@@ -2847,13 +2847,15 @@ def test_openclaw_skill_declares_network_endpoints():
 
 
 def test_openclaw_skill_declares_env():
-    """OpenClaw SKILL.md manifest should declare required env vars."""
+    """OpenClaw SKILL.md manifest should declare NVD_API_KEY as optional, not required."""
     from pathlib import Path
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"
     content = p.read_text()
     assert "requires:" in content
-    assert "env:" in content
+    assert "env: []" in content, "requires.env should be empty — no env vars are required"
+    assert "optional_env:" in content
     assert "NVD_API_KEY" in content
+    assert "required: false" in content
 
 
 def test_openclaw_skill_has_all_install_methods():
@@ -2875,6 +2877,19 @@ def test_openclaw_skill_has_verification_section():
     assert "cosign verify-blob" in content
     assert "Binary behavior audit" in content
     assert "--dry-run" in content
+    # Source code evidence for binary verifiability
+    assert "Source code evidence" in content
+    assert "credential_names" in content
+    assert "CONFIG_LOCATIONS" in content
+
+
+def test_openclaw_skill_has_file_reads_justification():
+    """OpenClaw SKILL.md should justify the broad file_reads list."""
+    from pathlib import Path
+    p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"
+    content = p.read_text()
+    assert "file_reads_justification:" in content
+    assert "silently skipped" in content
 
 
 def test_openclaw_skill_nvd_auth_consistent():
@@ -2899,6 +2914,7 @@ def test_openclaw_skill_nvd_auth_consistent():
 def test_cli_dry_run_shows_data_audit():
     """--dry-run should include Data Audit section showing what gets extracted and sent."""
     from click.testing import CliRunner
+
     from agent_bom.cli import main
     runner = CliRunner()
     result = runner.invoke(main, ["scan", "--dry-run"])
@@ -2952,7 +2968,7 @@ def test_badge_output_clean():
 
 def test_badge_output_with_vulns():
     """Badge output should reflect vulnerability severity."""
-    from agent_bom.models import AIBOMReport, Agent, AgentType, MCPServer, Package, Vulnerability, Severity
+    from agent_bom.models import Agent, AgentType, AIBOMReport, MCPServer, Package, Severity, Vulnerability
     report = AIBOMReport()
     vuln = Vulnerability(id="CVE-2024-0001", severity=Severity.HIGH, summary="test")
     pkg = Package(name="test-pkg", version="1.0.0", ecosystem="npm", vulnerabilities=[vuln])


### PR DESCRIPTION
## Summary

Addresses remaining ClawHub v0.31.3 "Suspicious / medium confidence" scanner feedback:

### CREDENTIALS fix (was: "NVD_API_KEY declared as required")
- **Moved** NVD_API_KEY from `requires.env` to new `optional_env` field with `required: false`
- `requires.env: []` now explicitly empty — no env vars are required
- Each optional env var now has `purpose`, `sent_only_to`, and `required` fields

### INSTRUCTION SCOPE fix (was: "binary behavior cannot be verified from manifest")
- **Added Source code evidence** section with actual code excerpts from:
  - `models.py:222-233` — `credential_names` property (only returns key names)
  - `discovery/__init__.py:160-167` — `parse_mcp_config` (structure-only extraction)
  - `discovery/__init__.py:30-107` — `CONFIG_LOCATIONS` (hardcoded paths, no dynamic paths)
- Each excerpt links to the exact GitHub source lines for verification

### PURPOSE & CAPABILITY fix (was: "broad set of locations")
- **Added `file_reads_justification`** metadata field explaining: 11 MCP clients x 2 OS variants = ~19 global + 5 project + 4 compose = 27 paths. Most don't exist on any given system.

## Test plan

- [x] 965 tests pass locally
- [ ] CI passes all checks
- [ ] Re-upload SKILL.md to ClawHub