### PR TITLE
feat: v0.31.5 — supply chain visualization + Docker hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ COPY src/ ./src/
 # Install agent-bom
 RUN pip install --no-cache-dir -e .
 
+# Create non-root user for least-privilege execution
+RUN addgroup --system abom && adduser --system --ingroup abom abom
+
 # Create workspace directory for mounting
 WORKDIR /workspace
+RUN chown abom:abom /workspace
+
+USER abom
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim
 
-ARG VERSION=0.31.4
+ARG VERSION=0.31.5
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"
@@ -30,6 +30,10 @@ COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
 RUN pip install --no-cache-dir ".[mcp-server]"
+
+# Create non-root user for least-privilege execution
+RUN addgroup --system abom && adduser --system --ingroup abom abom
+USER abom
 
 # Streamable HTTP transport defaults
 ENV PYTHONUNBUFFERED=1

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.31.4"
+  --version "0.31.5"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.31.4
-git push origin v0.31.4
+git tag v0.31.5
+git push origin v0.31.5
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.4` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.5` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -315,7 +315,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.4` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.5` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` | Inside any MCP client |
@@ -325,7 +325,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.31.4
+- uses: msaad00/agent-bom@v0.31.5
   with:
     severity-threshold: high
     upload-sarif: true

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: 'false'
   format:
-    description: 'Output format (sarif, json, cyclonedx, spdx, text, console).'
+    description: 'Output format (sarif, json, cyclonedx, spdx, text, console, html, svg, mermaid, graph, graph-html, badge).'
     required: false
     default: 'sarif'
   upload-sarif:

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius, policy enforcement, SBOM generation",
   "title": "agent-bom",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.31.4",
+      "version": "0.31.5",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: Scan AI agents and MCP servers for CVEs, generate SBOMs, map blast radius, enforce security policies
-version: 0.31.4
+version: 0.31.5
 metadata:
   openclaw:
     requires:
@@ -251,7 +251,7 @@ pipx install agent-bom
 ### Verify installation
 ```bash
 agent-bom --version
-# Should print: agent-bom 0.31.4
+# Should print: agent-bom 0.31.5
 ```
 
 ### Verify source
@@ -348,7 +348,8 @@ agent-bom scan --enrich --remediate remediation.md
 - **Deterministic**: Same input always produces the same output (modulo upstream API data freshness)
 - **Auditable**: Full source code at https://github.com/msaad00/agent-bom (Apache-2.0 license)
 - **Signed releases**: Every PyPI release is signed with Sigstore OIDC
-- **CI-verified**: Every commit passes 950+ automated tests including security scanning
+- **CI-verified**: Every commit passes 960+ automated tests including security scanning
+- **Docker non-root**: All container images run as unprivileged `abom` user (USER directive in every Dockerfile)
 
 ## Verification & provenance
 

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG VERSION=0.31.4
+ARG VERSION=0.31.5
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"
@@ -14,6 +14,10 @@ COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
 RUN pip install --no-cache-dir ".[mcp-server]"
+
+# Create non-root user for least-privilege execution
+RUN addgroup --system abom && adduser --system --ingroup abom abom
+USER abom
 
 ENV PYTHONUNBUFFERED=1
 

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius analysis, policy enforcement, and SBOM generation for MCP servers and AI agents",
   "title": "agent-bom",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.4",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.5",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.31.4": {
+        "ghcr.io/msaad00/agent-bom:v0.31.5": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.31.4"
+version = "0.31.5"
 description = "AI Bill of Materials (AI-BOM) generator — CVE scanning, blast radius, enterprise remediation plans, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF threat mapping, LLM-powered enrichment, OpenClaw discovery, MCP runtime introspection, and MCP registry for AI agents."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.31.4"
+    __version__ = "0.31.5"

--- a/src/agent_bom/output/mermaid.py
+++ b/src/agent_bom/output/mermaid.py
@@ -1,12 +1,16 @@
-"""Mermaid diagram generator for blast radius visualization.
+"""Mermaid diagram generator for supply chain and blast radius visualization.
 
-Generates Mermaid flowchart syntax from blast radius data, suitable for
-embedding in markdown documents, GitHub issues/PRs, or rendering with
-any Mermaid-compatible tool.
+Generates Mermaid flowchart syntax suitable for embedding in markdown
+documents, GitHub issues/PRs, or rendering with any Mermaid-compatible tool.
+
+Two modes:
+  - **supply-chain** (default): Full hierarchy Provider → Agent → Server → Package
+  - **attack-flow**: CVE-centric blast radius chains CVE → Package → Server → Agent
 
 Usage:
-    agent-bom scan --format mermaid
-    agent-bom scan --format mermaid --output blast-radius.mmd
+    agent-bom scan --format mermaid                          # supply-chain (default)
+    agent-bom scan --format mermaid --mermaid-mode attack-flow
+    agent-bom scan --format mermaid --output diagram.mmd
 """
 
 from __future__ import annotations
@@ -110,3 +114,125 @@ def to_mermaid(report: AIBOMReport, blast_radii: list[BlastRadius]) -> str:
             lines.append(f"    style {node} {style_map[sev]}")
 
     return "\n".join(lines) + "\n"
+
+
+def to_mermaid_supply_chain(report: AIBOMReport) -> str:
+    """Generate a Mermaid flowchart showing the full AI supply chain hierarchy.
+
+    Layout: Provider --> Agent --> MCP Server --> Package
+    Vulnerable packages and credential-bearing servers are highlighted.
+
+    Args:
+        report: The AI-BOM report.
+
+    Returns:
+        Mermaid flowchart as a string.
+    """
+    lines: list[str] = ["graph LR"]
+
+    if not report.agents:
+        lines.append('    empty["No agents discovered"]')
+        return "\n".join(lines)
+
+    edges: set[str] = set()
+    server_styles: dict[str, str] = {}
+    pkg_styles: dict[str, str] = {}
+    provider_seen: set[str] = set()
+
+    for agent in report.agents:
+        source = agent.source or "local"
+        prov_node = _sanitize_id(f"prov_{source}")
+        agt_node = _sanitize_id(f"agt_{agent.name}")
+
+        # Provider node (only once)
+        if source not in provider_seen:
+            provider_seen.add(source)
+            prov_label = _provider_label(source)
+            edges.add(f'    {prov_node}["{_sanitize_label(prov_label)}"]')
+
+        # Provider → Agent
+        edges.add(
+            f'    {prov_node} --> {agt_node}["{_sanitize_label(agent.name)}"]'
+        )
+
+        for srv in agent.mcp_servers:
+            srv_node = _sanitize_id(f"srv_{agent.name}_{srv.name}")
+            cred_badge = ""
+            if srv.has_credentials:
+                cred_badge = f" 🔑{len(srv.credential_names)}"
+                server_styles[srv_node] = "cred"
+
+            pkg_badge = f" ({len(srv.packages)})"
+            srv_label = f"{srv.name}{cred_badge}{pkg_badge}"
+
+            # Agent → Server
+            edges.add(
+                f'    {agt_node} --> {srv_node}["{_sanitize_label(srv_label)}"]'
+            )
+
+            # Server → Packages (show top 5 per server to avoid explosion)
+            for pkg in srv.packages[:5]:
+                pkg_node = _sanitize_id(f"pkg_{pkg.name}_{pkg.version}")
+                pkg_label = f"{pkg.name}@{pkg.version}"
+
+                if pkg.vulnerabilities:
+                    sev = max(
+                        (v.severity.value.lower() for v in pkg.vulnerabilities),
+                        key=lambda s: {"critical": 4, "high": 3, "medium": 2, "low": 1}.get(s, 0),
+                        default="low",
+                    )
+                    vuln_count = len(pkg.vulnerabilities)
+                    pkg_label += f" ⚠{vuln_count}"
+                    pkg_styles[pkg_node] = sev
+                    if srv_node not in server_styles:
+                        server_styles[srv_node] = "vuln"
+
+                edges.add(
+                    f'    {srv_node} --> {pkg_node}["{_sanitize_label(pkg_label)}"]'
+                )
+
+            if len(srv.packages) > 5:
+                more_node = _sanitize_id(f"more_{agent.name}_{srv.name}")
+                edges.add(
+                    f'    {srv_node} -.-> {more_node}["{len(srv.packages) - 5} more..."]'
+                )
+
+    for edge in sorted(edges):
+        lines.append(edge)
+
+    # Styling
+    sev_style = {
+        "critical": "fill:#d32f2f,color:#fff,stroke:#b71c1c",
+        "high": "fill:#f57c00,color:#fff,stroke:#e65100",
+        "medium": "fill:#fbc02d,color:#000,stroke:#f9a825",
+        "low": "fill:#81c784,color:#000,stroke:#66bb6a",
+    }
+    for node, sev in pkg_styles.items():
+        if sev in sev_style:
+            lines.append(f"    style {node} {sev_style[sev]}")
+
+    for node, stype in server_styles.items():
+        if stype == "cred":
+            lines.append(f"    style {node} fill:#fff3e0,stroke:#e65100,stroke-width:2px")
+        elif stype == "vuln":
+            lines.append(f"    style {node} fill:#fbe9e7,stroke:#b71c1c,stroke-width:2px")
+
+    return "\n".join(lines) + "\n"
+
+
+def _provider_label(source: str) -> str:
+    """Human-readable label for provider source."""
+    labels = {
+        "local": "Local",
+        "aws-bedrock": "AWS Bedrock",
+        "aws-ecs": "AWS ECS",
+        "azure-container-apps": "Azure Container Apps",
+        "gcp-vertex-ai": "GCP Vertex AI",
+        "databricks": "Databricks",
+        "snowflake": "Snowflake",
+        "snowflake-cortex": "Snowflake Cortex",
+        "mcp-registry": "MCP Registry",
+        "huggingface": "Hugging Face",
+        "openai": "OpenAI",
+    }
+    return labels.get(source, source.replace("-", " ").title())

--- a/src/agent_bom/output/svg.py
+++ b/src/agent_bom/output/svg.py
@@ -1,0 +1,345 @@
+"""SVG supply chain diagram generator.
+
+Produces a self-contained SVG file showing the full AI supply chain hierarchy:
+    Source/Provider --> Agent --> MCP Server --> Package (with CVE indicators)
+
+Pure Python implementation — no external rendering dependencies required.
+Output is viewable in any browser, image viewer, or embedded in HTML/markdown.
+
+Usage:
+    agent-bom scan --format svg -o supply-chain.svg
+"""
+
+from __future__ import annotations
+
+import html
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_bom.models import AIBOMReport, BlastRadius
+
+# ── Layout constants ──────────────────────────────────────────────────────────
+
+_COL_PROVIDER = 50
+_COL_AGENT = 320
+_COL_SERVER = 590
+_COL_PACKAGE = 860
+_COL_CVE = 1130
+
+_NODE_W = 200
+_NODE_H = 44
+_NODE_RX = 8
+_ROW_GAP = 14
+_HEADER_H = 80
+
+# ── Color palette ─────────────────────────────────────────────────────────────
+
+_COLORS = {
+    "provider": ("#1e3a5f", "#e8f0fe", "#90b4d6"),
+    "agent": ("#1b5e20", "#e8f5e9", "#81c784"),
+    "server_clean": ("#37474f", "#eceff1", "#90a4ae"),
+    "server_vuln": ("#b71c1c", "#fbe9e7", "#ef9a9a"),
+    "server_cred": ("#e65100", "#fff3e0", "#ffcc80"),
+    "pkg_clean": ("#455a64", "#eceff1", "#b0bec5"),
+    "pkg_vuln": ("#c62828", "#ffebee", "#ef9a9a"),
+    "cve_critical": ("#d32f2f", "#ffcdd2", "#ef5350"),
+    "cve_high": ("#e65100", "#ffe0b2", "#ff9800"),
+    "cve_medium": ("#f9a825", "#fff9c4", "#ffee58"),
+    "cve_low": ("#2e7d32", "#c8e6c9", "#66bb6a"),
+}
+
+_FONT = "system-ui, -apple-system, 'Segoe UI', sans-serif"
+
+
+def to_svg(
+    report: AIBOMReport,
+    blast_radii: list[BlastRadius],
+) -> str:
+    """Generate a self-contained SVG supply chain diagram.
+
+    Shows hierarchical layout: Provider -> Agent -> MCP Server -> Package -> CVE
+    Color-coded by severity and status.
+
+    Args:
+        report: The AI-BOM report.
+        blast_radii: List of BlastRadius objects for CVE indicators.
+
+    Returns:
+        Complete SVG document as a string.
+    """
+    vuln_pkg_keys: set[tuple[str, str]] = {
+        (br.package.name, br.package.ecosystem) for br in blast_radii
+    }
+    pkg_cve_map: dict[tuple[str, str], list[dict]] = {}
+    for br in blast_radii:
+        key = (br.package.name, br.package.ecosystem)
+        if key not in pkg_cve_map:
+            pkg_cve_map[key] = []
+        pkg_cve_map[key].append({
+            "id": br.vulnerability.id,
+            "severity": br.vulnerability.severity.value.lower(),
+        })
+
+    # ── Collect layout items per column ───────────────────────────────────
+    providers: list[dict] = []
+    agents: list[dict] = []
+    servers: list[dict] = []
+    packages: list[dict] = []
+    cves: list[dict] = []
+
+    provider_set: set[str] = set()
+    cve_set: set[str] = set()
+
+    # Maps for edge routing
+    provider_to_agents: list[tuple[str, str]] = []
+    agent_to_servers: list[tuple[str, str]] = []
+    server_to_packages: list[tuple[str, str]] = []
+    package_to_cves: list[tuple[str, str]] = []
+
+    for agent in report.agents:
+        source = agent.source or "local"
+        if source not in provider_set:
+            provider_set.add(source)
+            providers.append({"id": f"p:{source}", "label": _provider_label(source)})
+
+        aid = f"a:{agent.name}"
+        agents.append({
+            "id": aid,
+            "label": agent.name,
+            "type": agent.agent_type.value,
+            "servers": len(agent.mcp_servers),
+        })
+        provider_to_agents.append((f"p:{source}", aid))
+
+        for srv in agent.mcp_servers:
+            sid = f"s:{agent.name}:{srv.name}"
+            has_vuln = any(
+                (p.name, p.ecosystem) in vuln_pkg_keys for p in srv.packages
+            )
+            has_cred = srv.has_credentials
+            stype = "server_vuln" if has_vuln else ("server_cred" if has_cred else "server_clean")
+
+            cred_label = ""
+            if has_cred:
+                cred_label = f" [{len(srv.credential_names)} cred]"
+
+            servers.append({
+                "id": sid,
+                "label": srv.name + cred_label,
+                "type": stype,
+                "pkg_count": len(srv.packages),
+                "tool_count": len(srv.tools) if srv.tools else 0,
+            })
+            agent_to_servers.append((aid, sid))
+
+            for pkg in srv.packages:
+                pkg_key = (pkg.name, pkg.ecosystem)
+                pid = f"pkg:{pkg.name}:{pkg.ecosystem}"
+                is_vuln = pkg_key in vuln_pkg_keys
+
+                packages.append({
+                    "id": pid,
+                    "label": f"{pkg.name}@{pkg.version}",
+                    "type": "pkg_vuln" if is_vuln else "pkg_clean",
+                    "ecosystem": pkg.ecosystem,
+                })
+                server_to_packages.append((sid, pid))
+
+                if is_vuln and pkg_key in pkg_cve_map:
+                    for cve_info in pkg_cve_map[pkg_key]:
+                        cve_id = f"cve:{cve_info['id']}"
+                        if cve_info["id"] not in cve_set:
+                            cve_set.add(cve_info["id"])
+                            cves.append({
+                                "id": cve_id,
+                                "label": cve_info["id"],
+                                "type": f"cve_{cve_info['severity']}",
+                                "severity": cve_info["severity"],
+                            })
+                        package_to_cves.append((pid, cve_id))
+
+    # Deduplicate packages/servers (same ID can appear under multiple parents)
+    packages = _dedup_by_id(packages)
+    servers = _dedup_by_id(servers)
+
+    # ── Assign Y positions ────────────────────────────────────────────────
+    columns = [providers, agents, servers, packages, cves]
+    max_rows = max(len(col) for col in columns) if columns else 1
+    total_h = _HEADER_H + max_rows * (_NODE_H + _ROW_GAP) + 40
+
+    col_positions = [_COL_PROVIDER, _COL_AGENT, _COL_SERVER, _COL_PACKAGE, _COL_CVE]
+    node_y_map: dict[str, float] = {}
+
+    for col_items, _x in zip(columns, col_positions):
+        col_h = len(col_items) * (_NODE_H + _ROW_GAP)
+        start_y = _HEADER_H + (total_h - _HEADER_H - col_h) / 2
+        for i, item in enumerate(col_items):
+            node_y_map[item["id"]] = start_y + i * (_NODE_H + _ROW_GAP)
+
+    total_w = _COL_CVE + _NODE_W + 60 if cves else _COL_PACKAGE + _NODE_W + 60
+
+    # ── Build SVG ─────────────────────────────────────────────────────────
+    parts: list[str] = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {total_w} {total_h}" '
+        f'width="{total_w}" height="{total_h}" '
+        f'style="font-family: {_FONT}; font-size: 12px; background: #fafafa;">'
+    )
+
+    # Defs: arrowhead
+    parts.append("""<defs>
+  <marker id="arrow" viewBox="0 0 10 6" refX="10" refY="3"
+    markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+    <path d="M 0 0 L 10 3 L 0 6 z" fill="#999"/>
+  </marker>
+</defs>""")
+
+    # Title bar
+    agent_count = len(agents)
+    server_count = len(servers)
+    pkg_count = len(packages)
+    vuln_count = len(cves)
+    parts.append(
+        f'<text x="{total_w / 2}" y="30" text-anchor="middle" '
+        f'font-size="18" font-weight="bold" fill="#1a1a1a">'
+        f'AI Supply Chain — agent-bom</text>'
+    )
+    parts.append(
+        f'<text x="{total_w / 2}" y="52" text-anchor="middle" '
+        f'font-size="13" fill="#666">'
+        f'{agent_count} agents | {server_count} servers | '
+        f'{pkg_count} packages | {vuln_count} CVEs</text>'
+    )
+
+    # Column headers
+    headers = [
+        (_COL_PROVIDER, "Sources"), (_COL_AGENT, "Agents"),
+        (_COL_SERVER, "MCP Servers"), (_COL_PACKAGE, "Packages"),
+    ]
+    if cves:
+        headers.append((_COL_CVE, "CVEs"))
+    for x, label in headers:
+        parts.append(
+            f'<text x="{x + _NODE_W / 2}" y="{_HEADER_H - 12}" '
+            f'text-anchor="middle" font-size="13" font-weight="600" fill="#444">'
+            f'{label}</text>'
+        )
+
+    # Edges (draw first so nodes appear on top)
+    all_edges = (
+        provider_to_agents + agent_to_servers +
+        server_to_packages + package_to_cves
+    )
+    col_x_map = {}
+    for item in providers:
+        col_x_map[item["id"]] = _COL_PROVIDER
+    for item in agents:
+        col_x_map[item["id"]] = _COL_AGENT
+    for item in servers:
+        col_x_map[item["id"]] = _COL_SERVER
+    for item in packages:
+        col_x_map[item["id"]] = _COL_PACKAGE
+    for item in cves:
+        col_x_map[item["id"]] = _COL_CVE
+
+    seen_edges: set[tuple[str, str]] = set()
+    for src, tgt in all_edges:
+        if (src, tgt) in seen_edges:
+            continue
+        seen_edges.add((src, tgt))
+        if src not in node_y_map or tgt not in node_y_map:
+            continue
+        sx = col_x_map.get(src, 0) + _NODE_W
+        sy = node_y_map[src] + _NODE_H / 2
+        tx = col_x_map.get(tgt, 0)
+        ty = node_y_map[tgt] + _NODE_H / 2
+        mid = (sx + tx) / 2
+        parts.append(
+            f'<path d="M {sx} {sy} C {mid} {sy}, {mid} {ty}, {tx} {ty}" '
+            f'fill="none" stroke="#ccc" stroke-width="1.5" marker-end="url(#arrow)"/>'
+        )
+
+    # Nodes
+    def _draw_nodes(items: list[dict], col_x: int, color_key: str) -> None:
+        for item in items:
+            y = node_y_map.get(item["id"], 0)
+            ctype = item.get("type", color_key)
+            colors = _COLORS.get(ctype, _COLORS.get(color_key, ("#333", "#f5f5f5", "#999")))
+            text_color, bg_color, border_color = colors
+            label = html.escape(item["label"][:28])
+
+            parts.append(
+                f'<rect x="{col_x}" y="{y}" width="{_NODE_W}" height="{_NODE_H}" '
+                f'rx="{_NODE_RX}" fill="{bg_color}" stroke="{border_color}" stroke-width="1.5"/>'
+            )
+            parts.append(
+                f'<text x="{col_x + _NODE_W / 2}" y="{y + _NODE_H / 2 + 4}" '
+                f'text-anchor="middle" font-size="11" font-weight="500" fill="{text_color}">'
+                f'{label}</text>'
+            )
+
+    _draw_nodes(providers, _COL_PROVIDER, "provider")
+    _draw_nodes(agents, _COL_AGENT, "agent")
+    _draw_nodes(servers, _COL_SERVER, "server_clean")
+    _draw_nodes(packages, _COL_PACKAGE, "pkg_clean")
+    _draw_nodes(cves, _COL_CVE, "cve_medium")
+
+    # Empty state
+    if not report.agents:
+        parts.append(
+            f'<text x="{total_w / 2}" y="{total_h / 2}" text-anchor="middle" '
+            f'font-size="16" fill="#999">No agents discovered</text>'
+        )
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def export_svg(
+    report: AIBOMReport,
+    blast_radii: list[BlastRadius],
+    output_path: str,
+) -> None:
+    """Generate and write SVG supply chain diagram to a file."""
+    from pathlib import Path
+
+    svg = to_svg(report, blast_radii)
+    Path(output_path).write_text(svg, encoding="utf-8")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _dedup_by_id(items: list[dict]) -> list[dict]:
+    """Deduplicate items by their 'id' key, keeping first occurrence."""
+    seen: set[str] = set()
+    result: list[dict] = []
+    for item in items:
+        if item["id"] not in seen:
+            seen.add(item["id"])
+            result.append(item)
+    return result
+
+
+def _provider_label(source: str) -> str:
+    """Human-readable label for a provider source."""
+    labels = {
+        "local": "Local",
+        "aws-bedrock": "AWS Bedrock",
+        "aws-ecs": "AWS ECS",
+        "aws-sagemaker": "AWS SageMaker",
+        "azure-container-apps": "Azure Container Apps",
+        "azure-ai-foundry": "Azure AI Foundry",
+        "gcp-vertex-ai": "GCP Vertex AI",
+        "gcp-cloud-run": "GCP Cloud Run",
+        "databricks": "Databricks",
+        "snowflake-cortex": "Snowflake Cortex",
+        "snowflake-streamlit": "Snowflake Streamlit",
+        "snowflake": "Snowflake",
+        "mcp-registry": "MCP Registry",
+        "smithery": "Smithery",
+        "huggingface": "Hugging Face",
+        "openai": "OpenAI",
+        "mlflow": "MLflow",
+        "wandb": "W&B",
+    }
+    return labels.get(source, source.replace("-", " ").title())


### PR DESCRIPTION
## Summary

### New visualization formats
- **`--format svg`**: Self-contained SVG supply chain diagram showing Provider → Agent → MCP Server → Package → CVE hierarchy. Color-coded by severity, credential exposure indicators, bezier curve edges. Pure Python, no external dependencies.
- **`--format graph-html`**: Interactive standalone HTML with embedded Cytoscape.js + dagre layout. Dark theme, zoom/pan/click, node detail sidebar, PNG export button. Single file, works offline.
- **`--mermaid-mode supply-chain`** (new default): Full hierarchy Mermaid diagram showing Source → Agent → Server → Package with vulnerability and credential badges. Old attack-flow mode still available via `--mermaid-mode attack-flow`.

### Docker hardening (ClawHub trust)
- All 3 Dockerfiles (`Dockerfile`, `Dockerfile.sse`, `Dockerfile.mcp`) now create and run as non-root `abom` user
- Directly addresses ClawHub's "review the packaged code" recommendation

### Files changed (16)
| Category | Files |
|----------|-------|
| New | `src/agent_bom/output/svg.py` |
| Visualization | `output/mermaid.py`, `output/graph.py` |
| CLI | `cli.py` (new formats + --mermaid-mode) |
| Docker | `Dockerfile`, `Dockerfile.sse`, `Dockerfile.mcp` |
| Trust | `SKILL.md` (Docker non-root evidence) |
| Version | 10 files bumped 0.31.4 → 0.31.5 |
| Tests | 7 new tests (971 total) |

## Test plan
- [x] 971 tests pass locally
- [ ] CI passes all checks
- [ ] Test SVG output: `agent-bom scan --format svg -o test.svg && open test.svg`
- [ ] Test graph-html: `agent-bom scan --format graph-html -o test.html && open test.html`
- [ ] Test mermaid supply chain: `agent-bom scan --format mermaid`