### PR TITLE
feat: v0.31.6 — ClawHub-style trust assessment scanner

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim
 
-ARG VERSION=0.31.5
+ARG VERSION=0.31.6
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.31.5"
+  --version "0.31.6"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.31.5
-git push origin v0.31.5
+git tag v0.31.6
+git push origin v0.31.6
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.5` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.6` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -315,7 +315,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.5` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.31.6` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` | Inside any MCP client |
@@ -325,7 +325,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.31.5
+- uses: msaad00/agent-bom@v0.31.6
   with:
     severity-threshold: high
     upload-sarif: true

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius, policy enforcement, SBOM generation",
   "title": "agent-bom",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.31.5",
+      "version": "0.31.6",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: Scan AI agents and MCP servers for CVEs, generate SBOMs, map blast radius, enforce security policies
-version: 0.31.5
+version: 0.31.6
 metadata:
   openclaw:
     requires:
@@ -105,6 +105,11 @@ metadata:
       written_to_disk: false
     data_sent: "package names and versions only"
     data_not_sent: "file paths, config contents, env var values, hostnames, IP addresses"
+    checksums:
+      pypi_sha256: "auto-verified at install time via pip"
+      sigstore_signed: true
+      slsa_provenance: "GitHub Actions OIDC (see release.yml)"
+      verify_command: "cosign verify-blob dist/agent_bom-*.whl --bundle dist/agent_bom-*.whl.bundle --certificate-oidc-issuer https://token.actions.githubusercontent.com"
     telemetry: false
     persistence: false
     privilege_escalation: false
@@ -251,7 +256,7 @@ pipx install agent-bom
 ### Verify installation
 ```bash
 agent-bom --version
-# Should print: agent-bom 0.31.5
+# Should print: agent-bom 0.31.6
 ```
 
 ### Verify source
@@ -348,7 +353,7 @@ agent-bom scan --enrich --remediate remediation.md
 - **Deterministic**: Same input always produces the same output (modulo upstream API data freshness)
 - **Auditable**: Full source code at https://github.com/msaad00/agent-bom (Apache-2.0 license)
 - **Signed releases**: Every PyPI release is signed with Sigstore OIDC
-- **CI-verified**: Every commit passes 960+ automated tests including security scanning
+- **CI-verified**: Every commit passes 1000+ automated tests including security scanning
 - **Docker non-root**: All container images run as unprivileged `abom` user (USER directive in every Dockerfile)
 
 ## Verification & provenance
@@ -362,7 +367,7 @@ You can independently verify every claim in this manifest:
 | File access | `grep -rn "open(\|Path(" src/agent_bom/discovery/` — all file reads happen in the discovery module only |
 | Credential handling | `grep -n "credential_names\|SENSITIVE_PATTERNS\|REDACTED" src/agent_bom/` — values are never stored |
 | Signed release | `cosign verify-blob dist/agent_bom-*.whl --bundle dist/agent_bom-*.whl.bundle --certificate-oidc-issuer https://token.actions.githubusercontent.com` |
-| CI test count | See [GitHub Actions](https://github.com/msaad00/agent-bom/actions) — every commit runs 950+ tests including security scanning |
+| CI test count | See [GitHub Actions](https://github.com/msaad00/agent-bom/actions) — every commit runs 1000+ tests including security scanning |
 | OpenSSF Scorecard | [Scorecard viewer](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom) |
 | Dry-run audit | `agent-bom scan --dry-run` — shows every file, API, and data element that would be accessed, with a full data audit |
 

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG VERSION=0.31.5
+ARG VERSION=0.31.6
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius analysis, policy enforcement, and SBOM generation for MCP servers and AI agents",
   "title": "agent-bom",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.5",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.6",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.31.5": {
+        "ghcr.io/msaad00/agent-bom:v0.31.6": {
           "tier": "Community",
           "status": "Active",
           "tags": [
@@ -47,7 +47,8 @@
             "registry_lookup",
             "generate_sbom",
             "compliance",
-            "remediate"
+            "remediate",
+            "skill_trust"
           ]
         }
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.31.5"
+version = "0.31.6"
 description = "AI Bill of Materials (AI-BOM) generator — CVE scanning, blast radius, enterprise remediation plans, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF threat mapping, LLM-powered enrichment, OpenClaw discovery, MCP runtime introspection, and MCP registry for AI agents."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.31.5"
+    __version__ = "0.31.6"

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -318,6 +318,7 @@ class AIBOMReport:
     ai_threat_chains: list[str] = field(default_factory=list)  # LLM-generated threat chain analyses
     mcp_config_analysis: Optional[dict] = None  # LLM-powered MCP config security analysis
     skill_audit_data: Optional[dict] = None  # Serialized SkillAuditResult (set by CLI)
+    trust_assessment_data: Optional[dict] = None  # Serialized TrustAssessmentResult (set by CLI)
     prompt_scan_data: Optional[dict] = None  # Serialized PromptScanResult (set by CLI)
     model_files: list[dict] = field(default_factory=list)
 

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1063,6 +1063,10 @@ def to_json(report: AIBOMReport) -> dict:
     if report.skill_audit_data:
         result["skill_audit"] = report.skill_audit_data
 
+    # Trust assessment (only when skill files were scanned)
+    if report.trust_assessment_data:
+        result["trust_assessment"] = report.trust_assessment_data
+
     if report.prompt_scan_data:
         result["prompt_scan"] = report.prompt_scan_data
 

--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -1,0 +1,682 @@
+"""ClawHub-style trust assessment for SKILL.md files.
+
+Evaluates skill files across 5 trust categories and produces an overall
+verdict with confidence level and actionable recommendations.
+
+Categories:
+    1. Purpose & Capability — name/description, required binaries, network consistency
+    2. Instruction Scope — file reads bounded, justification, data handling
+    3. Install Mechanism — install methods, source, provenance/signing
+    4. Credentials — proportionate, documented, scoped
+    5. Persistence & Privilege — no persistence, no escalation, no telemetry
+
+Usage:
+    from agent_bom.parsers.trust_assessment import assess_trust
+    result = assess_trust(scan_result, audit_result)
+    print(result.verdict, result.confidence)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_bom.parsers.skill_audit import SkillAuditResult
+    from agent_bom.parsers.skills import SkillMetadata, SkillScanResult
+
+
+# ── Enums ────────────────────────────────────────────────────────────────────
+
+
+class TrustLevel(str, Enum):
+    """Assessment status for each trust category."""
+
+    PASS = "pass"
+    INFO = "info"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+class Verdict(str, Enum):
+    """Overall trust verdict."""
+
+    BENIGN = "benign"
+    SUSPICIOUS = "suspicious"
+    MALICIOUS = "malicious"
+
+
+class Confidence(str, Enum):
+    """Confidence level in the verdict."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+# ── Data structures ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class TrustCategoryResult:
+    """Assessment result for a single trust category."""
+
+    name: str
+    key: str
+    level: TrustLevel
+    summary: str
+    details: list[str] = field(default_factory=list)
+    evidence: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TrustAssessmentResult:
+    """Complete trust assessment across all 5 categories."""
+
+    categories: list[TrustCategoryResult] = field(default_factory=list)
+    verdict: Verdict = Verdict.BENIGN
+    confidence: Confidence = Confidence.LOW
+    recommendations: list[str] = field(default_factory=list)
+    skill_name: str = ""
+    source_file: str = ""
+
+    @property
+    def worst_level(self) -> TrustLevel:
+        """Return the worst trust level across all categories."""
+        for level in (TrustLevel.FAIL, TrustLevel.WARN, TrustLevel.INFO, TrustLevel.PASS):
+            if any(c.level == level for c in self.categories):
+                return level
+        return TrustLevel.PASS
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "skill_name": self.skill_name,
+            "source_file": self.source_file,
+            "verdict": self.verdict.value,
+            "confidence": self.confidence.value,
+            "categories": [
+                {
+                    "name": c.name,
+                    "key": c.key,
+                    "level": c.level.value,
+                    "summary": c.summary,
+                    "details": c.details,
+                    "evidence": c.evidence,
+                }
+                for c in self.categories
+            ],
+            "recommendations": self.recommendations,
+        }
+
+
+# ── Frontmatter helpers ─────────────────────────────────────────────────────
+
+
+def _fm_has(raw: str, field_name: str) -> bool:
+    """Check if a YAML field exists in raw frontmatter text."""
+    return bool(re.search(rf"^\s*{re.escape(field_name)}\s*:", raw, re.MULTILINE))
+
+
+def _fm_value(raw: str, field_name: str) -> str | None:
+    """Extract a simple scalar value from raw frontmatter."""
+    match = re.search(rf"^\s*{re.escape(field_name)}\s*:\s*(.+)$", raw, re.MULTILINE)
+    return match.group(1).strip().strip("'\"") if match else None
+
+
+def _fm_list(raw: str, field_name: str) -> list[str]:
+    """Extract list items under a YAML field from raw frontmatter."""
+    section = re.search(
+        rf"^\s*{re.escape(field_name)}\s*:\s*\n((?:\s+-\s+.+\n?)+)", raw, re.MULTILINE
+    )
+    if not section:
+        return []
+    return re.findall(r"^\s+-\s+(.+)$", section.group(1), re.MULTILINE)
+
+
+def _audit_has_category(audit: SkillAuditResult, *categories: str) -> bool:
+    """Check if audit has any finding in the given categories."""
+    return any(f.category in categories for f in audit.findings)
+
+
+def _audit_findings_for(audit: SkillAuditResult, *categories: str) -> list:
+    """Get findings matching given categories."""
+    return [f for f in audit.findings if f.category in categories]
+
+
+# ── Category assessors ───────────────────────────────────────────────────────
+
+
+def _assess_purpose_capability(
+    meta: SkillMetadata | None,
+    scan: SkillScanResult,
+    audit: SkillAuditResult,
+) -> TrustCategoryResult:
+    """Category 1: Purpose & Capability."""
+    details: list[str] = []
+    evidence: list[str] = []
+
+    has_name = bool(meta and meta.name)
+    has_desc = bool(meta and meta.description)
+    has_bins = bool(meta and meta.required_bins)
+
+    if has_name:
+        details.append(f"Name declared: {meta.name}")
+    if has_desc:
+        details.append("Description provided")
+    if has_bins:
+        details.append(f"Required binaries: {', '.join(meta.required_bins)}")
+        evidence.append(f"bins: {meta.required_bins}")
+
+    # Check for undocumented shell/exec access
+    shell_findings = _audit_findings_for(audit, "shell_access", "dangerous_tool")
+    if shell_findings:
+        details.append(f"{len(shell_findings)} shell/exec access pattern(s) detected")
+        for f in shell_findings[:3]:
+            evidence.append(f"{f.category}: {f.title}")
+
+    # Check for undocumented network
+    raw = (meta.raw_frontmatter if meta else "")
+    has_network_docs = _fm_has(raw, "network_endpoints")
+
+    if shell_findings:
+        return TrustCategoryResult(
+            name="Purpose & Capability",
+            key="purpose_capability",
+            level=TrustLevel.FAIL,
+            summary="Shell/exec access detected — inconsistent with typical scanning tool",
+            details=details,
+            evidence=evidence,
+        )
+
+    if not has_name or not has_desc:
+        return TrustCategoryResult(
+            name="Purpose & Capability",
+            key="purpose_capability",
+            level=TrustLevel.WARN,
+            summary="Missing name or description in metadata",
+            details=details,
+            evidence=evidence,
+        )
+
+    if not has_bins:
+        return TrustCategoryResult(
+            name="Purpose & Capability",
+            key="purpose_capability",
+            level=TrustLevel.INFO,
+            summary="Name and description present but no required binaries declared",
+            details=details,
+            evidence=evidence,
+        )
+
+    return TrustCategoryResult(
+        name="Purpose & Capability",
+        key="purpose_capability",
+        level=TrustLevel.PASS,
+        summary="Name, description, and required binaries declared" + (
+            "; network endpoints documented" if has_network_docs else ""
+        ),
+        details=details,
+        evidence=evidence,
+    )
+
+
+def _assess_instruction_scope(
+    meta: SkillMetadata | None,
+    scan: SkillScanResult,
+    audit: SkillAuditResult,
+) -> TrustCategoryResult:
+    """Category 2: Instruction Scope."""
+    details: list[str] = []
+    evidence: list[str] = []
+
+    raw = (meta.raw_frontmatter if meta else "")
+    has_file_reads = _fm_has(raw, "file_reads")
+    has_justification = _fm_has(raw, "file_reads_justification")
+    has_data_handling = _fm_has(raw, "sensitive_data_handling")
+    has_file_writes = _fm_has(raw, "file_writes")
+
+    if has_file_reads:
+        file_reads = _fm_list(raw, "file_reads")
+        details.append(f"File reads enumerated: {len(file_reads)} path(s)")
+    if has_justification:
+        details.append("File reads justification provided")
+    if has_data_handling:
+        details.append("Sensitive data handling documented")
+    if has_file_writes:
+        writes = _fm_list(raw, "file_writes")
+        if not writes:
+            details.append("No file writes declared (read-only)")
+        else:
+            details.append(f"File writes declared: {len(writes)} path(s)")
+            evidence.append(f"file_writes: {writes}")
+
+    # Check for credential file access or data exfiltration
+    dangerous_scope = _audit_findings_for(
+        audit, "credential_file_access", "data_exfiltration", "memory_poisoning"
+    )
+    if dangerous_scope:
+        for f in dangerous_scope[:3]:
+            details.append(f"Behavioral finding: {f.title}")
+            evidence.append(f"{f.category}: {f.detail[:100]}")
+
+    if dangerous_scope:
+        return TrustCategoryResult(
+            name="Instruction Scope",
+            key="instruction_scope",
+            level=TrustLevel.FAIL,
+            summary="Credential file access or data exfiltration pattern detected",
+            details=details,
+            evidence=evidence,
+        )
+
+    if not has_file_reads and not raw:
+        return TrustCategoryResult(
+            name="Instruction Scope",
+            key="instruction_scope",
+            level=TrustLevel.WARN,
+            summary="No metadata — cannot verify instruction scope",
+            details=details,
+            evidence=evidence,
+        )
+
+    if not has_file_reads:
+        return TrustCategoryResult(
+            name="Instruction Scope",
+            key="instruction_scope",
+            level=TrustLevel.WARN,
+            summary="No file_reads declared — scope unclear",
+            details=details,
+            evidence=evidence,
+        )
+
+    if has_file_reads and not has_justification:
+        return TrustCategoryResult(
+            name="Instruction Scope",
+            key="instruction_scope",
+            level=TrustLevel.INFO,
+            summary="File reads listed but no justification provided",
+            details=details,
+            evidence=evidence,
+        )
+
+    return TrustCategoryResult(
+        name="Instruction Scope",
+        key="instruction_scope",
+        level=TrustLevel.PASS,
+        summary="File reads bounded and justified" + (
+            "; data handling documented" if has_data_handling else ""
+        ),
+        details=details,
+        evidence=evidence,
+    )
+
+
+def _assess_install_mechanism(
+    meta: SkillMetadata | None,
+    scan: SkillScanResult,
+    audit: SkillAuditResult,
+) -> TrustCategoryResult:
+    """Category 3: Install Mechanism."""
+    details: list[str] = []
+    evidence: list[str] = []
+
+    raw = (meta.raw_frontmatter if meta else "")
+    has_source = bool(meta and meta.source)
+    has_homepage = bool(meta and meta.homepage)
+    install_methods = meta.install_methods if meta else []
+
+    if install_methods:
+        details.append(f"Install methods: {', '.join(install_methods)}")
+    if has_source:
+        details.append(f"Source: {meta.source}")
+        evidence.append(f"source: {meta.source}")
+    if has_homepage:
+        details.append(f"Homepage: {meta.homepage}")
+
+    # Check for verification/signing references
+    has_signing = bool(
+        re.search(r"(?:sigstore|cosign|checksum|sha256|provenance|slsa)", raw, re.IGNORECASE)
+    )
+    if has_signing:
+        details.append("Signing/provenance references found in metadata")
+
+    if not install_methods and not has_source:
+        return TrustCategoryResult(
+            name="Install Mechanism",
+            key="install_mechanism",
+            level=TrustLevel.FAIL,
+            summary="No install methods and no source URL — cannot verify provenance",
+            details=details,
+            evidence=evidence,
+        )
+
+    if not has_source:
+        return TrustCategoryResult(
+            name="Install Mechanism",
+            key="install_mechanism",
+            level=TrustLevel.WARN,
+            summary="No source URL provided — cannot audit code",
+            details=details,
+            evidence=evidence,
+        )
+
+    if len(install_methods) < 2 and not has_signing:
+        return TrustCategoryResult(
+            name="Install Mechanism",
+            key="install_mechanism",
+            level=TrustLevel.INFO,
+            summary="Source available but limited install methods or no signing references",
+            details=details,
+            evidence=evidence,
+        )
+
+    return TrustCategoryResult(
+        name="Install Mechanism",
+        key="install_mechanism",
+        level=TrustLevel.PASS,
+        summary=f"{len(install_methods)} install method(s), source available" + (
+            ", signed" if has_signing else ""
+        ),
+        details=details,
+        evidence=evidence,
+    )
+
+
+def _assess_credentials(
+    meta: SkillMetadata | None,
+    scan: SkillScanResult,
+    audit: SkillAuditResult,
+) -> TrustCategoryResult:
+    """Category 4: Credentials."""
+    details: list[str] = []
+    evidence: list[str] = []
+
+    raw = (meta.raw_frontmatter if meta else "")
+    cred_count = len(scan.credential_env_vars)
+    has_optional_env = _fm_has(raw, "optional_env")
+    has_required_env = _fm_has(raw, "env")
+    has_sent_only_to = "sent_only_to" in raw if raw else False
+
+    # Check what's declared
+    required_env_list = _fm_list(raw, "env")
+    env_empty = _fm_value(raw, "env")  # check for "env: []"
+
+    if cred_count == 0:
+        details.append("No credential env vars referenced")
+    else:
+        details.append(f"{cred_count} credential env var(s) referenced")
+        evidence.append(f"credentials: {scan.credential_env_vars[:5]}")
+
+    if has_optional_env:
+        details.append("Optional env vars documented")
+    if has_sent_only_to:
+        details.append("Credential scope documented (sent_only_to)")
+
+    # Excessive credentials from audit
+    excessive = _audit_findings_for(audit, "excessive_permissions")
+    bypass = _audit_findings_for(audit, "confirmation_bypass")
+
+    if bypass and cred_count > 0:
+        return TrustCategoryResult(
+            name="Credentials",
+            key="credentials",
+            level=TrustLevel.FAIL,
+            summary="Safety bypass patterns combined with credential access",
+            details=details,
+            evidence=evidence,
+        )
+
+    if excessive and not (has_optional_env and has_sent_only_to):
+        details.append("Excessive credential exposure detected")
+        return TrustCategoryResult(
+            name="Credentials",
+            key="credentials",
+            level=TrustLevel.WARN,
+            summary=f"Excessive credentials ({cred_count} env vars) — review scope",
+            details=details,
+            evidence=evidence,
+        )
+
+    if cred_count > 0 and not has_optional_env and not required_env_list:
+        return TrustCategoryResult(
+            name="Credentials",
+            key="credentials",
+            level=TrustLevel.INFO,
+            summary=f"{cred_count} credential(s) referenced but not documented in metadata",
+            details=details,
+            evidence=evidence,
+        )
+
+    return TrustCategoryResult(
+        name="Credentials",
+        key="credentials",
+        level=TrustLevel.PASS,
+        summary="No required credentials" + (
+            f"; {cred_count} optional, documented" if cred_count > 0 and has_optional_env
+            else ""
+        ),
+        details=details,
+        evidence=evidence,
+    )
+
+
+def _assess_persistence_privilege(
+    meta: SkillMetadata | None,
+    scan: SkillScanResult,
+    audit: SkillAuditResult,
+) -> TrustCategoryResult:
+    """Category 5: Persistence & Privilege."""
+    details: list[str] = []
+    evidence: list[str] = []
+
+    raw = (meta.raw_frontmatter if meta else "")
+
+    # Check frontmatter declarations
+    persistence_val = _fm_value(raw, "persistence")
+    telemetry_val = _fm_value(raw, "telemetry")
+    priv_esc_val = _fm_value(raw, "privilege_escalation")
+
+    if persistence_val is not None:
+        details.append(f"persistence: {persistence_val}")
+    if telemetry_val is not None:
+        details.append(f"telemetry: {telemetry_val}")
+    if priv_esc_val is not None:
+        details.append(f"privilege_escalation: {priv_esc_val}")
+
+    # Check audit behavioral findings
+    priv_findings = _audit_findings_for(
+        audit, "persistence_mechanism", "privilege_escalation", "confirmation_bypass"
+    )
+    if priv_findings:
+        for f in priv_findings[:3]:
+            details.append(f"Behavioral finding: {f.title}")
+            evidence.append(f"{f.category}: {f.detail[:100]}")
+
+    if priv_findings:
+        return TrustCategoryResult(
+            name="Persistence & Privilege",
+            key="persistence_privilege",
+            level=TrustLevel.FAIL,
+            summary="Privilege escalation or persistence mechanism detected",
+            details=details,
+            evidence=evidence,
+        )
+
+    # No frontmatter at all → cannot verify
+    if not raw:
+        return TrustCategoryResult(
+            name="Persistence & Privilege",
+            key="persistence_privilege",
+            level=TrustLevel.WARN,
+            summary="No metadata — cannot verify persistence or privilege claims",
+            details=details,
+            evidence=evidence,
+        )
+
+    # Frontmatter exists but missing key fields
+    missing = []
+    if persistence_val is None:
+        missing.append("persistence")
+    if telemetry_val is None:
+        missing.append("telemetry")
+    if priv_esc_val is None:
+        missing.append("privilege_escalation")
+
+    if missing:
+        return TrustCategoryResult(
+            name="Persistence & Privilege",
+            key="persistence_privilege",
+            level=TrustLevel.INFO,
+            summary=f"Missing field(s): {', '.join(missing)} — cannot fully verify",
+            details=details,
+            evidence=evidence,
+        )
+
+    # All declared as false → best case
+    all_false = (
+        persistence_val and persistence_val.lower() == "false"
+        and telemetry_val and telemetry_val.lower() == "false"
+        and priv_esc_val and priv_esc_val.lower() == "false"
+    )
+
+    if all_false:
+        return TrustCategoryResult(
+            name="Persistence & Privilege",
+            key="persistence_privilege",
+            level=TrustLevel.PASS,
+            summary="No persistence, no telemetry, no privilege escalation declared",
+            details=details,
+            evidence=evidence,
+        )
+
+    return TrustCategoryResult(
+        name="Persistence & Privilege",
+        key="persistence_privilege",
+        level=TrustLevel.INFO,
+        summary="Persistence/telemetry/privilege fields present but not all false",
+        details=details,
+        evidence=evidence,
+    )
+
+
+# ── Verdict computation ──────────────────────────────────────────────────────
+
+
+def _compute_verdict(
+    categories: list[TrustCategoryResult],
+) -> tuple[Verdict, Confidence]:
+    """Compute overall verdict and confidence from category results."""
+    fail_count = sum(1 for c in categories if c.level == TrustLevel.FAIL)
+    warn_count = sum(1 for c in categories if c.level == TrustLevel.WARN)
+    pass_count = sum(1 for c in categories if c.level == TrustLevel.PASS)
+    info_count = sum(1 for c in categories if c.level == TrustLevel.INFO)
+
+    if fail_count >= 2:
+        return Verdict.MALICIOUS, Confidence.HIGH
+    if fail_count == 1 and warn_count >= 2:
+        return Verdict.MALICIOUS, Confidence.MEDIUM
+    if fail_count == 1:
+        return Verdict.SUSPICIOUS, Confidence.MEDIUM
+    if warn_count >= 3:
+        return Verdict.SUSPICIOUS, Confidence.MEDIUM
+    if warn_count >= 1:
+        return Verdict.SUSPICIOUS, Confidence.LOW
+    if pass_count == len(categories):
+        return Verdict.BENIGN, Confidence.HIGH
+    if pass_count + info_count == len(categories):
+        return Verdict.BENIGN, Confidence.MEDIUM
+    return Verdict.BENIGN, Confidence.LOW
+
+
+# ── Recommendations ──────────────────────────────────────────────────────────
+
+
+def _generate_recommendations(categories: list[TrustCategoryResult]) -> list[str]:
+    """Generate actionable recommendations based on category results."""
+    recs: list[str] = []
+
+    for cat in categories:
+        if cat.level == TrustLevel.PASS:
+            continue
+
+        if cat.key == "purpose_capability":
+            if cat.level == TrustLevel.FAIL:
+                recs.append("Remove shell/exec access or document why it is needed")
+            elif cat.level == TrustLevel.WARN:
+                recs.append("Add name and description to YAML frontmatter")
+            else:
+                recs.append("Declare required binaries in requires.bins")
+
+        elif cat.key == "instruction_scope":
+            if cat.level == TrustLevel.FAIL:
+                recs.append("Remove credential file access patterns or isolate the tool")
+            elif cat.level == TrustLevel.WARN:
+                recs.append("Add file_reads list to enumerate all config paths accessed")
+            else:
+                recs.append("Add file_reads_justification explaining why each path is needed")
+
+        elif cat.key == "install_mechanism":
+            if cat.level == TrustLevel.FAIL:
+                recs.append("Provide at least one install method and a source URL")
+            elif cat.level == TrustLevel.WARN:
+                recs.append("Add source URL to metadata for code audit")
+            else:
+                recs.append("Add Sigstore/cosign signing or provide multiple install methods")
+
+        elif cat.key == "credentials":
+            if cat.level == TrustLevel.FAIL:
+                recs.append("Remove safety bypass patterns or revoke credential access")
+            elif cat.level == TrustLevel.WARN:
+                recs.append("Reduce credential count or scope with sent_only_to")
+            else:
+                recs.append("Document credentials in optional_env with sent_only_to scope")
+
+        elif cat.key == "persistence_privilege":
+            if cat.level == TrustLevel.FAIL:
+                recs.append("Remove privilege escalation or persistence mechanisms")
+            elif cat.level == TrustLevel.WARN:
+                recs.append("Add persistence, telemetry, and privilege_escalation fields to metadata")
+            else:
+                recs.append("Set persistence: false, telemetry: false, and privilege_escalation: false")
+
+    return recs
+
+
+# ── Main entry point ─────────────────────────────────────────────────────────
+
+
+def assess_trust(
+    scan: SkillScanResult,
+    audit: SkillAuditResult,
+) -> TrustAssessmentResult:
+    """Run ClawHub-style trust assessment on a parsed skill file.
+
+    Requires the skill to have been parsed (scan_skill_files) and audited
+    (audit_skill_result) first. Evaluates 5 trust categories and returns
+    an overall verdict with confidence and recommendations.
+    """
+    meta = scan.metadata
+    source_file = scan.source_files[0] if scan.source_files else "unknown"
+
+    categories = [
+        _assess_purpose_capability(meta, scan, audit),
+        _assess_instruction_scope(meta, scan, audit),
+        _assess_install_mechanism(meta, scan, audit),
+        _assess_credentials(meta, scan, audit),
+        _assess_persistence_privilege(meta, scan, audit),
+    ]
+
+    verdict, confidence = _compute_verdict(categories)
+    recommendations = _generate_recommendations(categories)
+
+    return TrustAssessmentResult(
+        categories=categories,
+        verdict=verdict,
+        confidence=confidence,
+        recommendations=recommendations,
+        skill_name=meta.name if meta else "",
+        source_file=source_file,
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,7 +255,7 @@ def empty_report():
 
 def test_version_sync():
     from agent_bom import __version__
-    assert __version__ == "0.31.5"
+    assert __version__ == "0.31.6"
 
 
 def test_report_version_matches():
@@ -2795,7 +2795,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.31.5"
+    assert data["version"] == "0.31.6"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -124,7 +124,7 @@ def test_server_card_has_all_tools():
     assert card["name"] == "agent-bom"
     assert "version" in card
     tool_names = [t["name"] for t in card["tools"]]
-    assert len(tool_names) == 8
+    assert len(tool_names) == 9
     assert "scan" in tool_names
     assert "check" in tool_names
     assert "blast_radius" in tool_names
@@ -132,6 +132,7 @@ def test_server_card_has_all_tools():
     assert "registry_lookup" in tool_names
     assert "generate_sbom" in tool_names
     assert "compliance" in tool_names
+    assert "skill_trust" in tool_names
     assert "remediate" in tool_names
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -54,12 +54,12 @@ def test_create_mcp_server_returns_object():
     assert server.name == "agent-bom"
 
 
-def test_mcp_server_has_eight_tools():
-    """Server should register exactly 8 tools."""
+def test_mcp_server_has_nine_tools():
+    """Server should register exactly 9 tools."""
     from agent_bom.mcp_server import create_mcp_server
     server = create_mcp_server()
     tools = _run(server.list_tools())
-    assert len(tools) == 8
+    assert len(tools) == 9
 
 
 def test_mcp_server_tool_names():
@@ -70,7 +70,7 @@ def test_mcp_server_tool_names():
     names = {t.name for t in tools}
     assert names == {
         "scan", "check", "blast_radius", "policy_check", "registry_lookup",
-        "generate_sbom", "compliance", "remediate",
+        "generate_sbom", "compliance", "remediate", "skill_trust",
     }
 
 

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -1,0 +1,575 @@
+"""Tests for ClawHub-style trust assessment."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_bom.parsers.skill_audit import SkillAuditResult, SkillFinding, audit_skill_result
+from agent_bom.parsers.skills import SkillMetadata, SkillScanResult
+from agent_bom.parsers.trust_assessment import (
+    Confidence,
+    TrustAssessmentResult,
+    TrustCategoryResult,
+    TrustLevel,
+    Verdict,
+    _compute_verdict,
+    _generate_recommendations,
+    assess_trust,
+)
+
+# ── Helper: build a well-formed SKILL.md frontmatter ────────────────────────
+
+_GOOD_FRONTMATTER = """\
+name: test-tool
+description: A test security scanner
+version: 1.0.0
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - test-tool
+      optional_bins:
+        - docker
+      env: []
+    optional_env:
+      - name: API_KEY
+        purpose: "Rate limit increase"
+        sent_only_to: "https://api.example.com"
+        required: false
+    homepage: https://github.com/example/test-tool
+    source: https://github.com/example/test-tool
+    license: MIT
+    install:
+      - kind: pip
+        package: test-tool
+      - kind: pipx
+        package: test-tool
+      - kind: uv
+        package: test-tool
+    file_reads:
+      - "~/.config/test/config.json"
+    file_reads_justification: |
+      Reads the test config to discover servers.
+    file_writes: []
+    network_endpoints:
+      - url: "https://api.example.com"
+        purpose: "Vulnerability lookup"
+        auth: false
+    sensitive_data_handling:
+      in_memory_only: true
+      written_to_disk: false
+    checksums:
+      sigstore_signed: true
+    telemetry: false
+    persistence: false
+    privilege_escalation: false
+"""
+
+_MINIMAL_FRONTMATTER = """\
+name: minimal
+description: Minimal tool
+version: 0.1.0
+"""
+
+
+def _make_scan(
+    frontmatter: str = _GOOD_FRONTMATTER,
+    cred_vars: list[str] | None = None,
+    source_files: list[str] | None = None,
+) -> SkillScanResult:
+    """Build a SkillScanResult with given frontmatter."""
+    meta = SkillMetadata(
+        raw_frontmatter=frontmatter,
+        name=_extract_yaml(frontmatter, "name"),
+        description=_extract_yaml(frontmatter, "description"),
+        source=_extract_yaml(frontmatter, "source"),
+        homepage=_extract_yaml(frontmatter, "homepage"),
+        license=_extract_yaml(frontmatter, "license"),
+    )
+    # Extract bins and install methods from frontmatter
+    import re
+    bins_match = re.search(r"requires:\s*\n\s+bins:\s*\n((?:\s+-\s+\S+\n?)+)", frontmatter)
+    if bins_match:
+        meta.required_bins = re.findall(r"^\s+-\s+(.+)$", bins_match.group(1), re.MULTILINE)
+    for kind in re.finditer(r"kind:\s*(\w+)", frontmatter):
+        meta.install_methods.append(kind.group(1))
+
+    return SkillScanResult(
+        metadata=meta,
+        credential_env_vars=cred_vars or [],
+        source_files=source_files or ["SKILL.md"],
+    )
+
+
+def _extract_yaml(raw: str, key: str) -> str:
+    """Extract a simple key: value from YAML-ish text."""
+    import re
+    m = re.search(rf"^\s*{key}:\s*(.+)$", raw, re.MULTILINE)
+    return m.group(1).strip().strip("'\"") if m else ""
+
+
+def _make_audit(**overrides) -> SkillAuditResult:
+    """Build a SkillAuditResult with optional overrides."""
+    defaults = {
+        "findings": [],
+        "packages_checked": 0,
+        "servers_checked": 0,
+        "credentials_checked": 0,
+        "passed": True,
+    }
+    defaults.update(overrides)
+    return SkillAuditResult(**defaults)
+
+
+def _finding(category: str, severity: str = "high", title: str = "test") -> SkillFinding:
+    """Build a minimal SkillFinding."""
+    return SkillFinding(
+        severity=severity,
+        category=category,
+        title=title,
+        detail="test detail",
+        source_file="SKILL.md",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. Data structure tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_trust_level_enum_values():
+    """TrustLevel has pass/info/warn/fail."""
+    assert TrustLevel.PASS.value == "pass"
+    assert TrustLevel.INFO.value == "info"
+    assert TrustLevel.WARN.value == "warn"
+    assert TrustLevel.FAIL.value == "fail"
+
+
+def test_verdict_enum_values():
+    """Verdict has benign/suspicious/malicious."""
+    assert Verdict.BENIGN.value == "benign"
+    assert Verdict.SUSPICIOUS.value == "suspicious"
+    assert Verdict.MALICIOUS.value == "malicious"
+
+
+def test_confidence_enum_values():
+    """Confidence has high/medium/low."""
+    assert Confidence.HIGH.value == "high"
+    assert Confidence.MEDIUM.value == "medium"
+    assert Confidence.LOW.value == "low"
+
+
+def test_trust_assessment_result_to_dict():
+    """TrustAssessmentResult serializes correctly."""
+    result = TrustAssessmentResult(
+        categories=[
+            TrustCategoryResult(
+                name="Test", key="test", level=TrustLevel.PASS,
+                summary="All good", details=["detail1"], evidence=["ev1"],
+            )
+        ],
+        verdict=Verdict.BENIGN,
+        confidence=Confidence.HIGH,
+        recommendations=[],
+        skill_name="test-tool",
+        source_file="SKILL.md",
+    )
+    d = result.to_dict()
+    assert d["verdict"] == "benign"
+    assert d["confidence"] == "high"
+    assert d["skill_name"] == "test-tool"
+    assert len(d["categories"]) == 1
+    assert d["categories"][0]["level"] == "pass"
+    assert d["categories"][0]["key"] == "test"
+
+
+def test_worst_level_property():
+    """worst_level returns the most severe level across categories."""
+    result = TrustAssessmentResult(
+        categories=[
+            TrustCategoryResult(name="A", key="a", level=TrustLevel.PASS, summary="ok"),
+            TrustCategoryResult(name="B", key="b", level=TrustLevel.WARN, summary="warn"),
+            TrustCategoryResult(name="C", key="c", level=TrustLevel.INFO, summary="info"),
+        ],
+    )
+    assert result.worst_level == TrustLevel.WARN
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. Category assessment tests — Purpose & Capability
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_purpose_capability_pass():
+    """Full metadata → PASS."""
+    scan = _make_scan()
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "purpose_capability")
+    assert cat.level == TrustLevel.PASS
+
+
+def test_purpose_capability_warn_no_name():
+    """Missing name → WARN."""
+    fm = "description: A tool\nversion: 1.0\n"
+    scan = _make_scan(frontmatter=fm)
+    scan.metadata.name = ""
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "purpose_capability")
+    assert cat.level == TrustLevel.WARN
+
+
+def test_purpose_capability_fail_shell_access():
+    """Shell access findings → FAIL."""
+    scan = _make_scan()
+    audit = _make_audit(findings=[_finding("shell_access")])
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "purpose_capability")
+    assert cat.level == TrustLevel.FAIL
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. Category assessment tests — Instruction Scope
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_instruction_scope_pass():
+    """file_reads + justification + data handling → PASS."""
+    scan = _make_scan()
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "instruction_scope")
+    assert cat.level == TrustLevel.PASS
+
+
+def test_instruction_scope_warn_no_file_reads():
+    """No file_reads → WARN."""
+    fm = _MINIMAL_FRONTMATTER  # has name/description but no file_reads
+    scan = _make_scan(frontmatter=fm)
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "instruction_scope")
+    assert cat.level == TrustLevel.WARN
+
+
+def test_instruction_scope_fail_credential_access():
+    """Credential file access → FAIL."""
+    scan = _make_scan()
+    audit = _make_audit(findings=[_finding("credential_file_access", severity="critical")])
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "instruction_scope")
+    assert cat.level == TrustLevel.FAIL
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. Category assessment tests — Install Mechanism
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_install_mechanism_pass():
+    """Multiple install methods + source + signing → PASS."""
+    scan = _make_scan()
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "install_mechanism")
+    assert cat.level == TrustLevel.PASS
+
+
+def test_install_mechanism_warn_no_source():
+    """No source URL → WARN."""
+    fm = "name: test\ndescription: test\nversion: 1.0\nmetadata:\n  openclaw:\n    install:\n      - kind: pip\n        package: test\n"
+    scan = _make_scan(frontmatter=fm)
+    scan.metadata.source = ""
+    scan.metadata.homepage = ""
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "install_mechanism")
+    assert cat.level == TrustLevel.WARN
+
+
+def test_install_mechanism_fail_no_install_no_source():
+    """No install methods and no source → FAIL."""
+    fm = "name: test\ndescription: test\nversion: 1.0\n"
+    scan = _make_scan(frontmatter=fm)
+    scan.metadata.source = ""
+    scan.metadata.install_methods = []
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "install_mechanism")
+    assert cat.level == TrustLevel.FAIL
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Category assessment tests — Credentials
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_credentials_pass_none():
+    """No credentials → PASS."""
+    scan = _make_scan(cred_vars=[])
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "credentials")
+    assert cat.level == TrustLevel.PASS
+
+
+def test_credentials_warn_excessive_undocumented():
+    """Excessive credentials without documentation → WARN."""
+    fm = "name: test\ndescription: test\nversion: 1.0\n"
+    scan = _make_scan(frontmatter=fm, cred_vars=["KEY1", "KEY2", "KEY3"])
+    audit = _make_audit(findings=[_finding("excessive_permissions", severity="medium")])
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "credentials")
+    assert cat.level == TrustLevel.WARN
+
+
+def test_credentials_fail_bypass_with_creds():
+    """Safety bypass + credential access → FAIL."""
+    scan = _make_scan(cred_vars=["SECRET_KEY"])
+    audit = _make_audit(findings=[_finding("confirmation_bypass", severity="critical")])
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "credentials")
+    assert cat.level == TrustLevel.FAIL
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. Category assessment tests — Persistence & Privilege
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_persistence_privilege_pass():
+    """All false → PASS."""
+    scan = _make_scan()
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "persistence_privilege")
+    assert cat.level == TrustLevel.PASS
+
+
+def test_persistence_privilege_warn_no_metadata():
+    """No frontmatter at all → WARN."""
+    scan = SkillScanResult(
+        metadata=SkillMetadata(raw_frontmatter=""),
+        source_files=["CLAUDE.md"],
+    )
+    # Patch out the empty raw_frontmatter
+    scan.metadata = SkillMetadata()  # no raw_frontmatter
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "persistence_privilege")
+    assert cat.level == TrustLevel.WARN
+
+
+def test_persistence_privilege_fail_escalation():
+    """Privilege escalation detected → FAIL."""
+    scan = _make_scan()
+    audit = _make_audit(findings=[_finding("privilege_escalation", severity="high")])
+    result = assess_trust(scan, audit)
+    cat = next(c for c in result.categories if c.key == "persistence_privilege")
+    assert cat.level == TrustLevel.FAIL
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. Verdict computation tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _cats(*levels: TrustLevel) -> list[TrustCategoryResult]:
+    """Build minimal categories with given levels."""
+    return [
+        TrustCategoryResult(name=f"Cat{i}", key=f"cat{i}", level=lv, summary="")
+        for i, lv in enumerate(levels)
+    ]
+
+
+def test_verdict_all_pass_is_benign_high():
+    verdict, conf = _compute_verdict(_cats(
+        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
+        TrustLevel.PASS, TrustLevel.PASS,
+    ))
+    assert verdict == Verdict.BENIGN
+    assert conf == Confidence.HIGH
+
+
+def test_verdict_pass_plus_info_is_benign_medium():
+    verdict, conf = _compute_verdict(_cats(
+        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
+        TrustLevel.INFO, TrustLevel.INFO,
+    ))
+    assert verdict == Verdict.BENIGN
+    assert conf == Confidence.MEDIUM
+
+
+def test_verdict_one_warn_is_suspicious_low():
+    verdict, conf = _compute_verdict(_cats(
+        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
+        TrustLevel.PASS, TrustLevel.WARN,
+    ))
+    assert verdict == Verdict.SUSPICIOUS
+    assert conf == Confidence.LOW
+
+
+def test_verdict_three_warns_is_suspicious_medium():
+    verdict, conf = _compute_verdict(_cats(
+        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.WARN,
+        TrustLevel.WARN, TrustLevel.WARN,
+    ))
+    assert verdict == Verdict.SUSPICIOUS
+    assert conf == Confidence.MEDIUM
+
+
+def test_verdict_one_fail_is_suspicious_medium():
+    verdict, conf = _compute_verdict(_cats(
+        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
+        TrustLevel.PASS, TrustLevel.FAIL,
+    ))
+    assert verdict == Verdict.SUSPICIOUS
+    assert conf == Confidence.MEDIUM
+
+
+def test_verdict_two_fails_is_malicious_high():
+    verdict, conf = _compute_verdict(_cats(
+        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
+        TrustLevel.FAIL, TrustLevel.FAIL,
+    ))
+    assert verdict == Verdict.MALICIOUS
+    assert conf == Confidence.HIGH
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 8. Recommendation tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_no_recommendations_when_all_pass():
+    recs = _generate_recommendations(_cats(
+        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
+        TrustLevel.PASS, TrustLevel.PASS,
+    ))
+    assert recs == []
+
+
+def test_recommendations_for_warn():
+    """WARN categories generate recommendations."""
+    cats = [
+        TrustCategoryResult(
+            name="Install Mechanism", key="install_mechanism",
+            level=TrustLevel.WARN, summary="No source",
+        ),
+    ]
+    recs = _generate_recommendations(cats)
+    assert len(recs) >= 1
+    assert any("source" in r.lower() for r in recs)
+
+
+def test_recommendations_for_fail():
+    """FAIL categories generate recommendations."""
+    cats = [
+        TrustCategoryResult(
+            name="Persistence & Privilege", key="persistence_privilege",
+            level=TrustLevel.FAIL, summary="Privilege escalation",
+        ),
+    ]
+    recs = _generate_recommendations(cats)
+    assert len(recs) >= 1
+    assert any("privilege" in r.lower() or "escalation" in r.lower() for r in recs)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 9. Integration tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_assess_trust_end_to_end():
+    """Full pipeline: parse → audit → assess for a well-formed skill."""
+    scan = _make_scan()
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+
+    assert len(result.categories) == 5
+    assert result.verdict == Verdict.BENIGN
+    assert result.confidence == Confidence.HIGH
+    assert result.skill_name == "test-tool"
+    assert result.source_file == "SKILL.md"
+
+    # All 5 categories should be PASS for the well-formed frontmatter
+    for cat in result.categories:
+        assert cat.level == TrustLevel.PASS, f"{cat.name} expected PASS, got {cat.level}"
+
+
+def test_assess_trust_no_frontmatter():
+    """Gracefully handles scan result with no metadata."""
+    scan = SkillScanResult(
+        metadata=None,
+        source_files=["CLAUDE.md"],
+    )
+    audit = _make_audit()
+    result = assess_trust(scan, audit)
+
+    assert len(result.categories) == 5
+    # Without metadata, most categories should be WARN or INFO
+    assert result.verdict in (Verdict.SUSPICIOUS, Verdict.MALICIOUS)
+
+
+def test_assess_trust_agent_bom_skill():
+    """Our own SKILL.md should score benign."""
+    skill_path = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"
+    if not skill_path.exists():
+        return  # Skip if not in the repo
+
+    from agent_bom.parsers.skills import parse_skill_file
+
+    scan = parse_skill_file(skill_path)
+    with patch("agent_bom.parsers.skill_audit._batch_verify_packages_sync",
+               return_value={}):
+        audit = audit_skill_result(scan)
+    result = assess_trust(scan, audit)
+
+    assert result.verdict == Verdict.BENIGN
+    assert result.confidence in (Confidence.HIGH, Confidence.MEDIUM)
+
+
+def test_trust_assessment_in_json_output():
+    """trust_assessment appears in JSON output when set."""
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output import to_json
+
+    report = AIBOMReport()
+    report.trust_assessment_data = {
+        "verdict": "benign",
+        "confidence": "high",
+        "categories": [],
+    }
+    data = to_json(report)
+    assert "trust_assessment" in data
+    assert data["trust_assessment"]["verdict"] == "benign"
+
+
+def test_trust_assessment_absent_when_no_skill():
+    """trust_assessment not in JSON when no skill files scanned."""
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output import to_json
+
+    report = AIBOMReport()
+    data = to_json(report)
+    assert "trust_assessment" not in data
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 10. MCP tool tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_mcp_skill_trust_tool_exists():
+    """skill_trust tool is registered on the MCP server."""
+    from agent_bom.mcp_server import _SERVER_CARD_TOOLS
+
+    tool_names = [t["name"] for t in _SERVER_CARD_TOOLS]
+    assert "skill_trust" in tool_names
+
+
+def test_mcp_server_card_has_9_tools():
+    """Server card lists 9 tools."""
+    from agent_bom.mcp_server import _SERVER_CARD_TOOLS
+
+    assert len(_SERVER_CARD_TOOLS) == 9


### PR DESCRIPTION
## Summary

- New `trust_assessment.py` module — ClawHub-style 5-category trust assessment for SKILL.md files
- New MCP tool `skill_trust` (tool 9) — assess trust level of any skill file via MCP
- Console rich panel showing category verdicts + overall assessment
- JSON output integration (`trust_assessment` key in report)
- SKILL.md enhanced with checksums/provenance metadata for ClawHub high confidence
- 36 new tests (1007 total), all passing

### Trust Categories

| Category | What it checks |
|----------|---------------|
| Purpose & Capability | name/description, required binaries, network consistency |
| Instruction Scope | file reads bounded, justification, data handling documented |
| Install Mechanism | install methods, source URL, provenance/signing |
| Credentials | proportionate, documented, scoped with sent_only_to |
| Persistence & Privilege | persistence/telemetry/escalation claims |

Verdict: benign / suspicious / malicious with confidence: high / medium / low

## Test plan

- [x] 36 new tests in `test_trust_assessment.py`
- [x] 1007 total tests passing
- [x] ruff clean
- [x] Our own SKILL.md scores benign/high
- [x] Version bump 0.31.5 → 0.31.6 across all 10 files