### PR TITLE
fix: Smithery publish payload field name

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -59,7 +59,7 @@ jobs:
             -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
             -F "payload={
               \"type\": \"external\",
-              \"url\": \"${MCP_URL}\",
+              \"upstreamUrl\": \"${MCP_URL}\",
               \"configSchema\": {
                 \"type\": \"object\",
                 \"properties\": {


### PR DESCRIPTION
## Summary
- Fixed Smithery API 400 error by renaming `url` → `upstreamUrl` in the external deployment payload
- The Smithery API schema requires `upstreamUrl` for external type releases, not `url`

## Test plan
- [ ] Merge and re-trigger publish-registries workflow
- [ ] Verify Smithery publish succeeds with HTTP 2xx
- [ ] Confirm server appears updated on smithery.ai