### PR TITLE
fix: Smithery build error + add andres-linero to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Default code owners — all PRs require review from repo owner
-* @msaad00
+# Default code owners — PRs require review from at least one owner
+* @msaad00 @andres-linero

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -65,16 +65,7 @@ jobs:
             -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
             -F "payload={
               \"type\": \"external\",
-              \"upstreamUrl\": \"${MCP_URL}\",
-              \"configSchema\": {
-                \"type\": \"object\",
-                \"properties\": {
-                  \"NVD_API_KEY\": {
-                    \"type\": \"string\",
-                    \"description\": \"NVD API key for higher rate limits on CVSS enrichment (optional)\"
-                  }
-                }
-              }
+              \"upstreamUrl\": \"${MCP_URL}\"
             }")
 
           echo "Smithery response (HTTP ${HTTP_STATUS}):"


### PR DESCRIPTION
## Summary
- Remove `configSchema` from Smithery publish payload to fix "Config is undefined" build error (Smithery instrumentation bug with external servers)
- Add @andres-linero to `.github/CODEOWNERS` for PR review approval

## Test plan
- [ ] Re-trigger Smithery publish after merge — Build step should pass
- [ ] Andres-linero can approve PRs as code owner