### PR TITLE
fix: handle ClawHub version-already-exists gracefully

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -122,10 +122,12 @@ jobs:
 
           npm install -g clawhub@latest
           clawhub login --token "${CLAWHUB_TOKEN}"
-          clawhub publish integrations/openclaw \
+          if clawhub publish integrations/openclaw \
             --slug agent-bom \
             --name "agent-bom" \
             --version "${VERSION}" \
-            --changelog "Release v${VERSION}"
-
-          echo "ClawHub publish succeeded"
+            --changelog "Release v${VERSION}"; then
+            echo "ClawHub publish succeeded"
+          else
+            echo "::warning::ClawHub publish failed (version may already exist) — continuing"
+          fi


### PR DESCRIPTION
## Summary
- ClawHub `clawhub publish` fails with exit code 1 when version already exists
- This makes the entire Publish to Registries workflow show as failed even when Smithery succeeds
- Fix: catch the error and emit a warning instead of failing the job