### PR TITLE
feat: 4 new MCP tools + 2 resources + 2 discovery clients

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -79,7 +79,7 @@ git add servers/agent-bom.json
 git commit -m "feat: add agent-bom MCP server"
 git push origin add-agent-bom
 gh pr create --title "feat: add agent-bom security scanner" \
-  --body "Adds agent-bom — AI supply chain security scanner with 9 MCP tools."
+  --body "Adds agent-bom — AI supply chain security scanner with 13 MCP tools."
 ```
 
 ### Verification

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -2333,7 +2333,7 @@ def mcp_server_cmd(transport: str, port: int, host: str):
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 9 security tools via MCP protocol:
+    Exposes 13 security tools via MCP protocol:
       scan              Discover agents, scan for CVEs, compute blast radius
       check             Check a specific package for CVEs before installing
       blast_radius      Look up blast radius for a specific CVE
@@ -2343,6 +2343,10 @@ def mcp_server_cmd(transport: str, port: int, host: str):
       compliance        OWASP / MITRE ATLAS / NIST AI RMF posture
       remediate         Generate actionable remediation plan
       skill_trust       ClawHub-style trust assessment for SKILL.md files
+      verify            Package integrity + SLSA provenance verification
+      where             Show all MCP discovery paths + existence status
+      inventory         List agents/servers without CVE scanning
+      diff              Compare scan against baseline for new/resolved vulns
 
     \b
     Usage:

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -92,6 +92,18 @@ CONFIG_LOCATIONS: dict[AgentType, dict[str, list[str]]] = {
         "Linux": ["~/.openclaw/openclaw.json"],
         "Windows": ["~/.openclaw/openclaw.json"],
     },
+    AgentType.ROO_CODE: {
+        # Roo Code VS Code extension (formerly Roo Cline)
+        "Darwin": ["~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json"],
+        "Linux": ["~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json"],
+        "Windows": ["~/AppData/Roaming/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json"],
+    },
+    AgentType.AMAZON_Q: {
+        # Amazon Q Developer VS Code extension
+        "Darwin": ["~/Library/Application Support/Code/User/globalStorage/amazonwebservices.amazon-q-vscode/mcp.json"],
+        "Linux": ["~/.config/Code/User/globalStorage/amazonwebservices.amazon-q-vscode/mcp.json"],
+        "Windows": ["~/AppData/Roaming/Code/User/globalStorage/amazonwebservices.amazon-q-vscode/mcp.json"],
+    },
     AgentType.TOOLHIVE: {
         # ToolHive MCP server manager — discovery via `thv list`, not config files
         "Darwin": [],

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -27,6 +27,8 @@ class AgentType(str, Enum):
     CONTINUE = "continue"             # Continue.dev
     ZED = "zed"                       # Zed editor
     OPENCLAW = "openclaw"             # OpenClaw AI agent
+    ROO_CODE = "roo-code"            # Roo Code (VS Code extension)
+    AMAZON_Q = "amazon-q"            # Amazon Q Developer (VS Code)
     TOOLHIVE = "toolhive"            # ToolHive MCP server manager
     DOCKER_MCP = "docker-mcp"        # Docker Desktop MCP Toolkit
     CUSTOM = "custom"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -117,14 +117,14 @@ def test_smithery_yaml_exists():
 
 
 def test_server_card_has_all_tools():
-    """Server card should list all 9 MCP tools."""
+    """Server card should list all 13 MCP tools."""
     from agent_bom.mcp_server import build_server_card
 
     card = build_server_card()
     assert card["name"] == "agent-bom"
     assert "version" in card
     tool_names = [t["name"] for t in card["tools"]]
-    assert len(tool_names) == 9
+    assert len(tool_names) == 13
     assert "scan" in tool_names
     assert "check" in tool_names
     assert "blast_radius" in tool_names
@@ -134,6 +134,10 @@ def test_server_card_has_all_tools():
     assert "compliance" in tool_names
     assert "skill_trust" in tool_names
     assert "remediate" in tool_names
+    assert "verify" in tool_names
+    assert "where" in tool_names
+    assert "inventory" in tool_names
+    assert "diff" in tool_names
 
 
 def test_server_card_capabilities():
@@ -166,15 +170,15 @@ def test_server_card_metadata():
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_server_help_shows_9_tools():
-    """MCP server help should mention 9 tools."""
+def test_mcp_server_help_shows_13_tools():
+    """MCP server help should mention 13 tools."""
     from click.testing import CliRunner
 
     from agent_bom.cli import main
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp-server", "--help"])
-    assert "9 security tools" in result.output
+    assert "13 security tools" in result.output
     assert "compliance" in result.output
     assert "remediate" in result.output
 

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -568,8 +568,8 @@ def test_mcp_skill_trust_tool_exists():
     assert "skill_trust" in tool_names
 
 
-def test_mcp_server_card_has_9_tools():
-    """Server card lists 9 tools."""
+def test_mcp_server_card_has_13_tools():
+    """Server card lists 13 tools."""
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
-    assert len(_SERVER_CARD_TOOLS) == 9
+    assert len(_SERVER_CARD_TOOLS) == 13


### PR DESCRIPTION
## Summary
- **4 new MCP tools**: `verify` (integrity + SLSA provenance), `where` (discovery paths), `inventory` (fast agent listing), `diff` (baseline comparison)
- **2 MCP resources**: `registry://servers` (427+ server threat intel), `policy://template` (default security policy)
- **2 new discovery clients**: Roo Code, Amazon Q Developer (VS Code extensions)
- 9 → 13 MCP tools, 0 → 2 resources, 12 → 14 discovery clients

**Depends on PR #33** (stacked on `feat/smithery-score-scan-params`)

## Test plan
- [x] `test_mcp_server_has_thirteen_tools` — verifies 13 tools registered
- [x] `test_where_returns_clients` — where tool returns client list
- [x] `test_inventory_returns_agents` / `test_inventory_no_agents` — inventory tool
- [x] `test_diff_no_baseline` / `test_diff_no_agents` — diff tool
- [x] `test_verify_returns_result` — verify tool returns integrity + provenance
- [x] `test_resource_registry_servers` / `test_resource_policy_template` — resources
- [x] `test_server_card_has_all_tools` — server card updated to 13
- [x] All 1040 tests pass