### PR TITLE
feat: trust UX + HTML trust section + --open flag + SKILL.md hardening

### DIFF
--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -45,6 +45,10 @@ metadata:
       - "~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/mcp.json"
       - "~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
       - "~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+      - "~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json"
+      - "~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json"
+      - "~/Library/Application Support/Code/User/globalStorage/amazonwebservices.amazon-q-vscode/mcp.json"
+      - "~/.config/Code/User/globalStorage/amazonwebservices.amazon-q-vscode/mcp.json"
       - "~/Library/Application Support/Code/User/mcp.json"
       - "~/.config/Code/User/mcp.json"
       - "~/.continue/config.json"
@@ -62,12 +66,12 @@ metadata:
       - "compose.yml"
       - "compose.yaml"
     file_reads_justification: |
-      These are the standard config file locations for 11 MCP clients.
+      These are the standard config file locations for 13 MCP clients.
       Each file is a JSON/YAML config containing MCP server definitions.
       agent-bom reads them to discover which MCP servers are configured,
       then extracts package names for CVE scanning. On any given system,
       only 2-4 of these files typically exist — the rest are silently skipped.
-      The 27 paths break down as: 11 MCP clients × ~2 OS variants = ~19 global
+      The 31 paths break down as: 13 MCP clients × ~2 OS variants = ~23 global
       paths + 5 project-level configs + 4 Docker Compose filenames.
       No directory traversal, no glob patterns, no recursive walks.
       Use --dry-run to see exactly which files exist on YOUR system.
@@ -148,6 +152,8 @@ patterns, no recursive walks.
 | Cursor | `~/Library/Application Support/Cursor/User/globalStorage/cursor.mcp/mcp.json`, `~/.cursor/mcp.json` | `~/.config/Cursor/User/globalStorage/cursor.mcp/mcp.json`, `~/.cursor/mcp.json` |
 | Windsurf | `~/.windsurf/mcp.json`, `~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/mcp.json` | `~/.windsurf/mcp.json` |
 | Cline (VS Code) | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Roo Code | `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json` | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json` |
+| Amazon Q | `~/Library/Application Support/Code/User/globalStorage/amazonwebservices.amazon-q-vscode/mcp.json` | `~/.config/Code/User/globalStorage/amazonwebservices.amazon-q-vscode/mcp.json` |
 | VS Code Copilot | `~/Library/Application Support/Code/User/mcp.json` | `~/.config/Code/User/mcp.json` |
 | Continue.dev | `~/.continue/config.json` | same |
 | Zed | `~/.config/zed/settings.json` | same |
@@ -159,7 +165,7 @@ patterns, no recursive walks.
 
 **Docker Compose files** (current working directory only): `docker-compose.yml`, `docker-compose.yaml`, `compose.yml`, `compose.yaml`
 
-**Total**: 27 specific file paths. All enumerated in `metadata.openclaw.file_reads` above.
+**Total**: 31 specific file paths. All enumerated in `metadata.openclaw.file_reads` above.
 
 ### What agent-bom extracts from these files
 

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -98,6 +98,8 @@ def main():
 @click.option("--config-dir", type=click.Path(exists=True), help="Custom agent config directory to scan")
 @click.option("--inventory", type=click.Path(exists=True), help="Manual inventory JSON file")
 @click.option("--output", "-o", type=str, help="Output file path (use '-' for stdout)")
+@click.option("--open", "open_report", is_flag=True, default=False,
+              help="Auto-open HTML/graph-html report in default browser after generation")
 @click.option(
     "--format", "-f", "output_format",
     type=click.Choice(["console", "json", "cyclonedx", "sarif", "spdx", "text", "html", "prometheus", "graph", "graph-html", "mermaid", "svg", "badge"]),
@@ -291,6 +293,7 @@ def scan(
     apply_fixes_flag: bool,
     apply_dry_run: bool,
     preset: Optional[str],
+    open_report: bool,
 ):
     """Discover agents, extract dependencies, scan for vulnerabilities.
 
@@ -804,7 +807,7 @@ def scan(
         con.print()
         con.print(TrustPanel(
             trust_table,
-            title="[bold]Trust Assessment[/bold]",
+            title=f"[bold]Trust Assessment — {Path(trust_result.source_file).name}[/bold]",
             subtitle=verdict_line,
             border_style=vstyle,
         ))
@@ -1356,7 +1359,11 @@ def scan(
         out_path = output or "agent-bom-report.html"
         export_html(report, out_path, blast_radii)
         con.print(f"\n  [green]✓[/green] HTML report: {out_path}")
-        con.print(f"  [dim]Open with:[/dim] open {out_path}")
+        if open_report:
+            import webbrowser
+            webbrowser.open(f"file://{Path(out_path).resolve()}")
+        else:
+            con.print(f"  [dim]Open with:[/dim] open {out_path}")
     elif output_format == "prometheus":
         out_path = output or "agent-bom-metrics.prom"
         export_prometheus(report, out_path, blast_radii)
@@ -1390,7 +1397,11 @@ def scan(
         out_path = output or "agent-bom-graph.html"
         export_graph_html(report, blast_radii, out_path)
         con.print(f"\n  [green]✓[/green] Interactive graph: {out_path}")
-        con.print(f"  [dim]Open with:[/dim] open {out_path}")
+        if open_report:
+            import webbrowser
+            webbrowser.open(f"file://{Path(out_path).resolve()}")
+        else:
+            con.print(f"  [dim]Open with:[/dim] open {out_path}")
     elif output_format == "badge":
         out_path = output or "agent-bom-badge.json"
         export_badge(report, out_path)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1144,6 +1144,52 @@ def test_cli_scan_has_html_format():
     assert "html" in result.output
 
 
+# ─── HTML trust assessment tests ──────────────────────────────────────────────
+
+
+def test_html_trust_assessment_section():
+    from agent_bom.output.html import to_html
+
+    report, blast_radii = _make_report_with_vuln()
+    report.trust_assessment_data = {
+        "skill_name": "test-skill",
+        "source_file": "/tmp/SKILL.md",
+        "verdict": "suspicious",
+        "confidence": "medium",
+        "categories": [
+            {"name": "Purpose & Capability", "key": "purpose", "level": "pass", "summary": "Standard tool"},
+            {"name": "Instruction Scope", "key": "scope", "level": "warn", "summary": "Broad permissions"},
+            {"name": "Install Mechanism", "key": "install", "level": "pass", "summary": "Trusted source"},
+            {"name": "Credentials", "key": "credentials", "level": "fail", "summary": "Excessive credential access"},
+            {"name": "Persistence & Privilege", "key": "persistence", "level": "info", "summary": "No persistence"},
+        ],
+        "recommendations": ["Restrict credential access", "Add scope limits"],
+    }
+    html = to_html(report, blast_radii)
+    assert "Trust Assessment" in html
+    assert "test-skill" in html
+    assert "SUSPICIOUS" in html
+    assert "medium confidence" in html
+    assert "Purpose &amp; Capability" in html
+    assert "Excessive credential access" in html
+    assert "Restrict credential access" in html
+    assert 'id="trust"' in html
+
+
+def test_html_trust_assessment_absent():
+    from agent_bom.output.html import to_html
+
+    report, blast_radii = _make_report_with_vuln()
+    html = to_html(report, blast_radii)
+    assert 'id="trust"' not in html
+
+
+def test_cli_open_flag_accepted():
+    runner = CliRunner()
+    result = runner.invoke(main, ["scan", "--help"])
+    assert "--open" in result.output
+
+
 # ─── Prometheus output tests ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Add trust assessment section to HTML reports with verdict badge, 5-category table, and recommendations
- Add `--open` flag to auto-open HTML/graph-html reports in default browser
- Update CLI trust panel title to show source file name (e.g. "Trust Assessment — SKILL.md")
- Declare Roo Code + Amazon Q `file_reads` in SKILL.md (27 → 31 paths, 11 → 13 clients)

## Test plan
- [x] 3 new tests: `test_html_trust_assessment_section`, `test_html_trust_assessment_absent`, `test_cli_open_flag_accepted`
- [x] Full suite: 1043 tests pass
- [x] Ruff lint clean
- [ ] Manual: `agent-bom scan --skill integrations/openclaw/SKILL.md -f html -o report.html --open` → verify trust section visible