### PR TITLE
chore: bump version to v0.32.0

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim
 
-ARG VERSION=0.31.9
+ARG VERSION=0.32.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.31.9"
+  --version "0.32.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.31.9
-git push origin v0.31.9
+git tag v0.32.0
+git push origin v0.32.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.9` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.32.0` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -315,7 +315,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.31.9` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.32.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` | Inside any MCP client |
@@ -325,7 +325,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.31.9
+- uses: msaad00/agent-bom@v0.32.0
   with:
     severity-threshold: high
     upload-sarif: true

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius, policy enforcement, SBOM generation",
   "title": "agent-bom",
-  "version": "0.31.9",
+  "version": "0.32.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.31.9",
+      "version": "0.32.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: Scan AI agents and MCP servers for CVEs, generate SBOMs, map blast radius, enforce security policies
-version: 0.31.9
+version: 0.32.0
 metadata:
   openclaw:
     requires:
@@ -259,7 +259,7 @@ uv tool install agent-bom
 ### Verify installation
 ```bash
 agent-bom --version
-# Should print: agent-bom 0.31.9
+# Should print: agent-bom 0.32.0
 ```
 
 ### Verify integrity and provenance

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG VERSION=0.31.9
+ARG VERSION=0.32.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVE scanning, blast radius analysis, policy enforcement, and SBOM generation for MCP servers and AI agents",
   "title": "agent-bom",
-  "version": "0.31.9",
+  "version": "0.32.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.31.9",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.32.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.31.9": {
+        "ghcr.io/msaad00/agent-bom:v0.32.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.31.9"
+version = "0.32.0"
 description = "AI Bill of Materials (AI-BOM) generator — CVE scanning, blast radius, enterprise remediation plans, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF threat mapping, LLM-powered enrichment, OpenClaw discovery, MCP runtime introspection, and MCP registry for AI agents."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.31.9"
+    __version__ = "0.32.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,7 +255,7 @@ def empty_report():
 
 def test_version_sync():
     from agent_bom import __version__
-    assert __version__ == "0.31.9"
+    assert __version__ == "0.32.0"
 
 
 def test_report_version_matches():
@@ -2841,7 +2841,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.31.9"
+    assert data["version"] == "0.32.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
- Version bump from v0.31.9 to v0.32.0 across all 10 files
- Minor version bump for new capabilities: 13 MCP tools, trust UX, HTML reports, scan presets

## What's new in v0.32.0
- Smithery 100/100 parameter descriptions
- 4 new MCP tools (verify, where, inventory, diff)
- 2 MCP resources (registry://servers, policy://template)
- 2 new discovery clients (Roo Code, Amazon Q)
- Scan presets (ci/enterprise/quick)
- HTML trust assessment section + compliance tables
- `--open` flag for auto-opening HTML reports
- SKILL.md hardened with 31 file_reads paths

## Test plan
- [x] 1043 tests pass
- [x] 10 files updated, zero remaining 0.31.9 references