### PR TITLE
fix: descriptions cover both CVEs and config security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 ARG VERSION=dev
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
-LABEL description="agent-bom: AI supply chain security scanner — discover MCP configs, scan package dependencies for CVEs, map blast radius"
+LABEL description="agent-bom: AI supply chain security scanner — CVE scanning for packages and images, config security assessment, blast radius mapping"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/msaad00/agent-bom"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center">
-  <b>AI supply chain security scanner. Discover MCP configs, scan package dependencies for CVEs, map blast radius. Privilege detection. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
+  <b>AI supply chain security scanner. CVE scanning for packages and images. Config security — credential exposure, tool access, privilege escalation. Blast radius mapping. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
 </p>
 
 <p align="center">

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'agent-bom Scan'
-description: 'Scan AI supply chain dependencies for CVEs — discover MCP configs, extract packages, map blast radius.'
+description: 'Scan AI supply chain for CVEs and config risks — packages, images, credential exposure, blast radius.'
 author: 'agent-bom'
 
 branding:

--- a/examples/Jenkinsfile
+++ b/examples/Jenkinsfile
@@ -1,6 +1,6 @@
 // agent-bom Jenkins Pipeline
 //
-// Scans AI supply chain dependencies for CVEs, fails the build on high/critical vulns,
+// Scans AI supply chain for CVEs and config risks, fails the build on high/critical vulns,
 // uploads SARIF to GitHub Security tab, and pushes metrics to Prometheus.
 //
 // Required Jenkins plugins:

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-bom
-description: AI supply chain security scanner — discover MCP configs, scan package dependencies for CVEs, generate SBOMs, map blast radius, check compliance
+description: AI supply chain security scanner — CVE scanning for packages and images, config security assessment, blast radius mapping, SBOMs, compliance
 version: 0.32.0
 metadata:
   openclaw:
@@ -29,8 +29,8 @@ metadata:
 
 # agent-bom — AI Supply Chain Security Scanner
 
-An MCP-powered skill that discovers MCP configs, scans package dependencies for CVEs,
-generates SBOMs, maps blast radius, and evaluates compliance — all through a remote MCP server.
+An MCP-powered skill that scans the AI supply chain for security risks — CVEs in packages
+and images, credential exposure, tool access risks, privilege escalation — all through a remote MCP server.
 No local binary install required.
 
 ## Setup
@@ -114,8 +114,12 @@ registry_lookup(server_name="brave-search")
 ## What the MCP Server Does
 
 The remote server discovers MCP client configurations, extracts package dependencies,
-and queries public vulnerability databases (OSV.dev, NVD, EPSS, CISA KEV). It returns
-structured results — CVE IDs, severity scores, blast radius chains, and remediation advice.
+queries public vulnerability databases (OSV.dev, NVD, EPSS, CISA KEV), and assesses
+config security (credential exposure, tool access patterns, privilege escalation risks).
+It returns structured results — CVE IDs, severity scores, config findings, blast radius
+chains linking vulnerabilities to exposed credentials and tools, and remediation advice.
+
+Agentless, read-only, non-root. No binary install required.
 
 **Data handling:**
 - Only package names and versions are sent to vulnerability APIs

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "AI supply chain security scanner — discover MCP configs, scan package dependencies for CVEs, map blast radius, generate SBOMs, enforce policies",
+  "description": "AI supply chain security scanner — CVE scanning for packages and images, config security assessment, blast radius mapping, SBOMs, policy enforcement",
   "title": "agent-bom",
   "version": "0.32.0",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.32.0"
-description = "AI supply chain security scanner — discover MCP configs, scan package dependencies for CVEs, map blast radius, generate SBOMs, enforce policies, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF compliance."
+description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/skills/pre-deploy-gate.md
+++ b/skills/pre-deploy-gate.md
@@ -4,7 +4,7 @@
 
 ## Goal
 
-Integrate agent-bom into your CI/CD pipeline to automatically scan AI supply chain dependencies, container images, and MCP server packages before deployment. Fail the build on critical/high CVEs, CISA KEV matches, policy violations, or excessive tool agency.
+Integrate agent-bom into your CI/CD pipeline to scan AI supply chain packages, container images, and MCP server configs before deployment. Fail the build on critical/high CVEs, credential exposure, CISA KEV matches, policy violations, or excessive tool agency.
 
 ## Prerequisites
 

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -2366,7 +2366,7 @@ def mcp_server_cmd(transport: str, port: int, host: str):
 
     \b
     Exposes 13 security tools via MCP protocol:
-      scan              Discover MCP configs, scan dependencies for CVEs, map blast radius
+      scan              Full scan — CVEs, config security, blast radius, compliance
       check             Check a specific package for CVEs before installing
       blast_radius      Look up blast radius for a specific CVE
       policy_check      Evaluate policy rules against scan findings

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -145,8 +145,8 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         port=port,
         instructions=(
             f"agent-bom v{__version__} — AI supply chain security scanner. "
-            "Discovers MCP configs, scans package dependencies for CVEs, maps blast radius, "
-            "generates SBOMs, and enforces security policies. Read-only."
+            "Scans packages and images for CVEs, assesses credential exposure and tool access risks, "
+            "maps blast radius, generates SBOMs, and enforces security policies. Agentless, read-only."
         ),
     )
     # Set the actual agent-bom version (FastMCP defaults to SDK version)
@@ -169,7 +169,8 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
         Discovers local MCP configurations (Claude Desktop, Cursor, Windsurf,
         VS Code Copilot, OpenClaw, etc.), extracts package dependencies, queries
-        OSV.dev for CVEs, computes blast radius, and returns structured results.
+        OSV.dev for CVEs, assesses config security (credential exposure, tool access),
+        computes blast radius, and returns structured results.
 
         Returns:
             JSON with the complete AI-BOM report including agents, packages,
@@ -804,7 +805,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         """List all discovered MCP configurations and servers without CVE scanning.
 
         Performs fast discovery and package extraction only — no vulnerability
-        scanning. Use this for a quick overview of your AI supply chain inventory.
+        scanning. Use this for a quick inventory of configs, servers, and packages.
 
         Returns:
             JSON with discovered agents, their MCP servers, packages, and

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -8,7 +8,7 @@ const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
 
 export const metadata: Metadata = {
   title: "agent-bom",
-  description: "AI supply chain security scanner — discover MCP configs, scan dependencies for CVEs, map blast radius",
+  description: "AI supply chain security scanner — CVEs, config security, blast radius, compliance",
   icons: { icon: "/favicon.ico" },
 };
 


### PR DESCRIPTION
## Summary

- Descriptions previously only mentioned CVE/package scanning after the PR #39 rewording
- agent-bom delivers value on **both sides** of the AI supply chain:
  - **CVEs**: packages, dependencies, images → traditional vulnerability scanning
  - **Config security**: credential exposure, tool access risks, privilege escalation → agent/MCP-specific
  - **Blast radius**: links them — a CVE in a package propagates through server → agent → credentials/tools
- Updated 11 files to accurately reflect the dual value chain
- SKILL.md "What the MCP Server Does" section now describes config security assessment + agentless/read-only/non-root model

## Files changed

| File | What changed |
|------|-------------|
| `action.yml` | "CVEs and config risks" |
| `pyproject.toml` | "+ credential exposure and tool access risks" |
| `README.md` | "Config security — credential exposure, tool access, privilege escalation" |
| `SKILL.md` | Full value chain in description + body |
| `mcp_server.py` | Server instructions + scan/inventory docstrings |
| `cli.py` | MCP serve help text |
| + 5 more | Consistent messaging across Dockerfile, toolhive, Jenkinsfile, skills, UI |

## Test plan

- [x] 1041 tests pass
- [ ] Verify descriptions render correctly on PyPI, GitHub, Docker Hub after release