### PR TITLE
feat: position as the open-source Grype for the AI era

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 ARG VERSION=dev
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
-LABEL description="agent-bom: AI supply chain security scanner — CVE scanning for packages and images, config security assessment, blast radius mapping"
+LABEL description="agent-bom: The open-source Grype for the AI era — CVEs, config security, blast radius, compliance"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/msaad00/agent-bom"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center">
-  <b>AI supply chain security scanner. CVE scanning for packages and images. Config security — credential exposure, tool access, privilege escalation. Blast radius mapping. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
+  <b>The open-source Grype for the AI era. Scan packages and images for CVEs. Assess config security — credential exposure, tool access, privilege escalation. Map blast radius from vulnerabilities to credentials and tools. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
 </p>
 
 <p align="center">
@@ -355,7 +355,7 @@ agent-bom mcp-server                    # stdio
 agent-bom mcp-server --transport sse    # remote
 ```
 
-8 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`
+13 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`
 
 ### Cloud UI
 
@@ -401,12 +401,16 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 
 ## Roadmap
 
-- [ ] CIS AI benchmarks
-- [ ] Agent guardrails engine — runtime policy enforcement
+- [ ] Cloud AI inventory wiring — AWS Bedrock, Azure AI Foundry, GCP Vertex, Snowflake Cortex (code exists, CLI integration in progress)
+- [ ] Runtime MCP traffic monitoring — live tool call analysis, anomaly detection
+- [ ] Tool poisoning / prompt injection detection — static + dynamic MCP tool analysis
+- [ ] Model security — weights, datasets, fine-tuning supply chain risks
+- [ ] GPU/VM infrastructure scanning — NVIDIA NIM, vLLM, compute fleet inventory
+- [ ] K8s AI workload discovery — pod-level agent and model scanning
 - [ ] EU AI Act compliance mapping
-- [ ] Multi-language SDK detection (Go, Rust, Java)
-- [ ] Workflow engine scanning (n8n, Zapier, Make)
+- [ ] CIS AI benchmarks
 - [ ] License compliance engine
+- [ ] Workflow engine scanning (n8n, Zapier, Make)
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'agent-bom Scan'
-description: 'Scan AI supply chain for CVEs and config risks — packages, images, credential exposure, blast radius.'
+description: 'The open-source Grype for the AI era — CVEs, credential exposure, blast radius, compliance.'
 author: 'agent-bom'
 
 branding:

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-bom
-description: AI supply chain security scanner — CVE scanning for packages and images, config security assessment, blast radius mapping, SBOMs, compliance
+description: The open-source Grype for the AI era — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, OWASP/MITRE/NIST compliance
 version: 0.32.0
 metadata:
   openclaw:
@@ -27,11 +27,15 @@ metadata:
     privilege_escalation: false
 ---
 
-# agent-bom — AI Supply Chain Security Scanner
+# agent-bom — The Open-Source Grype for the AI Era
 
-An MCP-powered skill that scans the AI supply chain for security risks — CVEs in packages
-and images, credential exposure, tool access risks, privilege escalation — all through a remote MCP server.
-No local binary install required.
+An MCP-powered skill that scans the AI supply chain for security risks:
+- **CVEs** in packages, dependencies, and images (OSV.dev + NVD + EPSS + CISA KEV)
+- **Config security** — credential exposure, tool access risks, privilege escalation
+- **Blast radius** — links CVEs to exposed credentials and tools via server → agent mapping
+- **Compliance** — OWASP LLM Top 10, MITRE ATLAS, NIST AI RMF
+
+All through a remote MCP server. No local binary install required. Agentless, read-only, non-root.
 
 ## Setup
 

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "AI supply chain security scanner — CVE scanning for packages and images, config security assessment, blast radius mapping, SBOMs, policy enforcement",
+  "description": "The open-source Grype for the AI era — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
   "version": "0.32.0",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.32.0"
-description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs, OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF compliance."
+description = "The open-source Grype for the AI era — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius from vulnerabilities to credentials and tools, generate SBOMs, OWASP/MITRE/NIST compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 authors = [
     {name = "W S", email = "34316639+msaad00@users.noreply.github.com"}
 ]
-keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "grype", "syft", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment"]
+keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "grype", "syft", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment", "credential-exposure", "config-security", "ai-supply-chain"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -144,9 +144,10 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         host=host,
         port=port,
         instructions=(
-            f"agent-bom v{__version__} — AI supply chain security scanner. "
+            f"agent-bom v{__version__} — The open-source Grype for the AI era. "
             "Scans packages and images for CVEs, assesses credential exposure and tool access risks, "
-            "maps blast radius, generates SBOMs, and enforces security policies. Agentless, read-only."
+            "maps blast radius from vulnerabilities to credentials and tools, generates SBOMs, "
+            "and enforces security policies. Agentless, read-only, non-root."
         ),
     )
     # Set the actual agent-bom version (FastMCP defaults to SDK version)

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -8,7 +8,7 @@ const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
 
 export const metadata: Metadata = {
   title: "agent-bom",
-  description: "AI supply chain security scanner — CVEs, config security, blast radius, compliance",
+  description: "The open-source Grype for the AI era — CVEs, config security, blast radius, compliance",
   icons: { icon: "/favicon.ico" },
 };
 


### PR DESCRIPTION
## Summary

Unified positioning across all 8 surfaces to reflect the full dual value chain:

**The core message**: agent-bom is the only open-source tool that does both CVE scanning AND config security assessment, linked by blast radius mapping.

| Surface | Tagline |
|---------|---------|
| README hero | "The open-source Grype for the AI era" |
| PyPI | "scan packages for CVEs, assess credential exposure, map blast radius" |
| ClawHub SKILL.md | 4 bullet points: CVEs, config security, blast radius, compliance |
| MCP server instructions | Full value chain + "agentless, read-only, non-root" |
| GitHub Action | Short form for 125-char limit |
| Docker, ToolHive, UI | Consistent variants |

### Also fixed
- MCP tools count: 8 → **13** (was wrong since v0.32.0)
- Roadmap expanded: cloud AI wiring, runtime monitoring, tool poisoning, model security, GPU/VM, K8s AI workloads
- PyPI keywords: +3 (`credential-exposure`, `config-security`, `ai-supply-chain`)

## What agent-bom actually covers

```
Agents → MCP Servers → Packages → CVEs (OSV + NVD + EPSS + KEV)
  │          │
  │       Configs → Credential exposure, tool access, privilege escalation
  │
  └── Blast Radius → links CVEs to exposed credentials and tools
```

## Test plan

- [x] 1041 tests pass
- [ ] Verify README renders on GitHub
- [ ] Verify PyPI description after next release