### PR TITLE
fix: resolve ClawHub suspicious rating + rebrand identity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 ARG VERSION=dev
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
-LABEL description="agent-bom: The open-source Grype for the AI era — CVEs, config security, blast radius, compliance"
+LABEL description="agent-bom: AI supply chain security scanner — CVEs, config security, blast radius, compliance"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/msaad00/agent-bom"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center">
-  <b>The open-source Grype for the AI era. Scan packages and images for CVEs. Assess config security — credential exposure, tool access, privilege escalation. Map blast radius from vulnerabilities to credentials and tools. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
+  <b>AI supply chain security scanner. Scan packages and images for CVEs. Assess config security — credential exposure, tool access, privilege escalation. Map blast radius from vulnerabilities to credentials and tools. OWASP LLM Top 10 + MITRE ATLAS + NIST AI RMF.</b>
 </p>
 
 <p align="center">
@@ -37,7 +37,7 @@
 
 ## Why agent-bom?
 
-> **Grype tells you a package has a CVE.**
+> **Traditional scanners tell you a package has a CVE.**
 > **agent-bom tells you which AI agents are compromised, which credentials leak, which tools an attacker reaches, and what the business impact is.**
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'agent-bom Scan'
-description: 'The open-source Grype for the AI era — CVEs, credential exposure, blast radius, compliance.'
+description: 'AI supply chain security scanner — CVEs, credential exposure, blast radius, compliance.'
 author: 'agent-bom'
 
 branding:

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "The open-source Grype for the AI era — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
+  "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
   "version": "0.33.0",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.33.0"
-description = "The open-source Grype for the AI era — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius from vulnerabilities to credentials and tools, generate SBOMs, OWASP/MITRE/NIST compliance."
+description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius from vulnerabilities to credentials and tools, generate SBOMs, OWASP/MITRE/NIST compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -180,7 +180,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         host=host,
         port=port,
         instructions=(
-            f"agent-bom v{__version__} — The open-source Grype for the AI era. "
+            f"agent-bom v{__version__} — AI supply chain security scanner. "
             "Scans packages and images for CVEs, assesses credential exposure and tool access risks, "
             "maps blast radius from vulnerabilities to credentials and tools, generates SBOMs, "
             "and enforces security policies. Agentless, read-only, non-root."

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2884,7 +2884,7 @@ def test_openclaw_skill_declares_mcp_endpoint():
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"
     content = p.read_text()
     assert "network_endpoints:" in content
-    assert "MCP server endpoint" in content
+    assert "Remote MCP server" in content
     assert "sse" in content.lower()
 
 
@@ -2969,9 +2969,9 @@ def test_openclaw_skill_describes_data_handling():
     from pathlib import Path
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"
     content = p.read_text()
-    assert "Data handling" in content
-    assert "package names and versions" in content
-    assert "never transmitted" in content
+    assert "package names" in content.lower()
+    assert "credentials" in content.lower()
+    assert "does not read your local files" in content.lower() or "does NOT read your local files" in content
 
 
 def test_svg_output_basic():

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -8,7 +8,7 @@ const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
 
 export const metadata: Metadata = {
   title: "agent-bom",
-  description: "The open-source Grype for the AI era — CVEs, config security, blast radius, compliance",
+  description: "AI supply chain security scanner — CVEs, config security, blast radius, compliance",
   icons: { icon: "/favicon.ico" },
 };
 


### PR DESCRIPTION
## Summary
- **ClawHub trust fix**: Rewrites SKILL.md to honestly separate SSE vs CLI capabilities. The remote server does NOT read local files — `file_reads: []` is accurate. Documents which tools work remotely (check, registry_lookup, blast_radius, compliance, skill_trust) vs which need local CLI install (scan auto-discovery, where, inventory).
- **Branding**: Replaces "The open-source Grype for the AI era" with "AI supply chain security scanner" across all 9 files.

## ClawHub assessment issues resolved
| Issue | Fix |
|---|---|
| "metadata empty file_reads inconsistent with discovery" | Clarified: remote server doesn't read local files. Auto-discovery is CLI-only. |
| "unclear what agent sends vs server reads" | Explicit: server receives only tool call arguments you provide |
| "conflicting claims about local config discovery" | Split tools into "works remotely" vs "needs local CLI" |
| "ambiguous data collection by remote endpoint" | Added "How the Remote Server Works" section with 4 clear guarantees |

## Test plan
- [ ] All 1136 tests pass
- [ ] ClawHub re-assessment shows improved trust rating
- [ ] No remaining "Grype for the AI era" references