### PR TITLE
fix: improve OpenSSF Scorecard — signed releases, pinned deps, vuln fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,14 +112,14 @@ jobs:
       - name: Sign wheels and sdist
         run: |
           for f in dist/*.whl dist/*.tar.gz; do
-            cosign sign-blob "$f" --yes --bundle "${f}.bundle"
+            cosign sign-blob "$f" --yes --bundle "${f}.sigstore.json"
           done
 
       - name: Upload signed bundles
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: python-package-signatures
-          path: dist/*.bundle
+          path: dist/*.sigstore.json
 
   provenance:
     name: Generate SLSA provenance

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:fba6f3b73795df99960f4269b297420bdbe01a8631fc31ea3f121f2486d332d0
 
 ARG VERSION=dev
 

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -11,7 +11,7 @@
 #   NVD_API_KEY  — Higher rate limits for CVSS enrichment
 #   PORT         — Override default port (Railway/Render inject this)
 
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
 ARG VERSION=0.33.0
 

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
 ARG VERSION=0.33.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     "toml>=0.10",
     "pyyaml>=6.0",
     "jsonschema>=4.0",
+    # Transitive dep pins — fix known CVEs flagged by OpenSSF/OSV
+    "jinja2>=3.1.6",  # GHSA-cpwx-vrp4-4pq7, GHSA-gmj6-6f8f-6699 (sandbox breakout)
+    "werkzeug>=3.1.3",  # GHSA-q34m-jh98-afg2 (debugger RCE)
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Fixes three OpenSSF Scorecard checks that were scoring 0:

| Check | Before | Fix |
|---|---|---|
| **Signed-Releases** | 0 | Rename `.bundle` → `.sigstore.json` (OpenSSF only recognizes `.sigstore.json`, `.sig`, `.asc` extensions) |
| **Pinned-Dependencies** | 4 | Pin all 3 Dockerfiles to SHA256 digests |
| **Vulnerabilities** | 0 | Pin `jinja2>=3.1.6` and `werkzeug>=3.1.3` to fix known CVEs in transitive deps |

**Cannot fix yet:**
- Maintained: 0 — repo is <90 days old (hard gate, resolves ~May 23)
- Code-Review: 5 — already improving, old self-merges aging out

## Test plan
- [ ] All 1136 tests pass
- [ ] Next release produces `.sigstore.json` assets (not `.bundle`)
- [ ] Docker builds still work with SHA-pinned base images