### PR TITLE
fix: audit cleanup — wire integrations, update docs and metadata

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 9 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 13 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f Dockerfile.sse -t agent-bom-sse .

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -121,6 +121,10 @@ Only package names and versions are sent. No user data is included in requests.
 | npm registry | `https://registry.npmjs.org/{pkg}/{version}` | Package name + version | Package metadata | None |
 | PyPI | `https://pypi.org/pypi/{pkg}/{version}/json` | Package name + version | Package metadata | None |
 | OpenSSF Scorecard | `https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}` | GitHub owner/repo | Scorecard scores | None |
+| Jira (optional) | `https://{instance}.atlassian.net/rest/api/3/issue` | Finding summaries | Ticket confirmation | API token (`--jira-token`) |
+| Slack (optional) | User-provided webhook URL | Finding summaries | Delivery status | Webhook URL (`--slack-webhook`) |
+| Vanta (optional) | `https://api.vanta.com/v1/` | Compliance evidence | Upload confirmation | API token (`--vanta-token`) |
+| Drata (optional) | `https://public-api.drata.com/` | Compliance evidence | Upload confirmation | API token (`--drata-token`) |
 
 ### Data flow
 
@@ -128,6 +132,8 @@ Only package names and versions are sent. No user data is included in requests.
 [Local config files]  →  extract server name, command, args, env var NAMES
                           ↓
 [Package names+versions]  →  sent to OSV.dev, NVD, EPSS, KEV, npm, PyPI, OpenSSF Scorecard
+                          ↓
+[Findings (optional)]     →  sent to Jira, Slack, Vanta, Drata (only if flags provided)
                           ↓
 [CVE results]  →  returned to local process, written to stdout or --output file
 ```

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 | GitHub Action | `uses: msaad00/agent-bom@v0.33.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
+| Runtime proxy | `agent-bom proxy` | Live MCP traffic audit |
 | MCP Server | `agent-bom mcp-server` | Inside any MCP client |
 | Dashboard | `agent-bom serve` | Team UI |
 | Prometheus | `--push-gateway` / `--otel-endpoint` | Monitoring |
@@ -432,6 +433,9 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 | `GET /v1/scan/{id}` | Results + status |
 | `GET /v1/scan/{id}/attack-flow` | Per-CVE blast radius graph |
 | `GET /v1/registry` | 427+ server registry |
+| `GET /v1/compliance` | Full 4-framework compliance posture |
+| `GET /v1/compliance/{framework}` | Single framework (owasp-llm, owasp-mcp, atlas, nist) |
+| `GET /v1/malicious/check` | Malicious package / typosquat check |
 
 ### MCP Server
 
@@ -504,10 +508,11 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - [x] Malicious package detection — OSV MAL- prefix flagging + typosquat heuristics
 - [x] OpenSSF Scorecard enrichment — `--scorecard` for package health scoring
 - [x] GPU infrastructure coverage — NVIDIA CUDA, AMD ROCm, TensorRT, Triton, vLLM, JAX
+- [x] Runtime MCP traffic monitoring — live tool call analysis, anomaly detection, credential leak detection
+- [x] Enterprise integrations — Jira, Slack, Vanta, Drata
+- [x] Runtime sidecar Docker container — `Dockerfile.runtime` + Docker Compose for MCP proxy deployment
 
 **Planned:**
-- [ ] Runtime MCP traffic monitoring — live tool call analysis, anomaly detection, credential leak detection
-- [ ] Enterprise integrations — Jira, Slack, Vanta, Drata
 - [ ] EU AI Act compliance mapping
 - [ ] CIS AI benchmarks
 - [ ] License compliance engine

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "AI supply chain security scanner — CVE scanning, blast radius, policy enforcement, SBOM generation",
+  "description": "AI supply chain security scanner — CVE scanning, blast radius, OWASP/MITRE/NIST compliance, policy enforcement, SBOM generation",
   "title": "agent-bom",
   "version": "0.33.0",
   "repository": {

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -48,7 +48,11 @@
             "generate_sbom",
             "compliance",
             "remediate",
-            "skill_trust"
+            "skill_trust",
+            "verify",
+            "where",
+            "inventory",
+            "diff"
           ]
         }
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 authors = [
     {name = "W S", email = "34316639+msaad00@users.noreply.github.com"}
 ]
-keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "grype", "syft", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment", "credential-exposure", "config-security", "ai-supply-chain", "gpu-security", "cuda", "rocm", "ai-infrastructure"]
+keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "grype", "syft", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment", "credential-exposure", "config-security", "ai-supply-chain", "gpu-security", "cuda", "rocm", "ai-infrastructure", "openssf-scorecard", "malicious-package-detection", "runtime-monitoring"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/src/agent_bom/integrations/slack.py
+++ b/src/agent_bom/integrations/slack.py
@@ -113,6 +113,17 @@ async def send_slack_alert(
         return False
 
 
+async def send_slack_payload(webhook_url: str, payload: dict) -> bool:
+    """Send a raw Slack payload to a webhook URL."""
+    async with create_client(timeout=10.0) as client:
+        response = await request_with_retry(
+            client, "POST", webhook_url, json_body=payload, max_retries=2,
+        )
+        if response and response.status_code == 200:
+            return True
+        return False
+
+
 def build_summary_message(findings: list[dict]) -> dict:
     """Build a summary Slack message for multiple findings.
 


### PR DESCRIPTION
## Summary

Post-merge audit of PRs #53-#62 found 9 gaps. This PR fixes all of them:

- **CLI: Wire enterprise integration flags** — `--jira-url`, `--jira-user`, `--jira-token`, `--jira-project`, `--slack-webhook`, `--vanta-token`, `--drata-token` now dispatch findings to integrations after scan
- **MCP server: Wire scorecard** — `scorecard` parameter added to MCP `scan` tool for OpenSSF Scorecard enrichment
- **README roadmap** — Runtime monitoring + enterprise integrations moved from Planned to Shipped
- **README endpoints table** — Added `/v1/compliance`, `/v1/compliance/{framework}`, `/v1/malicious/check`
- **README deployment table** — Added runtime proxy row
- **PERMISSIONS.md** — Added Jira/Slack/Vanta/Drata to external API calls table and data flow
- **Dockerfile.sse** — Fixed tool count comment (9 → 13)
- **ToolHive server.json** — Added 4 missing tools (verify, where, inventory, diff)
- **pyproject.toml** — Added keywords: openssf-scorecard, malicious-package-detection, runtime-monitoring

## Test plan

- [x] All 1,262 tests pass
- [x] Lint clean (ruff)
- [x] No new dependencies added
- [x] Enterprise flags use lazy imports — zero overhead when not used