### PR TITLE
fix: shorten MCP registry description to <=100 chars

### DIFF
--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "AI supply chain security scanner — CVE scanning, blast radius, OWASP/MITRE/NIST compliance, policy enforcement, SBOM generation",
+  "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
   "version": "0.34.0",
   "repository": {


### PR DESCRIPTION
MCP Registry validation requires `description` <= 100 characters.

The description added in #63 was 129 chars — shortened to 82 chars.

Fixes the failed `Publish to MCP Registry` workflow run.