### PR TITLE
fix: update SVG diagrams — accuracy, text overflow, outdated counts

### DIFF
--- a/docs/images/data-flow-dark.svg
+++ b/docs/images/data-flow-dark.svg
@@ -158,7 +158,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d29922">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1100+ automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,260+ automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d29922">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/data-flow-light.svg
+++ b/docs/images/data-flow-light.svg
@@ -151,7 +151,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#fffbeb" stroke="#d97706" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d97706">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1100+ automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,260+ automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d97706">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/integration-architecture-dark.svg
+++ b/docs/images/integration-architecture-dark.svg
@@ -137,35 +137,31 @@
   </g>
 
   <!-- Arrow 4→5 -->
-  <line x1="720" y1="148" x2="746" y2="148" stroke="#6e7681" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="720" y1="148" x2="734" y2="148" stroke="#6e7681" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
   <!-- Node 5: Enterprise / SIEM (red #f85149) -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <g transform="translate(752, 64)">
-    <rect width="104" height="168" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-    <rect x="0" y="0" width="104" height="4" rx="2" fill="#f85149" opacity="0.8"/>
-    <circle cx="52" cy="32" r="14" fill="#f85149" opacity="0.15"/>
-    <circle cx="52" cy="32" r="6" fill="#f85149" opacity="0.6"/>
-    <text x="52" y="62" text-anchor="middle" class="node-label">Enterprise / SIEM</text>
-    <g transform="translate(10, 76)">
+  <g transform="translate(740, 64)">
+    <rect width="120" height="168" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <rect x="0" y="0" width="120" height="4" rx="2" fill="#f85149" opacity="0.8"/>
+    <circle cx="60" cy="32" r="14" fill="#f85149" opacity="0.15"/>
+    <circle cx="60" cy="32" r="6" fill="#f85149" opacity="0.6"/>
+    <text x="60" y="62" text-anchor="middle" class="node-label">Enterprise</text>
+    <g transform="translate(14, 76)">
       <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.5"/>
       <text x="12" y="7" class="node-sub">Jira</text>
     </g>
-    <g transform="translate(10, 94)">
+    <g transform="translate(14, 94)">
       <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.5"/>
       <text x="12" y="7" class="node-sub">Slack</text>
     </g>
-    <g transform="translate(10, 112)">
+    <g transform="translate(14, 112)">
       <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.5"/>
-      <text x="12" y="7" class="node-sub">Vanta</text>
+      <text x="12" y="7" class="node-sub">Vanta / Drata</text>
     </g>
-    <g transform="translate(10, 130)">
-      <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.5"/>
-      <text x="12" y="7" class="node-sub">Drata</text>
-    </g>
-    <rect x="6" y="144" width="92" height="18" rx="9" fill="#f85149" opacity="0.12"/>
-    <text x="52" y="157" text-anchor="middle" class="node-tag" fill="#f85149">Alert &amp; remediate</text>
+    <rect x="10" y="138" width="100" height="18" rx="9" fill="#f85149" opacity="0.12"/>
+    <text x="60" y="151" text-anchor="middle" class="node-tag" fill="#f85149">Alert &amp; remediate</text>
   </g>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
@@ -197,7 +193,7 @@
   <g transform="translate(40, 362)">
     <rect width="800" height="36" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
     <text x="400" y="15" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e" letter-spacing="0.06em">COMPLIANCE</text>
-    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM Top 10  ·  MITRE ATLAS  ·  NIST AI RMF  ·  EU AI Act</text>
+    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM Top 10  ·  OWASP MCP Top 10  ·  MITRE ATLAS  ·  NIST AI RMF</text>
   </g>
 
   <!-- Footer -->

--- a/docs/images/integration-architecture-light.svg
+++ b/docs/images/integration-architecture-light.svg
@@ -137,35 +137,31 @@
   </g>
 
   <!-- Arrow 4→5 -->
-  <line x1="720" y1="148" x2="746" y2="148" stroke="#656d76" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="720" y1="148" x2="734" y2="148" stroke="#656d76" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
   <!-- Node 5: Enterprise / SIEM (red #f85149) -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <g transform="translate(752, 64)">
-    <rect width="104" height="168" rx="10" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
-    <rect x="0" y="0" width="104" height="4" rx="2" fill="#f85149" opacity="0.9"/>
-    <circle cx="52" cy="32" r="14" fill="#f85149" opacity="0.1"/>
-    <circle cx="52" cy="32" r="6" fill="#f85149" opacity="0.7"/>
-    <text x="52" y="62" text-anchor="middle" class="node-label">Enterprise / SIEM</text>
-    <g transform="translate(10, 76)">
+  <g transform="translate(740, 64)">
+    <rect width="120" height="168" rx="10" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+    <rect x="0" y="0" width="120" height="4" rx="2" fill="#f85149" opacity="0.9"/>
+    <circle cx="60" cy="32" r="14" fill="#f85149" opacity="0.1"/>
+    <circle cx="60" cy="32" r="6" fill="#f85149" opacity="0.7"/>
+    <text x="60" y="62" text-anchor="middle" class="node-label">Enterprise</text>
+    <g transform="translate(14, 76)">
       <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.6"/>
       <text x="12" y="7" class="node-sub">Jira</text>
     </g>
-    <g transform="translate(10, 94)">
+    <g transform="translate(14, 94)">
       <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.6"/>
       <text x="12" y="7" class="node-sub">Slack</text>
     </g>
-    <g transform="translate(10, 112)">
+    <g transform="translate(14, 112)">
       <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.6"/>
-      <text x="12" y="7" class="node-sub">Vanta</text>
+      <text x="12" y="7" class="node-sub">Vanta / Drata</text>
     </g>
-    <g transform="translate(10, 130)">
-      <circle cx="4" cy="4" r="2.5" fill="#f85149" opacity="0.6"/>
-      <text x="12" y="7" class="node-sub">Drata</text>
-    </g>
-    <rect x="6" y="144" width="92" height="18" rx="9" fill="#f85149" opacity="0.1"/>
-    <text x="52" y="157" text-anchor="middle" class="node-tag" fill="#cf222e">Alert &amp; remediate</text>
+    <rect x="10" y="138" width="100" height="18" rx="9" fill="#f85149" opacity="0.1"/>
+    <text x="60" y="151" text-anchor="middle" class="node-tag" fill="#cf222e">Alert &amp; remediate</text>
   </g>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
@@ -197,7 +193,7 @@
   <g transform="translate(40, 362)">
     <rect width="800" height="36" rx="8" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
     <text x="400" y="15" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#656d76" letter-spacing="0.06em">COMPLIANCE</text>
-    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM Top 10  ·  MITRE ATLAS  ·  NIST AI RMF  ·  EU AI Act</text>
+    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM Top 10  ·  OWASP MCP Top 10  ·  MITRE ATLAS  ·  NIST AI RMF</text>
   </g>
 
   <!-- Footer -->

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">7 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">13 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">7 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">13 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -122,7 +122,7 @@
   <rect x="608" y="340" width="264" height="72" rx="8" fill="#0d1117" stroke="#238636" stroke-width="1" opacity="0.8"/>
   <text x="740" y="360" text-anchor="middle" class="label" fill="#3fb950">Compliance &amp; Audit</text>
   <text x="740" y="376" text-anchor="middle" class="sub">CycloneDX AI-BOM for supply chain</text>
-  <text x="740" y="390" text-anchor="middle" class="sub">SPDX 2.3 for license + provenance</text>
+  <text x="740" y="390" text-anchor="middle" class="sub">SPDX 3.0 for license + provenance</text>
   <text x="740" y="404" text-anchor="middle" class="sub">Scan history + baseline diffs</text>
 
   <!-- ═══ Row 4: Data Sources ═══ -->

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -138,7 +138,7 @@
   <rect x="608" y="340" width="264" height="72" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
   <text x="740" y="360" text-anchor="middle" class="label" fill="#065f46">Compliance &amp; Audit</text>
   <text x="740" y="376" text-anchor="middle" class="sub">CycloneDX AI-BOM for supply chain</text>
-  <text x="740" y="390" text-anchor="middle" class="sub">SPDX 2.3 for license + provenance</text>
+  <text x="740" y="390" text-anchor="middle" class="sub">SPDX 3.0 for license + provenance</text>
   <text x="740" y="404" text-anchor="middle" class="sub">Scan history + baseline diffs</text>
 
   <!-- ═══ Row 4: Data Sources (external APIs) ═══ -->


### PR DESCRIPTION
## Summary
- Fixed "7 tools" → "13 tools" in offerings-map SVGs
- Widened Enterprise node in integration-architecture to fix text overflow
- Added OWASP MCP Top 10 to compliance bars (replaced EU AI Act which isn't implemented)
- Updated test count from 1100+ to 1,260+ in data-flow SVGs
- Fixed SPDX 2.3 → 3.0 in scan-workflow SVGs

## Test plan
- [x] No code changes — SVG assets only
- [ ] Verify diagrams render correctly on GitHub