### PR TITLE
fix: update SVG diagrams for runtime proxy + API endpoints

### DIFF
--- a/docs/images/data-flow-dark.svg
+++ b/docs/images/data-flow-dark.svg
@@ -158,7 +158,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d29922">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,260+ automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,279 automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d29922">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/data-flow-light.svg
+++ b/docs/images/data-flow-light.svg
@@ -151,7 +151,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#fffbeb" stroke="#d97706" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d97706">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,260+ automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,279 automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d97706">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -168,8 +168,8 @@
     <rect width="200" height="44" rx="6" fill="#161b22" stroke="#238636" stroke-width="1" opacity="0.8"/>
     <circle cx="16" cy="22" r="5" fill="#3fb950" opacity="0.5"/>
     <text x="28" y="15" class="node-label">REST API (FastAPI)</text>
-    <text x="28" y="28" class="node-sub">:8422 — async scan, SSE stream,</text>
-    <text x="28" y="38" class="node-sub">registry, trust headers</text>
+    <text x="28" y="28" class="node-sub">:8422 — scan, proxy status/alerts,</text>
+    <text x="28" y="38" class="node-sub">scorecard, SSE stream, registry</text>
   </g>
 
   <!-- Dashboards -->
@@ -204,7 +204,7 @@
     <rect width="200" height="36" rx="6" fill="#161b22" stroke="#238636" stroke-width="1" opacity="0.8"/>
     <circle cx="16" cy="18" r="5" fill="#3fb950" opacity="0.5"/>
     <text x="28" y="15" class="node-label">SIEM + Alerting</text>
-    <text x="28" y="28" class="node-sub">JSON webhook, HTML reports</text>
+    <text x="28" y="28" class="node-sub">Jira, Slack, Vanta, Drata webhooks</text>
   </g>
 
   <!-- ════════════════════════════════════════════════════════════════════ -->

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -168,8 +168,8 @@
     <rect width="200" height="44" rx="6" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
     <circle cx="16" cy="22" r="5" fill="#059669" opacity="0.6"/>
     <text x="28" y="15" class="node-label">REST API (FastAPI)</text>
-    <text x="28" y="28" class="node-sub">:8422 — async scan, SSE stream,</text>
-    <text x="28" y="38" class="node-sub">registry, trust headers</text>
+    <text x="28" y="28" class="node-sub">:8422 — scan, proxy status/alerts,</text>
+    <text x="28" y="38" class="node-sub">scorecard, SSE stream, registry</text>
   </g>
 
   <!-- Dashboards -->
@@ -204,7 +204,7 @@
     <rect width="200" height="36" rx="6" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
     <circle cx="16" cy="18" r="5" fill="#059669" opacity="0.6"/>
     <text x="28" y="15" class="node-label">SIEM + Alerting</text>
-    <text x="28" y="28" class="node-sub">JSON webhook, HTML reports</text>
+    <text x="28" y="28" class="node-sub">Jira, Slack, Vanta, Drata webhooks</text>
   </g>
 
   <!-- ════════════════════════════════════════════════════════════════════ -->

--- a/docs/images/integration-architecture-dark.svg
+++ b/docs/images/integration-architecture-dark.svg
@@ -126,11 +126,15 @@
     <text x="70" y="62" text-anchor="middle" class="node-label">Dashboard / API</text>
     <g transform="translate(14, 76)">
       <circle cx="4" cy="4" r="2.5" fill="#f0883e" opacity="0.5"/>
-      <text x="12" y="7" class="node-sub">REST API</text>
+      <text x="12" y="7" class="node-sub">REST API + SSE</text>
     </g>
     <g transform="translate(14, 94)">
       <circle cx="4" cy="4" r="2.5" fill="#f0883e" opacity="0.5"/>
-      <text x="12" y="7" class="node-sub">SSE stream</text>
+      <text x="12" y="7" class="node-sub">Runtime Proxy</text>
+    </g>
+    <g transform="translate(14, 112)">
+      <circle cx="4" cy="4" r="2.5" fill="#f0883e" opacity="0.5"/>
+      <text x="12" y="7" class="node-sub">Alert webhook</text>
     </g>
     <rect x="16" y="134" width="108" height="20" rx="10" fill="#f0883e" opacity="0.12"/>
     <text x="70" y="148" text-anchor="middle" class="node-tag" fill="#f0883e">Live monitoring</text>

--- a/docs/images/integration-architecture-light.svg
+++ b/docs/images/integration-architecture-light.svg
@@ -126,11 +126,15 @@
     <text x="70" y="62" text-anchor="middle" class="node-label">Dashboard / API</text>
     <g transform="translate(14, 76)">
       <circle cx="4" cy="4" r="2.5" fill="#f0883e" opacity="0.6"/>
-      <text x="12" y="7" class="node-sub">REST API</text>
+      <text x="12" y="7" class="node-sub">REST API + SSE</text>
     </g>
     <g transform="translate(14, 94)">
       <circle cx="4" cy="4" r="2.5" fill="#f0883e" opacity="0.6"/>
-      <text x="12" y="7" class="node-sub">SSE stream</text>
+      <text x="12" y="7" class="node-sub">Runtime Proxy</text>
+    </g>
+    <g transform="translate(14, 112)">
+      <circle cx="4" cy="4" r="2.5" fill="#f0883e" opacity="0.6"/>
+      <text x="12" y="7" class="node-sub">Alert webhook</text>
     </g>
     <rect x="16" y="134" width="108" height="20" rx="10" fill="#f0883e" opacity="0.1"/>
     <text x="70" y="148" text-anchor="middle" class="node-tag" fill="#bc4c00">Live monitoring</text>

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -71,8 +71,8 @@
   <rect x="630" y="370" width="170" height="56" rx="12" fill="#161b22" stroke="#f0883e" stroke-width="1.5"/>
   <rect x="630" y="370" width="170" height="4" rx="2" fill="#f0883e" opacity="0.6"/>
   <text x="715" y="394" text-anchor="middle" class="spoke-title" fill="#f0883e">REST API</text>
-  <text x="715" y="408" text-anchor="middle" class="spoke-line1">FastAPI server</text>
-  <text x="715" y="420" text-anchor="middle" class="spoke-line2">/v1/scan, /v1/blast-radius</text>
+  <text x="715" y="408" text-anchor="middle" class="spoke-line1">FastAPI server (:8422)</text>
+  <text x="715" y="420" text-anchor="middle" class="spoke-line2">/v1/scan, /v1/proxy, /v1/scorecard</text>
 
   <!-- ── Spoke 6: SSE Stream (bottom) ── -->
   <rect x="340" y="370" width="200" height="56" rx="12" fill="#161b22" stroke="#f0883e" stroke-width="1.5"/>
@@ -88,12 +88,12 @@
   <text x="165" y="408" text-anchor="middle" class="spoke-line1">Policy-as-code</text>
   <text x="165" y="420" text-anchor="middle" class="spoke-line2">YAML rules, CI enforcement</text>
 
-  <!-- ── Spoke 8: Watch Mode (left) ── -->
+  <!-- ── Spoke 8: Runtime Proxy (left) ── -->
   <rect x="42" y="224" width="170" height="56" rx="12" fill="#161b22" stroke="#d29922" stroke-width="1.5"/>
   <rect x="42" y="224" width="170" height="4" rx="2" fill="#d29922" opacity="0.6"/>
-  <text x="127" y="248" text-anchor="middle" class="spoke-title" fill="#d29922">Watch Mode</text>
-  <text x="127" y="262" text-anchor="middle" class="spoke-line1">File system watcher</text>
-  <text x="127" y="274" text-anchor="middle" class="spoke-line2">Config change alerts</text>
+  <text x="127" y="248" text-anchor="middle" class="spoke-title" fill="#d29922">Runtime Proxy</text>
+  <text x="127" y="262" text-anchor="middle" class="spoke-line1">MCP traffic monitoring</text>
+  <text x="127" y="274" text-anchor="middle" class="spoke-line2">5 detectors + alert webhook</text>
 
   <!-- Footer -->
   <text x="440" y="462" text-anchor="middle" class="footer">One engine, multiple deployment modes</text>

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -71,8 +71,8 @@
   <rect x="630" y="370" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#f0883e" stroke-width="1.5"/>
   <rect x="630" y="370" width="170" height="4" rx="2" fill="#f0883e" opacity="0.6"/>
   <text x="715" y="394" text-anchor="middle" class="spoke-title" fill="#bc4c00">REST API</text>
-  <text x="715" y="408" text-anchor="middle" class="spoke-line1">FastAPI server</text>
-  <text x="715" y="420" text-anchor="middle" class="spoke-line2">/v1/scan, /v1/blast-radius</text>
+  <text x="715" y="408" text-anchor="middle" class="spoke-line1">FastAPI server (:8422)</text>
+  <text x="715" y="420" text-anchor="middle" class="spoke-line2">/v1/scan, /v1/proxy, /v1/scorecard</text>
 
   <!-- ── Spoke 6: SSE Stream (bottom) ── -->
   <rect x="340" y="370" width="200" height="56" rx="12" fill="#f6f8fa" stroke="#f0883e" stroke-width="1.5"/>
@@ -88,12 +88,12 @@
   <text x="165" y="408" text-anchor="middle" class="spoke-line1">Policy-as-code</text>
   <text x="165" y="420" text-anchor="middle" class="spoke-line2">YAML rules, CI enforcement</text>
 
-  <!-- ── Spoke 8: Watch Mode (left) ── -->
+  <!-- ── Spoke 8: Runtime Proxy (left) ── -->
   <rect x="42" y="224" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#d29922" stroke-width="1.5"/>
   <rect x="42" y="224" width="170" height="4" rx="2" fill="#d29922" opacity="0.6"/>
-  <text x="127" y="248" text-anchor="middle" class="spoke-title" fill="#9a6700">Watch Mode</text>
-  <text x="127" y="262" text-anchor="middle" class="spoke-line1">File system watcher</text>
-  <text x="127" y="274" text-anchor="middle" class="spoke-line2">Config change alerts</text>
+  <text x="127" y="248" text-anchor="middle" class="spoke-title" fill="#9a6700">Runtime Proxy</text>
+  <text x="127" y="262" text-anchor="middle" class="spoke-line1">MCP traffic monitoring</text>
+  <text x="127" y="274" text-anchor="middle" class="spoke-line2">5 detectors + alert webhook</text>
 
   <!-- Footer -->
   <text x="440" y="462" text-anchor="middle" class="footer">One engine, multiple deployment modes</text>


### PR DESCRIPTION
## Summary
- **offerings-map**: Replace Watch Mode spoke with Runtime Proxy (5 detectors + alert webhook), update REST API spoke with `/v1/proxy`, `/v1/scorecard`
- **deployment**: Update REST API to show proxy status/alerts/scorecard endpoints, update SIEM to show Jira/Slack/Vanta/Drata webhooks
- **integration-architecture**: Add Runtime Proxy + Alert webhook to Dashboard/API node
- **data-flow**: Fix test count 1,260 → 1,279

## Test plan
- [ ] Verify SVGs render correctly in GitHub dark/light mode
- [ ] Confirm diagram text is accurate against current codebase