### PR TITLE
feat: CLI verbose/no-color, LLM03 training data poisoning, RAG coverage

### DIFF
--- a/src/agent_bom/atlas.py
+++ b/src/agent_bom/atlas.py
@@ -50,6 +50,11 @@ _AI_PACKAGES: frozenset[str] = frozenset({
     "dspy-ai", "guidance",
     "semantic-kernel",
     "pydantic-ai",
+    # Vector stores / RAG backends
+    "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
+    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
+    "pgvector", "lancedb",
+    "sentence-transformers",
 })
 
 # Severity levels considered high-risk

--- a/src/agent_bom/nist_ai_rmf.py
+++ b/src/agent_bom/nist_ai_rmf.py
@@ -55,6 +55,11 @@ _AI_PACKAGES: frozenset[str] = frozenset({
     "dspy-ai", "guidance",
     "semantic-kernel",
     "pydantic-ai",
+    # Vector stores / RAG backends
+    "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
+    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
+    "pgvector", "lancedb",
+    "sentence-transformers",
 })
 
 # Severity levels considered high-risk

--- a/src/agent_bom/owasp.py
+++ b/src/agent_bom/owasp.py
@@ -47,6 +47,23 @@ _AI_PACKAGES: frozenset[str] = frozenset({
     "dspy-ai", "guidance",
     "semantic-kernel",
     "pydantic-ai",
+    # Vector stores / RAG backends
+    "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
+    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
+    "pgvector", "lancedb",
+    # Embedding models
+    "sentence-transformers",
+})
+
+# Packages directly involved in training data handling and fine-tuning.
+# CVEs here risk training data poisoning (LLM03).
+_TRAINING_DATA_PACKAGES: frozenset[str] = frozenset({
+    "datasets", "huggingface-hub", "tokenizers",
+    "transformers", "diffusers", "accelerate", "trl",
+    "sentence-transformers", "peft",
+    "torch", "torchvision", "torchaudio",
+    "tensorflow", "tensorflow-gpu",
+    "safetensors", "optimum",
 })
 
 # Severity levels considered high-risk for agency/AI-poisoning checks
@@ -90,6 +107,10 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
         and br.vulnerability.severity in _HIGH_RISK_SEVERITIES
     ):
         tags.add("LLM08")
+
+    # LLM03 — training data poisoning: training/dataset package with CVE
+    if br.package.name.lower() in _TRAINING_DATA_PACKAGES:
+        tags.add("LLM03")
 
     # LLM04 — data/model poisoning: AI framework package with high CVE
     if (

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -34,7 +34,8 @@ _AI_FRAMEWORK_PACKAGES = frozenset({
     "sentence-transformers", "optimum",
     # Vector stores and RAG
     "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
-    "faiss-cpu", "faiss-gpu",
+    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
+    "pgvector", "lancedb",
     # MCP and agent infrastructure
     "mcp", "fastmcp", "modelcontextprotocol",
     # GPU / AI infrastructure — NVIDIA


### PR DESCRIPTION
## Summary
- Add `--verbose` (`-v`) and `--no-color` CLI flags for better debugging and CI/piping support
- Implement OWASP LLM03 (Training Data Poisoning) tagging for training/fine-tuning packages
- Add missing RAG/vector DB packages (pymilvus, milvus, pgvector, lancedb, sentence-transformers) to all 4 compliance framework lists

## Changes
- `cli.py` — `--verbose` enables `logging.DEBUG`, `--no-color` disables ANSI styling
- `owasp.py` — LLM03 tagged when package is in `_TRAINING_DATA_PACKAGES` (datasets, transformers, torch, accelerate, trl, peft, safetensors, etc.)
- `scanners/__init__.py`, `atlas.py`, `nist_ai_rmf.py` — added vector store / RAG packages to `_AI_FRAMEWORK_PACKAGES` / `_AI_PACKAGES`
- 12 new tests, 1,291 total passing

## Test plan
- [x] `pytest tests/ -x -q` — 1,291 passed
- [x] `ruff check` — all clean
- [x] `--verbose` and `--no-color` appear in `scan --help`
- [x] LLM03 tagged for training packages, not for non-training AI packages
- [x] RAG packages present in all 4 framework lists