### PR TITLE
feat: agent lifecycle visualization + OWASP MCP compliance UI

### DIFF
--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -693,6 +693,207 @@ async def list_agents() -> dict:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
+@app.get("/v1/agents/{agent_name}", tags=["discovery"])
+async def get_agent_detail(agent_name: str) -> dict:
+    """Get detailed view of a single agent with cross-referenced scan data."""
+    try:
+        from dataclasses import asdict
+
+        from agent_bom.discovery import discover_all
+        from agent_bom.parsers import extract_packages
+
+        agents = discover_all()
+        agent = None
+        for a in agents:
+            if a.name == agent_name:
+                agent = a
+                break
+
+        if agent is None:
+            raise HTTPException(status_code=404, detail=f"Agent '{agent_name}' not found")
+
+        for server in agent.mcp_servers:
+            if not server.packages:
+                server.packages = extract_packages(server)
+
+        # Cross-reference blast radii from completed scans
+        agent_blast: list[dict] = []
+        for job in _get_store().list_all():
+            if job.status != JobStatus.DONE or not job.result:
+                continue
+            for br in job.result.get("blast_radius", []):
+                if agent_name in br.get("affected_agents", []):
+                    agent_blast.append(br)
+
+        total_packages = sum(len(s.packages) for s in agent.mcp_servers)
+        total_tools = sum(len(s.tools) for s in agent.mcp_servers)
+        all_credentials: list[str] = []
+        for s in agent.mcp_servers:
+            all_credentials.extend(s.credential_names)
+
+        severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        for br in agent_blast:
+            sev = (br.get("severity") or "").lower()
+            if sev in severity_counts:
+                severity_counts[sev] += 1
+
+        return {
+            "agent": asdict(agent),
+            "summary": {
+                "total_servers": len(agent.mcp_servers),
+                "total_packages": total_packages,
+                "total_tools": total_tools,
+                "total_credentials": len(all_credentials),
+                "total_vulnerabilities": len(agent_blast),
+                "severity_breakdown": severity_counts,
+            },
+            "blast_radius": agent_blast,
+            "credentials": all_credentials,
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/v1/agents/{agent_name}/lifecycle", tags=["discovery"])
+async def get_agent_lifecycle(agent_name: str) -> dict:
+    """Get React Flow nodes/edges for an agent's full lifecycle graph.
+
+    Shows: Agent -> MCP Servers -> Tools/Credentials -> Packages -> CVEs
+    """
+    from agent_bom.output.attack_flow import _severity_color
+
+    detail = await get_agent_detail(agent_name)
+    agent_data = detail["agent"]
+
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen: set[str] = set()
+
+    agent_id = f"agent:{agent_data['name']}"
+    nodes.append({
+        "id": agent_id,
+        "type": "lifecycleNode",
+        "position": {"x": 0, "y": 200},
+        "data": {
+            "nodeType": "agent",
+            "label": agent_data["name"],
+            "agent_type": agent_data.get("agent_type", ""),
+        },
+    })
+
+    y_offset = 0
+    for srv in agent_data.get("mcp_servers", []):
+        srv_id = f"srv:{srv['name']}"
+        nodes.append({
+            "id": srv_id,
+            "type": "lifecycleNode",
+            "position": {"x": 350, "y": y_offset},
+            "data": {
+                "nodeType": "server",
+                "label": srv["name"],
+                "transport": srv.get("transport", "stdio"),
+                "package_count": len(srv.get("packages", [])),
+                "tool_count": len(srv.get("tools", [])),
+            },
+        })
+        edges.append({
+            "id": f"e:{agent_id}->{srv_id}",
+            "source": agent_id, "target": srv_id,
+            "type": "smoothstep", "animated": True,
+            "style": {"stroke": "#10b981"},
+        })
+
+        # Tools
+        ty = y_offset - 40
+        for tool in srv.get("tools", [])[:10]:
+            tid = f"tool:{srv['name']}:{tool['name']}"
+            if tid not in seen:
+                seen.add(tid)
+                nodes.append({
+                    "id": tid, "type": "lifecycleNode",
+                    "position": {"x": 700, "y": ty},
+                    "data": {"nodeType": "tool", "label": tool["name"],
+                             "description": tool.get("description", "")},
+                })
+                edges.append({
+                    "id": f"e:{srv_id}->{tid}", "source": srv_id, "target": tid,
+                    "type": "smoothstep", "style": {"stroke": "#a855f7"},
+                })
+                ty += 50
+
+        # Credentials
+        cy = ty + 10
+        env = srv.get("env", {})
+        _sens = ["key", "token", "secret", "password", "credential", "auth"]
+        cred_vars = [k for k in env if any(p in k.lower() for p in _sens)]
+        for cred in cred_vars:
+            cid = f"cred:{cred}"
+            if cid not in seen:
+                seen.add(cid)
+                nodes.append({
+                    "id": cid, "type": "lifecycleNode",
+                    "position": {"x": 700, "y": cy},
+                    "data": {"nodeType": "credential", "label": cred},
+                })
+                edges.append({
+                    "id": f"e:{srv_id}->{cid}", "source": srv_id, "target": cid,
+                    "type": "smoothstep", "animated": True,
+                    "style": {"stroke": "#eab308"},
+                })
+                cy += 50
+
+        # Packages
+        py_ = y_offset
+        for pkg in srv.get("packages", []):
+            pkg_key = f"{pkg['name']}@{pkg.get('version', '')}"
+            pid = f"pkg:{pkg_key}"
+            if pid not in seen:
+                seen.add(pid)
+                vulns = pkg.get("vulnerabilities", [])
+                nodes.append({
+                    "id": pid, "type": "lifecycleNode",
+                    "position": {"x": 1050, "y": py_},
+                    "data": {"nodeType": "package", "label": pkg["name"],
+                             "version": pkg.get("version", ""),
+                             "ecosystem": pkg.get("ecosystem", ""),
+                             "vuln_count": len(vulns)},
+                })
+                edges.append({
+                    "id": f"e:{srv_id}->{pid}", "source": srv_id, "target": pid,
+                    "type": "smoothstep", "style": {"stroke": "#3b82f6"},
+                })
+
+                # CVEs
+                vy = py_
+                for vuln in vulns:
+                    vid = vuln.get("id", "")
+                    cvid = f"cve:{vid}"
+                    if cvid not in seen:
+                        seen.add(cvid)
+                        sev = vuln.get("severity", "low")
+                        nodes.append({
+                            "id": cvid, "type": "lifecycleNode",
+                            "position": {"x": 1400, "y": vy},
+                            "data": {"nodeType": "cve", "label": vid,
+                                     "severity": sev,
+                                     "cvss_score": vuln.get("cvss_score"),
+                                     "fixed_version": vuln.get("fixed_version")},
+                        })
+                        edges.append({
+                            "id": f"e:{pid}->{cvid}", "source": pid, "target": cvid,
+                            "type": "smoothstep", "animated": True,
+                            "style": {"stroke": _severity_color(sev)},
+                        })
+                        vy += 70
+                py_ += max(len(vulns) * 70, 60)
+
+        y_offset = max(y_offset + 180, py_)
+
+    return {"nodes": nodes, "edges": edges, "stats": detail["summary"]}
+
+
 @app.get("/v1/jobs", tags=["scan"])
 async def list_jobs() -> dict:
     """List all scan jobs (for the UI job history panel)."""

--- a/tests/test_api_agent_detail.py
+++ b/tests/test_api_agent_detail.py
@@ -1,0 +1,111 @@
+"""Tests for agent detail and lifecycle API endpoints."""
+
+from unittest.mock import patch
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package
+
+
+def _mock_agents():
+    """Return a list with one test agent for mocking discover_all."""
+    srv = MCPServer(
+        name="test-server",
+        command="npx",
+        args=["-y", "test-server"],
+        env={"API_KEY": "sk-test", "DEBUG": "1"},
+        packages=[
+            Package(name="express", version="4.18.2", ecosystem="npm"),
+        ],
+        tools=[
+            MCPTool(name="read_file", description="Read file contents"),
+            MCPTool(name="write_file", description="Write file contents"),
+        ],
+    )
+    return [
+        Agent(
+            name="test-agent",
+            agent_type=AgentType.CLAUDE_DESKTOP,
+            config_path="/tmp/test-config.json",
+            mcp_servers=[srv],
+        ),
+    ]
+
+
+@patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
+def test_agent_detail_found(_mock):
+    """GET /v1/agents/{name} returns 200 with agent detail."""
+    client = TestClient(app)
+    resp = client.get("/v1/agents/test-agent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agent"]["name"] == "test-agent"
+    assert data["summary"]["total_servers"] == 1
+    assert data["summary"]["total_tools"] == 2
+    assert data["summary"]["total_credentials"] >= 1
+    assert "blast_radius" in data
+    assert "credentials" in data
+
+
+@patch("agent_bom.discovery.discover_all", return_value=[])
+def test_agent_detail_not_found(_mock):
+    """GET /v1/agents/{name} returns 404 for unknown agent."""
+    client = TestClient(app)
+    resp = client.get("/v1/agents/nonexistent-agent")
+    assert resp.status_code == 404
+
+
+@patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
+def test_agent_lifecycle_nodes_edges(_mock):
+    """GET /v1/agents/{name}/lifecycle returns React Flow graph structure."""
+    client = TestClient(app)
+    resp = client.get("/v1/agents/test-agent/lifecycle")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "nodes" in data
+    assert "edges" in data
+    assert "stats" in data
+    # Should have at least: agent + server + 2 tools + 1 credential + 1 package = 6 nodes
+    assert len(data["nodes"]) >= 5
+    assert len(data["edges"]) >= 4
+    # Check node types
+    node_types = {n["data"]["nodeType"] for n in data["nodes"]}
+    assert "agent" in node_types
+    assert "server" in node_types
+    assert "tool" in node_types
+    assert "package" in node_types
+
+
+@patch("agent_bom.discovery.discover_all", return_value=[])
+def test_agent_lifecycle_not_found(_mock):
+    """GET /v1/agents/{name}/lifecycle returns 404 for unknown agent."""
+    client = TestClient(app)
+    resp = client.get("/v1/agents/nonexistent-agent/lifecycle")
+    assert resp.status_code == 404
+
+
+@patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
+def test_agent_detail_credential_detection(_mock):
+    """Agent detail correctly identifies credential env vars."""
+    client = TestClient(app)
+    resp = client.get("/v1/agents/test-agent")
+    data = resp.json()
+    # API_KEY should be detected as credential, DEBUG should not
+    assert "API_KEY" in data["credentials"]
+    assert "DEBUG" not in data["credentials"]
+
+
+@patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
+def test_agent_lifecycle_edge_structure(_mock):
+    """Lifecycle edges have correct source/target and styling."""
+    client = TestClient(app)
+    resp = client.get("/v1/agents/test-agent/lifecycle")
+    data = resp.json()
+    # All edges should have required fields
+    for edge in data["edges"]:
+        assert "id" in edge
+        assert "source" in edge
+        assert "target" in edge
+        assert "type" in edge
+        assert edge["type"] == "smoothstep"

--- a/ui/app/agents/[name]/lifecycle/page.tsx
+++ b/ui/app/agents/[name]/lifecycle/page.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { use, useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  Handle,
+  Position,
+  ReactFlowProvider,
+  useReactFlow,
+  type Node,
+  type Edge,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import {
+  ArrowLeft,
+  Bug,
+  Download,
+  KeyRound,
+  Loader2,
+  Package,
+  Server,
+  ShieldAlert,
+  Wrench,
+  X,
+} from "lucide-react";
+import { api, type AgentLifecycleResponse, type AttackFlowNodeData } from "@/lib/api";
+import { SeverityBadge } from "@/components/severity-badge";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const NODE_ICONS: Record<string, React.ElementType> = {
+  cve: Bug,
+  package: Package,
+  server: Server,
+  agent: ShieldAlert,
+  credential: KeyRound,
+  tool: Wrench,
+};
+
+const NODE_COLORS: Record<string, string> = {
+  cve: "border-red-600 bg-red-950/80",
+  package: "border-zinc-600 bg-zinc-900/80",
+  server: "border-blue-600 bg-blue-950/80",
+  agent: "border-emerald-600 bg-emerald-950/80",
+  credential: "border-yellow-600 bg-yellow-950/80",
+  tool: "border-purple-600 bg-purple-950/80",
+};
+
+const MINIMAP_COLORS: Record<string, string> = {
+  cve: "#ef4444",
+  package: "#52525b",
+  server: "#3b82f6",
+  agent: "#10b981",
+  credential: "#eab308",
+  tool: "#a855f7",
+};
+
+// ─── Custom Node ─────────────────────────────────────────────────────────────
+
+function LifecycleNode({ data }: { data: AttackFlowNodeData }) {
+  const nodeType = data.nodeType;
+  const Icon = NODE_ICONS[nodeType] ?? Bug;
+
+  const sevColors: Record<string, string> = {
+    critical: "border-red-500 bg-red-950",
+    high: "border-orange-500 bg-orange-950",
+    medium: "border-yellow-500 bg-yellow-950",
+    low: "border-blue-500 bg-blue-950",
+  };
+  const border = nodeType === "cve" && data.severity
+    ? sevColors[data.severity.toLowerCase()] ?? NODE_COLORS[nodeType]
+    : NODE_COLORS[nodeType];
+
+  return (
+    <div className={`rounded-lg border-2 px-3 py-2 min-w-[140px] max-w-[200px] shadow-lg ${border}`}>
+      <Handle type="target" position={Position.Left} className="!bg-zinc-500 !w-2 !h-2" />
+      <div className="flex items-center gap-2">
+        <Icon className="w-3.5 h-3.5 shrink-0 text-zinc-300" />
+        <span className="text-xs font-semibold text-zinc-100 truncate">{data.label}</span>
+      </div>
+      {data.version && (
+        <div className="text-[10px] text-zinc-500 mt-0.5 font-mono">{data.version}</div>
+      )}
+      {data.severity && (
+        <div className="mt-1"><SeverityBadge severity={data.severity} /></div>
+      )}
+      {data.description && (
+        <div className="text-[10px] text-zinc-500 mt-0.5 truncate">{data.description}</div>
+      )}
+      <Handle type="source" position={Position.Right} className="!bg-zinc-500 !w-2 !h-2" />
+    </div>
+  );
+}
+
+const nodeTypes = { lifecycleNode: LifecycleNode };
+
+// ─── Stats Bar ───────────────────────────────────────────────────────────────
+
+function StatsBar({ stats }: { stats: Record<string, number> }) {
+  const items = [
+    { label: "Servers", value: stats.total_servers ?? 0, color: "text-blue-400" },
+    { label: "Packages", value: stats.total_packages ?? 0, color: "text-zinc-400" },
+    { label: "Tools", value: stats.total_tools ?? 0, color: "text-purple-400" },
+    { label: "Credentials", value: stats.total_credentials ?? 0, color: "text-yellow-400" },
+    { label: "Vulns", value: stats.total_vulnerabilities ?? 0, color: "text-red-400" },
+  ];
+  return (
+    <div className="flex items-center gap-4 text-xs">
+      {items.map((s) => (
+        <div key={s.label} className="flex items-center gap-1">
+          <span className={`font-bold ${s.color}`}>{s.value}</span>
+          <span className="text-zinc-500">{s.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Detail Panel ────────────────────────────────────────────────────────────
+
+function DetailPanel({
+  node,
+  onClose,
+}: {
+  node: Node<AttackFlowNodeData>;
+  onClose: () => void;
+}) {
+  const d = node.data;
+  const Icon = NODE_ICONS[d.nodeType] ?? Bug;
+  return (
+    <div className="absolute top-4 right-4 w-72 bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl z-50 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+        <div className="flex items-center gap-2">
+          <Icon className="w-4 h-4 text-zinc-400" />
+          <span className="font-semibold text-sm">{d.label}</span>
+        </div>
+        <button onClick={onClose} className="text-zinc-500 hover:text-zinc-200">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="px-4 py-3 space-y-2 text-xs">
+        <div className="flex justify-between text-zinc-400">
+          <span>Type</span>
+          <span className="text-zinc-200 capitalize">{d.nodeType}</span>
+        </div>
+        {d.severity && (
+          <div className="flex justify-between">
+            <span className="text-zinc-400">Severity</span>
+            <SeverityBadge severity={d.severity} />
+          </div>
+        )}
+        {d.cvss_score != null && (
+          <div className="flex justify-between text-zinc-400">
+            <span>CVSS</span>
+            <span className="text-zinc-200">{d.cvss_score}</span>
+          </div>
+        )}
+        {d.version && (
+          <div className="flex justify-between text-zinc-400">
+            <span>Version</span>
+            <span className="text-zinc-200 font-mono">{d.version}</span>
+          </div>
+        )}
+        {d.ecosystem && (
+          <div className="flex justify-between text-zinc-400">
+            <span>Ecosystem</span>
+            <span className="text-zinc-200">{d.ecosystem}</span>
+          </div>
+        )}
+        {d.agent_type && (
+          <div className="flex justify-between text-zinc-400">
+            <span>Agent Type</span>
+            <span className="text-zinc-200">{d.agent_type}</span>
+          </div>
+        )}
+        {d.description && (
+          <div className="text-zinc-400 pt-1 border-t border-zinc-800">
+            <span className="block mb-0.5">Description</span>
+            <span className="text-zinc-300">{d.description}</span>
+          </div>
+        )}
+        {d.fixed_version && (
+          <div className="flex justify-between text-zinc-400">
+            <span>Fix Available</span>
+            <span className="text-emerald-400 font-mono">{d.fixed_version}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Flow Canvas ─────────────────────────────────────────────────────────────
+
+function LifecycleFlow({
+  data,
+  agentName,
+}: {
+  data: AgentLifecycleResponse;
+  agentName: string;
+}) {
+  const { fitView } = useReactFlow();
+  const [selectedNode, setSelectedNode] = useState<Node<AttackFlowNodeData> | null>(null);
+
+  useEffect(() => {
+    setTimeout(() => fitView({ padding: 0.2 }), 100);
+  }, [fitView, data]);
+
+  const onNodeClick = useCallback((_: unknown, node: Node) => {
+    setSelectedNode(node as Node<AttackFlowNodeData>);
+  }, []);
+
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${agentName}-lifecycle.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="relative w-full h-full">
+      {/* Header bar */}
+      <div className="absolute top-0 left-0 right-0 z-10 bg-zinc-950/90 backdrop-blur-sm border-b border-zinc-800 px-4 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link
+            href={`/agents/${encodeURIComponent(agentName)}`}
+            className="text-zinc-400 hover:text-zinc-200 flex items-center gap-1 text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" /> {agentName}
+          </Link>
+          <span className="text-zinc-600">|</span>
+          <span className="text-sm font-semibold text-zinc-300">Lifecycle Graph</span>
+        </div>
+        <div className="flex items-center gap-4">
+          <StatsBar stats={data.stats} />
+          <button
+            onClick={handleExport}
+            className="text-zinc-400 hover:text-zinc-200 flex items-center gap-1 text-xs border border-zinc-700 rounded px-2 py-1"
+          >
+            <Download className="w-3.5 h-3.5" /> Export
+          </button>
+        </div>
+      </div>
+
+      <ReactFlow
+        nodes={data.nodes as Node[]}
+        edges={data.edges as Edge[]}
+        nodeTypes={nodeTypes}
+        onNodeClick={onNodeClick}
+        fitView
+        minZoom={0.1}
+        maxZoom={2}
+        className="!bg-zinc-950"
+      >
+        <Background color="#27272a" gap={20} />
+        <Controls className="!bg-zinc-900 !border-zinc-700 !rounded-lg [&>button]:!bg-zinc-800 [&>button]:!border-zinc-700 [&>button]:!text-zinc-300" />
+        <MiniMap
+          nodeColor={(n) => MINIMAP_COLORS[(n.data as AttackFlowNodeData)?.nodeType] ?? "#52525b"}
+          className="!bg-zinc-900 !border-zinc-700 !rounded-lg"
+          maskColor="rgba(0,0,0,0.7)"
+        />
+      </ReactFlow>
+
+      {selectedNode && (
+        <DetailPanel node={selectedNode} onClose={() => setSelectedNode(null)} />
+      )}
+    </div>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export default function AgentLifecyclePage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = use(params);
+  const agentName = decodeURIComponent(name);
+  const [data, setData] = useState<AgentLifecycleResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .getAgentLifecycle(agentName)
+      .then(setData)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [agentName]);
+
+  if (loading) {
+    return (
+      <div className="h-screen bg-zinc-950 flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-zinc-500" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="h-screen bg-zinc-950 p-8">
+        <Link href="/agents" className="text-zinc-400 hover:text-zinc-200 flex items-center gap-1 mb-6">
+          <ArrowLeft className="w-4 h-4" /> Back to agents
+        </Link>
+        <div className="text-red-400 bg-red-950 border border-red-800 rounded-lg p-4">
+          {error || "Agent not found"}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen bg-zinc-950">
+      <ReactFlowProvider>
+        <LifecycleFlow data={data} agentName={agentName} />
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/ui/app/agents/[name]/page.tsx
+++ b/ui/app/agents/[name]/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  api,
+  type AgentDetailResponse,
+  type BlastRadius,
+  severityColor,
+  OWASP_LLM_TOP10,
+  MITRE_ATLAS,
+} from "@/lib/api";
+import { SeverityBadge } from "@/components/severity-badge";
+import {
+  ArrowLeft,
+  Bug,
+  GitBranch,
+  KeyRound,
+  Loader2,
+  Package,
+  Server,
+  ShieldAlert,
+  Wrench,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+} from "lucide-react";
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export default function AgentDetailPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = use(params);
+  const agentName = decodeURIComponent(name);
+  const [data, setData] = useState<AgentDetailResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    api
+      .getAgentDetail(agentName)
+      .then(setData)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [agentName]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-zinc-950 flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-zinc-500" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen bg-zinc-950 p-8">
+        <Link href="/agents" className="text-zinc-400 hover:text-zinc-200 flex items-center gap-1 mb-6">
+          <ArrowLeft className="w-4 h-4" /> Back to agents
+        </Link>
+        <div className="text-red-400 bg-red-950 border border-red-800 rounded-lg p-4">
+          {error || "Agent not found"}
+        </div>
+      </div>
+    );
+  }
+
+  const { agent, summary, blast_radius, credentials } = data;
+  const sev = summary.severity_breakdown;
+
+  const toggleServer = (name: string) => {
+    setExpandedServers((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      {/* Header */}
+      <div className="border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-sm sticky top-0 z-10">
+        <div className="max-w-7xl mx-auto px-6 py-4">
+          <Link href="/agents" className="text-zinc-500 hover:text-zinc-300 flex items-center gap-1 text-sm mb-2">
+            <ArrowLeft className="w-3.5 h-3.5" /> All Agents
+          </Link>
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold flex items-center gap-3">
+                <ShieldAlert className="w-6 h-6 text-emerald-400" />
+                {agent.name}
+              </h1>
+              <div className="flex items-center gap-3 mt-1 text-sm text-zinc-500">
+                <span className="bg-zinc-800 px-2 py-0.5 rounded text-xs">
+                  {agent.agent_type}
+                </span>
+                {agent.config_path && (
+                  <span className="font-mono text-xs truncate max-w-md">
+                    {agent.config_path}
+                  </span>
+                )}
+              </div>
+            </div>
+            <Link
+              href={`/agents/${encodeURIComponent(agentName)}/lifecycle`}
+              className="bg-emerald-600 hover:bg-emerald-500 text-white px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-colors"
+            >
+              <GitBranch className="w-4 h-4" />
+              View Lifecycle Graph
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-6 py-6 space-y-6">
+        {/* Summary Stats */}
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+          <StatCard icon={Server} label="MCP Servers" value={summary.total_servers} color="text-blue-400" />
+          <StatCard icon={Package} label="Packages" value={summary.total_packages} color="text-zinc-400" />
+          <StatCard icon={Wrench} label="Tools" value={summary.total_tools} color="text-purple-400" />
+          <StatCard icon={KeyRound} label="Credentials" value={summary.total_credentials} color="text-yellow-400" />
+          <StatCard icon={Bug} label="Vulnerabilities" value={summary.total_vulnerabilities} color="text-red-400" />
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-3">
+            <div className="text-xs text-zinc-500 mb-1">Severity</div>
+            <div className="flex items-center gap-2 text-xs">
+              {sev.critical > 0 && <span className="text-red-400 font-bold">{sev.critical}C</span>}
+              {sev.high > 0 && <span className="text-orange-400 font-bold">{sev.high}H</span>}
+              {sev.medium > 0 && <span className="text-yellow-400">{sev.medium}M</span>}
+              {sev.low > 0 && <span className="text-blue-400">{sev.low}L</span>}
+              {sev.critical + sev.high + sev.medium + sev.low === 0 && (
+                <span className="text-emerald-400 font-medium">Clean</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Exposed Credentials */}
+        {credentials.length > 0 && (
+          <div className="bg-yellow-950/30 border border-yellow-800/50 rounded-xl p-4">
+            <h3 className="text-sm font-semibold text-yellow-400 flex items-center gap-2 mb-2">
+              <KeyRound className="w-4 h-4" /> Exposed Credentials ({credentials.length})
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {credentials.map((c) => (
+                <span key={c} className="bg-yellow-950 border border-yellow-800 text-yellow-300 px-2 py-0.5 rounded text-xs font-mono">
+                  {c}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* MCP Servers */}
+        <div>
+          <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+            <Server className="w-5 h-5 text-blue-400" /> MCP Servers
+          </h2>
+          <div className="space-y-2">
+            {agent.mcp_servers.map((srv) => {
+              const isExpanded = expandedServers.has(srv.name);
+              const srvPkgs = srv.packages || [];
+              const srvTools = srv.tools || [];
+              const vulnCount = srvPkgs.reduce(
+                (sum, p) => sum + (p.vulnerabilities?.length ?? 0),
+                0
+              );
+              return (
+                <div key={srv.name} className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+                  <button
+                    onClick={() => toggleServer(srv.name)}
+                    className="w-full px-4 py-3 flex items-center justify-between hover:bg-zinc-800/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      {isExpanded ? <ChevronDown className="w-4 h-4 text-zinc-500" /> : <ChevronRight className="w-4 h-4 text-zinc-500" />}
+                      <span className="font-medium">{srv.name}</span>
+                      <span className="text-xs bg-zinc-800 text-zinc-400 px-2 py-0.5 rounded">
+                        {srv.transport || "stdio"}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 text-xs text-zinc-500">
+                      <span>{srvPkgs.length} pkgs</span>
+                      <span>{srvTools.length} tools</span>
+                      {vulnCount > 0 && (
+                        <span className="text-red-400 font-medium">{vulnCount} vulns</span>
+                      )}
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="border-t border-zinc-800 px-4 py-3 space-y-3">
+                      {/* Tools */}
+                      {srvTools.length > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-purple-400 mb-1">Tools</h4>
+                          <div className="flex flex-wrap gap-1.5">
+                            {srvTools.map((t) => (
+                              <span key={t.name} className="bg-purple-950 border border-purple-800 text-purple-300 px-2 py-0.5 rounded text-xs">
+                                {t.name}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                      {/* Packages */}
+                      {srvPkgs.length > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-zinc-400 mb-1">Packages</h4>
+                          <div className="space-y-1">
+                            {srvPkgs.map((pkg) => (
+                              <div key={`${pkg.name}@${pkg.version}`} className="flex items-center justify-between text-xs">
+                                <span className="font-mono">
+                                  {pkg.name}
+                                  <span className="text-zinc-500">@{pkg.version}</span>
+                                </span>
+                                <span className="text-zinc-600">{pkg.ecosystem}</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Blast Radius */}
+        {blast_radius.length > 0 && (
+          <div>
+            <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+              <Bug className="w-5 h-5 text-red-400" /> Blast Radius ({blast_radius.length})
+            </h2>
+            <div className="space-y-2">
+              {blast_radius.map((br, i) => (
+                <div key={`${br.vulnerability_id}-${i}`} className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                      <SeverityBadge severity={br.severity} />
+                      <span className="font-mono font-medium">{br.vulnerability_id}</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-zinc-500">
+                      {br.cvss_score && <span>CVSS {br.cvss_score}</span>}
+                      {br.is_kev && <span className="text-red-400 font-bold">KEV</span>}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-3 text-xs text-zinc-400">
+                    {br.package && <span>Package: <span className="text-zinc-300">{br.package}</span></span>}
+                    {br.exposed_credentials.length > 0 && (
+                      <span className="text-yellow-400">{br.exposed_credentials.length} credentials exposed</span>
+                    )}
+                    {br.reachable_tools.length > 0 && (
+                      <span className="text-purple-400">{br.reachable_tools.length} tools reachable</span>
+                    )}
+                  </div>
+                  {/* Framework tags */}
+                  <div className="flex flex-wrap gap-1 mt-2">
+                    {(br.owasp_tags ?? []).map((t) => (
+                      <span key={t} className="bg-indigo-950 border border-indigo-800 text-indigo-300 px-1.5 py-0.5 rounded text-[10px]">
+                        {t} {OWASP_LLM_TOP10[t] ?? ""}
+                      </span>
+                    ))}
+                    {(br.atlas_tags ?? []).map((t) => (
+                      <span key={t} className="bg-rose-950 border border-rose-800 text-rose-300 px-1.5 py-0.5 rounded text-[10px]">
+                        {t} {MITRE_ATLAS[t] ?? ""}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Components ──────────────────────────────────────────────────────────────
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  color,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: number;
+  color: string;
+}) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-3">
+      <div className="flex items-center gap-1.5 text-xs text-zinc-500 mb-1">
+        <Icon className={`w-3.5 h-3.5 ${color}`} />
+        {label}
+      </div>
+      <div className="text-xl font-bold">{value}</div>
+    </div>
+  );
+}

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { api, Agent, isConfigured } from "@/lib/api";
-import { Server, Package, Wrench, Key, AlertCircle, Shield, ChevronDown, ChevronRight } from "lucide-react";
+import { Server, Package, Wrench, Key, AlertCircle, Shield, ChevronDown, ChevronRight, ArrowRight } from "lucide-react";
 
 function useAgentStats(agents: Agent[]) {
   const configured = agents.filter(isConfigured);
@@ -155,9 +156,19 @@ export default function AgentsPage() {
                   <span className="text-xs text-zinc-600">{agent.source}</span>
                 )}
               </div>
-              <span className="text-xs font-mono bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-zinc-400">
-                {agent.mcp_servers.length} server{agent.mcp_servers.length !== 1 ? "s" : ""}
-              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-mono bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-zinc-400">
+                  {agent.mcp_servers.length} server{agent.mcp_servers.length !== 1 ? "s" : ""}
+                </span>
+                <Link
+                  href={`/agents/${encodeURIComponent(agent.name)}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-zinc-500 hover:text-emerald-400 transition-colors"
+                  title="View agent detail"
+                >
+                  <ArrowRight className="w-4 h-4" />
+                </Link>
+              </div>
             </button>
 
             {!collapsed.has(i) && (

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -6,6 +6,7 @@ import {
   ComplianceResponse,
   ComplianceControl,
   OWASP_LLM_TOP10,
+  OWASP_MCP_TOP10,
   MITRE_ATLAS,
   NIST_AI_RMF,
   formatDate,
@@ -327,7 +328,7 @@ export default function CompliancePage() {
         </div>
 
         {/* Framework mini-cards */}
-        <div className="grid grid-cols-3 gap-4 mt-6">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
           <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
             <div className="text-xs text-zinc-500 mb-1">OWASP LLM Top 10</div>
             <div className="flex items-baseline gap-2">
@@ -337,6 +338,17 @@ export default function CompliancePage() {
             <div className="flex gap-2 mt-2 text-xs">
               {s.owasp_fail > 0 && <span className="text-red-400">{s.owasp_fail} fail</span>}
               {s.owasp_warn > 0 && <span className="text-yellow-400">{s.owasp_warn} warn</span>}
+            </div>
+          </div>
+          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+            <div className="text-xs text-amber-500/80 mb-1">OWASP MCP Top 10</div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-bold text-zinc-100">{s.owasp_mcp_pass}</span>
+              <span className="text-sm text-zinc-500">/ 10 pass</span>
+            </div>
+            <div className="flex gap-2 mt-2 text-xs">
+              {s.owasp_mcp_fail > 0 && <span className="text-red-400">{s.owasp_mcp_fail} fail</span>}
+              {s.owasp_mcp_warn > 0 && <span className="text-yellow-400">{s.owasp_mcp_warn} warn</span>}
             </div>
           </div>
           <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
@@ -369,6 +381,7 @@ export default function CompliancePage() {
         <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wider">Framework Coverage</h2>
         <FrameworkBar label="OWASP LLM Top 10" pass={s.owasp_pass} warn={s.owasp_warn} fail={s.owasp_fail} total={10} />
         <FrameworkBar label="MITRE ATLAS" pass={s.atlas_pass} warn={s.atlas_warn} fail={s.atlas_fail} total={data.mitre_atlas.length} />
+        <FrameworkBar label="OWASP MCP Top 10" pass={s.owasp_mcp_pass} warn={s.owasp_mcp_warn} fail={s.owasp_mcp_fail} total={10} />
         <FrameworkBar label="NIST AI RMF" pass={s.nist_pass} warn={s.nist_warn} fail={s.nist_fail} total={data.nist_ai_rmf.length} />
       </div>
 
@@ -382,6 +395,20 @@ export default function CompliancePage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {data.owasp_llm_top10.map((c) => (
             <ControlCard key={c.code} control={c} catalog={OWASP_LLM_TOP10} />
+          ))}
+        </div>
+      </section>
+
+      {/* ── OWASP MCP Top 10 ─────────────────────────────────────────── */}
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <Shield className="w-5 h-5 text-amber-400" />
+          <h2 className="text-lg font-semibold text-zinc-200">OWASP MCP Top 10</h2>
+          <span className="text-xs text-zinc-500 ml-2">MCP Security Risks</span>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {data.owasp_mcp_top10.map((c) => (
+            <ControlCard key={c.code} control={c} catalog={OWASP_MCP_TOP10} />
           ))}
         </div>
       </section>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -264,13 +264,37 @@ export interface ComplianceResponse {
   scan_count: number;
   latest_scan: string | null;
   owasp_llm_top10: ComplianceControl[];
+  owasp_mcp_top10: ComplianceControl[];
   mitre_atlas: ComplianceControl[];
   nist_ai_rmf: ComplianceControl[];
   summary: {
     owasp_pass: number; owasp_warn: number; owasp_fail: number;
+    owasp_mcp_pass: number; owasp_mcp_warn: number; owasp_mcp_fail: number;
     atlas_pass: number; atlas_warn: number; atlas_fail: number;
     nist_pass: number;  nist_warn: number;  nist_fail: number;
   };
+}
+
+// ─── Agent Detail Types ──────────────────────────────────────────────────────
+
+export interface AgentDetailResponse {
+  agent: Agent;
+  summary: {
+    total_servers: number;
+    total_packages: number;
+    total_tools: number;
+    total_credentials: number;
+    total_vulnerabilities: number;
+    severity_breakdown: Record<string, number>;
+  };
+  blast_radius: BlastRadius[];
+  credentials: string[];
+}
+
+export interface AgentLifecycleResponse {
+  nodes: AttackFlowNode[];
+  edges: AttackFlowEdge[];
+  stats: Record<string, number>;
 }
 
 // ─── Fetch helpers ────────────────────────────────────────────────────────────
@@ -315,6 +339,12 @@ export const api = {
 
   /** Quick agent discovery (no CVE scan) */
   listAgents: () => get<AgentsResponse>("/v1/agents"),
+
+  /** Get detailed view of a single agent */
+  getAgentDetail: (name: string) => get<AgentDetailResponse>(`/v1/agents/${encodeURIComponent(name)}`),
+
+  /** Get React Flow lifecycle graph for an agent */
+  getAgentLifecycle: (name: string) => get<AgentLifecycleResponse>(`/v1/agents/${encodeURIComponent(name)}/lifecycle`),
 
   /** MCP registry catalog */
   listRegistry: () => get<RegistryResponse>("/v1/registry"),
@@ -374,6 +404,20 @@ export const OWASP_LLM_TOP10: Record<string, string> = {
   LLM08: "Excessive Agency",
   LLM09: "Misinformation",
   LLM10: "Unbounded Consumption",
+};
+
+/** OWASP MCP Top 10 — code → human-readable name */
+export const OWASP_MCP_TOP10: Record<string, string> = {
+  MCP01: "Token Mismanagement & Secret Exposure",
+  MCP02: "Privilege Escalation via Scope Creep",
+  MCP03: "Tool Poisoning",
+  MCP04: "Software Supply Chain Attacks",
+  MCP05: "Command Injection & Execution",
+  MCP06: "Intent Flow Subversion",
+  MCP07: "Insufficient Auth & Authorization",
+  MCP08: "Lack of Audit & Telemetry",
+  MCP09: "Shadow MCP Servers",
+  MCP10: "Context Injection & Over-Sharing",
 };
 
 /** MITRE ATLAS — technique ID → human-readable name */


### PR DESCRIPTION
## Summary
- **Agent detail endpoint** (`/v1/agents/{name}`) — cross-references blast radii from completed scans, returns summary stats (servers, packages, tools, credentials, vulnerabilities, severity breakdown)
- **Agent lifecycle endpoint** (`/v1/agents/{name}/lifecycle`) — React Flow graph nodes/edges: Agent → MCP Servers → Tools/Credentials → Packages → CVEs
- **Agent detail page** — drill-down view with stat cards, exposed credentials, collapsible MCP server list, blast radius findings with OWASP/ATLAS tags
- **Agent lifecycle graph page** — full-screen React Flow with custom nodes, minimap, export JSON, click-to-inspect detail panel
- **Agents list** — now clickable with navigation to agent detail
- **Compliance page** — added OWASP MCP Top 10 framework bar and control cards section (backend already returned the data)
- **6 new tests** for agent detail and lifecycle API endpoints

## Test plan
- [ ] `pytest tests/test_api_agent_detail.py -x -q` — all 6 pass
- [ ] `agent-bom api` → `curl localhost:8422/v1/agents/{name}` → verify summary + blast_radius
- [ ] `curl localhost:8422/v1/agents/{name}/lifecycle` → verify nodes/edges structure
- [ ] `cd ui && npm run dev` → `/agents` → click agent → see detail page
- [ ] `/agents/{name}/lifecycle` → see React Flow lifecycle graph
- [ ] `/compliance` → see 4 framework cards including OWASP MCP Top 10