### PR TITLE
feat: platform packaging — dashboard topology + Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-# Install agent-bom
-RUN pip install --no-cache-dir -e .
+# Install agent-bom with API extras
+RUN pip install --no-cache-dir -e ".[api]"
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -1,0 +1,54 @@
+version: "3.8"
+
+# Platform deployment: API + Dashboard
+# Usage: docker compose -f docker-compose.platform.yml up --build
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: agent-bom:latest
+    container_name: agent-bom-api
+    command: api --host 0.0.0.0 --port 8422
+    ports:
+      - "8422:8422"
+    environment:
+      - AGENT_BOM_DB=/data/jobs.db
+      - CORS_ORIGINS=http://localhost:3000,http://ui:3000
+      - NVD_API_KEY=${NVD_API_KEY:-}
+    volumes:
+      - api-data:/data
+      - ~/.config:/root/.config:ro
+      - ~/.claude:/root/.claude:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8422/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  ui:
+    build:
+      context: ./ui
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: http://localhost:8422
+    image: agent-bom-ui:latest
+    container_name: agent-bom-ui
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8422
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  api-data:
+
+networks:
+  default:
+    name: agent-bom-platform

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,40 @@
+# ── Stage 1: Install dependencies ─────────────────────────────────────────────
+FROM node:20-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --ignore-scripts
+
+# ── Stage 2: Build ────────────────────────────────────────────────────────────
+FROM node:20-slim AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_API_URL=http://localhost:8422
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# ── Stage 3: Run ──────────────────────────────────────────────────────────────
+FROM node:20-slim AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy standalone output
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/ui/components/agent-topology.tsx
+++ b/ui/components/agent-topology.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ReactFlow,
+  Background,
+  ReactFlowProvider,
+  useReactFlow,
+  type Node,
+  type Edge,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { Server, ShieldAlert } from "lucide-react";
+import type { Agent } from "@/lib/api";
+
+// ─── Node renderers ─────────────────────────────────────────────────────────
+
+function AgentNode({ data }: { data: { label: string; type: string } }) {
+  return (
+    <div className="rounded-lg border-2 border-emerald-600 bg-emerald-950/80 px-3 py-2 min-w-[120px] shadow-lg">
+      <div className="flex items-center gap-2">
+        <ShieldAlert className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+        <span className="text-xs font-semibold text-zinc-100 truncate">{data.label}</span>
+      </div>
+      <div className="text-[10px] text-zinc-500 mt-0.5">{data.type}</div>
+    </div>
+  );
+}
+
+function ServerNode({ data }: { data: { label: string; pkgCount: number; toolCount: number } }) {
+  return (
+    <div className="rounded-lg border-2 border-blue-600 bg-blue-950/80 px-3 py-2 min-w-[120px] shadow-lg">
+      <div className="flex items-center gap-2">
+        <Server className="w-3.5 h-3.5 text-blue-400 shrink-0" />
+        <span className="text-xs font-semibold text-zinc-100 truncate">{data.label}</span>
+      </div>
+      <div className="text-[10px] text-zinc-500 mt-0.5">
+        {data.pkgCount} pkg{data.pkgCount !== 1 ? "s" : ""}
+        {data.toolCount > 0 && ` · ${data.toolCount} tool${data.toolCount !== 1 ? "s" : ""}`}
+      </div>
+    </div>
+  );
+}
+
+const nodeTypes = { agentNode: AgentNode, serverNode: ServerNode };
+
+// ─── Graph builder ──────────────────────────────────────────────────────────
+
+function buildGraph(agents: Agent[]): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const Y_GAP = 100;
+  const X_GAP = 280;
+
+  let agentY = 0;
+
+  for (const agent of agents) {
+    const agentId = `agent-${agent.name}`;
+    nodes.push({
+      id: agentId,
+      type: "agentNode",
+      position: { x: 0, y: agentY },
+      data: { label: agent.name, type: agent.agent_type },
+    });
+
+    const servers = agent.mcp_servers;
+    const serverStartY = agentY - ((servers.length - 1) * Y_GAP) / 2;
+
+    servers.forEach((srv, i) => {
+      const srvId = `srv-${agent.name}-${srv.name}`;
+      nodes.push({
+        id: srvId,
+        type: "serverNode",
+        position: { x: X_GAP, y: serverStartY + i * Y_GAP },
+        data: {
+          label: srv.name,
+          pkgCount: srv.packages.length,
+          toolCount: srv.tools?.length ?? 0,
+        },
+      });
+      edges.push({
+        id: `e-${agentId}-${srvId}`,
+        source: agentId,
+        target: srvId,
+        type: "smoothstep",
+        style: { stroke: "#10b981" },
+      });
+    });
+
+    agentY += Math.max(servers.length, 1) * Y_GAP + 40;
+  }
+
+  return { nodes, edges };
+}
+
+// ─── Inner flow (needs ReactFlowProvider) ───────────────────────────────────
+
+function TopologyFlow({ agents, onAgentClick }: { agents: Agent[]; onAgentClick: (name: string) => void }) {
+  const { fitView } = useReactFlow();
+  const { nodes, edges } = useMemo(() => buildGraph(agents), [agents]);
+
+  useEffect(() => {
+    setTimeout(() => fitView({ padding: 0.3 }), 100);
+  }, [fitView, nodes]);
+
+  const handleNodeClick = useCallback(
+    (_: unknown, node: Node) => {
+      if (node.id.startsWith("agent-")) {
+        onAgentClick(node.id.replace("agent-", ""));
+      }
+    },
+    [onAgentClick],
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      onNodeClick={handleNodeClick}
+      fitView
+      minZoom={0.3}
+      maxZoom={1.5}
+      panOnDrag
+      zoomOnScroll={false}
+      className="!bg-zinc-950"
+      proOptions={{ hideAttribution: true }}
+    >
+      <Background color="#27272a" gap={20} />
+    </ReactFlow>
+  );
+}
+
+// ─── Public component ───────────────────────────────────────────────────────
+
+export function AgentTopology({ agents }: { agents: Agent[] }) {
+  const router = useRouter();
+
+  const handleAgentClick = useCallback(
+    (name: string) => {
+      router.push(`/agents/${encodeURIComponent(name)}`);
+    },
+    [router],
+  );
+
+  if (agents.length === 0) return null;
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden" style={{ height: 320 }}>
+      <ReactFlowProvider>
+        <TopologyFlow agents={agents} onAgentClick={handleAgentClick} />
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- **Agent topology mini-graph** on dashboard — interactive React Flow showing Agent → Server relationships, click to navigate to agent detail
- **UI Dockerfile** — multi-stage Next.js standalone build (node:20-slim, ~150MB image)
- **`docker-compose.platform.yml`** — single command to deploy API + Dashboard together with SQLite persistence
- **SQLite auto-init** — set `AGENT_BOM_DB=/data/jobs.db` env to auto-configure persistent job store on startup
- **CORS env var** — set `CORS_ORIGINS=http://host1,http://host2` for flexible deployment
- **Dockerfile update** — install `[api]` extras so API server works in container

## Usage

```bash
# One-command platform deployment
docker compose -f docker-compose.platform.yml up --build

# Open dashboard at http://localhost:3000
# API available at http://localhost:8422
```

## Test plan
- [ ] `pytest tests/ -x -q` — all 1,297 pass
- [ ] `cd ui && npm run dev` → dashboard shows "Agent Topology" section with React Flow graph
- [ ] Click agent node → navigates to `/agents/{name}`
- [ ] `docker compose -f docker-compose.platform.yml up --build` → both services start
- [ ] API health check passes: `curl localhost:8422/health`
- [ ] UI loads at `http://localhost:3000`
- [ ] Set `AGENT_BOM_DB=/tmp/test.db` → SQLite store auto-configured on startup