### PR TITLE
feat: gateway policies with runtime MCP enforcement

### DIFF
--- a/src/agent_bom/api/policy_store.py
+++ b/src/agent_bom/api/policy_store.py
@@ -1,0 +1,288 @@
+"""Gateway policy persistence — CRUD + audit log for runtime MCP policies.
+
+Follows the same Protocol → InMemory → SQLite pattern as store.py and
+fleet_store.py.  All three stores can share the same AGENT_BOM_DB file.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from enum import Enum
+from typing import Protocol
+
+from pydantic import BaseModel
+
+# ── Models ────────────────────────────────────────────────────────────────────
+
+
+class PolicyMode(str, Enum):
+    AUDIT = "audit"
+    ENFORCE = "enforce"
+
+
+class GatewayRule(BaseModel):
+    id: str
+    description: str = ""
+    action: str = "block"
+    block_tools: list[str] = []
+    tool_name: str | None = None
+    tool_name_pattern: str | None = None
+    arg_pattern: dict[str, str] = {}
+    rate_limit: int | None = None
+    require_registry_verified: bool = False
+
+
+class GatewayPolicy(BaseModel):
+    policy_id: str
+    name: str
+    description: str = ""
+    mode: PolicyMode = PolicyMode.AUDIT
+    rules: list[GatewayRule] = []
+    bound_agents: list[str] = []
+    bound_agent_types: list[str] = []
+    bound_environments: list[str] = []
+    created_at: str = ""
+    updated_at: str = ""
+    enabled: bool = True
+
+
+class PolicyAuditEntry(BaseModel):
+    entry_id: str
+    policy_id: str
+    policy_name: str
+    rule_id: str
+    agent_name: str
+    tool_name: str
+    arguments_preview: dict = {}
+    action_taken: str  # "blocked" | "alerted" | "allowed"
+    reason: str
+    timestamp: str = ""
+
+
+# ── Protocol ──────────────────────────────────────────────────────────────────
+
+
+class PolicyStore(Protocol):
+    def put_policy(self, policy: GatewayPolicy) -> None: ...
+    def get_policy(self, policy_id: str) -> GatewayPolicy | None: ...
+    def delete_policy(self, policy_id: str) -> bool: ...
+    def list_policies(self) -> list[GatewayPolicy]: ...
+    def get_policies_for_agent(
+        self,
+        agent_name: str | None = None,
+        agent_type: str | None = None,
+        environment: str | None = None,
+    ) -> list[GatewayPolicy]: ...
+    def put_audit_entry(self, entry: PolicyAuditEntry) -> None: ...
+    def list_audit_entries(
+        self,
+        policy_id: str | None = None,
+        agent_name: str | None = None,
+        limit: int = 100,
+    ) -> list[PolicyAuditEntry]: ...
+
+
+# ── InMemory ──────────────────────────────────────────────────────────────────
+
+
+class InMemoryPolicyStore:
+    def __init__(self) -> None:
+        self._policies: dict[str, GatewayPolicy] = {}
+        self._audit: list[PolicyAuditEntry] = []
+
+    def put_policy(self, policy: GatewayPolicy) -> None:
+        self._policies[policy.policy_id] = policy
+
+    def get_policy(self, policy_id: str) -> GatewayPolicy | None:
+        return self._policies.get(policy_id)
+
+    def delete_policy(self, policy_id: str) -> bool:
+        if policy_id in self._policies:
+            del self._policies[policy_id]
+            return True
+        return False
+
+    def list_policies(self) -> list[GatewayPolicy]:
+        return list(self._policies.values())
+
+    def get_policies_for_agent(
+        self,
+        agent_name: str | None = None,
+        agent_type: str | None = None,
+        environment: str | None = None,
+    ) -> list[GatewayPolicy]:
+        results = []
+        for p in self._policies.values():
+            if not p.enabled:
+                continue
+            if p.bound_agents and agent_name and agent_name not in p.bound_agents:
+                continue
+            if p.bound_agent_types and agent_type and agent_type not in p.bound_agent_types:
+                continue
+            if p.bound_environments and environment and environment not in p.bound_environments:
+                continue
+            results.append(p)
+        return results
+
+    def put_audit_entry(self, entry: PolicyAuditEntry) -> None:
+        self._audit.append(entry)
+
+    def list_audit_entries(
+        self,
+        policy_id: str | None = None,
+        agent_name: str | None = None,
+        limit: int = 100,
+    ) -> list[PolicyAuditEntry]:
+        entries = self._audit
+        if policy_id:
+            entries = [e for e in entries if e.policy_id == policy_id]
+        if agent_name:
+            entries = [e for e in entries if e.agent_name == agent_name]
+        return entries[-limit:][::-1]
+
+
+# ── SQLite ────────────────────────────────────────────────────────────────────
+
+
+class SQLitePolicyStore:
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        return self._local.conn
+
+    def _init_db(self) -> None:
+        c = self._conn
+        c.execute(
+            """CREATE TABLE IF NOT EXISTS gateway_policies (
+                policy_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                updated_at TEXT,
+                data TEXT NOT NULL
+            )"""
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_gp_name ON gateway_policies(name)"
+        )
+        c.execute(
+            """CREATE TABLE IF NOT EXISTS policy_audit_log (
+                entry_id TEXT PRIMARY KEY,
+                policy_id TEXT NOT NULL,
+                agent_name TEXT,
+                action_taken TEXT,
+                timestamp TEXT,
+                data TEXT NOT NULL
+            )"""
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pal_policy ON policy_audit_log(policy_id)"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pal_agent ON policy_audit_log(agent_name)"
+        )
+        c.commit()
+
+    # ── policies ──
+
+    def put_policy(self, policy: GatewayPolicy) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO gateway_policies
+               (policy_id, name, mode, enabled, updated_at, data)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                policy.policy_id,
+                policy.name,
+                policy.mode.value,
+                int(policy.enabled),
+                policy.updated_at,
+                policy.model_dump_json(),
+            ),
+        )
+        self._conn.commit()
+
+    def get_policy(self, policy_id: str) -> GatewayPolicy | None:
+        row = self._conn.execute(
+            "SELECT data FROM gateway_policies WHERE policy_id = ?",
+            (policy_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return GatewayPolicy.model_validate_json(row[0])
+
+    def delete_policy(self, policy_id: str) -> bool:
+        cur = self._conn.execute(
+            "DELETE FROM gateway_policies WHERE policy_id = ?",
+            (policy_id,),
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    def list_policies(self) -> list[GatewayPolicy]:
+        rows = self._conn.execute(
+            "SELECT data FROM gateway_policies ORDER BY name"
+        ).fetchall()
+        return [GatewayPolicy.model_validate_json(r[0]) for r in rows]
+
+    def get_policies_for_agent(
+        self,
+        agent_name: str | None = None,
+        agent_type: str | None = None,
+        environment: str | None = None,
+    ) -> list[GatewayPolicy]:
+        policies = [p for p in self.list_policies() if p.enabled]
+        results = []
+        for p in policies:
+            if p.bound_agents and agent_name and agent_name not in p.bound_agents:
+                continue
+            if p.bound_agent_types and agent_type and agent_type not in p.bound_agent_types:
+                continue
+            if p.bound_environments and environment and environment not in p.bound_environments:
+                continue
+            results.append(p)
+        return results
+
+    # ── audit ──
+
+    def put_audit_entry(self, entry: PolicyAuditEntry) -> None:
+        self._conn.execute(
+            """INSERT INTO policy_audit_log
+               (entry_id, policy_id, agent_name, action_taken, timestamp, data)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                entry.entry_id,
+                entry.policy_id,
+                entry.agent_name,
+                entry.action_taken,
+                entry.timestamp,
+                entry.model_dump_json(),
+            ),
+        )
+        self._conn.commit()
+
+    def list_audit_entries(
+        self,
+        policy_id: str | None = None,
+        agent_name: str | None = None,
+        limit: int = 100,
+    ) -> list[PolicyAuditEntry]:
+        sql = "SELECT data FROM policy_audit_log WHERE 1=1"
+        params: list[str] = []
+        if policy_id:
+            sql += " AND policy_id = ?"
+            params.append(policy_id)
+        if agent_name:
+            sql += " AND agent_name = ?"
+            params.append(agent_name)
+        sql += " ORDER BY timestamp DESC LIMIT ?"
+        params.append(str(limit))
+        rows = self._conn.execute(sql, params).fetchall()
+        return [PolicyAuditEntry.model_validate_json(r[0]) for r in rows]

--- a/src/agent_bom/gateway.py
+++ b/src/agent_bom/gateway.py
@@ -1,0 +1,69 @@
+"""Gateway evaluation engine — bridges policy store with proxy check_policy.
+
+Converts GatewayPolicy models into the dict format that
+``proxy.check_policy()`` already understands, then delegates rule
+evaluation to that existing function.  This avoids duplicating logic.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agent_bom.proxy import check_policy
+
+if TYPE_CHECKING:
+    from agent_bom.api.policy_store import GatewayPolicy
+
+
+def gateway_policy_to_proxy_format(policy: "GatewayPolicy") -> dict:
+    """Convert a GatewayPolicy to the dict format proxy.check_policy expects.
+
+    The proxy format is::
+
+        {"rules": [{"id": "...", "action": "block", "block_tools": [...], ...}]}
+    """
+    rules = []
+    for rule in policy.rules:
+        d: dict = {"id": rule.id, "action": rule.action}
+        if rule.block_tools:
+            d["block_tools"] = rule.block_tools
+        if rule.tool_name:
+            d["tool_name"] = rule.tool_name
+        if rule.tool_name_pattern:
+            d["tool_name_pattern"] = rule.tool_name_pattern
+        if rule.arg_pattern:
+            d["arg_pattern"] = rule.arg_pattern
+        rules.append(d)
+    return {"rules": rules}
+
+
+def evaluate_gateway_policies(
+    policies: list["GatewayPolicy"],
+    tool_name: str,
+    arguments: dict,
+) -> tuple[bool, str, str | None]:
+    """Evaluate a tool call against a list of gateway policies.
+
+    Args:
+        policies: Active gateway policies to evaluate.
+        tool_name: Name of the tool being called.
+        arguments: Tool call arguments.
+
+    Returns:
+        ``(allowed, reason, policy_id)`` — if blocked, ``reason``
+        explains why and ``policy_id`` identifies the blocking policy.
+    """
+    for policy in policies:
+        if not policy.enabled:
+            continue
+
+        proxy_fmt = gateway_policy_to_proxy_format(policy)
+        allowed, reason = check_policy(proxy_fmt, tool_name, arguments)
+
+        if not allowed:
+            if policy.mode.value == "enforce":
+                return False, reason, policy.policy_id
+            # audit mode — log but allow
+            return True, f"[audit] {reason}", policy.policy_id
+
+    return True, "", None

--- a/tests/test_api_gateway.py
+++ b/tests/test_api_gateway.py
@@ -1,0 +1,232 @@
+"""Tests for gateway API endpoints (/v1/gateway/*)."""
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.policy_store import (
+    GatewayPolicy,
+    GatewayRule,
+    InMemoryPolicyStore,
+    PolicyAuditEntry,
+    PolicyMode,
+)
+from agent_bom.api.server import app, set_policy_store
+
+
+def _now() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fresh_client() -> tuple[TestClient, InMemoryPolicyStore]:
+    store = InMemoryPolicyStore()
+    set_policy_store(store)
+    return TestClient(app), store
+
+
+def _make_policy(
+    policy_id: str = "p-1",
+    name: str = "test-policy",
+    mode: PolicyMode = PolicyMode.ENFORCE,
+    **kw,
+) -> GatewayPolicy:
+    ts = _now()
+    return GatewayPolicy(
+        policy_id=policy_id,
+        name=name,
+        mode=mode,
+        rules=[GatewayRule(id="r1", action="block", block_tools=["exec"])],
+        created_at=ts,
+        updated_at=ts,
+        **kw,
+    )
+
+
+# ── List ──────────────────────────────────────────────────────────────────────
+
+
+def test_list_empty():
+    client, _ = _fresh_client()
+    resp = client.get("/v1/gateway/policies")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
+def test_list_with_policies():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy(policy_id="p-1", name="alpha"))
+    store.put_policy(_make_policy(policy_id="p-2", name="beta"))
+    resp = client.get("/v1/gateway/policies")
+    assert resp.json()["count"] == 2
+
+
+def test_list_filter_mode():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy(policy_id="p-1", mode=PolicyMode.AUDIT))
+    store.put_policy(_make_policy(policy_id="p-2", mode=PolicyMode.ENFORCE))
+    resp = client.get("/v1/gateway/policies?mode=enforce")
+    assert resp.json()["count"] == 1
+
+
+# ── Create ────────────────────────────────────────────────────────────────────
+
+
+def test_create_policy():
+    client, store = _fresh_client()
+    resp = client.post("/v1/gateway/policies", json={
+        "name": "block-exec",
+        "mode": "enforce",
+        "rules": [{"id": "r1", "action": "block", "block_tools": ["exec"]}],
+    })
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "block-exec"
+    assert data["mode"] == "enforce"
+    assert len(store.list_policies()) == 1
+
+
+def test_create_invalid_mode():
+    client, _ = _fresh_client()
+    resp = client.post("/v1/gateway/policies", json={"name": "bad", "mode": "bogus"})
+    assert resp.status_code == 400
+
+
+# ── Get ───────────────────────────────────────────────────────────────────────
+
+
+def test_get_policy():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy(policy_id="p-1", name="alpha"))
+    resp = client.get("/v1/gateway/policies/p-1")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "alpha"
+
+
+def test_get_not_found():
+    client, _ = _fresh_client()
+    resp = client.get("/v1/gateway/policies/missing")
+    assert resp.status_code == 404
+
+
+# ── Update ────────────────────────────────────────────────────────────────────
+
+
+def test_update_policy():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy())
+    resp = client.put("/v1/gateway/policies/p-1", json={"name": "renamed", "mode": "audit"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "renamed"
+    assert resp.json()["mode"] == "audit"
+
+
+def test_update_not_found():
+    client, _ = _fresh_client()
+    resp = client.put("/v1/gateway/policies/missing", json={"name": "x"})
+    assert resp.status_code == 404
+
+
+# ── Delete ────────────────────────────────────────────────────────────────────
+
+
+def test_delete_policy():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy())
+    resp = client.delete("/v1/gateway/policies/p-1")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    assert len(store.list_policies()) == 0
+
+
+def test_delete_not_found():
+    client, _ = _fresh_client()
+    resp = client.delete("/v1/gateway/policies/missing")
+    assert resp.status_code == 404
+
+
+# ── Evaluate ──────────────────────────────────────────────────────────────────
+
+
+def test_evaluate_allowed():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy())
+    resp = client.post("/v1/gateway/evaluate", json={"tool_name": "safe_tool"})
+    assert resp.status_code == 200
+    assert resp.json()["allowed"] is True
+
+
+def test_evaluate_blocked():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy())
+    resp = client.post("/v1/gateway/evaluate", json={"tool_name": "exec"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["allowed"] is False
+    assert "exec" in data["reason"]
+
+
+def test_evaluate_no_policies():
+    client, _ = _fresh_client()
+    resp = client.post("/v1/gateway/evaluate", json={"tool_name": "anything"})
+    assert resp.json()["allowed"] is True
+
+
+# ── Audit ─────────────────────────────────────────────────────────────────────
+
+
+def test_audit_empty():
+    client, _ = _fresh_client()
+    resp = client.get("/v1/gateway/audit")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
+def test_audit_populated():
+    client, store = _fresh_client()
+    store.put_audit_entry(PolicyAuditEntry(
+        entry_id="e-1",
+        policy_id="p-1",
+        policy_name="test",
+        rule_id="r1",
+        agent_name="agent-a",
+        tool_name="exec",
+        action_taken="blocked",
+        reason="blocked",
+        timestamp=_now(),
+    ))
+    resp = client.get("/v1/gateway/audit")
+    assert resp.json()["count"] == 1
+
+
+# ── Stats ─────────────────────────────────────────────────────────────────────
+
+
+def test_stats_empty():
+    client, _ = _fresh_client()
+    resp = client.get("/v1/gateway/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_policies"] == 0
+    assert data["blocked_count"] == 0
+
+
+def test_stats_populated():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy(policy_id="p-1", mode=PolicyMode.ENFORCE))
+    store.put_policy(_make_policy(policy_id="p-2", mode=PolicyMode.AUDIT))
+    store.put_audit_entry(PolicyAuditEntry(
+        entry_id="e-1",
+        policy_id="p-1",
+        policy_name="test",
+        rule_id="r1",
+        agent_name="a",
+        tool_name="exec",
+        action_taken="blocked",
+        reason="r",
+        timestamp=_now(),
+    ))
+    resp = client.get("/v1/gateway/stats")
+    data = resp.json()
+    assert data["total_policies"] == 2
+    assert data["enforce_count"] == 1
+    assert data["audit_count"] == 1
+    assert data["blocked_count"] == 1

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,132 @@
+"""Tests for agent_bom.gateway — gateway evaluation engine."""
+
+from agent_bom.api.policy_store import GatewayPolicy, GatewayRule, PolicyMode
+from agent_bom.gateway import evaluate_gateway_policies, gateway_policy_to_proxy_format
+
+
+def _now() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _policy(
+    policy_id: str = "p-1",
+    mode: PolicyMode = PolicyMode.ENFORCE,
+    rules: list[GatewayRule] | None = None,
+    enabled: bool = True,
+) -> GatewayPolicy:
+    ts = _now()
+    return GatewayPolicy(
+        policy_id=policy_id,
+        name="test",
+        mode=mode,
+        rules=rules or [],
+        enabled=enabled,
+        created_at=ts,
+        updated_at=ts,
+    )
+
+
+# ── Conversion ────────────────────────────────────────────────────────────────
+
+
+def test_convert_block_tools():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", block_tools=["exec", "rm"])])
+    fmt = gateway_policy_to_proxy_format(p)
+    assert fmt["rules"][0]["block_tools"] == ["exec", "rm"]
+
+
+def test_convert_pattern():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", tool_name_pattern="exec.*")])
+    fmt = gateway_policy_to_proxy_format(p)
+    assert fmt["rules"][0]["tool_name_pattern"] == "exec.*"
+
+
+def test_convert_arg_pattern():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", arg_pattern={"cmd": "rm.*"})])
+    fmt = gateway_policy_to_proxy_format(p)
+    assert fmt["rules"][0]["arg_pattern"] == {"cmd": "rm.*"}
+
+
+# ── Evaluation ────────────────────────────────────────────────────────────────
+
+
+def test_allow_when_no_policies():
+    allowed, reason, pid = evaluate_gateway_policies([], "exec", {})
+    assert allowed is True
+    assert reason == ""
+    assert pid is None
+
+
+def test_allow_when_no_matching_rules():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", block_tools=["dangerous"])])
+    allowed, reason, pid = evaluate_gateway_policies([p], "safe_tool", {})
+    assert allowed is True
+
+
+def test_block_enforce_mode():
+    p = _policy(
+        mode=PolicyMode.ENFORCE,
+        rules=[GatewayRule(id="r1", action="block", block_tools=["exec"])],
+    )
+    allowed, reason, pid = evaluate_gateway_policies([p], "exec", {})
+    assert allowed is False
+    assert "exec" in reason
+    assert pid == "p-1"
+
+
+def test_audit_mode_allows():
+    p = _policy(
+        mode=PolicyMode.AUDIT,
+        rules=[GatewayRule(id="r1", action="block", block_tools=["exec"])],
+    )
+    allowed, reason, pid = evaluate_gateway_policies([p], "exec", {})
+    assert allowed is True
+    assert "[audit]" in reason
+    assert pid == "p-1"
+
+
+def test_disabled_policy_skipped():
+    p = _policy(
+        enabled=False,
+        rules=[GatewayRule(id="r1", action="block", block_tools=["exec"])],
+    )
+    allowed, reason, pid = evaluate_gateway_policies([p], "exec", {})
+    assert allowed is True
+
+
+def test_multiple_policies_first_blocks():
+    p1 = _policy(
+        policy_id="p-1",
+        mode=PolicyMode.ENFORCE,
+        rules=[GatewayRule(id="r1", action="block", block_tools=["safe"])],
+    )
+    p2 = _policy(
+        policy_id="p-2",
+        mode=PolicyMode.ENFORCE,
+        rules=[GatewayRule(id="r2", action="block", block_tools=["exec"])],
+    )
+    allowed, reason, pid = evaluate_gateway_policies([p1, p2], "exec", {})
+    assert allowed is False
+    assert pid == "p-2"
+
+
+def test_tool_name_exact_match():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", tool_name="write_file")])
+    allowed, _, _ = evaluate_gateway_policies([p], "write_file", {})
+    assert allowed is False
+
+
+def test_tool_name_pattern_match():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", tool_name_pattern="execute.*")])
+    allowed, _, _ = evaluate_gateway_policies([p], "execute_command", {})
+    assert allowed is False
+
+
+def test_arg_pattern_match():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", arg_pattern={"path": r"/etc/.*"})])
+    allowed, _, _ = evaluate_gateway_policies([p], "read_file", {"path": "/etc/passwd"})
+    assert allowed is False
+    # Non-matching arg
+    allowed2, _, _ = evaluate_gateway_policies([p], "read_file", {"path": "/tmp/safe"})
+    assert allowed2 is True

--- a/tests/test_policy_store.py
+++ b/tests/test_policy_store.py
@@ -1,0 +1,204 @@
+"""Tests for agent_bom.api.policy_store — gateway policy persistence."""
+
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agent_bom.api.policy_store import (
+    GatewayPolicy,
+    GatewayRule,
+    InMemoryPolicyStore,
+    PolicyAuditEntry,
+    PolicyMode,
+    SQLitePolicyStore,
+)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_policy(
+    policy_id: str = "p-1",
+    name: str = "test-policy",
+    mode: PolicyMode = PolicyMode.AUDIT,
+    rules: list[GatewayRule] | None = None,
+    **kw,
+) -> GatewayPolicy:
+    ts = _now()
+    return GatewayPolicy(
+        policy_id=policy_id,
+        name=name,
+        mode=mode,
+        rules=rules or [GatewayRule(id="r1", action="block", block_tools=["exec"])],
+        created_at=ts,
+        updated_at=ts,
+        **kw,
+    )
+
+
+def _make_audit(
+    entry_id: str = "e-1",
+    policy_id: str = "p-1",
+    agent_name: str = "agent-a",
+    action_taken: str = "blocked",
+) -> PolicyAuditEntry:
+    return PolicyAuditEntry(
+        entry_id=entry_id,
+        policy_id=policy_id,
+        policy_name="test-policy",
+        rule_id="r1",
+        agent_name=agent_name,
+        tool_name="exec",
+        action_taken=action_taken,
+        reason="blocked by rule",
+        timestamp=_now(),
+    )
+
+
+# ── InMemoryPolicyStore ──────────────────────────────────────────────────────
+
+
+def test_put_and_get():
+    store = InMemoryPolicyStore()
+    store.put_policy(_make_policy())
+    assert store.get_policy("p-1") is not None
+    assert store.get_policy("p-1").name == "test-policy"
+
+
+def test_get_missing():
+    store = InMemoryPolicyStore()
+    assert store.get_policy("nope") is None
+
+
+def test_delete():
+    store = InMemoryPolicyStore()
+    store.put_policy(_make_policy())
+    assert store.delete_policy("p-1") is True
+    assert store.get_policy("p-1") is None
+    assert store.delete_policy("p-1") is False
+
+
+def test_list_policies():
+    store = InMemoryPolicyStore()
+    store.put_policy(_make_policy(policy_id="p-1", name="alpha"))
+    store.put_policy(_make_policy(policy_id="p-2", name="beta"))
+    assert len(store.list_policies()) == 2
+
+
+def test_get_policies_for_agent_unbound():
+    """Policies with no bindings match all agents."""
+    store = InMemoryPolicyStore()
+    store.put_policy(_make_policy())
+    result = store.get_policies_for_agent(agent_name="any")
+    assert len(result) == 1
+
+
+def test_get_policies_for_agent_bound():
+    """Policies bound to specific agents filter correctly."""
+    store = InMemoryPolicyStore()
+    store.put_policy(_make_policy(policy_id="p-1", bound_agents=["agent-a"]))
+    store.put_policy(_make_policy(policy_id="p-2", bound_agents=["agent-b"]))
+    result = store.get_policies_for_agent(agent_name="agent-a")
+    assert len(result) == 1
+    assert result[0].policy_id == "p-1"
+
+
+def test_get_policies_for_agent_disabled():
+    """Disabled policies are excluded."""
+    store = InMemoryPolicyStore()
+    store.put_policy(_make_policy(enabled=False))
+    result = store.get_policies_for_agent(agent_name="any")
+    assert len(result) == 0
+
+
+def test_audit_entries():
+    store = InMemoryPolicyStore()
+    store.put_audit_entry(_make_audit(entry_id="e-1", agent_name="a"))
+    store.put_audit_entry(_make_audit(entry_id="e-2", agent_name="b"))
+    all_entries = store.list_audit_entries()
+    assert len(all_entries) == 2
+    filtered = store.list_audit_entries(agent_name="a")
+    assert len(filtered) == 1
+
+
+def test_audit_entries_by_policy():
+    store = InMemoryPolicyStore()
+    store.put_audit_entry(_make_audit(entry_id="e-1", policy_id="p-1"))
+    store.put_audit_entry(_make_audit(entry_id="e-2", policy_id="p-2"))
+    result = store.list_audit_entries(policy_id="p-1")
+    assert len(result) == 1
+
+
+# ── SQLitePolicyStore ────────────────────────────────────────────────────────
+
+
+def _sqlite_store():
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    return SQLitePolicyStore(tmp.name), Path(tmp.name)
+
+
+def test_sqlite_put_get():
+    store, path = _sqlite_store()
+    try:
+        store.put_policy(_make_policy())
+        assert store.get_policy("p-1") is not None
+        assert store.get_policy("p-1").name == "test-policy"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_sqlite_delete():
+    store, path = _sqlite_store()
+    try:
+        store.put_policy(_make_policy())
+        assert store.delete_policy("p-1") is True
+        assert store.get_policy("p-1") is None
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_sqlite_list():
+    store, path = _sqlite_store()
+    try:
+        store.put_policy(_make_policy(policy_id="p-1", name="alpha"))
+        store.put_policy(_make_policy(policy_id="p-2", name="beta"))
+        assert len(store.list_policies()) == 2
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_sqlite_policies_for_agent():
+    store, path = _sqlite_store()
+    try:
+        store.put_policy(_make_policy(policy_id="p-1", bound_agents=["agent-a"]))
+        store.put_policy(_make_policy(policy_id="p-2", bound_agents=["agent-b"]))
+        result = store.get_policies_for_agent(agent_name="agent-a")
+        assert len(result) == 1
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_sqlite_audit():
+    store, path = _sqlite_store()
+    try:
+        store.put_audit_entry(_make_audit(entry_id="e-1"))
+        store.put_audit_entry(_make_audit(entry_id="e-2", agent_name="b"))
+        assert len(store.list_audit_entries()) == 2
+        assert len(store.list_audit_entries(agent_name="b")) == 1
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_sqlite_upsert():
+    store, path = _sqlite_store()
+    try:
+        policy = _make_policy()
+        store.put_policy(policy)
+        policy.description = "updated"
+        store.put_policy(policy)
+        assert store.get_policy("p-1").description == "updated"
+        assert len(store.list_policies()) == 1
+    finally:
+        path.unlink(missing_ok=True)

--- a/ui/app/gateway/page.tsx
+++ b/ui/app/gateway/page.tsx
@@ -1,0 +1,472 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  api,
+  type GatewayPolicy,
+  type GatewayStatsResponse,
+  type PolicyAuditEntry,
+  type PolicyMode,
+  formatDate,
+} from "@/lib/api";
+import {
+  Lock,
+  RefreshCw,
+  Loader2,
+  ShieldCheck,
+  ShieldAlert,
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Trash2,
+  Play,
+  FileText,
+} from "lucide-react";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const MODE_COLORS: Record<PolicyMode, string> = {
+  audit: "bg-blue-950 text-blue-300 border-blue-800",
+  enforce: "bg-red-950 text-red-300 border-red-800",
+};
+
+// ─── Page ───────────────────────────────────────────────────────────────────
+
+export default function GatewayPage() {
+  const [policies, setPolicies] = useState<GatewayPolicy[]>([]);
+  const [stats, setStats] = useState<GatewayStatsResponse | null>(null);
+  const [audit, setAudit] = useState<PolicyAuditEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [tab, setTab] = useState<"policies" | "audit" | "evaluate">("policies");
+
+  // Evaluate form state
+  const [evalTool, setEvalTool] = useState("");
+  const [evalArgs, setEvalArgs] = useState("{}");
+  const [evalResult, setEvalResult] = useState<{ allowed: boolean; reason: string } | null>(null);
+
+  // Create form state
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newMode, setNewMode] = useState<PolicyMode>("audit");
+  const [newBlockTools, setNewBlockTools] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+
+  const load = () => {
+    setLoading(true);
+    Promise.all([
+      api.listGatewayPolicies(),
+      api.getGatewayStats(),
+      api.listGatewayAudit(),
+    ])
+      .then(([p, s, a]) => {
+        setPolicies(p.policies);
+        setStats(s);
+        setAudit(a.entries);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const toggleExpand = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleCreate = async () => {
+    const tools = newBlockTools.split(",").map((t) => t.trim()).filter(Boolean);
+    const rules = tools.length > 0
+      ? [{ id: "r1", action: "block", block_tools: tools, description: "Block listed tools" }]
+      : [];
+    await api.createGatewayPolicy({
+      name: newName,
+      description: newDescription,
+      mode: newMode,
+      rules,
+      enabled: true,
+    } as Partial<GatewayPolicy>);
+    setShowCreate(false);
+    setNewName("");
+    setNewMode("audit");
+    setNewBlockTools("");
+    setNewDescription("");
+    load();
+  };
+
+  const handleDelete = async (id: string) => {
+    await api.deleteGatewayPolicy(id);
+    load();
+  };
+
+  const handleToggleEnabled = async (policy: GatewayPolicy) => {
+    await api.updateGatewayPolicy(policy.policy_id, { enabled: !policy.enabled } as Partial<GatewayPolicy>);
+    load();
+  };
+
+  const handleEvaluate = async () => {
+    try {
+      const args = JSON.parse(evalArgs);
+      const result = await api.evaluateGateway({ tool_name: evalTool, arguments: args });
+      setEvalResult(result);
+    } catch {
+      setEvalResult({ allowed: false, reason: "Invalid JSON arguments" });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
+            <Lock className="w-6 h-6 text-blue-400" />
+            Gateway Policies
+          </h1>
+          <p className="text-zinc-400 text-sm mt-1">
+            Runtime MCP gateway rules with policy-as-code enforcement
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Create Policy
+        </button>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <StatCard label="Total Policies" value={stats.total_policies} icon={Lock} color="text-zinc-400" />
+          <StatCard label="Enforce Mode" value={stats.enforce_count} icon={ShieldAlert} color="text-red-400" />
+          <StatCard label="Audit Mode" value={stats.audit_count} icon={ShieldCheck} color="text-blue-400" />
+          <StatCard label="Blocked" value={stats.blocked_count} icon={ShieldAlert} color="text-orange-400" />
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="flex gap-1.5">
+        {(["policies", "audit", "evaluate"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              tab === t
+                ? "bg-zinc-800 text-zinc-100"
+                : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900"
+            }`}
+          >
+            {t === "policies" ? "Policies" : t === "audit" ? "Audit Log" : "Evaluate"}
+          </button>
+        ))}
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+        </div>
+      )}
+
+      {/* Create modal */}
+      {showCreate && (
+        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-5 space-y-4">
+          <h3 className="text-sm font-semibold text-zinc-100">New Gateway Policy</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs text-zinc-500 block mb-1">Name</label>
+              <input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+                placeholder="block-exec-tools"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-zinc-500 block mb-1">Mode</label>
+              <select
+                value={newMode}
+                onChange={(e) => setNewMode(e.target.value as PolicyMode)}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+              >
+                <option value="audit">Audit (log only)</option>
+                <option value="enforce">Enforce (block)</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="text-xs text-zinc-500 block mb-1">Block Tools (comma-separated)</label>
+            <input
+              value={newBlockTools}
+              onChange={(e) => setNewBlockTools(e.target.value)}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+              placeholder="execute_command, write_file, http_request"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-zinc-500 block mb-1">Description</label>
+            <input
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+              placeholder="Block dangerous command execution tools"
+            />
+          </div>
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={() => setShowCreate(false)}
+              className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={!newName}
+              className="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded text-sm font-medium transition-colors"
+            >
+              Create
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Policies tab */}
+      {!loading && tab === "policies" && (
+        <>
+          {policies.length === 0 && (
+            <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+              <Lock className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
+              <p className="text-zinc-500 text-sm">No gateway policies yet.</p>
+              <p className="text-zinc-600 text-xs mt-1">
+                Create a policy to define runtime MCP tool enforcement rules.
+              </p>
+            </div>
+          )}
+          <div className="space-y-2">
+            {policies.map((policy) => {
+              const isExpanded = expanded.has(policy.policy_id);
+              return (
+                <div key={policy.policy_id} className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+                  <button
+                    onClick={() => toggleExpand(policy.policy_id)}
+                    className="w-full px-4 py-3 flex items-center justify-between hover:bg-zinc-800/50 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      {isExpanded ? <ChevronDown className="w-4 h-4 text-zinc-500" /> : <ChevronRight className="w-4 h-4 text-zinc-500" />}
+                      <span className="font-medium text-zinc-100">{policy.name}</span>
+                      <span className={`text-[10px] px-1.5 py-0.5 rounded border ${MODE_COLORS[policy.mode]}`}>
+                        {policy.mode}
+                      </span>
+                      {!policy.enabled && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded border bg-zinc-900 text-zinc-500 border-zinc-800">
+                          disabled
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 text-xs text-zinc-500">
+                      <span>{policy.rules.length} rule{policy.rules.length !== 1 ? "s" : ""}</span>
+                      {policy.bound_agents.length > 0 && (
+                        <span>{policy.bound_agents.length} bound</span>
+                      )}
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="border-t border-zinc-800 px-4 py-3 space-y-3">
+                      {policy.description && (
+                        <p className="text-xs text-zinc-400">{policy.description}</p>
+                      )}
+                      {/* Rules */}
+                      {policy.rules.length > 0 && (
+                        <div>
+                          <span className="text-xs text-zinc-500 block mb-1">Rules</span>
+                          <div className="space-y-1">
+                            {policy.rules.map((rule) => (
+                              <div key={rule.id} className="text-xs bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-zinc-400">
+                                <span className="text-zinc-200 font-mono">{rule.id}</span>
+                                {rule.description && <span className="ml-2">{rule.description}</span>}
+                                {rule.block_tools.length > 0 && (
+                                  <span className="ml-2 text-red-400">
+                                    blocks: {rule.block_tools.join(", ")}
+                                  </span>
+                                )}
+                                {rule.tool_name_pattern && (
+                                  <span className="ml-2 text-yellow-400">
+                                    pattern: {rule.tool_name_pattern}
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                      {/* Detail grid */}
+                      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
+                        <div>
+                          <span className="text-zinc-500">Created</span>
+                          <div className="text-zinc-300 mt-0.5">{policy.created_at ? formatDate(policy.created_at) : "—"}</div>
+                        </div>
+                        <div>
+                          <span className="text-zinc-500">Updated</span>
+                          <div className="text-zinc-300 mt-0.5">{policy.updated_at ? formatDate(policy.updated_at) : "—"}</div>
+                        </div>
+                        <div>
+                          <span className="text-zinc-500">Bound Agents</span>
+                          <div className="text-zinc-300 mt-0.5">{policy.bound_agents.length > 0 ? policy.bound_agents.join(", ") : "All"}</div>
+                        </div>
+                        <div>
+                          <span className="text-zinc-500">Environments</span>
+                          <div className="text-zinc-300 mt-0.5">{policy.bound_environments.length > 0 ? policy.bound_environments.join(", ") : "All"}</div>
+                        </div>
+                      </div>
+                      {/* Actions */}
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={(e) => { e.stopPropagation(); handleToggleEnabled(policy); }}
+                          className="text-[10px] px-2 py-0.5 rounded border transition-colors hover:opacity-80 bg-zinc-800 text-zinc-300 border-zinc-700"
+                        >
+                          {policy.enabled ? "Disable" : "Enable"}
+                        </button>
+                        <button
+                          onClick={(e) => { e.stopPropagation(); handleDelete(policy.policy_id); }}
+                          className="text-[10px] px-2 py-0.5 rounded border transition-colors hover:opacity-80 bg-red-950 text-red-300 border-red-800 flex items-center gap-1"
+                        >
+                          <Trash2 className="w-3 h-3" />
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {/* Audit tab */}
+      {!loading && tab === "audit" && (
+        <>
+          {audit.length === 0 ? (
+            <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+              <FileText className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
+              <p className="text-zinc-500 text-sm">No audit entries yet.</p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {audit.map((entry) => (
+                <div key={entry.entry_id} className="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded border ${
+                      entry.action_taken === "blocked"
+                        ? "bg-red-950 text-red-300 border-red-800"
+                        : entry.action_taken === "alerted"
+                        ? "bg-yellow-950 text-yellow-300 border-yellow-800"
+                        : "bg-emerald-950 text-emerald-300 border-emerald-800"
+                    }`}>
+                      {entry.action_taken}
+                    </span>
+                    <span className="text-xs text-zinc-300 font-mono">{entry.tool_name}</span>
+                    <span className="text-xs text-zinc-500">{entry.agent_name || "—"}</span>
+                    <span className="text-xs text-zinc-600 truncate max-w-xs">{entry.reason}</span>
+                  </div>
+                  <span className="text-xs text-zinc-600">{entry.timestamp ? formatDate(entry.timestamp) : ""}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Evaluate tab */}
+      {!loading && tab === "evaluate" && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 space-y-4">
+          <h3 className="text-sm font-semibold text-zinc-100 flex items-center gap-2">
+            <Play className="w-4 h-4 text-blue-400" />
+            Dry-Run Evaluation
+          </h3>
+          <p className="text-xs text-zinc-500">
+            Test how gateway policies would evaluate a tool call without actually making one.
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs text-zinc-500 block mb-1">Tool Name</label>
+              <input
+                value={evalTool}
+                onChange={(e) => setEvalTool(e.target.value)}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 font-mono focus:outline-none focus:border-blue-600"
+                placeholder="execute_command"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-zinc-500 block mb-1">Arguments (JSON)</label>
+              <input
+                value={evalArgs}
+                onChange={(e) => setEvalArgs(e.target.value)}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 font-mono focus:outline-none focus:border-blue-600"
+                placeholder='{"command": "rm -rf /"}'
+              />
+            </div>
+          </div>
+          <button
+            onClick={handleEvaluate}
+            disabled={!evalTool}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            <Play className="w-4 h-4" />
+            Evaluate
+          </button>
+          {evalResult && (
+            <div className={`rounded-lg border p-4 ${
+              evalResult.allowed
+                ? "border-emerald-800 bg-emerald-950/50"
+                : "border-red-800 bg-red-950/50"
+            }`}>
+              <div className="flex items-center gap-2">
+                {evalResult.allowed ? (
+                  <ShieldCheck className="w-5 h-5 text-emerald-400" />
+                ) : (
+                  <ShieldAlert className="w-5 h-5 text-red-400" />
+                )}
+                <span className={`text-sm font-semibold ${evalResult.allowed ? "text-emerald-300" : "text-red-300"}`}>
+                  {evalResult.allowed ? "Allowed" : "Blocked"}
+                </span>
+              </div>
+              {evalResult.reason && (
+                <p className="text-xs text-zinc-400 mt-1">{evalResult.reason}</p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Components ──────────────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  color,
+}: {
+  label: string;
+  value: number;
+  icon: React.ElementType;
+  color: string;
+}) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+      <Icon className={`w-4 h-4 mb-2 ${color}`} />
+      <div className="text-2xl font-bold font-mono">{value}</div>
+      <div className="text-xs text-zinc-500 mt-0.5">{label}</div>
+    </div>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -12,6 +12,7 @@ import {
   GitBranch,
   Library,
   Shield,
+  Lock,
   Users,
 } from "lucide-react";
 import { api } from "@/lib/api";
@@ -22,6 +23,7 @@ const links = [
   { href: "/agents",     label: "Agents",      icon: Server },
   { href: "/vulns",      label: "Vulns",       icon: Bug },
   { href: "/fleet",      label: "Fleet",       icon: Users },
+  { href: "/gateway",    label: "Gateway",     icon: Lock },
   { href: "/compliance", label: "Compliance",  icon: Shield },
   { href: "/graph",      label: "Graph",       icon: GitBranch },
   { href: "/registry",   label: "Registry",    icon: Library },


### PR DESCRIPTION
## Summary
- **Policy Store**: `policy_store.py` with GatewayPolicy, GatewayRule, PolicyAuditEntry models + Protocol + InMemory + SQLite backends. Shares same `AGENT_BOM_DB` with job and fleet stores.
- **Gateway Evaluation Engine**: `gateway.py` bridges GatewayPolicy models to existing `proxy.check_policy()` — no duplicated rule logic. Supports enforce (block) and audit (log-only) modes.
- **Proxy Integration**: `set_gateway_evaluator()` hook in `proxy.py` — gateway policies evaluated after existing policy check in `relay_client_to_server()`. Blocked calls return JSON-RPC -32600 error.
- **8 REST Endpoints**: CRUD for policies, dry-run evaluate, audit log query, gateway stats.
- **Gateway Dashboard**: Next.js page with policy cards, create/delete/enable-disable controls, audit log tab, and dry-run evaluate panel.
- **45 new tests** (1381 total): policy store CRUD + SQLite, gateway evaluation (enforce/audit/disabled/patterns), API endpoint coverage.

## Test plan
- [ ] `pytest tests/test_policy_store.py` — InMemory + SQLite CRUD, agent binding, audit entries
- [ ] `pytest tests/test_gateway.py` — enforce blocks, audit allows, patterns, arg matching, disabled skip
- [ ] `pytest tests/test_api_gateway.py` — all 8 endpoints, create/get/update/delete, evaluate, audit, stats
- [ ] `pytest tests/ -x -q` — full suite passes (1381 tests)
- [ ] `cd ui && npm run build` — frontend compiles