### PR TITLE
release: v0.35.0

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.34.0
+ARG VERSION=0.35.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.34.0
+ARG VERSION=0.35.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.34.0"
+  --version "0.35.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.34.0
-git push origin v0.34.0
+git tag v0.35.0
+git push origin v0.35.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.34.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.35.0 |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -345,18 +345,19 @@ agent-bom scan --aws -f graph -o graph.json   # export graph data
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.34.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.35.0 | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Live MCP traffic audit |
 | MCP Server | `agent-bom mcp-server` | Inside any MCP client |
 | Dashboard | `agent-bom serve` | API + Next.js dashboard |
+| Snowflake | `SNOWFLAKE_ACCOUNT=... agent-bom api` | Snowpark + SiS |
 | Prometheus | `--push-gateway` / `--otel-endpoint` | Monitoring |
 
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.34.0
+- uses: msaad00/agent-bom@v0.35.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -397,7 +398,37 @@ agent-bom mcp-server --transport sse    # remote
 cd ui && npm install && npm run dev   # http://localhost:3000
 ```
 
-Security posture dashboard, vulnerability explorer, attack flow diagrams, supply chain graph, registry browser, enterprise scan form.
+16-page Next.js dashboard:
+
+| Page | Description |
+|------|-------------|
+| Dashboard | Security posture summary + stat cards |
+| Scan | Enterprise scan form with cloud options |
+| Vulnerabilities | CVE browser with severity/EPSS/KEV filters |
+| Agents | Fleet registry + lifecycle state management |
+| Compliance | 4-framework compliance posture (OWASP, ATLAS, NIST) |
+| Lineage Graph | Interactive supply chain graph — dagre layout, 6 node types, filter panel |
+| Agent Mesh | Cross-agent topology — shared server detection, credential blast radius, tool overlap |
+| Attack Flow | Per-CVE blast radius visualization |
+| Gateway | Runtime MCP policy rules + audit log |
+| Registry | 427+ MCP server browser |
+
+### Snowflake Deployment
+
+```bash
+pip install 'agent-bom[api,snowflake]'
+```
+
+| Component | Description |
+|-----------|-------------|
+| Snowflake Table Storage | `SnowflakeJobStore`, `SnowflakeFleetStore`, `SnowflakePolicyStore` — auto-detect key-pair or password auth |
+| Snowpark Container Services | `Dockerfile.snowpark` + `snowflake/setup.sql` — run the API inside Snowflake |
+| Streamlit in Snowflake | `snowflake/streamlit_app.py` — 5-tab SiS dashboard reading from shared tables |
+| Native App | `snowflake/native-app/` — Marketplace-distributable package |
+
+Set `SNOWFLAKE_ACCOUNT` + `SNOWFLAKE_USER` + auth (`SNOWFLAKE_PRIVATE_KEY_PATH` or `SNOWFLAKE_PASSWORD`) and the API auto-switches to Snowflake persistence.
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for full Snowflake architecture and setup instructions.
 
 ---
 

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.34.0
+- uses: msaad00/agent-bom@v0.35.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: AI supply chain security scanner — check packages for CVEs, look up MCP servers in the threat registry, assess blast radius, generate SBOMs, enforce compliance
-version: 0.34.0
+version: 0.35.0
 metadata:
   openclaw:
     requires:
@@ -180,5 +180,5 @@ It extracts server names, package names, and env var **names** only — never va
 - **PyPI**: https://pypi.org/project/agent-bom/
 - **Smithery**: https://smithery.ai/server/agent-bom/agent-bom (99/100 quality score)
 - **Sigstore signed**: Every release is signed with Sigstore OIDC
-- **1,260+ tests**: Every commit passes automated security scanning
+- **1,430+ tests**: Every commit passes automated security scanning
 - **OpenSSF Scorecard**: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.34.0
+ARG VERSION=0.35.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.34.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.35.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.34.0": {
+        "ghcr.io/msaad00/agent-bom:v0.35.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.34.0"
+version = "0.35.0"
 description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs. OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF. GPU infrastructure (NVIDIA/AMD) coverage."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -5,6 +5,7 @@ Usage:
     python scripts/bump-version.py 0.29.0
     python scripts/bump-version.py 0.29.0 --dry-run
 """
+
 from __future__ import annotations
 
 import argparse
@@ -22,6 +23,7 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("pyproject.toml", re.compile(r'^(version\s*=\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
     ("src/agent_bom/__init__.py", re.compile(r'(__version__\s*=\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
     # Dockerfiles
+    ("Dockerfile.runtime", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     ("Dockerfile.sse", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     ("integrations/toolhive/Dockerfile.mcp", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     # MCP Registry server.json (version field + pypi identifier version)
@@ -35,8 +37,13 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
 
 # Patterns that reference the version in docs/tests (updated separately)
 DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
-    # README.md — GitHub Action version references
+    # README.md + docs — GitHub Action version references
     ("README.md", re.compile(r"(msaad00/agent-bom@v)[^\s\"]+"), r"\g<1>{v}"),
+    ("docs/AI_INFRASTRUCTURE_SCANNING.md", re.compile(r"(msaad00/agent-bom@v)[^\s\"]+"), r"\g<1>{v}"),
+    # PUBLISHING.md — version examples
+    ("PUBLISHING.md", re.compile(r'(--version\s+")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
+    ("PUBLISHING.md", re.compile(r"(git tag v)\S+", re.M), r"\g<1>{v}"),
+    ("PUBLISHING.md", re.compile(r"(git push origin v)\S+", re.M), r"\g<1>{v}"),
     # tests/test_core.py — version assertions
     ("tests/test_core.py", re.compile(r'(assert\s+__version__\s*==\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
     # Only match version assertions that currently contain a semver pattern (avoids clobbering SARIF "2.1.0")

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.34.0"
+    __version__ = "0.35.0"


### PR DESCRIPTION
## Summary
Version bump 0.34.0 → 0.35.0 across 13 files (20 occurrences).

## New since v0.34.0
- **Agent Mesh Topology** — `/mesh` page with shared server detection, credential blast mapping, tool overlap
- **Snowflake Table Storage** — `SnowflakeJobStore`, `SnowflakeFleetStore`, `SnowflakePolicyStore` with auto-detect auth
- **Snowpark Container Services** — `Dockerfile.snowpark` + `snowflake/setup.sql` deployment
- **Streamlit in Snowflake** — 5-tab SiS dashboard reading from shared tables
- **Snowflake Native App** — Marketplace-distributable package
- **Pre-commit hooks** — ruff check + format on every commit
- **Interactive Lineage Graph** — dagre layout, 6 node types, filter panel
- **1,430 tests** (up from 1,260)

## Files bumped
pyproject.toml, __init__.py, Dockerfile.runtime, Dockerfile.sse, Dockerfile.mcp, 2x server.json, SKILL.md, README.md (x3), docs/AI_INFRASTRUCTURE_SCANNING.md, PUBLISHING.md (x3), tests/test_core.py (x2)

## Docs updated
- README: Cloud UI section expanded to 16-page table + Snowflake deployment section
- SKILL.md: test count 1,260 → 1,430
- bump-version.py: added missing Dockerfile.runtime, docs/, PUBLISHING.md patterns

## Test plan
- [x] `ruff check src/` — passes
- [x] 1,430 tests pass
- [ ] CI green after merge
- [ ] Tag `v0.35.0` + push to trigger release workflow