### PR TITLE
fix: align all docs and metadata with actual capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ Privilege levels: **critical** (privileged container, CAP_SYS_ADMIN) → **high*
 
 Every finding is tagged against four frameworks simultaneously:
 
-- **OWASP LLM Top 10** — LLM01 through LLM10 (6 categories triggered)
+- **OWASP LLM Top 10** — LLM01 through LLM10 (7 categories triggered)
 - **OWASP MCP Top 10** — MCP01 through MCP10 (8 categories triggered) — token exposure, tool poisoning, supply chain, shadow servers
-- **MITRE ATLAS** — AML.T0010, AML.T0043, AML.T0051, etc. (8 techniques mapped)
+- **MITRE ATLAS** — AML.T0010, AML.T0043, AML.T0051, etc. (9 techniques mapped)
 - **NIST AI RMF 1.0** — Govern, Map, Measure, Manage (12 subcategories mapped)
 
 ### Enterprise remediation
@@ -217,7 +217,7 @@ agent-bom scan --policy policy.json --fail-on-severity high
 ### Cloud provider discovery
 
 ```bash
-agent-bom scan --aws --aws-region us-east-1       # Bedrock, Lambda, EKS, ECS, SageMaker, EC2
+agent-bom scan --aws --aws-region us-east-1       # Bedrock, Lambda, EKS, ECS, EC2, Step Functions
 agent-bom scan --snowflake                         # Cortex Agents, MCP Servers, Search, Snowpark
 agent-bom scan --databricks                        # Cluster libraries, model serving
 agent-bom scan --nebius --nebius-project-id proj   # GPU cloud K8s + containers
@@ -229,7 +229,7 @@ agent-bom scan --k8s --context=coreweave-cluster   # CoreWeave / any K8s
 
 | Provider | What's discovered | Install |
 |----------|------------------|---------|
-| **AWS** | Bedrock agents, Lambda, EKS, Step Functions, EC2, ECS, SageMaker | `pip install 'agent-bom[aws]'` |
+| **AWS** | Bedrock agents, Lambda, EKS, Step Functions, EC2, ECS | `pip install 'agent-bom[aws]'` |
 | **Snowflake** | Cortex Agents, native MCP Servers, Search, Snowpark, Streamlit, query history | `pip install 'agent-bom[snowflake]'` |
 | **Databricks** | Cluster packages, model serving endpoints | `pip install 'agent-bom[databricks]'` |
 | **Azure** | AI Foundry agents, Container Apps | `pip install 'agent-bom[azure]'` |
@@ -407,7 +407,7 @@ cd ui && npm install && npm run dev   # http://localhost:3000
 | Vulnerabilities | CVE browser with severity/EPSS/KEV filters |
 | Agents | Fleet registry + lifecycle state management |
 | Compliance | 4-framework compliance posture (OWASP, ATLAS, NIST) |
-| Lineage Graph | Interactive supply chain graph — dagre layout, 6 node types, filter panel |
+| Lineage Graph | Interactive supply chain graph — dagre layout, 7 node types, filter panel |
 | Agent Mesh | Cross-agent topology — shared server detection, credential blast radius, tool overlap |
 | Gateway | Runtime MCP policy rules + audit log |
 | Registry | 427+ MCP server browser |
@@ -426,7 +426,7 @@ pip install 'agent-bom[api,snowflake]'
 |-----------|-------------|
 | Snowflake Table Storage | `SnowflakeJobStore`, `SnowflakeFleetStore`, `SnowflakePolicyStore` — auto-detect key-pair or password auth |
 | Snowpark Container Services | `Dockerfile.snowpark` + `snowflake/setup.sql` — run the API inside Snowflake |
-| Streamlit in Snowflake | `snowflake/streamlit_app.py` — 5-tab SiS dashboard reading from shared tables |
+| Streamlit in Snowflake | `snowflake/streamlit_app.py` — 6-tab SiS dashboard reading from shared tables |
 | Native App | `snowflake/native-app/` — Marketplace-distributable package |
 
 Set `SNOWFLAKE_ACCOUNT` + `SNOWFLAKE_USER` + auth (`SNOWFLAKE_PRIVATE_KEY_PATH` or `SNOWFLAKE_PASSWORD`) and the API auto-switches to Snowflake persistence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.35.0"
 description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs. OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF. GPU infrastructure (NVIDIA/AMD) coverage."
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     {name = "W S", email = "34316639+msaad00@users.noreply.github.com"}
 ]
@@ -17,14 +17,16 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
+    "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Environment :: Console",
     "Topic :: Security",
-    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: System :: Monitoring",
 ]
 dependencies = [
     "click>=8.0",
@@ -53,9 +55,7 @@ otel = [
     "opentelemetry-exporter-otlp-proto-http>=1.20",
 ]
 ui = [
-    "fastapi>=0.115",
-    "uvicorn[standard]>=0.32",
-    "sse-starlette>=2.1",
+    "agent-bom[api]",
 ]
 aws = ["boto3>=1.34"]
 azure = [
@@ -127,7 +127,7 @@ server = "agent_bom.mcp_server:create_smithery_server"
 
 [tool.ruff]
 line-length = 140  # Relaxed from 120 for CLI help strings
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W"]


### PR DESCRIPTION
## Summary
Code freeze preparation — every public surface now matches what the code actually does.

**CLI fixes:**
- `serve` help text said "Streamlit dashboard (port 8501)" — actually starts FastAPI on 8422
- `check` command was the only one missing `--no-color`

**README accuracy (honesty fixes):**
- OWASP LLM: 6→7 triggered categories
- MITRE ATLAS: 8→9 mapped techniques
- Lineage graph: 6→7 node types
- Removed SageMaker from `--aws` (no `--aws-include-sagemaker` CLI flag)
- Streamlit SiS: 5→6 tabs

**PyPI metadata:**
- `ui` extra was identical duplicate of `api` — now aliases it
- `requires-python` 3.10→3.11 (CI only tests 3.11+3.13)
- Added missing classifiers: `Python 3 :: Only`, `System Administrators`, `Console`, `System :: Monitoring`
- `ruff target-version` py310→py311

## Test plan
- [x] 1,614 tests pass
- [x] `ruff check` clean
- [x] `agent-bom check express@4.17.1 -e npm --no-color` works
- [ ] CI passes all checks