### PR TITLE
fix: registry versions, NVIDIA advisories, Snowflake fleet sync, MCP attack-flow tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ agent-bom scan -f spdx -o ai-bom.spdx.json       # SPDX 3.0
 agent-bom scan -f sarif -o results.sarif           # GitHub Security tab
 agent-bom scan -f json -o ai-bom.json             # Full AI-BOM
 agent-bom scan -f html -o report.html              # Interactive dashboard
+agent-bom scan -f mermaid                          # Mermaid supply chain diagram
+agent-bom scan -f graph -o graph.json              # Cytoscape-compatible graph JSON
 ```
 
 ### Policy-as-code
@@ -334,13 +336,30 @@ agent-bom scan --model-files ./models
 </details>
 
 <details>
-<summary><b>Attack flow visualization</b></summary>
+<summary><b>Attack flow & supply chain visualization</b></summary>
 
-CLI attack flow tree, interactive HTML graphs (Cytoscape.js), per-CVE React Flow diagrams via REST API.
+Multiple visualization modes: CLI attack flow tree, Mermaid diagrams, interactive HTML (Cytoscape.js), React Flow graphs via REST API.
 
 ```bash
-agent-bom scan --aws -f graph -o graph.json   # export graph data
+agent-bom scan -f mermaid                              # supply chain diagram
+agent-bom scan -f mermaid --mermaid-mode attack-flow   # CVE blast radius
+agent-bom scan -f graph -o graph.json                  # Cytoscape-compatible JSON
+agent-bom scan -f html -o report.html                  # interactive HTML report
 ```
+
+Example Mermaid output:
+
+```mermaid
+graph TD
+    A["Cursor IDE"] --> S1["filesystem-server"]
+    A --> S2["github-server"]
+    S1 --> P1["@modelcontextprotocol/server-filesystem@2025.3.28"]
+    S2 --> P2["@modelcontextprotocol/server-github@2025.3.28"]
+    P1 -->|"GHSA-xxxx"| V1["CVE-2025-1234 CRITICAL"]
+    V1 -.->|"MCP04"| F1["Supply Chain Attack"]
+```
+
+The REST API (`agent-bom api`) serves interactive React Flow attack-flow graphs with OWASP LLM Top 10, OWASP MCP Top 10, and MITRE ATLAS framework tagging on every CVE node.
 
 </details>
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -20,49 +20,105 @@ from agent_bom.owasp_mcp import tag_blast_radius as tag_owasp_mcp
 
 # Known AI/ML framework packages — vulnerabilities in these carry elevated risk
 # because they run inside AI agents that have credentials and tool access
-_AI_FRAMEWORK_PACKAGES = frozenset({
-    # LLM orchestration
-    "langchain", "langchain-core", "langchain-community", "langchain-openai",
-    "langgraph", "llama-index", "llama_index", "llama-hub",
-    "autogen", "pyautogen", "crewai", "agency-swarm",
-    "haystack-ai", "semantic-kernel",
-    # LLM clients
-    "openai", "anthropic", "mistralai", "cohere", "together",
-    "google-generativeai", "google-cloud-aiplatform", "boto3",
-    # Model inference
-    "transformers", "huggingface-hub", "diffusers", "accelerate",
-    "sentence-transformers", "optimum",
-    # Vector stores and RAG
-    "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
-    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
-    "pgvector", "lancedb",
-    # MCP and agent infrastructure
-    "mcp", "fastmcp", "modelcontextprotocol",
-    # GPU / AI infrastructure — NVIDIA
-    "cuda-python", "cupy", "cupy-cuda11x", "cupy-cuda12x",
-    "nvidia-cublas-cu11", "nvidia-cublas-cu12",
-    "nvidia-cudnn-cu11", "nvidia-cudnn-cu12",
-    "nvidia-cufft-cu11", "nvidia-cufft-cu12",
-    "nvidia-cusolver-cu11", "nvidia-cusolver-cu12",
-    "nvidia-cusparse-cu11", "nvidia-cusparse-cu12",
-    "nvidia-nccl-cu11", "nvidia-nccl-cu12",
-    "nvidia-cuda-runtime-cu11", "nvidia-cuda-runtime-cu12",
-    "nvidia-cuda-nvrtc-cu11", "nvidia-cuda-nvrtc-cu12",
-    "tensorrt", "nvidia-tensorrt",
-    "triton", "tritonclient",
-    # GPU / AI infrastructure — AMD ROCm
-    "hip-python", "rocm-smi",
-    # ML frameworks with GPU backends
-    "torch", "torchvision", "torchaudio",
-    "tensorflow", "tensorflow-gpu", "tf-nightly",
-    "jax", "jaxlib",
-    # Inference servers
-    "vllm", "text-generation-inference",
-    "llama-cpp-python", "ctransformers",
-    # MLOps / experiment tracking
-    "mlflow", "wandb", "neptune", "clearml",
-    "ray", "ray[serve]",
-})
+_AI_FRAMEWORK_PACKAGES = frozenset(
+    {
+        # LLM orchestration
+        "langchain",
+        "langchain-core",
+        "langchain-community",
+        "langchain-openai",
+        "langgraph",
+        "llama-index",
+        "llama_index",
+        "llama-hub",
+        "autogen",
+        "pyautogen",
+        "crewai",
+        "agency-swarm",
+        "haystack-ai",
+        "semantic-kernel",
+        # LLM clients
+        "openai",
+        "anthropic",
+        "mistralai",
+        "cohere",
+        "together",
+        "google-generativeai",
+        "google-cloud-aiplatform",
+        "boto3",
+        # Model inference
+        "transformers",
+        "huggingface-hub",
+        "diffusers",
+        "accelerate",
+        "sentence-transformers",
+        "optimum",
+        # Vector stores and RAG
+        "chromadb",
+        "pinecone-client",
+        "weaviate-client",
+        "qdrant-client",
+        "faiss-cpu",
+        "faiss-gpu",
+        "pymilvus",
+        "milvus",
+        "pgvector",
+        "lancedb",
+        # MCP and agent infrastructure
+        "mcp",
+        "fastmcp",
+        "modelcontextprotocol",
+        # GPU / AI infrastructure — NVIDIA
+        "cuda-python",
+        "cupy",
+        "cupy-cuda11x",
+        "cupy-cuda12x",
+        "nvidia-cublas-cu11",
+        "nvidia-cublas-cu12",
+        "nvidia-cudnn-cu11",
+        "nvidia-cudnn-cu12",
+        "nvidia-cufft-cu11",
+        "nvidia-cufft-cu12",
+        "nvidia-cusolver-cu11",
+        "nvidia-cusolver-cu12",
+        "nvidia-cusparse-cu11",
+        "nvidia-cusparse-cu12",
+        "nvidia-nccl-cu11",
+        "nvidia-nccl-cu12",
+        "nvidia-cuda-runtime-cu11",
+        "nvidia-cuda-runtime-cu12",
+        "nvidia-cuda-nvrtc-cu11",
+        "nvidia-cuda-nvrtc-cu12",
+        "tensorrt",
+        "nvidia-tensorrt",
+        "triton",
+        "tritonclient",
+        # GPU / AI infrastructure — AMD ROCm
+        "hip-python",
+        "rocm-smi",
+        # ML frameworks with GPU backends
+        "torch",
+        "torchvision",
+        "torchaudio",
+        "tensorflow",
+        "tensorflow-gpu",
+        "tf-nightly",
+        "jax",
+        "jaxlib",
+        # Inference servers
+        "vllm",
+        "text-generation-inference",
+        "llama-cpp-python",
+        "ctransformers",
+        # MLOps / experiment tracking
+        "mlflow",
+        "wandb",
+        "neptune",
+        "clearml",
+        "ray",
+        "ray[serve]",
+    }
+)
 
 console = Console(stderr=True)
 
@@ -154,6 +210,7 @@ def parse_cvss_vector(vector: str) -> Optional[float]:
 
         # Roundup to one decimal (CVSS spec: ceiling to 1 decimal)
         import math
+
         return math.ceil(raw * 10) / 10.0
 
     except Exception:
@@ -222,13 +279,15 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         if not osv_ecosystem or pkg.version in ("unknown", "latest"):
             continue
 
-        queries.append({
-            "version": pkg.version,
-            "package": {
-                "name": pkg.name,
-                "ecosystem": osv_ecosystem,
+        queries.append(
+            {
+                "version": pkg.version,
+                "package": {
+                    "name": pkg.name,
+                    "ecosystem": osv_ecosystem,
+                },
             }
-        })
+        )
         pkg_index[len(queries) - 1] = pkg
 
     if not queries:
@@ -240,11 +299,13 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
     batch_size = 1000
     async with create_client(timeout=30.0) as client:
         for batch_start in range(0, len(queries), batch_size):
-            batch = queries[batch_start:batch_start + batch_size]
+            batch = queries[batch_start : batch_start + batch_size]
 
             async with _api_semaphore:
                 response = await request_with_retry(
-                    client, "POST", OSV_BATCH_URL,
+                    client,
+                    "POST",
+                    OSV_BATCH_URL,
                     json={"queries": batch},
                 )
 
@@ -287,11 +348,7 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
         severity, cvss_score = parse_osv_severity(vuln_data)
         fixed = parse_fixed_version(vuln_data, package.name)
 
-        references = [
-            ref.get("url", "")
-            for ref in vuln_data.get("references", [])
-            if ref.get("url")
-        ][:5]  # Limit to 5 references
+        references = [ref.get("url", "") for ref in vuln_data.get("references", []) if ref.get("url")][:5]  # Limit to 5 references
 
         # Use aliases to surface CVE ID when primary ID is GHSA/OSV/RUSTSEC
         aliases = vuln_data.get("aliases", [])
@@ -301,14 +358,16 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
 
         summary = vuln_data.get("summary", vuln_data.get("details", "No description available"))[:200]
 
-        vulns.append(Vulnerability(
-            id=canonical_id,
-            summary=summary,
-            severity=severity,
-            cvss_score=cvss_score,
-            fixed_version=fixed,
-            references=references,
-        ))
+        vulns.append(
+            Vulnerability(
+                id=canonical_id,
+                summary=summary,
+                severity=severity,
+                cvss_score=cvss_score,
+                fixed_version=fixed,
+                references=references,
+            )
+        )
 
     return vulns
 
@@ -331,6 +390,23 @@ async def scan_packages(packages: list[Package]) -> int:
             total_vulns += len(pkg.vulnerabilities)
             # Flag packages with MAL- prefixed vulnerability IDs as malicious
             flag_malicious_from_vulns(pkg)
+
+    # Supplemental: check NVIDIA advisories for AI framework packages
+    nvidia_packages = [
+        p
+        for p in scannable
+        if p.name.lower().replace("-", "_") in _AI_FRAMEWORK_PACKAGES and p.name.lower().startswith(("nvidia", "cuda", "tensorrt", "nccl"))
+    ]
+    if nvidia_packages:
+        try:
+            from agent_bom.scanners.nvidia_advisory import check_nvidia_advisories
+
+            nvidia_new = await check_nvidia_advisories(nvidia_packages)
+            if nvidia_new:
+                total_vulns += nvidia_new
+                console.print(f"  [green]✓[/green] NVIDIA advisories: {nvidia_new} additional CVE(s)")
+        except Exception as exc:
+            console.print(f"  [yellow]⚠[/yellow] NVIDIA advisory check skipped: {exc}")
 
     # Typosquat detection for all scanned packages
     for pkg in scannable:
@@ -420,6 +496,7 @@ async def scan_agents(agents: list[Agent]) -> list[BlastRadius]:
                 if reg:
                     if not server_tools and reg.get("tools"):
                         from agent_bom.models import MCPTool
+
                         server_tools = [MCPTool(name=t, description="") for t in reg["tools"]]
                     if not server_creds and reg.get("credential_env_vars"):
                         server_creds = reg["credential_env_vars"]
@@ -428,9 +505,10 @@ async def scan_agents(agents: list[Agent]) -> list[BlastRadius]:
             exposed_tools.extend(server_tools)
 
         # AI-native risk context: elevated when an AI framework has creds + tools
-        is_ai_framework = pkg.name.lower().replace("-", "_") in {
-            n.replace("-", "_") for n in _AI_FRAMEWORK_PACKAGES
-        } or pkg.name.lower() in _AI_FRAMEWORK_PACKAGES
+        is_ai_framework = (
+            pkg.name.lower().replace("-", "_") in {n.replace("-", "_") for n in _AI_FRAMEWORK_PACKAGES}
+            or pkg.name.lower() in _AI_FRAMEWORK_PACKAGES
+        )
         has_creds = bool(exposed_creds)
         has_tools = bool(exposed_tools)
         if is_ai_framework and has_creds and has_tools:

--- a/src/agent_bom/scanners/nvidia_advisory.py
+++ b/src/agent_bom/scanners/nvidia_advisory.py
@@ -1,0 +1,301 @@
+"""Supplemental NVIDIA security advisory enrichment.
+
+Fetches CSAF 2.0 advisories from NVIDIA's product-security GitHub repo and
+cross-references against GPU/ML packages found in scans.  This catches
+NVIDIA CVEs that may not yet be indexed by OSV.dev's PyPI advisory database.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import httpx
+
+from agent_bom.http_client import create_client, request_with_retry
+from agent_bom.models import Package, Severity, Vulnerability
+
+logger = logging.getLogger(__name__)
+
+# GitHub raw URL for the NVIDIA product-security repo
+_GITHUB_API = "https://api.github.com/repos/NVIDIA/product-security/contents"
+
+# Map NVIDIA product names (from CSAF) to PyPI package prefixes.
+# Advisory product names are lowercased for matching.
+_NVIDIA_PRODUCT_MAP: dict[str, list[str]] = {
+    "cuda toolkit": [
+        "cuda-python",
+        "nvidia-cuda-runtime-cu11",
+        "nvidia-cuda-runtime-cu12",
+        "nvidia-cuda-cupti-cu11",
+        "nvidia-cuda-cupti-cu12",
+        "nvidia-cuda-nvrtc-cu11",
+        "nvidia-cuda-nvrtc-cu12",
+        "nvidia-cublas-cu11",
+        "nvidia-cublas-cu12",
+        "nvidia-cusolver-cu11",
+        "nvidia-cusolver-cu12",
+        "nvidia-cusparse-cu11",
+        "nvidia-cusparse-cu12",
+        "nvidia-cufft-cu11",
+        "nvidia-cufft-cu12",
+        "nvidia-curand-cu11",
+        "nvidia-curand-cu12",
+        "nvidia-nvjitlink-cu12",
+    ],
+    "cudnn": [
+        "nvidia-cudnn-cu11",
+        "nvidia-cudnn-cu12",
+    ],
+    "nccl": [
+        "nvidia-nccl-cu11",
+        "nvidia-nccl-cu12",
+    ],
+    "tensorrt": [
+        "tensorrt",
+        "nvidia-tensorrt",
+    ],
+    "container toolkit": [
+        "nvidia-container-toolkit",
+    ],
+    "nvjpeg": [],  # Not typically a PyPI package, but tracked for image scans
+}
+
+# Reverse map: PyPI package name → NVIDIA product names it belongs to
+_PYPI_TO_NVIDIA: dict[str, list[str]] = {}
+for _product, _packages in _NVIDIA_PRODUCT_MAP.items():
+    for _pkg in _packages:
+        _PYPI_TO_NVIDIA.setdefault(_pkg.lower().replace("-", "_"), []).append(_product)
+
+
+def _normalise(name: str) -> str:
+    """Normalise package name for comparison (lowercase, underscores)."""
+    return name.lower().replace("-", "_")
+
+
+def get_nvidia_products_for_package(pkg_name: str) -> list[str]:
+    """Return NVIDIA product names that a PyPI package maps to."""
+    return _PYPI_TO_NVIDIA.get(_normalise(pkg_name), [])
+
+
+def _parse_csaf_severity(scores: list[dict]) -> tuple[Severity, float | None]:
+    """Extract severity and CVSS score from CSAF scores array."""
+    for score_entry in scores:
+        cvss = score_entry.get("cvss_v3") or score_entry.get("cvss_v4") or {}
+        base_score = cvss.get("baseScore")
+        if base_score is not None:
+            base_score = float(base_score)
+            if base_score >= 9.0:
+                return Severity.CRITICAL, base_score
+            elif base_score >= 7.0:
+                return Severity.HIGH, base_score
+            elif base_score >= 4.0:
+                return Severity.MEDIUM, base_score
+            else:
+                return Severity.LOW, base_score
+    return Severity.MEDIUM, None
+
+
+def _extract_fixed_version(vuln: dict) -> str | None:
+    """Extract fixed version from CSAF product_status.fixed entries."""
+    fixed = vuln.get("product_status", {}).get("fixed", [])
+    if fixed:
+        # Product IDs often contain version info like "CUDA Toolkit 12.9 Update 1"
+        for product_id in fixed:
+            m = re.search(r"(\d+\.\d+[\w. ]*)", str(product_id))
+            if m:
+                return m.group(1).strip()
+    return None
+
+
+async def fetch_nvidia_advisory_index(
+    years: list[str] | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> list[dict]:
+    """Fetch the list of advisory folders from NVIDIA's GitHub repo.
+
+    Returns list of dicts with 'name' and 'path' keys.
+    Only fetches recent years by default.
+    """
+    if years is None:
+        years = ["2025", "2026"]
+
+    close_client = False
+    if client is None:
+        client = httpx.AsyncClient(timeout=15.0)
+        close_client = True
+
+    advisories = []
+    try:
+        for year in years:
+            resp = await request_with_retry(
+                client,
+                "GET",
+                f"{_GITHUB_API}/{year}",
+                headers={"Accept": "application/vnd.github.v3+json"},
+            )
+            if resp and resp.status_code == 200:
+                for item in resp.json():
+                    if item.get("type") == "dir":
+                        advisories.append(
+                            {
+                                "id": item["name"],
+                                "path": item["path"],
+                                "url": f"https://raw.githubusercontent.com/NVIDIA/product-security/main/{item['path']}/{item['name']}.json",
+                            }
+                        )
+    finally:
+        if close_client:
+            await client.aclose()
+
+    return advisories
+
+
+async def fetch_nvidia_csaf(
+    advisory_url: str,
+    client: httpx.AsyncClient,
+) -> dict | None:
+    """Fetch a single NVIDIA CSAF advisory JSON."""
+    resp = await request_with_retry(client, "GET", advisory_url)
+    if resp and resp.status_code == 200:
+        try:
+            return resp.json()
+        except (ValueError, KeyError):
+            return None
+    return None
+
+
+def _csaf_affects_product(csaf: dict, product_names: set[str]) -> bool:
+    """Check if a CSAF advisory affects any of the given NVIDIA product names."""
+    title = (csaf.get("document", {}).get("title", "") or "").lower()
+    for product in product_names:
+        if product in title:
+            return True
+    # Also check product_tree branches
+    for branch in csaf.get("product_tree", {}).get("branches", []):
+        _name = (branch.get("name", "") or "").lower()
+        for product in product_names:
+            if product in _name:
+                return True
+        for sub in branch.get("branches", []):
+            _sname = (sub.get("name", "") or "").lower()
+            for product in product_names:
+                if product in _sname:
+                    return True
+    return False
+
+
+def extract_vulns_from_csaf(csaf: dict) -> list[Vulnerability]:
+    """Extract Vulnerability objects from a CSAF advisory."""
+    vulns = []
+    for vuln_data in csaf.get("vulnerabilities", []):
+        cve_id = vuln_data.get("cve", "")
+        if not cve_id:
+            continue
+
+        severity, cvss_score = _parse_csaf_severity(vuln_data.get("scores", []))
+        summary = ""
+        for note in vuln_data.get("notes", []):
+            if note.get("category") in ("description", "summary"):
+                summary = note.get("text", "")[:200]
+                break
+
+        cwe = vuln_data.get("cwe", {})
+        cwe_ids = [cwe["id"]] if cwe.get("id") else []
+
+        fixed_version = _extract_fixed_version(vuln_data)
+
+        refs = []
+        for ref in vuln_data.get("references", []):
+            url = ref.get("url", "")
+            if url:
+                refs.append(url)
+
+        vulns.append(
+            Vulnerability(
+                id=cve_id,
+                summary=summary or f"NVIDIA Security Advisory ({cve_id})",
+                severity=severity,
+                cvss_score=cvss_score,
+                fixed_version=fixed_version,
+                references=refs,
+                cwe_ids=cwe_ids,
+            )
+        )
+    return vulns
+
+
+async def check_nvidia_advisories(
+    packages: list[Package],
+    max_advisories: int = 20,
+) -> int:
+    """Check NVIDIA packages against NVIDIA's security advisories.
+
+    Fetches recent CSAF advisories from NVIDIA's GitHub repo and
+    cross-references against the given packages.  Only processes
+    advisories relevant to the NVIDIA products matching the packages.
+
+    Returns count of new vulnerabilities found.
+    """
+    # Determine which NVIDIA products are relevant
+    product_names: set[str] = set()
+    pkg_by_product: dict[str, list[Package]] = {}
+    for pkg in packages:
+        products = get_nvidia_products_for_package(pkg.name)
+        for product in products:
+            product_names.add(product)
+            pkg_by_product.setdefault(product, []).append(pkg)
+
+    if not product_names:
+        return 0
+
+    logger.info("NVIDIA advisory check for products: %s", product_names)
+
+    total_new = 0
+    async with create_client(timeout=15.0) as client:
+        # Fetch advisory index
+        advisories = await fetch_nvidia_advisory_index(client=client)
+        if not advisories:
+            logger.debug("No NVIDIA advisories found")
+            return 0
+
+        # Process most recent advisories first (higher ID = more recent)
+        advisories.sort(key=lambda a: a["id"], reverse=True)
+
+        checked = 0
+        for adv in advisories:
+            if checked >= max_advisories:
+                break
+
+            csaf = await fetch_nvidia_csaf(adv["url"], client)
+            if not csaf:
+                continue
+
+            checked += 1
+
+            if not _csaf_affects_product(csaf, product_names):
+                continue
+
+            csaf_vulns = extract_vulns_from_csaf(csaf)
+            if not csaf_vulns:
+                continue
+
+            # Assign vulnerabilities to matching packages (deduplicate by CVE ID)
+            for product, pkgs in pkg_by_product.items():
+                if product not in product_names:
+                    continue
+                # Check if this advisory affects this product
+                if not _csaf_affects_product(csaf, {product}):
+                    continue
+                for pkg in pkgs:
+                    existing_ids = {v.id for v in pkg.vulnerabilities}
+                    for vuln in csaf_vulns:
+                        if vuln.id not in existing_ids:
+                            pkg.vulnerabilities.append(vuln)
+                            existing_ids.add(vuln.id)
+                            total_new += 1
+
+    if total_new:
+        logger.info("NVIDIA advisories: found %d new CVE(s)", total_new)
+
+    return total_new

--- a/ui/app/scan/[id]/attack-flow/page.tsx
+++ b/ui/app/scan/[id]/attack-flow/page.tsx
@@ -38,6 +38,7 @@ import {
   type BlastRadius,
   severityColor,
   OWASP_LLM_TOP10,
+  OWASP_MCP_TOP10,
   MITRE_ATLAS,
 } from "@/lib/api";
 import { SeverityBadge } from "@/components/severity-badge";
@@ -127,10 +128,15 @@ function AttackFlowNode({ data }: { data: AttackFlowNodeData }) {
       </div>
 
       {/* Framework tags (CVE nodes only) */}
-      {nodeType === "cve" && (data.owasp_tags?.length || data.atlas_tags?.length) ? (
+      {nodeType === "cve" && (data.owasp_tags?.length || data.atlas_tags?.length || data.owasp_mcp_tags?.length) ? (
         <div className="flex flex-wrap gap-0.5 mt-1">
           {data.owasp_tags?.slice(0, 2).map((tag) => (
             <span key={tag} className="text-[9px] font-mono bg-purple-950/60 border border-purple-800/50 text-purple-400 rounded px-1">
+              {tag}
+            </span>
+          ))}
+          {data.owasp_mcp_tags?.slice(0, 2).map((tag) => (
+            <span key={tag} className="text-[9px] font-mono bg-amber-950/60 border border-amber-800/50 text-amber-400 rounded px-1">
               {tag}
             </span>
           ))}
@@ -220,6 +226,18 @@ function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () 
                   {data.owasp_tags.map((tag) => (
                     <div key={tag} className="text-xs font-mono bg-purple-950/40 border border-purple-800/50 text-purple-400 rounded px-2 py-1">
                       {tag} <span className="text-purple-600 font-sans">{OWASP_LLM_TOP10[tag]}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {data.owasp_mcp_tags && data.owasp_mcp_tags.length > 0 && (
+              <div>
+                <div className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1">OWASP MCP Top 10</div>
+                <div className="space-y-1">
+                  {data.owasp_mcp_tags.map((tag) => (
+                    <div key={tag} className="text-xs font-mono bg-amber-950/40 border border-amber-800/50 text-amber-400 rounded px-2 py-1">
+                      {tag} <span className="text-amber-600 font-sans">{OWASP_MCP_TOP10[tag]}</span>
                     </div>
                   ))}
                 </div>
@@ -369,6 +387,7 @@ function FilterBar({
     const tags = new Set<string>();
     for (const br of blastRadius) {
       for (const t of br.owasp_tags ?? []) tags.add(t);
+      for (const t of br.owasp_mcp_tags ?? []) tags.add(t);
       for (const t of br.atlas_tags ?? []) tags.add(t);
       for (const t of br.nist_ai_rmf_tags ?? []) tags.add(t);
     }
@@ -429,7 +448,7 @@ function FilterBar({
           <option value="">All Frameworks</option>
           {frameworkTags.map((tag) => (
             <option key={tag} value={tag}>
-              {tag} {OWASP_LLM_TOP10[tag] ? `- ${OWASP_LLM_TOP10[tag]}` : MITRE_ATLAS[tag] ? `- ${MITRE_ATLAS[tag]}` : ""}
+              {tag} {OWASP_LLM_TOP10[tag] ? `- ${OWASP_LLM_TOP10[tag]}` : OWASP_MCP_TOP10[tag] ? `- ${OWASP_MCP_TOP10[tag]}` : MITRE_ATLAS[tag] ? `- ${MITRE_ATLAS[tag]}` : ""}
             </option>
           ))}
         </select>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -123,6 +123,7 @@ export interface BlastRadius {
   owasp_tags?: string[];
   atlas_tags?: string[];
   nist_ai_rmf_tags?: string[];
+  owasp_mcp_tags?: string[];
 }
 
 // ─── Attack Flow Types ───────────────────────────────────────────────────────
@@ -140,6 +141,7 @@ export interface AttackFlowNodeData {
   owasp_tags?: string[];
   atlas_tags?: string[];
   nist_ai_rmf_tags?: string[];
+  owasp_mcp_tags?: string[];
   version?: string;
   ecosystem?: string;
   agent_type?: string;


### PR DESCRIPTION
## Summary
- **Registry version fix**: `lookup_mcp_registry()` was substituting the registry's `latest_version` for the user's actual installed version, causing OSV.dev to scan the wrong version. Now preserves installed version and stores registry latest in `registry_version` for drift comparison.
- **NVIDIA CSAF advisory enrichment**: New scanner fetches NVIDIA product-security advisories from GitHub for GPU packages (cuda-python, tensorrt, cudnn, nccl). Supplements OSV.dev with vendor-specific CVE data.
- **Snowflake fleet auto-sync**: Discovered agents now auto-populate the `fleet_agents` table after every API scan. Added vulnerability flattening view and cleanup stored procedure to native app SQL.
- **OWASP MCP Top 10 in attack-flow**: Attack-flow React Flow graph now renders MCP04/MCP01/etc tags on CVE nodes and detail panel, with filter support.
- **Mermaid export in README**: Documented `agent-bom scan -f mermaid` and graph export with example output.

## Test plan
- [x] 1497 tests pass
- [x] ruff clean
- [ ] Manual: `agent-bom scan` → verify `version_source` field on Package objects
- [ ] Manual: attack-flow UI shows OWASP MCP tags when present
- [ ] Snowflake: verify fleet table populates after scan (if SF creds available)