### PR TITLE
feat: GHSA enrichment, auto version resolution, Snowflake wiring, lifecycle diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 
 | | Grype / Syft / Trivy | agent-bom |
 |---|---|---|
-| Package CVE detection | Yes | Yes — OSV + NVD CVSS v4 + EPSS + CISA KEV |
+| Package CVE detection | Yes | Yes — OSV + NVD CVSS v4 + EPSS + CISA KEV + GHSA + NVIDIA CSAF |
 | SBOM generation | Yes (Syft) | Yes — CycloneDX 1.6, SPDX 3.0, SARIF |
 | **AI agent discovery** | — | 18 MCP clients + Docker Compose auto-discovered |
 | **Blast radius mapping** | — | CVE → package → server → agent → credentials → tools |
@@ -343,6 +343,7 @@ Multiple visualization modes: CLI attack flow tree, Mermaid diagrams, interactiv
 ```bash
 agent-bom scan -f mermaid                              # supply chain diagram
 agent-bom scan -f mermaid --mermaid-mode attack-flow   # CVE blast radius
+agent-bom scan -f mermaid --mermaid-mode lifecycle     # vulnerability lifecycle gantt
 agent-bom scan -f graph -o graph.json                  # Cytoscape-compatible JSON
 agent-bom scan -f html -o report.html                  # interactive HTML report
 ```
@@ -359,7 +360,31 @@ graph TD
     V1 -.->|"MCP04"| F1["Supply Chain Attack"]
 ```
 
+Example lifecycle gantt output:
+
+```mermaid
+gantt
+    title Vulnerability Lifecycle Timeline
+    dateFormat YYYY-MM-DD
+    section express@4.17.1
+        Scanned        :done, t0, 2025-06-15, 1d
+        CVE-2024-1234  :crit, t1, after t0, 1d
+        Fix → 4.18.0   :active, t2, after t1, 1d
+```
+
 The REST API (`agent-bom api`) serves interactive React Flow attack-flow graphs with OWASP LLM Top 10, OWASP MCP Top 10, and MITRE ATLAS framework tagging on every CVE node.
+
+</details>
+
+<details>
+<summary><b>Supplemental advisory enrichment</b></summary>
+
+Beyond OSV.dev, agent-bom checks supplemental sources to catch CVEs not yet indexed:
+
+- **GitHub Security Advisories (GHSA)** — all ecosystems (PyPI, npm, Go, Maven, Cargo, NuGet)
+- **NVIDIA CSAF advisories** — GPU/ML packages (CUDA, cuDNN, TensorRT, NCCL)
+
+Both sources deduplicate by CVE ID against OSV results. Packages without a pinned version are auto-resolved from npm/PyPI registries before scanning.
 
 </details>
 

--- a/snowflake/native-app/scripts/setup.sql
+++ b/snowflake/native-app/scripts/setup.sql
@@ -46,6 +46,42 @@ CREATE TABLE IF NOT EXISTS core.policy_audit_log (
     data VARIANT NOT NULL
 );
 
+-- 3b. App configuration table
+CREATE TABLE IF NOT EXISTS core.app_config (
+    key VARCHAR PRIMARY KEY,
+    value VARIANT NOT NULL,
+    updated_at TIMESTAMP_TZ DEFAULT CURRENT_TIMESTAMP()
+);
+
+INSERT INTO core.app_config (key, value)
+    SELECT 'scan_interval_hours', PARSE_JSON('6')
+    WHERE NOT EXISTS (SELECT 1 FROM core.app_config WHERE key = 'scan_interval_hours');
+
+INSERT INTO core.app_config (key, value)
+    SELECT 'retention_days', PARSE_JSON('90')
+    WHERE NOT EXISTS (SELECT 1 FROM core.app_config WHERE key = 'retention_days');
+
+-- 3c. Governance findings table
+CREATE TABLE IF NOT EXISTS core.governance_findings (
+    finding_id VARCHAR PRIMARY KEY,
+    category VARCHAR NOT NULL,
+    severity VARCHAR NOT NULL,
+    entity_type VARCHAR,
+    entity_name VARCHAR,
+    detail VARIANT NOT NULL,
+    detected_at TIMESTAMP_TZ DEFAULT CURRENT_TIMESTAMP(),
+    resolved_at TIMESTAMP_TZ
+);
+
+-- 3d. Activity events table
+CREATE TABLE IF NOT EXISTS core.activity_events (
+    event_id VARCHAR PRIMARY KEY,
+    event_type VARCHAR NOT NULL,
+    agent_name VARCHAR,
+    detail VARIANT NOT NULL,
+    created_at TIMESTAMP_TZ DEFAULT CURRENT_TIMESTAMP()
+);
+
 -- 4. Grant table access to app role
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA core TO APPLICATION ROLE app_user;
 
@@ -89,6 +125,59 @@ BEGIN
 END;
 
 GRANT USAGE ON PROCEDURE core.cleanup_old_jobs(INT) TO APPLICATION ROLE app_user;
+
+-- 8. Configuration stored procedures
+CREATE OR REPLACE PROCEDURE core.set_config(config_key VARCHAR, config_value VARIANT)
+    RETURNS VARCHAR
+    LANGUAGE SQL
+AS
+BEGIN
+    MERGE INTO core.app_config t
+    USING (SELECT :config_key AS key, :config_value AS value) s
+    ON t.key = s.key
+    WHEN MATCHED THEN UPDATE SET value = s.value, updated_at = CURRENT_TIMESTAMP()
+    WHEN NOT MATCHED THEN INSERT (key, value, updated_at) VALUES (s.key, s.value, CURRENT_TIMESTAMP());
+    RETURN 'OK';
+END;
+
+CREATE OR REPLACE PROCEDURE core.get_config(config_key VARCHAR)
+    RETURNS VARIANT
+    LANGUAGE SQL
+AS
+BEGIN
+    LET result VARIANT;
+    SELECT value INTO :result FROM core.app_config WHERE key = :config_key;
+    RETURN :result;
+END;
+
+GRANT USAGE ON PROCEDURE core.set_config(VARCHAR, VARIANT) TO APPLICATION ROLE app_user;
+GRANT USAGE ON PROCEDURE core.get_config(VARCHAR) TO APPLICATION ROLE app_user;
+
+-- 9. Trigger scan stored procedure
+CREATE OR REPLACE PROCEDURE core.trigger_scan()
+    RETURNS VARCHAR
+    LANGUAGE SQL
+AS
+DECLARE
+    job_id VARCHAR DEFAULT UUID_STRING();
+BEGIN
+    INSERT INTO core.scan_jobs (job_id, status, created_at, data)
+    VALUES (:job_id, 'pending', CURRENT_TIMESTAMP(), PARSE_JSON('{}'));
+
+    INSERT INTO core.activity_events (event_id, event_type, detail, created_at)
+    VALUES (UUID_STRING(), 'scan_started', PARSE_JSON('{"job_id": "' || :job_id || '"}'), CURRENT_TIMESTAMP());
+
+    RETURN 'Scan queued: ' || :job_id;
+END;
+
+GRANT USAGE ON PROCEDURE core.trigger_scan() TO APPLICATION ROLE app_user;
+
+-- 10. Auto-scan scheduled task (consumer starts with ALTER TASK ... RESUME)
+CREATE OR REPLACE TASK core.auto_scan_task
+    WAREHOUSE = 'COMPUTE_WH'
+    SCHEDULE = 'USING CRON 0 */6 * * * UTC'
+AS
+    CALL core.trigger_scan();
 
 -- 7. Streamlit dashboard (default_streamlit in manifest)
 CREATE STREAMLIT IF NOT EXISTS core.dashboard

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -119,9 +119,9 @@ def main():
 )
 @click.option(
     "--mermaid-mode",
-    type=click.Choice(["supply-chain", "attack-flow"]),
+    type=click.Choice(["supply-chain", "attack-flow", "lifecycle"]),
     default="supply-chain",
-    help="Mermaid diagram mode: supply-chain (full hierarchy) or attack-flow (CVE blast radius)",
+    help="Mermaid diagram mode: supply-chain (full hierarchy), attack-flow (CVE blast radius), or lifecycle (gantt timeline)",
 )
 @click.option(
     "--push-gateway",
@@ -1561,6 +1561,10 @@ def scan(
                 from agent_bom.output.mermaid import to_mermaid
 
                 sys.stdout.write(to_mermaid(report, blast_radii))
+            elif mermaid_mode == "lifecycle":
+                from agent_bom.output.mermaid import to_mermaid_lifecycle
+
+                sys.stdout.write(to_mermaid_lifecycle(report, blast_radii))
             else:
                 from agent_bom.output.mermaid import to_mermaid_supply_chain
 
@@ -1691,6 +1695,10 @@ def scan(
             from agent_bom.output.mermaid import to_mermaid
 
             Path(out_path).write_text(to_mermaid(report, blast_radii))
+        elif mermaid_mode == "lifecycle":
+            from agent_bom.output.mermaid import to_mermaid_lifecycle
+
+            Path(out_path).write_text(to_mermaid_lifecycle(report, blast_radii))
         else:
             from agent_bom.output.mermaid import to_mermaid_supply_chain
 

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -24,12 +24,14 @@ console = Console()
 def print_summary(report: AIBOMReport) -> None:
     """Print a summary of the AI-BOM report to console."""
     console.print("\n")
-    console.print(Panel.fit(
-        f"[bold]AI-BOM Report[/bold]\n"
-        f"Generated: {report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
-        f"agent-bom v{report.tool_version}",
-        border_style="blue",
-    ))
+    console.print(
+        Panel.fit(
+            f"[bold]AI-BOM Report[/bold]\n"
+            f"Generated: {report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
+            f"agent-bom v{report.tool_version}",
+            border_style="blue",
+        )
+    )
 
     # Summary stats
     table = Table(show_header=False, box=None, padding=(0, 2))
@@ -140,10 +142,7 @@ def print_posture_summary(report: AIBOMReport) -> None:
         lines.append("  [bold]Credentials[/bold]       None detected")
 
     # Privilege summary
-    elevated_servers = sum(
-        1 for a in report.agents for s in a.mcp_servers
-        if s.permission_profile and s.permission_profile.is_elevated
-    )
+    elevated_servers = sum(1 for a in report.agents for s in a.mcp_servers if s.permission_profile and s.permission_profile.is_elevated)
     if elevated_servers:
         lines.append(f"  [bold red]Privileges[/bold red]        {elevated_servers} server(s) with elevated privileges")
     else:
@@ -197,10 +196,7 @@ def print_posture_summary(report: AIBOMReport) -> None:
                     sev_parts.append(f"{info['sevs'][sev]} {sev.lower()}")
             kev_flag = ", [red bold]CISA KEV[/red bold]" if info["kev"] else ""
             agents_str = ", ".join(sorted(info["agents"]))
-            lines.append(
-                f"    {pkg_name} ({info['eco']})    "
-                f"{', '.join(sev_parts)}{kev_flag} — affects {agents_str}"
-            )
+            lines.append(f"    {pkg_name} ({info['eco']})    {', '.join(sev_parts)}{kev_flag} — affects {agents_str}")
 
     content = "\n".join(lines)
     console.print(Panel(content, border_style=border_style, padding=(1, 1)))
@@ -225,10 +221,7 @@ def print_agent_tree(report: AIBOMReport) -> None:
         if total_creds:
             stats_parts.append(f"{total_creds} credential{'s' if total_creds != 1 else ''}")
 
-        agent_tree = Tree(
-            f"\U0001f916 Agent: [bold]{agent.name}[/bold] ({agent.agent_type.value})"
-            f"{status_str}"
-        )
+        agent_tree = Tree(f"\U0001f916 Agent: [bold]{agent.name}[/bold] ({agent.agent_type.value}){status_str}")
         agent_tree.add(f"[dim]{agent.config_path}[/dim]")
         sep = " \u00b7 "
         agent_tree.add(f"[dim]{sep.join(stats_parts)}[/dim]")
@@ -267,8 +260,7 @@ def print_agent_tree(report: AIBOMReport) -> None:
                 transitive_pkgs = [p for p in server.packages if not p.is_direct]
 
                 pkg_branch = server_branch.add(
-                    f"\U0001f4e6 Packages ({len(server.packages)}) \u2014 "
-                    f"{len(direct_pkgs)} direct, {len(transitive_pkgs)} transitive"
+                    f"\U0001f4e6 Packages ({len(server.packages)}) \u2014 {len(direct_pkgs)} direct, {len(transitive_pkgs)} transitive"
                 )
 
                 # Show direct packages first
@@ -280,9 +272,7 @@ def print_agent_tree(report: AIBOMReport) -> None:
                     if pkg.scorecard_score is not None:
                         sc_color = "green" if pkg.scorecard_score >= 7.0 else "yellow" if pkg.scorecard_score >= 4.0 else "red"
                         sc_str = f" [{sc_color}]SC:{pkg.scorecard_score:.1f}[/{sc_color}]"
-                    pkg_branch.add(
-                        f"{pkg.name}@{pkg.version} [{pkg.ecosystem}]{sc_str}{vuln_str}"
-                    )
+                    pkg_branch.add(f"{pkg.name}@{pkg.version} [{pkg.ecosystem}]{sc_str}{vuln_str}")
 
                 # Show transitive packages grouped by depth (limit display)
                 if transitive_pkgs:
@@ -293,9 +283,7 @@ def print_agent_tree(report: AIBOMReport) -> None:
                             vuln_str = f" [red]({len(pkg.vulnerabilities)} vuln(s))[/red]"
                         indent = "  " * pkg.dependency_depth
                         parent_str = f" ← {pkg.parent_package}" if pkg.parent_package else ""
-                        transitive_branch.add(
-                            f"[dim]{indent}{pkg.name}@{pkg.version}{parent_str}{vuln_str}[/dim]"
-                        )
+                        transitive_branch.add(f"[dim]{indent}{pkg.name}@{pkg.version}{parent_str}{vuln_str}[/dim]")
                     if len(transitive_pkgs) > 20:
                         transitive_branch.add(f"[dim]...and {len(transitive_pkgs) - 20} more[/dim]")
 
@@ -366,10 +354,7 @@ def print_blast_radius(report: AIBOMReport) -> None:
         blast_display = "/".join(blast_parts) if blast_parts else "—"
 
         # Vulnerability: ID + package on two lines
-        vuln_display = (
-            f"{br.vulnerability.id}\n"
-            f"[dim]{br.package.name}@{br.package.version}[/dim]"
-        )
+        vuln_display = f"{br.vulnerability.id}\n[dim]{br.package.name}@{br.package.version}[/dim]"
 
         # Threats column: actual framework tag IDs per finding
         threat_lines = []
@@ -405,8 +390,7 @@ def print_blast_radius(report: AIBOMReport) -> None:
     console.print(table)
 
     if len(report.blast_radii) > 25:
-        console.print(f"\n  [dim]...and {len(report.blast_radii) - 25} more findings. "
-                       f"Use --output to export full report.[/dim]")
+        console.print(f"\n  [dim]...and {len(report.blast_radii) - 25} more findings. Use --output to export full report.[/dim]")
 
     # Verification sources — one link per unique CVE
     seen_ids: set[str] = set()
@@ -600,6 +584,7 @@ def print_threat_frameworks(report: AIBOMReport) -> None:
     # OWASP MCP Top 10 table
     if owasp_mcp_counts:
         from agent_bom.owasp_mcp import OWASP_MCP_TOP10
+
         mcp_table = Table(title="OWASP MCP Top 10", title_style="bold yellow", border_style="dim")
         mcp_table.add_column("Code", width=7, style="bold yellow")
         mcp_table.add_column("Risk", width=42)
@@ -631,12 +616,25 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
     """
     from collections import defaultdict
 
-    groups: dict[tuple, dict] = defaultdict(lambda: {
-        "package": "", "ecosystem": "", "current": "", "fix": None,
-        "vulns": [], "agents": set(), "creds": set(), "tools": set(),
-        "owasp": set(), "atlas": set(), "nist": set(), "owasp_mcp": set(),
-        "max_severity": Severity.NONE, "has_kev": False, "ai_risk": False,
-    })
+    groups: dict[tuple, dict] = defaultdict(
+        lambda: {
+            "package": "",
+            "ecosystem": "",
+            "current": "",
+            "fix": None,
+            "vulns": [],
+            "agents": set(),
+            "creds": set(),
+            "tools": set(),
+            "owasp": set(),
+            "atlas": set(),
+            "nist": set(),
+            "owasp_mcp": set(),
+            "max_severity": Severity.NONE,
+            "has_kev": False,
+            "ai_risk": False,
+        }
+    )
     severity_order = {Severity.CRITICAL: 4, Severity.HIGH: 3, Severity.MEDIUM: 2, Severity.LOW: 1, Severity.NONE: 0}
 
     for br in blast_radii:
@@ -671,9 +669,9 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
         g["owasp"] = sorted(g["owasp"])
         g["atlas"] = sorted(g["atlas"])
         g["nist"] = sorted(g["nist"])
+        g["owasp_mcp"] = sorted(g["owasp_mcp"])
         g["impact"] = (
-            len(g["agents"]) * 10 + len(g["creds"]) * 3 + len(g["vulns"])
-            + (5 if g["has_kev"] else 0) + (3 if g["ai_risk"] else 0)
+            len(g["agents"]) * 10 + len(g["creds"]) * 3 + len(g["vulns"]) + (5 if g["has_kev"] else 0) + (3 if g["ai_risk"] else 0)
         )
         plan.append(g)
 
@@ -705,8 +703,11 @@ def print_remediation_plan(report: AIBOMReport) -> None:
     console.print()
 
     sev_style = {
-        Severity.CRITICAL: "red bold", Severity.HIGH: "red",
-        Severity.MEDIUM: "yellow", Severity.LOW: "dim", Severity.NONE: "white",
+        Severity.CRITICAL: "red bold",
+        Severity.HIGH: "red",
+        Severity.MEDIUM: "yellow",
+        Severity.LOW: "dim",
+        Severity.NONE: "white",
     }
 
     if fixable:
@@ -744,8 +745,10 @@ def print_remediation_plan(report: AIBOMReport) -> None:
             if item["creds"]:
                 console.print(f"     [dim]credentials:[/dim]  [yellow]{', '.join(item['creds'])}[/yellow]")
             if item["tools"]:
-                console.print(f"     [dim]tools:[/dim]  {', '.join(item['tools'][:8])}"
-                              + (f" +{len(item['tools']) - 8} more" if len(item["tools"]) > 8 else ""))
+                console.print(
+                    f"     [dim]tools:[/dim]  {', '.join(item['tools'][:8])}"
+                    + (f" +{len(item['tools']) - 8} more" if len(item["tools"]) > 8 else "")
+                )
 
             # Threat framework tags
             tags = []
@@ -759,11 +762,13 @@ def print_remediation_plan(report: AIBOMReport) -> None:
                 console.print(f"     [dim]mitigates:[/dim]  {' '.join(tags)}")
 
             # Risk narrative — what happens if NOT fixed
-            console.print(f"     [dim red]⚠ if not fixed:[/dim red] "
-                          f"[dim]attacker exploiting {item['vulns'][0]} can reach "
-                          f"{'[yellow]' + ', '.join(item['creds'][:2]) + '[/yellow]' if item['creds'] else 'no credentials'} "
-                          f"via {', '.join(item['agents'][:2])}"
-                          f"{' through ' + ', '.join(item['tools'][:3]) if item['tools'] else ''}[/dim]")
+            console.print(
+                f"     [dim red]⚠ if not fixed:[/dim red] "
+                f"[dim]attacker exploiting {item['vulns'][0]} can reach "
+                f"{'[yellow]' + ', '.join(item['creds'][:2]) + '[/yellow]' if item['creds'] else 'no credentials'} "
+                f"via {', '.join(item['agents'][:2])}"
+                f"{' through ' + ', '.join(item['tools'][:3]) if item['tools'] else ''}[/dim]"
+            )
             console.print()
 
     if unfixable:
@@ -796,6 +801,7 @@ def print_export_hint(report: AIBOMReport) -> None:
         owasp_mcp_hit.update(br.owasp_mcp_tags)
 
     from agent_bom.owasp_mcp import OWASP_MCP_TOP10
+
     owasp_total = len(OWASP_LLM_TOP10)
     atlas_total = len(ATLAS_TECHNIQUES)
     nist_total = len(NIST_AI_RMF)
@@ -808,7 +814,9 @@ def print_export_hint(report: AIBOMReport) -> None:
         # OWASP bar
         owasp_pct = int(len(owasp_hit) / owasp_total * 100) if owasp_total else 0
         owasp_bar = _coverage_bar(len(owasp_hit), owasp_total, "purple")
-        lines.append(f"  [bold purple]OWASP LLM Top 10[/bold purple]  {owasp_bar}  [purple]{len(owasp_hit)}/{owasp_total}[/purple] ({owasp_pct}%)")
+        lines.append(
+            f"  [bold purple]OWASP LLM Top 10[/bold purple]  {owasp_bar}  [purple]{len(owasp_hit)}/{owasp_total}[/purple] ({owasp_pct}%)"
+        )
 
         # ATLAS bar
         atlas_pct = int(len(atlas_hit) / atlas_total * 100) if atlas_total else 0
@@ -823,7 +831,9 @@ def print_export_hint(report: AIBOMReport) -> None:
         # OWASP MCP bar
         owasp_mcp_pct = int(len(owasp_mcp_hit) / owasp_mcp_total * 100) if owasp_mcp_total else 0
         owasp_mcp_bar = _coverage_bar(len(owasp_mcp_hit), owasp_mcp_total, "yellow")
-        lines.append(f"  [bold yellow]OWASP MCP Top 10 [/bold yellow]  {owasp_mcp_bar}  [yellow]{len(owasp_mcp_hit)}/{owasp_mcp_total}[/yellow] ({owasp_mcp_pct}%)")
+        lines.append(
+            f"  [bold yellow]OWASP MCP Top 10 [/bold yellow]  {owasp_mcp_bar}  [yellow]{len(owasp_mcp_hit)}/{owasp_mcp_total}[/yellow] ({owasp_mcp_pct}%)"
+        )
 
         lines.append("")
 
@@ -889,27 +899,29 @@ def _build_remediation_json(report: AIBOMReport) -> list[dict]:
         n_agents = len(item["agents"])
         n_creds = len(item["creds"])
         n_tools = len(item["tools"])
-        result.append({
-            "package": item["package"],
-            "ecosystem": item["ecosystem"],
-            "current_version": item["current"],
-            "fixed_version": item["fix"],
-            "severity": item["max_severity"].value,
-            "is_kev": item["has_kev"],
-            "impact_score": item["impact"],
-            "vulnerabilities": item["vulns"],
-            "affected_agents": item["agents"],
-            "agents_pct": round(n_agents / total_agents * 100),
-            "exposed_credentials": item["creds"],
-            "credentials_pct": round(n_creds / total_creds * 100) if n_creds else 0,
-            "reachable_tools": item["tools"],
-            "tools_pct": round(n_tools / total_tools * 100) if n_tools else 0,
-            "owasp_tags": item["owasp"],
-            "atlas_tags": item["atlas"],
-            "nist_ai_rmf_tags": item["nist"],
-            "owasp_mcp_tags": item["owasp_mcp"],
-            "risk_narrative": _risk_narrative(item),
-        })
+        result.append(
+            {
+                "package": item["package"],
+                "ecosystem": item["ecosystem"],
+                "current_version": item["current"],
+                "fixed_version": item["fix"],
+                "severity": item["max_severity"].value,
+                "is_kev": item["has_kev"],
+                "impact_score": item["impact"],
+                "vulnerabilities": item["vulns"],
+                "affected_agents": item["agents"],
+                "agents_pct": round(n_agents / total_agents * 100),
+                "exposed_credentials": item["creds"],
+                "credentials_pct": round(n_creds / total_creds * 100) if n_creds else 0,
+                "reachable_tools": item["tools"],
+                "tools_pct": round(n_tools / total_tools * 100) if n_tools else 0,
+                "owasp_tags": item["owasp"],
+                "atlas_tags": item["atlas"],
+                "nist_ai_rmf_tags": item["nist"],
+                "owasp_mcp_tags": item["owasp_mcp"],
+                "risk_narrative": _risk_narrative(item),
+            }
+        )
     return result
 
 
@@ -1030,10 +1042,7 @@ def to_json(report: AIBOMReport) -> dict:
                         "mcp_version": server.mcp_version,
                         "has_credentials": server.has_credentials,
                         "credential_env_vars": server.credential_names,
-                        "tools": [
-                            {"name": t.name, "description": t.description}
-                            for t in server.tools
-                        ],
+                        "tools": [{"name": t.name, "description": t.description} for t in server.tools],
                         "packages": [
                             {
                                 "name": pkg.name,
@@ -1044,6 +1053,8 @@ def to_json(report: AIBOMReport) -> dict:
                                 "parent_package": pkg.parent_package,
                                 "dependency_depth": pkg.dependency_depth,
                                 "resolved_from_registry": pkg.resolved_from_registry,
+                                "version_source": pkg.version_source,
+                                "registry_version": pkg.registry_version,
                                 "scorecard_score": pkg.scorecard_score,
                                 "scorecard_checks": pkg.scorecard_checks or None,
                                 "vulnerabilities": [
@@ -1078,7 +1089,8 @@ def to_json(report: AIBOMReport) -> dict:
                                 "filesystem_write": server.permission_profile.filesystem_write,
                                 "shell_access": server.permission_profile.shell_access,
                             }
-                            if server.permission_profile else None
+                            if server.permission_profile
+                            else None
                         ),
                     }
                     for server in agent.mcp_servers
@@ -1171,18 +1183,20 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
         agent_ref = f"agent-{agent.name}"
         agent_deps = []
 
-        components.append({
-            "type": "application",
-            "bom-ref": agent_ref,
-            "name": agent.name,
-            "version": agent.version or "unknown",
-            "description": f"AI Agent ({agent.agent_type.value})",
-            "properties": [
-                {"name": "agent-bom:type", "value": "ai-agent"},
-                {"name": "agent-bom:config-path", "value": agent.config_path},
-                {"name": "agent-bom:status", "value": agent.status.value},
-            ],
-        })
+        components.append(
+            {
+                "type": "application",
+                "bom-ref": agent_ref,
+                "name": agent.name,
+                "version": agent.version or "unknown",
+                "description": f"AI Agent ({agent.agent_type.value})",
+                "properties": [
+                    {"name": "agent-bom:type", "value": "ai-agent"},
+                    {"name": "agent-bom:config-path", "value": agent.config_path},
+                    {"name": "agent-bom:status", "value": agent.status.value},
+                ],
+            }
+        )
 
         for server in agent.mcp_servers:
             server_ref = f"mcp-server-{server.name}-{comp_id}"
@@ -1195,17 +1209,17 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                 {"name": "agent-bom:transport", "value": server.transport.value},
             ]
             if server.has_credentials:
-                server_props.append({
-                    "name": "agent-bom:has-credentials", "value": "true"
-                })
+                server_props.append({"name": "agent-bom:has-credentials", "value": "true"})
 
-            components.append({
-                "type": "application",
-                "bom-ref": server_ref,
-                "name": server.name,
-                "description": f"MCP Server ({server.transport.value})",
-                "properties": server_props,
-            })
+            components.append(
+                {
+                    "type": "application",
+                    "bom-ref": server_ref,
+                    "name": server.name,
+                    "description": f"MCP Server ({server.transport.value})",
+                    "properties": server_props,
+                }
+            )
             agent_deps.append(server_ref)
 
             for pkg in server.packages:
@@ -1219,22 +1233,20 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                     {"name": "agent-bom:resolved-from-registry", "value": str(pkg.resolved_from_registry).lower()},
                 ]
                 if pkg.parent_package:
-                    pkg_properties.append({
-                        "name": "agent-bom:parent-package", "value": pkg.parent_package
-                    })
+                    pkg_properties.append({"name": "agent-bom:parent-package", "value": pkg.parent_package})
                 if pkg.scorecard_score is not None:
-                    pkg_properties.append({
-                        "name": "agent-bom:scorecard-score", "value": str(pkg.scorecard_score)
-                    })
+                    pkg_properties.append({"name": "agent-bom:scorecard-score", "value": str(pkg.scorecard_score)})
 
-                components.append({
-                    "type": "library",
-                    "bom-ref": pkg_ref,
-                    "name": pkg.name,
-                    "version": pkg.version,
-                    "purl": pkg.purl,
-                    "properties": pkg_properties,
-                })
+                components.append(
+                    {
+                        "type": "library",
+                        "bom-ref": pkg_ref,
+                        "name": pkg.name,
+                        "version": pkg.version,
+                        "purl": pkg.purl,
+                        "properties": pkg_properties,
+                    }
+                )
                 server_deps.append(pkg_ref)
                 bom_ref_map[f"{pkg.ecosystem}:{pkg.name}@{pkg.version}"] = pkg_ref
 
@@ -1248,15 +1260,19 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                         "affects": [{"ref": pkg_ref}],
                     }
                     if vuln.cvss_score:
-                        vuln_entry["ratings"].append({
-                            "score": vuln.cvss_score,
-                            "severity": vuln.severity.value,
-                            "method": "CVSSv3",
-                        })
+                        vuln_entry["ratings"].append(
+                            {
+                                "score": vuln.cvss_score,
+                                "severity": vuln.severity.value,
+                                "method": "CVSSv3",
+                            }
+                        )
                     else:
-                        vuln_entry["ratings"].append({
-                            "severity": vuln.severity.value,
-                        })
+                        vuln_entry["ratings"].append(
+                            {
+                                "severity": vuln.severity.value,
+                            }
+                        )
                     if vuln.fixed_version:
                         vuln_entry["recommendation"] = f"Upgrade to {vuln.fixed_version}"
                     vulnerabilities_cdx.append(vuln_entry)
@@ -1339,10 +1355,7 @@ def to_sarif(report: AIBOMReport) -> dict:
             rules.append(rule)
 
         affected = ", ".join(a.name for a in br.affected_agents)
-        message_text = (
-            f"{vuln.id} ({vuln.severity.value}) in {br.package.name}@{br.package.version}. "
-            f"Affects agents: {affected}."
-        )
+        message_text = f"{vuln.id} ({vuln.severity.value}) in {br.package.name}@{br.package.version}. Affects agents: {affected}."
         if vuln.fixed_version:
             message_text += f" Fix: upgrade to {vuln.fixed_version}."
 
@@ -1430,10 +1443,7 @@ def print_compact_summary(report: AIBOMReport) -> None:
     cred_names = sorted(set(cred_names))
 
     # Privilege count
-    elevated = sum(
-        1 for a in report.agents for s in a.mcp_servers
-        if s.permission_profile and s.permission_profile.is_elevated
-    )
+    elevated = sum(1 for a in report.agents for s in a.mcp_servers if s.permission_profile and s.permission_profile.is_elevated)
 
     lines = [
         f"  [bold]SECURITY POSTURE:[/bold]  {posture}",
@@ -1450,12 +1460,14 @@ def print_compact_summary(report: AIBOMReport) -> None:
     if elevated:
         lines.append(f"  [red]Privileges:[/red]  {elevated} server(s) elevated")
 
-    console.print(Panel(
-        "\n".join(lines),
-        title=f"[bold]AI-BOM Report[/bold]  v{report.tool_version}",
-        border_style=border_style,
-        padding=(0, 1),
-    ))
+    console.print(
+        Panel(
+            "\n".join(lines),
+            title=f"[bold]AI-BOM Report[/bold]  v{report.tool_version}",
+            border_style=border_style,
+            padding=(0, 1),
+        )
+    )
 
 
 def print_compact_agents(report: AIBOMReport) -> None:
@@ -1508,8 +1520,10 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 5) -> None:
     table.add_column("Fix", ratio=1)
 
     severity_colors = {
-        Severity.CRITICAL: "red bold", Severity.HIGH: "red",
-        Severity.MEDIUM: "yellow", Severity.LOW: "dim",
+        Severity.CRITICAL: "red bold",
+        Severity.HIGH: "red",
+        Severity.MEDIUM: "yellow",
+        Severity.LOW: "dim",
     }
 
     for br in report.blast_radii[:limit]:
@@ -1551,8 +1565,11 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 3) -> None:
     console.print(f"  [bold]{title}[/bold]")
 
     sev_style = {
-        Severity.CRITICAL: "red bold", Severity.HIGH: "red",
-        Severity.MEDIUM: "yellow", Severity.LOW: "dim", Severity.NONE: "white",
+        Severity.CRITICAL: "red bold",
+        Severity.HIGH: "red",
+        Severity.MEDIUM: "yellow",
+        Severity.LOW: "dim",
+        Severity.NONE: "white",
     }
 
     for i, item in enumerate(fixable[:limit], 1):
@@ -1578,8 +1595,7 @@ def print_compact_export_hint(report: AIBOMReport) -> None:
         f"[bold]{report.total_vulnerabilities} vulns[/bold]",
         "",
         "  [green]agent-bom scan -f[/green] json | cyclonedx | sarif | spdx | html",
-        "  [green]agent-bom serve[/green]  [dim]API + dashboard[/dim]    "
-        "[green]--verbose[/green]  [dim]full tree & details[/dim]",
+        "  [green]agent-bom serve[/green]  [dim]API + dashboard[/dim]    [green]--verbose[/green]  [dim]full tree & details[/dim]",
     ]
     console.print(Panel("\n".join(lines), border_style="blue", padding=(0, 1)))
 
@@ -1593,8 +1609,7 @@ def print_diff(diff: dict) -> None:
     baseline_ts = diff["baseline_generated_at"]
     current_ts = diff["current_generated_at"]
 
-    console.print(f"\n[bold blue]📊 Scan Diff[/bold blue]  "
-                  f"[dim]{baseline_ts}[/dim] → [dim]{current_ts}[/dim]\n")
+    console.print(f"\n[bold blue]📊 Scan Diff[/bold blue]  [dim]{baseline_ts}[/dim] → [dim]{current_ts}[/dim]\n")
 
     parts = []
     if summary["new_findings"]:
@@ -1615,8 +1630,10 @@ def print_diff(diff: dict) -> None:
         return
 
     severity_styles = {
-        "CRITICAL": "red bold", "HIGH": "red",
-        "MEDIUM": "yellow", "LOW": "dim",
+        "CRITICAL": "red bold",
+        "HIGH": "red",
+        "MEDIUM": "yellow",
+        "LOW": "dim",
     }
 
     if diff["new"]:
@@ -1628,8 +1645,7 @@ def print_diff(diff: dict) -> None:
             ai = " [magenta][AI-RISK][/magenta]" if br.get("ai_risk_context") else ""
             fix = f" → fix: {br['fixed_version']}" if br.get("fixed_version") else " (no fix)"
             console.print(
-                f"    [+] [{style}]{br.get('vulnerability_id', '?')}[/{style}]  "
-                f"{br.get('package', '?')}  [{sev}]{kev}{ai}[dim]{fix}[/dim]"
+                f"    [+] [{style}]{br.get('vulnerability_id', '?')}[/{style}]  {br.get('package', '?')}  [{sev}]{kev}{ai}[dim]{fix}[/dim]"
             )
         if len(diff["new"]) > 20:
             console.print(f"    [dim]...and {len(diff['new']) - 20} more[/dim]")
@@ -1638,10 +1654,7 @@ def print_diff(diff: dict) -> None:
     if diff["resolved"]:
         console.print(f"  [green]Resolved findings ({len(diff['resolved'])}):[/green]")
         for br in diff["resolved"][:10]:
-            console.print(
-                f"    [-] [dim]{br.get('vulnerability_id', '?')}  "
-                f"{br.get('package', '?')}[/dim]"
-            )
+            console.print(f"    [-] [dim]{br.get('vulnerability_id', '?')}  {br.get('package', '?')}[/dim]")
         console.print()
 
     if diff["new_packages"]:
@@ -1673,10 +1686,7 @@ def print_policy_results(policy_result: dict) -> None:
     if warnings:
         console.print(f"  [yellow]⚠ {len(warnings)} warning(s):[/yellow]")
         for v in warnings[:10]:
-            console.print(
-                f"    [yellow]WARN[/yellow]  [{v['rule_id']}]  "
-                f"{v['vulnerability_id']}  {v['package']}  [{v['severity']}]"
-            )
+            console.print(f"    [yellow]WARN[/yellow]  [{v['rule_id']}]  {v['vulnerability_id']}  {v['package']}  [{v['severity']}]")
             console.print(f"           [dim]{v['rule_description']}[/dim]")
         console.print()
 
@@ -1686,8 +1696,7 @@ def print_policy_results(policy_result: dict) -> None:
             kev = " [red bold][KEV][/red bold]" if v.get("is_kev") else ""
             ai = " [magenta][AI-RISK][/magenta]" if v.get("ai_risk_context") else ""
             console.print(
-                f"    [red bold]FAIL[/red bold]  [{v['rule_id']}]  "
-                f"{v['vulnerability_id']}  {v['package']}  [{v['severity']}]{kev}{ai}"
+                f"    [red bold]FAIL[/red bold]  [{v['rule_id']}]  {v['vulnerability_id']}  {v['package']}  [{v['severity']}]{kev}{ai}"
             )
             console.print(f"           [dim]{v['rule_description']}[/dim]")
         if len(failures) > 10:
@@ -1734,11 +1743,7 @@ def print_severity_chart(report: AIBOMReport) -> None:
         bar = "█" * bar_len
         style = styles[sev]
         pct = int(100 * count / total) if total else 0
-        console.print(
-            f"  [{style}]{sev:8}[/{style}]  "
-            f"[{style}]{bar:<{bar_width}}[/{style}]  "
-            f"[dim]{count:3} ({pct}%)[/dim]"
-        )
+        console.print(f"  [{style}]{sev:8}[/{style}]  [{style}]{bar:<{bar_width}}[/{style}]  [dim]{count:3} ({pct}%)[/dim]")
     console.print()
 
 
@@ -1818,13 +1823,15 @@ def to_spdx(report: AIBOMReport) -> dict:
                 server_element["versionInfo"] = server.mcp_version
             elements.append(server_element)
 
-            relationships.append({
-                "type": "Relationship",
-                "spdxId": _next_id("SPDXRef-Rel"),
-                "relationshipType": "CONTAINS",
-                "from": agent_id,
-                "to": [server_id],
-            })
+            relationships.append(
+                {
+                    "type": "Relationship",
+                    "spdxId": _next_id("SPDXRef-Rel"),
+                    "relationshipType": "CONTAINS",
+                    "from": agent_id,
+                    "to": [server_id],
+                }
+            )
 
             for pkg in server.packages:
                 pkg_key = f"{pkg.ecosystem}:{pkg.name}@{pkg.version}"
@@ -1840,19 +1847,19 @@ def to_spdx(report: AIBOMReport) -> dict:
                         "primaryPurpose": "LIBRARY",
                     }
                     if pkg.purl:
-                        pkg_element["externalIdentifier"] = [
-                            {"type": "PackageURL", "identifier": pkg.purl}
-                        ]
+                        pkg_element["externalIdentifier"] = [{"type": "PackageURL", "identifier": pkg.purl}]
                     elements.append(pkg_element)
 
                 pkg_id = pkg_ref_map[pkg_key]
-                relationships.append({
-                    "type": "Relationship",
-                    "spdxId": _next_id("SPDXRef-Rel"),
-                    "relationshipType": "DEPENDS_ON",
-                    "from": server_id,
-                    "to": [pkg_id],
-                })
+                relationships.append(
+                    {
+                        "type": "Relationship",
+                        "spdxId": _next_id("SPDXRef-Rel"),
+                        "relationshipType": "DEPENDS_ON",
+                        "from": server_id,
+                        "to": [pkg_id],
+                    }
+                )
 
                 # Security relationships for each vulnerability
                 for vuln in pkg.vulnerabilities:
@@ -1862,9 +1869,7 @@ def to_spdx(report: AIBOMReport) -> dict:
                         "spdxId": vuln_element_id,
                         "name": vuln.id,
                         "description": vuln.summary or "",
-                        "externalIdentifier": [{"type": "cve", "identifier": vuln.id}]
-                        if vuln.id.startswith("CVE-")
-                        else [],
+                        "externalIdentifier": [{"type": "cve", "identifier": vuln.id}] if vuln.id.startswith("CVE-") else [],
                     }
                     if vuln.cvss_score is not None:
                         vuln_element["assessedElement"] = pkg_id
@@ -1915,12 +1920,14 @@ def export_spdx(report: AIBOMReport, output_path: str) -> None:
 def to_html(report: AIBOMReport, blast_radii: list | None = None) -> str:
     """Generate a self-contained HTML report string."""
     from agent_bom.output.html import to_html as _to_html
+
     return _to_html(report, blast_radii or [])
 
 
 def export_html(report: AIBOMReport, output_path: str, blast_radii: list | None = None) -> None:
     """Export report as a self-contained HTML file."""
     from agent_bom.output.html import export_html as _export_html
+
     _export_html(report, output_path, blast_radii or [])
 
 
@@ -1930,14 +1937,14 @@ def export_html(report: AIBOMReport, output_path: str, blast_radii: list | None 
 def to_prometheus(report: AIBOMReport, blast_radii: list | None = None) -> str:
     """Generate Prometheus text exposition format string."""
     from agent_bom.output.prometheus import to_prometheus as _to_prometheus
+
     return _to_prometheus(report, blast_radii or [])
 
 
-def export_prometheus(
-    report: AIBOMReport, output_path: str, blast_radii: list | None = None
-) -> None:
+def export_prometheus(report: AIBOMReport, output_path: str, blast_radii: list | None = None) -> None:
     """Write Prometheus metrics to a .prom file."""
     from agent_bom.output.prometheus import export_prometheus as _export_prometheus
+
     _export_prometheus(report, output_path, blast_radii or [])
 
 
@@ -1950,6 +1957,7 @@ def push_to_gateway(
 ) -> None:
     """Push scan metrics to a Prometheus Pushgateway."""
     from agent_bom.output.prometheus import push_to_gateway as _push
+
     _push(gateway_url, report, blast_radii or [], job=job, instance=instance)
 
 
@@ -1960,6 +1968,7 @@ def push_otlp(
 ) -> None:
     """Export metrics via OpenTelemetry OTLP/HTTP (requires agent-bom[otel])."""
     from agent_bom.output.prometheus import push_otlp as _push_otlp
+
     _push_otlp(endpoint, report, blast_radii or [])
 
 

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -1,0 +1,201 @@
+"""Supplemental GitHub Security Advisory (GHSA) enrichment.
+
+Queries the public GitHub Advisory Database REST API to find advisories
+that may not yet be indexed by OSV.dev.  Deduplicates by CVE ID against
+existing package vulnerabilities.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+from agent_bom.http_client import create_client, request_with_retry
+from agent_bom.models import Package, Severity, Vulnerability
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_ADVISORY_API = "https://api.github.com/advisories"
+
+# Map internal ecosystem names to GitHub Advisory API ecosystem values
+_ECOSYSTEM_MAP: dict[str, str] = {
+    "pypi": "pip",
+    "npm": "npm",
+    "go": "go",
+    "maven": "maven",
+    "cargo": "rust",
+    "nuget": "nuget",
+    "rubygems": "rubygems",
+}
+
+
+def _parse_ghsa_severity(advisory: dict) -> tuple[Severity, float | None]:
+    """Extract severity and CVSS score from a GHSA advisory."""
+    cvss = advisory.get("cvss", {}) or {}
+    score = cvss.get("score")
+    sev_str = (advisory.get("severity") or "").upper()
+
+    if score is not None:
+        score = float(score)
+
+    severity_map = {
+        "CRITICAL": Severity.CRITICAL,
+        "HIGH": Severity.HIGH,
+        "MEDIUM": Severity.MEDIUM,
+        "LOW": Severity.LOW,
+    }
+    severity = severity_map.get(sev_str, Severity.MEDIUM)
+    return severity, score
+
+
+def _extract_fixed_version(advisory: dict, package_name: str) -> str | None:
+    """Extract the first patched version for a specific package."""
+    for vuln in advisory.get("vulnerabilities", []):
+        pkg = vuln.get("package", {})
+        if pkg.get("name", "").lower() == package_name.lower():
+            patched = vuln.get("patched_versions")
+            if patched:
+                # patched_versions is a range string like ">= 4.18.0"
+                cleaned = patched.lstrip(">= ").split(",")[0].strip()
+                if cleaned:
+                    return cleaned
+    return None
+
+
+def _get_cwe_ids(advisory: dict) -> list[str]:
+    """Extract CWE IDs from GHSA advisory."""
+    cwes = advisory.get("cwes", []) or []
+    return [c.get("cwe_id", "") for c in cwes if c.get("cwe_id")]
+
+
+async def _fetch_advisories_for_package(
+    pkg: Package,
+    client: httpx.AsyncClient,
+    semaphore: asyncio.Semaphore,
+) -> list[dict]:
+    """Fetch GitHub advisories for a single package."""
+    eco = _ECOSYSTEM_MAP.get(pkg.ecosystem.lower(), "")
+    if not eco:
+        return []
+
+    async with semaphore:
+        await asyncio.sleep(1.0)  # Rate limit: stay under 60 req/hr
+        resp = await request_with_retry(
+            client,
+            "GET",
+            _GITHUB_ADVISORY_API,
+            params={
+                "ecosystem": eco,
+                "package": pkg.name,
+                "per_page": "30",
+            },
+            headers={"Accept": "application/vnd.github+json"},
+        )
+        if resp and resp.status_code == 200:
+            try:
+                return resp.json()
+            except (ValueError, KeyError):
+                return []
+        return []
+
+
+async def check_github_advisories(
+    packages: list[Package],
+    max_packages: int = 50,
+) -> int:
+    """Check packages against GitHub Security Advisories (GHSA).
+
+    Queries the public GitHub Advisory Database REST API for each package,
+    deduplicates by CVE ID against existing vulnerabilities, and appends
+    any new findings.
+
+    Returns count of new vulnerabilities found.
+    """
+    if not packages:
+        return 0
+
+    # Filter to supported ecosystems and deduplicate by name+ecosystem
+    seen_keys: set[str] = set()
+    queryable: list[Package] = []
+    for pkg in packages:
+        eco = _ECOSYSTEM_MAP.get(pkg.ecosystem.lower(), "")
+        if not eco:
+            continue
+        key = f"{eco}:{pkg.name.lower()}"
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        queryable.append(pkg)
+
+    if not queryable:
+        return 0
+
+    # Cap to avoid rate limit exhaustion
+    queryable = queryable[:max_packages]
+
+    logger.info("GHSA advisory check for %d packages", len(queryable))
+
+    # Build a reverse lookup: all packages sharing the same name+ecosystem
+    pkg_groups: dict[str, list[Package]] = {}
+    for pkg in packages:
+        eco = _ECOSYSTEM_MAP.get(pkg.ecosystem.lower(), "")
+        if eco:
+            key = f"{eco}:{pkg.name.lower()}"
+            pkg_groups.setdefault(key, []).append(pkg)
+
+    total_new = 0
+    semaphore = asyncio.Semaphore(5)
+
+    async with create_client(timeout=15.0) as client:
+        tasks = [_fetch_advisories_for_package(p, client, semaphore) for p in queryable]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                logger.debug("GHSA fetch failed for %s: %s", queryable[i].name, result)
+                continue
+            if not result:
+                continue
+
+            pkg = queryable[i]
+            eco = _ECOSYSTEM_MAP.get(pkg.ecosystem.lower(), "")
+            key = f"{eco}:{pkg.name.lower()}"
+            target_pkgs = pkg_groups.get(key, [pkg])
+
+            for advisory in result:
+                ghsa_id = advisory.get("ghsa_id", "")
+                cve_id = advisory.get("cve_id") or ""
+                vuln_id = cve_id or ghsa_id
+                if not vuln_id:
+                    continue
+
+                severity, cvss_score = _parse_ghsa_severity(advisory)
+                summary = advisory.get("summary", "") or f"GitHub Advisory ({vuln_id})"
+                cwe_ids = _get_cwe_ids(advisory)
+                refs = [advisory.get("html_url", "")] if advisory.get("html_url") else []
+
+                for target_pkg in target_pkgs:
+                    existing_ids = {v.id for v in target_pkg.vulnerabilities}
+                    # Skip if CVE or GHSA ID already present
+                    if vuln_id in existing_ids or (cve_id and cve_id in existing_ids) or (ghsa_id and ghsa_id in existing_ids):
+                        continue
+
+                    fixed = _extract_fixed_version(advisory, target_pkg.name)
+                    vuln = Vulnerability(
+                        id=vuln_id,
+                        summary=summary[:200],
+                        severity=severity,
+                        cvss_score=cvss_score,
+                        fixed_version=fixed,
+                        references=refs,
+                        cwe_ids=cwe_ids,
+                    )
+                    target_pkg.vulnerabilities.append(vuln)
+                    total_new += 1
+
+    if total_new:
+        logger.info("GHSA advisories: found %d new CVE(s)", total_new)
+
+    return total_new

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -633,6 +633,11 @@ def test_osv_empty_response_yields_no_blast_radii(monkeypatch):
 
     monkeypatch.setattr("agent_bom.scanners.query_osv_batch", _empty_osv)
 
+    async def _no_ghsa(packages, **kwargs):
+        return 0
+
+    monkeypatch.setattr("agent_bom.scanners.ghsa_advisory.check_github_advisories", _no_ghsa)
+
     pkg = Package(name="express", version="4.18.2", ecosystem="npm")
     server = MCPServer(name="srv", command="node", env={}, packages=[pkg])
     agent = Agent(name="agt", agent_type=AgentType.CUSTOM, config_path="/tmp", mcp_servers=[server])

--- a/tests/test_ghsa_advisory.py
+++ b/tests/test_ghsa_advisory.py
@@ -1,0 +1,119 @@
+"""Tests for GitHub Security Advisory (GHSA) enrichment module."""
+
+from __future__ import annotations
+
+from agent_bom.models import Package, Severity, Vulnerability
+from agent_bom.scanners.ghsa_advisory import (
+    _ECOSYSTEM_MAP,
+    _extract_fixed_version,
+    _get_cwe_ids,
+    _parse_ghsa_severity,
+)
+
+
+def test_ecosystem_mapping_covers_major_ecosystems():
+    """Ecosystem map covers PyPI, npm, Go, Maven, Cargo, NuGet."""
+    assert _ECOSYSTEM_MAP["pypi"] == "pip"
+    assert _ECOSYSTEM_MAP["npm"] == "npm"
+    assert _ECOSYSTEM_MAP["go"] == "go"
+    assert _ECOSYSTEM_MAP["maven"] == "maven"
+    assert _ECOSYSTEM_MAP["cargo"] == "rust"
+    assert _ECOSYSTEM_MAP["nuget"] == "nuget"
+
+
+def test_severity_parsing_critical():
+    """CRITICAL severity maps correctly with CVSS score."""
+    sev, score = _parse_ghsa_severity({"severity": "critical", "cvss": {"score": 9.8}})
+    assert sev == Severity.CRITICAL
+    assert score == 9.8
+
+
+def test_severity_parsing_high():
+    """HIGH severity maps correctly."""
+    sev, score = _parse_ghsa_severity({"severity": "high", "cvss": {"score": 7.5}})
+    assert sev == Severity.HIGH
+    assert score == 7.5
+
+
+def test_severity_parsing_medium():
+    """MEDIUM severity maps correctly."""
+    sev, score = _parse_ghsa_severity({"severity": "medium", "cvss": {"score": 5.0}})
+    assert sev == Severity.MEDIUM
+
+
+def test_severity_parsing_low():
+    """LOW severity maps correctly."""
+    sev, score = _parse_ghsa_severity({"severity": "low", "cvss": {"score": 2.0}})
+    assert sev == Severity.LOW
+
+
+def test_severity_parsing_missing():
+    """Missing severity defaults to MEDIUM."""
+    sev, score = _parse_ghsa_severity({})
+    assert sev == Severity.MEDIUM
+    assert score is None
+
+
+def test_fixed_version_extraction():
+    """Extracts fixed version from GHSA vulnerability ranges."""
+    advisory = {
+        "vulnerabilities": [
+            {
+                "package": {"name": "express", "ecosystem": "npm"},
+                "patched_versions": ">= 4.18.0",
+            }
+        ]
+    }
+    result = _extract_fixed_version(advisory, "express")
+    assert result == "4.18.0"
+
+
+def test_fixed_version_extraction_no_patch():
+    """Returns None when no patched version available."""
+    advisory = {"vulnerabilities": [{"package": {"name": "express"}, "patched_versions": ""}]}
+    result = _extract_fixed_version(advisory, "express")
+    assert result is None
+
+
+def test_fixed_version_extraction_wrong_package():
+    """Returns None when package name doesn't match."""
+    advisory = {"vulnerabilities": [{"package": {"name": "lodash"}, "patched_versions": ">= 4.17.21"}]}
+    result = _extract_fixed_version(advisory, "express")
+    assert result is None
+
+
+def test_cwe_ids_extraction():
+    """Extracts CWE IDs from advisory."""
+    advisory = {"cwes": [{"cwe_id": "CWE-79"}, {"cwe_id": "CWE-89"}]}
+    result = _get_cwe_ids(advisory)
+    assert result == ["CWE-79", "CWE-89"]
+
+
+def test_cwe_ids_empty():
+    """Returns empty list when no CWEs."""
+    assert _get_cwe_ids({}) == []
+    assert _get_cwe_ids({"cwes": []}) == []
+
+
+def test_dedup_skips_existing_cve():
+    """GHSA enrichment should skip CVEs already present on a package."""
+    pkg = Package(
+        name="express",
+        version="4.17.1",
+        ecosystem="npm",
+        vulnerabilities=[
+            Vulnerability(
+                id="CVE-2024-1234",
+                summary="existing",
+                severity=Severity.HIGH,
+            )
+        ],
+    )
+    existing_ids = {v.id for v in pkg.vulnerabilities}
+    # Simulate a GHSA advisory returning the same CVE
+    assert "CVE-2024-1234" in existing_ids
+
+
+def test_unknown_ecosystem_skipped():
+    """Packages with unsupported ecosystems should not be queried."""
+    assert "unknown_eco" not in _ECOSYSTEM_MAP

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -13,7 +13,7 @@ from agent_bom.models import (
     TransportType,
     Vulnerability,
 )
-from agent_bom.output.mermaid import to_mermaid
+from agent_bom.output.mermaid import to_mermaid, to_mermaid_lifecycle
 
 
 def _make_report_and_blast_radii():
@@ -172,3 +172,23 @@ def test_mermaid_no_duplicate_edges():
     # Count occurrences of the CVE → package edge
     edge_count = result.count("-->|affects|")
     assert edge_count == 1
+
+
+def test_mermaid_lifecycle_basic():
+    """Lifecycle mode generates gantt chart with package section."""
+    report, brs = _make_report_and_blast_radii()
+    result = to_mermaid_lifecycle(report, brs)
+    assert result.startswith("gantt\n")
+    assert "Vulnerability Lifecycle Timeline" in result
+    assert "express@4.17.1" in result
+    assert "CVE-2024-1234" in result
+    assert "Fix" in result
+    assert "4.18.0" in result
+
+
+def test_mermaid_lifecycle_empty():
+    """Empty blast radii returns minimal gantt."""
+    report = AIBOMReport(agents=[], blast_radii=[])
+    result = to_mermaid_lifecycle(report, [])
+    assert "gantt" in result
+    assert "No vulnerabilities" in result

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -166,6 +166,15 @@ export function LineageDetailPanel({
           <div className="space-y-3">
             {data.ecosystem && <Row label="Ecosystem" value={data.ecosystem} />}
             {data.version && <Row label="Version" value={data.version} />}
+            {data.versionSource && (
+              <Row label="Version source" value={data.versionSource} />
+            )}
+            {data.registryVersion && data.registryVersion !== data.version && (
+              <div className="text-xs">
+                <span className="text-zinc-500">Registry latest: </span>
+                <span className="text-amber-400 font-mono">{data.registryVersion}</span>
+              </div>
+            )}
             {(data.vulnCount ?? 0) > 0 ? (
               <Row label="Vulnerabilities" value={data.vulnCount!} className="text-red-400" />
             ) : (

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -40,6 +40,8 @@ export type LineageNodeData = {
   // Package
   ecosystem?: string;
   version?: string;
+  versionSource?: string;
+  registryVersion?: string;
   // Vulnerability
   severity?: string;
   cvssScore?: number;


### PR DESCRIPTION
## Summary
- **GHSA advisory enrichment**: New `ghsa_advisory.py` module queries the GitHub Security Advisory Database REST API for all supported ecosystems (PyPI, npm, Go, Maven, Cargo, NuGet, RubyGems). Deduplicates by CVE/GHSA ID against existing vulns. Rate-limited with semaphore + delay.
- **Auto version resolution**: Packages with `version="latest"/"unknown"/""` are auto-resolved from npm/PyPI registries before OSV scanning, improving CVE accuracy.
- **Snowflake native app wiring**: Added `app_config` table (with defaults), `governance_findings` + `activity_events` tables, `set_config`/`get_config`/`trigger_scan` stored procs, and `auto_scan_task` scheduled CRON task.
- **Lifecycle Mermaid mode**: New `--mermaid-mode lifecycle` generates Mermaid gantt charts showing vulnerability timelines (scan → vuln discovered → fix available).
- **Lineage panel polish**: `version_source` and `registry_version` now appear in JSON output and UI lineage detail panel.
- **Bug fix**: `owasp_mcp` set was not converted to list in `_build_remediation_json`, causing JSON serialization failures.

## Test plan
- [x] 1512 tests pass (`pytest tests/ -x -q`)
- [x] `ruff check src/` clean
- [x] New `test_ghsa_advisory.py` (11 tests) covers ecosystem mapping, severity parsing, dedup, edge cases
- [x] New lifecycle mermaid tests in `test_mermaid.py`
- [x] `test_prompt_scan_data_in_json_output` now passes (was failing due to owasp_mcp set bug)