### PR TITLE
fix: restore SVG diagrams — Mermaid unreadable on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,42 +19,12 @@
   <b>AI supply chain security scanner. Scan packages and images for CVEs. Assess config security — credential exposure, tool access, privilege escalation. Map blast radius from vulnerabilities to credentials and tools. OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF.</b>
 </p>
 
-```mermaid
-graph LR
-    subgraph Discovery["1. Discovery"]
-        MCP["MCP Configs\n18 clients"]
-        Cloud["Cloud Providers\nAWS · Azure · GCP\nSnowflake · Databricks"]
-        Img["Docker Images\nGrype + Syft"]
-        K8s["Kubernetes\nPod scanning"]
-        SBOM_In["Existing SBOMs\nCycloneDX · SPDX"]
-    end
-
-    subgraph Enrichment["2. Enrichment"]
-        OSV["OSV.dev\nBatch CVE lookup"]
-        NVD["NVD\nCVSS v3/v4"]
-        EPSS["FIRST EPSS\nExploit probability"]
-        KEV["CISA KEV\nActive exploitation"]
-        GHSA["GHSA · NVIDIA CSAF\nSupplemental advisories"]
-        Reg["MCP Registry\n427+ servers"]
-    end
-
-    subgraph Analysis["3. Analysis"]
-        Blast["Blast Radius\nCVE → pkg → server →\nagent → creds → tools"]
-        OWASP["OWASP LLM Top 10\n+ MCP Top 10"]
-        ATLAS["MITRE ATLAS\n+ NIST AI RMF"]
-        Enforce["Enforcement\nPolicy gates"]
-    end
-
-    subgraph Output["4. Output"]
-        Console["Console · HTML"]
-        SARIF["SARIF"]
-        CDX["CycloneDX 1.6"]
-        SPDX["SPDX 3.0"]
-        JSON_Out["JSON · Mermaid"]
-    end
-
-    Discovery --> Enrichment --> Analysis --> Output
-```
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="How agent-bom works" width="800" style="padding: 20px 0" />
+  </picture>
+</p>
 
 ---
 
@@ -521,50 +491,12 @@ Set `SNOWFLAKE_ACCOUNT` + `SNOWFLAKE_USER` + auth (`SNOWFLAKE_PRIVATE_KEY_PATH` 
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for full Snowflake architecture and setup instructions.
 
-```mermaid
-graph TD
-    subgraph External["External Clients"]
-        MCP_C["MCP Clients\nClaude · Cursor · etc."]
-        NextJS["Next.js Dashboard"]
-        CLI_E["CLI\nagent-bom scan --snowflake"]
-    end
-
-    subgraph SF["Snowflake Account"]
-        subgraph Discover["Cortex Discovery"]
-            CA["Cortex Agents"]
-            MCP_SF["Native MCP Servers"]
-            CS["Cortex Search · RAG"]
-            SC["Snowpark Containers"]
-            QH["Query History · 365 days"]
-            GOV["Governance · Roles + Grants"]
-        end
-
-        subgraph Runtime["Snowpark Container Services"]
-            API["agent-bom API\nFastAPI :8422"]
-        end
-
-        subgraph Storage["Snowflake Tables"]
-            Jobs["SCAN_JOBS"]
-            Fleet["FLEET_AGENTS"]
-            Policies["GATEWAY_POLICIES"]
-            Audit["POLICY_AUDIT_LOG"]
-        end
-
-        subgraph SiS["Streamlit in Snowflake"]
-            Dash["6-Tab Dashboard\nJobs · Fleet · Policies\nVulns · Compliance · Audit"]
-        end
-
-        subgraph NativeApp["Native App"]
-            NA["Marketplace Distribution\nmanifest.yml + setup.sql"]
-        end
-    end
-
-    External --> API
-    Discover --> API
-    API --> Storage
-    SiS --> Storage
-    NA --> Storage
-```
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/snowflake-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/snowflake-light.svg" alt="Snowflake Deployment Architecture" width="800" />
+  </picture>
+</p>
 
 <p align="center">
   <picture>

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
+  <style>
+    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
+    .phase { font: 700 10px system-ui, sans-serif; letter-spacing: 0.08em; }
+    .item-label { font: 600 11px system-ui, sans-serif; fill: #e6edf3; }
+    .item-sub { font: 400 9.5px system-ui, sans-serif; fill: #8b949e; }
+    .footer { font: 500 9.5px system-ui, sans-serif; fill: #6e7681; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M1 1L9 5L1 9" stroke="#6e7681" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="420" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="440" y="32" text-anchor="middle" class="title">How agent-bom works</text>
+
+  <!-- ── Phase 1: Discovery ── -->
+  <rect x="24" y="52" width="192" height="6" rx="3" fill="#58a6ff" opacity="0.7"/>
+  <text x="120" y="76" text-anchor="middle" class="phase" fill="#58a6ff">DISCOVERY</text>
+
+  <g transform="translate(36, 88)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">MCP Configs (18 clients)</text>
+    <text x="16" y="22" class="item-sub">Claude, Cursor, Codex, Gemini, Goose, +13</text>
+  </g>
+  <g transform="translate(36, 118)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Cloud Providers</text>
+    <text x="16" y="22" class="item-sub">AWS, Azure, GCP, Snowflake, Databricks, Nebius</text>
+  </g>
+  <g transform="translate(36, 148)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Docker Images</text>
+    <text x="16" y="22" class="item-sub">Grype + Syft deep scanning</text>
+  </g>
+  <g transform="translate(36, 178)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Kubernetes Pods</text>
+    <text x="16" y="22" class="item-sub">kubectl multi-namespace</text>
+  </g>
+  <g transform="translate(36, 208)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Existing SBOMs</text>
+    <text x="16" y="22" class="item-sub">CycloneDX + SPDX import</text>
+  </g>
+  <g transform="translate(36, 238)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Agent Frameworks</text>
+    <text x="16" y="22" class="item-sub">LangChain, CrewAI, ADK</text>
+  </g>
+
+  <!-- Arrow 1 -->
+  <g transform="translate(226, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Phase 2: Enrichment ── -->
+  <rect x="252" y="52" width="192" height="6" rx="3" fill="#d29922" opacity="0.7"/>
+  <text x="348" y="76" text-anchor="middle" class="phase" fill="#d29922">ENRICHMENT</text>
+
+  <g transform="translate(264, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">OSV.dev</text>
+    <text x="16" y="22" class="item-sub">Batch CVE lookup, all ecosystems</text>
+  </g>
+  <g transform="translate(264, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">NVD / NIST</text>
+    <text x="16" y="22" class="item-sub">CVSS v3.1 / v4.0 severity</text>
+  </g>
+  <g transform="translate(264, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">FIRST EPSS</text>
+    <text x="16" y="22" class="item-sub">Exploit probability scores</text>
+  </g>
+  <g transform="translate(264, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">CISA KEV</text>
+    <text x="16" y="22" class="item-sub">Known exploited vulns catalog</text>
+  </g>
+  <g transform="translate(264, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">MCP Registry</text>
+    <text x="16" y="22" class="item-sub">427+ server provenance checks</text>
+  </g>
+
+  <!-- Arrow 2 -->
+  <g transform="translate(454, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Phase 3: Analysis ── -->
+  <rect x="480" y="52" width="192" height="6" rx="3" fill="#f47067" opacity="0.7"/>
+  <text x="576" y="76" text-anchor="middle" class="phase" fill="#f47067">ANALYSIS</text>
+
+  <g transform="translate(492, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#f47067" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Blast Radius</text>
+    <text x="16" y="22" class="item-sub">Agent / credential / tool impact</text>
+  </g>
+  <g transform="translate(492, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#f47067" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">OWASP LLM Top 10</text>
+    <text x="16" y="22" class="item-sub">LLM02 / LLM05 / LLM06 / LLM08</text>
+  </g>
+  <g transform="translate(492, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#f47067" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">MITRE ATLAS</text>
+    <text x="16" y="22" class="item-sub">AI adversarial threat mapping</text>
+  </g>
+  <g transform="translate(492, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#f47067" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Enforcement Engine</text>
+    <text x="16" y="22" class="item-sub">Tool poisoning + policy gates</text>
+  </g>
+  <g transform="translate(492, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#f47067" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Model Provenance</text>
+    <text x="16" y="22" class="item-sub">SHA-256, Sigstore, HuggingFace</text>
+  </g>
+
+  <!-- Arrow 3 -->
+  <g transform="translate(682, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Phase 4: Output ── -->
+  <rect x="708" y="52" width="148" height="6" rx="3" fill="#3fb950" opacity="0.7"/>
+  <text x="782" y="76" text-anchor="middle" class="phase" fill="#3fb950">OUTPUT</text>
+
+  <g transform="translate(720, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Console + HTML</text>
+    <text x="16" y="22" class="item-sub">Rich tables + dashboard</text>
+  </g>
+  <g transform="translate(720, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">SARIF</text>
+    <text x="16" y="22" class="item-sub">GitHub Security tab</text>
+  </g>
+  <g transform="translate(720, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">CycloneDX 1.6</text>
+    <text x="16" y="22" class="item-sub">AI-BOM standard</text>
+  </g>
+  <g transform="translate(720, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">SPDX 3.0</text>
+    <text x="16" y="22" class="item-sub">License + provenance</text>
+  </g>
+  <g transform="translate(720, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">JSON + REST API</text>
+    <text x="16" y="22" class="item-sub">FastAPI on :8422</text>
+  </g>
+
+  <!-- Separator line -->
+  <line x1="40" y1="284" x2="840" y2="284" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Trust bar -->
+  <g transform="translate(40, 300)">
+    <rect width="800" height="44" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.05em">TRUST PRINCIPLES</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">Read-only  ·  Agentless  ·  Never writes configs  ·  Never runs MCP servers  ·  Never stores credentials  ·  Sigstore-signed releases</text>
+  </g>
+
+  <!-- Integration row -->
+  <g transform="translate(40, 358)">
+    <rect width="800" height="44" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.05em">INTERFACES</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">CLI (pip install)  ·  REST API (FastAPI)  ·  GitHub Actions  ·  Cloud UI  ·  Skills  ·  Prometheus / OTLP</text>
+  </g>
+</svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
+  <style>
+    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #0f172a; }
+    .phase { font: 700 10px system-ui, sans-serif; letter-spacing: 0.08em; }
+    .item-label { font: 600 11px system-ui, sans-serif; fill: #1e293b; }
+    .item-sub { font: 400 9.5px system-ui, sans-serif; fill: #64748b; }
+    .footer { font: 500 9.5px system-ui, sans-serif; fill: #94a3b8; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M1 1L9 5L1 9" stroke="#94a3b8" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="420" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="440" y="32" text-anchor="middle" class="title">How agent-bom works</text>
+
+  <!-- ── Phase 1: Discovery ── -->
+  <rect x="24" y="52" width="192" height="6" rx="3" fill="#3b82f6" opacity="0.8"/>
+  <text x="120" y="76" text-anchor="middle" class="phase" fill="#2563eb">DISCOVERY</text>
+
+  <g transform="translate(36, 88)">
+    <circle cx="6" cy="6" r="3.5" fill="#3b82f6" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">MCP Configs (18 clients)</text>
+    <text x="16" y="22" class="item-sub">Claude, Cursor, Codex, Gemini, Goose, +13</text>
+  </g>
+  <g transform="translate(36, 118)">
+    <circle cx="6" cy="6" r="3.5" fill="#3b82f6" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Cloud Providers</text>
+    <text x="16" y="22" class="item-sub">AWS, Azure, GCP, Snowflake, Databricks, Nebius</text>
+  </g>
+  <g transform="translate(36, 148)">
+    <circle cx="6" cy="6" r="3.5" fill="#3b82f6" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Docker Images</text>
+    <text x="16" y="22" class="item-sub">Grype + Syft deep scanning</text>
+  </g>
+  <g transform="translate(36, 178)">
+    <circle cx="6" cy="6" r="3.5" fill="#3b82f6" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Kubernetes Pods</text>
+    <text x="16" y="22" class="item-sub">kubectl multi-namespace</text>
+  </g>
+  <g transform="translate(36, 208)">
+    <circle cx="6" cy="6" r="3.5" fill="#3b82f6" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Existing SBOMs</text>
+    <text x="16" y="22" class="item-sub">CycloneDX + SPDX import</text>
+  </g>
+  <g transform="translate(36, 238)">
+    <circle cx="6" cy="6" r="3.5" fill="#3b82f6" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Agent Frameworks</text>
+    <text x="16" y="22" class="item-sub">LangChain, CrewAI, ADK</text>
+  </g>
+
+  <!-- Arrow 1 -->
+  <g transform="translate(226, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#94a3b8" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#94a3b8" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Phase 2: Enrichment ── -->
+  <rect x="252" y="52" width="192" height="6" rx="3" fill="#d97706" opacity="0.8"/>
+  <text x="348" y="76" text-anchor="middle" class="phase" fill="#b45309">ENRICHMENT</text>
+
+  <g transform="translate(264, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#d97706" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">OSV.dev</text>
+    <text x="16" y="22" class="item-sub">Batch CVE lookup, all ecosystems</text>
+  </g>
+  <g transform="translate(264, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#d97706" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">NVD / NIST</text>
+    <text x="16" y="22" class="item-sub">CVSS v3.1 / v4.0 severity</text>
+  </g>
+  <g transform="translate(264, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#d97706" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">FIRST EPSS</text>
+    <text x="16" y="22" class="item-sub">Exploit probability scores</text>
+  </g>
+  <g transform="translate(264, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#d97706" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">CISA KEV</text>
+    <text x="16" y="22" class="item-sub">Known exploited vulns catalog</text>
+  </g>
+  <g transform="translate(264, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#d97706" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">MCP Registry</text>
+    <text x="16" y="22" class="item-sub">427+ server provenance checks</text>
+  </g>
+
+  <!-- Arrow 2 -->
+  <g transform="translate(454, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#94a3b8" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#94a3b8" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Phase 3: Analysis ── -->
+  <rect x="480" y="52" width="192" height="6" rx="3" fill="#e11d48" opacity="0.8"/>
+  <text x="576" y="76" text-anchor="middle" class="phase" fill="#be123c">ANALYSIS</text>
+
+  <g transform="translate(492, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#e11d48" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Blast Radius</text>
+    <text x="16" y="22" class="item-sub">Agent / credential / tool impact</text>
+  </g>
+  <g transform="translate(492, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#e11d48" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">OWASP LLM Top 10</text>
+    <text x="16" y="22" class="item-sub">LLM02 / LLM05 / LLM06 / LLM08</text>
+  </g>
+  <g transform="translate(492, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#e11d48" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">MITRE ATLAS</text>
+    <text x="16" y="22" class="item-sub">AI adversarial threat mapping</text>
+  </g>
+  <g transform="translate(492, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#e11d48" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Enforcement Engine</text>
+    <text x="16" y="22" class="item-sub">Tool poisoning + policy gates</text>
+  </g>
+  <g transform="translate(492, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#e11d48" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Model Provenance</text>
+    <text x="16" y="22" class="item-sub">SHA-256, Sigstore, HuggingFace</text>
+  </g>
+
+  <!-- Arrow 3 -->
+  <g transform="translate(682, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#94a3b8" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#94a3b8" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Phase 4: Output ── -->
+  <rect x="708" y="52" width="148" height="6" rx="3" fill="#059669" opacity="0.8"/>
+  <text x="782" y="76" text-anchor="middle" class="phase" fill="#047857">OUTPUT</text>
+
+  <g transform="translate(720, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#059669" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Console + HTML</text>
+    <text x="16" y="22" class="item-sub">Rich tables + dashboard</text>
+  </g>
+  <g transform="translate(720, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#059669" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">SARIF</text>
+    <text x="16" y="22" class="item-sub">GitHub Security tab</text>
+  </g>
+  <g transform="translate(720, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#059669" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">CycloneDX 1.6</text>
+    <text x="16" y="22" class="item-sub">AI-BOM standard</text>
+  </g>
+  <g transform="translate(720, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#059669" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">SPDX 3.0</text>
+    <text x="16" y="22" class="item-sub">License + provenance</text>
+  </g>
+  <g transform="translate(720, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#059669" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">JSON + REST API</text>
+    <text x="16" y="22" class="item-sub">FastAPI on :8422</text>
+  </g>
+
+  <!-- Separator line -->
+  <line x1="40" y1="284" x2="840" y2="284" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Trust bar -->
+  <g transform="translate(40, 300)">
+    <rect width="800" height="44" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#475569" letter-spacing="0.05em">TRUST PRINCIPLES</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">Read-only  ·  Agentless  ·  Never writes configs  ·  Never runs MCP servers  ·  Never stores credentials  ·  Sigstore-signed releases</text>
+  </g>
+
+  <!-- Integration row -->
+  <g transform="translate(40, 358)">
+    <rect width="800" height="44" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#475569" letter-spacing="0.05em">INTERFACES</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">CLI (pip install)  ·  REST API (FastAPI)  ·  GitHub Actions  ·  Cloud UI  ·  Skills  ·  Prometheus / OTLP</text>
+  </g>
+</svg>

--- a/docs/images/snowflake-dark.svg
+++ b/docs/images/snowflake-dark.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
+  <style>
+    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
+    .phase { font: 700 10px system-ui, sans-serif; letter-spacing: 0.08em; }
+    .item-label { font: 600 11px system-ui, sans-serif; fill: #e6edf3; }
+    .item-sub { font: 400 9.5px system-ui, sans-serif; fill: #8b949e; }
+    .footer { font: 500 9.5px system-ui, sans-serif; fill: #6e7681; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M1 1L9 5L1 9" stroke="#6e7681" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="420" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="440" y="32" text-anchor="middle" class="title">Snowflake Deployment Architecture</text>
+
+  <!-- ── Column 1: Scan Sources ── -->
+  <rect x="24" y="52" width="192" height="6" rx="3" fill="#29b5e8" opacity="0.7"/>
+  <text x="120" y="76" text-anchor="middle" class="phase" fill="#29b5e8">SCAN SOURCES</text>
+
+  <g transform="translate(36, 88)">
+    <circle cx="6" cy="6" r="3.5" fill="#29b5e8" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Cortex Agents</text>
+    <text x="16" y="22" class="item-sub">Agent names, models, tools</text>
+  </g>
+  <g transform="translate(36, 118)">
+    <circle cx="6" cy="6" r="3.5" fill="#29b5e8" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Native MCP Servers</text>
+    <text x="16" y="22" class="item-sub">SHOW MCP SERVERS discovery</text>
+  </g>
+  <g transform="translate(36, 148)">
+    <circle cx="6" cy="6" r="3.5" fill="#29b5e8" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Cortex Search</text>
+    <text x="16" y="22" class="item-sub">RAG service inventory</text>
+  </g>
+  <g transform="translate(36, 178)">
+    <circle cx="6" cy="6" r="3.5" fill="#29b5e8" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Snowpark Containers</text>
+    <text x="16" y="22" class="item-sub">Container service images</text>
+  </g>
+  <g transform="translate(36, 208)">
+    <circle cx="6" cy="6" r="3.5" fill="#29b5e8" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Query History</text>
+    <text x="16" y="22" class="item-sub">365-day AI observability</text>
+  </g>
+  <g transform="translate(36, 238)">
+    <circle cx="6" cy="6" r="3.5" fill="#29b5e8" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Governance</text>
+    <text x="16" y="22" class="item-sub">Roles, grants, data classification</text>
+  </g>
+
+  <!-- Arrow 1 -->
+  <g transform="translate(226, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Column 2: agent-bom API ── -->
+  <rect x="252" y="52" width="192" height="6" rx="3" fill="#58a6ff" opacity="0.7"/>
+  <text x="348" y="76" text-anchor="middle" class="phase" fill="#58a6ff">AGENT-BOM API (:8422)</text>
+
+  <g transform="translate(264, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">FastAPI Server</text>
+    <text x="16" y="22" class="item-sub">Scan, registry, compliance</text>
+  </g>
+  <g transform="translate(264, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Snowflake Job Store</text>
+    <text x="16" y="22" class="item-sub">Scan results → SF tables</text>
+  </g>
+  <g transform="translate(264, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Snowflake Fleet Store</text>
+    <text x="16" y="22" class="item-sub">Agent registry → SF tables</text>
+  </g>
+  <g transform="translate(264, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Snowflake Policy Store</text>
+    <text x="16" y="22" class="item-sub">Policy rules → SF tables</text>
+  </g>
+  <g transform="translate(264, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#58a6ff" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Auto Auth</text>
+    <text x="16" y="22" class="item-sub">Key-pair or password detection</text>
+  </g>
+
+  <!-- Arrow 2 -->
+  <g transform="translate(454, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Column 3: Snowflake Runtime ── -->
+  <rect x="480" y="52" width="192" height="6" rx="3" fill="#3fb950" opacity="0.7"/>
+  <text x="576" y="76" text-anchor="middle" class="phase" fill="#3fb950">SNOWFLAKE RUNTIME</text>
+
+  <g transform="translate(492, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Snowpark Container</text>
+    <text x="16" y="22" class="item-sub">Dockerfile.snowpark + setup.sql</text>
+  </g>
+  <g transform="translate(492, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Streamlit in Snowflake</text>
+    <text x="16" y="22" class="item-sub">6-tab SiS dashboard</text>
+  </g>
+  <g transform="translate(492, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Native App</text>
+    <text x="16" y="22" class="item-sub">Marketplace distribution</text>
+  </g>
+  <g transform="translate(492, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Shared Tables</text>
+    <text x="16" y="22" class="item-sub">Jobs, fleet, policies</text>
+  </g>
+  <g transform="translate(492, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#3fb950" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Activity Timeline</text>
+    <text x="16" y="22" class="item-sub">Query history + AI observability</text>
+  </g>
+
+  <!-- Arrow 3 -->
+  <g transform="translate(682, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#6e7681" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Column 4: UI Surfaces ── -->
+  <rect x="708" y="52" width="148" height="6" rx="3" fill="#d29922" opacity="0.7"/>
+  <text x="782" y="76" text-anchor="middle" class="phase" fill="#d29922">UI SURFACES</text>
+
+  <g transform="translate(720, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Next.js Cloud UI</text>
+    <text x="16" y="22" class="item-sub">13-section dashboard</text>
+  </g>
+  <g transform="translate(720, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">SiS Dashboard</text>
+    <text x="16" y="22" class="item-sub">6 tabs inside Snowsight</text>
+  </g>
+  <g transform="translate(720, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Governance View</text>
+    <text x="16" y="22" class="item-sub">Roles + grants + classification</text>
+  </g>
+  <g transform="translate(720, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Activity View</text>
+    <text x="16" y="22" class="item-sub">AI observability timeline</text>
+  </g>
+  <g transform="translate(720, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#d29922" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">REST API Docs</text>
+    <text x="16" y="22" class="item-sub">OpenAPI on :8422/docs</text>
+  </g>
+
+  <!-- Separator line -->
+  <line x1="40" y1="284" x2="840" y2="284" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Auth flow -->
+  <g transform="translate(40, 300)">
+    <rect width="800" height="44" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.05em">AUTHENTICATION</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">SNOWFLAKE_ACCOUNT + SNOWFLAKE_USER + auth (key-pair or password)  ·  API auto-detects and switches to Snowflake persistence</text>
+  </g>
+
+  <!-- Setup flow -->
+  <g transform="translate(40, 358)">
+    <rect width="800" height="44" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.05em">SETUP</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">pip install 'agent-bom[api,snowflake]'  ·  Set env vars  ·  agent-bom api  ·  Tables auto-created on first scan</text>
+  </g>
+</svg>

--- a/docs/images/snowflake-light.svg
+++ b/docs/images/snowflake-light.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
+  <style>
+    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #1f2328; }
+    .phase { font: 700 10px system-ui, sans-serif; letter-spacing: 0.08em; }
+    .item-label { font: 600 11px system-ui, sans-serif; fill: #1f2328; }
+    .item-sub { font: 400 9.5px system-ui, sans-serif; fill: #656d76; }
+    .footer { font: 500 9.5px system-ui, sans-serif; fill: #656d76; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M1 1L9 5L1 9" stroke="#d0d7de" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="420" rx="12" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="440" y="32" text-anchor="middle" class="title">Snowflake Deployment Architecture</text>
+
+  <!-- ── Column 1: Scan Sources ── -->
+  <rect x="24" y="52" width="192" height="6" rx="3" fill="#0969da" opacity="0.7"/>
+  <text x="120" y="76" text-anchor="middle" class="phase" fill="#0969da">SCAN SOURCES</text>
+
+  <g transform="translate(36, 88)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Cortex Agents</text>
+    <text x="16" y="22" class="item-sub">Agent names, models, tools</text>
+  </g>
+  <g transform="translate(36, 118)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Native MCP Servers</text>
+    <text x="16" y="22" class="item-sub">SHOW MCP SERVERS discovery</text>
+  </g>
+  <g transform="translate(36, 148)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Cortex Search</text>
+    <text x="16" y="22" class="item-sub">RAG service inventory</text>
+  </g>
+  <g transform="translate(36, 178)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Snowpark Containers</text>
+    <text x="16" y="22" class="item-sub">Container service images</text>
+  </g>
+  <g transform="translate(36, 208)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Query History</text>
+    <text x="16" y="22" class="item-sub">365-day AI observability</text>
+  </g>
+  <g transform="translate(36, 238)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Governance</text>
+    <text x="16" y="22" class="item-sub">Roles, grants, data classification</text>
+  </g>
+
+  <!-- Arrow 1 -->
+  <g transform="translate(226, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#d0d7de" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#d0d7de" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Column 2: agent-bom API ── -->
+  <rect x="252" y="52" width="192" height="6" rx="3" fill="#0969da" opacity="0.5"/>
+  <text x="348" y="76" text-anchor="middle" class="phase" fill="#0969da">AGENT-BOM API (:8422)</text>
+
+  <g transform="translate(264, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.4"/>
+    <text x="16" y="10" class="item-label">FastAPI Server</text>
+    <text x="16" y="22" class="item-sub">Scan, registry, compliance</text>
+  </g>
+  <g transform="translate(264, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.4"/>
+    <text x="16" y="10" class="item-label">Snowflake Job Store</text>
+    <text x="16" y="22" class="item-sub">Scan results → SF tables</text>
+  </g>
+  <g transform="translate(264, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.4"/>
+    <text x="16" y="10" class="item-label">Snowflake Fleet Store</text>
+    <text x="16" y="22" class="item-sub">Agent registry → SF tables</text>
+  </g>
+  <g transform="translate(264, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.4"/>
+    <text x="16" y="10" class="item-label">Snowflake Policy Store</text>
+    <text x="16" y="22" class="item-sub">Policy rules → SF tables</text>
+  </g>
+  <g transform="translate(264, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#0969da" opacity="0.4"/>
+    <text x="16" y="10" class="item-label">Auto Auth</text>
+    <text x="16" y="22" class="item-sub">Key-pair or password detection</text>
+  </g>
+
+  <!-- Arrow 2 -->
+  <g transform="translate(454, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#d0d7de" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#d0d7de" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Column 3: Snowflake Runtime ── -->
+  <rect x="480" y="52" width="192" height="6" rx="3" fill="#1a7f37" opacity="0.7"/>
+  <text x="576" y="76" text-anchor="middle" class="phase" fill="#1a7f37">SNOWFLAKE RUNTIME</text>
+
+  <g transform="translate(492, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#1a7f37" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Snowpark Container</text>
+    <text x="16" y="22" class="item-sub">Dockerfile.snowpark + setup.sql</text>
+  </g>
+  <g transform="translate(492, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#1a7f37" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Streamlit in Snowflake</text>
+    <text x="16" y="22" class="item-sub">6-tab SiS dashboard</text>
+  </g>
+  <g transform="translate(492, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#1a7f37" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Native App</text>
+    <text x="16" y="22" class="item-sub">Marketplace distribution</text>
+  </g>
+  <g transform="translate(492, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#1a7f37" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Shared Tables</text>
+    <text x="16" y="22" class="item-sub">Jobs, fleet, policies</text>
+  </g>
+  <g transform="translate(492, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#1a7f37" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Activity Timeline</text>
+    <text x="16" y="22" class="item-sub">Query history + AI observability</text>
+  </g>
+
+  <!-- Arrow 3 -->
+  <g transform="translate(682, 168)">
+    <path d="M0 0L14 16L0 32" stroke="#d0d7de" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10 0L24 16L10 32" stroke="#d0d7de" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  </g>
+
+  <!-- ── Column 4: UI Surfaces ── -->
+  <rect x="708" y="52" width="148" height="6" rx="3" fill="#9a6700" opacity="0.7"/>
+  <text x="782" y="76" text-anchor="middle" class="phase" fill="#9a6700">UI SURFACES</text>
+
+  <g transform="translate(720, 90)">
+    <circle cx="6" cy="6" r="3.5" fill="#9a6700" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Next.js Cloud UI</text>
+    <text x="16" y="22" class="item-sub">13-section dashboard</text>
+  </g>
+  <g transform="translate(720, 126)">
+    <circle cx="6" cy="6" r="3.5" fill="#9a6700" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">SiS Dashboard</text>
+    <text x="16" y="22" class="item-sub">6 tabs inside Snowsight</text>
+  </g>
+  <g transform="translate(720, 162)">
+    <circle cx="6" cy="6" r="3.5" fill="#9a6700" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Governance View</text>
+    <text x="16" y="22" class="item-sub">Roles + grants + classification</text>
+  </g>
+  <g transform="translate(720, 198)">
+    <circle cx="6" cy="6" r="3.5" fill="#9a6700" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">Activity View</text>
+    <text x="16" y="22" class="item-sub">AI observability timeline</text>
+  </g>
+  <g transform="translate(720, 234)">
+    <circle cx="6" cy="6" r="3.5" fill="#9a6700" opacity="0.5"/>
+    <text x="16" y="10" class="item-label">REST API Docs</text>
+    <text x="16" y="22" class="item-sub">OpenAPI on :8422/docs</text>
+  </g>
+
+  <!-- Separator line -->
+  <line x1="40" y1="284" x2="840" y2="284" stroke="#d0d7de" stroke-width="1"/>
+
+  <!-- Auth flow -->
+  <g transform="translate(40, 300)">
+    <rect width="800" height="44" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#656d76" letter-spacing="0.05em">AUTHENTICATION</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">SNOWFLAKE_ACCOUNT + SNOWFLAKE_USER + auth (key-pair or password)  ·  API auto-detects and switches to Snowflake persistence</text>
+  </g>
+
+  <!-- Setup flow -->
+  <g transform="translate(40, 358)">
+    <rect width="800" height="44" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1"/>
+    <text x="400" y="18" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#656d76" letter-spacing="0.05em">SETUP</text>
+    <text x="400" y="34" text-anchor="middle" class="footer">pip install 'agent-bom[api,snowflake]'  ·  Set env vars  ·  agent-bom api  ·  Tables auto-created on first scan</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Mermaid `graph LR` with 20+ nodes renders as a tiny unreadable strip on GitHub README
- Restore the purpose-built SVGs that render cleanly at width=800 with proper spacing
- Keep the MCP server robustness changes from #94 (validation, truncation, exception logging)

## What happened
PR #94 replaced SVGs with Mermaid blocks. GitHub's Mermaid renderer crushes wide graphs into a narrow viewport, making the architecture diagram illegible. The hand-crafted SVGs were specifically designed for GitHub's layout.