### PR TITLE
fix: restore architecture + snowflake diagrams as proper SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,42 +19,12 @@
   <b>AI supply chain security scanner. Scan packages and images for CVEs. Assess config security — credential exposure, tool access, privilege escalation. Map blast radius from vulnerabilities to credentials and tools. OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF.</b>
 </p>
 
-```mermaid
-graph LR
-    subgraph Discovery["1. Discovery"]
-        MCP["MCP Configs\n18 clients"]
-        Cloud["Cloud Providers\nAWS · Azure · GCP\nSnowflake · Databricks"]
-        Img["Docker Images\nGrype + Syft"]
-        K8s["Kubernetes\nPod scanning"]
-        SBOM_In["Existing SBOMs\nCycloneDX · SPDX"]
-    end
-
-    subgraph Enrichment["2. Enrichment"]
-        OSV["OSV.dev\nBatch CVE lookup"]
-        NVD["NVD\nCVSS v3/v4"]
-        EPSS["FIRST EPSS\nExploit probability"]
-        KEV["CISA KEV\nActive exploitation"]
-        GHSA["GHSA · NVIDIA CSAF\nSupplemental advisories"]
-        Reg["MCP Registry\n427+ servers"]
-    end
-
-    subgraph Analysis["3. Analysis"]
-        Blast["Blast Radius\nCVE → pkg → server →\nagent → creds → tools"]
-        OWASP["OWASP LLM Top 10\n+ MCP Top 10"]
-        ATLAS["MITRE ATLAS\n+ NIST AI RMF"]
-        Enforce["Enforcement\nPolicy gates"]
-    end
-
-    subgraph Output["4. Output"]
-        Console["Console · HTML"]
-        SARIF["SARIF"]
-        CDX["CycloneDX 1.6"]
-        SPDX["SPDX 3.0"]
-        JSON_Out["JSON · Mermaid"]
-    end
-
-    Discovery --> Enrichment --> Analysis --> Output
-```
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="How agent-bom works" width="800" />
+  </picture>
+</p>
 
 ---
 
@@ -521,50 +491,12 @@ Set `SNOWFLAKE_ACCOUNT` + `SNOWFLAKE_USER` + auth (`SNOWFLAKE_PRIVATE_KEY_PATH` 
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for full Snowflake architecture and setup instructions.
 
-```mermaid
-graph TD
-    subgraph External["External Clients"]
-        MCP_C["MCP Clients\nClaude · Cursor · etc."]
-        NextJS["Next.js Dashboard"]
-        CLI_E["CLI\nagent-bom scan --snowflake"]
-    end
-
-    subgraph SF["Snowflake Account"]
-        subgraph Discover["Cortex Discovery"]
-            CA["Cortex Agents"]
-            MCP_SF["Native MCP Servers"]
-            CS["Cortex Search · RAG"]
-            SC["Snowpark Containers"]
-            QH["Query History · 365 days"]
-            GOV["Governance · Roles + Grants"]
-        end
-
-        subgraph Runtime["Snowpark Container Services"]
-            API["agent-bom API\nFastAPI :8422"]
-        end
-
-        subgraph Storage["Snowflake Tables"]
-            Jobs["SCAN_JOBS"]
-            Fleet["FLEET_AGENTS"]
-            Policies["GATEWAY_POLICIES"]
-            Audit["POLICY_AUDIT_LOG"]
-        end
-
-        subgraph SiS["Streamlit in Snowflake"]
-            Dash["6-Tab Dashboard\nJobs · Fleet · Policies\nVulns · Compliance · Audit"]
-        end
-
-        subgraph NativeApp["Native App"]
-            NA["Marketplace Distribution\nmanifest.yml + setup.sql"]
-        end
-    end
-
-    External --> API
-    Discover --> API
-    API --> Storage
-    SiS --> Storage
-    NA --> Storage
-```
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/snowflake-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/snowflake-light.svg" alt="Snowflake Deployment Architecture" width="800" />
+  </picture>
+</p>
 
 <p align="center">
   <picture>

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,0 +1,212 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" fill="none">
+  <style>
+    .title { font: 700 13px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
+    .section-title { font: 700 10px system-ui, sans-serif; letter-spacing: 0.06em; }
+    .box-label { font: 600 10.5px system-ui, sans-serif; fill: #e6edf3; }
+    .box-sub { font: 400 9px system-ui, sans-serif; fill: #8b949e; }
+    .arrow-label { font: 500 8px system-ui, sans-serif; fill: #6e7681; }
+    .footer { font: 500 9px system-ui, sans-serif; fill: #6e7681; }
+  </style>
+  <defs>
+    <marker id="a1" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#58a6ff" opacity="0.6"/>
+    </marker>
+    <marker id="a2" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#d29922" opacity="0.6"/>
+    </marker>
+    <marker id="a3" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f47067" opacity="0.6"/>
+    </marker>
+    <marker id="a4" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#3fb950" opacity="0.6"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="460" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="440" y="28" text-anchor="middle" class="title">How agent-bom works</text>
+
+  <!-- ═══ Phase 1: Discovery (left column) ═══ -->
+  <rect x="16" y="42" width="170" height="280" rx="8" fill="#161b22" stroke="#58a6ff" stroke-width="1" opacity="0.8"/>
+  <text x="101" y="58" text-anchor="middle" class="section-title" fill="#58a6ff">DISCOVERY</text>
+
+  <rect x="28" y="66" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="101" y="80" text-anchor="middle" class="box-label">MCP Configs</text>
+  <text x="101" y="90" text-anchor="middle" class="box-sub">18 clients · auto-detect</text>
+
+  <rect x="28" y="100" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="101" y="114" text-anchor="middle" class="box-label">Cloud Providers</text>
+  <text x="101" y="124" text-anchor="middle" class="box-sub">AWS · Azure · GCP · Snowflake</text>
+
+  <rect x="28" y="134" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="101" y="148" text-anchor="middle" class="box-label">Docker Images</text>
+  <text x="101" y="158" text-anchor="middle" class="box-sub">Grype + Syft deep scan</text>
+
+  <rect x="28" y="168" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="101" y="182" text-anchor="middle" class="box-label">Kubernetes</text>
+  <text x="101" y="192" text-anchor="middle" class="box-sub">Multi-namespace pod scan</text>
+
+  <rect x="28" y="202" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="101" y="216" text-anchor="middle" class="box-label">Existing SBOMs</text>
+  <text x="101" y="226" text-anchor="middle" class="box-sub">CycloneDX + SPDX import</text>
+
+  <rect x="28" y="236" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="101" y="250" text-anchor="middle" class="box-label">Agent Frameworks</text>
+  <text x="101" y="260" text-anchor="middle" class="box-sub">LangChain · CrewAI · ADK</text>
+
+  <rect x="28" y="280" width="146" height="32" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+  <text x="101" y="294" text-anchor="middle" class="box-sub">→ Agents · Servers</text>
+  <text x="101" y="306" text-anchor="middle" class="box-sub">→ Packages · Credentials · Tools</text>
+
+  <!-- Arrow: Discovery → Enrichment -->
+  <line x1="186" y1="180" x2="210" y2="180" stroke="#58a6ff" stroke-width="2" marker-end="url(#a1)"/>
+
+  <!-- ═══ Phase 2: Enrichment (center-left) ═══ -->
+  <rect x="214" y="42" width="170" height="280" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1" opacity="0.8"/>
+  <text x="299" y="58" text-anchor="middle" class="section-title" fill="#d29922">ENRICHMENT</text>
+
+  <rect x="226" y="66" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="299" y="80" text-anchor="middle" class="box-label">OSV.dev</text>
+  <text x="299" y="90" text-anchor="middle" class="box-sub">Batch CVE lookup · all ecosystems</text>
+
+  <rect x="226" y="100" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="299" y="114" text-anchor="middle" class="box-label">NVD / NIST</text>
+  <text x="299" y="124" text-anchor="middle" class="box-sub">CVSS v3.1 + v4.0 scoring</text>
+
+  <rect x="226" y="134" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="299" y="148" text-anchor="middle" class="box-label">FIRST EPSS</text>
+  <text x="299" y="158" text-anchor="middle" class="box-sub">Exploit probability scores</text>
+
+  <rect x="226" y="168" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="299" y="182" text-anchor="middle" class="box-label">CISA KEV</text>
+  <text x="299" y="192" text-anchor="middle" class="box-sub">Known exploited vulns</text>
+
+  <rect x="226" y="202" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="299" y="216" text-anchor="middle" class="box-label">GHSA + NVIDIA CSAF</text>
+  <text x="299" y="226" text-anchor="middle" class="box-sub">Supplemental advisories</text>
+
+  <rect x="226" y="236" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="299" y="250" text-anchor="middle" class="box-label">MCP Registry</text>
+  <text x="299" y="260" text-anchor="middle" class="box-sub">427+ server provenance</text>
+
+  <rect x="226" y="280" width="146" height="32" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1" opacity="0.4"/>
+  <text x="299" y="294" text-anchor="middle" class="box-sub">→ CVEs with CVSS + EPSS</text>
+  <text x="299" y="306" text-anchor="middle" class="box-sub">→ KEV flags · Fixed versions</text>
+
+  <!-- Arrow: Enrichment → Analysis -->
+  <line x1="384" y1="180" x2="408" y2="180" stroke="#d29922" stroke-width="2" marker-end="url(#a2)"/>
+
+  <!-- ═══ Phase 3: Analysis (center-right) ═══ -->
+  <rect x="412" y="42" width="170" height="280" rx="8" fill="#161b22" stroke="#f47067" stroke-width="1" opacity="0.8"/>
+  <text x="497" y="58" text-anchor="middle" class="section-title" fill="#f47067">ANALYSIS</text>
+
+  <rect x="424" y="66" width="146" height="40" rx="5" fill="#0d1117" stroke="#f47067" stroke-width="1" opacity="0.6"/>
+  <text x="497" y="82" text-anchor="middle" class="box-label">Blast Radius</text>
+  <text x="497" y="96" text-anchor="middle" class="box-sub">CVE → pkg → server → agent → creds → tools</text>
+
+  <rect x="424" y="114" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="497" y="128" text-anchor="middle" class="box-label">OWASP LLM Top 10</text>
+  <text x="497" y="138" text-anchor="middle" class="box-sub">LLM02 · LLM05 · LLM06 · LLM08</text>
+
+  <rect x="424" y="148" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="497" y="162" text-anchor="middle" class="box-label">OWASP MCP Top 10</text>
+  <text x="497" y="172" text-anchor="middle" class="box-sub">MCP01–MCP10 tagging</text>
+
+  <rect x="424" y="182" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="497" y="196" text-anchor="middle" class="box-label">MITRE ATLAS</text>
+  <text x="497" y="206" text-anchor="middle" class="box-sub">AI adversarial threat mapping</text>
+
+  <rect x="424" y="216" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="497" y="230" text-anchor="middle" class="box-label">NIST AI RMF</text>
+  <text x="497" y="240" text-anchor="middle" class="box-sub">Risk management framework</text>
+
+  <rect x="424" y="250" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="497" y="264" text-anchor="middle" class="box-label">Enforcement Engine</text>
+  <text x="497" y="274" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
+
+  <rect x="424" y="284" width="146" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="497" y="298" text-anchor="middle" class="box-label">Model Provenance</text>
+  <text x="497" y="308" text-anchor="middle" class="box-sub">SHA-256 · Sigstore · HuggingFace</text>
+
+  <!-- Arrow: Analysis → Output -->
+  <line x1="582" y1="180" x2="606" y2="180" stroke="#f47067" stroke-width="2" marker-end="url(#a3)"/>
+
+  <!-- ═══ Phase 4: Output (right) ═══ -->
+  <rect x="610" y="42" width="130" height="280" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1" opacity="0.8"/>
+  <text x="675" y="58" text-anchor="middle" class="section-title" fill="#3fb950">OUTPUT</text>
+
+  <rect x="622" y="66" width="106" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="675" y="80" text-anchor="middle" class="box-label">Console + HTML</text>
+  <text x="675" y="90" text-anchor="middle" class="box-sub">Rich tables + dashboard</text>
+
+  <rect x="622" y="100" width="106" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="675" y="114" text-anchor="middle" class="box-label">SARIF</text>
+  <text x="675" y="124" text-anchor="middle" class="box-sub">GitHub Security tab</text>
+
+  <rect x="622" y="134" width="106" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="675" y="148" text-anchor="middle" class="box-label">CycloneDX 1.6</text>
+  <text x="675" y="158" text-anchor="middle" class="box-sub">AI-BOM standard</text>
+
+  <rect x="622" y="168" width="106" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="675" y="182" text-anchor="middle" class="box-label">SPDX 3.0</text>
+  <text x="675" y="192" text-anchor="middle" class="box-sub">License + provenance</text>
+
+  <rect x="622" y="202" width="106" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="675" y="216" text-anchor="middle" class="box-label">JSON + Mermaid</text>
+  <text x="675" y="226" text-anchor="middle" class="box-sub">Machine-readable</text>
+
+  <rect x="622" y="240" width="106" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="675" y="254" text-anchor="middle" class="box-label">REST API</text>
+  <text x="675" y="264" text-anchor="middle" class="box-sub">FastAPI on :8422</text>
+
+  <!-- ═══ Interfaces (far right) ═══ -->
+  <rect x="756" y="42" width="108" height="280" rx="8" fill="#161b22" stroke="#a371f7" stroke-width="1" opacity="0.8"/>
+  <text x="810" y="58" text-anchor="middle" class="section-title" fill="#a371f7">INTERFACES</text>
+
+  <rect x="764" y="70" width="92" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="810" y="84" text-anchor="middle" class="box-label">CLI</text>
+  <text x="810" y="94" text-anchor="middle" class="box-sub">pip install agent-bom</text>
+
+  <rect x="764" y="106" width="92" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="810" y="120" text-anchor="middle" class="box-label">MCP Server</text>
+  <text x="810" y="130" text-anchor="middle" class="box-sub">13 tools · stdio/SSE</text>
+
+  <rect x="764" y="142" width="92" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="810" y="156" text-anchor="middle" class="box-label">GitHub Action</text>
+  <text x="810" y="166" text-anchor="middle" class="box-sub">CI/CD integration</text>
+
+  <rect x="764" y="178" width="92" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="810" y="192" text-anchor="middle" class="box-label">Cloud UI</text>
+  <text x="810" y="202" text-anchor="middle" class="box-sub">Next.js dashboard</text>
+
+  <rect x="764" y="214" width="92" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="810" y="228" text-anchor="middle" class="box-label">Snowflake</text>
+  <text x="810" y="238" text-anchor="middle" class="box-sub">Streamlit + Native App</text>
+
+  <!-- Arrow: Output → Interfaces -->
+  <line x1="740" y1="180" x2="752" y2="180" stroke="#3fb950" stroke-width="2" marker-end="url(#a4)"/>
+
+  <!-- ═══ Trust bar ═══ -->
+  <rect x="16" y="338" width="848" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="440" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#8b949e" letter-spacing="0.05em">TRUST PRINCIPLES</text>
+  <text x="440" y="368" text-anchor="middle" class="footer">Read-only  ·  Agentless  ·  Never writes configs  ·  Never runs MCP servers  ·  Never stores credentials  ·  Sigstore-signed releases</text>
+
+  <!-- ═══ Data flow legend ═══ -->
+  <rect x="16" y="384" width="848" height="66" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="440" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#8b949e" letter-spacing="0.05em">DATA FLOW</text>
+
+  <!-- Flow arrows in legend -->
+  <line x1="80" y1="420" x2="110" y2="420" stroke="#58a6ff" stroke-width="2" marker-end="url(#a1)"/>
+  <text x="118" y="424" class="footer" fill="#58a6ff">Discover</text>
+
+  <line x1="200" y1="420" x2="230" y2="420" stroke="#d29922" stroke-width="2" marker-end="url(#a2)"/>
+  <text x="238" y="424" class="footer" fill="#d29922">Enrich</text>
+
+  <line x1="310" y1="420" x2="340" y2="420" stroke="#f47067" stroke-width="2" marker-end="url(#a3)"/>
+  <text x="348" y="424" class="footer" fill="#f47067">Analyze</text>
+
+  <line x1="420" y1="420" x2="450" y2="420" stroke="#3fb950" stroke-width="2" marker-end="url(#a4)"/>
+  <text x="458" y="424" class="footer" fill="#3fb950">Report</text>
+
+  <text x="440" y="442" text-anchor="middle" class="footer">MCP Client Configs → Agents + Servers + Packages → OSV + NVD + EPSS + KEV + GHSA → Blast Radius + OWASP + ATLAS → SARIF / CycloneDX / SPDX / JSON</text>
+</svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,0 +1,207 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" fill="none">
+  <style>
+    .title { font: 700 13px system-ui, -apple-system, sans-serif; fill: #1f2328; }
+    .section-title { font: 700 10px system-ui, sans-serif; letter-spacing: 0.06em; }
+    .box-label { font: 600 10.5px system-ui, sans-serif; fill: #1f2328; }
+    .box-sub { font: 400 9px system-ui, sans-serif; fill: #656d76; }
+    .arrow-label { font: 500 8px system-ui, sans-serif; fill: #656d76; }
+    .footer { font: 500 9px system-ui, sans-serif; fill: #656d76; }
+  </style>
+  <defs>
+    <marker id="a1" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#0969da" opacity="0.7"/>
+    </marker>
+    <marker id="a2" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9a6700" opacity="0.7"/>
+    </marker>
+    <marker id="a3" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#cf222e" opacity="0.7"/>
+    </marker>
+    <marker id="a4" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a7f37" opacity="0.7"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="460" rx="12" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="440" y="28" text-anchor="middle" class="title">How agent-bom works</text>
+
+  <!-- ═══ Phase 1: Discovery ═══ -->
+  <rect x="16" y="42" width="170" height="280" rx="8" fill="#f6f8fa" stroke="#0969da" stroke-width="1" opacity="0.8"/>
+  <text x="101" y="58" text-anchor="middle" class="section-title" fill="#0969da">DISCOVERY</text>
+
+  <rect x="28" y="66" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="101" y="80" text-anchor="middle" class="box-label">MCP Configs</text>
+  <text x="101" y="90" text-anchor="middle" class="box-sub">18 clients · auto-detect</text>
+
+  <rect x="28" y="100" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="101" y="114" text-anchor="middle" class="box-label">Cloud Providers</text>
+  <text x="101" y="124" text-anchor="middle" class="box-sub">AWS · Azure · GCP · Snowflake</text>
+
+  <rect x="28" y="134" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="101" y="148" text-anchor="middle" class="box-label">Docker Images</text>
+  <text x="101" y="158" text-anchor="middle" class="box-sub">Grype + Syft deep scan</text>
+
+  <rect x="28" y="168" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="101" y="182" text-anchor="middle" class="box-label">Kubernetes</text>
+  <text x="101" y="192" text-anchor="middle" class="box-sub">Multi-namespace pod scan</text>
+
+  <rect x="28" y="202" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="101" y="216" text-anchor="middle" class="box-label">Existing SBOMs</text>
+  <text x="101" y="226" text-anchor="middle" class="box-sub">CycloneDX + SPDX import</text>
+
+  <rect x="28" y="236" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="101" y="250" text-anchor="middle" class="box-label">Agent Frameworks</text>
+  <text x="101" y="260" text-anchor="middle" class="box-sub">LangChain · CrewAI · ADK</text>
+
+  <rect x="28" y="280" width="146" height="32" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="1" opacity="0.3"/>
+  <text x="101" y="294" text-anchor="middle" class="box-sub">→ Agents · Servers</text>
+  <text x="101" y="306" text-anchor="middle" class="box-sub">→ Packages · Credentials · Tools</text>
+
+  <line x1="186" y1="180" x2="210" y2="180" stroke="#0969da" stroke-width="2" marker-end="url(#a1)"/>
+
+  <!-- ═══ Phase 2: Enrichment ═══ -->
+  <rect x="214" y="42" width="170" height="280" rx="8" fill="#f6f8fa" stroke="#9a6700" stroke-width="1" opacity="0.8"/>
+  <text x="299" y="58" text-anchor="middle" class="section-title" fill="#9a6700">ENRICHMENT</text>
+
+  <rect x="226" y="66" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="299" y="80" text-anchor="middle" class="box-label">OSV.dev</text>
+  <text x="299" y="90" text-anchor="middle" class="box-sub">Batch CVE lookup · all ecosystems</text>
+
+  <rect x="226" y="100" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="299" y="114" text-anchor="middle" class="box-label">NVD / NIST</text>
+  <text x="299" y="124" text-anchor="middle" class="box-sub">CVSS v3.1 + v4.0 scoring</text>
+
+  <rect x="226" y="134" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="299" y="148" text-anchor="middle" class="box-label">FIRST EPSS</text>
+  <text x="299" y="158" text-anchor="middle" class="box-sub">Exploit probability scores</text>
+
+  <rect x="226" y="168" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="299" y="182" text-anchor="middle" class="box-label">CISA KEV</text>
+  <text x="299" y="192" text-anchor="middle" class="box-sub">Known exploited vulns</text>
+
+  <rect x="226" y="202" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="299" y="216" text-anchor="middle" class="box-label">GHSA + NVIDIA CSAF</text>
+  <text x="299" y="226" text-anchor="middle" class="box-sub">Supplemental advisories</text>
+
+  <rect x="226" y="236" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="299" y="250" text-anchor="middle" class="box-label">MCP Registry</text>
+  <text x="299" y="260" text-anchor="middle" class="box-sub">427+ server provenance</text>
+
+  <rect x="226" y="280" width="146" height="32" rx="5" fill="#ffffff" stroke="#9a6700" stroke-width="1" opacity="0.3"/>
+  <text x="299" y="294" text-anchor="middle" class="box-sub">→ CVEs with CVSS + EPSS</text>
+  <text x="299" y="306" text-anchor="middle" class="box-sub">→ KEV flags · Fixed versions</text>
+
+  <line x1="384" y1="180" x2="408" y2="180" stroke="#9a6700" stroke-width="2" marker-end="url(#a2)"/>
+
+  <!-- ═══ Phase 3: Analysis ═══ -->
+  <rect x="412" y="42" width="170" height="280" rx="8" fill="#f6f8fa" stroke="#cf222e" stroke-width="1" opacity="0.8"/>
+  <text x="497" y="58" text-anchor="middle" class="section-title" fill="#cf222e">ANALYSIS</text>
+
+  <rect x="424" y="66" width="146" height="40" rx="5" fill="#ffffff" stroke="#cf222e" stroke-width="1" opacity="0.5"/>
+  <text x="497" y="82" text-anchor="middle" class="box-label">Blast Radius</text>
+  <text x="497" y="96" text-anchor="middle" class="box-sub">CVE → pkg → server → agent → creds → tools</text>
+
+  <rect x="424" y="114" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="497" y="128" text-anchor="middle" class="box-label">OWASP LLM Top 10</text>
+  <text x="497" y="138" text-anchor="middle" class="box-sub">LLM02 · LLM05 · LLM06 · LLM08</text>
+
+  <rect x="424" y="148" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="497" y="162" text-anchor="middle" class="box-label">OWASP MCP Top 10</text>
+  <text x="497" y="172" text-anchor="middle" class="box-sub">MCP01–MCP10 tagging</text>
+
+  <rect x="424" y="182" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="497" y="196" text-anchor="middle" class="box-label">MITRE ATLAS</text>
+  <text x="497" y="206" text-anchor="middle" class="box-sub">AI adversarial threat mapping</text>
+
+  <rect x="424" y="216" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="497" y="230" text-anchor="middle" class="box-label">NIST AI RMF</text>
+  <text x="497" y="240" text-anchor="middle" class="box-sub">Risk management framework</text>
+
+  <rect x="424" y="250" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="497" y="264" text-anchor="middle" class="box-label">Enforcement Engine</text>
+  <text x="497" y="274" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
+
+  <rect x="424" y="284" width="146" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="497" y="298" text-anchor="middle" class="box-label">Model Provenance</text>
+  <text x="497" y="308" text-anchor="middle" class="box-sub">SHA-256 · Sigstore · HuggingFace</text>
+
+  <line x1="582" y1="180" x2="606" y2="180" stroke="#cf222e" stroke-width="2" marker-end="url(#a3)"/>
+
+  <!-- ═══ Phase 4: Output ═══ -->
+  <rect x="610" y="42" width="130" height="280" rx="8" fill="#f6f8fa" stroke="#1a7f37" stroke-width="1" opacity="0.8"/>
+  <text x="675" y="58" text-anchor="middle" class="section-title" fill="#1a7f37">OUTPUT</text>
+
+  <rect x="622" y="66" width="106" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="675" y="80" text-anchor="middle" class="box-label">Console + HTML</text>
+  <text x="675" y="90" text-anchor="middle" class="box-sub">Rich tables + dashboard</text>
+
+  <rect x="622" y="100" width="106" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="675" y="114" text-anchor="middle" class="box-label">SARIF</text>
+  <text x="675" y="124" text-anchor="middle" class="box-sub">GitHub Security tab</text>
+
+  <rect x="622" y="134" width="106" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="675" y="148" text-anchor="middle" class="box-label">CycloneDX 1.6</text>
+  <text x="675" y="158" text-anchor="middle" class="box-sub">AI-BOM standard</text>
+
+  <rect x="622" y="168" width="106" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="675" y="182" text-anchor="middle" class="box-label">SPDX 3.0</text>
+  <text x="675" y="192" text-anchor="middle" class="box-sub">License + provenance</text>
+
+  <rect x="622" y="202" width="106" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="675" y="216" text-anchor="middle" class="box-label">JSON + Mermaid</text>
+  <text x="675" y="226" text-anchor="middle" class="box-sub">Machine-readable</text>
+
+  <rect x="622" y="240" width="106" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="675" y="254" text-anchor="middle" class="box-label">REST API</text>
+  <text x="675" y="264" text-anchor="middle" class="box-sub">FastAPI on :8422</text>
+
+  <!-- ═══ Interfaces ═══ -->
+  <rect x="756" y="42" width="108" height="280" rx="8" fill="#f6f8fa" stroke="#8250df" stroke-width="1" opacity="0.8"/>
+  <text x="810" y="58" text-anchor="middle" class="section-title" fill="#8250df">INTERFACES</text>
+
+  <rect x="764" y="70" width="92" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="810" y="84" text-anchor="middle" class="box-label">CLI</text>
+  <text x="810" y="94" text-anchor="middle" class="box-sub">pip install agent-bom</text>
+
+  <rect x="764" y="106" width="92" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="810" y="120" text-anchor="middle" class="box-label">MCP Server</text>
+  <text x="810" y="130" text-anchor="middle" class="box-sub">13 tools · stdio/SSE</text>
+
+  <rect x="764" y="142" width="92" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="810" y="156" text-anchor="middle" class="box-label">GitHub Action</text>
+  <text x="810" y="166" text-anchor="middle" class="box-sub">CI/CD integration</text>
+
+  <rect x="764" y="178" width="92" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="810" y="192" text-anchor="middle" class="box-label">Cloud UI</text>
+  <text x="810" y="202" text-anchor="middle" class="box-sub">Next.js dashboard</text>
+
+  <rect x="764" y="214" width="92" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="810" y="228" text-anchor="middle" class="box-label">Snowflake</text>
+  <text x="810" y="238" text-anchor="middle" class="box-sub">Streamlit + Native App</text>
+
+  <line x1="740" y1="180" x2="752" y2="180" stroke="#1a7f37" stroke-width="2" marker-end="url(#a4)"/>
+
+  <!-- ═══ Trust bar ═══ -->
+  <rect x="16" y="338" width="848" height="36" rx="6" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="440" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#656d76" letter-spacing="0.05em">TRUST PRINCIPLES</text>
+  <text x="440" y="368" text-anchor="middle" class="footer">Read-only  ·  Agentless  ·  Never writes configs  ·  Never runs MCP servers  ·  Never stores credentials  ·  Sigstore-signed releases</text>
+
+  <!-- ═══ Data flow legend ═══ -->
+  <rect x="16" y="384" width="848" height="66" rx="6" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="440" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#656d76" letter-spacing="0.05em">DATA FLOW</text>
+
+  <line x1="80" y1="420" x2="110" y2="420" stroke="#0969da" stroke-width="2" marker-end="url(#a1)"/>
+  <text x="118" y="424" class="footer" fill="#0969da">Discover</text>
+
+  <line x1="200" y1="420" x2="230" y2="420" stroke="#9a6700" stroke-width="2" marker-end="url(#a2)"/>
+  <text x="238" y="424" class="footer" fill="#9a6700">Enrich</text>
+
+  <line x1="310" y1="420" x2="340" y2="420" stroke="#cf222e" stroke-width="2" marker-end="url(#a3)"/>
+  <text x="348" y="424" class="footer" fill="#cf222e">Analyze</text>
+
+  <line x1="420" y1="420" x2="450" y2="420" stroke="#1a7f37" stroke-width="2" marker-end="url(#a4)"/>
+  <text x="458" y="424" class="footer" fill="#1a7f37">Report</text>
+
+  <text x="440" y="442" text-anchor="middle" class="footer">MCP Client Configs → Agents + Servers + Packages → OSV + NVD + EPSS + KEV + GHSA → Blast Radius + OWASP + ATLAS → SARIF / CycloneDX / SPDX / JSON</text>
+</svg>

--- a/docs/images/snowflake-dark.svg
+++ b/docs/images/snowflake-dark.svg
@@ -1,0 +1,131 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 520" fill="none">
+  <style>
+    .title { font: 700 13px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
+    .section-title { font: 700 10px system-ui, sans-serif; fill: #8b949e; letter-spacing: 0.06em; }
+    .box-label { font: 600 10.5px system-ui, sans-serif; fill: #e6edf3; }
+    .box-sub { font: 400 9px system-ui, sans-serif; fill: #8b949e; }
+    .arrow-label { font: 500 8px system-ui, sans-serif; fill: #6e7681; }
+  </style>
+  <defs>
+    <marker id="ah" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#58a6ff" opacity="0.6"/>
+    </marker>
+    <marker id="ag" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#3fb950" opacity="0.6"/>
+    </marker>
+    <marker id="ao" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#d29922" opacity="0.6"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="520" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="440" y="28" text-anchor="middle" class="title">Snowflake Deployment Architecture</text>
+
+  <!-- ═══ Snowflake Account Boundary ═══ -->
+  <rect x="200" y="42" width="660" height="432" rx="10" fill="none" stroke="#29b5e8" stroke-width="1.5" stroke-dasharray="6 3" opacity="0.5"/>
+  <text x="530" y="58" text-anchor="middle" class="section-title" fill="#29b5e8">SNOWFLAKE ACCOUNT</text>
+
+  <!-- ═══ External Clients (left) ═══ -->
+  <text x="100" y="60" text-anchor="middle" class="section-title">EXTERNAL CLIENTS</text>
+  <rect x="30" y="74" width="140" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="100" y="90" text-anchor="middle" class="box-label">MCP Clients</text>
+  <text x="100" y="102" text-anchor="middle" class="box-sub">Claude · Cursor · Codex</text>
+
+  <rect x="30" y="120" width="140" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="100" y="136" text-anchor="middle" class="box-label">Next.js Dashboard</text>
+  <text x="100" y="148" text-anchor="middle" class="box-sub">13-section cloud UI</text>
+
+  <rect x="30" y="166" width="140" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="100" y="182" text-anchor="middle" class="box-label">CLI</text>
+  <text x="100" y="194" text-anchor="middle" class="box-sub">agent-bom scan --snowflake</text>
+
+  <!-- ═══ Cortex Discovery (top inside boundary) ═══ -->
+  <rect x="220" y="68" width="280" height="170" rx="8" fill="#161b22" stroke="#29b5e8" stroke-width="1" opacity="0.8"/>
+  <text x="360" y="84" text-anchor="middle" class="section-title" fill="#29b5e8">CORTEX DISCOVERY</text>
+
+  <rect x="234" y="94" width="118" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="293" y="112" text-anchor="middle" class="box-label">Cortex Agents</text>
+
+  <rect x="362" y="94" width="126" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="425" y="112" text-anchor="middle" class="box-label">Native MCP Servers</text>
+
+  <rect x="234" y="130" width="118" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="293" y="148" text-anchor="middle" class="box-label">Cortex Search</text>
+
+  <rect x="362" y="130" width="126" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="425" y="148" text-anchor="middle" class="box-label">Snowpark Containers</text>
+
+  <rect x="234" y="166" width="118" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="293" y="184" text-anchor="middle" class="box-label">Query History</text>
+
+  <rect x="362" y="166" width="126" height="28" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="425" y="184" text-anchor="middle" class="box-label">Governance</text>
+
+  <rect x="234" y="202" width="254" height="28" rx="5" fill="#0d1117" stroke="#29b5e8" stroke-width="1" opacity="0.4"/>
+  <text x="361" y="220" text-anchor="middle" class="box-sub">6 discovery sources → agents, servers, packages, tools</text>
+
+  <!-- ═══ agent-bom API (center) ═══ -->
+  <rect x="540" y="80" width="170" height="70" rx="8" fill="#161b22" stroke="#58a6ff" stroke-width="1.5"/>
+  <text x="625" y="104" text-anchor="middle" class="box-label" fill="#58a6ff">agent-bom API</text>
+  <text x="625" y="118" text-anchor="middle" class="box-sub">FastAPI :8422</text>
+  <text x="625" y="130" text-anchor="middle" class="box-sub">Scan · Registry · Compliance</text>
+
+  <!-- Arrow: Discovery → API -->
+  <line x1="500" y1="115" x2="536" y2="115" stroke="#29b5e8" stroke-width="1.5" marker-end="url(#ah)" opacity="0.6"/>
+
+  <!-- Arrow: External → API -->
+  <line x1="170" y1="92" x2="196" y2="92" stroke="#58a6ff" stroke-width="1" stroke-dasharray="4 2" opacity="0.4"/>
+  <line x1="170" y1="138" x2="196" y2="138" stroke="#58a6ff" stroke-width="1" stroke-dasharray="4 2" opacity="0.4"/>
+  <line x1="170" y1="184" x2="196" y2="184" stroke="#58a6ff" stroke-width="1" stroke-dasharray="4 2" opacity="0.4"/>
+  <!-- Vertical connector outside boundary → API -->
+  <path d="M196 92 L196 184" stroke="#58a6ff" stroke-width="1" stroke-dasharray="4 2" opacity="0.4"/>
+  <path d="M196 138 L540 115" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#ah)" opacity="0.5"/>
+
+  <!-- ═══ Snowflake Tables (center-bottom) ═══ -->
+  <rect x="310" y="274" width="300" height="120" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="460" y="294" text-anchor="middle" class="section-title" fill="#3fb950">SNOWFLAKE TABLES</text>
+
+  <rect x="324" y="304" width="130" height="26" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="389" y="321" text-anchor="middle" class="box-label">SCAN_JOBS</text>
+
+  <rect x="466" y="304" width="130" height="26" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="531" y="321" text-anchor="middle" class="box-label">FLEET_AGENTS</text>
+
+  <rect x="324" y="338" width="130" height="26" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="389" y="355" text-anchor="middle" class="box-label">GATEWAY_POLICIES</text>
+
+  <rect x="466" y="338" width="130" height="26" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="531" y="355" text-anchor="middle" class="box-label">POLICY_AUDIT_LOG</text>
+
+  <rect x="324" y="370" width="272" height="16" rx="4" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.3"/>
+  <text x="460" y="382" text-anchor="middle" class="box-sub">+ APP_CONFIG · GOVERNANCE_FINDINGS · ACTIVITY_EVENTS</text>
+
+  <!-- Arrow: API → Tables (writes) -->
+  <path d="M625 150 L625 200 L460 200 L460 270" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#ah)" fill="none"/>
+  <text x="555" y="196" class="arrow-label">writes scan results</text>
+
+  <!-- ═══ Streamlit in Snowflake (bottom-left) ═══ -->
+  <rect x="220" y="420" width="180" height="48" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1.5"/>
+  <text x="310" y="440" text-anchor="middle" class="box-label" fill="#d29922">Streamlit Dashboard</text>
+  <text x="310" y="454" text-anchor="middle" class="box-sub">6 tabs · Jobs · Fleet · Policies · Vulns</text>
+
+  <!-- Arrow: Tables → Streamlit (reads) -->
+  <path d="M390 394 L390 406 L310 406 L310 416" stroke="#d29922" stroke-width="1.5" marker-end="url(#ao)" fill="none"/>
+  <text x="336" y="412" class="arrow-label">reads</text>
+
+  <!-- ═══ Native App (bottom-right) ═══ -->
+  <rect x="540" y="420" width="180" height="48" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1.5"/>
+  <text x="630" y="440" text-anchor="middle" class="box-label" fill="#d29922">Native App</text>
+  <text x="630" y="454" text-anchor="middle" class="box-sub">Marketplace · manifest.yml + setup.sql</text>
+
+  <!-- Arrow: Tables → Native App (reads) -->
+  <path d="M530 394 L530 406 L630 406 L630 416" stroke="#d29922" stroke-width="1.5" marker-end="url(#ao)" fill="none"/>
+  <text x="594" y="412" class="arrow-label">reads</text>
+
+  <!-- ═══ Auth footer ═══ -->
+  <rect x="28" y="480" width="824" height="30" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="440" y="496" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#8b949e" letter-spacing="0.03em">AUTH: SNOWFLAKE_ACCOUNT + SNOWFLAKE_USER + key-pair or password  ·  API auto-detects and switches to Snowflake persistence  ·  Tables auto-created on first scan</text>
+</svg>

--- a/docs/images/snowflake-light.svg
+++ b/docs/images/snowflake-light.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 520" fill="none">
+  <style>
+    .title { font: 700 13px system-ui, -apple-system, sans-serif; fill: #1f2328; }
+    .section-title { font: 700 10px system-ui, sans-serif; fill: #656d76; letter-spacing: 0.06em; }
+    .box-label { font: 600 10.5px system-ui, sans-serif; fill: #1f2328; }
+    .box-sub { font: 400 9px system-ui, sans-serif; fill: #656d76; }
+    .arrow-label { font: 500 8px system-ui, sans-serif; fill: #656d76; }
+  </style>
+  <defs>
+    <marker id="ah" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#0969da" opacity="0.7"/>
+    </marker>
+    <marker id="ag" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a7f37" opacity="0.7"/>
+    </marker>
+    <marker id="ao" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#9a6700" opacity="0.7"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="880" height="520" rx="12" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="440" y="28" text-anchor="middle" class="title">Snowflake Deployment Architecture</text>
+
+  <!-- ═══ Snowflake Account Boundary ═══ -->
+  <rect x="200" y="42" width="660" height="432" rx="10" fill="none" stroke="#0969da" stroke-width="1.5" stroke-dasharray="6 3" opacity="0.4"/>
+  <text x="530" y="58" text-anchor="middle" class="section-title" fill="#0969da">SNOWFLAKE ACCOUNT</text>
+
+  <!-- ═══ External Clients (left) ═══ -->
+  <text x="100" y="60" text-anchor="middle" class="section-title">EXTERNAL CLIENTS</text>
+  <rect x="30" y="74" width="140" height="36" rx="6" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="100" y="90" text-anchor="middle" class="box-label">MCP Clients</text>
+  <text x="100" y="102" text-anchor="middle" class="box-sub">Claude · Cursor · Codex</text>
+
+  <rect x="30" y="120" width="140" height="36" rx="6" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="100" y="136" text-anchor="middle" class="box-label">Next.js Dashboard</text>
+  <text x="100" y="148" text-anchor="middle" class="box-sub">13-section cloud UI</text>
+
+  <rect x="30" y="166" width="140" height="36" rx="6" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="100" y="182" text-anchor="middle" class="box-label">CLI</text>
+  <text x="100" y="194" text-anchor="middle" class="box-sub">agent-bom scan --snowflake</text>
+
+  <!-- ═══ Cortex Discovery (top inside boundary) ═══ -->
+  <rect x="220" y="68" width="280" height="170" rx="8" fill="#f6f8fa" stroke="#0969da" stroke-width="1" opacity="0.8"/>
+  <text x="360" y="84" text-anchor="middle" class="section-title" fill="#0969da">CORTEX DISCOVERY</text>
+
+  <rect x="234" y="94" width="118" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="293" y="112" text-anchor="middle" class="box-label">Cortex Agents</text>
+
+  <rect x="362" y="94" width="126" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="425" y="112" text-anchor="middle" class="box-label">Native MCP Servers</text>
+
+  <rect x="234" y="130" width="118" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="293" y="148" text-anchor="middle" class="box-label">Cortex Search</text>
+
+  <rect x="362" y="130" width="126" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="425" y="148" text-anchor="middle" class="box-label">Snowpark Containers</text>
+
+  <rect x="234" y="166" width="118" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="293" y="184" text-anchor="middle" class="box-label">Query History</text>
+
+  <rect x="362" y="166" width="126" height="28" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="425" y="184" text-anchor="middle" class="box-label">Governance</text>
+
+  <rect x="234" y="202" width="254" height="28" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="1" opacity="0.3"/>
+  <text x="361" y="220" text-anchor="middle" class="box-sub">6 discovery sources → agents, servers, packages, tools</text>
+
+  <!-- ═══ agent-bom API (center) ═══ -->
+  <rect x="540" y="80" width="170" height="70" rx="8" fill="#f6f8fa" stroke="#0969da" stroke-width="1.5"/>
+  <text x="625" y="104" text-anchor="middle" class="box-label" fill="#0969da">agent-bom API</text>
+  <text x="625" y="118" text-anchor="middle" class="box-sub">FastAPI :8422</text>
+  <text x="625" y="130" text-anchor="middle" class="box-sub">Scan · Registry · Compliance</text>
+
+  <!-- Arrow: Discovery → API -->
+  <line x1="500" y1="115" x2="536" y2="115" stroke="#0969da" stroke-width="1.5" marker-end="url(#ah)" opacity="0.6"/>
+
+  <!-- Arrow: External → API -->
+  <line x1="170" y1="92" x2="196" y2="92" stroke="#0969da" stroke-width="1" stroke-dasharray="4 2" opacity="0.3"/>
+  <line x1="170" y1="138" x2="196" y2="138" stroke="#0969da" stroke-width="1" stroke-dasharray="4 2" opacity="0.3"/>
+  <line x1="170" y1="184" x2="196" y2="184" stroke="#0969da" stroke-width="1" stroke-dasharray="4 2" opacity="0.3"/>
+  <path d="M196 92 L196 184" stroke="#0969da" stroke-width="1" stroke-dasharray="4 2" opacity="0.3"/>
+  <path d="M196 138 L540 115" stroke="#0969da" stroke-width="1.5" marker-end="url(#ah)" opacity="0.5"/>
+
+  <!-- ═══ Snowflake Tables (center-bottom) ═══ -->
+  <rect x="310" y="274" width="300" height="120" rx="8" fill="#f6f8fa" stroke="#1a7f37" stroke-width="1.5"/>
+  <text x="460" y="294" text-anchor="middle" class="section-title" fill="#1a7f37">SNOWFLAKE TABLES</text>
+
+  <rect x="324" y="304" width="130" height="26" rx="5" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="389" y="321" text-anchor="middle" class="box-label">SCAN_JOBS</text>
+
+  <rect x="466" y="304" width="130" height="26" rx="5" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="531" y="321" text-anchor="middle" class="box-label">FLEET_AGENTS</text>
+
+  <rect x="324" y="338" width="130" height="26" rx="5" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="389" y="355" text-anchor="middle" class="box-label">GATEWAY_POLICIES</text>
+
+  <rect x="466" y="338" width="130" height="26" rx="5" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="531" y="355" text-anchor="middle" class="box-label">POLICY_AUDIT_LOG</text>
+
+  <rect x="324" y="370" width="272" height="16" rx="4" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.3"/>
+  <text x="460" y="382" text-anchor="middle" class="box-sub">+ APP_CONFIG · GOVERNANCE_FINDINGS · ACTIVITY_EVENTS</text>
+
+  <!-- Arrow: API → Tables (writes) -->
+  <path d="M625 150 L625 200 L460 200 L460 270" stroke="#0969da" stroke-width="1.5" marker-end="url(#ah)" fill="none"/>
+  <text x="555" y="196" class="arrow-label">writes scan results</text>
+
+  <!-- ═══ Streamlit in Snowflake (bottom-left) ═══ -->
+  <rect x="220" y="420" width="180" height="48" rx="8" fill="#f6f8fa" stroke="#9a6700" stroke-width="1.5"/>
+  <text x="310" y="440" text-anchor="middle" class="box-label" fill="#9a6700">Streamlit Dashboard</text>
+  <text x="310" y="454" text-anchor="middle" class="box-sub">6 tabs · Jobs · Fleet · Policies · Vulns</text>
+
+  <!-- Arrow: Tables → Streamlit (reads) -->
+  <path d="M390 394 L390 406 L310 406 L310 416" stroke="#9a6700" stroke-width="1.5" marker-end="url(#ao)" fill="none"/>
+  <text x="336" y="412" class="arrow-label">reads</text>
+
+  <!-- ═══ Native App (bottom-right) ═══ -->
+  <rect x="540" y="420" width="180" height="48" rx="8" fill="#f6f8fa" stroke="#9a6700" stroke-width="1.5"/>
+  <text x="630" y="440" text-anchor="middle" class="box-label" fill="#9a6700">Native App</text>
+  <text x="630" y="454" text-anchor="middle" class="box-sub">Marketplace · manifest.yml + setup.sql</text>
+
+  <!-- Arrow: Tables → Native App (reads) -->
+  <path d="M530 394 L530 406 L630 406 L630 416" stroke="#9a6700" stroke-width="1.5" marker-end="url(#ao)" fill="none"/>
+  <text x="594" y="412" class="arrow-label">reads</text>
+
+  <!-- ═══ Auth footer ═══ -->
+  <rect x="28" y="480" width="824" height="30" rx="6" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="440" y="496" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#656d76" letter-spacing="0.03em">AUTH: SNOWFLAKE_ACCOUNT + SNOWFLAKE_USER + key-pair or password  ·  API auto-detects and switches to Snowflake persistence  ·  Tables auto-created on first scan</text>
+</svg>


### PR DESCRIPTION
## Summary
- Replace Mermaid code blocks (rendered as tiny unreadable strips on GitHub) with hand-crafted SVG architecture diagrams
- **Architecture diagram**: 5-column pipeline (Discovery → Enrichment → Analysis → Output → Interfaces) with component boxes and directional arrows
- **Snowflake diagram**: Snowflake Account boundary with Cortex Discovery, API, Tables, Streamlit, and Native App — directional arrows show data flow
- Both diagrams have light/dark theme variants via `<picture>` tags

## Test plan
- [ ] Verify architecture diagram renders on GitHub README (light + dark)
- [ ] Verify snowflake diagram renders on GitHub README (light + dark)
- [ ] Confirm example Mermaid output blocks (attack-flow, lifecycle gantt) still intact