### PR TITLE
fix: Cortex Code detection + license scanning + binary fallback

### DIFF
--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -112,6 +112,7 @@ class Package:
     version_source: str = "detected"  # "detected" | "manifest" | "registry_fallback"
     is_malicious: bool = False  # True if flagged as known malicious (MAL- prefix in OSV)
     malicious_reason: Optional[str] = None  # Why this package is flagged (e.g. "MAL-2024-1234")
+    license: Optional[str] = None  # SPDX license identifier (e.g. "MIT", "Apache-2.0")
 
     # OpenSSF Scorecard enrichment (populated by --scorecard flag)
     scorecard_score: Optional[float] = None  # 0.0-10.0 overall score

--- a/src/agent_bom/resolver.py
+++ b/src/agent_bom/resolver.py
@@ -17,44 +17,88 @@ NPM_REGISTRY = "https://registry.npmjs.org"
 PYPI_API = "https://pypi.org/pypi"
 
 
-async def resolve_npm_version(package_name: str, client: httpx.AsyncClient) -> Optional[str]:
+async def resolve_npm_metadata(
+    package_name: str,
+    client: httpx.AsyncClient,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return (version, license) from npm registry."""
     encoded_name = package_name.replace("/", "%2F")
     response = await request_with_retry(
-        client, "GET", f"{NPM_REGISTRY}/{encoded_name}/latest",
+        client,
+        "GET",
+        f"{NPM_REGISTRY}/{encoded_name}/latest",
     )
     if response and response.status_code == 200:
         try:
-            return response.json().get("version")
+            data = response.json()
+            version = data.get("version")
+            lic = data.get("license")
+            # license can be a string or {"type": "MIT"} object
+            if isinstance(lic, dict):
+                lic = lic.get("type")
+            return version, lic if isinstance(lic, str) else None
         except (ValueError, KeyError):
             pass
-    return None
+    return None, None
 
 
-async def resolve_pypi_version(package_name: str, client: httpx.AsyncClient) -> Optional[str]:
+async def resolve_pypi_metadata(
+    package_name: str,
+    client: httpx.AsyncClient,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return (version, license) from PyPI."""
     response = await request_with_retry(
-        client, "GET", f"{PYPI_API}/{package_name}/json",
+        client,
+        "GET",
+        f"{PYPI_API}/{package_name}/json",
     )
     if response and response.status_code == 200:
         try:
-            return response.json().get("info", {}).get("version")
+            info = response.json().get("info", {})
+            version = info.get("version")
+            lic = info.get("license")
+            # PyPI license can be empty string or "UNKNOWN"
+            if lic and lic.upper() not in ("UNKNOWN", ""):
+                return version, lic
+            return version, None
         except (ValueError, KeyError):
             pass
-    return None
+    return None, None
 
 
 async def resolve_package_version(pkg: Package, client: httpx.AsyncClient) -> bool:
     if pkg.version not in ("latest", "unknown", ""):
         return False
-    version = None
+    version, lic = None, None
     if pkg.ecosystem == "npm":
-        version = await resolve_npm_version(pkg.name, client)
+        version, lic = await resolve_npm_metadata(pkg.name, client)
     elif pkg.ecosystem == "pypi":
-        version = await resolve_pypi_version(pkg.name, client)
+        version, lic = await resolve_pypi_metadata(pkg.name, client)
     if version:
         pkg.version = version
         pkg.purl = f"pkg:{pkg.ecosystem}/{pkg.name}@{version}"
+        if lic and not pkg.license:
+            pkg.license = lic
         return True
     return False
+
+
+async def enrich_licenses(packages: list[Package], client: httpx.AsyncClient) -> int:
+    """Fetch license info for packages that already have a version but no license."""
+    need_license = [p for p in packages if not p.license and p.version not in ("latest", "unknown", "")]
+    if not need_license:
+        return 0
+    count = 0
+    for pkg in need_license:
+        _, lic = None, None
+        if pkg.ecosystem == "npm":
+            _, lic = await resolve_npm_metadata(pkg.name, client)
+        elif pkg.ecosystem == "pypi":
+            _, lic = await resolve_pypi_metadata(pkg.name, client)
+        if lic:
+            pkg.license = lic
+            count += 1
+    return count
 
 
 async def resolve_all_versions(packages: list[Package]) -> int:
@@ -68,11 +112,33 @@ async def resolve_all_versions(packages: list[Package]) -> int:
         for i, result in enumerate(results):
             if result is True:
                 resolved_count += 1
-                console.print(f"  [green]✓[/green] Resolved {unresolved[i].name} → {unresolved[i].version}")
+                lic_tag = f" ({unresolved[i].license})" if unresolved[i].license else ""
+                console.print(f"  [green]✓[/green] Resolved {unresolved[i].name} → {unresolved[i].version}{lic_tag}")
             elif isinstance(result, Exception):
                 console.print(f"  [yellow]⚠[/yellow] Failed to resolve {unresolved[i].name}: {result}")
+        # Enrich licenses for packages that already had versions
+        lic_count = await enrich_licenses(packages, client)
+        if lic_count:
+            console.print(f"  [green]✓[/green] Enriched {lic_count} package license(s)")
     return resolved_count
 
 
 def resolve_all_versions_sync(packages: list[Package]) -> int:
     return asyncio.run(resolve_all_versions(packages))
+
+
+# Backward-compatible aliases (used by registry.py)
+async def resolve_npm_version(
+    package_name: str,
+    client: httpx.AsyncClient,
+) -> Optional[str]:
+    version, _ = await resolve_npm_metadata(package_name, client)
+    return version
+
+
+async def resolve_pypi_version(
+    package_name: str,
+    client: httpx.AsyncClient,
+) -> Optional[str]:
+    version, _ = await resolve_pypi_metadata(package_name, client)
+    return version


### PR DESCRIPTION
## Summary
- **Cortex Code CLI detection**: binary search now checks `~/.local/bin`, `/usr/local/bin`, `~/.cargo/bin` as fallback when not on PATH; also detects via install signal files (`~/.snowflake/cortex/logs/coco.log`)
- **License scanning**: Package model now has a `license` field, populated from npm/PyPI registry during version resolution. Included in CycloneDX, SPDX, and JSON output
- **License enrichment**: `enrich_licenses()` backfills license for packages that already had resolved versions (no extra API call for packages resolved in the same session)

## Test plan
- [ ] 1529 tests pass (9 new: binary fallback, signal file detection, license field, CycloneDX/SPDX/JSON license output)
- [ ] Run `agent-bom scan` and verify license shows in resolved output (e.g. `Resolved express → 4.21.2 (MIT)`)
- [ ] Run `agent-bom scan -f cyclonedx` and verify `licenses` key on library components
- [ ] Verify Cortex Code shows as "installed but not configured" on machines with CoCo installed