### PR TITLE
fix: GHSA false positives + richer scan output + skill listing

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -860,6 +860,8 @@ def scan(
             skill_result = scan_skill_files(skill_file_list)
             if skill_result.servers or skill_result.packages or skill_result.credential_env_vars:
                 con.print(f"\n[bold blue]Scanning {len(skill_file_list)} skill file(s)...[/bold blue]\n")
+                for sf in skill_file_list:
+                    con.print(f"  [dim]•[/dim] {sf.name}  [dim]{sf.parent}[/dim]")
                 if skill_result.servers:
                     from agent_bom.models import Agent, AgentType
 
@@ -1595,7 +1597,7 @@ def scan(
             # Compact output (default)
             print_compact_summary(report)
             print_compact_agents(report)
-            print_compact_blast_radius(report, limit=5)
+            print_compact_blast_radius(report)
 
         # AI enrichment output (both modes)
         if report.executive_summary:
@@ -1646,7 +1648,7 @@ def scan(
             print_remediation_plan(report)
             print_export_hint(report)
         else:
-            print_compact_remediation(report, limit=3)
+            print_compact_remediation(report)
             print_compact_export_hint(report)
     elif output_format == "text" and not output:
         _print_text(report, blast_radii)

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -177,6 +177,13 @@ async def check_github_advisories(
                 refs = [advisory.get("html_url", "")] if advisory.get("html_url") else []
 
                 for target_pkg in target_pkgs:
+                    # Verify this advisory actually affects the target package
+                    # (GitHub API does substring matching, so "express" returns
+                    # advisories for "express-session", "express-validator", etc.)
+                    advisory_pkg_names = {v.get("package", {}).get("name", "").lower() for v in advisory.get("vulnerabilities", [])}
+                    if target_pkg.name.lower() not in advisory_pkg_names:
+                        continue
+
                     existing_ids = {v.id for v in target_pkg.vulnerabilities}
                     # Skip if CVE or GHSA ID already present
                     if vuln_id in existing_ids or (cve_id and cve_id in existing_ids) or (ghsa_id and ghsa_id in existing_ids):


### PR DESCRIPTION
## Summary
- **Critical bug fix**: GHSA enrichment was adding advisories for wrong packages (GitHub API does substring matching — querying "express" returns advisories for "express-session", "express-validator", etc.). Now verifies each advisory's vulnerability entries list the exact target package name before adding. This likely reduces your 210 GHSA advisories to the actual ~5-10 that match your packages.
- **Richer compact output**: Default blast radius table now shows EPSS%, affected Agent name, and compliance Framework tags (OWASP LLM/MCP, ATLAS) — no longer need `--verbose` to see what matters. Default limits increased from 5→10 findings and 3→5 remediation items.
- **Skill file listing**: All scanned skill files are now listed by name in output, not just findings.

## Test plan
- [ ] Run `agent-bom scan` and verify GHSA advisory count is dramatically lower (should match actual package advisories, not substring matches)
- [ ] Verify compact output shows EPSS, Agent, Frameworks columns
- [ ] Verify skill files are listed by name during scan
- [ ] 1531 tests pass (2 new GHSA filtering tests)