### PR TITLE
fix: false positive reduction + README viz overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,43 +338,24 @@ agent-bom scan --model-files ./models
 </details>
 
 <details>
-<summary><b>Attack flow & supply chain visualization</b></summary>
+<summary><b>Interactive security graph visualization</b></summary>
 
-Multiple visualization modes: CLI attack flow tree, Mermaid diagrams, interactive HTML (Cytoscape.js), React Flow graphs via REST API.
+The dashboard (`agent-bom api`) serves interactive [React Flow](https://reactflow.dev/) graphs — the same rendering approach used by enterprise security platforms:
+
+- **Agent Mesh** (`/mesh`) — cross-agent topology with vulnerability overlay, shared server detection, credential blast analysis, severity filtering, and search
+- **Attack Flow** (`/scan?view=attack-flow`) — CVE-centric blast radius graph: CVE → Package → Server → Agent → Credentials → Tools
+- **Supply Chain Lineage** (`/graph`) — full dependency lineage with hover highlighting and detail panels
+
+All graph views include: dagre auto-layout, hover highlighting (BFS connected nodes), click-to-inspect detail panels, minimap, OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF framework tagging on every node.
+
+CLI output formats for CI/CD and automation:
 
 ```bash
-agent-bom scan -f mermaid                              # supply chain diagram
-agent-bom scan -f mermaid --mermaid-mode attack-flow   # CVE blast radius
-agent-bom scan -f mermaid --mermaid-mode lifecycle     # vulnerability lifecycle gantt
-agent-bom scan -f graph -o graph.json                  # Cytoscape-compatible JSON
-agent-bom scan -f html -o report.html                  # interactive HTML report
+agent-bom scan -f graph -o graph.json    # Cytoscape-compatible JSON
+agent-bom scan -f html -o report.html    # standalone interactive HTML report
+agent-bom scan -f mermaid                # Mermaid text (for docs/markdown)
+agent-bom scan -f sarif -o results.sarif # GitHub Security tab integration
 ```
-
-Example Mermaid output:
-
-```mermaid
-graph TD
-    A["Cursor IDE"] --> S1["filesystem-server"]
-    A --> S2["github-server"]
-    S1 --> P1["@modelcontextprotocol/server-filesystem@2025.3.28"]
-    S2 --> P2["@modelcontextprotocol/server-github@2025.3.28"]
-    P1 -->|"GHSA-xxxx"| V1["CVE-2025-1234 CRITICAL"]
-    V1 -.->|"MCP04"| F1["Supply Chain Attack"]
-```
-
-Example lifecycle gantt output:
-
-```mermaid
-gantt
-    title Vulnerability Lifecycle Timeline
-    dateFormat YYYY-MM-DD
-    section express@4.17.1
-        Scanned        :done, t0, 2025-06-15, 1d
-        CVE-2024-1234  :crit, t1, after t0, 1d
-        Fix → 4.18.0   :active, t2, after t1, 1d
-```
-
-The REST API (`agent-bom api`) serves interactive React Flow attack-flow graphs with OWASP LLM Top 10, OWASP MCP Top 10, and MITRE ATLAS framework tagging on every CVE node.
 
 </details>
 

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" fill="none">
   <style>
     .title { font: 700 13px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
     .section-title { font: 700 10px system-ui, sans-serif; letter-spacing: 0.06em; }
@@ -6,6 +6,12 @@
     .box-sub { font: 400 9px system-ui, sans-serif; fill: #8b949e; }
     .arrow-label { font: 500 8px system-ui, sans-serif; fill: #6e7681; }
     .footer { font: 500 9px system-ui, sans-serif; fill: #6e7681; }
+    .trust-label { font: 700 11px system-ui, sans-serif; fill: #a3b3c7; letter-spacing: 0.06em; }
+    .trust-pill { font: 600 9.5px system-ui, sans-serif; fill: #c9d1d9; }
+    .flow-title { font: 700 10px system-ui, sans-serif; fill: #a3b3c7; letter-spacing: 0.06em; }
+    .flow-zone { font: 700 9px system-ui, sans-serif; letter-spacing: 0.04em; }
+    .flow-detail { font: 400 8.5px system-ui, sans-serif; fill: #8b949e; }
+    .flow-arrow { font: 600 8.5px system-ui, sans-serif; }
   </style>
   <defs>
     <marker id="a1" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
@@ -23,222 +29,213 @@
   </defs>
 
   <!-- Background -->
-  <rect width="960" height="520" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <rect width="960" height="620" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="480" y="28" text-anchor="middle" class="title">How agent-bom works</text>
 
   <!-- ═══ Phase 1: Discovery (x=16, w=170) ═══ -->
   <rect x="16" y="44" width="170" height="366" rx="8" fill="#161b22" stroke="#58a6ff" stroke-width="1" opacity="0.8"/>
   <text x="101" y="60" text-anchor="middle" class="section-title" fill="#58a6ff">DISCOVERY</text>
 
-  <!-- Box 1: MCP Configs (y=68, h=32) -->
   <rect x="28" y="68" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="84" text-anchor="middle" class="box-label">MCP Configs</text>
   <text x="101" y="96" text-anchor="middle" class="box-sub">18 clients · auto-detect</text>
 
-  <!-- Box 2: Cloud Providers (y=106) -->
   <rect x="28" y="106" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="122" text-anchor="middle" class="box-label">Cloud Providers</text>
   <text x="101" y="134" text-anchor="middle" class="box-sub">AWS · Azure · GCP · Snowflake</text>
 
-  <!-- Box 3: Docker Images (y=144) -->
   <rect x="28" y="144" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="160" text-anchor="middle" class="box-label">Docker Images</text>
   <text x="101" y="172" text-anchor="middle" class="box-sub">Grype + Syft deep scan</text>
 
-  <!-- Box 4: Kubernetes (y=182) -->
   <rect x="28" y="182" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="198" text-anchor="middle" class="box-label">Kubernetes</text>
   <text x="101" y="210" text-anchor="middle" class="box-sub">Multi-namespace pod scan</text>
 
-  <!-- Box 5: Existing SBOMs (y=220) -->
   <rect x="28" y="220" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="236" text-anchor="middle" class="box-label">Existing SBOMs</text>
   <text x="101" y="248" text-anchor="middle" class="box-sub">CycloneDX + SPDX import</text>
 
-  <!-- Box 6: Agent Frameworks (y=258) -->
   <rect x="28" y="258" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="274" text-anchor="middle" class="box-label">Agent Frameworks</text>
   <text x="101" y="286" text-anchor="middle" class="box-sub">LangChain · CrewAI · ADK</text>
 
-  <!-- Summary row (y=302, h=36) -->
   <rect x="28" y="302" width="146" height="36" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
   <text x="101" y="318" text-anchor="middle" class="box-sub">Agents · Servers</text>
   <text x="101" y="332" text-anchor="middle" class="box-sub">Packages · Credentials · Tools</text>
 
-  <!-- Arrow: Discovery -> Enrichment -->
   <line x1="186" y1="227" x2="212" y2="227" stroke="#58a6ff" stroke-width="2" marker-end="url(#a1)"/>
 
   <!-- ═══ Phase 2: Enrichment (x=216, w=170) ═══ -->
   <rect x="216" y="44" width="170" height="366" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1" opacity="0.8"/>
   <text x="301" y="60" text-anchor="middle" class="section-title" fill="#d29922">ENRICHMENT</text>
 
-  <!-- Box 1: OSV.dev (y=68) -->
   <rect x="228" y="68" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="301" y="84" text-anchor="middle" class="box-label">OSV.dev</text>
   <text x="301" y="96" text-anchor="middle" class="box-sub">Batch CVE lookup · all ecosystems</text>
 
-  <!-- Box 2: NVD / NIST (y=106) -->
   <rect x="228" y="106" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="301" y="122" text-anchor="middle" class="box-label">NVD / NIST</text>
   <text x="301" y="134" text-anchor="middle" class="box-sub">CVSS v3.1 + v4.0 scoring</text>
 
-  <!-- Box 3: FIRST EPSS (y=144) -->
   <rect x="228" y="144" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="301" y="160" text-anchor="middle" class="box-label">FIRST EPSS</text>
   <text x="301" y="172" text-anchor="middle" class="box-sub">Exploit probability scores</text>
 
-  <!-- Box 4: CISA KEV (y=182) -->
   <rect x="228" y="182" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="301" y="198" text-anchor="middle" class="box-label">CISA KEV</text>
   <text x="301" y="210" text-anchor="middle" class="box-sub">Known exploited vulns</text>
 
-  <!-- Box 5: GHSA + NVIDIA CSAF (y=220) -->
   <rect x="228" y="220" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="301" y="236" text-anchor="middle" class="box-label">GHSA + NVIDIA CSAF</text>
   <text x="301" y="248" text-anchor="middle" class="box-sub">Supplemental advisories</text>
 
-  <!-- Box 6: MCP Registry (y=258) -->
   <rect x="228" y="258" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="301" y="274" text-anchor="middle" class="box-label">MCP Registry</text>
   <text x="301" y="286" text-anchor="middle" class="box-sub">427+ server provenance</text>
 
-  <!-- Summary row (y=302, h=36) -->
   <rect x="228" y="302" width="146" height="36" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1" opacity="0.4"/>
   <text x="301" y="318" text-anchor="middle" class="box-sub">CVEs with CVSS + EPSS</text>
   <text x="301" y="332" text-anchor="middle" class="box-sub">KEV flags · Fixed versions</text>
 
-  <!-- Arrow: Enrichment -> Analysis -->
   <line x1="386" y1="227" x2="412" y2="227" stroke="#d29922" stroke-width="2" marker-end="url(#a2)"/>
 
   <!-- ═══ Phase 3: Analysis (x=416, w=180) ═══ -->
   <rect x="416" y="44" width="180" height="366" rx="8" fill="#161b22" stroke="#f47067" stroke-width="1" opacity="0.8"/>
   <text x="506" y="60" text-anchor="middle" class="section-title" fill="#f47067">ANALYSIS</text>
 
-  <!-- Box 1: Blast Radius (y=68, h=40 - featured) -->
   <rect x="428" y="68" width="156" height="40" rx="5" fill="#0d1117" stroke="#f47067" stroke-width="1" opacity="0.6"/>
   <text x="506" y="84" text-anchor="middle" class="box-label">Blast Radius</text>
-  <text x="506" y="100" text-anchor="middle" class="box-sub">CVE -> pkg -> server -> agent -> creds -> tools</text>
+  <text x="506" y="100" text-anchor="middle" class="box-sub">CVE → pkg → server → agent → creds → tools</text>
 
-  <!-- Box 2: OWASP LLM Top 10 (y=114) -->
   <rect x="428" y="114" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="506" y="130" text-anchor="middle" class="box-label">OWASP LLM Top 10</text>
   <text x="506" y="142" text-anchor="middle" class="box-sub">LLM02 · LLM05 · LLM06 · LLM08</text>
 
-  <!-- Box 3: OWASP MCP Top 10 (y=152) -->
   <rect x="428" y="152" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="506" y="168" text-anchor="middle" class="box-label">OWASP MCP Top 10</text>
   <text x="506" y="180" text-anchor="middle" class="box-sub">MCP01-MCP10 tagging</text>
 
-  <!-- Box 4: MITRE ATLAS (y=190) -->
   <rect x="428" y="190" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="506" y="206" text-anchor="middle" class="box-label">MITRE ATLAS</text>
   <text x="506" y="218" text-anchor="middle" class="box-sub">AI adversarial threat mapping</text>
 
-  <!-- Box 5: NIST AI RMF (y=228) -->
   <rect x="428" y="228" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="506" y="244" text-anchor="middle" class="box-label">NIST AI RMF</text>
   <text x="506" y="256" text-anchor="middle" class="box-sub">Risk management framework</text>
 
-  <!-- Box 6: Enforcement Engine (y=266) -->
   <rect x="428" y="266" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="506" y="282" text-anchor="middle" class="box-label">Enforcement Engine</text>
   <text x="506" y="294" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
 
-  <!-- Box 7: Model Provenance (y=304) -->
   <rect x="428" y="304" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="506" y="320" text-anchor="middle" class="box-label">Model Provenance</text>
   <text x="506" y="332" text-anchor="middle" class="box-sub">SHA-256 · Sigstore · HuggingFace</text>
 
-  <!-- Arrow: Analysis -> Output -->
   <line x1="596" y1="227" x2="622" y2="227" stroke="#f47067" stroke-width="2" marker-end="url(#a3)"/>
 
   <!-- ═══ Phase 4: Output (x=626, w=140) ═══ -->
   <rect x="626" y="44" width="140" height="366" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1" opacity="0.8"/>
   <text x="696" y="60" text-anchor="middle" class="section-title" fill="#3fb950">OUTPUT</text>
 
-  <!-- Box 1: Console + HTML (y=68) -->
   <rect x="638" y="68" width="116" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="696" y="84" text-anchor="middle" class="box-label">Console + HTML</text>
   <text x="696" y="96" text-anchor="middle" class="box-sub">Rich tables + dashboard</text>
 
-  <!-- Box 2: SARIF (y=106) -->
   <rect x="638" y="106" width="116" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="696" y="122" text-anchor="middle" class="box-label">SARIF</text>
   <text x="696" y="134" text-anchor="middle" class="box-sub">GitHub Security tab</text>
 
-  <!-- Box 3: CycloneDX 1.6 (y=144) -->
   <rect x="638" y="144" width="116" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="696" y="160" text-anchor="middle" class="box-label">CycloneDX 1.6</text>
   <text x="696" y="172" text-anchor="middle" class="box-sub">AI-BOM standard</text>
 
-  <!-- Box 4: SPDX 3.0 (y=182) -->
   <rect x="638" y="182" width="116" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="696" y="198" text-anchor="middle" class="box-label">SPDX 3.0</text>
   <text x="696" y="210" text-anchor="middle" class="box-sub">License + provenance</text>
 
-  <!-- Box 5: JSON + Mermaid (y=220) -->
   <rect x="638" y="220" width="116" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="696" y="236" text-anchor="middle" class="box-label">JSON + Mermaid</text>
-  <text x="696" y="248" text-anchor="middle" class="box-sub">Machine-readable</text>
+  <text x="696" y="236" text-anchor="middle" class="box-label">JSON + Graph</text>
+  <text x="696" y="248" text-anchor="middle" class="box-sub">Cytoscape + React Flow</text>
 
-  <!-- Box 6: REST API (y=258) -->
   <rect x="638" y="258" width="116" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="696" y="274" text-anchor="middle" class="box-label">REST API</text>
   <text x="696" y="286" text-anchor="middle" class="box-sub">FastAPI on :8422</text>
 
-  <!-- Arrow: Output -> Interfaces -->
   <line x1="766" y1="227" x2="792" y2="227" stroke="#3fb950" stroke-width="2" marker-end="url(#a4)"/>
 
   <!-- ═══ Phase 5: Interfaces (x=796, w=148) ═══ -->
   <rect x="796" y="44" width="148" height="366" rx="8" fill="#161b22" stroke="#a371f7" stroke-width="1" opacity="0.8"/>
   <text x="870" y="60" text-anchor="middle" class="section-title" fill="#a371f7">INTERFACES</text>
 
-  <!-- Box 1: CLI (y=68) -->
   <rect x="808" y="68" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="84" text-anchor="middle" class="box-label">CLI</text>
   <text x="870" y="96" text-anchor="middle" class="box-sub">pip install agent-bom</text>
 
-  <!-- Box 2: MCP Server (y=106) -->
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
   <text x="870" y="134" text-anchor="middle" class="box-sub">13 tools · stdio/SSE</text>
 
-  <!-- Box 3: GitHub Action (y=144) -->
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>
   <text x="870" y="172" text-anchor="middle" class="box-sub">CI/CD integration</text>
 
-  <!-- Box 4: Cloud UI (y=182) -->
   <rect x="808" y="182" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="198" text-anchor="middle" class="box-label">Cloud UI</text>
   <text x="870" y="210" text-anchor="middle" class="box-sub">Next.js dashboard</text>
 
-  <!-- Box 5: Snowflake (y=220) -->
   <rect x="808" y="220" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="236" text-anchor="middle" class="box-label">Snowflake</text>
   <text x="870" y="248" text-anchor="middle" class="box-sub">Streamlit + Native App</text>
 
-  <!-- ═══ Trust Principles bar (y=426) ═══ -->
-  <rect x="16" y="426" width="928" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="480" y="442" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#8b949e" letter-spacing="0.05em">TRUST PRINCIPLES</text>
-  <text x="480" y="456" text-anchor="middle" class="footer">Read-only  ·  Agentless  ·  Never writes configs  ·  Never runs MCP servers  ·  Never stores credentials  ·  Sigstore-signed releases</text>
+  <!-- ═══ Trust Principles (y=420, h=56) — enlarged ═══ -->
+  <rect x="16" y="420" width="928" height="56" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1" opacity="0.6"/>
+  <text x="480" y="438" text-anchor="middle" class="trust-label" fill="#3fb950">TRUST PRINCIPLES</text>
+  <!-- 6 pill badges -->
+  <rect x="48" y="446" width="90" height="22" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="93" y="460" text-anchor="middle" class="trust-pill">Read-only</text>
+  <rect x="150" y="446" width="90" height="22" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="195" y="460" text-anchor="middle" class="trust-pill">Agentless</text>
+  <rect x="252" y="446" width="140" height="22" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="322" y="460" text-anchor="middle" class="trust-pill">Never writes configs</text>
+  <rect x="404" y="446" width="150" height="22" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="479" y="460" text-anchor="middle" class="trust-pill">Never runs MCP servers</text>
+  <rect x="566" y="446" width="160" height="22" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="646" y="460" text-anchor="middle" class="trust-pill">Never stores credentials</text>
+  <rect x="738" y="446" width="130" height="22" rx="11" fill="#0d1117" stroke="#3fb950" stroke-width="1" opacity="0.5"/>
+  <text x="803" y="460" text-anchor="middle" class="trust-pill">Sigstore-signed</text>
 
-  <!-- ═══ Data Flow legend bar (y=468) ═══ -->
-  <rect x="16" y="468" width="928" height="42" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="480" y="483" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#8b949e" letter-spacing="0.05em">DATA FLOW</text>
+  <!-- ═══ Data Flow (y=486, h=120) — expanded with 3 zones ═══ -->
+  <rect x="16" y="486" width="928" height="120" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="480" y="504" text-anchor="middle" class="flow-title">DATA FLOW</text>
 
-  <!-- Flow arrows in legend -->
-  <line x1="100" y1="500" x2="130" y2="500" stroke="#58a6ff" stroke-width="2" marker-end="url(#a1)"/>
-  <text x="138" y="504" class="footer" fill="#58a6ff">Discover</text>
+  <!-- Zone 1: Your Machine -->
+  <rect x="32" y="514" width="260" height="78" rx="6" fill="#0d1117" stroke="#58a6ff" stroke-width="1" opacity="0.5"/>
+  <text x="162" y="530" text-anchor="middle" class="flow-zone" fill="#58a6ff">YOUR MACHINE (READ-ONLY)</text>
+  <text x="162" y="546" text-anchor="middle" class="flow-detail" fill="#8b949e">Extracted: server names, package names,</text>
+  <text x="162" y="558" text-anchor="middle" class="flow-detail" fill="#8b949e">env var names, tool lists</text>
+  <text x="162" y="574" text-anchor="middle" class="flow-detail" fill="#f47067">Never extracted: secrets, tokens, passwords</text>
+  <text x="162" y="586" text-anchor="middle" class="flow-detail" fill="#3fb950">--dry-run previews everything first</text>
 
-  <line x1="220" y1="500" x2="250" y2="500" stroke="#d29922" stroke-width="2" marker-end="url(#a2)"/>
-  <text x="258" y="504" class="footer" fill="#d29922">Enrich</text>
+  <!-- Arrow: Machine → Engine -->
+  <line x1="296" y1="553" x2="326" y2="553" stroke="#58a6ff" stroke-width="2" marker-end="url(#a1)"/>
 
-  <line x1="330" y1="500" x2="360" y2="500" stroke="#f47067" stroke-width="2" marker-end="url(#a3)"/>
-  <text x="368" y="504" class="footer" fill="#f47067">Analyze</text>
+  <!-- Zone 2: Agent-BOM Engine -->
+  <rect x="330" y="514" width="280" height="78" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1" opacity="0.5"/>
+  <text x="470" y="530" text-anchor="middle" class="flow-zone" fill="#d29922">AGENT-BOM ENGINE</text>
+  <text x="470" y="546" text-anchor="middle" class="flow-detail" fill="#8b949e">Sends to APIs: package names + versions only</text>
+  <text x="470" y="560" text-anchor="middle" class="flow-detail" fill="#8b949e">Blast radius · Threat models · Enforcement</text>
+  <text x="470" y="574" text-anchor="middle" class="flow-detail" fill="#8b949e">OWASP + ATLAS + NIST framework tagging</text>
+  <text x="470" y="586" text-anchor="middle" class="flow-detail" fill="#f47067">No credentials leave your machine</text>
 
-  <line x1="440" y1="500" x2="470" y2="500" stroke="#3fb950" stroke-width="2" marker-end="url(#a4)"/>
-  <text x="478" y="504" class="footer" fill="#3fb950">Report</text>
+  <!-- Arrow: Engine → APIs -->
+  <line x1="614" y1="553" x2="644" y2="553" stroke="#d29922" stroke-width="2" marker-end="url(#a2)"/>
 
-  <text x="740" y="504" text-anchor="middle" class="footer">MCP Configs -> OSV + NVD + EPSS + KEV -> OWASP + ATLAS -> SARIF / CycloneDX / SPDX</text>
+  <!-- Zone 3: Public APIs -->
+  <rect x="648" y="514" width="280" height="78" rx="6" fill="#0d1117" stroke="#f47067" stroke-width="1" opacity="0.5"/>
+  <text x="788" y="530" text-anchor="middle" class="flow-zone" fill="#f47067">PUBLIC APIs (READ-ONLY)</text>
+  <text x="788" y="546" text-anchor="middle" class="flow-detail" fill="#8b949e">OSV.dev · NVD · FIRST EPSS · CISA KEV</text>
+  <text x="788" y="560" text-anchor="middle" class="flow-detail" fill="#8b949e">GitHub Security Advisories · NVIDIA CSAF</text>
+  <text x="788" y="574" text-anchor="middle" class="flow-detail" fill="#8b949e">Receives: package name + version + ecosystem</text>
+  <text x="788" y="586" text-anchor="middle" class="flow-detail" fill="#3fb950">Returns: CVEs, CVSS, EPSS, KEV, fix versions</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" fill="none">
   <style>
     .title { font: 700 13px system-ui, -apple-system, sans-serif; fill: #1f2328; }
     .section-title { font: 700 10px system-ui, sans-serif; letter-spacing: 0.06em; }
@@ -6,239 +6,230 @@
     .box-sub { font: 400 9px system-ui, sans-serif; fill: #656d76; }
     .arrow-label { font: 500 8px system-ui, sans-serif; fill: #656d76; }
     .footer { font: 500 9px system-ui, sans-serif; fill: #656d76; }
+    .trust-label { font: 700 11px system-ui, sans-serif; fill: #424a53; letter-spacing: 0.06em; }
+    .trust-pill { font: 600 9.5px system-ui, sans-serif; fill: #1f2328; }
+    .flow-title { font: 700 10px system-ui, sans-serif; fill: #424a53; letter-spacing: 0.06em; }
+    .flow-zone { font: 700 9px system-ui, sans-serif; letter-spacing: 0.04em; }
+    .flow-detail { font: 400 8.5px system-ui, sans-serif; fill: #656d76; }
+    .flow-arrow { font: 600 8.5px system-ui, sans-serif; }
   </style>
   <defs>
     <marker id="a1" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#58a6ff" opacity="0.7"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#0969da" opacity="0.6"/>
     </marker>
     <marker id="a2" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#d29922" opacity="0.7"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#bf8700" opacity="0.6"/>
     </marker>
     <marker id="a3" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#f47067" opacity="0.7"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#cf222e" opacity="0.6"/>
     </marker>
     <marker id="a4" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#3fb950" opacity="0.7"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1a7f37" opacity="0.6"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="960" height="520" rx="12" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect width="960" height="620" rx="12" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="480" y="28" text-anchor="middle" class="title">How agent-bom works</text>
 
   <!-- ═══ Phase 1: Discovery (x=16, w=170) ═══ -->
-  <rect x="16" y="44" width="170" height="366" rx="8" fill="#f6f8fa" stroke="#58a6ff" stroke-width="1" opacity="0.8"/>
-  <text x="101" y="60" text-anchor="middle" class="section-title" fill="#58a6ff">DISCOVERY</text>
+  <rect x="16" y="44" width="170" height="366" rx="8" fill="#f6f8fa" stroke="#0969da" stroke-width="1" opacity="0.8"/>
+  <text x="101" y="60" text-anchor="middle" class="section-title" fill="#0969da">DISCOVERY</text>
 
-  <!-- Box 1: MCP Configs (y=68, h=32) -->
-  <rect x="28" y="68" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="28" y="68" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="84" text-anchor="middle" class="box-label">MCP Configs</text>
   <text x="101" y="96" text-anchor="middle" class="box-sub">18 clients · auto-detect</text>
 
-  <!-- Box 2: Cloud Providers (y=106) -->
-  <rect x="28" y="106" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="28" y="106" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="122" text-anchor="middle" class="box-label">Cloud Providers</text>
   <text x="101" y="134" text-anchor="middle" class="box-sub">AWS · Azure · GCP · Snowflake</text>
 
-  <!-- Box 3: Docker Images (y=144) -->
-  <rect x="28" y="144" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="28" y="144" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="160" text-anchor="middle" class="box-label">Docker Images</text>
   <text x="101" y="172" text-anchor="middle" class="box-sub">Grype + Syft deep scan</text>
 
-  <!-- Box 4: Kubernetes (y=182) -->
-  <rect x="28" y="182" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="28" y="182" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="198" text-anchor="middle" class="box-label">Kubernetes</text>
   <text x="101" y="210" text-anchor="middle" class="box-sub">Multi-namespace pod scan</text>
 
-  <!-- Box 5: Existing SBOMs (y=220) -->
-  <rect x="28" y="220" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="28" y="220" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="236" text-anchor="middle" class="box-label">Existing SBOMs</text>
   <text x="101" y="248" text-anchor="middle" class="box-sub">CycloneDX + SPDX import</text>
 
-  <!-- Box 6: Agent Frameworks (y=258) -->
-  <rect x="28" y="258" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="28" y="258" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="274" text-anchor="middle" class="box-label">Agent Frameworks</text>
   <text x="101" y="286" text-anchor="middle" class="box-sub">LangChain · CrewAI · ADK</text>
 
-  <!-- Summary row (y=302, h=36) -->
-  <rect x="28" y="302" width="146" height="36" rx="5" fill="#ffffff" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+  <rect x="28" y="302" width="146" height="36" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="1" opacity="0.4"/>
   <text x="101" y="318" text-anchor="middle" class="box-sub">Agents · Servers</text>
   <text x="101" y="332" text-anchor="middle" class="box-sub">Packages · Credentials · Tools</text>
 
-  <!-- Arrow: Discovery -> Enrichment -->
-  <line x1="186" y1="227" x2="212" y2="227" stroke="#58a6ff" stroke-width="2" marker-end="url(#a1)"/>
+  <line x1="186" y1="227" x2="212" y2="227" stroke="#0969da" stroke-width="2" marker-end="url(#a1)"/>
 
   <!-- ═══ Phase 2: Enrichment (x=216, w=170) ═══ -->
-  <rect x="216" y="44" width="170" height="366" rx="8" fill="#f6f8fa" stroke="#d29922" stroke-width="1" opacity="0.8"/>
-  <text x="301" y="60" text-anchor="middle" class="section-title" fill="#d29922">ENRICHMENT</text>
+  <rect x="216" y="44" width="170" height="366" rx="8" fill="#f6f8fa" stroke="#bf8700" stroke-width="1" opacity="0.8"/>
+  <text x="301" y="60" text-anchor="middle" class="section-title" fill="#bf8700">ENRICHMENT</text>
 
-  <!-- Box 1: OSV.dev (y=68) -->
-  <rect x="228" y="68" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="228" y="68" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="301" y="84" text-anchor="middle" class="box-label">OSV.dev</text>
   <text x="301" y="96" text-anchor="middle" class="box-sub">Batch CVE lookup · all ecosystems</text>
 
-  <!-- Box 2: NVD / NIST (y=106) -->
-  <rect x="228" y="106" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="228" y="106" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="301" y="122" text-anchor="middle" class="box-label">NVD / NIST</text>
   <text x="301" y="134" text-anchor="middle" class="box-sub">CVSS v3.1 + v4.0 scoring</text>
 
-  <!-- Box 3: FIRST EPSS (y=144) -->
-  <rect x="228" y="144" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="228" y="144" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="301" y="160" text-anchor="middle" class="box-label">FIRST EPSS</text>
   <text x="301" y="172" text-anchor="middle" class="box-sub">Exploit probability scores</text>
 
-  <!-- Box 4: CISA KEV (y=182) -->
-  <rect x="228" y="182" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="228" y="182" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="301" y="198" text-anchor="middle" class="box-label">CISA KEV</text>
   <text x="301" y="210" text-anchor="middle" class="box-sub">Known exploited vulns</text>
 
-  <!-- Box 5: GHSA + NVIDIA CSAF (y=220) -->
-  <rect x="228" y="220" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="228" y="220" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="301" y="236" text-anchor="middle" class="box-label">GHSA + NVIDIA CSAF</text>
   <text x="301" y="248" text-anchor="middle" class="box-sub">Supplemental advisories</text>
 
-  <!-- Box 6: MCP Registry (y=258) -->
-  <rect x="228" y="258" width="146" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="228" y="258" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="301" y="274" text-anchor="middle" class="box-label">MCP Registry</text>
   <text x="301" y="286" text-anchor="middle" class="box-sub">427+ server provenance</text>
 
-  <!-- Summary row (y=302, h=36) -->
-  <rect x="228" y="302" width="146" height="36" rx="5" fill="#ffffff" stroke="#d29922" stroke-width="1" opacity="0.4"/>
+  <rect x="228" y="302" width="146" height="36" rx="5" fill="#ffffff" stroke="#bf8700" stroke-width="1" opacity="0.4"/>
   <text x="301" y="318" text-anchor="middle" class="box-sub">CVEs with CVSS + EPSS</text>
   <text x="301" y="332" text-anchor="middle" class="box-sub">KEV flags · Fixed versions</text>
 
-  <!-- Arrow: Enrichment -> Analysis -->
-  <line x1="386" y1="227" x2="412" y2="227" stroke="#d29922" stroke-width="2" marker-end="url(#a2)"/>
+  <line x1="386" y1="227" x2="412" y2="227" stroke="#bf8700" stroke-width="2" marker-end="url(#a2)"/>
 
   <!-- ═══ Phase 3: Analysis (x=416, w=180) ═══ -->
-  <rect x="416" y="44" width="180" height="366" rx="8" fill="#f6f8fa" stroke="#f47067" stroke-width="1" opacity="0.8"/>
-  <text x="506" y="60" text-anchor="middle" class="section-title" fill="#f47067">ANALYSIS</text>
+  <rect x="416" y="44" width="180" height="366" rx="8" fill="#f6f8fa" stroke="#cf222e" stroke-width="1" opacity="0.8"/>
+  <text x="506" y="60" text-anchor="middle" class="section-title" fill="#cf222e">ANALYSIS</text>
 
-  <!-- Box 1: Blast Radius (y=68, h=40 - featured) -->
-  <rect x="428" y="68" width="156" height="40" rx="5" fill="#ffffff" stroke="#f47067" stroke-width="1" opacity="0.6"/>
+  <rect x="428" y="68" width="156" height="40" rx="5" fill="#ffffff" stroke="#cf222e" stroke-width="1" opacity="0.6"/>
   <text x="506" y="84" text-anchor="middle" class="box-label">Blast Radius</text>
-  <text x="506" y="100" text-anchor="middle" class="box-sub">CVE -> pkg -> server -> agent -> creds -> tools</text>
+  <text x="506" y="100" text-anchor="middle" class="box-sub">CVE → pkg → server → agent → creds → tools</text>
 
-  <!-- Box 2: OWASP LLM Top 10 (y=114) -->
-  <rect x="428" y="114" width="156" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="428" y="114" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="506" y="130" text-anchor="middle" class="box-label">OWASP LLM Top 10</text>
   <text x="506" y="142" text-anchor="middle" class="box-sub">LLM02 · LLM05 · LLM06 · LLM08</text>
 
-  <!-- Box 3: OWASP MCP Top 10 (y=152) -->
-  <rect x="428" y="152" width="156" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="428" y="152" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="506" y="168" text-anchor="middle" class="box-label">OWASP MCP Top 10</text>
   <text x="506" y="180" text-anchor="middle" class="box-sub">MCP01-MCP10 tagging</text>
 
-  <!-- Box 4: MITRE ATLAS (y=190) -->
-  <rect x="428" y="190" width="156" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="428" y="190" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="506" y="206" text-anchor="middle" class="box-label">MITRE ATLAS</text>
   <text x="506" y="218" text-anchor="middle" class="box-sub">AI adversarial threat mapping</text>
 
-  <!-- Box 5: NIST AI RMF (y=228) -->
-  <rect x="428" y="228" width="156" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="428" y="228" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="506" y="244" text-anchor="middle" class="box-label">NIST AI RMF</text>
   <text x="506" y="256" text-anchor="middle" class="box-sub">Risk management framework</text>
 
-  <!-- Box 6: Enforcement Engine (y=266) -->
-  <rect x="428" y="266" width="156" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="428" y="266" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="506" y="282" text-anchor="middle" class="box-label">Enforcement Engine</text>
   <text x="506" y="294" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
 
-  <!-- Box 7: Model Provenance (y=304) -->
-  <rect x="428" y="304" width="156" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="428" y="304" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="506" y="320" text-anchor="middle" class="box-label">Model Provenance</text>
   <text x="506" y="332" text-anchor="middle" class="box-sub">SHA-256 · Sigstore · HuggingFace</text>
 
-  <!-- Arrow: Analysis -> Output -->
-  <line x1="596" y1="227" x2="622" y2="227" stroke="#f47067" stroke-width="2" marker-end="url(#a3)"/>
+  <line x1="596" y1="227" x2="622" y2="227" stroke="#cf222e" stroke-width="2" marker-end="url(#a3)"/>
 
   <!-- ═══ Phase 4: Output (x=626, w=140) ═══ -->
-  <rect x="626" y="44" width="140" height="366" rx="8" fill="#f6f8fa" stroke="#3fb950" stroke-width="1" opacity="0.8"/>
-  <text x="696" y="60" text-anchor="middle" class="section-title" fill="#3fb950">OUTPUT</text>
+  <rect x="626" y="44" width="140" height="366" rx="8" fill="#f6f8fa" stroke="#1a7f37" stroke-width="1" opacity="0.8"/>
+  <text x="696" y="60" text-anchor="middle" class="section-title" fill="#1a7f37">OUTPUT</text>
 
-  <!-- Box 1: Console + HTML (y=68) -->
-  <rect x="638" y="68" width="116" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="638" y="68" width="116" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="696" y="84" text-anchor="middle" class="box-label">Console + HTML</text>
   <text x="696" y="96" text-anchor="middle" class="box-sub">Rich tables + dashboard</text>
 
-  <!-- Box 2: SARIF (y=106) -->
-  <rect x="638" y="106" width="116" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="638" y="106" width="116" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="696" y="122" text-anchor="middle" class="box-label">SARIF</text>
   <text x="696" y="134" text-anchor="middle" class="box-sub">GitHub Security tab</text>
 
-  <!-- Box 3: CycloneDX 1.6 (y=144) -->
-  <rect x="638" y="144" width="116" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="638" y="144" width="116" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="696" y="160" text-anchor="middle" class="box-label">CycloneDX 1.6</text>
   <text x="696" y="172" text-anchor="middle" class="box-sub">AI-BOM standard</text>
 
-  <!-- Box 4: SPDX 3.0 (y=182) -->
-  <rect x="638" y="182" width="116" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="638" y="182" width="116" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="696" y="198" text-anchor="middle" class="box-label">SPDX 3.0</text>
   <text x="696" y="210" text-anchor="middle" class="box-sub">License + provenance</text>
 
-  <!-- Box 5: JSON + Mermaid (y=220) -->
-  <rect x="638" y="220" width="116" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
-  <text x="696" y="236" text-anchor="middle" class="box-label">JSON + Mermaid</text>
-  <text x="696" y="248" text-anchor="middle" class="box-sub">Machine-readable</text>
+  <rect x="638" y="220" width="116" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="696" y="236" text-anchor="middle" class="box-label">JSON + Graph</text>
+  <text x="696" y="248" text-anchor="middle" class="box-sub">Cytoscape + React Flow</text>
 
-  <!-- Box 6: REST API (y=258) -->
-  <rect x="638" y="258" width="116" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="638" y="258" width="116" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="696" y="274" text-anchor="middle" class="box-label">REST API</text>
   <text x="696" y="286" text-anchor="middle" class="box-sub">FastAPI on :8422</text>
 
-  <!-- Arrow: Output -> Interfaces -->
-  <line x1="766" y1="227" x2="792" y2="227" stroke="#3fb950" stroke-width="2" marker-end="url(#a4)"/>
+  <line x1="766" y1="227" x2="792" y2="227" stroke="#1a7f37" stroke-width="2" marker-end="url(#a4)"/>
 
   <!-- ═══ Phase 5: Interfaces (x=796, w=148) ═══ -->
-  <rect x="796" y="44" width="148" height="366" rx="8" fill="#f6f8fa" stroke="#a371f7" stroke-width="1" opacity="0.8"/>
-  <text x="870" y="60" text-anchor="middle" class="section-title" fill="#a371f7">INTERFACES</text>
+  <rect x="796" y="44" width="148" height="366" rx="8" fill="#f6f8fa" stroke="#8250df" stroke-width="1" opacity="0.8"/>
+  <text x="870" y="60" text-anchor="middle" class="section-title" fill="#8250df">INTERFACES</text>
 
-  <!-- Box 1: CLI (y=68) -->
-  <rect x="808" y="68" width="124" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="808" y="68" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="84" text-anchor="middle" class="box-label">CLI</text>
   <text x="870" y="96" text-anchor="middle" class="box-sub">pip install agent-bom</text>
 
-  <!-- Box 2: MCP Server (y=106) -->
-  <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
   <text x="870" y="134" text-anchor="middle" class="box-sub">13 tools · stdio/SSE</text>
 
-  <!-- Box 3: GitHub Action (y=144) -->
-  <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>
   <text x="870" y="172" text-anchor="middle" class="box-sub">CI/CD integration</text>
 
-  <!-- Box 4: Cloud UI (y=182) -->
-  <rect x="808" y="182" width="124" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="808" y="182" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="198" text-anchor="middle" class="box-label">Cloud UI</text>
   <text x="870" y="210" text-anchor="middle" class="box-sub">Next.js dashboard</text>
 
-  <!-- Box 5: Snowflake (y=220) -->
-  <rect x="808" y="220" width="124" height="32" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="808" y="220" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="236" text-anchor="middle" class="box-label">Snowflake</text>
   <text x="870" y="248" text-anchor="middle" class="box-sub">Streamlit + Native App</text>
 
-  <!-- ═══ Trust Principles bar (y=426) ═══ -->
-  <rect x="16" y="426" width="928" height="36" rx="6" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1"/>
-  <text x="480" y="442" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#656d76" letter-spacing="0.05em">TRUST PRINCIPLES</text>
-  <text x="480" y="456" text-anchor="middle" class="footer">Read-only  ·  Agentless  ·  Never writes configs  ·  Never runs MCP servers  ·  Never stores credentials  ·  Sigstore-signed releases</text>
+  <!-- ═══ Trust Principles (y=420, h=56) — enlarged ═══ -->
+  <rect x="16" y="420" width="928" height="56" rx="8" fill="#f6f8fa" stroke="#1a7f37" stroke-width="1" opacity="0.6"/>
+  <text x="480" y="438" text-anchor="middle" class="trust-label" fill="#1a7f37">TRUST PRINCIPLES</text>
+  <rect x="48" y="446" width="90" height="22" rx="11" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="93" y="460" text-anchor="middle" class="trust-pill">Read-only</text>
+  <rect x="150" y="446" width="90" height="22" rx="11" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="195" y="460" text-anchor="middle" class="trust-pill">Agentless</text>
+  <rect x="252" y="446" width="140" height="22" rx="11" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="322" y="460" text-anchor="middle" class="trust-pill">Never writes configs</text>
+  <rect x="404" y="446" width="150" height="22" rx="11" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="479" y="460" text-anchor="middle" class="trust-pill">Never runs MCP servers</text>
+  <rect x="566" y="446" width="160" height="22" rx="11" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="646" y="460" text-anchor="middle" class="trust-pill">Never stores credentials</text>
+  <rect x="738" y="446" width="130" height="22" rx="11" fill="#ffffff" stroke="#1a7f37" stroke-width="1" opacity="0.5"/>
+  <text x="803" y="460" text-anchor="middle" class="trust-pill">Sigstore-signed</text>
 
-  <!-- ═══ Data Flow legend bar (y=468) ═══ -->
-  <rect x="16" y="468" width="928" height="42" rx="6" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1"/>
-  <text x="480" y="483" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9.5" font-weight="700" fill="#656d76" letter-spacing="0.05em">DATA FLOW</text>
+  <!-- ═══ Data Flow (y=486, h=120) — expanded with 3 zones ═══ -->
+  <rect x="16" y="486" width="928" height="120" rx="8" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="480" y="504" text-anchor="middle" class="flow-title">DATA FLOW</text>
 
-  <!-- Flow arrows in legend -->
-  <line x1="100" y1="500" x2="130" y2="500" stroke="#58a6ff" stroke-width="2" marker-end="url(#a1)"/>
-  <text x="138" y="504" class="footer" fill="#58a6ff">Discover</text>
+  <rect x="32" y="514" width="260" height="78" rx="6" fill="#ffffff" stroke="#0969da" stroke-width="1" opacity="0.5"/>
+  <text x="162" y="530" text-anchor="middle" class="flow-zone" fill="#0969da">YOUR MACHINE (READ-ONLY)</text>
+  <text x="162" y="546" text-anchor="middle" class="flow-detail">Extracted: server names, package names,</text>
+  <text x="162" y="558" text-anchor="middle" class="flow-detail">env var names, tool lists</text>
+  <text x="162" y="574" text-anchor="middle" class="flow-detail" fill="#cf222e">Never extracted: secrets, tokens, passwords</text>
+  <text x="162" y="586" text-anchor="middle" class="flow-detail" fill="#1a7f37">--dry-run previews everything first</text>
 
-  <line x1="220" y1="500" x2="250" y2="500" stroke="#d29922" stroke-width="2" marker-end="url(#a2)"/>
-  <text x="258" y="504" class="footer" fill="#d29922">Enrich</text>
+  <line x1="296" y1="553" x2="326" y2="553" stroke="#0969da" stroke-width="2" marker-end="url(#a1)"/>
 
-  <line x1="330" y1="500" x2="360" y2="500" stroke="#f47067" stroke-width="2" marker-end="url(#a3)"/>
-  <text x="368" y="504" class="footer" fill="#f47067">Analyze</text>
+  <rect x="330" y="514" width="280" height="78" rx="6" fill="#ffffff" stroke="#bf8700" stroke-width="1" opacity="0.5"/>
+  <text x="470" y="530" text-anchor="middle" class="flow-zone" fill="#bf8700">AGENT-BOM ENGINE</text>
+  <text x="470" y="546" text-anchor="middle" class="flow-detail">Sends to APIs: package names + versions only</text>
+  <text x="470" y="560" text-anchor="middle" class="flow-detail">Blast radius · Threat models · Enforcement</text>
+  <text x="470" y="574" text-anchor="middle" class="flow-detail">OWASP + ATLAS + NIST framework tagging</text>
+  <text x="470" y="586" text-anchor="middle" class="flow-detail" fill="#cf222e">No credentials leave your machine</text>
 
-  <line x1="440" y1="500" x2="470" y2="500" stroke="#3fb950" stroke-width="2" marker-end="url(#a4)"/>
-  <text x="478" y="504" class="footer" fill="#3fb950">Report</text>
+  <line x1="614" y1="553" x2="644" y2="553" stroke="#bf8700" stroke-width="2" marker-end="url(#a2)"/>
 
-  <text x="740" y="504" text-anchor="middle" class="footer">MCP Configs -> OSV + NVD + EPSS + KEV -> OWASP + ATLAS -> SARIF / CycloneDX / SPDX</text>
+  <rect x="648" y="514" width="280" height="78" rx="6" fill="#ffffff" stroke="#cf222e" stroke-width="1" opacity="0.5"/>
+  <text x="788" y="530" text-anchor="middle" class="flow-zone" fill="#cf222e">PUBLIC APIs (READ-ONLY)</text>
+  <text x="788" y="546" text-anchor="middle" class="flow-detail">OSV.dev · NVD · FIRST EPSS · CISA KEV</text>
+  <text x="788" y="560" text-anchor="middle" class="flow-detail">GitHub Security Advisories · NVIDIA CSAF</text>
+  <text x="788" y="574" text-anchor="middle" class="flow-detail">Receives: package name + version + ecosystem</text>
+  <text x="788" y="586" text-anchor="middle" class="flow-detail" fill="#1a7f37">Returns: CVEs, CVSS, EPSS, KEV, fix versions</text>
 </svg>

--- a/src/agent_bom/owasp.py
+++ b/src/agent_bom/owasp.py
@@ -1,9 +1,9 @@
 """OWASP Top 10 for LLM Applications — tag blast radius findings.
 
 Maps agent-bom findings to the OWASP Top 10 for Large Language Model
-Applications (2025 edition). Every finding gets at minimum LLM05
-(Supply Chain Vulnerabilities) since any package CVE in an AI agent's
-dependency tree is by definition a supply chain risk.
+Applications (2025 edition). LLM05 (Supply Chain Vulnerabilities) is
+applied when the package is an AI/ML framework or shares an MCP server
+with one — not unconditionally.
 
 Reference: https://owasp.org/www-project-top-10-for-large-language-model-applications/
 """
@@ -35,42 +35,79 @@ OWASP_LLM_TOP10: dict[str, str] = {
 }
 
 # Package names associated with AI/ML frameworks
-_AI_PACKAGES: frozenset[str] = frozenset({
-    "torch", "torchvision", "torchaudio",
-    "transformers", "diffusers", "tokenizers",
-    "langchain", "langchain-core", "langchain-community",
-    "langchain-openai", "langchain-anthropic",
-    "openai", "anthropic", "google-generativeai",
-    "crewai", "autogen", "pyautogen",
-    "haystack", "haystack-ai",
-    "llama-index", "llama-cpp-python",
-    "dspy-ai", "guidance",
-    "semantic-kernel",
-    "pydantic-ai",
-    # Vector stores / RAG backends
-    "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
-    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
-    "pgvector", "lancedb",
-    # Embedding models
-    "sentence-transformers",
-})
+_AI_PACKAGES: frozenset[str] = frozenset(
+    {
+        "torch",
+        "torchvision",
+        "torchaudio",
+        "transformers",
+        "diffusers",
+        "tokenizers",
+        "langchain",
+        "langchain-core",
+        "langchain-community",
+        "langchain-openai",
+        "langchain-anthropic",
+        "openai",
+        "anthropic",
+        "google-generativeai",
+        "crewai",
+        "autogen",
+        "pyautogen",
+        "haystack",
+        "haystack-ai",
+        "llama-index",
+        "llama-cpp-python",
+        "dspy-ai",
+        "guidance",
+        "semantic-kernel",
+        "pydantic-ai",
+        # Vector stores / RAG backends
+        "chromadb",
+        "pinecone-client",
+        "weaviate-client",
+        "qdrant-client",
+        "faiss-cpu",
+        "faiss-gpu",
+        "pymilvus",
+        "milvus",
+        "pgvector",
+        "lancedb",
+        # Embedding models
+        "sentence-transformers",
+    }
+)
 
 # Packages directly involved in training data handling and fine-tuning.
 # CVEs here risk training data poisoning (LLM03).
-_TRAINING_DATA_PACKAGES: frozenset[str] = frozenset({
-    "datasets", "huggingface-hub", "tokenizers",
-    "transformers", "diffusers", "accelerate", "trl",
-    "sentence-transformers", "peft",
-    "torch", "torchvision", "torchaudio",
-    "tensorflow", "tensorflow-gpu",
-    "safetensors", "optimum",
-})
+_TRAINING_DATA_PACKAGES: frozenset[str] = frozenset(
+    {
+        "datasets",
+        "huggingface-hub",
+        "tokenizers",
+        "transformers",
+        "diffusers",
+        "accelerate",
+        "trl",
+        "sentence-transformers",
+        "peft",
+        "torch",
+        "torchvision",
+        "torchaudio",
+        "tensorflow",
+        "tensorflow-gpu",
+        "safetensors",
+        "optimum",
+    }
+)
 
 # Severity levels considered high-risk for agency/AI-poisoning checks
-_HIGH_RISK_SEVERITIES: frozenset[Severity] = frozenset({
-    Severity.CRITICAL,
-    Severity.HIGH,
-})
+_HIGH_RISK_SEVERITIES: frozenset[Severity] = frozenset(
+    {
+        Severity.CRITICAL,
+        Severity.HIGH,
+    }
+)
 
 
 # ─── Tagger ───────────────────────────────────────────────────────────────────
@@ -80,14 +117,18 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     """Return sorted OWASP LLM Top 10 codes applicable to this blast radius.
 
     Rules applied:
-    - LLM05: Always — any package CVE in an AI agent is a supply chain risk.
+    - LLM05: Package is an AI/ML framework or shares a server with one.
     - LLM06: Credential env vars are exposed alongside a vulnerable package.
     - LLM02: A reachable tool has EXECUTE capability (code injection risk).
     - LLM07: A reachable tool has READ capability (context leakage risk).
     - LLM08: Server has >5 tools AND severity is CRITICAL/HIGH (excessive agency).
     - LLM04: Vulnerable package is a core AI/ML framework AND severity is HIGH+.
     """
-    tags: set[str] = {"LLM05"}  # always — supply chain vulnerability
+    tags: set[str] = set()
+
+    # LLM05 — supply chain vulnerability: only when package is AI-related
+    if br.package.name.lower() in _AI_PACKAGES or br.package.name.lower() in _TRAINING_DATA_PACKAGES:
+        tags.add("LLM05")
 
     # LLM06 — sensitive information disclosure via credential exposure
     if br.exposed_credentials:
@@ -102,10 +143,7 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
             tags.add("LLM07")
 
     # LLM08 — excessive agency: many tools + high-severity CVE
-    if (
-        len(br.exposed_tools) > 5
-        and br.vulnerability.severity in _HIGH_RISK_SEVERITIES
-    ):
+    if len(br.exposed_tools) > 5 and br.vulnerability.severity in _HIGH_RISK_SEVERITIES:
         tags.add("LLM08")
 
     # LLM03 — training data poisoning: training/dataset package with CVE
@@ -113,10 +151,7 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
         tags.add("LLM03")
 
     # LLM04 — data/model poisoning: AI framework package with high CVE
-    if (
-        br.package.name.lower() in _AI_PACKAGES
-        and br.vulnerability.severity in _HIGH_RISK_SEVERITIES
-    ):
+    if br.package.name.lower() in _AI_PACKAGES and br.vulnerability.severity in _HIGH_RISK_SEVERITIES:
         tags.add("LLM04")
 
     return sorted(tags)

--- a/tests/test_false_positives.py
+++ b/tests/test_false_positives.py
@@ -1,0 +1,208 @@
+"""Tests for false positive reduction — tool dedup, credential dedup, OWASP tagging."""
+
+from __future__ import annotations
+
+from agent_bom.models import (
+    BlastRadius,
+    MCPServer,
+    MCPTool,
+    Package,
+    Severity,
+    Vulnerability,
+)
+from agent_bom.owasp import tag_blast_radius
+
+
+def _vuln(vid: str = "CVE-2024-0001", severity: str = "high") -> Vulnerability:
+    return Vulnerability(id=vid, summary="test vulnerability", severity=Severity(severity))
+
+
+def _pkg(name: str = "express", version: str = "4.17.1", ecosystem: str = "npm") -> Package:
+    return Package(name=name, version=version, ecosystem=ecosystem)
+
+
+def _tool(name: str) -> MCPTool:
+    return MCPTool(name=name, description="")
+
+
+def _server(name: str, tools: list[MCPTool] | None = None, env: dict | None = None) -> MCPServer:
+    return MCPServer(name=name, tools=tools or [], env=env or {})
+
+
+class TestToolDeduplication:
+    """exposed_tools should be deduplicated by name across servers."""
+
+    def test_same_tool_from_multiple_servers(self):
+        """Same tool name from 3 servers should appear once in blast radius."""
+        tool = _tool("read_file")
+        servers = [
+            _server("srv1", tools=[tool]),
+            _server("srv2", tools=[MCPTool(name="read_file", description="different desc")]),
+            _server("srv3", tools=[tool]),
+        ]
+        br = BlastRadius(
+            vulnerability=_vuln(),
+            package=_pkg(),
+            affected_servers=servers,
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[],  # will be filled by scanner, but test the model
+        )
+        # Simulate what the fixed scanner does: dedup by name
+        all_tools = []
+        for s in servers:
+            all_tools.extend(s.tools)
+
+        seen: set[str] = set()
+        deduped = []
+        for t in all_tools:
+            if t.name not in seen:
+                seen.add(t.name)
+                deduped.append(t)
+
+        assert len(all_tools) == 3
+        assert len(deduped) == 1
+        assert deduped[0].name == "read_file"
+
+    def test_different_tools_preserved(self):
+        """Distinct tool names should all be preserved."""
+        tools = [_tool("read_file"), _tool("write_file"), _tool("execute")]
+        seen: set[str] = set()
+        deduped = []
+        for t in tools:
+            if t.name not in seen:
+                seen.add(t.name)
+                deduped.append(t)
+        assert len(deduped) == 3
+
+
+class TestCredentialDedup:
+    """Credential lists should be consistent between message and score."""
+
+    def test_same_cred_from_multiple_servers(self):
+        """Same credential name from 2 servers should count once."""
+        creds = ["API_KEY", "API_KEY", "DB_PASSWORD"]
+        deduped = list(set(creds))
+        assert len(deduped) == 2
+        assert "API_KEY" in deduped
+        assert "DB_PASSWORD" in deduped
+
+
+class TestOwaspLLM05Tagging:
+    """LLM05 should only be applied to AI/ML packages, not all findings."""
+
+    def test_non_ai_package_no_llm05(self):
+        """A generic npm package should NOT get LLM05."""
+        br = BlastRadius(
+            vulnerability=_vuln(),
+            package=_pkg("express", "4.17.1", "npm"),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[],
+        )
+        br.calculate_risk_score()
+        tags = tag_blast_radius(br)
+        assert "LLM05" not in tags
+
+    def test_ai_package_gets_llm05(self):
+        """An AI framework package should get LLM05."""
+        br = BlastRadius(
+            vulnerability=_vuln(),
+            package=_pkg("langchain", "0.1.0", "pypi"),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[],
+        )
+        br.calculate_risk_score()
+        tags = tag_blast_radius(br)
+        assert "LLM05" in tags
+
+    def test_training_package_gets_llm05(self):
+        """A training data package should get LLM05."""
+        br = BlastRadius(
+            vulnerability=_vuln(),
+            package=_pkg("transformers", "4.30.0", "pypi"),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[],
+        )
+        br.calculate_risk_score()
+        tags = tag_blast_radius(br)
+        assert "LLM05" in tags
+
+    def test_vector_store_gets_llm05(self):
+        """A vector store package should get LLM05."""
+        br = BlastRadius(
+            vulnerability=_vuln(),
+            package=_pkg("chromadb", "0.4.0", "pypi"),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[],
+        )
+        br.calculate_risk_score()
+        tags = tag_blast_radius(br)
+        assert "LLM05" in tags
+
+    def test_cred_exposure_gets_llm06(self):
+        """Credential exposure should trigger LLM06 regardless of package type."""
+        br = BlastRadius(
+            vulnerability=_vuln(),
+            package=_pkg("express", "4.17.1", "npm"),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=["API_KEY"],
+            exposed_tools=[],
+        )
+        br.calculate_risk_score()
+        tags = tag_blast_radius(br)
+        assert "LLM06" in tags
+
+
+class TestRiskScoreNotInflated:
+    """Risk scores should not be inflated by tool/credential duplication."""
+
+    def test_tool_factor_capped(self):
+        """tool_factor should be capped at 1.0 regardless of tool count."""
+        br = BlastRadius(
+            vulnerability=_vuln(severity="critical"),
+            package=_pkg(),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[_tool(f"tool_{i}") for i in range(20)],
+        )
+        br.calculate_risk_score()
+        # tool_factor = min(20 * 0.1, 1.0) = 1.0
+        # base(8.0) + agent(0.5) + cred(0) + tool(1.0) = 9.5
+        assert br.risk_score <= 10.0
+
+    def test_deduped_tools_lower_score(self):
+        """Deduped tools should give lower score than inflated count."""
+        # With 20 duplicate tools (inflated)
+        br_inflated = BlastRadius(
+            vulnerability=_vuln(severity="medium"),
+            package=_pkg(),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[_tool("read_file") for _ in range(20)],
+        )
+        br_inflated.calculate_risk_score()
+
+        # With 1 unique tool (deduped)
+        br_deduped = BlastRadius(
+            vulnerability=_vuln(severity="medium"),
+            package=_pkg(),
+            affected_servers=[],
+            affected_agents=["agent1"],
+            exposed_credentials=[],
+            exposed_tools=[_tool("read_file")],
+        )
+        br_deduped.calculate_risk_score()
+
+        # Deduped should have lower or equal risk score
+        assert br_deduped.risk_score <= br_inflated.risk_score


### PR DESCRIPTION
## Summary
- **Tool deduplication**: `exposed_tools` deduplicated by name across servers — prevents inflated blast radius scores
- **Registry caching**: Registry tool lookups cached per server name, no longer recreated per vulnerability iteration
- **Credential consistency**: Credentials deduplicated before `ai_risk_context` message construction (was only deduped for scoring)
- **Conditional LLM05**: OWASP LLM05 (Supply Chain Vulnerabilities) now only tags AI/ML framework packages — was unconditionally applied to 100% of findings
- **Architecture SVG redesign**: Trust Principles expanded with pill badges, Data Flow section redesigned with 3-zone layout (Your Machine → Engine → Public APIs)
- **README visualization section**: Leads with React Flow dashboard (Agent Mesh, Attack Flow, Supply Chain Lineage), repositions Mermaid as CLI convenience format
- **10 new regression tests** in `test_false_positives.py` covering tool dedup, credential dedup, OWASP tagging, and risk score inflation

## Test plan
- [x] All 1641 tests pass (`pytest tests/ -x -q`)
- [x] Ruff lint clean
- [x] Verify LLM05 only triggers for AI packages (langchain, transformers, chromadb) not generic packages (express, glob)
- [x] Verify deduped tools produce lower risk scores than inflated counts
- [x] Architecture SVG renders with readable trust + data flow sections