### PR TITLE
fix: align outputs, docs, diagrams with 6-framework / 14-tool state

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 13 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 14 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f Dockerfile.sse -t agent-bom-sse .

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -79,7 +79,7 @@ git add servers/agent-bom.json
 git commit -m "feat: add agent-bom MCP server"
 git push origin add-agent-bom
 gh pr create --title "feat: add agent-bom security scanner" \
-  --body "Adds agent-bom — AI supply chain security scanner with 13 MCP tools."
+  --body "Adds agent-bom — AI supply chain security scanner with 14 MCP tools."
 ```
 
 ### Verification

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 | **MCP tool reachability** | — | Which tools an attacker reaches post-exploit |
 | **Privilege detection** | — | runs_as_root, shell_access, container_privileged, per-tool permissions |
 | **Enterprise remediation** | — | Named assets, impact percentages, risk narratives |
-| **Quad-framework compliance** | — | OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF |
+| **6-framework compliance** | — | OWASP Agentic Top 10 + OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF + EU AI Act |
 | **Malicious package detection** | — | OSV MAL- prefix + typosquat heuristics (57 popular packages) |
 | **OpenSSF Scorecard enrichment** | — | Package health scores from api.securityscorecards.dev |
 | **Tool poisoning detection** | — | Description injection, capability combos, CVE exposure, drift |
@@ -192,14 +192,16 @@ Every MCP server is assessed for privilege escalation risk:
 
 Privilege levels: **critical** (privileged container, CAP_SYS_ADMIN) → **high** (root, shell) → **medium** (fs write, network) → **low** (read-only).
 
-### Quad-framework compliance mapping
+### 6-framework compliance mapping
 
-Every finding is tagged against four frameworks simultaneously:
+Every finding is tagged against six frameworks simultaneously:
 
+- **OWASP Agentic Top 10** — ASI01 through ASI10 (agent autonomy, tool misuse, spawn persistence)
 - **OWASP LLM Top 10** — LLM01 through LLM10 (7 categories triggered)
 - **OWASP MCP Top 10** — MCP01 through MCP10 (8 categories triggered) — token exposure, tool poisoning, supply chain, shadow servers
 - **MITRE ATLAS** — AML.T0010, AML.T0043, AML.T0051, etc. (9 techniques mapped)
 - **NIST AI RMF 1.0** — Govern, Map, Measure, Manage (12 subcategories mapped)
+- **EU AI Act** — ART-5 through ART-17 (prohibited practices, high-risk classification, cybersecurity)
 
 ### Enterprise remediation
 
@@ -419,8 +421,9 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 | `GET /v1/scan/{id}` | Results + status |
 | `GET /v1/scan/{id}/attack-flow` | Per-CVE blast radius graph |
 | `GET /v1/registry` | 427+ server registry |
-| `GET /v1/compliance` | Full 4-framework compliance posture |
-| `GET /v1/compliance/{framework}` | Single framework (owasp-llm, owasp-mcp, atlas, nist) |
+| `GET /v1/compliance` | Full 6-framework compliance posture |
+| `GET /v1/compliance/{framework}` | Single framework (owasp-llm, owasp-mcp, owasp-agentic, atlas, nist, eu-ai-act) |
+| `POST /v1/traces` | OpenTelemetry trace ingestion + vulnerable tool call flagging |
 | `GET /v1/malicious/check` | Malicious package / typosquat check |
 
 ### MCP Server
@@ -431,7 +434,7 @@ agent-bom mcp-server                    # stdio
 agent-bom mcp-server --transport sse    # remote
 ```
 
-13 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`
+14 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`, `marketplace_check`
 
 ### Cloud UI
 
@@ -439,7 +442,7 @@ agent-bom mcp-server --transport sse    # remote
 cd ui && npm install && npm run dev   # http://localhost:3000
 ```
 
-13-section Next.js dashboard:
+14-section Next.js dashboard:
 
 | Page | Description |
 |------|-------------|
@@ -447,7 +450,7 @@ cd ui && npm install && npm run dev   # http://localhost:3000
 | Scan | Enterprise scan form with cloud options |
 | Vulnerabilities | CVE browser with severity/EPSS/KEV filters |
 | Agents | Fleet registry + lifecycle state management |
-| Compliance | 4-framework compliance posture (OWASP, ATLAS, NIST) |
+| Compliance | 6-framework compliance posture (OWASP Agentic, OWASP LLM, OWASP MCP, ATLAS, NIST, EU AI Act) |
 | Lineage Graph | Interactive supply chain graph — dagre layout, 7 node types, filter panel |
 | Agent Mesh | Cross-agent topology — shared server detection, credential blast radius, tool overlap |
 | Gateway | Runtime MCP policy rules + audit log |
@@ -455,6 +458,7 @@ cd ui && npm install && npm run dev   # http://localhost:3000
 | Fleet | Agent trust scoring + fleet management |
 | Activity | Agent activity timeline + AI observability |
 | Governance | Snowflake access, privileges, data classification |
+| Traces | OpenTelemetry trace ingestion + vulnerable tool call flagging |
 | Jobs | Background scan job management |
 
 ### Snowflake Deployment
@@ -544,9 +548,17 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - [x] Runtime MCP proxy — opt-in stdio proxy (`agent-bom proxy`) wraps individual MCP server commands for traffic interception; requires per-server client reconfiguration
 - [x] Enterprise integrations — Jira, Slack, Vanta, Drata
 - [x] Runtime sidecar Docker container — `Dockerfile.runtime` + Docker Compose for MCP proxy deployment
+- [x] EU AI Act compliance mapping — ART-5 through ART-17 risk classification
+- [x] OWASP Agentic Top 10 — ASI01 through ASI10 agent-specific risk tagging
+- [x] Marketplace trust check — `marketplace_check` MCP tool for pre-install validation
+- [x] OpenTelemetry trace ingestion — `POST /v1/traces` for vulnerable tool call flagging
+- [x] CMMC/FedRAMP compliance evidence export — `--compliance-export` ZIP bundles
+- [x] Agent spawn tree visualization — parent-child delegation chains
+- [x] RSP v3.0 alignment badge — Anthropic Responsible Scaling Policy compliance indicator
+- [x] Claude Code config security scanner — Check Point CVE vector detection
+- [x] Over-permission analyzer — mission profile enforcement per agent type
 
 **Planned:**
-- [ ] EU AI Act compliance mapping
 - [ ] CIS AI benchmarks
 - [ ] License compliance engine
 - [ ] Workflow engine scanning (n8n, Zapier, Make)

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -125,11 +125,19 @@
   <text x="506" y="256" text-anchor="middle" class="box-sub">Risk management framework</text>
 
   <rect x="428" y="266" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="506" y="282" text-anchor="middle" class="box-label">Enforcement Engine</text>
-  <text x="506" y="294" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
+  <text x="506" y="282" text-anchor="middle" class="box-label">OWASP Agentic Top 10</text>
+  <text x="506" y="294" text-anchor="middle" class="box-sub">ASI01-ASI10 agent risks</text>
 
   <rect x="428" y="304" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="506" y="320" text-anchor="middle" class="box-label">Model Provenance</text>
+  <text x="506" y="320" text-anchor="middle" class="box-label">EU AI Act</text>
+  <text x="506" y="332" text-anchor="middle" class="box-sub">ART-5 through ART-17</text>
+
+  <rect x="428" y="342" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="506" y="358" text-anchor="middle" class="box-label">Enforcement Engine</text>
+  <text x="506" y="370" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
+
+  <rect x="428" y="380" width="156" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <text x="506" y="396" text-anchor="middle" class="box-label">Model Provenance</text>
   <text x="506" y="332" text-anchor="middle" class="box-sub">SHA-256 · Sigstore · HuggingFace</text>
 
   <line x1="596" y1="227" x2="622" y2="227" stroke="#f47067" stroke-width="2" marker-end="url(#a3)"/>
@@ -174,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">13 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">14 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>
@@ -225,7 +233,7 @@
   <text x="470" y="530" text-anchor="middle" class="flow-zone" fill="#d29922">AGENT-BOM ENGINE</text>
   <text x="470" y="546" text-anchor="middle" class="flow-detail" fill="#8b949e">Sends to APIs: package names + versions only</text>
   <text x="470" y="560" text-anchor="middle" class="flow-detail" fill="#8b949e">Blast radius · Threat models · Enforcement</text>
-  <text x="470" y="574" text-anchor="middle" class="flow-detail" fill="#8b949e">OWASP + ATLAS + NIST framework tagging</text>
+  <text x="470" y="574" text-anchor="middle" class="flow-detail" fill="#8b949e">OWASP + ATLAS + NIST + EU AI Act framework tagging</text>
   <text x="470" y="586" text-anchor="middle" class="flow-detail" fill="#f47067">No credentials leave your machine</text>
 
   <!-- Arrow: Engine → APIs -->

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -125,11 +125,19 @@
   <text x="506" y="256" text-anchor="middle" class="box-sub">Risk management framework</text>
 
   <rect x="428" y="266" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
-  <text x="506" y="282" text-anchor="middle" class="box-label">Enforcement Engine</text>
-  <text x="506" y="294" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
+  <text x="506" y="282" text-anchor="middle" class="box-label">OWASP Agentic Top 10</text>
+  <text x="506" y="294" text-anchor="middle" class="box-sub">ASI01-ASI10 agent risks</text>
 
   <rect x="428" y="304" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
-  <text x="506" y="320" text-anchor="middle" class="box-label">Model Provenance</text>
+  <text x="506" y="320" text-anchor="middle" class="box-label">EU AI Act</text>
+  <text x="506" y="332" text-anchor="middle" class="box-sub">ART-5 through ART-17</text>
+
+  <rect x="428" y="342" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="506" y="358" text-anchor="middle" class="box-label">Enforcement Engine</text>
+  <text x="506" y="370" text-anchor="middle" class="box-sub">Tool poisoning + policy gates</text>
+
+  <rect x="428" y="380" width="156" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <text x="506" y="396" text-anchor="middle" class="box-label">Model Provenance</text>
   <text x="506" y="332" text-anchor="middle" class="box-sub">SHA-256 · Sigstore · HuggingFace</text>
 
   <line x1="596" y1="227" x2="622" y2="227" stroke="#cf222e" stroke-width="2" marker-end="url(#a3)"/>
@@ -174,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">13 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">14 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>
@@ -221,7 +229,7 @@
   <text x="470" y="530" text-anchor="middle" class="flow-zone" fill="#bf8700">AGENT-BOM ENGINE</text>
   <text x="470" y="546" text-anchor="middle" class="flow-detail">Sends to APIs: package names + versions only</text>
   <text x="470" y="560" text-anchor="middle" class="flow-detail">Blast radius · Threat models · Enforcement</text>
-  <text x="470" y="574" text-anchor="middle" class="flow-detail">OWASP + ATLAS + NIST framework tagging</text>
+  <text x="470" y="574" text-anchor="middle" class="flow-detail">OWASP + ATLAS + NIST + EU AI Act framework tagging</text>
   <text x="470" y="586" text-anchor="middle" class="flow-detail" fill="#cf222e">No credentials leave your machine</text>
 
   <line x1="614" y1="553" x2="644" y2="553" stroke="#bf8700" stroke-width="2" marker-end="url(#a2)"/>

--- a/docs/images/before-after-dark.svg
+++ b/docs/images/before-after-dark.svg
@@ -85,7 +85,7 @@
   </g>
   <g transform="translate(484, 270)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.4"/>
-    <text x="18" y="12" class="bullet">4 compliance frameworks auto-mapped</text>
+    <text x="18" y="12" class="bullet">6 compliance frameworks auto-mapped</text>
   </g>
   <g transform="translate(484, 308)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.4"/>

--- a/docs/images/before-after-light.svg
+++ b/docs/images/before-after-light.svg
@@ -85,7 +85,7 @@
   </g>
   <g transform="translate(484, 270)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.35"/>
-    <text x="18" y="12" class="bullet">4 compliance frameworks auto-mapped</text>
+    <text x="18" y="12" class="bullet">6 compliance frameworks auto-mapped</text>
   </g>
   <g transform="translate(484, 308)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.35"/>

--- a/docs/images/blast-radius-dark.svg
+++ b/docs/images/blast-radius-dark.svg
@@ -157,7 +157,7 @@
 
   <text x="584" y="392" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#a78bfa">6</text>
   <text x="608" y="388" class="node-name" fill="#8b949e">threat categories</text>
-  <text x="608" y="400" class="node-detail">4 OWASP LLM + 2 MITRE ATLAS</text>
+  <text x="608" y="400" class="node-detail">4 OWASP LLM + 2 ATLAS + ASI + EU</text>
 
   <!-- Remediation callout -->
   <rect x="580" y="406" width="260" height="2" rx="1" fill="#3fb950" opacity="0.5"/>

--- a/docs/images/blast-radius-light.svg
+++ b/docs/images/blast-radius-light.svg
@@ -150,7 +150,7 @@
 
   <text x="584" y="392" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#8250df">6</text>
   <text x="608" y="388" class="node-name" fill="#656d76">threat categories</text>
-  <text x="608" y="400" class="node-detail">4 OWASP LLM + 2 MITRE ATLAS</text>
+  <text x="608" y="400" class="node-detail">4 OWASP LLM + 2 ATLAS + ASI + EU</text>
 
   <rect x="580" y="406" width="260" height="2" rx="1" fill="#1a7f37" opacity="0.4"/>
   <text x="710" y="424" text-anchor="middle" font-family="'SF Mono', monospace" font-size="9" font-weight="600" fill="#1a7f37">FIX: upgrade better-sqlite3 → 11.7.0</text>

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -167,7 +167,7 @@
       <rect width="286" height="48" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6e7681">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">13 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">14 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -166,7 +166,7 @@
       <rect width="286" height="48" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#94a3b8">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">13 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">14 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/integration-architecture-dark.svg
+++ b/docs/images/integration-architecture-dark.svg
@@ -109,7 +109,7 @@
     </g>
     <!-- Tag pill -->
     <rect x="16" y="158" width="132" height="22" rx="11" fill="#bc8cff" opacity="0.12"/>
-    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#bc8cff">4 compliance frameworks</text>
+    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#bc8cff">6 compliance frameworks</text>
   </g>
 
   <!-- Arrow 3→4 -->
@@ -197,7 +197,7 @@
   <g transform="translate(40, 362)">
     <rect width="800" height="36" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
     <text x="400" y="15" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e" letter-spacing="0.06em">COMPLIANCE</text>
-    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM Top 10  ·  OWASP MCP Top 10  ·  MITRE ATLAS  ·  NIST AI RMF</text>
+    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM  ·  OWASP MCP  ·  OWASP Agentic  ·  MITRE ATLAS  ·  NIST AI RMF  ·  EU AI Act</text>
   </g>
 
   <!-- Footer -->

--- a/docs/images/integration-architecture-light.svg
+++ b/docs/images/integration-architecture-light.svg
@@ -109,7 +109,7 @@
     </g>
     <!-- Tag pill -->
     <rect x="16" y="158" width="132" height="22" rx="11" fill="#bc8cff" opacity="0.1"/>
-    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#8250df">4 compliance frameworks</text>
+    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#8250df">6 compliance frameworks</text>
   </g>
 
   <!-- Arrow 3→4 -->
@@ -197,7 +197,7 @@
   <g transform="translate(40, 362)">
     <rect width="800" height="36" rx="8" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
     <text x="400" y="15" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#656d76" letter-spacing="0.06em">COMPLIANCE</text>
-    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM Top 10  ·  OWASP MCP Top 10  ·  MITRE ATLAS  ·  NIST AI RMF</text>
+    <text x="400" y="28" text-anchor="middle" class="footer">OWASP LLM  ·  OWASP MCP  ·  OWASP Agentic  ·  MITRE ATLAS  ·  NIST AI RMF  ·  EU AI Act</text>
   </g>
 
   <!-- Footer -->

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">13 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">14 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">13 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">14 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -155,5 +155,5 @@
   <!-- Footer -->
   <rect x="32" y="504" width="840" height="44" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
   <text x="450" y="522" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.05em">WHY agent-bom vs Wiz / Snyk / Prisma</text>
-  <text x="450" y="538" text-anchor="middle" class="note">Free &amp; open source  ·  AI-native threat models (OWASP LLM + ATLAS)  ·  MCP supply chain focus  ·  No cloud access needed  ·  Runs in your CI, your laptop, your air-gap</text>
+  <text x="450" y="538" text-anchor="middle" class="note">Free &amp; open source  ·  AI-native threat models (6 frameworks)  ·  MCP supply chain focus  ·  No cloud access needed  ·  Runs in your CI, your laptop, your air-gap</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -171,5 +171,5 @@
   <!-- Footer: key differentiators -->
   <rect x="32" y="504" width="840" height="44" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
   <text x="450" y="522" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#475569" letter-spacing="0.05em">WHY agent-bom vs Wiz / Snyk / Prisma</text>
-  <text x="450" y="538" text-anchor="middle" class="note">Free &amp; open source  ·  AI-native threat models (OWASP LLM + ATLAS)  ·  MCP supply chain focus  ·  No cloud access needed  ·  Runs in your CI, your laptop, your air-gap</text>
+  <text x="450" y="538" text-anchor="middle" class="note">Free &amp; open source  ·  AI-native threat models (6 frameworks)  ·  MCP supply chain focus  ·  No cloud access needed  ·  Runs in your CI, your laptop, your air-gap</text>
 </svg>

--- a/docs/images/workflow-dark.svg
+++ b/docs/images/workflow-dark.svg
@@ -81,9 +81,9 @@
   <line x1="568" y1="98" x2="668" y2="98" stroke="#30363d" stroke-width="0.5"/>
   <text x="618" y="116" text-anchor="middle" class="step-detail">Blast radius mapping</text>
   <text x="618" y="130" text-anchor="middle" class="step-detail">OWASP LLM Top 10</text>
-  <text x="618" y="144" text-anchor="middle" class="step-detail">OWASP MCP Top 10</text>
+  <text x="618" y="144" text-anchor="middle" class="step-detail">OWASP MCP + Agentic</text>
   <text x="618" y="158" text-anchor="middle" class="step-detail">MITRE ATLAS</text>
-  <text x="618" y="172" text-anchor="middle" class="step-detail">Tool poisoning</text>
+  <text x="618" y="172" text-anchor="middle" class="step-detail">NIST AI RMF + EU AI Act</text>
   <text x="618" y="186" text-anchor="middle" class="step-detail">Malicious packages</text>
   <line x1="568" y1="196" x2="668" y2="196" stroke="#30363d" stroke-width="0.5"/>
   <text x="618" y="212" text-anchor="middle" class="example">--enforce --policy</text>

--- a/docs/images/workflow-light.svg
+++ b/docs/images/workflow-light.svg
@@ -81,9 +81,9 @@
   <line x1="568" y1="98" x2="668" y2="98" stroke="#d0d7de" stroke-width="0.5"/>
   <text x="618" y="116" text-anchor="middle" class="step-detail">Blast radius mapping</text>
   <text x="618" y="130" text-anchor="middle" class="step-detail">OWASP LLM Top 10</text>
-  <text x="618" y="144" text-anchor="middle" class="step-detail">OWASP MCP Top 10</text>
+  <text x="618" y="144" text-anchor="middle" class="step-detail">OWASP MCP + Agentic</text>
   <text x="618" y="158" text-anchor="middle" class="step-detail">MITRE ATLAS</text>
-  <text x="618" y="172" text-anchor="middle" class="step-detail">Tool poisoning</text>
+  <text x="618" y="172" text-anchor="middle" class="step-detail">NIST AI RMF + EU AI Act</text>
   <text x="618" y="186" text-anchor="middle" class="step-detail">Malicious packages</text>
   <line x1="568" y1="196" x2="668" y2="196" stroke="#d0d7de" stroke-width="0.5"/>
   <text x="618" y="212" text-anchor="middle" class="example">--enforce --policy</text>

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -33,7 +33,7 @@ An MCP server that provides security scanning tools for AI infrastructure:
 - **CVE lookup** — check any package against OSV.dev, NVD, EPSS, CISA KEV
 - **MCP registry** — look up any MCP server in the 427+ server threat intelligence registry
 - **Blast radius** — map how a CVE reaches credentials and tools
-- **Compliance** — OWASP LLM Top 10, MITRE ATLAS, NIST AI RMF
+- **Compliance** — OWASP LLM Top 10, OWASP Agentic Top 10, EU AI Act, MITRE ATLAS, NIST AI RMF
 
 ## Security Boundaries
 
@@ -93,7 +93,7 @@ For OpenClaw, add this to `~/.openclaw/openclaw.json`. For other MCP clients
 
 ## Available MCP Tools
 
-Once connected, the agent-bom MCP server provides **13 tools**:
+Once connected, the agent-bom MCP server provides **14 tools**:
 
 ### Tools that work fully via remote server (no local access needed)
 
@@ -102,13 +102,14 @@ Once connected, the agent-bom MCP server provides **13 tools**:
 | `check` | Check a specific package for known vulnerabilities (you provide package name + ecosystem) |
 | `blast_radius` | Map the impact chain of a CVE across agents, servers, credentials, and tools |
 | `registry_lookup` | Look up an MCP server in the 427+ server threat intelligence registry |
-| `compliance` | Check OWASP LLM Top 10, MITRE ATLAS, and NIST AI RMF compliance |
+| `compliance` | Check OWASP LLM Top 10, OWASP Agentic Top 10, EU AI Act, MITRE ATLAS, and NIST AI RMF compliance |
 | `remediate` | Generate a prioritized remediation plan for discovered vulnerabilities |
 | `verify` | Check package integrity and SLSA provenance |
 | `skill_trust` | Assess trust level of a skill file (5-category analysis with verdict) |
 | `generate_sbom` | Generate a Software Bill of Materials (CycloneDX or SPDX) |
 | `policy_check` | Evaluate scan results against a security policy |
 | `diff` | Compare two scan reports to see what changed |
+| `marketplace_check` | Pre-install marketplace trust check with registry cross-reference |
 
 ### Tools that scan the server's own environment (not your machine)
 

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -2831,20 +2831,21 @@ def mcp_server_cmd(transport: str, port: int, host: str):
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 13 security tools via MCP protocol:
+    Exposes 14 security tools via MCP protocol:
       scan              Full scan — CVEs, config security, blast radius, compliance
       check             Check a specific package for CVEs before installing
       blast_radius      Look up blast radius for a specific CVE
       policy_check      Evaluate policy rules against scan findings
       registry_lookup   Query the MCP server threat intelligence registry
       generate_sbom     Generate CycloneDX or SPDX SBOM
-      compliance        OWASP / MITRE ATLAS / NIST AI RMF posture
+      compliance        6-framework compliance posture
       remediate         Generate actionable remediation plan
       skill_trust       ClawHub-style trust assessment for SKILL.md files
       verify            Package integrity + SLSA provenance verification
       where             Show all MCP discovery paths + existence status
       inventory         List agents/servers without CVE scanning
       diff              Compare scan against baseline for new/resolved vulns
+      marketplace_check Pre-install marketplace trust check
 
     \b
     Usage:

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1339,7 +1339,7 @@ _SERVER_CARD_TOOLS = [
     {"name": "generate_sbom", "description": "Generate CycloneDX or SPDX SBOM", "annotations": {"readOnlyHint": True}},
     {
         "name": "compliance",
-        "description": "OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF posture",
+        "description": "6-framework compliance posture (OWASP LLM + MCP + Agentic, ATLAS, NIST, EU AI Act)",
         "annotations": {"readOnlyHint": True},
     },
     {"name": "remediate", "description": "Generate actionable remediation plan", "annotations": {"readOnlyHint": True}},
@@ -1348,6 +1348,11 @@ _SERVER_CARD_TOOLS = [
     {"name": "where", "description": "Show all MCP discovery paths + existence status", "annotations": {"readOnlyHint": True}},
     {"name": "inventory", "description": "List agents/servers without CVE scanning", "annotations": {"readOnlyHint": True}},
     {"name": "diff", "description": "Compare scan against baseline for new/resolved vulns", "annotations": {"readOnlyHint": True}},
+    {
+        "name": "marketplace_check",
+        "description": "Pre-install marketplace trust check with registry cross-reference",
+        "annotations": {"readOnlyHint": True},
+    },
 ]
 
 _SERVER_CARD_PROMPTS = [

--- a/src/agent_bom/output/attack_flow.py
+++ b/src/agent_bom/output/attack_flow.py
@@ -55,6 +55,8 @@ def build_attack_flow(
             or framework in br.get("atlas_tags", [])
             or framework in br.get("nist_ai_rmf_tags", [])
             or framework in br.get("owasp_mcp_tags", [])
+            or framework in br.get("owasp_agentic_tags", [])
+            or framework in br.get("eu_ai_act_tags", [])
         ]
     if agent_name:
         filtered = [br for br in filtered if agent_name in br.get("affected_agents", [])]
@@ -135,6 +137,8 @@ def build_attack_flow(
                         "atlas_tags": br.get("atlas_tags", []),
                         "nist_ai_rmf_tags": br.get("nist_ai_rmf_tags", []),
                         "owasp_mcp_tags": br.get("owasp_mcp_tags", []),
+                        "owasp_agentic_tags": br.get("owasp_agentic_tags", []),
+                        "eu_ai_act_tags": br.get("eu_ai_act_tags", []),
                     },
                 }
             )

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -38,9 +38,7 @@ def build_graph_elements(
       - ``affects``     — package → CVE
     """
     elements: list[dict] = []
-    vuln_pkg_keys: set[tuple[str, str]] = {
-        (br.package.name, br.package.ecosystem) for br in blast_radii
-    }
+    vuln_pkg_keys: set[tuple[str, str]] = {(br.package.name, br.package.ecosystem) for br in blast_radii}
 
     # Track which provider nodes we've already created
     providers_seen: set[str] = set()
@@ -54,60 +52,72 @@ def build_graph_elements(
         key = (br.package.name, br.package.ecosystem)
         if key not in pkg_to_vulns:
             pkg_to_vulns[key] = []
-        pkg_to_vulns[key].append({
-            "id": br.vulnerability.id,
-            "severity": br.vulnerability.severity.value,
-            "summary": br.vulnerability.summary[:100] if br.vulnerability.summary else "",
-            "risk_score": br.risk_score,
-            "cvss_score": br.vulnerability.cvss_score or 0,
-            "fix_version": br.vulnerability.fixed_version or "",
-        })
+        pkg_to_vulns[key].append(
+            {
+                "id": br.vulnerability.id,
+                "severity": br.vulnerability.severity.value,
+                "summary": br.vulnerability.summary[:100] if br.vulnerability.summary else "",
+                "risk_score": br.risk_score,
+                "cvss_score": br.vulnerability.cvss_score or 0,
+                "fix_version": br.vulnerability.fixed_version or "",
+                "owasp_tags": list(br.owasp_tags),
+                "atlas_tags": list(br.atlas_tags),
+                "nist_ai_rmf_tags": list(br.nist_ai_rmf_tags),
+                "owasp_mcp_tags": list(br.owasp_mcp_tags),
+                "owasp_agentic_tags": list(br.owasp_agentic_tags),
+                "eu_ai_act_tags": list(br.eu_ai_act_tags),
+            }
+        )
 
     for agent in report.agents:
         # ── Provider node ─────────────────────────────────────────────
         source = agent.source or "local"
         if source not in providers_seen:
             providers_seen.add(source)
-            elements.append({"data": {
-                "id": f"provider:{source}",
-                "label": _provider_label(source),
-                "type": "provider",
-                "tip": f"Source: {source}",
-            }})
+            elements.append(
+                {
+                    "data": {
+                        "id": f"provider:{source}",
+                        "label": _provider_label(source),
+                        "type": "provider",
+                        "tip": f"Source: {source}",
+                    }
+                }
+            )
 
         # ── Agent node ────────────────────────────────────────────────
         aid = f"a:{agent.name}"
-        elements.append({"data": {
-            "id": aid,
-            "label": agent.name,
-            "type": "agent",
-            "tip": (
-                f"Agent: {agent.name}\n"
-                f"Type: {agent.agent_type.value}\n"
-                f"Source: {source}\n"
-                f"Servers: {len(agent.mcp_servers)}"
-            ),
-            "agentType": agent.agent_type.value,
-            "configPath": agent.config_path or "",
-            "source": source,
-            "serverCount": len(agent.mcp_servers),
-            "packageCount": agent.total_packages,
-            "vulnCount": agent.total_vulnerabilities,
-        }})
+        elements.append(
+            {
+                "data": {
+                    "id": aid,
+                    "label": agent.name,
+                    "type": "agent",
+                    "tip": (f"Agent: {agent.name}\nType: {agent.agent_type.value}\nSource: {source}\nServers: {len(agent.mcp_servers)}"),
+                    "agentType": agent.agent_type.value,
+                    "configPath": agent.config_path or "",
+                    "source": source,
+                    "serverCount": len(agent.mcp_servers),
+                    "packageCount": agent.total_packages,
+                    "vulnCount": agent.total_vulnerabilities,
+                }
+            }
+        )
         # Edge: provider → agent
-        elements.append({"data": {
-            "source": f"provider:{source}",
-            "target": aid,
-            "type": "hosts",
-        }})
+        elements.append(
+            {
+                "data": {
+                    "source": f"provider:{source}",
+                    "target": aid,
+                    "type": "hosts",
+                }
+            }
+        )
 
         # ── Server nodes ──────────────────────────────────────────────
         for srv in agent.mcp_servers:
             sid = f"s:{agent.name}:{srv.name}"
-            vuln_count = sum(
-                1 for p in srv.packages
-                if (p.name, p.ecosystem) in vuln_pkg_keys
-            )
+            vuln_count = sum(1 for p in srv.packages if (p.name, p.ecosystem) in vuln_pkg_keys)
             has_vuln = vuln_count > 0
             has_cred = srv.has_credentials
             stype = "server_vuln" if has_vuln else ("server_cred" if has_cred else "server_clean")
@@ -118,23 +128,31 @@ def build_graph_elements(
             cinfo = f"\nCredentials: {', '.join(srv.credential_names)}" if has_cred else ""
             pkg_badge = f" ({len(srv.packages)})"
 
-            elements.append({"data": {
-                "id": sid,
-                "label": srv.name + pkg_badge,
-                "type": stype,
-                "tip": f"MCP Server: {srv.name}{pkg_note}{cinfo}",
-                "command": ((srv.command or "") + " " + " ".join((srv.args or [])[:3]))[:80].strip(),
-                "packageCount": len(srv.packages),
-                "vulnCount": vuln_count,
-                "credentials": json.dumps(srv.credential_names) if srv.credential_names else "[]",
-                "toolNames": json.dumps([t.name for t in srv.tools[:10]]) if srv.tools else "[]",
-            }})
+            elements.append(
+                {
+                    "data": {
+                        "id": sid,
+                        "label": srv.name + pkg_badge,
+                        "type": stype,
+                        "tip": f"MCP Server: {srv.name}{pkg_note}{cinfo}",
+                        "command": ((srv.command or "") + " " + " ".join((srv.args or [])[:3]))[:80].strip(),
+                        "packageCount": len(srv.packages),
+                        "vulnCount": vuln_count,
+                        "credentials": json.dumps(srv.credential_names) if srv.credential_names else "[]",
+                        "toolNames": json.dumps([t.name for t in srv.tools[:10]]) if srv.tools else "[]",
+                    }
+                }
+            )
             # Edge: agent → server
-            elements.append({"data": {
-                "source": aid,
-                "target": sid,
-                "type": "uses",
-            }})
+            elements.append(
+                {
+                    "data": {
+                        "source": aid,
+                        "target": sid,
+                        "type": "uses",
+                    }
+                }
+            )
 
             # ── Package nodes (vulnerable only) ───────────────────────
             seen_pkg_ids: set[str] = set()
@@ -146,36 +164,48 @@ def build_graph_elements(
                 pid = f"pkg:{pkg.name}:{pkg.ecosystem}"
                 if pid in seen_pkg_ids:
                     # Just add another edge for shared package
-                    elements.append({"data": {
-                        "source": sid,
-                        "target": pid,
-                        "type": "depends_on",
-                    }})
+                    elements.append(
+                        {
+                            "data": {
+                                "source": sid,
+                                "target": pid,
+                                "type": "depends_on",
+                            }
+                        }
+                    )
                     continue
                 seen_pkg_ids.add(pid)
 
                 vc = len(pkg.vulnerabilities)
                 vuln_ids = [vi["id"] for vi in pkg_to_vulns.get(pkg_key, [])]
-                elements.append({"data": {
-                    "id": pid,
-                    "label": f"{pkg.name}\n{pkg.version}",
-                    "type": "pkg_vuln",
-                    "tip": (
-                        f"Package: {pkg.name}\n"
-                        f"Version: {pkg.version}\n"
-                        f"Ecosystem: {pkg.ecosystem}\n"
-                        f"Vulnerabilities: {vc if vc else '(via blast radius)'}"
-                    ),
-                    "ecosystem": pkg.ecosystem,
-                    "version": pkg.version,
-                    "vulnIds": json.dumps(vuln_ids),
-                }})
+                elements.append(
+                    {
+                        "data": {
+                            "id": pid,
+                            "label": f"{pkg.name}\n{pkg.version}",
+                            "type": "pkg_vuln",
+                            "tip": (
+                                f"Package: {pkg.name}\n"
+                                f"Version: {pkg.version}\n"
+                                f"Ecosystem: {pkg.ecosystem}\n"
+                                f"Vulnerabilities: {vc if vc else '(via blast radius)'}"
+                            ),
+                            "ecosystem": pkg.ecosystem,
+                            "version": pkg.version,
+                            "vulnIds": json.dumps(vuln_ids),
+                        }
+                    }
+                )
                 # Edge: server → package
-                elements.append({"data": {
-                    "source": sid,
-                    "target": pid,
-                    "type": "depends_on",
-                }})
+                elements.append(
+                    {
+                        "data": {
+                            "source": sid,
+                            "target": pid,
+                            "type": "depends_on",
+                        }
+                    }
+                )
 
                 # ── CVE nodes ─────────────────────────────────────────
                 if include_cve_nodes and pkg_key in pkg_to_vulns:
@@ -184,26 +214,36 @@ def build_graph_elements(
                         if cve_id not in cve_nodes_seen:
                             cve_nodes_seen.add(cve_id)
                             sev = vuln_info["severity"]
-                            elements.append({"data": {
-                                "id": cve_id,
-                                "label": vuln_info["id"],
-                                "type": f"cve_{sev}",
-                                "tip": (
-                                    f"{vuln_info['id']}\n"
-                                    f"Severity: {sev}\n"
-                                    f"{vuln_info['summary']}"
-                                ),
-                                "severity": sev,
-                                "cvssScore": vuln_info.get("cvss_score", 0),
-                                "summary": vuln_info.get("summary", ""),
-                                "fixVersion": vuln_info.get("fix_version", ""),
-                            }})
+                            elements.append(
+                                {
+                                    "data": {
+                                        "id": cve_id,
+                                        "label": vuln_info["id"],
+                                        "type": f"cve_{sev}",
+                                        "tip": (f"{vuln_info['id']}\nSeverity: {sev}\n{vuln_info['summary']}"),
+                                        "severity": sev,
+                                        "cvssScore": vuln_info.get("cvss_score", 0),
+                                        "summary": vuln_info.get("summary", ""),
+                                        "fixVersion": vuln_info.get("fix_version", ""),
+                                        "owaspTags": vuln_info.get("owasp_tags", []),
+                                        "atlasTags": vuln_info.get("atlas_tags", []),
+                                        "nistAiRmfTags": vuln_info.get("nist_ai_rmf_tags", []),
+                                        "owaspMcpTags": vuln_info.get("owasp_mcp_tags", []),
+                                        "owaspAgenticTags": vuln_info.get("owasp_agentic_tags", []),
+                                        "euAiActTags": vuln_info.get("eu_ai_act_tags", []),
+                                    }
+                                }
+                            )
                         # Edge: package → CVE
-                        elements.append({"data": {
-                            "source": pid,
-                            "target": cve_id,
-                            "type": "affects",
-                        }})
+                        elements.append(
+                            {
+                                "data": {
+                                    "source": pid,
+                                    "target": cve_id,
+                                    "type": "affects",
+                                }
+                            }
+                        )
 
     return elements
 
@@ -288,34 +328,31 @@ def build_attack_flow_elements(
         cve_id = f"cve:{v.id}"
         score_text = f"\nCVSS: {v.cvss_score:.1f}" if v.cvss_score else ""
         fix_text = f"\nFix: {v.fixed_version}" if v.fixed_version else "\nNo fix available"
-        _add_node(cve_id,
-                  label=v.id,
-                  type=f"cve_{sev}",
-                  tip=f"{v.id}\nSeverity: {sev}{score_text}\nBlast score: {br.risk_score:.1f}{fix_text}")
+        _add_node(
+            cve_id, label=v.id, type=f"cve_{sev}", tip=f"{v.id}\nSeverity: {sev}{score_text}\nBlast score: {br.risk_score:.1f}{fix_text}"
+        )
 
         # Package node
         pkg_id = f"pkg:{br.package.name}"
-        _add_node(pkg_id,
-                  label=f"{br.package.name}\n@{br.package.version}",
-                  type="pkg_vuln",
-                  tip=f"Package: {br.package.name}\nVersion: {br.package.version}\nEcosystem: {br.package.ecosystem}")
+        _add_node(
+            pkg_id,
+            label=f"{br.package.name}\n@{br.package.version}",
+            type="pkg_vuln",
+            tip=f"Package: {br.package.name}\nVersion: {br.package.version}\nEcosystem: {br.package.ecosystem}",
+        )
         _add_edge(cve_id, pkg_id, "exploits")
 
         # Servers that use this package
         for agent in br.affected_agents:
             for srv in agent.mcp_servers:
-                pkg_match = any(
-                    p.name == br.package.name and p.ecosystem == br.package.ecosystem
-                    for p in srv.packages
-                )
+                pkg_match = any(p.name == br.package.name and p.ecosystem == br.package.ecosystem for p in srv.packages)
                 if not pkg_match:
                     continue
 
                 srv_id = f"srv:{agent.name}:{srv.name}"
-                _add_node(srv_id,
-                          label=srv.name,
-                          type="server",
-                          tip=f"MCP Server: {srv.name}\nAgent: {agent.name}\nPackages: {len(srv.packages)}")
+                _add_node(
+                    srv_id, label=srv.name, type="server", tip=f"MCP Server: {srv.name}\nAgent: {agent.name}\nPackages: {len(srv.packages)}"
+                )
                 _add_edge(pkg_id, srv_id, "runs_on")
 
                 # Exposed credentials
@@ -333,10 +370,7 @@ def build_attack_flow_elements(
 
                 # Affected agent
                 agent_id = f"agent:{agent.name}"
-                _add_node(agent_id,
-                          label=agent.name,
-                          type="agent",
-                          tip=f"Agent: {agent.name}\nType: {agent.agent_type.value}")
+                _add_node(agent_id, label=agent.name, type="agent", tip=f"Agent: {agent.name}\nType: {agent.agent_type.value}")
                 _add_edge(srv_id, agent_id, "compromises")
 
     return elements

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -47,13 +47,7 @@ def _sev_badge(sev: str) -> str:
 
 
 def _esc(s: object) -> str:
-    return (
-        str(s)
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-    )
+    return str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
 
 
 # ─── Data builders ────────────────────────────────────────────────────────────
@@ -74,18 +68,20 @@ def _chart_data(blast_radii: list["BlastRadius"]) -> str:
     blast_scores = [round(br.risk_score, 2) for br in top10]
     blast_colors = [_SEV_COLOR.get(br.vulnerability.severity.value.lower(), "#6b7280") for br in top10]
 
-    return json.dumps({
-        "sev": {
-            "labels": [k.capitalize() for k in sev_counts],
-            "data": list(sev_counts.values()),
-            "colors": [_SEV_COLOR[k] for k in sev_counts],
-        },
-        "blast": {
-            "labels": blast_labels,
-            "scores": blast_scores,
-            "colors": blast_colors,
-        },
-    })
+    return json.dumps(
+        {
+            "sev": {
+                "labels": [k.capitalize() for k in sev_counts],
+                "data": list(sev_counts.values()),
+                "colors": [_SEV_COLOR[k] for k in sev_counts],
+            },
+            "blast": {
+                "labels": blast_labels,
+                "scores": blast_scores,
+                "colors": blast_colors,
+            },
+        }
+    )
 
 
 def _cytoscape_elements(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
@@ -120,43 +116,38 @@ def _summary_cards(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> s
             f'<div class="stat-icon">{icon}</div>'
             f'<div class="stat-value" style="color:{accent}">{_esc(value)}</div>'
             f'<div class="stat-label">{label}</div>'
-            f'{sub_html}'
-            f'</div>'
+            f"{sub_html}"
+            f"</div>"
         )
 
-    return '<div class="stat-grid">' + "".join([
-        card("&#x1f916;", str(report.total_agents),   "Agents",          "#60a5fa",
-             f"{report.total_servers} servers"),
-        card("&#x1f4e6;", str(report.total_packages), "Packages",        "#38bdf8",
-             "direct + transitive"),
-        card("&#x26a0;&#xfe0f;",  str(total_vulns),           "Vulnerabilities", "#f87171" if total_vulns else "#34d399",
-             "across all agents"),
-        card("&#x1f511;", str(cred_servers),          "Servers w/ Creds", "#fbbf24" if cred_servers else "#34d399",
-             "credential exposure"),
-        card("&#x1f6a8;", str(crit),                  "Critical",        "#ef4444" if crit else "#34d399",
-             "needs immediate fix"),
-        card("&#x1f9a0;", str(kev_count),             "CISA KEV",        "#a855f7" if kev_count else "#34d399",
-             "actively exploited"),
-    ]) + "</div>"
+    return (
+        '<div class="stat-grid">'
+        + "".join(
+            [
+                card("&#x1f916;", str(report.total_agents), "Agents", "#60a5fa", f"{report.total_servers} servers"),
+                card("&#x1f4e6;", str(report.total_packages), "Packages", "#38bdf8", "direct + transitive"),
+                card("&#x26a0;&#xfe0f;", str(total_vulns), "Vulnerabilities", "#f87171" if total_vulns else "#34d399", "across all agents"),
+                card("&#x1f511;", str(cred_servers), "Servers w/ Creds", "#fbbf24" if cred_servers else "#34d399", "credential exposure"),
+                card("&#x1f6a8;", str(crit), "Critical", "#ef4444" if crit else "#34d399", "needs immediate fix"),
+                card("&#x1f9a0;", str(kev_count), "CISA KEV", "#a855f7" if kev_count else "#34d399", "actively exploited"),
+            ]
+        )
+        + "</div>"
+    )
 
 
 def _vuln_table(blast_radii: list["BlastRadius"]) -> str:
     if not blast_radii:
-        return (
-            '<div class="empty-state">&#x2705; No vulnerabilities found in scanned packages.</div>'
-        )
+        return '<div class="empty-state">&#x2705; No vulnerabilities found in scanned packages.</div>'
 
-    has_missing = any(
-        not br.vulnerability.cvss_score or not br.vulnerability.summary
-        for br in blast_radii
-    )
+    has_missing = any(not br.vulnerability.cvss_score or not br.vulnerability.summary for br in blast_radii)
     hint = ""
     if has_missing:
         hint = (
             '<div class="hint-box">'
-            '&#x1f4a1; <strong>Some entries are missing CVSS scores or descriptions.</strong> '
-            'Run with <code>--enrich</code> to fetch full NVD metadata, CVSS 3.x vectors, EPSS, and CISA KEV status.'
-            '</div>'
+            "&#x1f4a1; <strong>Some entries are missing CVSS scores or descriptions.</strong> "
+            "Run with <code>--enrich</code> to fetch full NVD metadata, CVSS 3.x vectors, EPSS, and CISA KEV status."
+            "</div>"
         )
 
     sorted_brs = sorted(
@@ -180,14 +171,12 @@ def _vuln_table(blast_radii: list["BlastRadius"]) -> str:
             )
         else:
             cvss_bar = '<span style="color:#334155">&mdash;</span>'
-        epss = f'{v.epss_score:.1%}' if v.epss_score else '<span style="color:#334155">&mdash;</span>'
-        kev = (
-            '<span class="badge-kev">KEV</span>'
-            if v.is_kev else '<span style="color:#334155">&mdash;</span>'
-        )
+        epss = f"{v.epss_score:.1%}" if v.epss_score else '<span style="color:#334155">&mdash;</span>'
+        kev = '<span class="badge-kev">KEV</span>' if v.is_kev else '<span style="color:#334155">&mdash;</span>'
         fix = (
             f'<code style="color:#4ade80">{_esc(v.fixed_version)}</code>'
-            if v.fixed_version else '<span style="color:#475569">No fix</span>'
+            if v.fixed_version
+            else '<span style="color:#475569">No fix</span>'
         )
         summary_text = (v.summary or "")[:90]
         summary = _esc(summary_text) if summary_text else '<span style="color:#475569;font-style:italic">Run --enrich</span>'
@@ -200,21 +189,20 @@ def _vuln_table(blast_radii: list["BlastRadius"]) -> str:
             f'<tr data-severity="{sev}" data-kev="{"1" if v.is_kev else "0"}" '
             f'data-cvss="{v.cvss_score if v.cvss_score else 0}">'
             f'<td><code class="vuln-id">{_esc(v.id)}</code></td>'
-            f'<td>{_sev_badge(sev)}</td>'
+            f"<td>{_sev_badge(sev)}</td>"
             f'<td><strong style="color:#e2e8f0">{_esc(br.package.name)}</strong>'
             f'<span style="color:#475569;font-size:.78rem">@{_esc(br.package.version)}</span></td>'
-            f'<td>{cvss_bar}</td>'
+            f"<td>{cvss_bar}</td>"
             f'<td style="text-align:center;font-size:.82rem;color:#94a3b8">{epss}</td>'
             f'<td style="text-align:center">{kev}</td>'
-            f'<td>{fix}</td>'
+            f"<td>{fix}</td>"
             f'<td style="font-size:.78rem;color:#94a3b8">{agents_s}</td>'
             f'<td style="font-size:.78rem">{creds_s}</td>'
             f'<td style="font-size:.75rem;color:#64748b;max-width:180px">{summary}</td>'
-            f'</tr>'
+            f"</tr>"
         )
 
-    headers = ["Vuln ID", "Severity", "Package", "CVSS", "EPSS", "KEV", "Fix",
-               "Affected Agents", "Exposed Creds", "Summary"]
+    headers = ["Vuln ID", "Severity", "Package", "CVSS", "EPSS", "KEV", "Fix", "Affected Agents", "Exposed Creds", "Summary"]
 
     filter_bar = (
         '<div class="vuln-filter-bar" style="display:flex;flex-wrap:wrap;gap:12px;align-items:center;'
@@ -235,17 +223,17 @@ def _vuln_table(blast_radii: list["BlastRadius"]) -> str:
         '<input type="text" id="vulnSearch" placeholder="Search vulns&hellip;" '
         'style="padding:6px 10px;background:#1e293b;border:1px solid #334155;border-radius:6px;'
         'color:#e2e8f0;font-size:.78rem;width:160px;outline:none">'
-        '</div>'
+        "</div>"
     )
 
     return (
         hint
         + filter_bar
         + '<div class="table-wrap"><table class="data-table sortable" id="vulnTable">'
-        + '<thead><tr>'
+        + "<thead><tr>"
         + "".join(f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>' for i, h in enumerate(headers))
-        + '</tr></thead>'
-        + f'<tbody>{"".join(rows)}</tbody></table></div>'
+        + "</tr></thead>"
+        + f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
 
@@ -259,41 +247,37 @@ def _blast_table(blast_radii: list["BlastRadius"]) -> str:
         sev = v.severity.value.lower()
         color = _SEV_COLOR.get(sev, "#6b7280")
         bar_w = int(br.risk_score * 9)
-        ai_badge = (
-            '<span class="badge-ai">AI</span>' if br.ai_risk_context else ""
-        )
-        kev_badge = (
-            '<span class="badge-kev">KEV</span>' if v.is_kev else ""
-        )
+        ai_badge = '<span class="badge-ai">AI</span>' if br.ai_risk_context else ""
+        kev_badge = '<span class="badge-kev">KEV</span>' if v.is_kev else ""
         fix = (
             f'<code style="color:#4ade80;font-size:.8rem">{_esc(v.fixed_version)}</code>'
-            if v.fixed_version else '<span style="color:#475569">&mdash;</span>'
+            if v.fixed_version
+            else '<span style="color:#475569">&mdash;</span>'
         )
         rows.append(
-            f'<tr>'
+            f"<tr>"
             f'<td style="color:#475569;font-weight:600">#{i}</td>'
             f'<td><code class="vuln-id">{_esc(v.id)}</code></td>'
-            f'<td>{_sev_badge(sev)}</td>'
-            f'<td>'
+            f"<td>{_sev_badge(sev)}</td>"
+            f"<td>"
             f'<div style="display:flex;align-items:center;gap:8px">'
             f'<div style="background:#0f172a;border-radius:3px;height:5px;width:90px">'
             f'<div style="background:{color};border-radius:3px;height:5px;width:{bar_w}px"></div></div>'
             f'<strong style="color:{color}">{br.risk_score:.1f}</strong></div>'
-            f'</td>'
+            f"</td>"
             f'<td style="text-align:center;color:#e2e8f0">{len(br.affected_agents)}</td>'
             f'<td style="text-align:center;color:#fbbf24">{len(br.exposed_credentials)}</td>'
             f'<td style="text-align:center;color:#94a3b8">{len(br.exposed_tools)}</td>'
-            f'<td>{ai_badge}{kev_badge}</td>'
-            f'<td>{fix}</td>'
-            f'</tr>'
+            f"<td>{ai_badge}{kev_badge}</td>"
+            f"<td>{fix}</td>"
+            f"</tr>"
         )
-    headers = ["#", "Vuln ID", "Severity", "Blast Score (0&ndash;10)",
-               "Agents Hit", "Creds Exposed", "Tools Reachable", "Flags", "Fix"]
+    headers = ["#", "Vuln ID", "Severity", "Blast Score (0&ndash;10)", "Agents Hit", "Creds Exposed", "Tools Reachable", "Flags", "Fix"]
     return (
         '<div class="table-wrap"><table class="data-table sortable">'
-        + '<thead><tr>'
+        + "<thead><tr>"
         + "".join(f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>' for i, h in enumerate(headers))
-        + f'</tr></thead><tbody>{"".join(rows)}</tbody></table></div>'
+        + f"</tr></thead><tbody>{''.join(rows)}</tbody></table></div>"
     )
 
 
@@ -311,7 +295,8 @@ def _remediation_list(blast_radii: list["BlastRadius"]) -> str:
         v = br.vulnerability
         creds_note = (
             f' &middot; frees <strong style="color:#fbbf24">{len(br.exposed_credentials)}</strong> credential(s)'
-            if br.exposed_credentials else ""
+            if br.exposed_credentials
+            else ""
         )
         items.append(
             f'<div class="remediation-item">'
@@ -322,27 +307,23 @@ def _remediation_list(blast_radii: list["BlastRadius"]) -> str:
             f'<div style="font-size:.8rem;color:#64748b;margin-top:3px">'
             f'<code class="vuln-id">{_esc(v.id)}</code>'
             f' &middot; upgrade to <code style="color:#4ade80">{_esc(v.fixed_version)}</code>'
-            f' &middot; protects <strong>{len(br.affected_agents)}</strong> agent(s)'
-            f'{creds_note}'
-            f'</div></div>'
+            f" &middot; protects <strong>{len(br.affected_agents)}</strong> agent(s)"
+            f"{creds_note}"
+            f"</div></div>"
             f'<div style="flex-shrink:0;color:#475569;font-size:.78rem;padding-top:3px">score&nbsp;{br.risk_score:.1f}</div>'
-            f'</div>'
+            f"</div>"
         )
     nf_html = ""
     if no_fix:
         nf_rows = "".join(
             f'<div style="padding:9px 0;border-bottom:1px solid #1e293b;font-size:.82rem">'
-            f'{_sev_badge(b.vulnerability.severity.value.lower())} '
+            f"{_sev_badge(b.vulnerability.severity.value.lower())} "
             f'<code class="vuln-id">{_esc(b.vulnerability.id)}</code> &mdash; '
             f'<strong style="color:#e2e8f0">{_esc(b.package.name)}</strong>@{_esc(b.package.version)}'
             f' &mdash; <span style="color:#475569">no fix available &mdash; monitor upstream</span></div>'
             for b in no_fix
         )
-        nf_html = (
-            '<div style="margin-top:20px">'
-            '<div class="subsection-label">No Fix Available</div>'
-            + nf_rows + '</div>'
-        )
+        nf_html = '<div style="margin-top:20px"><div class="subsection-label">No Fix Available</div>' + nf_rows + "</div>"
     return "".join(items) + nf_html
 
 
@@ -368,17 +349,21 @@ def _skill_audit_section(report: "AIBOMReport") -> str:
         summary_html = (
             f'<div class="hint-box" style="border-color:#818cf840;background:#1e1b4b40">'
             f'<strong style="color:#c7d2fe">AI Analysis:</strong> {_esc(ai_summary)}'
-            f'</div>'
+            f"</div>"
         )
 
     stats_html = (
         f'<div style="display:flex;gap:24px;margin-bottom:16px;font-size:.82rem;color:#94a3b8">'
         f'<span>Status: <strong style="color:{status_color}">{status_text}</strong></span>'
-        f'<span>Packages checked: <strong>{pkgs_checked}</strong></span>'
-        f'<span>Servers checked: <strong>{servers_checked}</strong></span>'
-        f'<span>Credentials checked: <strong>{creds_checked}</strong></span>'
-        + (f'<span>AI risk level: <strong style="color:{_SEV_COLOR.get(ai_risk, "#64748b")}">{_esc(ai_risk).upper()}</strong></span>' if ai_risk else "")
-        + '</div>'
+        f"<span>Packages checked: <strong>{pkgs_checked}</strong></span>"
+        f"<span>Servers checked: <strong>{servers_checked}</strong></span>"
+        f"<span>Credentials checked: <strong>{creds_checked}</strong></span>"
+        + (
+            f'<span>AI risk level: <strong style="color:{_SEV_COLOR.get(ai_risk, "#64748b")}">{_esc(ai_risk).upper()}</strong></span>'
+            if ai_risk
+            else ""
+        )
+        + "</div>"
     )
 
     if not findings:
@@ -387,30 +372,30 @@ def _skill_audit_section(report: "AIBOMReport") -> str:
             f'<div class="sec-title">&#x1f6e1;&#xfe0f; Skill File Audit</div>'
             f'<div class="panel">{stats_html}{summary_html}'
             f'<div class="empty-state">&#x2705; No security findings in skill files.</div>'
-            f'</div></section>'
+            f"</div></section>"
         )
 
     rows = []
     for f in findings:
         sev = f.get("severity", "low")
         rows.append(
-            f'<tr>'
-            f'<td>{_sev_badge(sev)}</td>'
+            f"<tr>"
+            f"<td>{_sev_badge(sev)}</td>"
             f'<td style="color:#e2e8f0;font-weight:600;font-size:.85rem">{_esc(f.get("title", ""))}</td>'
             f'<td><code style="color:#94a3b8;font-size:.75rem">{_esc(f.get("category", ""))}</code></td>'
             f'<td style="font-size:.78rem;color:#94a3b8;max-width:300px">{_esc(f.get("detail", ""))}</td>'
             f'<td style="font-size:.75rem;color:#64748b">{_esc(f.get("source_file", ""))}</td>'
             f'<td style="font-size:.75rem;color:#4ade80">{_esc(f.get("recommendation", ""))}</td>'
-            f'</tr>'
+            f"</tr>"
         )
 
     headers = ["Severity", "Finding", "Category", "Detail", "Source", "Recommendation"]
     table_html = (
         '<div class="table-wrap"><table class="data-table sortable">'
-        + '<thead><tr>'
+        + "<thead><tr>"
         + "".join(f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>' for i, h in enumerate(headers))
-        + '</tr></thead>'
-        + f'<tbody>{"".join(rows)}</tbody></table></div>'
+        + "</tr></thead>"
+        + f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
     return (
@@ -418,7 +403,7 @@ def _skill_audit_section(report: "AIBOMReport") -> str:
         f'<div class="sec-title">&#x1f6e1;&#xfe0f; Skill File Audit'
         f'<sup style="font-size:.7rem;color:#475569;margin-left:6px">{len(findings)}</sup></div>'
         f'<div class="panel">{stats_html}{summary_html}{table_html}</div>'
-        f'</section>'
+        f"</section>"
     )
 
 
@@ -447,12 +432,12 @@ def _trust_assessment_section(report: "AIBOMReport") -> str:
         icon = level_icons.get(level, "?")
         color = level_colors.get(level, "#6b7280")
         cat_rows.append(
-            f'<tr>'
+            f"<tr>"
             f'<td style="text-align:center;color:{color};font-size:1.1rem">{icon}</td>'
             f'<td style="color:#e2e8f0;font-weight:600;font-size:.85rem">{_esc(cat.get("name", ""))}</td>'
-            f'<td>{_sev_badge(level)}</td>'
+            f"<td>{_sev_badge(level)}</td>"
             f'<td style="font-size:.78rem;color:#94a3b8">{_esc(cat.get("summary", ""))}</td>'
-            f'</tr>'
+            f"</tr>"
         )
 
     verdict_badge = (
@@ -462,7 +447,9 @@ def _trust_assessment_section(report: "AIBOMReport") -> str:
     )
 
     title_suffix = f" &mdash; {skill_name}" if skill_name else ""
-    source_note = f'<div style="font-size:.72rem;color:#475569;margin-bottom:12px">Source: <code>{source_file}</code></div>' if source_file else ""
+    source_note = (
+        f'<div style="font-size:.72rem;color:#475569;margin-bottom:12px">Source: <code>{source_file}</code></div>' if source_file else ""
+    )
 
     rec_html = ""
     if recommendations:
@@ -472,21 +459,21 @@ def _trust_assessment_section(report: "AIBOMReport") -> str:
     headers = ["", "Category", "Level", "Summary"]
     table_html = (
         '<div class="table-wrap"><table class="data-table">'
-        + '<thead><tr>'
-        + "".join(f'<th>{h}</th>' for h in headers)
-        + '</tr></thead>'
-        + f'<tbody>{"".join(cat_rows)}</tbody></table></div>'
+        + "<thead><tr>"
+        + "".join(f"<th>{h}</th>" for h in headers)
+        + "</tr></thead>"
+        + f"<tbody>{''.join(cat_rows)}</tbody></table></div>"
     )
 
     return (
         f'<section id="trust">'
         f'<div class="sec-title">&#x1f50d; Trust Assessment{title_suffix}</div>'
         f'<div class="panel">'
-        f'{source_note}'
+        f"{source_note}"
         f'<div style="margin-bottom:16px">{verdict_badge}</div>'
-        f'{table_html}'
-        f'{rec_html}'
-        f'</div></section>'
+        f"{table_html}"
+        f"{rec_html}"
+        f"</div></section>"
     )
 
 
@@ -509,11 +496,11 @@ def _enforcement_section(report: "AIBOMReport") -> str:
     stats_html = (
         f'<div style="display:flex;gap:24px;margin-bottom:16px;font-size:.82rem;color:#94a3b8">'
         f'<span>Status: <strong style="color:{status_color}">{status_text}</strong></span>'
-        f'<span>Servers checked: <strong>{servers_checked}</strong></span>'
-        f'<span>Tools checked: <strong>{tools_checked}</strong></span>'
+        f"<span>Servers checked: <strong>{servers_checked}</strong></span>"
+        f"<span>Tools checked: <strong>{tools_checked}</strong></span>"
         f'<span>Critical: <strong style="color:#dc2626">{critical_count}</strong></span>'
         f'<span>High: <strong style="color:#ea580c">{high_count}</strong></span>'
-        f'</div>'
+        f"</div>"
     )
 
     if not findings:
@@ -522,30 +509,30 @@ def _enforcement_section(report: "AIBOMReport") -> str:
             f'<div class="sec-title">&#x1f6a8; Enforcement</div>'
             f'<div class="panel">{stats_html}'
             f'<div class="empty-state">&#x2705; No enforcement findings — all checks passed.</div>'
-            f'</div></section>'
+            f"</div></section>"
         )
 
     rows = []
     for f in findings:
         sev = f.get("severity", "low")
         rows.append(
-            f'<tr>'
-            f'<td>{_sev_badge(sev)}</td>'
+            f"<tr>"
+            f"<td>{_sev_badge(sev)}</td>"
             f'<td><code style="color:#94a3b8;font-size:.75rem">{_esc(f.get("category", ""))}</code></td>'
             f'<td style="color:#e2e8f0;font-weight:600;font-size:.85rem">{_esc(f.get("server_name", ""))}</td>'
             f'<td style="font-size:.78rem;color:#94a3b8">{_esc(f.get("tool_name", "") or "—")}</td>'
             f'<td style="font-size:.78rem;color:#94a3b8;max-width:350px">{_esc(f.get("reason", ""))}</td>'
             f'<td style="font-size:.75rem;color:#4ade80">{_esc(f.get("recommendation", ""))}</td>'
-            f'</tr>'
+            f"</tr>"
         )
 
     headers = ["Severity", "Category", "Server", "Tool", "Reason", "Recommendation"]
     table_html = (
         '<div class="table-wrap"><table class="data-table sortable">'
-        + '<thead><tr>'
+        + "<thead><tr>"
         + "".join(f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>' for i, h in enumerate(headers))
-        + '</tr></thead>'
-        + f'<tbody>{"".join(rows)}</tbody></table></div>'
+        + "</tr></thead>"
+        + f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
     return (
@@ -553,7 +540,7 @@ def _enforcement_section(report: "AIBOMReport") -> str:
         f'<div class="sec-title">&#x1f6a8; Enforcement'
         f'<sup style="font-size:.7rem;color:#475569;margin-left:6px">{len(findings)}</sup></div>'
         f'<div class="panel">{stats_html}{table_html}</div>'
-        f'</section>'
+        f"</section>"
     )
 
 
@@ -570,17 +557,17 @@ def _attack_flow_section(blast_radii: list["BlastRadius"]) -> str:
         '<section id="attackflow">'
         '<div class="sec-title">&#x1f525; CVE Attack Flow'
         '<span style="font-size:.68rem;font-weight:400;opacity:.5;margin-left:8px">'
-        f'{len(blast_radii)} CVEs &#x2192; {total_agents} agents &#x2192; '
-        f'{total_creds} credentials &#x2192; {total_tools} tools at risk'
-        '</span></div>'
+        f"{len(blast_radii)} CVEs &#x2192; {total_agents} agents &#x2192; "
+        f"{total_creds} credentials &#x2192; {total_tools} tools at risk"
+        "</span></div>"
         '<div class="graph-container">'
         '<div id="cyAttack" class="cy-graph"></div>'
         '<div class="graph-controls" style="top:12px;right:12px">'
         '<button class="graph-btn" id="afZoomIn" title="Zoom in">+</button>'
         '<button class="graph-btn" id="afZoomOut" title="Zoom out">&minus;</button>'
         '<button class="graph-btn" id="afFitBtn" title="Fit to view">&#x2922;</button>'
-        '</div>'
-        '</div>'
+        "</div>"
+        "</div>"
         '<div class="legend">'
         '<span><i class="diamond" style="background:#f87171"></i>CVE</span>'
         '<span><i style="background:#dc2626"></i>Vulnerable Package</span>'
@@ -588,8 +575,8 @@ def _attack_flow_section(blast_radii: list["BlastRadius"]) -> str:
         '<span><i style="background:#fbbf24"></i>Credential</span>'
         '<span><i style="background:#818cf8"></i>Tool</span>'
         '<span><i style="background:#3b82f6"></i>Agent</span>'
-        '</div>'
-        '</section>'
+        "</div>"
+        "</section>"
     )
 
 
@@ -600,13 +587,9 @@ def _inventory_cards(report: "AIBOMReport") -> str:
         total_creds = sum(len(s.credential_names) for s in agent.mcp_servers)
         agent_badges = []
         if total_vulns:
-            agent_badges.append(
-                f'<span class="badge-vuln">{total_vulns} vuln{"s" if total_vulns != 1 else ""}</span>'
-            )
+            agent_badges.append(f'<span class="badge-vuln">{total_vulns} vuln{"s" if total_vulns != 1 else ""}</span>')
         if total_creds:
-            agent_badges.append(
-                f'<span class="badge-cred">{total_creds} credential{"s" if total_creds != 1 else ""}</span>'
-            )
+            agent_badges.append(f'<span class="badge-cred">{total_creds} credential{"s" if total_creds != 1 else ""}</span>')
         badges_html = " ".join(agent_badges)
 
         servers_html = []
@@ -624,7 +607,7 @@ def _inventory_cards(report: "AIBOMReport") -> str:
                 cmd_parts = [srv.command] + srv.args[:3]
                 cmd = _esc(" ".join(cmd_parts))
                 if srv.args and len(srv.args) > 3:
-                    cmd += f' <span style="color:#334155">&hellip;+{len(srv.args)-3} args</span>'
+                    cmd += f' <span style="color:#334155">&hellip;+{len(srv.args) - 3} args</span>'
 
             # Credentials section
             creds_html = ""
@@ -632,8 +615,7 @@ def _inventory_cards(report: "AIBOMReport") -> str:
                 creds_html = (
                     '<div style="margin-top:8px">'
                     + "".join(
-                        f'<div style="font-size:.74rem;color:#fbbf24;padding:2px 0">'
-                        f'&#x1f511; <code>{_esc(c)}</code></div>'
+                        f'<div style="font-size:.74rem;color:#fbbf24;padding:2px 0">&#x1f511; <code>{_esc(c)}</code></div>'
                         for c in srv.credential_names
                     )
                     + "</div>"
@@ -647,6 +629,7 @@ def _inventory_cards(report: "AIBOMReport") -> str:
 
             def pkg_row(p: object) -> str:
                 from agent_bom.models import Package
+
                 if not isinstance(p, Package):
                     return ""
                 color = "#f87171" if p.has_vulnerabilities else "#38bdf8"
@@ -656,7 +639,7 @@ def _inventory_cards(report: "AIBOMReport") -> str:
                     f'<span><code style="color:{color};font-size:.72rem">{_esc(p.ecosystem)}</code>'
                     f' <span class="pkg-name">{_esc(p.name)}</span></span>'
                     f'<span class="pkg-ver">{_esc(p.version)}{vuln_mark}</span>'
-                    f'</div>'
+                    f"</div>"
                 )
 
             pkg_html = ""
@@ -667,11 +650,11 @@ def _inventory_cards(report: "AIBOMReport") -> str:
                     rest_rows = "".join(pkg_row(p) for p in rest)
                     pkg_html = (
                         f'<div style="margin-top:8px">'
-                        f'{preview_rows}'
+                        f"{preview_rows}"
                         f'<div id="{uid}" style="display:none">{rest_rows}</div>'
                         f'<button class="toggle-btn" onclick="togglePkgs(\'{uid}\',this)">'
-                        f'Show {len(rest)} more packages &#x25bc;</button>'
-                        f'</div>'
+                        f"Show {len(rest)} more packages &#x25bc;</button>"
+                        f"</div>"
                     )
                 else:
                     pkg_html = f'<div style="margin-top:8px">{preview_rows}</div>'
@@ -681,42 +664,40 @@ def _inventory_cards(report: "AIBOMReport") -> str:
                 f'<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">'
                 f'<div style="font-weight:600;color:#e2e8f0;font-size:.9rem">&#x2699;&#xfe0f; {_esc(srv.name)} {srv_badges_html}</div>'
                 f'<div style="font-size:.72rem;color:#475569">{pkg_count} pkg{"s" if pkg_count != 1 else ""}</div>'
-                f'</div>'
+                f"</div>"
             )
             cmd_html = (
-                f'<div style="font-size:.72rem;color:#475569;font-family:monospace;'
-                f'margin-bottom:6px;word-break:break-all">{cmd}</div>'
-                if cmd else ""
+                f'<div style="font-size:.72rem;color:#475569;font-family:monospace;margin-bottom:6px;word-break:break-all">{cmd}</div>'
+                if cmd
+                else ""
             )
 
             servers_html.append(
-                f'<div class="server-card" style="border-left-color:{accent}">'
-                f'{srv_header}{cmd_html}{creds_html}{pkg_html}'
-                f'</div>'
+                f'<div class="server-card" style="border-left-color:{accent}">{srv_header}{cmd_html}{creds_html}{pkg_html}</div>'
             )
 
-        servers_content = "".join(servers_html) if servers_html else (
-            '<p style="color:#334155;font-size:.85rem">No MCP servers configured.</p>'
+        servers_content = (
+            "".join(servers_html) if servers_html else ('<p style="color:#334155;font-size:.85rem">No MCP servers configured.</p>')
         )
 
         cards.append(
             f'<details class="agent-card" open>'
             f'<summary class="agent-summary">'
-            f'<span>&#x1f916; {_esc(agent.name)}</span>'
+            f"<span>&#x1f916; {_esc(agent.name)}</span>"
             f'<span style="display:flex;align-items:center;gap:8px">'
-            f'{badges_html}'
+            f"{badges_html}"
             f'<span style="font-size:.72rem;color:#475569">'
-            f'{len(agent.mcp_servers)} server(s) &middot; {agent.total_packages} pkg(s)'
-            f'</span>'
-            f'</span>'
-            f'</summary>'
+            f"{len(agent.mcp_servers)} server(s) &middot; {agent.total_packages} pkg(s)"
+            f"</span>"
+            f"</span>"
+            f"</summary>"
             f'<div class="agent-detail">'
             f'<div style="font-size:.72rem;color:#475569;margin-bottom:12px">'
-            f'{_esc(agent.agent_type.value)} &middot; {_esc(agent.config_path or "")}'
-            f'</div>'
-            f'{servers_content}'
-            f'</div>'
-            f'</details>'
+            f"{_esc(agent.agent_type.value)} &middot; {_esc(agent.config_path or '')}"
+            f"</div>"
+            f"{servers_content}"
+            f"</div>"
+            f"</details>"
         )
     return "".join(cards)
 
@@ -734,19 +715,25 @@ def _compliance_section(blast_radii: list["BlastRadius"]) -> str:
     """Build OWASP/ATLAS/NIST compliance tables from blast radius tags."""
     try:
         from agent_bom.atlas import ATLAS_TECHNIQUES
+        from agent_bom.eu_ai_act import EU_AI_ACT
         from agent_bom.nist_ai_rmf import NIST_AI_RMF
         from agent_bom.owasp import OWASP_LLM_TOP10
+        from agent_bom.owasp_agentic import OWASP_AGENTIC_TOP10
     except ImportError:
         return ""
 
     br_dicts = []
     for br in blast_radii:
-        br_dicts.append({
-            "severity": br.vulnerability.severity.value,
-            "owasp_tags": list(br.owasp_tags),
-            "atlas_tags": list(br.atlas_tags),
-            "nist_ai_rmf_tags": list(br.nist_ai_rmf_tags),
-        })
+        br_dicts.append(
+            {
+                "severity": br.vulnerability.severity.value,
+                "owasp_tags": list(br.owasp_tags),
+                "atlas_tags": list(br.atlas_tags),
+                "nist_ai_rmf_tags": list(br.nist_ai_rmf_tags),
+                "owasp_agentic_tags": list(br.owasp_agentic_tags),
+                "eu_ai_act_tags": list(br.eu_ai_act_tags),
+            }
+        )
 
     def _build_rows(catalog: dict, tag_field: str) -> tuple[str, int, int, int]:
         rows = []
@@ -778,12 +765,14 @@ def _compliance_section(blast_radii: list["BlastRadius"]) -> str:
     owasp_rows, op, of, ow = _build_rows(OWASP_LLM_TOP10, "owasp_tags")
     atlas_rows, ap, af, aw = _build_rows(ATLAS_TECHNIQUES, "atlas_tags")
     nist_rows, np_, nf, nw = _build_rows(NIST_AI_RMF, "nist_ai_rmf_tags")
+    agentic_rows, oap, oaf, oaw = _build_rows(OWASP_AGENTIC_TOP10, "owasp_agentic_tags")
+    eu_rows, ep, ef_, ew = _build_rows(EU_AI_ACT, "eu_ai_act_tags")
 
-    total = (op + of + ow) + (ap + af + aw) + (np_ + nf + nw)
-    total_pass = op + ap + np_
+    total = (op + of + ow) + (ap + af + aw) + (np_ + nf + nw) + (oap + oaf + oaw) + (ep + ef_ + ew)
+    total_pass = op + ap + np_ + oap + ep
     score = round((total_pass / total) * 100, 1) if total > 0 else 100.0
-    has_fail = (of + af + nf) > 0
-    has_warn = (ow + aw + nw) > 0
+    has_fail = (of + af + nf + oaf + ef_) > 0
+    has_warn = (ow + aw + nw + oaw + ew) > 0
     overall = "fail" if has_fail else ("warning" if has_warn else "pass")
     overall_badge = _STATUS_BADGE[overall]
 
@@ -794,20 +783,22 @@ def _compliance_section(blast_radii: list["BlastRadius"]) -> str:
             f'<summary style="cursor:pointer;font-weight:600;padding:6px 0">'
             f'{title} <span style="font-size:.8rem;color:#94a3b8">({p}/{sub_total} pass)</span></summary>'
             f'<table class="vtable" style="margin-top:8px"><thead><tr>'
-            f'<th>Code</th><th>Control</th><th>Findings</th><th>Status</th></tr></thead>'
-            f'<tbody>{rows}</tbody></table></details>'
+            f"<th>Code</th><th>Control</th><th>Findings</th><th>Status</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table></details>"
         )
 
     return (
         f'<section id="compliance">'
         f'<div class="sec-title">&#x1f6e1;&#xfe0f; Compliance Posture'
         f'<sup style="font-size:.7rem;color:#475569;margin-left:6px">'
-        f'Score: {score}% {overall_badge}</sup></div>'
+        f"Score: {score}% {overall_badge}</sup></div>"
         f'<div class="panel">'
-        f'{_framework_table("OWASP LLM Top 10", owasp_rows, op, of, ow)}'
-        f'{_framework_table("MITRE ATLAS", atlas_rows, ap, af, aw)}'
-        f'{_framework_table("NIST AI RMF", nist_rows, np_, nf, nw)}'
-        f'</div></section>'
+        f"{_framework_table('OWASP LLM Top 10', owasp_rows, op, of, ow)}"
+        f"{_framework_table('OWASP Agentic Top 10', agentic_rows, oap, oaf, oaw)}"
+        f"{_framework_table('MITRE ATLAS', atlas_rows, ap, af, aw)}"
+        f"{_framework_table('NIST AI RMF', nist_rows, np_, nf, nw)}"
+        f"{_framework_table('EU AI Act', eu_rows, ep, ef_, ew)}"
+        f"</div></section>"
     )
 
 
@@ -837,20 +828,20 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
             f'<section id="vulns">'
             f'<div class="sec-title">&#x26a0;&#xfe0f; Vulnerabilities'
             f'<sup style="font-size:.7rem;color:#475569;margin-left:6px">{len(blast_radii)}</sup>'
-            f'</div>'
+            f"</div>"
             f'<div class="panel">{_vuln_table(blast_radii)}</div>'
-            f'</section>'
+            f"</section>"
             f'<section id="blast">'
             f'<div class="sec-title">&#x1f4a5; Blast Radius'
             f'<sup style="font-size:.65rem;color:#475569;margin-left:6px;font-weight:400">'
-            f'risk = CVSS + agents + creds + tools + KEV/EPSS boosts (max 10)'
-            f'</sup></div>'
+            f"risk = CVSS + agents + creds + tools + KEV/EPSS boosts (max 10)"
+            f"</sup></div>"
             f'<div class="panel">{_blast_table(blast_radii)}</div>'
-            f'</section>'
+            f"</section>"
             f'<section id="remediation">'
             f'<div class="sec-title">&#x1f527; Remediation Plan</div>'
             f'<div class="panel">{_remediation_list(blast_radii)}</div>'
-            f'</section>'
+            f"</section>"
         )
 
     vuln_nav = (
@@ -858,7 +849,8 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
         '<a href="#vulns">Vulnerabilities</a>'
         '<a href="#blast">Blast Radius</a>'
         '<a href="#remediation">Remediation</a>'
-        if blast_radii else ""
+        if blast_radii
+        else ""
     )
 
     # Compliance section
@@ -880,8 +872,7 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
     # Determine node counts for graph subtitle
     vuln_node_count = len({(br.package.name, br.package.ecosystem) for br in blast_radii})
     graph_note = (
-        f"agents + servers + {vuln_node_count} vulnerable pkg(s) only — "
-        f"{report.total_packages - vuln_node_count} clean packages hidden"
+        f"agents + servers + {vuln_node_count} vulnerable pkg(s) only — {report.total_packages - vuln_node_count} clean packages hidden"
         if report.total_packages > vuln_node_count
         else "agents + servers + packages"
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2985,7 +2985,7 @@ def test_openclaw_skill_declares_mcp_endpoint():
 
 
 def test_openclaw_skill_lists_tools():
-    """OpenClaw SKILL.md should document all 13 MCP tools."""
+    """OpenClaw SKILL.md should document all 14 MCP tools."""
     from pathlib import Path
 
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"
@@ -3004,6 +3004,7 @@ def test_openclaw_skill_lists_tools():
         "inventory",
         "diff",
         "skill_trust",
+        "marketplace_check",
     ]:
         assert tool in content, f"Tool '{tool}' should be documented in SKILL.md"
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -117,14 +117,14 @@ def test_smithery_yaml_exists():
 
 
 def test_server_card_has_all_tools():
-    """Server card should list all 13 MCP tools."""
+    """Server card should list all 14 MCP tools."""
     from agent_bom.mcp_server import build_server_card
 
     card = build_server_card()
     assert card["name"] == "agent-bom"
     assert "version" in card
     tool_names = [t["name"] for t in card["tools"]]
-    assert len(tool_names) == 13
+    assert len(tool_names) == 14
     assert "scan" in tool_names
     assert "check" in tool_names
     assert "blast_radius" in tool_names
@@ -170,15 +170,15 @@ def test_server_card_metadata():
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_server_help_shows_13_tools():
-    """MCP server help should mention 13 tools."""
+def test_mcp_server_help_shows_14_tools():
+    """MCP server help should mention 14 tools."""
     from click.testing import CliRunner
 
     from agent_bom.cli import main
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp-server", "--help"])
-    assert "13 security tools" in result.output
+    assert "14 security tools" in result.output
     assert "compliance" in result.output
     assert "remediate" in result.output
 

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -87,6 +87,7 @@ def _make_scan(
     )
     # Extract bins and install methods from frontmatter
     import re
+
     bins_match = re.search(r"requires:\s*\n\s+bins:\s*\n((?:\s+-\s+\S+\n?)+)", frontmatter)
     if bins_match:
         meta.required_bins = re.findall(r"^\s+-\s+(.+)$", bins_match.group(1), re.MULTILINE)
@@ -103,6 +104,7 @@ def _make_scan(
 def _extract_yaml(raw: str, key: str) -> str:
     """Extract a simple key: value from YAML-ish text."""
     import re
+
     m = re.search(rf"^\s*{key}:\s*(.+)$", raw, re.MULTILINE)
     return m.group(1).strip().strip("'\"") if m else ""
 
@@ -163,8 +165,12 @@ def test_trust_assessment_result_to_dict():
     result = TrustAssessmentResult(
         categories=[
             TrustCategoryResult(
-                name="Test", key="test", level=TrustLevel.PASS,
-                summary="All good", details=["detail1"], evidence=["ev1"],
+                name="Test",
+                key="test",
+                level=TrustLevel.PASS,
+                summary="All good",
+                details=["detail1"],
+                evidence=["ev1"],
             )
         ],
         verdict=Verdict.BENIGN,
@@ -376,62 +382,89 @@ def test_persistence_privilege_fail_escalation():
 
 def _cats(*levels: TrustLevel) -> list[TrustCategoryResult]:
     """Build minimal categories with given levels."""
-    return [
-        TrustCategoryResult(name=f"Cat{i}", key=f"cat{i}", level=lv, summary="")
-        for i, lv in enumerate(levels)
-    ]
+    return [TrustCategoryResult(name=f"Cat{i}", key=f"cat{i}", level=lv, summary="") for i, lv in enumerate(levels)]
 
 
 def test_verdict_all_pass_is_benign_high():
-    verdict, conf = _compute_verdict(_cats(
-        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
-        TrustLevel.PASS, TrustLevel.PASS,
-    ))
+    verdict, conf = _compute_verdict(
+        _cats(
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+        )
+    )
     assert verdict == Verdict.BENIGN
     assert conf == Confidence.HIGH
 
 
 def test_verdict_pass_plus_info_is_benign_medium():
-    verdict, conf = _compute_verdict(_cats(
-        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
-        TrustLevel.INFO, TrustLevel.INFO,
-    ))
+    verdict, conf = _compute_verdict(
+        _cats(
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.INFO,
+            TrustLevel.INFO,
+        )
+    )
     assert verdict == Verdict.BENIGN
     assert conf == Confidence.MEDIUM
 
 
 def test_verdict_one_warn_is_suspicious_low():
-    verdict, conf = _compute_verdict(_cats(
-        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
-        TrustLevel.PASS, TrustLevel.WARN,
-    ))
+    verdict, conf = _compute_verdict(
+        _cats(
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.WARN,
+        )
+    )
     assert verdict == Verdict.SUSPICIOUS
     assert conf == Confidence.LOW
 
 
 def test_verdict_three_warns_is_suspicious_medium():
-    verdict, conf = _compute_verdict(_cats(
-        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.WARN,
-        TrustLevel.WARN, TrustLevel.WARN,
-    ))
+    verdict, conf = _compute_verdict(
+        _cats(
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.WARN,
+            TrustLevel.WARN,
+            TrustLevel.WARN,
+        )
+    )
     assert verdict == Verdict.SUSPICIOUS
     assert conf == Confidence.MEDIUM
 
 
 def test_verdict_one_fail_is_suspicious_medium():
-    verdict, conf = _compute_verdict(_cats(
-        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
-        TrustLevel.PASS, TrustLevel.FAIL,
-    ))
+    verdict, conf = _compute_verdict(
+        _cats(
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.FAIL,
+        )
+    )
     assert verdict == Verdict.SUSPICIOUS
     assert conf == Confidence.MEDIUM
 
 
 def test_verdict_two_fails_is_malicious_high():
-    verdict, conf = _compute_verdict(_cats(
-        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
-        TrustLevel.FAIL, TrustLevel.FAIL,
-    ))
+    verdict, conf = _compute_verdict(
+        _cats(
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.FAIL,
+            TrustLevel.FAIL,
+        )
+    )
     assert verdict == Verdict.MALICIOUS
     assert conf == Confidence.HIGH
 
@@ -442,10 +475,15 @@ def test_verdict_two_fails_is_malicious_high():
 
 
 def test_no_recommendations_when_all_pass():
-    recs = _generate_recommendations(_cats(
-        TrustLevel.PASS, TrustLevel.PASS, TrustLevel.PASS,
-        TrustLevel.PASS, TrustLevel.PASS,
-    ))
+    recs = _generate_recommendations(
+        _cats(
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+            TrustLevel.PASS,
+        )
+    )
     assert recs == []
 
 
@@ -453,8 +491,10 @@ def test_recommendations_for_warn():
     """WARN categories generate recommendations."""
     cats = [
         TrustCategoryResult(
-            name="Install Mechanism", key="install_mechanism",
-            level=TrustLevel.WARN, summary="No source",
+            name="Install Mechanism",
+            key="install_mechanism",
+            level=TrustLevel.WARN,
+            summary="No source",
         ),
     ]
     recs = _generate_recommendations(cats)
@@ -466,8 +506,10 @@ def test_recommendations_for_fail():
     """FAIL categories generate recommendations."""
     cats = [
         TrustCategoryResult(
-            name="Persistence & Privilege", key="persistence_privilege",
-            level=TrustLevel.FAIL, summary="Privilege escalation",
+            name="Persistence & Privilege",
+            key="persistence_privilege",
+            level=TrustLevel.FAIL,
+            summary="Privilege escalation",
         ),
     ]
     recs = _generate_recommendations(cats)
@@ -520,8 +562,7 @@ def test_assess_trust_agent_bom_skill():
     from agent_bom.parsers.skills import parse_skill_file
 
     scan = parse_skill_file(skill_path)
-    with patch("agent_bom.parsers.skill_audit._batch_verify_packages_sync",
-               return_value={}):
+    with patch("agent_bom.parsers.skill_audit._batch_verify_packages_sync", return_value={}):
         audit = audit_skill_result(scan)
     result = assess_trust(scan, audit)
 
@@ -568,8 +609,8 @@ def test_mcp_skill_trust_tool_exists():
     assert "skill_trust" in tool_names
 
 
-def test_mcp_server_card_has_13_tools():
-    """Server card lists 13 tools."""
+def test_mcp_server_card_has_14_tools():
+    """Server card lists 14 tools."""
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
-    assert len(_SERVER_CARD_TOOLS) == 13
+    assert len(_SERVER_CARD_TOOLS) == 14


### PR DESCRIPTION
## Summary
- Add `owasp_agentic_tags` + `eu_ai_act_tags` to **graph.py** (Cytoscape), **html.py**, and **attack_flow.py** — all visualization formats now reflect the full 6-framework compliance set
- Update README, SKILL.md, CLI help, server card, Dockerfile.sse, PUBLISHING.md from "13 tools / quad-framework" to "14 tools / 6-framework"
- Update 14 SVG diagrams (architecture, deployment, workflow, blast-radius, integration, offerings, before-after, scan-workflow) with correct framework counts and names
- Fix all test assertions referencing old 13-tool count (test_deployment, test_trust_assessment, test_core)
- Add `marketplace_check` to `_SERVER_CARD_TOOLS` and SKILL.md tool table

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/ -x -q` — 1,739 passed
- [x] `grep -r "13 tools\|13 MCP" .` — no stale references remaining