### PR TITLE
feat: agent config permissions scanning + v0.36.0

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.35.0
+ARG VERSION=0.36.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.35.0
+ARG VERSION=0.36.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.35.0"
+  --version "0.36.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.35.0
-git push origin v0.35.0
+git tag v0.36.0
+git push origin v0.36.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.35.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.36.0` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -381,7 +381,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.35.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.36.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Opt-in MCP traffic audit (per-server) |
@@ -400,7 +400,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.35.0
+- uses: msaad00/agent-bom@v0.36.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -527,7 +527,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.35.0` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.36.0` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.35.0
+- uses: msaad00/agent-bom@v0.36.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: AI supply chain security scanner — check packages for CVEs, look up MCP servers in the threat registry, assess blast radius, generate SBOMs, enforce compliance
-version: 0.35.0
+version: 0.36.0
 metadata:
   openclaw:
     requires:

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.35.0
+ARG VERSION=0.36.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.35.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.36.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.35.0": {
+        "ghcr.io/msaad00/agent-bom:v0.36.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.35.0"
+version = "0.36.0"
 description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs. OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF. GPU infrastructure (NVIDIA/AMD) coverage."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.35.0"
+    __version__ = "0.36.0"

--- a/tests/test_claude_config.py
+++ b/tests/test_claude_config.py
@@ -64,3 +64,123 @@ def test_multiple_findings():
     findings = check_claude_config(path)
     os.unlink(path)
     assert len(findings) == 3
+
+
+# ─── permissions.allow scanning ──────────────────────────────────────────────
+
+
+def test_broad_bash_permission():
+    """Unrestricted Bash permission should be flagged as critical."""
+    path = _write_config({"permissions": {"allow": ["Bash(*)"]}})
+    findings = check_claude_config(path)
+    os.unlink(path)
+    critical = [f for f in findings if f.severity == "critical" and f.category == "claude_permissions"]
+    assert len(critical) >= 1
+    assert "Bash" in critical[0].reason
+
+
+def test_broad_read_permission():
+    """Overly broad Read permission should be flagged."""
+    path = _write_config({"permissions": {"allow": ["Read(//**)"]}})
+    findings = check_claude_config(path)
+    os.unlink(path)
+    high = [f for f in findings if f.severity == "high" and "Read" in f.reason]
+    assert len(high) >= 1
+
+
+def test_broad_edit_permission():
+    """Overly broad Edit/Write permission should be flagged."""
+    path = _write_config({"permissions": {"allow": ["Edit(//**)"]}})
+    findings = check_claude_config(path)
+    os.unlink(path)
+    high = [f for f in findings if f.severity == "high" and "Edit" in f.reason]
+    assert len(high) >= 1
+
+
+def test_large_webfetch_allowlist():
+    """More than 10 WebFetch domains should trigger a finding."""
+    domains = [f"WebFetch(domain:site{i}.com)" for i in range(12)]
+    path = _write_config({"permissions": {"allow": domains}})
+    findings = check_claude_config(path)
+    os.unlink(path)
+    medium = [f for f in findings if f.severity == "medium" and "WebFetch" in f.reason]
+    assert len(medium) >= 1
+    assert "12 domains" in medium[0].reason
+
+
+def test_small_webfetch_allowlist_ok():
+    """A small number of WebFetch domains should not trigger."""
+    path = _write_config({"permissions": {"allow": ["WebFetch(domain:docs.genesiscomputing.com)"]}})
+    findings = check_claude_config(path)
+    os.unlink(path)
+    webfetch = [f for f in findings if "WebFetch" in f.reason]
+    assert len(webfetch) == 0
+
+
+def test_default_allow_posture():
+    """Large allow list with no deny list should be flagged."""
+    allows = [f"Bash(cmd{i}:*)" for i in range(25)]
+    path = _write_config({"permissions": {"allow": allows}})
+    findings = check_claude_config(path)
+    os.unlink(path)
+    posture = [f for f in findings if "Default-allow" in f.reason]
+    assert len(posture) >= 1
+
+
+def test_hardcoded_secret_in_mcp_server():
+    """Hardcoded API keys in mcpServers env should be flagged."""
+    path = _write_config(
+        {
+            "mcpServers": {
+                "my-server": {
+                    "command": "npx",
+                    "args": ["my-mcp"],
+                    "env": {"API_KEY": "sk-abc123-real-key"},
+                }
+            }
+        }
+    )
+    findings = check_claude_config(path)
+    os.unlink(path)
+    secret = [f for f in findings if "Hardcoded secret" in f.reason]
+    assert len(secret) >= 1
+    assert secret[0].severity == "high"
+
+
+def test_env_ref_secret_ok():
+    """Secret using env variable reference should not be flagged."""
+    path = _write_config(
+        {
+            "mcpServers": {
+                "my-server": {
+                    "command": "npx",
+                    "args": ["my-mcp"],
+                    "env": {"API_KEY": "${env:MY_API_KEY}"},
+                }
+            }
+        }
+    )
+    findings = check_claude_config(path)
+    os.unlink(path)
+    secret = [f for f in findings if "Hardcoded secret" in f.reason]
+    assert len(secret) == 0
+
+
+def test_scoped_permissions_clean():
+    """Properly scoped permissions should not trigger findings."""
+    path = _write_config(
+        {
+            "permissions": {
+                "allow": [
+                    "Bash(git status:*)",
+                    "Bash(npm test:*)",
+                    "WebFetch(domain:docs.example.com)",
+                ],
+                "deny": ["Bash(rm -rf:*)"],
+            }
+        }
+    )
+    findings = check_claude_config(path)
+    os.unlink(path)
+    perm_findings = [f for f in findings if f.category == "claude_permissions"]
+    assert len(perm_findings) == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.35.0"
+    assert __version__ == "0.36.0"
 
 
 def test_report_version_matches():
@@ -2933,7 +2933,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.35.0"
+    assert data["version"] == "0.36.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
- **New: permissions.allow scanning** — detects overly broad agent config permissions that expand attack surface:
  - Unrestricted `Bash(*)` / `Read(//**)` / `Edit(//**)` → CRITICAL/HIGH
  - Large WebFetch domain allowlists (>10 domains) → MEDIUM exfiltration surface
  - Default-allow posture (many allows, no deny list) → MEDIUM
  - Hardcoded secrets in `mcpServers` env vars → HIGH
  - Properly scoped permissions (e.g., `Bash(git status:*)`) pass clean
- **Version bump** 0.35.0 → 0.36.0 across all 12 version-synced files
- **1,748 tests passing** (9 new for permissions scanning)

## Context
Your `.claude/settings.json` `permissions.allow` section (and similar in Cursor, Windsurf, Zed, etc.) defines the agent's blast radius. Overly broad grants like `Bash(*)` give any MCP tool full shell access. This scanner flags those patterns during `--enforce` runs.

## Test plan
- [x] `pytest tests/test_claude_config.py` — 15 tests pass (6 existing + 9 new)
- [x] `pytest tests/ -x -q` — 1,748 passed
- [x] `ruff check src/ tests/` — clean
- [x] Version sync verified across pyproject.toml, __init__.py, Dockerfiles, server.json, SKILL.md, README.md