### PR TITLE
feat: full PostgreSQL coverage for all store backends

### DIFF
--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -107,11 +107,14 @@ async def _lifespan(app_instance: FastAPI):
     # ── Schedule store ──
     global _schedule_store
     if _schedule_store is None:
-        db_path = _os.environ.get("AGENT_BOM_DB")
-        if db_path:
+        if _os.environ.get("AGENT_BOM_POSTGRES_URL"):
+            from agent_bom.api.postgres_store import PostgresScheduleStore
+
+            _schedule_store = PostgresScheduleStore()
+        elif _os.environ.get("AGENT_BOM_DB"):
             from agent_bom.api.schedule_store import SQLiteScheduleStore
 
-            _schedule_store = SQLiteScheduleStore(db_path)
+            _schedule_store = SQLiteScheduleStore(_os.environ["AGENT_BOM_DB"])
         else:
             from agent_bom.api.schedule_store import InMemoryScheduleStore
 


### PR DESCRIPTION
## Summary
- Add `PostgresScheduleStore` — recurring scan schedule persistence via Postgres
- Add `PostgresScanCache` — shared OSV vulnerability cache across instances
- Wire Postgres schedule store in server lifespan (`AGENT_BOM_POSTGRES_URL` priority)
- CLI `api` command auto-detects Postgres URL, no longer hardcoded to SQLite only
- Fix mock infrastructure for `GROUP BY` and `COUNT(*)` queries in test suite

All 5 store backends now have full Postgres parity:

| Store | SQLite | Postgres | Snowflake |
|-------|--------|----------|-----------|
| JobStore | ✓ | ✓ | ✓ |
| FleetStore | ✓ | ✓ | ✓ |
| PolicyStore | ✓ | ✓ | ✓ |
| ScheduleStore | ✓ | **✓ NEW** | — |
| ScanCache | ✓ | **✓ NEW** | — |

## Test plan
- [x] 1938 tests pass (`pytest tests/ -x -q`)
- [x] Lint clean (`ruff check src/ tests/`)
- [ ] Verify `AGENT_BOM_POSTGRES_URL` picks up schedule store + scan cache in deployed env