### PR TITLE
fix: harden PostgreSQL Docker setup — security + production readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,11 +39,20 @@ CACHE_ENABLED=true
 CACHE_TTL=3600
 REDIS_URL=redis://localhost:6379/0
 
-# PostgreSQL (for multi-instance / production deployments)
-# Set POSTGRES_PASSWORD to enable — docker-compose will refuse to start without it
+# ── PostgreSQL ──────────────────────────────────────────────────────────────
+# Docker Compose requires POSTGRES_PASSWORD (will refuse to start without it).
+# POSTGRES_APP_PASSWORD enables least-privilege: the app connects as agent_bom_app
+# (DML only — cannot CREATE/DROP/ALTER tables). If not set, falls back to admin user.
+
+# Admin user (owns schema, runs migrations — do NOT give to the app)
 POSTGRES_PASSWORD=
 POSTGRES_USER=agent_bom
 POSTGRES_DB=agent_bom
 POSTGRES_PORT=5432
-# Constructed automatically by docker-compose; set manually for external Postgres:
-# AGENT_BOM_POSTGRES_URL=postgresql://agent_bom:<password>@localhost:5432/agent_bom
+
+# App user (least privilege — SELECT, INSERT, UPDATE, DELETE only)
+POSTGRES_APP_PASSWORD=
+POSTGRES_APP_USER=agent_bom_app
+
+# For external/managed Postgres (Supabase, Neon, RDS), set this directly:
+# AGENT_BOM_POSTGRES_URL=postgresql://agent_bom_app:<password>@<host>:5432/agent_bom

--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -1,8 +1,15 @@
 version: "3.8"
 
-# Platform deployment: API + Dashboard + PostgreSQL
+# Production-like platform deployment: API + Dashboard + PostgreSQL
+#
+# Defense in depth:
+#   - Postgres on internal 'backend' network only — not reachable from host or internet
+#   - API bridges backend + frontend networks
+#   - UI on frontend only — cannot reach Postgres directly
+#   - App connects as agent_bom_app (DML only, no DDL) when POSTGRES_APP_PASSWORD is set
+#
 # Usage:
-#   cp .env.example .env   # then set POSTGRES_PASSWORD
+#   cp .env.example .env   # set POSTGRES_PASSWORD + POSTGRES_APP_PASSWORD
 #   docker compose -f docker-compose.platform.yml up --build
 
 services:
@@ -13,9 +20,11 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-agent_bom}
       POSTGRES_USER: ${POSTGRES_USER:-agent_bom}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_APP_PASSWORD: ${POSTGRES_APP_PASSWORD:-}
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./infra/postgres/init-wrapper.sh:/docker-entrypoint-initdb.d/00-init-wrapper.sh:ro
       - ./infra/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-agent_bom} -d ${POSTGRES_DB:-agent_bom}"]
@@ -31,6 +40,9 @@ services:
         -c log_statement=ddl
         -c max_connections=100
         -c shared_buffers=128MB
+    # NO ports exposed — only reachable from backend network
+    networks:
+      - backend
     restart: unless-stopped
 
   api:
@@ -43,7 +55,8 @@ services:
     ports:
       - "8422:8422"
     environment:
-      - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_USER:-agent_bom}:${POSTGRES_PASSWORD:?err}@postgres:5432/${POSTGRES_DB:-agent_bom}
+      # Use app user (DML only) when available, fall back to admin for dev
+      - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_APP_USER:-${POSTGRES_USER:-agent_bom}}:${POSTGRES_APP_PASSWORD:-${POSTGRES_PASSWORD:?err}}@postgres:5432/${POSTGRES_DB:-agent_bom}
       - CORS_ORIGINS=http://localhost:3000,http://ui:3000
       - NVD_API_KEY=${NVD_API_KEY:-}
     depends_on:
@@ -55,6 +68,10 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    # API bridges both networks: talks to Postgres on backend, serves UI on frontend
+    networks:
+      - backend
+      - frontend
     restart: unless-stopped
 
   ui:
@@ -72,11 +89,18 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    # UI on frontend only — cannot reach Postgres directly
+    networks:
+      - frontend
     restart: unless-stopped
 
 volumes:
   postgres-data:
 
 networks:
-  default:
-    name: agent-bom-platform
+  backend:
+    name: agent-bom-backend
+    # Internal: not routable from host — only containers on this network can reach Postgres
+    internal: true
+  frontend:
+    name: agent-bom-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 version: '3.8'
 
+# Development compose — scanner + Redis + PostgreSQL
+# Usage:
+#   cp .env.example .env   # set POSTGRES_PASSWORD (required)
+#   docker compose up
+
 services:
   # agent-bom scanner service
   agent-bom:
@@ -7,9 +12,10 @@ services:
     image: agent-bom:latest
     container_name: agent-bom-scanner
     environment:
-      # PostgreSQL — single env var, picks up all 5 store backends
-      - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_USER:-agent_bom}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-agent_bom}
-      # API keys (load from .env file or set here)
+      # PostgreSQL — app user (DML only) when POSTGRES_APP_PASSWORD is set,
+      # falls back to admin user for dev convenience
+      - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_APP_USER:-${POSTGRES_USER:-agent_bom}}:${POSTGRES_APP_PASSWORD:-${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}}@postgres:5432/${POSTGRES_DB:-agent_bom}
+      # API keys
       - NVD_API_KEY=${NVD_API_KEY:-}
       # Cloud credentials
       - SNOWFLAKE_ACCOUNT=${SNOWFLAKE_ACCOUNT:-}
@@ -27,6 +33,8 @@ services:
       # Mount test configs
       - ./tests:/workspace/tests:ro
     command: scan --enrich --format json --output /workspace/reports/ai-bom.json
+    networks:
+      - backend
     depends_on:
       postgres:
         condition: service_healthy
@@ -40,6 +48,8 @@ services:
     volumes:
       - redis-data:/data
     command: redis-server --appendonly yes
+    networks:
+      - backend
 
   # PostgreSQL for persistent storage
   postgres:
@@ -49,12 +59,14 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-agent_bom}
       POSTGRES_USER: ${POSTGRES_USER:-agent_bom}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
-      # scram-sha-256 is the strongest built-in auth method
+      POSTGRES_APP_PASSWORD: ${POSTGRES_APP_PASSWORD:-}
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
     ports:
+      # Exposed for dev — platform compose does NOT expose this
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./infra/postgres/init-wrapper.sh:/docker-entrypoint-initdb.d/00-init-wrapper.sh:ro
       - ./infra/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-agent_bom} -d ${POSTGRES_DB:-agent_bom}"]
@@ -62,7 +74,6 @@ services:
       timeout: 3s
       retries: 5
       start_period: 10s
-    # Hardened Postgres settings
     command: >
       postgres
         -c password_encryption=scram-sha-256
@@ -72,11 +83,13 @@ services:
         -c max_connections=100
         -c shared_buffers=128MB
         -c work_mem=4MB
+    networks:
+      - backend
 
 volumes:
   redis-data:
   postgres-data:
 
 networks:
-  default:
-    name: agent-bom-network
+  backend:
+    name: agent-bom-backend

--- a/infra/postgres/init-wrapper.sh
+++ b/infra/postgres/init-wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Wrapper to pass POSTGRES_APP_PASSWORD into the init SQL via current_setting().
+# docker-entrypoint-initdb.d runs this before 01-init.sql.
+set -euo pipefail
+
+# Set the app password as a custom GUC so init.sql can read it
+if [ -n "${POSTGRES_APP_PASSWORD:-}" ]; then
+    echo "Setting init.app_password for least-privilege app user creation"
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-SQL
+        ALTER DATABASE ${POSTGRES_DB} SET init.app_password = '${POSTGRES_APP_PASSWORD}';
+SQL
+else
+    echo "POSTGRES_APP_PASSWORD not set — app will use admin user (dev mode)"
+fi

--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -1,12 +1,15 @@
 -- agent-bom PostgreSQL initialization
 -- Runs once on first container start via docker-entrypoint-initdb.d
 --
--- Security: scram-sha-256 auth, least-privilege roles, row-level defaults.
+-- Principle: POSTGRES_USER (admin) owns the schema and creates tables.
+-- A separate app user (agent_bom_app) gets DML-only access.
+-- A read-only role exists for dashboards and BI tools.
+--
+-- Auth: scram-sha-256 (set via POSTGRES_INITDB_ARGS + runtime config)
 -- All tables use IF NOT EXISTS — safe to re-run.
 
 -- ── Extensions ────────────────────────────────────────────────────────────────
 
--- pgcrypto for gen_random_uuid() if needed
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- ── Tables: Scan Jobs ─────────────────────────────────────────────────────────
@@ -76,7 +79,59 @@ CREATE TABLE IF NOT EXISTS osv_cache (
 
 CREATE INDEX IF NOT EXISTS idx_cache_age ON osv_cache(cached_at);
 
--- ── Read-only role for dashboards / BI tools ──────────────────────────────────
+-- ══════════════════════════════════════════════════════════════════════════════
+-- LEAST PRIVILEGE: App user — DML only, no DDL (cannot CREATE/DROP/ALTER)
+-- ══════════════════════════════════════════════════════════════════════════════
+
+-- Password is injected via POSTGRES_APP_PASSWORD env var in the wrapper script.
+-- If not set, this block is skipped and the admin user is used (dev fallback).
+DO $$
+DECLARE
+    app_pass TEXT;
+BEGIN
+    -- Read password from env via current_setting (set by init wrapper)
+    app_pass := current_setting('init.app_password', true);
+
+    IF app_pass IS NOT NULL AND app_pass != '' THEN
+        -- Create app user if not exists
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+            EXECUTE format('CREATE ROLE agent_bom_app LOGIN PASSWORD %L', app_pass);
+        ELSE
+            EXECUTE format('ALTER ROLE agent_bom_app PASSWORD %L', app_pass);
+        END IF;
+
+        -- Connection limit: prevent app from exhausting all connections
+        ALTER ROLE agent_bom_app CONNECTION LIMIT 20;
+
+        -- Statement timeout: kill runaway queries after 30 seconds
+        ALTER ROLE agent_bom_app SET statement_timeout = '30s';
+
+        -- Lock timeout: don't wait forever for row locks
+        ALTER ROLE agent_bom_app SET lock_timeout = '5s';
+
+        -- DML only: SELECT, INSERT, UPDATE, DELETE on all current + future tables
+        GRANT CONNECT ON DATABASE agent_bom TO agent_bom_app;
+        GRANT USAGE ON SCHEMA public TO agent_bom_app;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO agent_bom_app;
+        GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO agent_bom_app;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO agent_bom_app;
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT USAGE, SELECT ON SEQUENCES TO agent_bom_app;
+
+        -- Explicitly deny DDL — app cannot CREATE, DROP, ALTER, or TRUNCATE
+        REVOKE CREATE ON SCHEMA public FROM agent_bom_app;
+
+        RAISE NOTICE 'agent_bom_app user created with DML-only access';
+    ELSE
+        RAISE NOTICE 'POSTGRES_APP_PASSWORD not set — skipping app user creation (dev mode)';
+    END IF;
+END
+$$;
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- READ-ONLY ROLE: For dashboards, BI tools, and audit queries
+-- ══════════════════════════════════════════════════════════════════════════════
 
 DO $$
 BEGIN
@@ -86,8 +141,19 @@ BEGIN
 END
 $$;
 
+GRANT CONNECT ON DATABASE agent_bom TO agent_bom_readonly;
+GRANT USAGE ON SCHEMA public TO agent_bom_readonly;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO agent_bom_readonly;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_bom_readonly;
 
--- Done. All 5 store backends ready.
--- Connection: AGENT_BOM_POSTGRES_URL=postgresql://agent_bom:<password>@<host>:5432/agent_bom
+-- ══════════════════════════════════════════════════════════════════════════════
+-- SUMMARY
+-- ══════════════════════════════════════════════════════════════════════════════
+--
+--  Role               | Can do                          | Cannot do
+--  -------------------|--------------------------------|---------------------------
+--  agent_bom (admin)  | DDL + DML (schema owner)       | — (superuser on this DB)
+--  agent_bom_app      | SELECT, INSERT, UPDATE, DELETE  | CREATE, DROP, ALTER, TRUNCATE
+--  agent_bom_readonly | SELECT only                     | Any writes
+--
+--  Connection: AGENT_BOM_POSTGRES_URL=postgresql://agent_bom_app:<pw>@<host>:5432/agent_bom


### PR DESCRIPTION
## Summary
- Remove hardcoded `changeme` password — `POSTGRES_PASSWORD` is now **required** via `.env` (compose refuses to start without it)
- Enable **scram-sha-256** auth (strongest built-in Postgres auth, replaces md5)
- Add **healthchecks** so app services wait for Postgres readiness before starting
- Upgrade `postgres:15-alpine` → `postgres:16-alpine`
- Wire `AGENT_BOM_POSTGRES_URL` automatically in both compose files
- **Platform compose**: replace SQLite with Postgres for multi-replica API deployments
- Add `infra/postgres/init.sql` — pre-creates all 5 tables, indexes, and a read-only role for BI/dashboards
- Fix `.env.example` — correct env var name, no hardcoded credentials

## Security changes
| Before | After |
|--------|-------|
| `POSTGRES_PASSWORD=changeme` hardcoded | Required via `.env`, compose fails without it |
| md5 auth (default) | scram-sha-256 (initdb + runtime) |
| No healthcheck | `pg_isready` healthcheck, services depend on it |
| No logging | `log_connections`, `log_disconnections`, `log_statement=ddl` |
| No read-only role | `agent_bom_readonly` role for dashboard/BI access |

## Quick start
```bash
cp .env.example .env
# Set a strong POSTGRES_PASSWORD in .env
docker compose -f docker-compose.platform.yml up --build
```

## Test plan
- [x] 1938 tests pass
- [x] Lint clean
- [ ] `docker compose -f docker-compose.platform.yml config` validates
- [ ] `docker compose -f docker-compose.platform.yml up` starts cleanly with `.env`