### PR TITLE
fix: medium-priority enterprise hardening

### DIFF
--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -499,6 +499,9 @@ def _sync_scan_agents_to_fleet(agents: list) -> None:
     store = _get_fleet_store()
     now = _now()
 
+    # Collect all agents for a single batch upsert (atomicity)
+    to_upsert: list[FleetAgent] = []
+
     for agent in agents:
         existing = store.get_by_name(agent.name)
         server_count = len(agent.mcp_servers)
@@ -516,7 +519,7 @@ def _sync_scan_agents_to_fleet(agents: list) -> None:
             existing.trust_score = score
             existing.trust_factors = factors
             existing.updated_at = now
-            store.put(existing)
+            to_upsert.append(existing)
         else:
             fleet_agent = FleetAgent(
                 agent_id=str(uuid.uuid4()),
@@ -534,7 +537,10 @@ def _sync_scan_agents_to_fleet(agents: list) -> None:
                 created_at=now,
                 updated_at=now,
             )
-            store.put(fleet_agent)
+            to_upsert.append(fleet_agent)
+
+    if to_upsert:
+        store.batch_put(to_upsert)
 
 
 def _run_scan_sync(job: ScanJob) -> None:

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -37,6 +37,18 @@ _ENRICHMENT_TTL = 604_800  # 7 days
 _nvd_file_cache: dict[str, dict] = {}
 _epss_file_cache: dict[str, dict] = {}
 _enrichment_cache_loaded = False
+_MAX_ENRICHMENT_CACHE_ENTRIES = 10_000  # Prevent unbounded memory growth
+
+
+def _evict_oldest(cache: dict[str, dict], max_entries: int) -> None:
+    """Evict oldest entries when cache exceeds max_entries."""
+    if len(cache) <= max_entries:
+        return
+    # Sort by _cached_at and remove oldest
+    by_age = sorted(cache.items(), key=lambda kv: kv[1].get("_cached_at", 0))
+    to_remove = len(cache) - max_entries
+    for key, _ in by_age[:to_remove]:
+        del cache[key]
 
 
 def _load_enrichment_cache() -> None:
@@ -111,6 +123,7 @@ async def fetch_nvd_data(cve_id: str, client: httpx.AsyncClient, api_key: Option
                 result = vulnerabilities[0].get("cve", {})
                 # Store in persistent cache
                 _nvd_file_cache[cve_id] = {**result, "_cached_at": time.time()}
+                _evict_oldest(_nvd_file_cache, _MAX_ENRICHMENT_CACHE_ENTRIES)
                 return result
         except (ValueError, KeyError) as e:
             console.print(f"  [dim yellow]NVD parse error for {cve_id}: {e}[/dim yellow]")
@@ -173,6 +186,7 @@ async def fetch_epss_scores(cve_ids: list[str], client: httpx.AsyncClient) -> di
                     }
                     scores[cve] = entry
                     _epss_file_cache[cve] = {**entry, "_cached_at": time.time()}
+            _evict_oldest(_epss_file_cache, _MAX_ENRICHMENT_CACHE_ENTRIES)
         except (ValueError, KeyError) as e:
             console.print(f"  [dim yellow]EPSS parse error: {e}[/dim yellow]")
 

--- a/src/agent_bom/http_client.py
+++ b/src/agent_bom/http_client.py
@@ -51,17 +51,22 @@ def _safe_url(url: str) -> str:  # noqa: PLW0108
         return "<redacted-url>"
 
 
-def create_client(timeout: float = 30.0) -> httpx.AsyncClient:
+def create_client(timeout: float = 30.0, max_redirects: int = 5) -> httpx.AsyncClient:
     """Create an httpx.AsyncClient with connection-level retries.
 
     Uses httpx's built-in transport retry for connection failures (DNS, TCP reset).
-    Application-level retries (429, 5xx) are handled by `request_with_retry`.
+    Application-level retries (429, 5xx) are handled by ``request_with_retry``.
+
+    Args:
+        timeout: Per-request timeout in seconds.
+        max_redirects: Maximum number of HTTP redirects to follow (default 5).
     """
     transport = httpx.AsyncHTTPTransport(retries=2)
     return httpx.AsyncClient(
         timeout=timeout,
         transport=transport,
         follow_redirects=True,
+        max_redirects=max_redirects,
     )
 
 

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -403,6 +403,66 @@ def _packages_from_tar(tar_path: Path) -> list[Package]:
                                 pkg_name = pkg_version = ""
                 except Exception:
                     _logger.debug("Failed to parse dpkg status from container")
+
+            # --- Alpine: apk installed ---
+            apk_installed = "lib/apk/db/installed"
+            if apk_installed in names:
+                try:
+                    member = tf.getmember(apk_installed)
+                    f = tf.extractfile(member)
+                    if f:
+                        content = f.read().decode("utf-8", errors="ignore")
+                        pkg_name = pkg_version = ""
+                        for line in content.splitlines():
+                            if line.startswith("P:"):
+                                pkg_name = line[2:].strip()
+                            elif line.startswith("V:"):
+                                pkg_version = line[2:].strip()
+                            elif line == "" and pkg_name and pkg_version:
+                                _add(pkg_name, pkg_version, "apk", f"pkg:apk/alpine/{pkg_name}@{pkg_version}")
+                                pkg_name = pkg_version = ""
+                        # Handle last entry if file doesn't end with blank line
+                        if pkg_name and pkg_version:
+                            _add(pkg_name, pkg_version, "apk", f"pkg:apk/alpine/{pkg_name}@{pkg_version}")
+                except Exception:
+                    _logger.debug("Failed to parse Alpine apk db from container")
+
+            # --- RHEL/Fedora: rpm database ---
+            # rpm stores a plain text list at /var/lib/rpm/Packages or rpmdb.sqlite
+            # Fallback: look for rpm manifest written by some base images
+            for rpm_path in ("var/lib/rpm/rpmdb.sqlite", "var/lib/rpm/Packages"):
+                if rpm_path in names:
+                    # Can't easily parse binary rpm db from tar; skip to
+                    # installed-rpms manifest if present
+                    break
+
+            rpm_manifest = "var/log/installed-rpms"
+            if rpm_manifest in names:
+                try:
+                    member = tf.getmember(rpm_manifest)
+                    f = tf.extractfile(member)
+                    if f:
+                        for raw_line in f:
+                            line = raw_line.decode("utf-8", errors="ignore").strip()
+                            if not line:
+                                continue
+                            # Format: name-version-release.arch (e.g. bash-5.2.26-4.el9.x86_64)
+                            # Split from right at the second-to-last hyphen
+                            parts = line.split()
+                            nvr = parts[0] if parts else line
+                            # Find the last two hyphens to split name from version-release
+                            idx2 = nvr.rfind("-")
+                            if idx2 > 0:
+                                idx1 = nvr.rfind("-", 0, idx2)
+                                if idx1 > 0:
+                                    rpm_name = nvr[:idx1]
+                                    if rpm_name == "gpg-pubkey":
+                                        continue
+                                    rpm_ver = nvr[idx1 + 1 : idx2]
+                                    _add(rpm_name, rpm_ver, "rpm", f"pkg:rpm/redhat/{rpm_name}@{rpm_ver}")
+                except Exception:
+                    _logger.debug("Failed to parse rpm manifest from container")
+
     except tarfile.TarError as e:
         raise ImageScanError(f"Failed to read container filesystem: {e}")
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -249,11 +249,14 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float]]:
         if sev.get("type") in ("CVSS_V3", "CVSS_V3_1"):
             score_str = sev.get("score", "")
             try:
-                cvss_score = float(score_str)
+                parsed = float(score_str)
+                # CVSS scores must be 0.0–10.0
+                if 0.0 <= parsed <= 10.0:
+                    cvss_score = parsed
             except ValueError:
                 # It's a CVSS vector string — compute the base score
                 computed = parse_cvss_vector(score_str)
-                if computed is not None:
+                if computed is not None and 0.0 <= computed <= 10.0:
                     cvss_score = computed
 
     # Check database_specific for severity label (reliable fallback)
@@ -277,15 +280,32 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float]]:
 
 
 def parse_fixed_version(vuln_data: dict, package_name: str) -> Optional[str]:
-    """Extract fixed version from OSV affected data."""
+    """Extract fixed version from OSV affected data.
+
+    Prefers stable releases over pre-release versions.
+    """
+    prerelease_candidate: Optional[str] = None
+
     for affected in vuln_data.get("affected", []):
         pkg = affected.get("package", {})
         if pkg.get("name", "").lower() == package_name.lower():
             for rng in affected.get("ranges", []):
                 for event in rng.get("events", []):
                     if "fixed" in event:
-                        return event["fixed"]
-    return None
+                        fixed = event["fixed"]
+                        try:
+                            from packaging.version import Version
+
+                            pv = Version(fixed)
+                            if not pv.is_prerelease:
+                                return fixed
+                            # Remember pre-release as fallback
+                            if prerelease_candidate is None:
+                                prerelease_candidate = fixed
+                        except Exception:  # noqa: BLE001
+                            # Can't parse (e.g. non-PEP440 npm version) — return as-is
+                            return fixed
+    return prerelease_candidate
 
 
 async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:

--- a/src/agent_bom/transitive.py
+++ b/src/agent_bom/transitive.py
@@ -22,10 +22,19 @@ _npm_cache: dict[str, dict] = {}
 _pypi_cache: dict[str, dict] = {}
 
 
+def _is_prerelease(version_str: str) -> bool:
+    """Check if an npm version string is a pre-release (e.g., 1.0.0-beta.1)."""
+    # Semver pre-release: anything with a hyphen after the version core
+    # e.g., "1.0.0-alpha", "2.1.0-rc.1", "3.0.0-beta"
+    base = version_str.split("+")[0]  # strip build metadata
+    return "-" in base
+
+
 def _resolve_npm_version(version_range: str, pkg_data: dict) -> str:
     """Pick the best npm version satisfying a semver range.
 
     Uses a simplified semver matcher sufficient for most ^X.Y.Z / ~X.Y.Z / >=X patterns.
+    Excludes pre-release versions (e.g., 1.0.0-beta) unless no stable match is found.
     Falls back to dist-tags.latest if no match found.
     """
     latest = pkg_data.get("dist-tags", {}).get("latest", "")
@@ -51,6 +60,8 @@ def _resolve_npm_version(version_range: str, pkg_data: dict) -> str:
         major = min_parts[0] if min_parts else 0
         candidates = []
         for v in available:
+            if _is_prerelease(v):
+                continue
             try:
                 parts = tuple(int(x) for x in v.split(".") if x.isdigit())
                 if parts[0] == major and parts >= min_parts:
@@ -65,6 +76,8 @@ def _resolve_npm_version(version_range: str, pkg_data: dict) -> str:
         minor = min_parts[1] if len(min_parts) > 1 else 0
         candidates = []
         for v in available:
+            if _is_prerelease(v):
+                continue
             try:
                 parts = tuple(int(x) for x in v.split(".") if x.isdigit())
                 if len(parts) >= 2 and parts[0] == major and parts[1] == minor and parts >= min_parts:
@@ -76,6 +89,8 @@ def _resolve_npm_version(version_range: str, pkg_data: dict) -> str:
     elif ">=" in version_range:
         candidates = []
         for v in available:
+            if _is_prerelease(v):
+                continue
             try:
                 parts = tuple(int(x) for x in v.split(".") if x.isdigit())
                 if parts >= min_parts:
@@ -117,11 +132,7 @@ def _resolve_pip_version(version_spec: str, releases: dict) -> str:
     return re.sub(r"[^0-9.]", "", version_spec.split(",")[0]) or "unknown"
 
 
-async def fetch_npm_metadata(
-    package_name: str,
-    version: str,
-    client: httpx.AsyncClient
-) -> Optional[dict]:
+async def fetch_npm_metadata(package_name: str, version: str, client: httpx.AsyncClient) -> Optional[dict]:
     """Fetch package metadata from npm registry, resolving ranges to exact versions."""
     cache_key = f"{package_name}@{version}"
     if cache_key in _npm_cache:
@@ -132,7 +143,9 @@ async def fetch_npm_metadata(
 
     if is_range:
         response = await request_with_retry(
-            client, "GET", f"{NPM_REGISTRY}/{encoded_name}",
+            client,
+            "GET",
+            f"{NPM_REGISTRY}/{encoded_name}",
         )
         if response and response.status_code == 200:
             try:
@@ -146,7 +159,9 @@ async def fetch_npm_metadata(
                 pass
     else:
         response = await request_with_retry(
-            client, "GET", f"{NPM_REGISTRY}/{encoded_name}/{version}",
+            client,
+            "GET",
+            f"{NPM_REGISTRY}/{encoded_name}/{version}",
         )
         if response and response.status_code == 200:
             try:
@@ -159,11 +174,7 @@ async def fetch_npm_metadata(
     return None
 
 
-async def fetch_pypi_metadata(
-    package_name: str,
-    version: str,
-    client: httpx.AsyncClient
-) -> Optional[dict]:
+async def fetch_pypi_metadata(package_name: str, version: str, client: httpx.AsyncClient) -> Optional[dict]:
     """Fetch package metadata from PyPI, resolving version specifiers to exact versions."""
     cache_key = f"{package_name}@{version}"
     if cache_key in _pypi_cache:
@@ -173,7 +184,9 @@ async def fetch_pypi_metadata(
 
     if is_range:
         response = await request_with_retry(
-            client, "GET", f"{PYPI_API}/{package_name}/json",
+            client,
+            "GET",
+            f"{PYPI_API}/{package_name}/json",
         )
         if response and response.status_code == 200:
             try:
@@ -182,7 +195,9 @@ async def fetch_pypi_metadata(
                 resolved = _resolve_pip_version(version if version not in ("latest", "unknown", "") else "", releases)
                 if resolved and resolved != "unknown":
                     version_data = await request_with_retry(
-                        client, "GET", f"{PYPI_API}/{package_name}/{resolved}/json",
+                        client,
+                        "GET",
+                        f"{PYPI_API}/{package_name}/{resolved}/json",
                     )
                     if version_data and version_data.status_code == 200:
                         data = version_data.json()
@@ -194,7 +209,9 @@ async def fetch_pypi_metadata(
                 pass
     else:
         response = await request_with_retry(
-            client, "GET", f"{PYPI_API}/{package_name}/{version}/json",
+            client,
+            "GET",
+            f"{PYPI_API}/{package_name}/{version}/json",
         )
         if response and response.status_code == 200:
             try:
@@ -306,7 +323,7 @@ async def resolve_pypi_dependencies(
             continue  # Skip optional dependencies
 
         # Extract package name and version
-        match = re.match(r'^([a-zA-Z0-9_.-]+)\s*([<>=!~]+)?\s*([a-zA-Z0-9_.*+-]+)?', dep_spec)
+        match = re.match(r"^([a-zA-Z0-9_.-]+)\s*([<>=!~]+)?\s*([a-zA-Z0-9_.*+-]+)?", dep_spec)
         if not match:
             continue
 

--- a/tests/test_medium_hardening.py
+++ b/tests/test_medium_hardening.py
@@ -1,0 +1,479 @@
+"""Tests for medium-priority hardening fixes.
+
+Covers: HTTP redirect limits, enrichment cache bounds, CVSS validation,
+Alpine/RHEL image scanning, pre-release version filtering, fleet sync atomicity.
+"""
+
+from __future__ import annotations
+
+import tarfile
+import tempfile
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+# ── M1: HTTP redirect limits ─────────────────────────────────────────────────
+
+
+def test_create_client_default_redirects():
+    """create_client sets max_redirects=5 by default."""
+    import asyncio
+
+    from agent_bom.http_client import create_client
+
+    client = create_client()
+    assert client.max_redirects == 5
+    asyncio.run(client.aclose())
+
+
+def test_create_client_custom_redirects():
+    """create_client accepts a custom max_redirects."""
+    import asyncio
+
+    from agent_bom.http_client import create_client
+
+    client = create_client(max_redirects=10)
+    assert client.max_redirects == 10
+    asyncio.run(client.aclose())
+
+
+def test_create_client_follows_redirects():
+    """create_client enables follow_redirects."""
+    import asyncio
+
+    from agent_bom.http_client import create_client
+
+    client = create_client()
+    assert client.follow_redirects is True
+    asyncio.run(client.aclose())
+
+
+# ── M2: Enrichment cache bounds ──────────────────────────────────────────────
+
+
+def test_evict_oldest_noop_under_limit():
+    """_evict_oldest does nothing when cache is within limit."""
+    from agent_bom.enrichment import _evict_oldest
+
+    cache = {f"CVE-{i}": {"_cached_at": i} for i in range(5)}
+    _evict_oldest(cache, 10)
+    assert len(cache) == 5
+
+
+def test_evict_oldest_trims_to_max():
+    """_evict_oldest removes oldest entries when cache exceeds max."""
+    from agent_bom.enrichment import _evict_oldest
+
+    cache = {f"CVE-{i}": {"_cached_at": float(i)} for i in range(20)}
+    _evict_oldest(cache, 10)
+    assert len(cache) == 10
+    # Oldest entries (0-9) should be gone, newest (10-19) should remain
+    assert "CVE-0" not in cache
+    assert "CVE-19" in cache
+
+
+def test_evict_oldest_exact_limit():
+    """_evict_oldest does nothing when cache is exactly at max."""
+    from agent_bom.enrichment import _evict_oldest
+
+    cache = {f"CVE-{i}": {"_cached_at": float(i)} for i in range(10)}
+    _evict_oldest(cache, 10)
+    assert len(cache) == 10
+
+
+def test_max_enrichment_cache_entries_defined():
+    """_MAX_ENRICHMENT_CACHE_ENTRIES is set to a reasonable value."""
+    from agent_bom.enrichment import _MAX_ENRICHMENT_CACHE_ENTRIES
+
+    assert _MAX_ENRICHMENT_CACHE_ENTRIES == 10_000
+
+
+# ── M3: CVSS validation ─────────────────────────────────────────────────────
+
+
+def test_cvss_valid_score_accepted():
+    """Valid CVSS scores (0.0-10.0) are parsed correctly."""
+    from agent_bom.scanners import parse_osv_severity
+
+    # Build a minimal OSV vuln with a CVSS score of 7.5
+    vuln_data = {
+        "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"}],
+        "database_specific": {"severity": "HIGH"},
+    }
+
+    severity, score = parse_osv_severity(vuln_data)
+    # Should accept the score — exact value depends on CVSS parsing
+    assert severity is not None
+
+
+def test_cvss_out_of_range_rejected():
+    """Out-of-range CVSS scores are rejected."""
+    from agent_bom.scanners import parse_osv_severity
+
+    # Build a vuln with an impossible CVSS score
+    vuln_data = {
+        "severity": [{"type": "CVSS_V3", "score": "15.0"}],
+        "database_specific": {"severity": "CRITICAL"},
+    }
+
+    severity, score = parse_osv_severity(vuln_data)
+    # Should reject the out-of-range score and fall back to label
+    assert score is None or (score is not None and 0.0 <= score <= 10.0)
+
+
+def test_cvss_negative_rejected():
+    """Negative CVSS scores are rejected."""
+    from agent_bom.scanners import parse_osv_severity
+
+    vuln_data = {
+        "severity": [{"type": "CVSS_V3", "score": "-5.0"}],
+        "database_specific": {"severity": "LOW"},
+    }
+
+    severity, score = parse_osv_severity(vuln_data)
+    assert score is None or (score is not None and 0.0 <= score <= 10.0)
+
+
+# ── M4: Alpine/RHEL image scanning ──────────────────────────────────────────
+
+
+def _make_tar_with_file(path: str, content: str) -> bytes:
+    """Create an in-memory tar archive with a single file."""
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        data = content.encode("utf-8")
+        info = tarfile.TarInfo(name=path)
+        info.size = len(data)
+        tf.addfile(info, BytesIO(data))
+    return buf.getvalue()
+
+
+def test_alpine_apk_extraction():
+    """Alpine apk database is parsed from container tar."""
+    from agent_bom.image import _packages_from_tar
+
+    apk_content = """C:Q1abc123=
+P:musl
+V:1.2.3-r0
+A:x86_64
+S:123456
+I:234567
+T:musl C library
+U:https://musl.libc.org/
+L:MIT
+
+P:busybox
+V:1.36.1-r0
+A:x86_64
+S:500000
+I:600000
+T:BusyBox utilities
+U:https://busybox.net/
+L:GPL-2.0
+
+"""
+    tar_bytes = _make_tar_with_file("lib/apk/db/installed", apk_content)
+
+    with tempfile.NamedTemporaryFile(suffix=".tar") as tmp:
+        tmp.write(tar_bytes)
+        tmp.flush()
+        packages = _packages_from_tar(tmp.name)
+
+    apk_pkgs = [p for p in packages if p.ecosystem == "apk"]
+    assert len(apk_pkgs) >= 2
+    names = {p.name for p in apk_pkgs}
+    assert "musl" in names
+    assert "busybox" in names
+    # Check version parsing
+    musl = next(p for p in apk_pkgs if p.name == "musl")
+    assert musl.version == "1.2.3-r0"
+    assert "pkg:apk/alpine/musl" in musl.purl
+
+
+def test_rpm_manifest_extraction():
+    """RHEL/Fedora rpm manifest is parsed from container tar."""
+    from agent_bom.image import _packages_from_tar
+
+    rpm_content = """gpg-pubkey-fd431d51-4ae0493b
+bash-5.2.26-3.el9.x86_64
+coreutils-9.1-12.el9.x86_64
+glibc-2.34-83.el9.x86_64
+"""
+    tar_bytes = _make_tar_with_file("var/log/installed-rpms", rpm_content)
+
+    with tempfile.NamedTemporaryFile(suffix=".tar") as tmp:
+        tmp.write(tar_bytes)
+        tmp.flush()
+        packages = _packages_from_tar(tmp.name)
+
+    rpm_pkgs = [p for p in packages if p.ecosystem == "rpm"]
+    assert len(rpm_pkgs) >= 3
+    names = {p.name for p in rpm_pkgs}
+    assert "bash" in names
+    assert "coreutils" in names
+    assert "glibc" in names
+    # gpg-pubkey should be skipped
+    assert "gpg-pubkey" not in names
+    # Check version parsing
+    bash = next(p for p in rpm_pkgs if p.name == "bash")
+    assert "5.2.26" in bash.version
+
+
+# ── M5: Pre-release version filtering ────────────────────────────────────────
+
+
+def test_npm_resolve_skips_prerelease():
+    """npm version resolver skips pre-release versions."""
+    from agent_bom.transitive import _resolve_npm_version
+
+    pkg_data = {
+        "dist-tags": {"latest": "1.2.0"},
+        "versions": {
+            "1.0.0": {},
+            "1.1.0-beta.1": {},
+            "1.1.0-rc.1": {},
+            "1.1.0": {},
+            "1.2.0-alpha": {},
+            "1.2.0": {},
+        },
+    }
+
+    result = _resolve_npm_version("^1.0.0", pkg_data)
+    assert result == "1.2.0"
+    assert "alpha" not in result
+    assert "beta" not in result
+    assert "rc" not in result
+
+
+def test_npm_resolve_all_prerelease_falls_back_to_latest():
+    """When all candidates are pre-release, falls back to latest."""
+    from agent_bom.transitive import _resolve_npm_version
+
+    pkg_data = {
+        "dist-tags": {"latest": "1.0.0-beta"},
+        "versions": {
+            "1.0.0-alpha": {},
+            "1.0.0-beta": {},
+        },
+    }
+
+    result = _resolve_npm_version("^1.0.0", pkg_data)
+    # No stable candidates, should fall back to latest
+    assert result == "1.0.0-beta"
+
+
+def test_npm_is_prerelease():
+    """_is_prerelease correctly identifies semver pre-releases."""
+    from agent_bom.transitive import _is_prerelease
+
+    assert _is_prerelease("1.0.0-beta") is True
+    assert _is_prerelease("2.1.0-rc.1") is True
+    assert _is_prerelease("3.0.0-alpha.2") is True
+    assert _is_prerelease("1.0.0") is False
+    assert _is_prerelease("2.3.4") is False
+    # Build metadata only is NOT a pre-release
+    assert _is_prerelease("1.0.0+build.123") is False
+
+
+def test_npm_tilde_skips_prerelease():
+    """Tilde range resolver skips pre-release versions."""
+    from agent_bom.transitive import _resolve_npm_version
+
+    pkg_data = {
+        "dist-tags": {"latest": "1.2.3"},
+        "versions": {
+            "1.2.0": {},
+            "1.2.1-beta": {},
+            "1.2.1": {},
+            "1.2.2-rc.1": {},
+            "1.2.2": {},
+        },
+    }
+
+    result = _resolve_npm_version("~1.2.0", pkg_data)
+    assert result == "1.2.2"
+
+
+def test_npm_gte_skips_prerelease():
+    """>= range resolver skips pre-release versions."""
+    from agent_bom.transitive import _resolve_npm_version
+
+    pkg_data = {
+        "dist-tags": {"latest": "3.0.0"},
+        "versions": {
+            "2.0.0": {},
+            "2.1.0-beta": {},
+            "2.1.0": {},
+            "3.0.0-rc.1": {},
+            "3.0.0": {},
+        },
+    }
+
+    result = _resolve_npm_version(">=2.0.0", pkg_data)
+    assert result == "3.0.0"
+
+
+def test_fixed_version_prefers_stable():
+    """parse_fixed_version prefers stable releases over pre-releases."""
+    from agent_bom.scanners import parse_fixed_version
+
+    vuln_data = {
+        "affected": [
+            {
+                "package": {"name": "requests", "ecosystem": "PyPI"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "0"},
+                            {"fixed": "2.32.0"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = parse_fixed_version(vuln_data, "requests")
+    assert result == "2.32.0"
+
+
+def test_fixed_version_skips_prerelease():
+    """parse_fixed_version skips pre-release fixed versions when stable exists."""
+    from agent_bom.scanners import parse_fixed_version
+
+    vuln_data = {
+        "affected": [
+            {
+                "package": {"name": "flask", "ecosystem": "PyPI"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "0"},
+                            {"fixed": "3.0.0rc1"},
+                            {"fixed": "3.0.0"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = parse_fixed_version(vuln_data, "flask")
+    assert result == "3.0.0"
+
+
+def test_fixed_version_fallback_to_prerelease():
+    """parse_fixed_version falls back to pre-release if no stable fix exists."""
+    from agent_bom.scanners import parse_fixed_version
+
+    vuln_data = {
+        "affected": [
+            {
+                "package": {"name": "mylib", "ecosystem": "PyPI"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "0"},
+                            {"fixed": "2.0.0a1"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    result = parse_fixed_version(vuln_data, "mylib")
+    assert result == "2.0.0a1"
+
+
+# ── M6: Fleet sync atomicity ─────────────────────────────────────────────────
+
+
+def test_sync_uses_batch_put():
+    """_sync_scan_agents_to_fleet uses batch_put for atomic upsert."""
+    from agent_bom.api.server import _sync_scan_agents_to_fleet
+
+    mock_store = MagicMock()
+    mock_store.get_by_name.return_value = None  # All new agents
+
+    # Create mock agents
+    agents = []
+    for i in range(3):
+        agent = MagicMock()
+        agent.name = f"agent-{i}"
+        agent.agent_type.value = "mcp_client"
+        agent.config_path = f"/path/{i}"
+        server = MagicMock()
+        server.packages = []
+        server.credential_names = []
+        server.total_vulnerabilities = 0
+        agent.mcp_servers = [server]
+        agents.append(agent)
+
+    with (
+        patch("agent_bom.api.server._get_fleet_store", return_value=mock_store),
+        patch("agent_bom.fleet.trust_scoring.compute_trust_score", return_value=(0.8, {"test": True})),
+    ):
+        _sync_scan_agents_to_fleet(agents)
+
+    # batch_put should be called once with all 3 agents
+    mock_store.batch_put.assert_called_once()
+    call_args = mock_store.batch_put.call_args[0][0]
+    assert len(call_args) == 3
+
+
+def test_sync_batch_put_with_existing():
+    """_sync_scan_agents_to_fleet handles mix of new and existing agents."""
+    from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState
+    from agent_bom.api.server import _sync_scan_agents_to_fleet
+
+    existing_agent = FleetAgent(
+        agent_id="existing-id",
+        name="agent-0",
+        agent_type="mcp_client",
+        lifecycle_state=FleetLifecycleState.APPROVED,
+        trust_score=0.5,
+    )
+
+    mock_store = MagicMock()
+    mock_store.get_by_name.side_effect = lambda name: existing_agent if name == "agent-0" else None
+
+    agents = []
+    for i in range(2):
+        agent = MagicMock()
+        agent.name = f"agent-{i}"
+        agent.agent_type.value = "mcp_client"
+        agent.config_path = f"/path/{i}"
+        server = MagicMock()
+        server.packages = []
+        server.credential_names = []
+        server.total_vulnerabilities = 0
+        agent.mcp_servers = [server]
+        agents.append(agent)
+
+    with (
+        patch("agent_bom.api.server._get_fleet_store", return_value=mock_store),
+        patch("agent_bom.fleet.trust_scoring.compute_trust_score", return_value=(0.9, {})),
+    ):
+        _sync_scan_agents_to_fleet(agents)
+
+    # batch_put called with 2 agents (1 existing updated + 1 new)
+    mock_store.batch_put.assert_called_once()
+    call_args = mock_store.batch_put.call_args[0][0]
+    assert len(call_args) == 2
+    # No individual put calls
+    mock_store.put.assert_not_called()
+
+
+def test_sync_empty_agents_no_batch_put():
+    """_sync_scan_agents_to_fleet skips batch_put for empty list."""
+    from agent_bom.api.server import _sync_scan_agents_to_fleet
+
+    mock_store = MagicMock()
+
+    with patch("agent_bom.api.server._get_fleet_store", return_value=mock_store):
+        _sync_scan_agents_to_fleet([])
+
+    mock_store.batch_put.assert_not_called()


### PR DESCRIPTION
## Summary

- **M1**: HTTP redirect cap (`max_redirects=5`) on `create_client()` prevents infinite redirect loops
- **M2**: Enrichment cache bounds (10K entries) with oldest-first eviction in NVD/EPSS caches
- **M3**: CVSS score range validation rejects out-of-range values (must be 0.0–10.0)
- **M4**: Alpine apk + RHEL rpm package extraction in Docker fallback scanner
- **M5**: npm pre-release version filtering (`_is_prerelease`) + stable-preferred OSV fixed versions
- **M6**: Fleet sync atomicity via `batch_put()` instead of per-agent individual puts

## Files changed (7)

| File | Change |
|------|--------|
| `src/agent_bom/http_client.py` | `max_redirects` parameter |
| `src/agent_bom/enrichment.py` | `_evict_oldest()` + `_MAX_ENRICHMENT_CACHE_ENTRIES` |
| `src/agent_bom/scanners/__init__.py` | CVSS range check + pre-release aware `parse_fixed_version` |
| `src/agent_bom/transitive.py` | `_is_prerelease()` + npm resolver filtering |
| `src/agent_bom/image.py` | Alpine apk + RHEL rpm extraction, gpg-pubkey skip |
| `src/agent_bom/api/server.py` | `_sync_scan_agents_to_fleet` uses `batch_put()` |
| `tests/test_medium_hardening.py` | 23 new tests |

## Test plan

- [x] All 23 new tests pass (`tests/test_medium_hardening.py`)
- [x] Full suite: 1,976 tests pass
- [x] Ruff lint + format clean