### PR TITLE
release: v0.38.0

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.37.0
+ARG VERSION=0.38.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.37.0
+ARG VERSION=0.38.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.37.0"
+  --version "0.38.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.37.0
-git push origin v0.37.0
+git tag v0.38.0
+git push origin v0.38.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.37.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.38.0` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -460,7 +460,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.37.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.38.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Opt-in MCP traffic audit (per-server) |
@@ -479,7 +479,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.37.0
+- uses: msaad00/agent-bom@v0.38.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -609,7 +609,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.37.0` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.38.0` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.37.0
+- uses: msaad00/agent-bom@v0.38.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bom
 description: AI supply chain security scanner — check packages for CVEs, look up MCP servers in the threat registry, assess blast radius, generate SBOMs, enforce compliance
-version: 0.37.0
+version: 0.38.0
 metadata:
   openclaw:
     requires:
@@ -210,8 +210,8 @@ It extracts server names, package names, and env var **names** only — never va
 - **Source code**: https://github.com/msaad00/agent-bom (Apache-2.0, fully auditable)
 - **PyPI**: https://pypi.org/project/agent-bom/
 - **Smithery**: https://smithery.ai/server/agent-bom/agent-bom (99/100 quality score)
-- **Sigstore signed**: Every release is signed with Sigstore OIDC — verify with `agent-bom verify agent-bom@0.37.0`
-- **1,800 tests**: Every commit passes automated security scanning (CodeQL + OpenSSF Scorecard)
+- **Sigstore signed**: Every release is signed with Sigstore OIDC — verify with `agent-bom verify agent-bom@0.38.0`
+- **2,040 tests**: Every commit passes automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
 - **Self-hostable**: Run your own instance with `docker build -f Dockerfile.sse` — no vendor dependency required
 - **No telemetry**: `telemetry: false` — zero tracking, zero analytics, zero phone-home

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.37.0
+ARG VERSION=0.38.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.37.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.38.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.37.0": {
+        "ghcr.io/msaad00/agent-bom:v0.38.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.37.0"
+version = "0.38.0"
 description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs. OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF. GPU infrastructure (NVIDIA/AMD) coverage."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.37.0"
+    __version__ = "0.38.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.37.0"
+    assert __version__ == "0.38.0"
 
 
 def test_report_version_matches():
@@ -2933,7 +2933,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.37.0"
+    assert data["version"] == "0.38.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
Version bump 0.37.0 → 0.38.0 across 12 files.

### What's new in v0.38.0

**Enterprise Security Operations**
- Posture scorecard — letter grade (A–F), numeric score (0–100), 6-dimension breakdown
- Incident correlation — per-agent vulnerability grouping with P1–P4 priority
- Credential risk ranking — blast radius severity ranking for exposed credentials
- 3 new API endpoints: `/v1/posture`, `/v1/posture/credentials`, `/v1/posture/incidents`

**Alert Enrichment**
- Slack webhook payloads include risk score, affected agents, credentials, fix versions
- Scan alerts enriched with affected_agents, credentials_exposed, fixed_version, cvss/epss

**Policy Engine**
- `min_scorecard_score` — trigger on poorly-maintained packages (OpenSSF)
- `max_epss_score` — trigger on high exploit probability
- `has_kev_with_no_fix` — KEV vulnerabilities without remediation

**Enterprise Hardening (PRs #121–#123)**
- Thread safety, path validation, bounded caches
- SQLite indexes, stuck job cleanup, Content-Length validation
- Pre-release version filtering, fleet sync atomicity
- Proxy metrics bounds, audit log retention

### Stats
- 2,040 tests passing
- 12 files updated for version bump
- ruff clean

## Test plan
- [x] `pytest tests/ -x -q` — 2,040 passed
- [x] `ruff check src/ tests/` — all checks passed
- [x] Version string verified in all 12 files
- [x] No remaining 0.37.0 references

After merge: `git tag v0.38.0 && git push origin v0.38.0` to trigger release pipeline.