### PR TITLE
fix: add install metadata to SKILL.md for OpenClaw

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -16,7 +16,7 @@ Smithery requires a publicly accessible HTTP URL for the MCP server.
 
 ### Step 1: Deploy SSE server
 
-The SSE server is deployed on Railway at `https://trustworthy-solace-production-14a6.up.railway.app` (automated via `deploy-mcp-sse.yml`).
+The SSE server is deployed on Railway at `https://agent-bom-mcp.up.railway.app` (automated via `deploy-mcp-sse.yml`).
 
 ### Step 2: Publish to Smithery
 
@@ -24,7 +24,7 @@ The SSE server is deployed on Railway at `https://trustworthy-solace-production-
 1. Go to https://smithery.ai/servers/new
 2. Namespace: `agent-bom`
 3. Server ID: `agent-bom`
-4. MCP Server URL: `https://trustworthy-solace-production-14a6.up.railway.app/mcp`
+4. MCP Server URL: `https://agent-bom-mcp.up.railway.app/mcp`
 5. Click **Continue**
 
 **Option B — Automated**:

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -39,7 +39,7 @@ metadata:
     file_reads: []
     file_writes: []
     network_endpoints:
-      - url: "https://trustworthy-solace-production-14a6.up.railway.app/sse"
+      - url: "https://agent-bom-mcp.up.railway.app/sse"
         purpose: "Optional remote MCP endpoint — queries public vulnerability databases (OSV, NVD, EPSS, KEV) and the bundled registry. Local-first scanning recommended."
         auth: false
     telemetry: false
@@ -148,7 +148,7 @@ configurations), a convenience endpoint is available:
   "mcpServers": {
     "agent-bom": {
       "type": "sse",
-      "url": "https://trustworthy-solace-production-14a6.up.railway.app/sse"
+      "url": "https://agent-bom-mcp.up.railway.app/sse"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `install` metadata (pipx, pip, docker) to SKILL.md frontmatter
- Resolves OpenClaw feedback: "instruction-only skill with no install spec in the registry bundle"

## Test plan

- [ ] CI green
- [ ] OpenClaw re-assessment picks up install instructions