### PR TITLE
fix: enterprise security hardening — thread safety, SSRF, error sanitization, least privilege

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -27,7 +27,10 @@ from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
-_HMAC_KEY = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY", "agent-bom-default-audit-key").encode()
+_HMAC_DEFAULT = "agent-bom-default-audit-key"
+_HMAC_KEY = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY", _HMAC_DEFAULT).encode()
+if os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") is None:
+    logger.warning("AGENT_BOM_AUDIT_HMAC_KEY not set — audit log HMAC uses default key (not tamper-proof in production)")
 
 
 @dataclass

--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -72,66 +72,77 @@ class FleetStore(Protocol):
 
 
 class InMemoryFleetStore:
-    """Dict-based in-memory fleet store."""
+    """Dict-based in-memory fleet store. Thread-safe via lock."""
 
     def __init__(self) -> None:
         self._agents: dict[str, FleetAgent] = {}
+        self._lock = threading.Lock()
 
     def put(self, agent: FleetAgent) -> None:
-        self._agents[agent.agent_id] = agent
+        with self._lock:
+            self._agents[agent.agent_id] = agent
 
     def get(self, agent_id: str) -> FleetAgent | None:
-        return self._agents.get(agent_id)
+        with self._lock:
+            return self._agents.get(agent_id)
 
     def get_by_name(self, name: str) -> FleetAgent | None:
-        for a in self._agents.values():
-            if a.name == name:
-                return a
-        return None
+        with self._lock:
+            for a in self._agents.values():
+                if a.name == name:
+                    return a
+            return None
 
     def delete(self, agent_id: str) -> bool:
-        if agent_id in self._agents:
-            del self._agents[agent_id]
-            return True
-        return False
+        with self._lock:
+            if agent_id in self._agents:
+                del self._agents[agent_id]
+                return True
+            return False
 
     def list_all(self) -> list[FleetAgent]:
-        return list(self._agents.values())
+        with self._lock:
+            return list(self._agents.values())
 
     def list_summary(self) -> list[dict]:
-        return [
-            {
-                "agent_id": a.agent_id,
-                "name": a.name,
-                "lifecycle_state": a.lifecycle_state,
-                "trust_score": a.trust_score,
-                "updated_at": a.updated_at,
-            }
-            for a in self._agents.values()
-        ]
+        with self._lock:
+            return [
+                {
+                    "agent_id": a.agent_id,
+                    "name": a.name,
+                    "lifecycle_state": a.lifecycle_state,
+                    "trust_score": a.trust_score,
+                    "updated_at": a.updated_at,
+                }
+                for a in self._agents.values()
+            ]
 
     def list_by_tenant(self, tenant_id: str) -> list[FleetAgent]:
-        return [a for a in self._agents.values() if a.tenant_id == tenant_id]
+        with self._lock:
+            return [a for a in self._agents.values() if a.tenant_id == tenant_id]
 
     def list_tenants(self) -> list[dict]:
-        counts: dict[str, int] = {}
-        for a in self._agents.values():
-            counts[a.tenant_id] = counts.get(a.tenant_id, 0) + 1
-        return [{"tenant_id": tid, "agent_count": cnt} for tid, cnt in sorted(counts.items())]
+        with self._lock:
+            counts: dict[str, int] = {}
+            for a in self._agents.values():
+                counts[a.tenant_id] = counts.get(a.tenant_id, 0) + 1
+            return [{"tenant_id": tid, "agent_count": cnt} for tid, cnt in sorted(counts.items())]
 
     def update_state(self, agent_id: str, state: FleetLifecycleState) -> bool:
-        agent = self._agents.get(agent_id)
-        if agent is None:
-            return False
-        agent.lifecycle_state = state
-        agent.updated_at = datetime.now(timezone.utc).isoformat()
-        return True
+        with self._lock:
+            agent = self._agents.get(agent_id)
+            if agent is None:
+                return False
+            agent.lifecycle_state = state
+            agent.updated_at = datetime.now(timezone.utc).isoformat()
+            return True
 
     def batch_put(self, agents: list[FleetAgent]) -> int:
         """Upsert multiple agents at once."""
-        for agent in agents:
-            self._agents[agent.agent_id] = agent
-        return len(agents)
+        with self._lock:
+            for agent in agents:
+                self._agents[agent.agent_id] = agent
+            return len(agents)
 
 
 # ─── SQLite ──────────────────────────────────────────────────────────────────

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -137,7 +137,7 @@ async def _lifespan(app_instance: FastAPI):
         )
         _get_store().put(job)
         _jobs_put(job.job_id, job)
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         loop.run_in_executor(_executor, _run_scan_sync, job)
         return job.job_id
 
@@ -200,13 +200,18 @@ from starlette.types import ASGIApp  # noqa: E402
 
 
 class TrustHeadersMiddleware(BaseHTTPMiddleware):
-    """Add read-only + no-credential-storage trust headers to every response."""
+    """Add trust + standard security headers to every response."""
 
     async def dispatch(self, request: StarletteRequest, call_next):
         response = await call_next(request)
         response.headers["X-Agent-Bom-Read-Only"] = "true"
         response.headers["X-Agent-Bom-No-Credential-Storage"] = "true"
         response.headers["X-Agent-Bom-Version"] = __version__
+        # Standard security headers
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["Content-Security-Policy"] = "default-src 'self'"
         return response
 
 
@@ -376,6 +381,15 @@ def set_job_store(store: Any) -> None:
 # In-memory job refs for SSE streaming (bounded, thread-safe)
 _jobs: dict[str, "ScanJob"] = {}
 _jobs_lock = threading.Lock()
+_job_locks: dict[str, threading.Lock] = {}  # per-job locks for thread-safe field access
+
+
+def _job_lock(job_id: str) -> threading.Lock:
+    """Get or create a per-job lock for thread-safe field access."""
+    with _jobs_lock:
+        if job_id not in _job_locks:
+            _job_locks[job_id] = threading.Lock()
+        return _job_locks[job_id]
 
 
 def _jobs_put(job_id: str, job: "ScanJob") -> None:
@@ -495,8 +509,9 @@ PIPELINE_STEPS = ["discovery", "extraction", "scanning", "enrichment", "analysis
 class ScanPipeline:
     """Track scan pipeline steps and emit structured events to job.progress."""
 
-    def __init__(self, job: ScanJob) -> None:
+    def __init__(self, job: ScanJob, lock: threading.Lock | None = None) -> None:
         self._job = job
+        self._lock = lock
         self._steps: dict[str, dict[str, Any]] = {}
         for step_id in PIPELINE_STEPS:
             self._steps[step_id] = {
@@ -562,12 +577,17 @@ class ScanPipeline:
         self._emit(event)
 
     def _emit(self, event: dict[str, Any]) -> None:
-        """Serialize step event to job.progress for SSE pickup."""
+        """Serialize step event to job.progress for SSE pickup (thread-safe)."""
         import json as _json_mod
 
         # Convert enum values to strings for JSON serialization
         serializable = {k: (v.value if isinstance(v, Enum) else v) for k, v in event.items()}
-        self._job.progress.append(_json_mod.dumps(serializable))
+        line = _json_mod.dumps(serializable)
+        if self._lock:
+            with self._lock:
+                self._job.progress.append(line)
+        else:
+            self._job.progress.append(line)
 
 
 class VersionInfo(BaseModel):
@@ -648,9 +668,11 @@ def _sync_scan_agents_to_fleet(agents: list) -> None:
 
 def _run_scan_sync(job: ScanJob) -> None:
     """Run the full scan pipeline in a thread (blocking). Updates job in-place."""
-    job.status = JobStatus.RUNNING
-    job.started_at = _now()
-    pipeline = ScanPipeline(job)
+    lock = _job_lock(job.job_id)
+    with lock:
+        job.status = JobStatus.RUNNING
+        job.started_at = _now()
+    pipeline = ScanPipeline(job, lock)
 
     try:
         from agent_bom.discovery import discover_all
@@ -867,28 +889,33 @@ def _run_scan_sync(job: ScanJob) -> None:
         report = AIBOMReport(agents=agents, blast_radii=blast_radii)
         report_json = to_json(report)
         report_json["warnings"] = warnings_all
-        job.result = report_json
-        job.status = JobStatus.DONE
+        with lock:
+            job.result = report_json
+            job.status = JobStatus.DONE
         pipeline.complete_step("output", "Report ready")
 
         # Auto-sync discovered agents to fleet registry
         try:
             _sync_scan_agents_to_fleet(agents)
         except Exception as fleet_exc:  # noqa: BLE001
-            job.progress.append(f"Fleet sync skipped: {fleet_exc}")
+            with lock:
+                job.progress.append(f"Fleet sync skipped: {fleet_exc}")
 
     except Exception as exc:  # noqa: BLE001
-        job.status = JobStatus.FAILED
-        job.error = str(exc)
+        with lock:
+            job.status = JobStatus.FAILED
+            job.error = sanitize_error(exc)
         # Mark whichever step was running as failed
         for step_id in PIPELINE_STEPS:
             if pipeline._steps[step_id]["status"] == StepStatus.RUNNING:
-                pipeline.fail_step(step_id, str(exc))
+                pipeline.fail_step(step_id, sanitize_error(exc))
                 break
         else:
-            job.progress.append(f"Error: {exc}")
+            with lock:
+                job.progress.append(f"Error: {sanitize_error(exc)}")
     finally:
-        job.completed_at = _now()
+        with lock:
+            job.completed_at = _now()
         # Persist final state
         _get_store().put(job)
 
@@ -969,7 +996,7 @@ async def create_scan(request: ScanRequest) -> ScanJob:
     # Keep in-memory ref for SSE streaming (progress list updates in real-time)
     _jobs_put(job.job_id, job)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     loop.run_in_executor(_executor, _run_scan_sync, job)
 
     return job
@@ -1128,12 +1155,17 @@ async def stream_scan(job_id: str):
 
     async def event_generator():
         sent = 0
-        while True:
+        lock = _job_lock(job_id)
+        start = time.monotonic()
+        while time.monotonic() - start < 2100:  # 35 min max (exceeds stuck-job timeout)
             current = _jobs_get(job_id)
             if current is None:
                 break
-            # Send any new progress lines (structured steps or legacy strings)
-            for line in current.progress[sent:]:
+            # Thread-safe snapshot of new progress lines and status
+            with lock:
+                new_lines = list(current.progress[sent:])
+                status = current.status
+            for line in new_lines:
                 try:
                     parsed = _json.loads(line)
                     if isinstance(parsed, dict) and parsed.get("type") == "step":
@@ -1143,8 +1175,8 @@ async def stream_scan(job_id: str):
                 except (_json.JSONDecodeError, ValueError):
                     yield {"data": _json.dumps({"type": "progress", "message": line})}
                 sent += 1
-            if current.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED):
-                yield {"data": _json.dumps({"type": "done", "status": current.status, "job_id": job_id})}
+            if status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED):
+                yield {"data": _json.dumps({"type": "done", "status": status, "job_id": job_id})}
                 break
             await asyncio.sleep(0.25)
 
@@ -2488,6 +2520,8 @@ async def governance_report(days: int = 30):
     """
     import os as _os
 
+    days = max(1, min(days, 365))
+
     if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
@@ -2512,6 +2546,8 @@ async def governance_findings(
 ):
     """Return only governance findings, optionally filtered."""
     import os as _os
+
+    days = max(1, min(days, 365))
 
     if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
@@ -2552,6 +2588,8 @@ async def activity_timeline(days: int = 30):
     """
     import os as _os
 
+    days = max(1, min(days, 365))
+
     if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
@@ -2580,6 +2618,8 @@ async def cortex_telemetry(hours: int = 24):
     health status.
     """
     import os as _os
+
+    hours = max(1, min(hours, 8760))
 
     if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
@@ -3061,7 +3101,15 @@ async def list_siem_connectors() -> dict:
 @app.post("/v1/siem/test", tags=["enterprise"])
 async def test_siem_connection(siem_type: str = "", url: str = "", token: str = "") -> dict:
     """Test SIEM connectivity."""
+    from agent_bom.security import validate_url
     from agent_bom.siem import SIEMConfig, create_connector
+
+    # Validate URL to prevent SSRF
+    if url:
+        try:
+            validate_url(url)
+        except Exception as url_exc:
+            raise HTTPException(status_code=400, detail=f"Invalid URL: {sanitize_error(url_exc)}")
 
     try:
         connector = create_connector(siem_type, SIEMConfig(name=siem_type, url=url, token=token))

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -29,49 +29,56 @@ class JobStore(Protocol):
 
 
 class InMemoryJobStore:
-    """Dict-based in-memory store (original behavior)."""
+    """Dict-based in-memory store (original behavior). Thread-safe via lock."""
 
     def __init__(self) -> None:
         self._jobs: dict[str, ScanJob] = {}
+        self._lock = threading.Lock()
 
     def put(self, job: ScanJob) -> None:
-        self._jobs[job.job_id] = job
+        with self._lock:
+            self._jobs[job.job_id] = job
 
     def get(self, job_id: str) -> ScanJob | None:
-        return self._jobs.get(job_id)
+        with self._lock:
+            return self._jobs.get(job_id)
 
     def delete(self, job_id: str) -> bool:
-        if job_id in self._jobs:
-            del self._jobs[job_id]
-            return True
-        return False
+        with self._lock:
+            if job_id in self._jobs:
+                del self._jobs[job_id]
+                return True
+            return False
 
     def list_all(self) -> list[ScanJob]:
-        return list(self._jobs.values())
+        with self._lock:
+            return list(self._jobs.values())
 
     def list_summary(self) -> list[dict]:
-        return [
-            {
-                "job_id": j.job_id,
-                "status": j.status,
-                "created_at": j.created_at,
-                "completed_at": j.completed_at,
-            }
-            for j in self._jobs.values()
-        ]
+        with self._lock:
+            return [
+                {
+                    "job_id": j.job_id,
+                    "status": j.status,
+                    "created_at": j.created_at,
+                    "completed_at": j.completed_at,
+                }
+                for j in self._jobs.values()
+            ]
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
-        now = datetime.now(timezone.utc)
-        expired = [
-            jid
-            for jid, job in self._jobs.items()
-            if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)
-            and job.completed_at
-            and (now - datetime.fromisoformat(job.completed_at)).total_seconds() > ttl_seconds
-        ]
-        for jid in expired:
-            del self._jobs[jid]
-        return len(expired)
+        with self._lock:
+            now = datetime.now(timezone.utc)
+            expired = [
+                jid
+                for jid, job in self._jobs.items()
+                if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)
+                and job.completed_at
+                and (now - datetime.fromisoformat(job.completed_at)).total_seconds() > ttl_seconds
+            ]
+            for jid in expired:
+                del self._jobs[jid]
+            return len(expired)
 
 
 class SQLiteJobStore:

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -30,6 +30,7 @@ from agent_bom.governance import (
     QueryHistoryRecord,
 )
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+from agent_bom.security import sanitize_error
 
 from .base import CloudDiscoveryError
 
@@ -101,7 +102,7 @@ def discover(
     try:
         conn = snowflake.connector.connect(**conn_kwargs)
     except (DatabaseError, Exception) as exc:
-        warnings.append(f"Could not connect to Snowflake: {exc}")
+        warnings.append(f"Could not connect to Snowflake: {sanitize_error(exc)}")
         return agents, warnings
 
     try:
@@ -228,7 +229,7 @@ def _discover_cortex_services(
 
     except Exception as exc:
         # Cortex Search Services may not be available in all accounts
-        warnings.append(f"Could not list Cortex Search Services: {exc}")
+        warnings.append(f"Could not list Cortex Search Services: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -257,7 +258,7 @@ def _discover_snowpark_packages(
 
     except Exception as exc:
         # INFORMATION_SCHEMA.PACKAGES may not exist or may not be accessible
-        warnings.append(f"Could not query Snowpark packages: {exc}")
+        warnings.append(f"Could not query Snowpark packages: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -300,7 +301,7 @@ def _discover_streamlit_apps(
             agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not list Streamlit apps: {exc}")
+        warnings.append(f"Could not list Streamlit apps: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -366,7 +367,7 @@ def _discover_cortex_agents(
             agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not list Cortex Agents: {exc}")
+        warnings.append(f"Could not list Cortex Agents: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -420,7 +421,7 @@ def _discover_mcp_servers(
             agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not list Snowflake MCP Servers: {exc}")
+        warnings.append(f"Could not list Snowflake MCP Servers: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -477,7 +478,7 @@ def _describe_mcp_server_tools(
                     pass
 
     except Exception as exc:
-        warnings.append(f"Could not describe MCP Server {server_name}: {exc}")
+        warnings.append(f"Could not describe MCP Server {server_name}: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -535,7 +536,7 @@ def _discover_from_query_history(
             agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not query Snowflake query history: {exc}")
+        warnings.append(f"Could not query Snowflake query history: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -593,7 +594,7 @@ def _discover_custom_tools(
                 )
             )
     except Exception as exc:
-        warnings.append(f"Could not query custom functions: {exc}")
+        warnings.append(f"Could not query custom functions: {sanitize_error(exc)}")
     finally:
         cursor.close()
 
@@ -624,7 +625,7 @@ def _discover_custom_tools(
                 )
             )
     except Exception as exc:
-        warnings.append(f"Could not query stored procedures: {exc}")
+        warnings.append(f"Could not query stored procedures: {sanitize_error(exc)}")
     finally:
         proc_cursor.close()
 
@@ -704,7 +705,7 @@ def discover_governance(
     try:
         conn = snowflake.connector.connect(**conn_kwargs)
     except (DatabaseError, Exception) as exc:
-        report.warnings.append(f"Could not connect to Snowflake: {exc}")
+        report.warnings.append(f"Could not connect to Snowflake: {sanitize_error(exc)}")
         return report
 
     try:
@@ -792,7 +793,7 @@ def _mine_access_history(
         if "access_history" in msg.lower() or "enterprise" in msg.lower():
             warnings.append("ACCESS_HISTORY requires Enterprise edition or higher. Skipping access pattern analysis.")
         else:
-            warnings.append(f"Could not query ACCESS_HISTORY: {exc}")
+            warnings.append(f"Could not query ACCESS_HISTORY: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -849,7 +850,7 @@ def _mine_grants_to_roles(
             )
 
     except Exception as exc:
-        warnings.append(f"Could not query GRANTS_TO_ROLES: {exc}")
+        warnings.append(f"Could not query GRANTS_TO_ROLES: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -905,7 +906,7 @@ def _mine_tag_references(
         if "tag_references" in msg.lower():
             warnings.append("TAG_REFERENCES not accessible. Data classification analysis skipped.")
         else:
-            warnings.append(f"Could not query TAG_REFERENCES: {exc}")
+            warnings.append(f"Could not query TAG_REFERENCES: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -965,7 +966,7 @@ def _mine_cortex_agent_usage(
         if "cortex_agent_usage" in msg.lower() or "does not exist" in msg.lower():
             warnings.append("CORTEX_AGENT_USAGE_HISTORY not available. Requires Cortex Agents (GA Feb 2026). Skipping agent telemetry.")
         else:
-            warnings.append(f"Could not query CORTEX_AGENT_USAGE_HISTORY: {exc}")
+            warnings.append(f"Could not query CORTEX_AGENT_USAGE_HISTORY: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -1382,7 +1383,7 @@ def discover_activity(
     try:
         conn = snowflake.connector.connect(**conn_kwargs)
     except (DatabaseError, Exception) as exc:
-        timeline.warnings.append(f"Could not connect to Snowflake: {exc}")
+        timeline.warnings.append(f"Could not connect to Snowflake: {sanitize_error(exc)}")
         return timeline
 
     try:
@@ -1470,7 +1471,7 @@ def _mine_query_history_365(
                 "ACCOUNT_USAGE.QUERY_HISTORY not accessible. Requires ACCOUNTADMIN or IMPORTED PRIVILEGES on SNOWFLAKE database."
             )
         else:
-            warnings.append(f"Could not query QUERY_HISTORY: {exc}")
+            warnings.append(f"Could not query QUERY_HISTORY: {sanitize_error(exc)}")
 
     finally:
         cursor.close()
@@ -1533,7 +1534,7 @@ def _mine_observability_events(
         if "ai_observability" in msg.lower() or "does not exist" in msg.lower():
             warnings.append("AI_OBSERVABILITY_EVENTS not available. Enable AI observability in Snowflake to capture agent traces.")
         else:
-            warnings.append(f"Could not query AI_OBSERVABILITY_EVENTS: {exc}")
+            warnings.append(f"Could not query AI_OBSERVABILITY_EVENTS: {sanitize_error(exc)}")
 
     finally:
         cursor.close()

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -509,7 +509,7 @@ def parse_snowflake_connections(config_path: str) -> list[MCPServer]:
         if conn_def.get("password"):
             env["password"] = "***REDACTED***"
         if conn_def.get("private_key_file"):
-            env["private_key_file"] = conn_def["private_key_file"]
+            env["private_key_file"] = "***KEY_FILE_PRESENT***"
 
         server = MCPServer(
             name=f"sf-connection:{name}",

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -156,6 +156,28 @@ async def _run_scan_pipeline(
     from agent_bom.scanners import scan_agents, scan_agents_with_enrichment
 
     warnings: list[str] = []
+
+    # Validate user-provided paths against directory traversal
+    if config_path:
+        try:
+            config_path = str(_safe_path(config_path))
+        except ValueError as exc:
+            return json.dumps({"error": sanitize_error(exc)})
+
+    if sbom_path:
+        try:
+            sbom_path = str(_safe_path(sbom_path))
+        except ValueError as exc:
+            return json.dumps({"error": sanitize_error(exc)})
+
+    if image:
+        try:
+            from agent_bom.security import validate_image_ref
+
+            validate_image_ref(image)
+        except Exception as exc:
+            return json.dumps({"error": sanitize_error(exc)})
+
     agents = discover_all(project_dir=config_path)
 
     # Docker image scanning
@@ -166,7 +188,7 @@ async def _run_scan_pipeline(
             img_agents, _warnings = scan_image(image)
             agents.extend(img_agents)
         except Exception as exc:
-            msg = f"Image scan failed for {image}: {exc}"
+            msg = f"Image scan failed for {image}: {sanitize_error(exc)}"
             logger.warning(msg)
             warnings.append(msg)
 

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -451,7 +451,7 @@ async def run_proxy(
         """Read from our stdin, forward to server stdin."""
         reader = asyncio.StreamReader()
         protocol = asyncio.StreamReaderProtocol(reader)
-        await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin.buffer)
+        await asyncio.get_running_loop().connect_read_pipe(lambda: protocol, sys.stdin.buffer)
 
         while True:
             line = await reader.readline()

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -107,12 +107,12 @@ def resolve_role(api_key: str | None = None, role_header: str | None = None) -> 
         except ValueError:
             pass
 
-    # Default role
-    default = os.environ.get("AGENT_BOM_DEFAULT_ROLE", "admin")
+    # Default role — least privilege (viewer) unless explicitly overridden
+    default = os.environ.get("AGENT_BOM_DEFAULT_ROLE", "viewer")
     try:
         return Role(default)
     except ValueError:
-        return Role.ADMIN
+        return Role.VIEWER
 
 
 def check_permission(role: Role, action: str) -> bool:

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -143,7 +143,16 @@ ECOSYSTEM_MAP = {
 # Rate limiting: max concurrent API requests + delay between batches
 MAX_CONCURRENT_REQUESTS = 10
 BATCH_DELAY_SECONDS = 0.5  # 500ms between OSV batch calls
-_api_semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
+
+def _get_api_semaphore() -> asyncio.Semaphore:
+    """Create a semaphore bound to the current event loop.
+
+    Module-level semaphores can bind to the wrong event loop when called from
+    different threads (e.g. concurrent scans via ThreadPoolExecutor + asyncio.run()).
+    """
+    return asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
 
 _logger = logging.getLogger(__name__)
 
@@ -365,11 +374,12 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
 
     # OSV batch API accepts up to 1000 queries; rate-limited with retries
     batch_size = 1000
+    semaphore = _get_api_semaphore()
     async with create_client(timeout=30.0) as client:
         for batch_start in range(0, len(queries), batch_size):
             batch = queries[batch_start : batch_start + batch_size]
 
-            async with _api_semaphore:
+            async with semaphore:
                 response = await request_with_retry(
                     client,
                     "POST",

--- a/tests/test_enterprise_gaps.py
+++ b/tests/test_enterprise_gaps.py
@@ -77,7 +77,7 @@ class TestRBAC:
         from agent_bom.rbac import resolve_role
 
         role = resolve_role()
-        assert role.value == "admin"  # backward compatible
+        assert role.value == "viewer"  # least privilege default
 
     @patch.dict(os.environ, {"AGENT_BOM_DEFAULT_ROLE": "viewer"})
     def test_resolve_role_env_default(self):


### PR DESCRIPTION
## Summary

Full security audit identified 2 HIGH, 11 MEDIUM findings across the codebase. All fixed in this PR.

### HIGH severity fixes
- **Thread-safe ScanJob**: Per-job `threading.Lock` protecting `progress`, `status`, `result`, `completed_at` fields shared between background scan thread and async SSE generator
- **SSRF protection**: `/v1/siem/test` now validates URLs via `validate_url()` — blocks internal IPs and non-HTTPS
- **Event loop safety**: Module-level `asyncio.Semaphore` replaced with per-call factory to prevent cross-loop binding under concurrent scans

### MEDIUM severity fixes
- `InMemoryJobStore` + `InMemoryFleetStore` — thread locks added for safe concurrent access
- `sanitize_error()` on scan job failure path (was leaking internal paths/connection strings)
- HMAC audit log warns when using default key (not tamper-proof)
- RBAC default role: `admin` → `viewer` (least privilege)
- Private key file path redacted in Snowflake connection discovery
- Path traversal protection on `config_path`/`sbom_path`/`image` in MCP scan tool
- Standard security response headers (X-Content-Type-Options, X-Frame-Options, CSP, Cache-Control)
- All 18 Snowflake exception messages sanitized via `sanitize_error()`
- `days`/`hours` query params clamped (1-365 / 1-8760) on governance endpoints
- SSE streaming timeout cap (35 min) to prevent infinite polling on stuck jobs
- Deprecated `asyncio.get_event_loop()` → `get_running_loop()` in server + proxy

## Test plan
- [x] All 2335 tests pass
- [x] `ruff check` clean
- [x] RBAC test updated for new viewer default
- [ ] Manual: verify security headers appear in API responses
- [ ] Manual: verify SIEM test endpoint rejects internal URLs