### PR TITLE
fix: README + diagram alignment — stale counts, missing features, workflow redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 | **Incident correlation** | — | Group vulns by agent, P1–P4 priority, SOC-ready incident summaries |
 | **Credential risk ranking** | — | Rank exposed credentials by blast radius severity tier |
 | **AI framework recognition** | — | GPU/ML packages flagged as high-risk in image scans (via Grype/Syft) |
+| **Lateral movement analysis** | — | Agent context graph, shared server/credential detection, BFS attack paths |
 | **427+ server MCP registry** | — | Risk levels, tool inventories, auto-synced weekly |
 
 <p align="center">
@@ -179,7 +180,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
      │ Console   │ JSON/SBOM │  API  │ Alerts     │ Fleet    │
      │ HTML      │ CDX/SPDX  │ REST  │ Slack      │ Trust    │
      │ Graphs    │ SARIF     │ MCP   │ Webhook    │ Scoring  │
-     │ Badges    │ Prometheus│ SSE   │ PagerDuty  │ Tenants  │
+     │ Badges    │ Prometheus│ SSE   │ Jira       │ Tenants  │
      └───────────┴───────────┴───────┴────────────┴──────────┘
 ```
 
@@ -426,6 +427,7 @@ The dashboard (`agent-bom api`) serves interactive [React Flow](https://reactflo
 - **Agent Mesh** (`/mesh`) — cross-agent topology with vulnerability overlay, shared server detection, credential blast analysis, severity filtering, and search
 - **Attack Flow** (`/scan?view=attack-flow`) — CVE-centric blast radius graph: CVE → Package → Server → Agent → Credentials → Tools
 - **Supply Chain Lineage** (`/graph`) — full dependency lineage with hover highlighting and detail panels
+- **Context Graph** (`/context`) — lateral movement analysis: agent-to-agent attack paths via shared servers, credentials, and tools
 
 All graph views include: dagre auto-layout, hover highlighting (BFS connected nodes), click-to-inspect detail panels, minimap, OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF framework tagging on every node.
 
@@ -506,6 +508,7 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 | `GET /v1/posture/credentials` | Credential risk ranking by blast radius |
 | `GET /v1/posture/incidents` | Incident correlation by agent (P1–P4) |
 | `POST /v1/traces` | OpenTelemetry trace ingestion + vulnerable tool call flagging |
+| `GET /v1/scan/{id}/context-graph` | Agent context graph + lateral movement paths |
 | `GET /v1/malicious/check` | Malicious package / typosquat check |
 
 ### MCP Server
@@ -516,7 +519,7 @@ agent-bom mcp-server                    # stdio
 agent-bom mcp-server --transport sse    # remote
 ```
 
-14 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`, `marketplace_check`
+15 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`, `marketplace_check`, `context_graph`
 
 ### Cloud UI
 
@@ -524,7 +527,7 @@ agent-bom mcp-server --transport sse    # remote
 cd ui && npm install && npm run dev   # http://localhost:3000
 ```
 
-14-section Next.js dashboard:
+15-section Next.js dashboard:
 
 | Page | Description |
 |------|-------------|
@@ -541,6 +544,7 @@ cd ui && npm install && npm run dev   # http://localhost:3000
 | Activity | Agent activity timeline + AI observability |
 | Governance | Snowflake access, privileges, data classification |
 | Traces | OpenTelemetry trace ingestion + vulnerable tool call flagging |
+| Context Graph | Lateral movement analysis — agent-to-agent attack paths, shared credentials, tool overlap |
 | Jobs | Background scan job management |
 
 ### Snowflake Deployment
@@ -648,6 +652,8 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - [x] Slack blast radius enrichment — webhook payloads include risk score, agents, credentials, fix versions
 - [x] Advanced policy conditions — `min_scorecard_score`, `max_epss_score`, `has_kev_with_no_fix`
 - [x] Enterprise hardening — bounded caches, SQLite indexes, stuck job cleanup, Content-Length validation
+- [x] Agent context graph — lateral movement analysis via shared servers, credentials, and tools; BFS attack path discovery
+- [x] Enterprise security hardening — per-job thread locks, SSRF protection, error sanitization, RBAC least privilege, path traversal guards
 
 **Planned:**
 - [ ] CIS AI benchmarks

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">14 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">15 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">14 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">15 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/data-flow-dark.svg
+++ b/docs/images/data-flow-dark.svg
@@ -158,7 +158,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d29922">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,554 automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,335 automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d29922">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/data-flow-light.svg
+++ b/docs/images/data-flow-light.svg
@@ -151,7 +151,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#fffbeb" stroke="#d97706" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d97706">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 1,554 automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,335 automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d97706">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -167,7 +167,7 @@
       <rect width="286" height="48" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6e7681">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">14 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">15 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -166,7 +166,7 @@
       <rect width="286" height="48" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#94a3b8">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">14 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">15 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -260,6 +260,6 @@
 
   <!-- MCP Server badge -->
   <rect x="516" y="454" width="228" height="40" rx="6" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="471" class="side-label" fill="#58a6ff">14 MCP Tools · 6 Frameworks</text>
-  <text x="528" y="484" class="box-sub">1,800 tests · Sigstore signed · OpenSSF scored</text>
+  <text x="528" y="471" class="side-label" fill="#58a6ff">15 MCP Tools · 6 Frameworks</text>
+  <text x="528" y="484" class="box-sub">2,335 tests · Sigstore signed · OpenSSF scored</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -236,6 +236,6 @@
   <text x="528" y="440" class="box-sub">✓ AI-native · MCP-first · runs anywhere</text>
 
   <rect x="516" y="454" width="228" height="40" rx="6" fill="#ffffff" stroke="#0969da" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="471" class="side-label" fill="#0969da">14 MCP Tools · 6 Frameworks</text>
-  <text x="528" y="484" class="box-sub">1,800 tests · Sigstore signed · OpenSSF scored</text>
+  <text x="528" y="471" class="side-label" fill="#0969da">15 MCP Tools · 6 Frameworks</text>
+  <text x="528" y="484" class="box-sub">2,335 tests · Sigstore signed · OpenSSF scored</text>
 </svg>

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">14 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">15 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">14 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">15 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -1,159 +1,234 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 620" fill="none">
   <style>
     .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
-    .subtitle { font: 400 11px system-ui, sans-serif; fill: #8b949e; }
+    .subtitle { font: 400 10px system-ui, sans-serif; fill: #8b949e; }
     .phase { font: 700 9px system-ui, sans-serif; letter-spacing: 0.1em; }
     .label { font: 600 11px system-ui, sans-serif; }
     .sub { font: 400 9px system-ui, sans-serif; fill: #8b949e; }
     .badge { font: 600 8px system-ui, sans-serif; }
+    .data-label { font: 500 8px monospace; }
     .note { font: 400 9px system-ui, sans-serif; fill: #6e7681; }
-    .arrow { stroke: #484f58; stroke-width: 1.5; fill: none; }
   </style>
   <defs>
     <marker id="a" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#484f58"/>
+      <path d="M0 0L8 3L0 6Z" fill="#6e7681"/>
+    </marker>
+    <marker id="ab" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
+      <path d="M0 0L8 3L0 6Z" fill="#58a6ff"/>
+    </marker>
+    <marker id="ag" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
+      <path d="M0 0L8 3L0 6Z" fill="#3fb950"/>
+    </marker>
+    <marker id="ar" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
+      <path d="M0 0L8 3L0 6Z" fill="#f85149"/>
+    </marker>
+    <marker id="ap" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
+      <path d="M0 0L8 3L0 6Z" fill="#bc8cff"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="900" height="560" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <rect width="940" height="620" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
 
   <!-- Title -->
-  <text x="450" y="30" text-anchor="middle" class="title">Enterprise Scan Workflow</text>
-  <text x="450" y="48" text-anchor="middle" class="subtitle">How agent-bom fits into your security stack — no agents, no access, just analysis</text>
+  <text x="470" y="28" text-anchor="middle" class="title">Enterprise Scan Workflow — Architecture &amp; Data Flow</text>
+  <text x="470" y="44" text-anchor="middle" class="subtitle">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
 
-  <!-- ═══ Row 1: Input Sources ═══ -->
-  <text x="32" y="80" class="phase" fill="#58a6ff">INPUT SOURCES</text>
+  <!-- ═══ COLUMN 1: Input Sources (x=20, w=180) ═══ -->
+  <rect x="20" y="60" width="180" height="498" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="110" y="78" text-anchor="middle" class="phase" fill="#58a6ff">INPUT SOURCES</text>
 
-  <rect x="32" y="92" width="160" height="56" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1" opacity="0.7"/>
-  <text x="112" y="112" text-anchor="middle" class="label" fill="#58a6ff">Developer Machines</text>
-  <text x="112" y="126" text-anchor="middle" class="sub">18 clients: Claude, Cursor,</text>
-  <text x="112" y="138" text-anchor="middle" class="sub">Codex, Gemini, Goose, +13</text>
+  <rect x="32" y="88" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="106" text-anchor="middle" class="label" fill="#58a6ff">MCP Configs</text>
+  <text x="110" y="120" text-anchor="middle" class="sub">18 clients auto-discovered</text>
 
-  <rect x="208" y="92" width="160" height="56" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1" opacity="0.7"/>
-  <text x="288" y="112" text-anchor="middle" class="label" fill="#58a6ff">Container Registry</text>
-  <text x="288" y="126" text-anchor="middle" class="sub">Docker Hub, ECR, GCR</text>
-  <text x="288" y="138" text-anchor="middle" class="sub">OCI images</text>
+  <rect x="32" y="138" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="156" text-anchor="middle" class="label" fill="#58a6ff">Docker Images</text>
+  <text x="110" y="170" text-anchor="middle" class="sub">Grype / Syft / Docker CLI</text>
 
-  <rect x="384" y="92" width="160" height="56" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1" opacity="0.7"/>
-  <text x="464" y="112" text-anchor="middle" class="label" fill="#58a6ff">Kubernetes Cluster</text>
-  <text x="464" y="126" text-anchor="middle" class="sub">Pod image discovery</text>
-  <text x="464" y="138" text-anchor="middle" class="sub">Multi-namespace kubectl</text>
+  <rect x="32" y="188" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="206" text-anchor="middle" class="label" fill="#58a6ff">Kubernetes</text>
+  <text x="110" y="220" text-anchor="middle" class="sub">Multi-namespace pod scan</text>
 
-  <rect x="560" y="92" width="160" height="56" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1" opacity="0.7"/>
-  <text x="640" y="112" text-anchor="middle" class="label" fill="#58a6ff">Existing SBOMs</text>
-  <text x="640" y="126" text-anchor="middle" class="sub">CycloneDX / SPDX import</text>
-  <text x="640" y="138" text-anchor="middle" class="sub">Vendor-provided BOMs</text>
+  <rect x="32" y="238" width="156" height="52" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="256" text-anchor="middle" class="label" fill="#58a6ff">Cloud APIs</text>
+  <text x="110" y="270" text-anchor="middle" class="sub">AWS Bedrock · Snowflake Cortex</text>
+  <text x="110" y="282" text-anchor="middle" class="sub">Azure AI · GCP Vertex · Databricks</text>
 
-  <rect x="736" y="92" width="136" height="56" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1" opacity="0.7"/>
-  <text x="804" y="112" text-anchor="middle" class="label" fill="#58a6ff">Inventory File</text>
-  <text x="804" y="126" text-anchor="middle" class="sub">Manual package list</text>
-  <text x="804" y="138" text-anchor="middle" class="sub">JSON / YAML</text>
+  <rect x="32" y="298" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="316" text-anchor="middle" class="label" fill="#58a6ff">SBOMs</text>
+  <text x="110" y="330" text-anchor="middle" class="sub">CycloneDX / SPDX import</text>
 
-  <!-- Arrows down from inputs -->
-  <line x1="112" y1="148" x2="112" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="288" y1="148" x2="288" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="464" y1="148" x2="464" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="640" y1="148" x2="640" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="804" y1="148" x2="804" y2="170" class="arrow" marker-end="url(#a)"/>
+  <rect x="32" y="348" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="366" text-anchor="middle" class="label" fill="#58a6ff">IaC + CI/CD</text>
+  <text x="110" y="380" text-anchor="middle" class="sub">Terraform · GitHub Actions</text>
 
-  <!-- ═══ Row 2: agent-bom Core ═══ -->
-  <rect x="32" y="176" width="840" height="100" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
-  <text x="450" y="194" text-anchor="middle" class="phase" fill="#8b949e">AGENT-BOM SCANNER (READ-ONLY · NO AGENTS · LOCAL EXECUTION)</text>
+  <rect x="32" y="398" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="416" text-anchor="middle" class="label" fill="#58a6ff">AI Frameworks</text>
+  <text x="110" y="430" text-anchor="middle" class="sub">LangChain · CrewAI · ADK</text>
 
-  <rect x="52" y="206" width="148" height="56" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="126" y="222" text-anchor="middle" class="badge" fill="#8b949e">STEP 1</text>
-  <text x="126" y="238" text-anchor="middle" class="label" fill="#c9d1d9">Parse &amp; Extract</text>
-  <text x="126" y="252" text-anchor="middle" class="sub">Packages, versions,</text>
-  <text x="126" y="262" text-anchor="middle" class="sub">PURLs, credentials</text>
+  <rect x="32" y="448" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="466" text-anchor="middle" class="label" fill="#58a6ff">SaaS Connectors</text>
+  <text x="110" y="480" text-anchor="middle" class="sub">Jira · Slack · ServiceNow</text>
 
-  <line x1="200" y1="234" x2="218" y2="234" class="arrow" marker-end="url(#a)"/>
+  <rect x="32" y="498" width="156" height="50" rx="6" fill="#161b22" stroke="#1f6feb" stroke-width="0.8"/>
+  <text x="110" y="516" text-anchor="middle" class="badge" fill="#58a6ff">EXTRACTED DATA</text>
+  <text x="110" y="530" text-anchor="middle" class="data-label" fill="#8b949e">packages · versions · PURLs</text>
+  <text x="110" y="542" text-anchor="middle" class="data-label" fill="#8b949e">env var names · tool lists</text>
 
-  <rect x="224" y="206" width="148" height="56" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="298" y="222" text-anchor="middle" class="badge" fill="#8b949e">STEP 2</text>
-  <text x="298" y="238" text-anchor="middle" class="label" fill="#c9d1d9">CVE Scan</text>
-  <text x="298" y="252" text-anchor="middle" class="sub">OSV.dev batch API</text>
-  <text x="298" y="262" text-anchor="middle" class="sub">Grype for images</text>
+  <!-- Arrow: Sources → Pipeline -->
+  <line x1="200" y1="310" x2="228" y2="310" stroke="#58a6ff" stroke-width="2" marker-end="url(#ab)"/>
 
-  <line x1="372" y1="234" x2="390" y2="234" class="arrow" marker-end="url(#a)"/>
+  <!-- ═══ COLUMN 2: Scanner Pipeline (x=232, w=200) ═══ -->
+  <rect x="232" y="60" width="200" height="498" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1.2"/>
+  <text x="332" y="78" text-anchor="middle" class="phase" fill="#d29922">SCANNER PIPELINE</text>
+  <text x="332" y="92" text-anchor="middle" class="sub">read-only · local execution</text>
 
-  <rect x="396" y="206" width="148" height="56" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="470" y="222" text-anchor="middle" class="badge" fill="#8b949e">STEP 3</text>
-  <text x="470" y="238" text-anchor="middle" class="label" fill="#c9d1d9">Enrich</text>
-  <text x="470" y="252" text-anchor="middle" class="sub">NVD CVSS + EPSS</text>
-  <text x="470" y="262" text-anchor="middle" class="sub">CISA KEV + CWEs</text>
+  <!-- Step 1 -->
+  <rect x="246" y="104" width="172" height="58" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <rect x="246" y="104" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
+  <text x="332" y="117" text-anchor="middle" class="badge" fill="#d29922">STEP 1 · DISCOVER</text>
+  <text x="332" y="138" text-anchor="middle" class="sub">Auto-detect agent configs</text>
+  <text x="332" y="150" text-anchor="middle" class="sub">Parse packages + credentials</text>
 
-  <line x1="544" y1="234" x2="562" y2="234" class="arrow" marker-end="url(#a)"/>
+  <line x1="332" y1="162" x2="332" y2="176" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <rect x="568" y="206" width="148" height="56" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="642" y="222" text-anchor="middle" class="badge" fill="#8b949e">STEP 4</text>
-  <text x="642" y="238" text-anchor="middle" class="label" fill="#c9d1d9">Threat Model</text>
-  <text x="642" y="252" text-anchor="middle" class="sub">Blast radius + OWASP</text>
-  <text x="642" y="262" text-anchor="middle" class="sub">ATLAS + risk scoring</text>
+  <!-- Step 2 -->
+  <rect x="246" y="180" width="172" height="58" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <rect x="246" y="180" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
+  <text x="332" y="193" text-anchor="middle" class="badge" fill="#d29922">STEP 2 · CVE SCAN</text>
+  <text x="332" y="214" text-anchor="middle" class="sub">OSV.dev batch API</text>
+  <text x="332" y="226" text-anchor="middle" class="sub">Grype for container images</text>
 
-  <line x1="716" y1="234" x2="734" y2="234" class="arrow" marker-end="url(#a)"/>
+  <line x1="332" y1="238" x2="332" y2="252" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <rect x="740" y="206" width="120" height="56" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="800" y="222" text-anchor="middle" class="badge" fill="#8b949e">STEP 5</text>
-  <text x="800" y="238" text-anchor="middle" class="label" fill="#c9d1d9">Report</text>
-  <text x="800" y="252" text-anchor="middle" class="sub">JSON / SARIF / BOM</text>
-  <text x="800" y="262" text-anchor="middle" class="sub">+ source URLs</text>
+  <!-- Step 3 -->
+  <rect x="246" y="256" width="172" height="68" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <rect x="246" y="256" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
+  <text x="332" y="269" text-anchor="middle" class="badge" fill="#d29922">STEP 3 · ENRICH</text>
+  <text x="332" y="290" text-anchor="middle" class="sub">NVD CVSS v3.1/v4.0 scoring</text>
+  <text x="332" y="302" text-anchor="middle" class="sub">FIRST EPSS exploit probability</text>
+  <text x="332" y="314" text-anchor="middle" class="sub">CISA KEV + GHSA + NVIDIA CSAF</text>
 
-  <!-- Arrows down from core -->
-  <line x1="200" y1="276" x2="200" y2="310" class="arrow" marker-end="url(#a)"/>
-  <line x1="450" y1="276" x2="450" y2="310" class="arrow" marker-end="url(#a)"/>
-  <line x1="700" y1="276" x2="700" y2="310" class="arrow" marker-end="url(#a)"/>
+  <line x1="332" y1="324" x2="332" y2="338" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <!-- ═══ Row 3: Enterprise Integration ═══ -->
-  <text x="32" y="330" class="phase" fill="#3fb950">ENTERPRISE INTEGRATION</text>
+  <!-- Step 4 -->
+  <rect x="246" y="342" width="172" height="68" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <rect x="246" y="342" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
+  <text x="332" y="355" text-anchor="middle" class="badge" fill="#d29922">STEP 4 · ANALYZE</text>
+  <text x="332" y="376" text-anchor="middle" class="sub">Blast radius mapping</text>
+  <text x="332" y="388" text-anchor="middle" class="sub">6-framework threat tagging</text>
+  <text x="332" y="400" text-anchor="middle" class="sub">Tool poisoning detection</text>
 
-  <rect x="32" y="340" width="260" height="72" rx="8" fill="#0d1117" stroke="#238636" stroke-width="1" opacity="0.8"/>
-  <text x="162" y="360" text-anchor="middle" class="label" fill="#3fb950">CI/CD Pipeline</text>
-  <text x="162" y="376" text-anchor="middle" class="sub">GitHub Actions / GitLab CI</text>
-  <text x="162" y="390" text-anchor="middle" class="sub">SARIF upload → Security tab auto-triage</text>
-  <text x="162" y="404" text-anchor="middle" class="sub">Policy gates: fail build on critical CVEs</text>
+  <line x1="332" y1="410" x2="332" y2="424" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <rect x="310" y="340" width="280" height="72" rx="8" fill="#0d1117" stroke="#238636" stroke-width="1" opacity="0.8"/>
-  <text x="450" y="360" text-anchor="middle" class="label" fill="#3fb950">Security Dashboard</text>
-  <text x="450" y="376" text-anchor="middle" class="sub">Next.js Cloud UI on localhost:3000</text>
-  <text x="450" y="390" text-anchor="middle" class="sub">REST API on localhost:8422</text>
-  <text x="450" y="404" text-anchor="middle" class="sub">Live scan progress + history diffs</text>
+  <!-- Step 5 -->
+  <rect x="246" y="428" width="172" height="58" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <rect x="246" y="428" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
+  <text x="332" y="441" text-anchor="middle" class="badge" fill="#d29922">STEP 5 · CONTEXT GRAPH</text>
+  <text x="332" y="462" text-anchor="middle" class="sub">Lateral movement paths</text>
+  <text x="332" y="474" text-anchor="middle" class="sub">Shared server/credential analysis</text>
 
-  <rect x="608" y="340" width="264" height="72" rx="8" fill="#0d1117" stroke="#238636" stroke-width="1" opacity="0.8"/>
-  <text x="740" y="360" text-anchor="middle" class="label" fill="#3fb950">Compliance &amp; Audit</text>
-  <text x="740" y="376" text-anchor="middle" class="sub">CycloneDX AI-BOM for supply chain</text>
-  <text x="740" y="390" text-anchor="middle" class="sub">SPDX 3.0 for license + provenance</text>
-  <text x="740" y="404" text-anchor="middle" class="sub">Scan history + baseline diffs</text>
+  <line x1="332" y1="486" x2="332" y2="500" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <!-- ═══ Row 4: Data Sources ═══ -->
-  <text x="32" y="440" class="phase" fill="#bc8cff">EXTERNAL DATA SOURCES (PUBLIC APIs · NO AUTH · NO USER DATA SENT)</text>
+  <!-- Step 6 -->
+  <rect x="246" y="504" width="172" height="46" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <rect x="246" y="504" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
+  <text x="332" y="517" text-anchor="middle" class="badge" fill="#d29922">STEP 6 · REPORT</text>
+  <text x="332" y="536" text-anchor="middle" class="sub">Generate outputs + alerts</text>
 
-  <rect x="32" y="450" width="130" height="36" rx="6" fill="#161b22" stroke="#8b5cf6" stroke-width="1" opacity="0.6"/>
-  <text x="97" y="466" text-anchor="middle" class="label" fill="#bc8cff">OSV.dev</text>
-  <text x="97" y="480" text-anchor="middle" class="sub">CVE database</text>
+  <!-- Arrow: Pipeline → Analysis -->
+  <line x1="432" y1="310" x2="460" y2="310" stroke="#d29922" stroke-width="2" marker-end="url(#a)"/>
 
-  <rect x="176" y="450" width="130" height="36" rx="6" fill="#161b22" stroke="#8b5cf6" stroke-width="1" opacity="0.6"/>
-  <text x="241" y="466" text-anchor="middle" class="label" fill="#bc8cff">NVD / NIST</text>
-  <text x="241" y="480" text-anchor="middle" class="sub">CVSS scores</text>
+  <!-- ═══ COLUMN 3: Analysis Output (x=464, w=210) ═══ -->
+  <rect x="464" y="60" width="210" height="498" rx="8" fill="#161b22" stroke="#bc8cff" stroke-width="1.2"/>
+  <text x="569" y="78" text-anchor="middle" class="phase" fill="#bc8cff">ANALYSIS + SCORING</text>
 
-  <rect x="320" y="450" width="130" height="36" rx="6" fill="#161b22" stroke="#8b5cf6" stroke-width="1" opacity="0.6"/>
-  <text x="385" y="466" text-anchor="middle" class="label" fill="#bc8cff">FIRST EPSS</text>
-  <text x="385" y="480" text-anchor="middle" class="sub">Exploit probability</text>
+  <rect x="478" y="96" width="182" height="58" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="114" text-anchor="middle" class="label" fill="#bc8cff">Blast Radius Engine</text>
+  <text x="569" y="130" text-anchor="middle" class="sub">CVE → pkg → server → agent</text>
+  <text x="569" y="142" text-anchor="middle" class="sub">→ credentials → tools → risk score</text>
 
-  <rect x="464" y="450" width="130" height="36" rx="6" fill="#161b22" stroke="#8b5cf6" stroke-width="1" opacity="0.6"/>
-  <text x="529" y="466" text-anchor="middle" class="label" fill="#bc8cff">CISA KEV</text>
-  <text x="529" y="480" text-anchor="middle" class="sub">Exploited vulns</text>
+  <rect x="478" y="162" width="182" height="68" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="180" text-anchor="middle" class="label" fill="#bc8cff">6-Framework Tagging</text>
+  <text x="569" y="196" text-anchor="middle" class="sub">OWASP LLM · MCP · Agentic</text>
+  <text x="569" y="208" text-anchor="middle" class="sub">MITRE ATLAS · NIST AI RMF</text>
+  <text x="569" y="220" text-anchor="middle" class="sub">EU AI Act</text>
 
-  <rect x="608" y="450" width="130" height="36" rx="6" fill="#161b22" stroke="#8b5cf6" stroke-width="1" opacity="0.6"/>
-  <text x="673" y="466" text-anchor="middle" class="label" fill="#bc8cff">MCP Registry</text>
-  <text x="673" y="480" text-anchor="middle" class="sub">427+ servers</text>
+  <rect x="478" y="238" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="256" text-anchor="middle" class="label" fill="#bc8cff">Posture Scorecard</text>
+  <text x="569" y="272" text-anchor="middle" class="sub">Grade A–F · 6 dimensions</text>
+  <text x="569" y="282" text-anchor="middle" class="sub">Weighted enterprise score</text>
 
-  <rect x="752" y="450" width="120" height="36" rx="6" fill="#161b22" stroke="#8b5cf6" stroke-width="1" opacity="0.6"/>
-  <text x="812" y="466" text-anchor="middle" class="label" fill="#bc8cff">Grype DB</text>
-  <text x="812" y="480" text-anchor="middle" class="sub">Image vulns</text>
+  <rect x="478" y="294" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="312" text-anchor="middle" class="label" fill="#bc8cff">Incident Correlation</text>
+  <text x="569" y="328" text-anchor="middle" class="sub">P1–P4 priority by agent</text>
+  <text x="569" y="338" text-anchor="middle" class="sub">SOC-ready incident summaries</text>
 
-  <!-- Footer -->
-  <rect x="32" y="504" width="840" height="44" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="450" y="522" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.05em">WHY agent-bom vs Wiz / Snyk / Prisma</text>
-  <text x="450" y="538" text-anchor="middle" class="note">Free &amp; open source  ·  AI-native threat models (6 frameworks)  ·  MCP supply chain focus  ·  No cloud access needed  ·  Runs in your CI, your laptop, your air-gap</text>
+  <rect x="478" y="350" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="368" text-anchor="middle" class="label" fill="#bc8cff">Credential Risk Ranking</text>
+  <text x="569" y="384" text-anchor="middle" class="sub">Blast radius severity tiers</text>
+  <text x="569" y="394" text-anchor="middle" class="sub">Cross-agent aggregation</text>
+
+  <rect x="478" y="406" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="424" text-anchor="middle" class="label" fill="#bc8cff">Context Graph</text>
+  <text x="569" y="440" text-anchor="middle" class="sub">Lateral movement BFS paths</text>
+  <text x="569" y="450" text-anchor="middle" class="sub">Shared servers + credentials</text>
+
+  <rect x="478" y="462" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="480" text-anchor="middle" class="label" fill="#bc8cff">Policy Evaluation</text>
+  <text x="569" y="496" text-anchor="middle" class="sub">16 rule conditions</text>
+  <text x="569" y="506" text-anchor="middle" class="sub">fail / warn / info gates</text>
+
+  <rect x="478" y="518" width="182" height="32" rx="6" fill="#161b22" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="569" y="538" text-anchor="middle" class="badge" fill="#bc8cff">Remediation: named assets + fix priority</text>
+
+  <!-- Arrow: Analysis → Outputs -->
+  <line x1="674" y1="310" x2="702" y2="310" stroke="#bc8cff" stroke-width="2" marker-end="url(#ap)"/>
+
+  <!-- ═══ COLUMN 4: Outputs (x=706, w=214) ═══ -->
+  <rect x="706" y="60" width="214" height="498" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="813" y="78" text-anchor="middle" class="phase" fill="#3fb950">DEPLOYMENT SURFACES</text>
+
+  <rect x="720" y="96" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="114" text-anchor="middle" class="label" fill="#3fb950">Console + HTML Report</text>
+  <text x="813" y="128" text-anchor="middle" class="sub">Rich tables · interactive dashboard</text>
+
+  <rect x="720" y="146" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="164" text-anchor="middle" class="label" fill="#3fb950">SARIF + SBOM Export</text>
+  <text x="813" y="178" text-anchor="middle" class="sub">CycloneDX 1.6 · SPDX 3.0 · GitHub</text>
+
+  <rect x="720" y="196" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="214" text-anchor="middle" class="label" fill="#3fb950">REST API + SSE</text>
+  <text x="813" y="228" text-anchor="middle" class="sub">FastAPI :8422 · live streaming</text>
+
+  <rect x="720" y="246" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="264" text-anchor="middle" class="label" fill="#3fb950">Next.js Dashboard</text>
+  <text x="813" y="278" text-anchor="middle" class="sub">15 pages · React Flow graphs</text>
+
+  <rect x="720" y="296" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="314" text-anchor="middle" class="label" fill="#3fb950">CI/CD Pipeline Gate</text>
+  <text x="813" y="328" text-anchor="middle" class="sub">GitHub Actions · --fail-on-severity</text>
+
+  <rect x="720" y="346" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="364" text-anchor="middle" class="label" fill="#3fb950">MCP Server</text>
+  <text x="813" y="378" text-anchor="middle" class="sub">15 tools · stdio + SSE transport</text>
+
+  <rect x="720" y="396" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="414" text-anchor="middle" class="label" fill="#3fb950">Observability</text>
+  <text x="813" y="428" text-anchor="middle" class="sub">Prometheus · OpenTelemetry</text>
+
+  <rect x="720" y="446" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="464" text-anchor="middle" class="label" fill="#3fb950">Alert Pipeline</text>
+  <text x="813" y="478" text-anchor="middle" class="sub">Slack · Jira · Vanta · Drata</text>
+
+  <rect x="720" y="496" width="186" height="60" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="813" y="514" text-anchor="middle" class="label" fill="#3fb950">Snowflake Deployment</text>
+  <text x="813" y="528" text-anchor="middle" class="sub">Snowpark Container Services</text>
+  <text x="813" y="540" text-anchor="middle" class="sub">Streamlit · Native App</text>
+
+  <!-- ═══ Bottom Bar: Trust + Data Flow ═══ -->
+  <rect x="20" y="570" width="900" height="38" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="470" y="586" text-anchor="middle" class="badge" fill="#8b949e">TRUST MODEL</text>
+  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,335 tests</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -1,175 +1,234 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 620" fill="none">
   <style>
     .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #0f172a; }
-    .subtitle { font: 400 11px system-ui, sans-serif; fill: #64748b; }
+    .subtitle { font: 400 10px system-ui, sans-serif; fill: #64748b; }
     .phase { font: 700 9px system-ui, sans-serif; letter-spacing: 0.1em; }
     .label { font: 600 11px system-ui, sans-serif; }
     .sub { font: 400 9px system-ui, sans-serif; fill: #64748b; }
     .badge { font: 600 8px system-ui, sans-serif; }
+    .data-label { font: 500 8px monospace; }
     .note { font: 400 9px system-ui, sans-serif; fill: #94a3b8; }
-    .arrow { stroke: #cbd5e1; stroke-width: 1.5; fill: none; }
   </style>
   <defs>
     <marker id="a" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#cbd5e1"/>
+      <path d="M0 0L8 3L0 6Z" fill="#94a3b8"/>
+    </marker>
+    <marker id="ab" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
+      <path d="M0 0L8 3L0 6Z" fill="#2563eb"/>
     </marker>
     <marker id="ag" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
       <path d="M0 0L8 3L0 6Z" fill="#059669"/>
     </marker>
+    <marker id="ar" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
+      <path d="M0 0L8 3L0 6Z" fill="#dc2626"/>
+    </marker>
+    <marker id="ap" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
+      <path d="M0 0L8 3L0 6Z" fill="#7c3aed"/>
+    </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="900" height="560" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <rect width="940" height="620" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
 
   <!-- Title -->
-  <text x="450" y="30" text-anchor="middle" class="title">Enterprise Scan Workflow</text>
-  <text x="450" y="48" text-anchor="middle" class="subtitle">How agent-bom fits into your security stack — no agents, no access, just analysis</text>
+  <text x="470" y="28" text-anchor="middle" class="title">Enterprise Scan Workflow — Architecture &amp; Data Flow</text>
+  <text x="470" y="44" text-anchor="middle" class="subtitle">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
 
-  <!-- ═══ Row 1: Input Sources ═══ -->
-  <text x="32" y="80" class="phase" fill="#2563eb">INPUT SOURCES</text>
+  <!-- ═══ COLUMN 1: Input Sources (x=20, w=180) ═══ -->
+  <rect x="20" y="60" width="180" height="498" rx="8" fill="#f0f9ff" stroke="#2563eb" stroke-width="1.2"/>
+  <text x="110" y="78" text-anchor="middle" class="phase" fill="#2563eb">INPUT SOURCES</text>
 
-  <!-- Developer Workstation -->
-  <rect x="32" y="92" width="160" height="56" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="112" y="112" text-anchor="middle" class="label" fill="#1e40af">Developer Machines</text>
-  <text x="112" y="126" text-anchor="middle" class="sub">18 clients: Claude, Cursor,</text>
-  <text x="112" y="138" text-anchor="middle" class="sub">Codex, Gemini, Goose, +13</text>
+  <rect x="32" y="88" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="106" text-anchor="middle" class="label" fill="#1e40af">MCP Configs</text>
+  <text x="110" y="120" text-anchor="middle" class="sub">18 clients auto-discovered</text>
 
-  <!-- Container Registry -->
-  <rect x="208" y="92" width="160" height="56" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="288" y="112" text-anchor="middle" class="label" fill="#1e40af">Container Registry</text>
-  <text x="288" y="126" text-anchor="middle" class="sub">Docker Hub, ECR, GCR</text>
-  <text x="288" y="138" text-anchor="middle" class="sub">OCI images</text>
+  <rect x="32" y="138" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="156" text-anchor="middle" class="label" fill="#1e40af">Docker Images</text>
+  <text x="110" y="170" text-anchor="middle" class="sub">Grype / Syft / Docker CLI</text>
 
-  <!-- Kubernetes -->
-  <rect x="384" y="92" width="160" height="56" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="464" y="112" text-anchor="middle" class="label" fill="#1e40af">Kubernetes Cluster</text>
-  <text x="464" y="126" text-anchor="middle" class="sub">Pod image discovery</text>
-  <text x="464" y="138" text-anchor="middle" class="sub">Multi-namespace kubectl</text>
+  <rect x="32" y="188" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="206" text-anchor="middle" class="label" fill="#1e40af">Kubernetes</text>
+  <text x="110" y="220" text-anchor="middle" class="sub">Multi-namespace pod scan</text>
 
-  <!-- Existing SBOMs -->
-  <rect x="560" y="92" width="160" height="56" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="640" y="112" text-anchor="middle" class="label" fill="#1e40af">Existing SBOMs</text>
-  <text x="640" y="126" text-anchor="middle" class="sub">CycloneDX / SPDX import</text>
-  <text x="640" y="138" text-anchor="middle" class="sub">Vendor-provided BOMs</text>
+  <rect x="32" y="238" width="156" height="52" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="256" text-anchor="middle" class="label" fill="#1e40af">Cloud APIs</text>
+  <text x="110" y="270" text-anchor="middle" class="sub">AWS Bedrock · Snowflake Cortex</text>
+  <text x="110" y="282" text-anchor="middle" class="sub">Azure AI · GCP Vertex · Databricks</text>
 
-  <!-- Inventory File -->
-  <rect x="736" y="92" width="136" height="56" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="804" y="112" text-anchor="middle" class="label" fill="#1e40af">Inventory File</text>
-  <text x="804" y="126" text-anchor="middle" class="sub">Manual package list</text>
-  <text x="804" y="138" text-anchor="middle" class="sub">JSON / YAML</text>
+  <rect x="32" y="298" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="316" text-anchor="middle" class="label" fill="#1e40af">SBOMs</text>
+  <text x="110" y="330" text-anchor="middle" class="sub">CycloneDX / SPDX import</text>
 
-  <!-- Arrows down from inputs -->
-  <line x1="112" y1="148" x2="112" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="288" y1="148" x2="288" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="464" y1="148" x2="464" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="640" y1="148" x2="640" y2="170" class="arrow" marker-end="url(#a)"/>
-  <line x1="804" y1="148" x2="804" y2="170" class="arrow" marker-end="url(#a)"/>
+  <rect x="32" y="348" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="366" text-anchor="middle" class="label" fill="#1e40af">IaC + CI/CD</text>
+  <text x="110" y="380" text-anchor="middle" class="sub">Terraform · GitHub Actions</text>
 
-  <!-- ═══ Row 2: agent-bom Core ═══ -->
-  <rect x="32" y="176" width="840" height="100" rx="10" fill="#fafafa" stroke="#e2e8f0" stroke-width="1.5"/>
-  <text x="450" y="194" text-anchor="middle" class="phase" fill="#475569">AGENT-BOM SCANNER (READ-ONLY · NO AGENTS · LOCAL EXECUTION)</text>
+  <rect x="32" y="398" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="416" text-anchor="middle" class="label" fill="#1e40af">AI Frameworks</text>
+  <text x="110" y="430" text-anchor="middle" class="sub">LangChain · CrewAI · ADK</text>
 
-  <!-- Step 1: Parse -->
-  <rect x="52" y="206" width="148" height="56" rx="6" fill="#ffffff" stroke="#d1d5db" stroke-width="1"/>
-  <text x="126" y="222" text-anchor="middle" class="badge" fill="#6b7280">STEP 1</text>
-  <text x="126" y="238" text-anchor="middle" class="label" fill="#374151">Parse &amp; Extract</text>
-  <text x="126" y="252" text-anchor="middle" class="sub">Packages, versions,</text>
-  <text x="126" y="262" text-anchor="middle" class="sub">PURLs, credentials</text>
+  <rect x="32" y="448" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="110" y="466" text-anchor="middle" class="label" fill="#1e40af">SaaS Connectors</text>
+  <text x="110" y="480" text-anchor="middle" class="sub">Jira · Slack · ServiceNow</text>
 
-  <line x1="200" y1="234" x2="218" y2="234" class="arrow" marker-end="url(#a)"/>
+  <rect x="32" y="498" width="156" height="50" rx="6" fill="#eff6ff" stroke="#2563eb" stroke-width="0.8"/>
+  <text x="110" y="516" text-anchor="middle" class="badge" fill="#2563eb">EXTRACTED DATA</text>
+  <text x="110" y="530" text-anchor="middle" class="data-label" fill="#475569">packages · versions · PURLs</text>
+  <text x="110" y="542" text-anchor="middle" class="data-label" fill="#475569">env var names · tool lists</text>
 
-  <!-- Step 2: Scan -->
-  <rect x="224" y="206" width="148" height="56" rx="6" fill="#ffffff" stroke="#d1d5db" stroke-width="1"/>
-  <text x="298" y="222" text-anchor="middle" class="badge" fill="#6b7280">STEP 2</text>
-  <text x="298" y="238" text-anchor="middle" class="label" fill="#374151">CVE Scan</text>
-  <text x="298" y="252" text-anchor="middle" class="sub">OSV.dev batch API</text>
-  <text x="298" y="262" text-anchor="middle" class="sub">Grype for images</text>
+  <!-- Arrow: Sources → Pipeline -->
+  <line x1="200" y1="310" x2="228" y2="310" stroke="#2563eb" stroke-width="2" marker-end="url(#ab)"/>
 
-  <line x1="372" y1="234" x2="390" y2="234" class="arrow" marker-end="url(#a)"/>
+  <!-- ═══ COLUMN 2: Scanner Pipeline (x=232, w=200) ═══ -->
+  <rect x="232" y="60" width="200" height="498" rx="8" fill="#fffbeb" stroke="#d97706" stroke-width="1.2"/>
+  <text x="332" y="78" text-anchor="middle" class="phase" fill="#d97706">SCANNER PIPELINE</text>
+  <text x="332" y="92" text-anchor="middle" class="sub">read-only · local execution</text>
 
-  <!-- Step 3: Enrich -->
-  <rect x="396" y="206" width="148" height="56" rx="6" fill="#ffffff" stroke="#d1d5db" stroke-width="1"/>
-  <text x="470" y="222" text-anchor="middle" class="badge" fill="#6b7280">STEP 3</text>
-  <text x="470" y="238" text-anchor="middle" class="label" fill="#374151">Enrich</text>
-  <text x="470" y="252" text-anchor="middle" class="sub">NVD CVSS + EPSS</text>
-  <text x="470" y="262" text-anchor="middle" class="sub">CISA KEV + CWEs</text>
+  <!-- Step 1 -->
+  <rect x="246" y="104" width="172" height="58" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
+  <rect x="246" y="104" width="172" height="18" rx="6" fill="#fef3c7"/>
+  <text x="332" y="117" text-anchor="middle" class="badge" fill="#92400e">STEP 1 · DISCOVER</text>
+  <text x="332" y="138" text-anchor="middle" class="sub">Auto-detect agent configs</text>
+  <text x="332" y="150" text-anchor="middle" class="sub">Parse packages + credentials</text>
 
-  <line x1="544" y1="234" x2="562" y2="234" class="arrow" marker-end="url(#a)"/>
+  <line x1="332" y1="162" x2="332" y2="176" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <!-- Step 4: Analyze -->
-  <rect x="568" y="206" width="148" height="56" rx="6" fill="#ffffff" stroke="#d1d5db" stroke-width="1"/>
-  <text x="642" y="222" text-anchor="middle" class="badge" fill="#6b7280">STEP 4</text>
-  <text x="642" y="238" text-anchor="middle" class="label" fill="#374151">Threat Model</text>
-  <text x="642" y="252" text-anchor="middle" class="sub">Blast radius + OWASP</text>
-  <text x="642" y="262" text-anchor="middle" class="sub">ATLAS + risk scoring</text>
+  <!-- Step 2 -->
+  <rect x="246" y="180" width="172" height="58" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
+  <rect x="246" y="180" width="172" height="18" rx="6" fill="#fef3c7"/>
+  <text x="332" y="193" text-anchor="middle" class="badge" fill="#92400e">STEP 2 · CVE SCAN</text>
+  <text x="332" y="214" text-anchor="middle" class="sub">OSV.dev batch API</text>
+  <text x="332" y="226" text-anchor="middle" class="sub">Grype for container images</text>
 
-  <line x1="716" y1="234" x2="734" y2="234" class="arrow" marker-end="url(#a)"/>
+  <line x1="332" y1="238" x2="332" y2="252" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <!-- Step 5: Report -->
-  <rect x="740" y="206" width="120" height="56" rx="6" fill="#ffffff" stroke="#d1d5db" stroke-width="1"/>
-  <text x="800" y="222" text-anchor="middle" class="badge" fill="#6b7280">STEP 5</text>
-  <text x="800" y="238" text-anchor="middle" class="label" fill="#374151">Report</text>
-  <text x="800" y="252" text-anchor="middle" class="sub">JSON / SARIF / BOM</text>
-  <text x="800" y="262" text-anchor="middle" class="sub">+ source URLs</text>
+  <!-- Step 3 -->
+  <rect x="246" y="256" width="172" height="68" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
+  <rect x="246" y="256" width="172" height="18" rx="6" fill="#fef3c7"/>
+  <text x="332" y="269" text-anchor="middle" class="badge" fill="#92400e">STEP 3 · ENRICH</text>
+  <text x="332" y="290" text-anchor="middle" class="sub">NVD CVSS v3.1/v4.0 scoring</text>
+  <text x="332" y="302" text-anchor="middle" class="sub">FIRST EPSS exploit probability</text>
+  <text x="332" y="314" text-anchor="middle" class="sub">CISA KEV + GHSA + NVIDIA CSAF</text>
 
-  <!-- Arrows down from core -->
-  <line x1="200" y1="276" x2="200" y2="310" class="arrow" marker-end="url(#a)"/>
-  <line x1="450" y1="276" x2="450" y2="310" class="arrow" marker-end="url(#a)"/>
-  <line x1="700" y1="276" x2="700" y2="310" class="arrow" marker-end="url(#a)"/>
+  <line x1="332" y1="324" x2="332" y2="338" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <!-- ═══ Row 3: Enterprise Integration ═══ -->
-  <text x="32" y="330" class="phase" fill="#059669">ENTERPRISE INTEGRATION</text>
+  <!-- Step 4 -->
+  <rect x="246" y="342" width="172" height="68" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
+  <rect x="246" y="342" width="172" height="18" rx="6" fill="#fef3c7"/>
+  <text x="332" y="355" text-anchor="middle" class="badge" fill="#92400e">STEP 4 · ANALYZE</text>
+  <text x="332" y="376" text-anchor="middle" class="sub">Blast radius mapping</text>
+  <text x="332" y="388" text-anchor="middle" class="sub">6-framework threat tagging</text>
+  <text x="332" y="400" text-anchor="middle" class="sub">Tool poisoning detection</text>
 
-  <!-- CI/CD -->
-  <rect x="32" y="340" width="260" height="72" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="162" y="360" text-anchor="middle" class="label" fill="#065f46">CI/CD Pipeline</text>
-  <text x="162" y="376" text-anchor="middle" class="sub">GitHub Actions / GitLab CI</text>
-  <text x="162" y="390" text-anchor="middle" class="sub">SARIF upload → Security tab auto-triage</text>
-  <text x="162" y="404" text-anchor="middle" class="sub">Policy gates: fail build on critical CVEs</text>
+  <line x1="332" y1="410" x2="332" y2="424" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <!-- Security Dashboard -->
-  <rect x="310" y="340" width="280" height="72" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="450" y="360" text-anchor="middle" class="label" fill="#065f46">Security Dashboard</text>
-  <text x="450" y="376" text-anchor="middle" class="sub">Next.js Cloud UI on localhost:3000</text>
-  <text x="450" y="390" text-anchor="middle" class="sub">REST API on localhost:8422</text>
-  <text x="450" y="404" text-anchor="middle" class="sub">Live scan progress + history diffs</text>
+  <!-- Step 5 -->
+  <rect x="246" y="428" width="172" height="58" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
+  <rect x="246" y="428" width="172" height="18" rx="6" fill="#fef3c7"/>
+  <text x="332" y="441" text-anchor="middle" class="badge" fill="#92400e">STEP 5 · CONTEXT GRAPH</text>
+  <text x="332" y="462" text-anchor="middle" class="sub">Lateral movement paths</text>
+  <text x="332" y="474" text-anchor="middle" class="sub">Shared server/credential analysis</text>
 
-  <!-- Compliance -->
-  <rect x="608" y="340" width="264" height="72" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="740" y="360" text-anchor="middle" class="label" fill="#065f46">Compliance &amp; Audit</text>
-  <text x="740" y="376" text-anchor="middle" class="sub">CycloneDX AI-BOM for supply chain</text>
-  <text x="740" y="390" text-anchor="middle" class="sub">SPDX 3.0 for license + provenance</text>
-  <text x="740" y="404" text-anchor="middle" class="sub">Scan history + baseline diffs</text>
+  <line x1="332" y1="486" x2="332" y2="500" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
 
-  <!-- ═══ Row 4: Data Sources (external APIs) ═══ -->
-  <text x="32" y="440" class="phase" fill="#7c3aed">EXTERNAL DATA SOURCES (PUBLIC APIs · NO AUTH · NO USER DATA SENT)</text>
+  <!-- Step 6 -->
+  <rect x="246" y="504" width="172" height="46" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
+  <rect x="246" y="504" width="172" height="18" rx="6" fill="#fef3c7"/>
+  <text x="332" y="517" text-anchor="middle" class="badge" fill="#92400e">STEP 6 · REPORT</text>
+  <text x="332" y="536" text-anchor="middle" class="sub">Generate outputs + alerts</text>
 
-  <rect x="32" y="450" width="130" height="36" rx="6" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="1"/>
-  <text x="97" y="466" text-anchor="middle" class="label" fill="#6d28d9">OSV.dev</text>
-  <text x="97" y="480" text-anchor="middle" class="sub">CVE database</text>
+  <!-- Arrow: Pipeline → Analysis -->
+  <line x1="432" y1="310" x2="460" y2="310" stroke="#d97706" stroke-width="2" marker-end="url(#a)"/>
 
-  <rect x="176" y="450" width="130" height="36" rx="6" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="1"/>
-  <text x="241" y="466" text-anchor="middle" class="label" fill="#6d28d9">NVD / NIST</text>
-  <text x="241" y="480" text-anchor="middle" class="sub">CVSS scores</text>
+  <!-- ═══ COLUMN 3: Analysis Output (x=464, w=210) ═══ -->
+  <rect x="464" y="60" width="210" height="498" rx="8" fill="#faf5ff" stroke="#7c3aed" stroke-width="1.2"/>
+  <text x="569" y="78" text-anchor="middle" class="phase" fill="#7c3aed">ANALYSIS + SCORING</text>
 
-  <rect x="320" y="450" width="130" height="36" rx="6" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="1"/>
-  <text x="385" y="466" text-anchor="middle" class="label" fill="#6d28d9">FIRST EPSS</text>
-  <text x="385" y="480" text-anchor="middle" class="sub">Exploit probability</text>
+  <rect x="478" y="96" width="182" height="58" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="569" y="114" text-anchor="middle" class="label" fill="#5b21b6">Blast Radius Engine</text>
+  <text x="569" y="130" text-anchor="middle" class="sub">CVE → pkg → server → agent</text>
+  <text x="569" y="142" text-anchor="middle" class="sub">→ credentials → tools → risk score</text>
 
-  <rect x="464" y="450" width="130" height="36" rx="6" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="1"/>
-  <text x="529" y="466" text-anchor="middle" class="label" fill="#6d28d9">CISA KEV</text>
-  <text x="529" y="480" text-anchor="middle" class="sub">Exploited vulns</text>
+  <rect x="478" y="162" width="182" height="68" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="569" y="180" text-anchor="middle" class="label" fill="#5b21b6">6-Framework Tagging</text>
+  <text x="569" y="196" text-anchor="middle" class="sub">OWASP LLM · MCP · Agentic</text>
+  <text x="569" y="208" text-anchor="middle" class="sub">MITRE ATLAS · NIST AI RMF</text>
+  <text x="569" y="220" text-anchor="middle" class="sub">EU AI Act</text>
 
-  <rect x="608" y="450" width="130" height="36" rx="6" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="1"/>
-  <text x="673" y="466" text-anchor="middle" class="label" fill="#6d28d9">MCP Registry</text>
-  <text x="673" y="480" text-anchor="middle" class="sub">427+ servers</text>
+  <rect x="478" y="238" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="569" y="256" text-anchor="middle" class="label" fill="#5b21b6">Posture Scorecard</text>
+  <text x="569" y="272" text-anchor="middle" class="sub">Grade A–F · 6 dimensions</text>
+  <text x="569" y="282" text-anchor="middle" class="sub">Weighted enterprise score</text>
 
-  <rect x="752" y="450" width="120" height="36" rx="6" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="1"/>
-  <text x="812" y="466" text-anchor="middle" class="label" fill="#6d28d9">Grype DB</text>
-  <text x="812" y="480" text-anchor="middle" class="sub">Image vulns</text>
+  <rect x="478" y="294" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="569" y="312" text-anchor="middle" class="label" fill="#5b21b6">Incident Correlation</text>
+  <text x="569" y="328" text-anchor="middle" class="sub">P1–P4 priority by agent</text>
+  <text x="569" y="338" text-anchor="middle" class="sub">SOC-ready incident summaries</text>
 
-  <!-- Footer: key differentiators -->
-  <rect x="32" y="504" width="840" height="44" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="450" y="522" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#475569" letter-spacing="0.05em">WHY agent-bom vs Wiz / Snyk / Prisma</text>
-  <text x="450" y="538" text-anchor="middle" class="note">Free &amp; open source  ·  AI-native threat models (6 frameworks)  ·  MCP supply chain focus  ·  No cloud access needed  ·  Runs in your CI, your laptop, your air-gap</text>
+  <rect x="478" y="350" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="569" y="368" text-anchor="middle" class="label" fill="#5b21b6">Credential Risk Ranking</text>
+  <text x="569" y="384" text-anchor="middle" class="sub">Blast radius severity tiers</text>
+  <text x="569" y="394" text-anchor="middle" class="sub">Cross-agent aggregation</text>
+
+  <rect x="478" y="406" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="569" y="424" text-anchor="middle" class="label" fill="#5b21b6">Context Graph</text>
+  <text x="569" y="440" text-anchor="middle" class="sub">Lateral movement BFS paths</text>
+  <text x="569" y="450" text-anchor="middle" class="sub">Shared servers + credentials</text>
+
+  <rect x="478" y="462" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="569" y="480" text-anchor="middle" class="label" fill="#5b21b6">Policy Evaluation</text>
+  <text x="569" y="496" text-anchor="middle" class="sub">16 rule conditions</text>
+  <text x="569" y="506" text-anchor="middle" class="sub">fail / warn / info gates</text>
+
+  <rect x="478" y="518" width="182" height="32" rx="6" fill="#f5f3ff" stroke="#7c3aed" stroke-width="0.8"/>
+  <text x="569" y="538" text-anchor="middle" class="badge" fill="#7c3aed">Remediation: named assets + fix priority</text>
+
+  <!-- Arrow: Analysis → Outputs -->
+  <line x1="674" y1="310" x2="702" y2="310" stroke="#7c3aed" stroke-width="2" marker-end="url(#ap)"/>
+
+  <!-- ═══ COLUMN 4: Outputs (x=706, w=214) ═══ -->
+  <rect x="706" y="60" width="214" height="498" rx="8" fill="#ecfdf5" stroke="#059669" stroke-width="1.2"/>
+  <text x="813" y="78" text-anchor="middle" class="phase" fill="#059669">DEPLOYMENT SURFACES</text>
+
+  <rect x="720" y="96" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="114" text-anchor="middle" class="label" fill="#065f46">Console + HTML Report</text>
+  <text x="813" y="128" text-anchor="middle" class="sub">Rich tables · interactive dashboard</text>
+
+  <rect x="720" y="146" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="164" text-anchor="middle" class="label" fill="#065f46">SARIF + SBOM Export</text>
+  <text x="813" y="178" text-anchor="middle" class="sub">CycloneDX 1.6 · SPDX 3.0 · GitHub</text>
+
+  <rect x="720" y="196" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="214" text-anchor="middle" class="label" fill="#065f46">REST API + SSE</text>
+  <text x="813" y="228" text-anchor="middle" class="sub">FastAPI :8422 · live streaming</text>
+
+  <rect x="720" y="246" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="264" text-anchor="middle" class="label" fill="#065f46">Next.js Dashboard</text>
+  <text x="813" y="278" text-anchor="middle" class="sub">15 pages · React Flow graphs</text>
+
+  <rect x="720" y="296" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="314" text-anchor="middle" class="label" fill="#065f46">CI/CD Pipeline Gate</text>
+  <text x="813" y="328" text-anchor="middle" class="sub">GitHub Actions · --fail-on-severity</text>
+
+  <rect x="720" y="346" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="364" text-anchor="middle" class="label" fill="#065f46">MCP Server</text>
+  <text x="813" y="378" text-anchor="middle" class="sub">15 tools · stdio + SSE transport</text>
+
+  <rect x="720" y="396" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="414" text-anchor="middle" class="label" fill="#065f46">Observability</text>
+  <text x="813" y="428" text-anchor="middle" class="sub">Prometheus · OpenTelemetry</text>
+
+  <rect x="720" y="446" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="464" text-anchor="middle" class="label" fill="#065f46">Alert Pipeline</text>
+  <text x="813" y="478" text-anchor="middle" class="sub">Slack · Jira · Vanta · Drata</text>
+
+  <rect x="720" y="496" width="186" height="60" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="813" y="514" text-anchor="middle" class="label" fill="#065f46">Snowflake Deployment</text>
+  <text x="813" y="528" text-anchor="middle" class="sub">Snowpark Container Services</text>
+  <text x="813" y="540" text-anchor="middle" class="sub">Streamlit · Native App</text>
+
+  <!-- ═══ Bottom Bar: Trust + Data Flow ═══ -->
+  <rect x="20" y="570" width="900" height="38" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="470" y="586" text-anchor="middle" class="badge" fill="#475569">TRUST MODEL</text>
+  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,335 tests</text>
 </svg>

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -93,7 +93,7 @@ docker run -p 8080:8080 agent-bom-sse
 # Connect: { "type": "sse", "url": "http://localhost:8080/sse" }
 ```
 
-## Available MCP Tools (14 tools)
+## Available MCP Tools (15 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -111,6 +111,7 @@ docker run -p 8080:8080 agent-bom-sse
 | `marketplace_check` | Pre-install trust check with registry cross-reference |
 | `where` | Show MCP client config discovery paths |
 | `inventory` | List discovered agents, servers, packages |
+| `context_graph` | Agent context graph with lateral movement analysis |
 
 ## MCP Resources
 


### PR DESCRIPTION
## Summary

- Fix MCP tool count **14 → 15** across README, 10 SVGs, and SKILL.md (`context_graph` added in v0.41.0)
- Fix test count **1,554/1,800 → 2,335** across enterprise-overview + data-flow SVGs
- Replace **PagerDuty** (not implemented — generic webhook only) with **Jira** (fully implemented) in architecture data flow diagram
- Add **context graph endpoint**, **MCP tool**, and **UI page** to all README tables
- Add **lateral movement analysis** to comparison table and shipped roadmap
- **Redesign scan-workflow SVGs**: purely descriptive → real 4-column architecture workflow
  - Input Sources (9 sources incl. cloud, SaaS) → Scanner Pipeline (6 steps incl. context graph) → Analysis + Scoring (7 engines) → Deployment Surfaces (9 targets)
  - Trust model bar at bottom

### Files changed (14)
- `README.md` — 7 text fixes (tool count, API table, dashboard table, comparison, roadmap, PagerDuty, graph section)
- 10 SVG diagrams — stale number updates (tool count, test count)
- `scan-workflow-light.svg` + `scan-workflow-dark.svg` — full redesign
- `integrations/openclaw/SKILL.md` — tool count + context_graph entry