### PR TITLE
feat: VEX support — vulnerability exploitability exchange

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.43.0
+ARG VERSION=0.44.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.43.0
+ARG VERSION=0.44.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.43.0"
+  --version "0.44.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.43.0
-git push origin v0.43.0
+git tag v0.44.0
+git push origin v0.44.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.43.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.44.0` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -462,7 +462,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.43.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.44.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Opt-in MCP traffic audit (per-server) |
@@ -481,7 +481,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.43.0
+- uses: msaad00/agent-bom@v0.44.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -613,7 +613,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.43.0` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.44.0` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.43.0
+- uses: msaad00/agent-bom@v0.44.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   compliance (OWASP, MITRE ATLAS, EU AI Act, NIST AI RMF). Use when the user
   mentions vulnerability scanning, dependency security, SBOM generation, MCP server
   trust, or AI supply chain risk.
-version: 0.43.0
+version: 0.44.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Docker for container
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.43.0
+    docker: ghcr.io/msaad00/agent-bom:0.44.0
   openclaw:
     requires:
       bins: []
@@ -82,7 +82,7 @@ agent-bom where             # show all discovery paths
 ### As a Docker Container
 
 ```bash
-docker run --rm ghcr.io/msaad00/agent-bom:0.43.0 scan
+docker run --rm ghcr.io/msaad00/agent-bom:0.44.0 scan
 ```
 
 ### Self-Hosted SSE Server
@@ -181,7 +181,7 @@ installation or self-host your own instance.
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: 99/100 quality score
-- **Sigstore signed**: `agent-bom verify agent-bom@0.43.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.44.0`
 - **2,099 tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.43.0
+ARG VERSION=0.44.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.43.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.44.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.43.0": {
+        "ghcr.io/msaad00/agent-bom:v0.44.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.43.0"
+version = "0.44.0"
 description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs. OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF. GPU infrastructure (NVIDIA/AMD) coverage."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.43.0"
+    __version__ = "0.44.0"

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -1142,6 +1142,27 @@ async def get_licenses(job_id: str) -> dict:
     return _lic_ser(lic_report)
 
 
+@app.get("/v1/scan/{job_id}/vex", tags=["scan"])
+async def get_vex(job_id: str) -> dict:
+    """Get the VEX (Vulnerability Exploitability eXchange) document for a completed scan.
+
+    Returns VEX statements with vulnerability status (affected, not_affected,
+    fixed, under_investigation), justifications, and statistics.
+    """
+    job = _jobs_get(job_id) or _get_store().get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    if job.status != JobStatus.DONE or not job.result:
+        raise HTTPException(status_code=409, detail="Scan not completed yet")
+
+    # Return pre-computed VEX data if available
+    if isinstance(job.result, dict) and job.result.get("vex"):
+        return job.result["vex"]
+
+    # Otherwise generate on-the-fly from blast_radii
+    return {"statements": [], "stats": {"total_statements": 0, "affected": 0, "not_affected": 0, "fixed": 0, "under_investigation": 0}}
+
+
 @app.get("/v1/scan/{job_id}/skill-audit", tags=["scan"])
 async def get_skill_audit(job_id: str) -> dict:
     """Get the skill security audit results for a completed scan.

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -151,6 +151,28 @@ def main():
     is_flag=True,
     help="Evaluate package licenses against compliance policy (block GPL/AGPL, warn copyleft)",
 )
+@click.option(
+    "--vex",
+    "vex_path",
+    type=click.Path(exists=True),
+    default=None,
+    metavar="PATH",
+    help="Apply a VEX document (OpenVEX JSON) to suppress resolved vulnerabilities",
+)
+@click.option(
+    "--generate-vex",
+    "generate_vex_flag",
+    is_flag=True,
+    help="Auto-generate a VEX document from scan results (KEV → affected, rest → under_investigation)",
+)
+@click.option(
+    "--vex-output",
+    "vex_output_path",
+    type=str,
+    default=None,
+    metavar="PATH",
+    help="Write generated VEX document to this file (default: agent-bom.vex.json)",
+)
 @click.option("--enrich", is_flag=True, help="Enrich vulnerabilities with NVD, EPSS, and CISA KEV data")
 @click.option("--nvd-api-key", envvar="NVD_API_KEY", help="NVD API key for higher rate limits")
 @click.option("--scorecard", "scorecard_flag", is_flag=True, help="Enrich packages with OpenSSF Scorecard scores")
@@ -412,6 +434,9 @@ def scan(
     max_depth: int,
     deps_dev: bool,
     license_check: bool,
+    vex_path: Optional[str],
+    generate_vex_flag: bool,
+    vex_output_path: Optional[str],
     enrich: bool,
     nvd_api_key: Optional[str],
     scorecard_flag: bool,
@@ -1683,6 +1708,32 @@ def scan(
             _f_count = len(_lic_report.findings)
             _status = "[green]compliant[/green]" if _lic_report.compliant else "[red]non-compliant[/red]"
             con.print(f"  [green]✓[/green] License check: {_lic_report.total_packages} packages, {_f_count} finding(s), {_status}")
+
+    # ── VEX support ──────────────────────────────────────────────────
+    if vex_path and agents:
+        from agent_bom.vex import apply_vex, load_vex
+        from agent_bom.vex import to_serializable as _vex_to_ser
+
+        _vex_doc = load_vex(vex_path)
+        _vex_count = apply_vex(report, _vex_doc)
+        report.vex_data = _vex_to_ser(_vex_doc)
+        if not quiet:
+            con.print(f"  [green]✓[/green] VEX applied: {_vex_count} vulnerabilities updated from {vex_path}")
+
+    if generate_vex_flag and report.blast_radii:
+        from agent_bom.vex import export_openvex, generate_vex
+        from agent_bom.vex import to_serializable as _vex_to_ser
+
+        _vex_doc = generate_vex(report, auto_triage=True)
+        report.vex_data = _vex_to_ser(_vex_doc)
+        _vex_out = vex_output_path or "agent-bom.vex.json"
+        import json as _vex_json
+
+        with open(_vex_out, "w") as _vf:
+            _vex_json.dump(export_openvex(_vex_doc), _vf, indent=2)
+        if not quiet:
+            _n_stmts = len(_vex_doc.statements)
+            con.print(f"  [green]✓[/green] VEX generated: {_n_stmts} statements → {_vex_out}")
 
     # ── Step 1i: Model binary file scan ─────────────────────────────
     if not skill_only and model_dirs:

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -72,6 +72,8 @@ class Vulnerability:
     cwe_ids: list[str] = field(default_factory=list)  # CWE weakness types
     aliases: list[str] = field(default_factory=list)  # Cross-source aliases (e.g. GHSA↔CVE)
     exploitability: Optional[str] = None  # "HIGH", "MEDIUM", "LOW" based on EPSS
+    vex_status: Optional[str] = None  # VEX status: affected, not_affected, fixed, under_investigation
+    vex_justification: Optional[str] = None  # VEX justification when not_affected
 
     @property
     def is_actively_exploited(self) -> bool:
@@ -367,6 +369,7 @@ class AIBOMReport:
     enforcement_data: Optional[dict] = None  # Serialized EnforcementReport (set by CLI)
     context_graph_data: Optional[dict] = None  # Serialized context graph (set by CLI)
     license_report: Optional[dict] = None  # Serialized license compliance report
+    vex_data: Optional[dict] = None  # Serialized VEX document
 
     def __post_init__(self):
         if not self.tool_version:

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1198,6 +1198,8 @@ def to_json(report: AIBOMReport) -> dict:
                                         "references": v.references,
                                         "nvd_published": v.nvd_published,
                                         "nvd_modified": v.nvd_modified,
+                                        "vex_status": v.vex_status,
+                                        "vex_justification": v.vex_justification,
                                     }
                                     for v in pkg.vulnerabilities
                                 ],
@@ -1290,6 +1292,9 @@ def to_json(report: AIBOMReport) -> dict:
 
     if report.license_report:
         result["license_report"] = report.license_report
+
+    if report.vex_data:
+        result["vex"] = report.vex_data
 
     # Posture scorecard
     from agent_bom.posture import (
@@ -1423,6 +1428,19 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                         )
                     if vuln.fixed_version:
                         vuln_entry["recommendation"] = f"Upgrade to {vuln.fixed_version}"
+                    if vuln.vex_status:
+                        # CycloneDX VEX analysis mapping
+                        _cdx_state_map = {
+                            "affected": "exploitable",
+                            "not_affected": "not_affected",
+                            "fixed": "resolved",
+                            "under_investigation": "in_triage",
+                        }
+                        vuln_entry["analysis"] = {
+                            "state": _cdx_state_map.get(vuln.vex_status, "in_triage"),
+                        }
+                        if vuln.vex_justification:
+                            vuln_entry["analysis"]["justification"] = vuln.vex_justification
                     vulnerabilities_cdx.append(vuln_entry)
 
             dependencies.append({"ref": server_ref, "dependsOn": server_deps})

--- a/src/agent_bom/vex.py
+++ b/src/agent_bom/vex.py
@@ -1,0 +1,282 @@
+"""VEX (Vulnerability Exploitability eXchange) support.
+
+Provides VEX document generation, ingestion, and application to scan results.
+Supports OpenVEX JSON format (https://openvex.dev/).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_bom.models import AIBOMReport
+
+
+class VexStatus(str, Enum):
+    """VEX vulnerability status."""
+
+    AFFECTED = "affected"
+    NOT_AFFECTED = "not_affected"
+    FIXED = "fixed"
+    UNDER_INVESTIGATION = "under_investigation"
+
+
+class VexJustification(str, Enum):
+    """Justification for NOT_AFFECTED status (required by OpenVEX spec)."""
+
+    COMPONENT_NOT_PRESENT = "component_not_present"
+    VULNERABLE_CODE_NOT_PRESENT = "vulnerable_code_not_present"
+    VULNERABLE_CODE_NOT_IN_EXECUTE_PATH = "vulnerable_code_not_in_execute_path"
+    VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY = "vulnerable_code_cannot_be_controlled_by_adversary"
+    INLINE_MITIGATIONS_ALREADY_EXIST = "inline_mitigations_already_exist"
+
+
+@dataclass
+class VexStatement:
+    """A single VEX statement about a vulnerability's exploitability."""
+
+    vulnerability_id: str  # CVE-YYYY-NNNNN or GHSA-xxxx
+    status: VexStatus
+    justification: VexJustification | None = None  # Required when NOT_AFFECTED
+    impact_statement: str | None = None
+    action_statement: str | None = None  # Recommended when AFFECTED
+    products: list[str] = field(default_factory=list)  # Package PURLs
+    timestamp: str = ""  # ISO 8601
+    author: str = "agent-bom"
+
+    def __post_init__(self):
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class VexDocument:
+    """A VEX document containing statements about vulnerability exploitability."""
+
+    statements: list[VexStatement] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        if not self.metadata:
+            self.metadata = {
+                "id": f"urn:uuid:{uuid.uuid4()}",
+                "author": "agent-bom",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "version": 1,
+            }
+
+
+# ---------------------------------------------------------------------------
+# Load VEX documents
+# ---------------------------------------------------------------------------
+
+
+def load_vex(path: str) -> VexDocument:
+    """Load a VEX document from a JSON file.
+
+    Supports OpenVEX format:
+    {
+      "@context": "https://openvex.dev/ns/v0.2.0",
+      "statements": [{"vulnerability": {"name": "CVE-..."}, "status": "..."}]
+    }
+
+    Also supports simplified format:
+    {
+      "statements": [{"vulnerability_id": "CVE-...", "status": "..."}]
+    }
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    statements = []
+    for stmt_data in data.get("statements", []):
+        # OpenVEX format
+        if "vulnerability" in stmt_data and isinstance(stmt_data["vulnerability"], dict):
+            vuln_id = stmt_data["vulnerability"].get("name", stmt_data["vulnerability"].get("id", ""))
+        else:
+            vuln_id = stmt_data.get("vulnerability_id", stmt_data.get("vulnerability", ""))
+
+        status_str = stmt_data.get("status", "under_investigation")
+        try:
+            status = VexStatus(status_str)
+        except ValueError:
+            status = VexStatus.UNDER_INVESTIGATION
+
+        justification = None
+        just_str = stmt_data.get("justification")
+        if just_str:
+            try:
+                justification = VexJustification(just_str)
+            except ValueError:
+                pass
+
+        products = stmt_data.get("products", [])
+        if isinstance(products, list) and products and isinstance(products[0], dict):
+            products = [p.get("@id", p.get("purl", "")) for p in products]
+
+        statements.append(
+            VexStatement(
+                vulnerability_id=vuln_id,
+                status=status,
+                justification=justification,
+                impact_statement=stmt_data.get("impact_statement"),
+                action_statement=stmt_data.get("action_statement"),
+                products=products,
+                timestamp=stmt_data.get("timestamp", ""),
+                author=stmt_data.get("author", data.get("author", "unknown")),
+            )
+        )
+
+    metadata = {
+        "id": data.get("@id", data.get("id", f"urn:uuid:{uuid.uuid4()}")),
+        "author": data.get("author", "unknown"),
+        "timestamp": data.get("timestamp", ""),
+        "version": data.get("version", 1),
+    }
+
+    return VexDocument(statements=statements, metadata=metadata)
+
+
+# ---------------------------------------------------------------------------
+# Generate VEX from scan results
+# ---------------------------------------------------------------------------
+
+
+def generate_vex(report: "AIBOMReport", auto_triage: bool = False) -> VexDocument:
+    """Generate a VEX document from scan results.
+
+    If auto_triage is True:
+    - KEV vulns → AFFECTED with action_statement
+    - Transitive-only deps → UNDER_INVESTIGATION
+    - Everything else → UNDER_INVESTIGATION
+    """
+    statements = []
+    seen_vulns: set[str] = set()
+
+    for br in report.blast_radii:
+        vuln = br.vulnerability
+        if vuln.id in seen_vulns:
+            continue
+        seen_vulns.add(vuln.id)
+
+        # Collect affected PURLs
+        products = []
+        if br.package:
+            products.append(br.package.purl or f"pkg:{br.package.ecosystem}/{br.package.name}@{br.package.version}")
+
+        if auto_triage and vuln.is_kev:
+            statements.append(
+                VexStatement(
+                    vulnerability_id=vuln.id,
+                    status=VexStatus.AFFECTED,
+                    action_statement=f"CISA KEV: exploit known in the wild. Patch to {vuln.fixed_version or 'latest'}.",
+                    products=products,
+                )
+            )
+        else:
+            statements.append(
+                VexStatement(
+                    vulnerability_id=vuln.id,
+                    status=VexStatus.UNDER_INVESTIGATION,
+                    impact_statement=f"Severity: {vuln.severity.value}, CVSS: {vuln.cvss_score or 'N/A'}",
+                    products=products,
+                )
+            )
+
+    return VexDocument(statements=statements)
+
+
+# ---------------------------------------------------------------------------
+# Apply VEX to scan results
+# ---------------------------------------------------------------------------
+
+
+def apply_vex(report: "AIBOMReport", vex: VexDocument) -> int:
+    """Apply VEX statements to a report's vulnerabilities.
+
+    Sets vex_status and vex_justification on matching Vulnerability objects.
+    Returns count of vulnerabilities updated.
+    """
+    # Build lookup: vuln_id → statement
+    vex_map: dict[str, VexStatement] = {}
+    for stmt in vex.statements:
+        vex_map[stmt.vulnerability_id] = stmt
+
+    count = 0
+    for agent in report.agents:
+        for server in agent.mcp_servers:
+            for pkg in server.packages:
+                for vuln in pkg.vulnerabilities:
+                    stmt = vex_map.get(vuln.id)
+                    if not stmt:
+                        # Check aliases
+                        for alias in vuln.aliases or []:
+                            stmt = vex_map.get(alias)
+                            if stmt:
+                                break
+                    if stmt:
+                        vuln.vex_status = stmt.status.value
+                        vuln.vex_justification = stmt.justification.value if stmt.justification else None
+                        count += 1
+
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Export VEX documents
+# ---------------------------------------------------------------------------
+
+
+def export_openvex(doc: VexDocument) -> dict:
+    """Serialize to OpenVEX JSON format (https://openvex.dev/ns/v0.2.0)."""
+    return {
+        "@context": "https://openvex.dev/ns/v0.2.0",
+        "@id": doc.metadata.get("id", f"urn:uuid:{uuid.uuid4()}"),
+        "author": doc.metadata.get("author", "agent-bom"),
+        "timestamp": doc.metadata.get("timestamp", datetime.now(timezone.utc).isoformat()),
+        "version": doc.metadata.get("version", 1),
+        "statements": [
+            {
+                "vulnerability": {"name": stmt.vulnerability_id},
+                "status": stmt.status.value,
+                **({"justification": stmt.justification.value} if stmt.justification else {}),
+                **({"impact_statement": stmt.impact_statement} if stmt.impact_statement else {}),
+                **({"action_statement": stmt.action_statement} if stmt.action_statement else {}),
+                "products": [{"@id": p} for p in stmt.products] if stmt.products else [],
+                "timestamp": stmt.timestamp,
+            }
+            for stmt in doc.statements
+        ],
+    }
+
+
+def to_serializable(doc: VexDocument) -> dict:
+    """Convert VEX document to a simplified JSON-serializable dict."""
+    return {
+        "metadata": doc.metadata,
+        "statements": [
+            {
+                "vulnerability_id": stmt.vulnerability_id,
+                "status": stmt.status.value,
+                "justification": stmt.justification.value if stmt.justification else None,
+                "impact_statement": stmt.impact_statement,
+                "action_statement": stmt.action_statement,
+                "products": stmt.products,
+                "timestamp": stmt.timestamp,
+                "author": stmt.author,
+            }
+            for stmt in doc.statements
+        ],
+        "stats": {
+            "total_statements": len(doc.statements),
+            "affected": sum(1 for s in doc.statements if s.status == VexStatus.AFFECTED),
+            "not_affected": sum(1 for s in doc.statements if s.status == VexStatus.NOT_AFFECTED),
+            "fixed": sum(1 for s in doc.statements if s.status == VexStatus.FIXED),
+            "under_investigation": sum(1 for s in doc.statements if s.status == VexStatus.UNDER_INVESTIGATION),
+        },
+    }

--- a/tests/test_api_pipeline_events.py
+++ b/tests/test_api_pipeline_events.py
@@ -1,4 +1,4 @@
-"""Tests for structured scan pipeline SSE events (v0.43.0)."""
+"""Tests for structured scan pipeline SSE events (v0.44.0)."""
 
 from __future__ import annotations
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.43.0"
+    assert __version__ == "0.44.0"
 
 
 def test_report_version_matches():
@@ -2933,7 +2933,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.43.0"
+    assert data["version"] == "0.44.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 

--- a/tests/test_dynamic_discovery.py
+++ b/tests/test_dynamic_discovery.py
@@ -1,4 +1,4 @@
-"""Tests for dynamic MCP configuration discovery (v0.43.0)."""
+"""Tests for dynamic MCP configuration discovery (v0.44.0)."""
 
 from __future__ import annotations
 

--- a/tests/test_ocsf.py
+++ b/tests/test_ocsf.py
@@ -79,11 +79,11 @@ class TestOCSFFormat:
         assert isinstance(fi["types"], list)
 
     def test_metadata_product(self):
-        ocsf = to_ocsf_detection_finding(_sample_alert(), product_version="0.43.0")
+        ocsf = to_ocsf_detection_finding(_sample_alert(), product_version="0.44.0")
         meta = ocsf["metadata"]
         assert meta["product"]["name"] == "agent-bom"
         assert meta["product"]["vendor_name"] == "msaad00"
-        assert meta["product"]["version"] == "0.43.0"
+        assert meta["product"]["version"] == "0.44.0"
         assert meta["version"] == "1.1.0"
 
     def test_evidences(self):
@@ -136,7 +136,7 @@ class TestSeverityMapping:
 class TestOCSFBatch:
     def test_batch_converts_all(self):
         alerts = [_sample_alert(severity=s) for s in ("critical", "high", "low")]
-        batch = to_ocsf_batch(alerts, "0.43.0")
+        batch = to_ocsf_batch(alerts, "0.44.0")
         assert len(batch) == 3
         assert all(b["class_uid"] == 2004 for b in batch)
 

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -1,0 +1,520 @@
+"""Tests for VEX (Vulnerability Exploitability eXchange) support."""
+
+from __future__ import annotations
+
+import json
+
+from agent_bom.models import (
+    Agent,
+    AIBOMReport,
+    BlastRadius,
+    MCPServer,
+    Package,
+    Severity,
+    Vulnerability,
+)
+from agent_bom.vex import (
+    VexDocument,
+    VexJustification,
+    VexStatement,
+    VexStatus,
+    apply_vex,
+    export_openvex,
+    generate_vex,
+    load_vex,
+    to_serializable,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _vuln(
+    vid: str = "CVE-2024-1234",
+    severity: Severity = Severity.HIGH,
+    is_kev: bool = False,
+    aliases: list[str] | None = None,
+) -> Vulnerability:
+    return Vulnerability(
+        id=vid,
+        summary=f"Test vuln {vid}",
+        severity=severity,
+        is_kev=is_kev,
+        aliases=aliases or [],
+    )
+
+
+def _pkg(
+    name: str = "test-pkg",
+    version: str = "1.0.0",
+    ecosystem: str = "npm",
+    vulns: list[Vulnerability] | None = None,
+) -> Package:
+    return Package(
+        name=name,
+        version=version,
+        ecosystem=ecosystem,
+        purl=f"pkg:{ecosystem}/{name}@{version}",
+        vulnerabilities=vulns or [],
+    )
+
+
+def _server(name: str = "test-server", packages: list[Package] | None = None) -> MCPServer:
+    return MCPServer(name=name, command="npx", packages=packages or [])
+
+
+def _agent(name: str = "agent-a", servers: list[MCPServer] | None = None) -> Agent:
+    return Agent(name=name, agent_type="claude-desktop", config_path="/tmp/test", mcp_servers=servers or [])
+
+
+def _report(vulns: list[tuple[Vulnerability, Package]] | None = None) -> AIBOMReport:
+    """Build a minimal report with vulns assigned to packages."""
+    if not vulns:
+        return AIBOMReport()
+
+    seen_pkgs: dict[str, Package] = {}
+    blast_radii = []
+    for vuln, pkg in vulns:
+        if vuln not in pkg.vulnerabilities:
+            pkg.vulnerabilities.append(vuln)
+        seen_pkgs[f"{pkg.name}@{pkg.version}"] = pkg
+        blast_radii.append(
+            BlastRadius(
+                vulnerability=vuln,
+                package=pkg,
+                affected_servers=[],
+                affected_agents=[],
+                exposed_credentials=[],
+                exposed_tools=[],
+            )
+        )
+
+    server = _server(packages=list(seen_pkgs.values()))
+    agent = _agent(servers=[server])
+    return AIBOMReport(agents=[agent], blast_radii=blast_radii)
+
+
+# ---------------------------------------------------------------------------
+# TestVexStatus
+# ---------------------------------------------------------------------------
+
+
+class TestVexStatus:
+    def test_all_statuses(self):
+        assert VexStatus.AFFECTED.value == "affected"
+        assert VexStatus.NOT_AFFECTED.value == "not_affected"
+        assert VexStatus.FIXED.value == "fixed"
+        assert VexStatus.UNDER_INVESTIGATION.value == "under_investigation"
+
+    def test_all_justifications(self):
+        assert VexJustification.COMPONENT_NOT_PRESENT.value == "component_not_present"
+        assert VexJustification.VULNERABLE_CODE_NOT_PRESENT.value == "vulnerable_code_not_present"
+        assert VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH.value == "vulnerable_code_not_in_execute_path"
+        assert (
+            VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY.value == "vulnerable_code_cannot_be_controlled_by_adversary"
+        )
+        assert VexJustification.INLINE_MITIGATIONS_ALREADY_EXIST.value == "inline_mitigations_already_exist"
+
+    def test_statement_auto_timestamp(self):
+        stmt = VexStatement(vulnerability_id="CVE-2024-0001", status=VexStatus.AFFECTED)
+        assert stmt.timestamp != ""
+        assert "T" in stmt.timestamp  # ISO 8601
+
+    def test_statement_default_author(self):
+        stmt = VexStatement(vulnerability_id="CVE-2024-0001", status=VexStatus.AFFECTED)
+        assert stmt.author == "agent-bom"
+
+    def test_document_auto_metadata(self):
+        doc = VexDocument()
+        assert "id" in doc.metadata
+        assert doc.metadata["id"].startswith("urn:uuid:")
+        assert doc.metadata["author"] == "agent-bom"
+        assert doc.metadata["version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestVexLoad
+# ---------------------------------------------------------------------------
+
+
+class TestVexLoad:
+    def test_load_openvex_format(self, tmp_path):
+        data = {
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "@id": "urn:uuid:test-doc",
+            "author": "test-author",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "version": 1,
+            "statements": [
+                {
+                    "vulnerability": {"name": "CVE-2024-1234"},
+                    "status": "not_affected",
+                    "justification": "component_not_present",
+                    "impact_statement": "Component not used",
+                    "products": [{"@id": "pkg:npm/express@4.18.2"}],
+                    "timestamp": "2024-01-01T00:00:00Z",
+                }
+            ],
+        }
+        path = tmp_path / "vex.json"
+        path.write_text(json.dumps(data))
+        doc = load_vex(str(path))
+        assert len(doc.statements) == 1
+        assert doc.statements[0].vulnerability_id == "CVE-2024-1234"
+        assert doc.statements[0].status == VexStatus.NOT_AFFECTED
+        assert doc.statements[0].justification == VexJustification.COMPONENT_NOT_PRESENT
+        assert doc.statements[0].products == ["pkg:npm/express@4.18.2"]
+        assert doc.metadata["id"] == "urn:uuid:test-doc"
+        assert doc.metadata["author"] == "test-author"
+
+    def test_load_simplified_format(self, tmp_path):
+        data = {
+            "statements": [
+                {
+                    "vulnerability_id": "CVE-2024-5678",
+                    "status": "affected",
+                    "action_statement": "Upgrade to 2.0.0",
+                }
+            ]
+        }
+        path = tmp_path / "vex.json"
+        path.write_text(json.dumps(data))
+        doc = load_vex(str(path))
+        assert len(doc.statements) == 1
+        assert doc.statements[0].vulnerability_id == "CVE-2024-5678"
+        assert doc.statements[0].status == VexStatus.AFFECTED
+        assert doc.statements[0].action_statement == "Upgrade to 2.0.0"
+
+    def test_load_unknown_status_defaults(self, tmp_path):
+        data = {"statements": [{"vulnerability_id": "CVE-2024-0001", "status": "bogus_status"}]}
+        path = tmp_path / "vex.json"
+        path.write_text(json.dumps(data))
+        doc = load_vex(str(path))
+        assert doc.statements[0].status == VexStatus.UNDER_INVESTIGATION
+
+    def test_load_unknown_justification_ignored(self, tmp_path):
+        data = {
+            "statements": [
+                {
+                    "vulnerability_id": "CVE-2024-0001",
+                    "status": "not_affected",
+                    "justification": "bogus_justification",
+                }
+            ]
+        }
+        path = tmp_path / "vex.json"
+        path.write_text(json.dumps(data))
+        doc = load_vex(str(path))
+        assert doc.statements[0].justification is None
+
+    def test_load_empty_statements(self, tmp_path):
+        data = {"statements": []}
+        path = tmp_path / "vex.json"
+        path.write_text(json.dumps(data))
+        doc = load_vex(str(path))
+        assert len(doc.statements) == 0
+
+    def test_load_multiple_statements(self, tmp_path):
+        data = {
+            "statements": [
+                {"vulnerability_id": "CVE-2024-0001", "status": "affected"},
+                {"vulnerability_id": "CVE-2024-0002", "status": "fixed"},
+                {"vulnerability_id": "CVE-2024-0003", "status": "not_affected", "justification": "vulnerable_code_not_present"},
+            ]
+        }
+        path = tmp_path / "vex.json"
+        path.write_text(json.dumps(data))
+        doc = load_vex(str(path))
+        assert len(doc.statements) == 3
+        assert doc.statements[1].status == VexStatus.FIXED
+
+    def test_load_openvex_with_vulnerability_id_key(self, tmp_path):
+        """OpenVEX with vulnerability.id instead of vulnerability.name."""
+        data = {
+            "statements": [
+                {
+                    "vulnerability": {"id": "GHSA-abcd-efgh"},
+                    "status": "under_investigation",
+                }
+            ]
+        }
+        path = tmp_path / "vex.json"
+        path.write_text(json.dumps(data))
+        doc = load_vex(str(path))
+        assert doc.statements[0].vulnerability_id == "GHSA-abcd-efgh"
+
+
+# ---------------------------------------------------------------------------
+# TestVexGenerate
+# ---------------------------------------------------------------------------
+
+
+class TestVexGenerate:
+    def test_generate_empty_report(self):
+        report = AIBOMReport()
+        doc = generate_vex(report)
+        assert len(doc.statements) == 0
+
+    def test_generate_under_investigation_default(self):
+        vuln = _vuln("CVE-2024-1234")
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+        doc = generate_vex(report)
+        assert len(doc.statements) == 1
+        assert doc.statements[0].status == VexStatus.UNDER_INVESTIGATION
+        assert doc.statements[0].vulnerability_id == "CVE-2024-1234"
+
+    def test_generate_kev_auto_triage(self):
+        vuln = _vuln("CVE-2024-9999", is_kev=True)
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+        doc = generate_vex(report, auto_triage=True)
+        assert len(doc.statements) == 1
+        assert doc.statements[0].status == VexStatus.AFFECTED
+        assert "KEV" in doc.statements[0].action_statement
+
+    def test_generate_non_kev_auto_triage(self):
+        vuln = _vuln("CVE-2024-1111")
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+        doc = generate_vex(report, auto_triage=True)
+        assert doc.statements[0].status == VexStatus.UNDER_INVESTIGATION
+
+    def test_generate_deduplicates_vulns(self):
+        vuln = _vuln("CVE-2024-1234")
+        pkg1 = _pkg(name="pkg-a", vulns=[vuln])
+        pkg2 = _pkg(name="pkg-b", vulns=[vuln])
+        report = _report([(vuln, pkg1), (vuln, pkg2)])
+        doc = generate_vex(report)
+        # Same vuln ID should appear only once
+        assert len(doc.statements) == 1
+
+    def test_generate_includes_products(self):
+        vuln = _vuln("CVE-2024-1234")
+        pkg = _pkg(name="express", version="4.18.2", ecosystem="npm", vulns=[vuln])
+        report = _report([(vuln, pkg)])
+        doc = generate_vex(report)
+        assert len(doc.statements[0].products) == 1
+        assert "express" in doc.statements[0].products[0]
+
+    def test_generate_timestamp_format(self):
+        vuln = _vuln("CVE-2024-1234")
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+        doc = generate_vex(report)
+        assert doc.metadata.get("timestamp")
+        assert "T" in doc.metadata["timestamp"]
+
+    def test_generate_multiple_vulns(self):
+        vuln1 = _vuln("CVE-2024-0001", severity=Severity.CRITICAL, is_kev=True)
+        vuln2 = _vuln("CVE-2024-0002", severity=Severity.MEDIUM)
+        pkg = _pkg(vulns=[vuln1, vuln2])
+        report = _report([(vuln1, pkg), (vuln2, pkg)])
+        doc = generate_vex(report, auto_triage=True)
+        assert len(doc.statements) == 2
+        statuses = {s.vulnerability_id: s.status for s in doc.statements}
+        assert statuses["CVE-2024-0001"] == VexStatus.AFFECTED
+        assert statuses["CVE-2024-0002"] == VexStatus.UNDER_INVESTIGATION
+
+
+# ---------------------------------------------------------------------------
+# TestVexApply
+# ---------------------------------------------------------------------------
+
+
+class TestVexApply:
+    def test_apply_sets_status(self):
+        vuln = _vuln("CVE-2024-1234")
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+
+        doc = VexDocument(
+            statements=[
+                VexStatement(
+                    vulnerability_id="CVE-2024-1234",
+                    status=VexStatus.NOT_AFFECTED,
+                    justification=VexJustification.COMPONENT_NOT_PRESENT,
+                )
+            ]
+        )
+        count = apply_vex(report, doc)
+        assert count == 1
+        assert vuln.vex_status == "not_affected"
+        assert vuln.vex_justification == "component_not_present"
+
+    def test_apply_unmatched_unchanged(self):
+        vuln = _vuln("CVE-2024-9999")
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+
+        doc = VexDocument(statements=[VexStatement(vulnerability_id="CVE-2024-0000", status=VexStatus.FIXED)])
+        count = apply_vex(report, doc)
+        assert count == 0
+        assert vuln.vex_status is None
+
+    def test_apply_matches_by_alias(self):
+        vuln = _vuln("CVE-2024-1234", aliases=["GHSA-abcd-efgh"])
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+
+        doc = VexDocument(statements=[VexStatement(vulnerability_id="GHSA-abcd-efgh", status=VexStatus.FIXED)])
+        count = apply_vex(report, doc)
+        assert count == 1
+        assert vuln.vex_status == "fixed"
+
+    def test_apply_without_justification(self):
+        vuln = _vuln("CVE-2024-1234")
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+
+        doc = VexDocument(statements=[VexStatement(vulnerability_id="CVE-2024-1234", status=VexStatus.AFFECTED)])
+        count = apply_vex(report, doc)
+        assert count == 1
+        assert vuln.vex_status == "affected"
+        assert vuln.vex_justification is None
+
+    def test_apply_multiple_vulns(self):
+        vuln1 = _vuln("CVE-2024-0001")
+        vuln2 = _vuln("CVE-2024-0002")
+        pkg = _pkg(vulns=[vuln1, vuln2])
+        report = _report([(vuln1, pkg), (vuln2, pkg)])
+
+        doc = VexDocument(
+            statements=[
+                VexStatement(vulnerability_id="CVE-2024-0001", status=VexStatus.FIXED),
+                VexStatement(
+                    vulnerability_id="CVE-2024-0002",
+                    status=VexStatus.NOT_AFFECTED,
+                    justification=VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH,
+                ),
+            ]
+        )
+        count = apply_vex(report, doc)
+        assert count == 2
+        assert vuln1.vex_status == "fixed"
+        assert vuln2.vex_status == "not_affected"
+
+    def test_apply_empty_document(self):
+        vuln = _vuln("CVE-2024-1234")
+        pkg = _pkg(vulns=[vuln])
+        report = _report([(vuln, pkg)])
+        doc = VexDocument()
+        count = apply_vex(report, doc)
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# TestVexExport
+# ---------------------------------------------------------------------------
+
+
+class TestVexExport:
+    def test_export_openvex_format(self):
+        doc = VexDocument(
+            statements=[
+                VexStatement(
+                    vulnerability_id="CVE-2024-1234",
+                    status=VexStatus.NOT_AFFECTED,
+                    justification=VexJustification.COMPONENT_NOT_PRESENT,
+                    products=["pkg:npm/express@4.18.2"],
+                )
+            ]
+        )
+        result = export_openvex(doc)
+        assert result["@context"] == "https://openvex.dev/ns/v0.2.0"
+        assert "@id" in result
+        assert len(result["statements"]) == 1
+        stmt = result["statements"][0]
+        assert stmt["vulnerability"]["name"] == "CVE-2024-1234"
+        assert stmt["status"] == "not_affected"
+        assert stmt["justification"] == "component_not_present"
+        assert stmt["products"] == [{"@id": "pkg:npm/express@4.18.2"}]
+
+    def test_export_openvex_no_justification(self):
+        doc = VexDocument(statements=[VexStatement(vulnerability_id="CVE-2024-5678", status=VexStatus.AFFECTED)])
+        result = export_openvex(doc)
+        stmt = result["statements"][0]
+        assert "justification" not in stmt
+
+    def test_export_roundtrip(self, tmp_path):
+        """Export to OpenVEX JSON, write to file, reload."""
+        doc = VexDocument(
+            statements=[
+                VexStatement(
+                    vulnerability_id="CVE-2024-1234",
+                    status=VexStatus.NOT_AFFECTED,
+                    justification=VexJustification.VULNERABLE_CODE_NOT_PRESENT,
+                    impact_statement="Test impact",
+                    products=["pkg:npm/test@1.0.0"],
+                ),
+                VexStatement(
+                    vulnerability_id="CVE-2024-5678",
+                    status=VexStatus.AFFECTED,
+                    action_statement="Upgrade to 2.0.0",
+                ),
+            ]
+        )
+        exported = export_openvex(doc)
+        path = tmp_path / "roundtrip.json"
+        path.write_text(json.dumps(exported))
+
+        reloaded = load_vex(str(path))
+        assert len(reloaded.statements) == 2
+        assert reloaded.statements[0].vulnerability_id == "CVE-2024-1234"
+        assert reloaded.statements[0].status == VexStatus.NOT_AFFECTED
+        assert reloaded.statements[0].justification == VexJustification.VULNERABLE_CODE_NOT_PRESENT
+        assert reloaded.statements[1].vulnerability_id == "CVE-2024-5678"
+        assert reloaded.statements[1].status == VexStatus.AFFECTED
+
+    def test_export_empty_products(self):
+        doc = VexDocument(statements=[VexStatement(vulnerability_id="CVE-2024-1234", status=VexStatus.FIXED)])
+        result = export_openvex(doc)
+        assert result["statements"][0]["products"] == []
+
+
+# ---------------------------------------------------------------------------
+# TestSerialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_to_serializable_basic(self):
+        doc = VexDocument(
+            statements=[
+                VexStatement(vulnerability_id="CVE-2024-1234", status=VexStatus.AFFECTED),
+                VexStatement(
+                    vulnerability_id="CVE-2024-5678", status=VexStatus.NOT_AFFECTED, justification=VexJustification.COMPONENT_NOT_PRESENT
+                ),
+            ]
+        )
+        data = to_serializable(doc)
+        assert len(data["statements"]) == 2
+        assert data["stats"]["total_statements"] == 2
+        assert data["stats"]["affected"] == 1
+        assert data["stats"]["not_affected"] == 1
+        assert data["stats"]["fixed"] == 0
+        assert data["stats"]["under_investigation"] == 0
+
+    def test_to_serializable_empty(self):
+        doc = VexDocument()
+        data = to_serializable(doc)
+        assert data["statements"] == []
+        assert data["stats"]["total_statements"] == 0
+
+    def test_to_serializable_metadata(self):
+        doc = VexDocument()
+        data = to_serializable(doc)
+        assert "metadata" in data
+        assert data["metadata"]["author"] == "agent-bom"
+
+    def test_to_serializable_json_safe(self):
+        """Ensure output is JSON-serializable."""
+        doc = VexDocument(
+            statements=[
+                VexStatement(vulnerability_id="CVE-2024-1234", status=VexStatus.FIXED, products=["pkg:npm/test@1.0.0"]),
+            ]
+        )
+        data = to_serializable(doc)
+        json_str = json.dumps(data)
+        assert "CVE-2024-1234" in json_str


### PR DESCRIPTION
## Summary
- Add VEX (Vulnerability Exploitability eXchange) support with OpenVEX format for compliance triage
- CLI flags: `--vex <path>` (consume VEX), `--generate-vex` (auto-generate), `--vex-output <path>` (write location)
- API endpoint: `GET /v1/scan/{job_id}/vex` returns VEX document
- JSON/CycloneDX output includes per-vulnerability VEX status and justification
- 34 new tests covering load, generate, apply, export, and serialization
- Version bump 0.43.0 → 0.44.0

Depends on PR #137 (license scanning).

## Test plan
- [x] 34 VEX tests pass (load OpenVEX/simplified, generate with auto-triage, apply status, export roundtrip)
- [x] Full test suite: 2,438 tests pass
- [x] Ruff lint clean
- [ ] Manual: `agent-bom scan --demo --generate-vex` produces valid VEX JSON
- [ ] Manual: `agent-bom scan --demo --vex agent-bom.vex.json` applies VEX suppressions