### PR TITLE
feat: enterprise RBAC + API key management

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.47.0
+ARG VERSION=0.48.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.47.0
+ARG VERSION=0.48.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.47.0"
+  --version "0.48.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.47.0
-git push origin v0.47.0
+git tag v0.48.0
+git push origin v0.48.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.47.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.48.0` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -462,7 +462,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.47.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.48.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Opt-in MCP traffic audit (per-server) |
@@ -481,7 +481,7 @@ Both sources deduplicate by CVE ID against OSV results. Packages without a pinne
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.47.0
+- uses: msaad00/agent-bom@v0.48.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -613,7 +613,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.47.0` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.48.0` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.47.0
+- uses: msaad00/agent-bom@v0.48.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   compliance (OWASP, MITRE ATLAS, EU AI Act, NIST AI RMF). Use when the user
   mentions vulnerability scanning, dependency security, SBOM generation, MCP server
   trust, or AI supply chain risk.
-version: 0.47.0
+version: 0.48.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Docker for container
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.47.0
+    docker: ghcr.io/msaad00/agent-bom:0.48.0
   openclaw:
     requires:
       bins: []
@@ -82,7 +82,7 @@ agent-bom where             # show all discovery paths
 ### As a Docker Container
 
 ```bash
-docker run --rm ghcr.io/msaad00/agent-bom:0.47.0 scan
+docker run --rm ghcr.io/msaad00/agent-bom:0.48.0 scan
 ```
 
 ### Self-Hosted SSE Server
@@ -181,7 +181,7 @@ installation or self-host your own instance.
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: 99/100 quality score
-- **Sigstore signed**: `agent-bom verify agent-bom@0.47.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.48.0`
 - **2,099 tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.47.0
+ARG VERSION=0.48.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.47.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.48.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.47.0": {
+        "ghcr.io/msaad00/agent-bom:v0.48.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.47.0"
+version = "0.48.0"
 description = "AI supply chain security scanner — scan packages and images for CVEs, assess credential exposure and tool access risks, map blast radius, generate SBOMs. OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF. GPU infrastructure (NVIDIA/AMD) coverage."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.47.0"
+    __version__ = "0.48.0"

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -1,0 +1,169 @@
+"""Role-based access control (RBAC) and API key management.
+
+Provides API key creation, verification, and role-based endpoint protection
+for enterprise deployments.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+
+class Role(str, Enum):
+    """User roles for RBAC."""
+
+    ADMIN = "admin"
+    ANALYST = "analyst"
+    VIEWER = "viewer"
+
+
+# Role hierarchy: admin > analyst > viewer
+_ROLE_HIERARCHY: dict[Role, int] = {
+    Role.ADMIN: 3,
+    Role.ANALYST: 2,
+    Role.VIEWER: 1,
+}
+
+
+@dataclass
+class ApiKey:
+    """Stored API key metadata (the raw key is never stored)."""
+
+    key_id: str
+    key_hash: str  # SHA-256 of the raw key
+    key_prefix: str  # First 8 chars for identification
+    name: str
+    role: Role
+    created_at: str = ""
+    expires_at: str | None = None
+    scopes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            self.created_at = datetime.now(timezone.utc).isoformat()
+
+    def is_expired(self) -> bool:
+        if not self.expires_at:
+            return False
+        return datetime.now(timezone.utc).isoformat() > self.expires_at
+
+    def has_role(self, required: Role) -> bool:
+        """Check if this key's role meets or exceeds the required role."""
+        return _ROLE_HIERARCHY.get(self.role, 0) >= _ROLE_HIERARCHY.get(required, 0)
+
+    def to_dict(self) -> dict:
+        return {
+            "key_id": self.key_id,
+            "key_prefix": self.key_prefix,
+            "name": self.name,
+            "role": self.role.value,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "scopes": self.scopes,
+        }
+
+
+def _hash_key(raw_key: str) -> str:
+    """SHA-256 hash of a raw API key."""
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+def create_api_key(
+    name: str,
+    role: Role,
+    expires_at: str | None = None,
+    scopes: list[str] | None = None,
+) -> tuple[str, ApiKey]:
+    """Generate a new API key.
+
+    Returns (raw_key, api_key_record). The raw key is only returned once
+    and should be given to the user. Only the hash is stored.
+    """
+    raw_key = f"abom_{secrets.token_urlsafe(32)}"
+    key_hash = _hash_key(raw_key)
+    key_id = secrets.token_hex(8)
+
+    api_key = ApiKey(
+        key_id=key_id,
+        key_hash=key_hash,
+        key_prefix=raw_key[:12],
+        name=name,
+        role=role,
+        expires_at=expires_at,
+        scopes=scopes or [],
+    )
+    return raw_key, api_key
+
+
+def verify_api_key(raw_key: str, stored_keys: list[ApiKey]) -> ApiKey | None:
+    """Verify a raw API key against stored keys.
+
+    Returns the matching ApiKey if found and not expired, else None.
+    """
+    key_hash = _hash_key(raw_key)
+    for stored in stored_keys:
+        if hmac.compare_digest(stored.key_hash, key_hash):
+            if stored.is_expired():
+                return None
+            return stored
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Key store (in-memory singleton)
+# ---------------------------------------------------------------------------
+
+
+class KeyStore:
+    """Thread-safe in-memory API key store."""
+
+    def __init__(self) -> None:
+        self._keys: list[ApiKey] = []
+        self._lock = threading.Lock()
+
+    def add(self, key: ApiKey) -> None:
+        with self._lock:
+            self._keys.append(key)
+
+    def remove(self, key_id: str) -> bool:
+        with self._lock:
+            before = len(self._keys)
+            self._keys = [k for k in self._keys if k.key_id != key_id]
+            return len(self._keys) < before
+
+    def list_keys(self) -> list[ApiKey]:
+        with self._lock:
+            return list(self._keys)
+
+    def verify(self, raw_key: str) -> ApiKey | None:
+        with self._lock:
+            return verify_api_key(raw_key, self._keys)
+
+    def has_keys(self) -> bool:
+        with self._lock:
+            return len(self._keys) > 0
+
+
+_key_store: KeyStore | None = None
+_store_lock = threading.Lock()
+
+
+def get_key_store() -> KeyStore:
+    global _key_store
+    if _key_store is None:
+        with _store_lock:
+            if _key_store is None:
+                _key_store = KeyStore()
+    return _key_store
+
+
+def set_key_store(store: KeyStore) -> None:
+    global _key_store
+    with _store_lock:
+        _key_store = store

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -22,6 +22,11 @@ Endpoints:
     GET  /v1/governance                Snowflake governance report
     GET  /v1/governance/findings       governance findings (filtered)
     GET  /v1/activity                  agent activity timeline
+    POST /v1/auth/keys                 create RBAC API key
+    GET  /v1/auth/keys                 list API keys
+    DELETE /v1/auth/keys/{id}          revoke an API key
+    GET  /v1/audit                     query audit log
+    GET  /v1/audit/integrity           verify audit log HMAC integrity
 """
 
 from __future__ import annotations
@@ -219,30 +224,100 @@ app.add_middleware(TrustHeadersMiddleware)
 
 
 class APIKeyMiddleware(BaseHTTPMiddleware):
-    """Optional API key authentication via Bearer token or X-API-Key header."""
+    """Optional API key authentication via Bearer token or X-API-Key header.
+
+    Supports two modes:
+    - Simple mode: single static API key (backward compatible)
+    - RBAC mode: role-based access control via KeyStore with per-endpoint role checks
+    """
 
     _EXEMPT_PATHS = {"/", "/health", "/version", "/docs", "/redoc", "/openapi.json"}
+
+    # Endpoints requiring ADMIN role (mutating / destructive operations)
+    _ADMIN_PATHS: set[tuple[str, str]] = {
+        ("DELETE", "/v1/scan/"),
+        ("POST", "/v1/gateway/policies"),
+        ("PUT", "/v1/gateway/policies/"),
+        ("DELETE", "/v1/gateway/policies/"),
+        ("POST", "/v1/fleet/sync"),
+        ("PUT", "/v1/fleet/"),
+        ("POST", "/v1/auth/keys"),
+        ("DELETE", "/v1/auth/keys/"),
+        ("POST", "/v1/exceptions"),
+        ("PUT", "/v1/exceptions/"),
+        ("DELETE", "/v1/exceptions/"),
+    }
+
+    # Endpoints requiring ANALYST role (scan + write operations)
+    _ANALYST_PATHS: set[tuple[str, str]] = {
+        ("POST", "/v1/scan"),
+        ("POST", "/v1/gateway/evaluate"),
+        ("POST", "/v1/traces"),
+        ("POST", "/v1/results/push"),
+        ("POST", "/v1/schedules"),
+        ("DELETE", "/v1/schedules/"),
+        ("PUT", "/v1/schedules/"),
+    }
 
     def __init__(self, app: ASGIApp, api_key: str):
         super().__init__(app)
         self._api_key = api_key
 
+    def _required_role(self, method: str, path: str) -> str:
+        """Determine the minimum role required for a request."""
+        for m, p in self._ADMIN_PATHS:
+            if method == m and path.startswith(p):
+                return "admin"
+        for m, p in self._ANALYST_PATHS:
+            if method == m and path.startswith(p):
+                return "analyst"
+        return "viewer"
+
     async def dispatch(self, request: StarletteRequest, call_next):
         if request.url.path in self._EXEMPT_PATHS:
             return await call_next(request)
 
-        # Check Authorization: Bearer <key>
+        # Extract raw key from headers
+        raw_key = ""
         auth = request.headers.get("authorization", "")
-        if auth.startswith("Bearer ") and secrets.compare_digest(auth[7:], self._api_key):
+        if auth.startswith("Bearer "):
+            raw_key = auth[7:]
+        if not raw_key:
+            raw_key = request.headers.get("x-api-key", "")
+
+        if not raw_key:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized — provide API key via Authorization: Bearer <key> or X-API-Key header"},
+            )
+
+        # Simple mode: single static key (backward compatible, all access)
+        if secrets.compare_digest(raw_key, self._api_key):
+            request.state.api_key_name = "static-key"
+            request.state.api_key_role = "admin"
             return await call_next(request)
 
-        # Check X-API-Key header
-        header_key = request.headers.get("x-api-key", "")
-        if header_key and secrets.compare_digest(header_key, self._api_key):
-            return await call_next(request)
+        # RBAC mode: check against KeyStore
+        from agent_bom.api.auth import Role, get_key_store
+
+        store = get_key_store()
+        if store.has_keys():
+            api_key = store.verify(raw_key)
+            if api_key:
+                required = self._required_role(request.method, request.url.path)
+                required_role = Role(required)
+                if not api_key.has_role(required_role):
+                    return JSONResponse(
+                        status_code=403,
+                        content={"detail": f"Forbidden — requires {required} role, you have {api_key.role.value}"},
+                    )
+                request.state.api_key_name = api_key.name
+                request.state.api_key_role = api_key.role.value
+                return await call_next(request)
 
         return JSONResponse(
-            status_code=401, content={"detail": "Unauthorized — provide API key via Authorization: Bearer <key> or X-API-Key header"}
+            status_code=401,
+            content={"detail": "Unauthorized — invalid API key"},
         )
 
 
@@ -2968,6 +3043,70 @@ async def toggle_schedule(schedule_id: str) -> dict:
     s.updated_at = datetime.now(timezone.utc).isoformat()
     _schedule_store.put(s)
     return s.model_dump()
+
+
+# ── Enterprise: API Key Management (RBAC) ──────────────────────────────────
+
+
+class CreateKeyRequest(BaseModel):
+    name: str
+    role: str = "viewer"
+    expires_at: str | None = None
+    scopes: list[str] = []
+
+
+@app.post("/v1/auth/keys", tags=["enterprise"], status_code=201)
+async def create_key(req: CreateKeyRequest) -> dict:
+    """Create a new API key. Returns the raw key once — store it securely."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.auth import Role, create_api_key, get_key_store
+
+    try:
+        role = Role(req.role)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid role: {req.role}. Must be admin, analyst, or viewer")
+
+    raw_key, api_key = create_api_key(
+        name=req.name,
+        role=role,
+        expires_at=req.expires_at,
+        scopes=req.scopes,
+    )
+    get_key_store().add(api_key)
+
+    log_action("auth.key_created", actor=req.name, resource=f"key/{api_key.key_id}", role=req.role)
+
+    return {
+        "raw_key": raw_key,
+        "key_id": api_key.key_id,
+        "key_prefix": api_key.key_prefix,
+        "name": api_key.name,
+        "role": api_key.role.value,
+        "created_at": api_key.created_at,
+        "expires_at": api_key.expires_at,
+        "message": "Store the raw_key securely — it will not be shown again.",
+    }
+
+
+@app.get("/v1/auth/keys", tags=["enterprise"])
+async def list_keys() -> dict:
+    """List all API keys (without hashes or raw values)."""
+    from agent_bom.api.auth import get_key_store
+
+    keys = get_key_store().list_keys()
+    return {"keys": [k.to_dict() for k in keys]}
+
+
+@app.delete("/v1/auth/keys/{key_id}", tags=["enterprise"], status_code=204)
+async def delete_key(key_id: str) -> None:
+    """Revoke an API key."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.auth import get_key_store
+
+    if not get_key_store().remove(key_id):
+        raise HTTPException(status_code=404, detail=f"Key {key_id} not found")
+
+    log_action("auth.key_revoked", resource=f"key/{key_id}")
 
 
 # ── Enterprise: Audit Log ────────────────────────────────────────────────────

--- a/tests/test_api_pipeline_events.py
+++ b/tests/test_api_pipeline_events.py
@@ -1,4 +1,4 @@
-"""Tests for structured scan pipeline SSE events (v0.47.0)."""
+"""Tests for structured scan pipeline SSE events (v0.48.0)."""
 
 from __future__ import annotations
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,214 @@
+"""Tests for RBAC and API key management."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from agent_bom.api.auth import (
+    KeyStore,
+    Role,
+    create_api_key,
+    get_key_store,
+    set_key_store,
+    verify_api_key,
+)
+
+# ---------------------------------------------------------------------------
+# Role hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestRoleHierarchy:
+    def test_admin_has_all_roles(self):
+        _, key = create_api_key("admin", Role.ADMIN)
+        assert key.has_role(Role.ADMIN)
+        assert key.has_role(Role.ANALYST)
+        assert key.has_role(Role.VIEWER)
+
+    def test_analyst_has_analyst_and_viewer(self):
+        _, key = create_api_key("analyst", Role.ANALYST)
+        assert not key.has_role(Role.ADMIN)
+        assert key.has_role(Role.ANALYST)
+        assert key.has_role(Role.VIEWER)
+
+    def test_viewer_only_viewer(self):
+        _, key = create_api_key("viewer", Role.VIEWER)
+        assert not key.has_role(Role.ADMIN)
+        assert not key.has_role(Role.ANALYST)
+        assert key.has_role(Role.VIEWER)
+
+
+# ---------------------------------------------------------------------------
+# API key creation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateApiKey:
+    def test_returns_raw_key_and_record(self):
+        raw, key = create_api_key("test-key", Role.ANALYST)
+        assert raw.startswith("abom_")
+        assert len(raw) > 20
+        assert key.name == "test-key"
+        assert key.role == Role.ANALYST
+
+    def test_key_prefix_matches_raw(self):
+        raw, key = create_api_key("pfx", Role.VIEWER)
+        assert key.key_prefix == raw[:12]
+
+    def test_key_hash_is_sha256(self):
+        _, key = create_api_key("hash-test", Role.ADMIN)
+        assert len(key.key_hash) == 64  # SHA-256 hex length
+
+    def test_key_id_generated(self):
+        _, key = create_api_key("id-test", Role.VIEWER)
+        assert len(key.key_id) == 16  # hex(8 bytes)
+
+    def test_created_at_set(self):
+        _, key = create_api_key("ts-test", Role.VIEWER)
+        assert key.created_at
+        # Verify ISO 8601
+        datetime.fromisoformat(key.created_at)
+
+    def test_scopes_default_empty(self):
+        _, key = create_api_key("scope-test", Role.ANALYST)
+        assert key.scopes == []
+
+    def test_scopes_custom(self):
+        _, key = create_api_key("scope-test", Role.ANALYST, scopes=["scan", "vex"])
+        assert key.scopes == ["scan", "vex"]
+
+    def test_expires_at_optional(self):
+        _, key = create_api_key("no-expire", Role.VIEWER)
+        assert key.expires_at is None
+
+    def test_expires_at_set(self):
+        exp = "2099-12-31T23:59:59+00:00"
+        _, key = create_api_key("expire-test", Role.VIEWER, expires_at=exp)
+        assert key.expires_at == exp
+
+
+# ---------------------------------------------------------------------------
+# API key verification
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyApiKey:
+    def test_valid_key_returns_record(self):
+        raw, key = create_api_key("verify-test", Role.ANALYST)
+        result = verify_api_key(raw, [key])
+        assert result is not None
+        assert result.key_id == key.key_id
+
+    def test_invalid_key_returns_none(self):
+        _, key = create_api_key("miss", Role.VIEWER)
+        result = verify_api_key("abom_wrong_key_value", [key])
+        assert result is None
+
+    def test_expired_key_returns_none(self):
+        raw, key = create_api_key("expired", Role.ADMIN, expires_at="2020-01-01T00:00:00+00:00")
+        result = verify_api_key(raw, [key])
+        assert result is None
+
+    def test_not_expired_key_works(self):
+        raw, key = create_api_key("future", Role.ADMIN, expires_at="2099-12-31T23:59:59+00:00")
+        result = verify_api_key(raw, [key])
+        assert result is not None
+
+    def test_multiple_stored_keys(self):
+        raw1, key1 = create_api_key("key1", Role.ADMIN)
+        raw2, key2 = create_api_key("key2", Role.VIEWER)
+        assert verify_api_key(raw1, [key1, key2]) is not None
+        assert verify_api_key(raw2, [key1, key2]) is not None
+        assert verify_api_key("abom_nope", [key1, key2]) is None
+
+
+# ---------------------------------------------------------------------------
+# ApiKey.is_expired
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyExpiry:
+    def test_no_expiry_not_expired(self):
+        _, key = create_api_key("no-exp", Role.VIEWER)
+        assert not key.is_expired()
+
+    def test_past_expiry_is_expired(self):
+        _, key = create_api_key("past", Role.VIEWER, expires_at="2020-01-01T00:00:00+00:00")
+        assert key.is_expired()
+
+    def test_future_expiry_not_expired(self):
+        _, key = create_api_key("future", Role.VIEWER, expires_at="2099-12-31T23:59:59+00:00")
+        assert not key.is_expired()
+
+
+# ---------------------------------------------------------------------------
+# ApiKey.to_dict
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyToDict:
+    def test_to_dict_structure(self):
+        _, key = create_api_key("dict-test", Role.ANALYST, scopes=["scan"])
+        d = key.to_dict()
+        assert d["name"] == "dict-test"
+        assert d["role"] == "analyst"
+        assert d["scopes"] == ["scan"]
+        assert "key_hash" not in d  # Hash should NOT be exposed
+
+
+# ---------------------------------------------------------------------------
+# KeyStore
+# ---------------------------------------------------------------------------
+
+
+class TestKeyStore:
+    def test_add_and_list(self):
+        store = KeyStore()
+        _, key = create_api_key("store-test", Role.ADMIN)
+        store.add(key)
+        assert len(store.list_keys()) == 1
+
+    def test_remove(self):
+        store = KeyStore()
+        _, key = create_api_key("rm-test", Role.VIEWER)
+        store.add(key)
+        assert store.remove(key.key_id)
+        assert len(store.list_keys()) == 0
+
+    def test_remove_nonexistent(self):
+        store = KeyStore()
+        assert not store.remove("nonexistent")
+
+    def test_verify(self):
+        store = KeyStore()
+        raw, key = create_api_key("v-test", Role.ANALYST)
+        store.add(key)
+        assert store.verify(raw) is not None
+        assert store.verify("abom_wrong") is None
+
+    def test_has_keys(self):
+        store = KeyStore()
+        assert not store.has_keys()
+        _, key = create_api_key("hk", Role.VIEWER)
+        store.add(key)
+        assert store.has_keys()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    def test_get_key_store_returns_same_instance(self):
+        s1 = get_key_store()
+        s2 = get_key_store()
+        assert s1 is s2
+
+    def test_set_key_store_replaces(self):
+        original = get_key_store()
+        new_store = KeyStore()
+        set_key_store(new_store)
+        assert get_key_store() is new_store
+        # Restore
+        set_key_store(original)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.47.0"
+    assert __version__ == "0.48.0"
 
 
 def test_report_version_matches():
@@ -2933,7 +2933,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.47.0"
+    assert data["version"] == "0.48.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 

--- a/tests/test_dynamic_discovery.py
+++ b/tests/test_dynamic_discovery.py
@@ -1,4 +1,4 @@
-"""Tests for dynamic MCP configuration discovery (v0.47.0)."""
+"""Tests for dynamic MCP configuration discovery (v0.48.0)."""
 
 from __future__ import annotations
 

--- a/tests/test_ocsf.py
+++ b/tests/test_ocsf.py
@@ -79,11 +79,11 @@ class TestOCSFFormat:
         assert isinstance(fi["types"], list)
 
     def test_metadata_product(self):
-        ocsf = to_ocsf_detection_finding(_sample_alert(), product_version="0.47.0")
+        ocsf = to_ocsf_detection_finding(_sample_alert(), product_version="0.48.0")
         meta = ocsf["metadata"]
         assert meta["product"]["name"] == "agent-bom"
         assert meta["product"]["vendor_name"] == "msaad00"
-        assert meta["product"]["version"] == "0.47.0"
+        assert meta["product"]["version"] == "0.48.0"
         assert meta["version"] == "1.1.0"
 
     def test_evidences(self):
@@ -136,7 +136,7 @@ class TestSeverityMapping:
 class TestOCSFBatch:
     def test_batch_converts_all(self):
         alerts = [_sample_alert(severity=s) for s in ("critical", "high", "low")]
-        batch = to_ocsf_batch(alerts, "0.47.0")
+        batch = to_ocsf_batch(alerts, "0.48.0")
         assert len(batch) == 3
         assert all(b["class_uid"] == 2004 for b in batch)
 


### PR DESCRIPTION
## Summary
- Role-based access control (RBAC) with `admin`, `analyst`, `viewer` hierarchy
- API key lifecycle: `POST /v1/auth/keys` (create), `GET /v1/auth/keys` (list), `DELETE /v1/auth/keys/{id}` (revoke)
- Enhanced `APIKeyMiddleware` with RBAC enforcement — admin-only endpoints (DELETE, fleet sync, key management), analyst endpoints (scan, evaluate), viewer for all GETs
- Backward compatible: single static API key mode still works, RBAC activates when keys are added to KeyStore
- SHA-256 hashed key storage with constant-time HMAC verification
- All key management actions logged to audit log
- Version bump 0.47.0 → 0.48.0

## Test plan
- [x] 28 tests in `tests/test_auth.py` covering:
  - Role hierarchy (admin > analyst > viewer)
  - API key creation, verification, expiry
  - KeyStore operations (add, remove, list, verify)
  - Singleton store management
- [x] Full suite: 2,553 passed, 13 skipped