### PR TITLE
refactor: centralize shared constants (dedup 5x AI_PACKAGES, 5x severities, 3x patterns)

### DIFF
--- a/src/agent_bom/atlas.py
+++ b/src/agent_bom/atlas.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from agent_bom.models import Severity
+from agent_bom.constants import AI_PACKAGES as _AI_PACKAGES
+from agent_bom.constants import high_risk_severities
 from agent_bom.risk_analyzer import ToolCapability, classify_tool
 
 if TYPE_CHECKING:
@@ -37,31 +38,7 @@ ATLAS_TECHNIQUES: dict[str, str] = {
     "AML.T0062": "Exfiltration via AI Agent Tool Invocation",
 }
 
-# AI/ML framework packages — CVEs here enable model-level attacks
-_AI_PACKAGES: frozenset[str] = frozenset({
-    "torch", "torchvision", "torchaudio",
-    "transformers", "diffusers", "tokenizers",
-    "langchain", "langchain-core", "langchain-community",
-    "langchain-openai", "langchain-anthropic",
-    "openai", "anthropic", "google-generativeai",
-    "crewai", "autogen", "pyautogen",
-    "haystack", "haystack-ai",
-    "llama-index", "llama-cpp-python",
-    "dspy-ai", "guidance",
-    "semantic-kernel",
-    "pydantic-ai",
-    # Vector stores / RAG backends
-    "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
-    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
-    "pgvector", "lancedb",
-    "sentence-transformers",
-})
-
-# Severity levels considered high-risk
-_HIGH_RISK: frozenset[Severity] = frozenset({
-    Severity.CRITICAL,
-    Severity.HIGH,
-})
+_HIGH_RISK = high_risk_severities()
 
 
 # ─── Tagger ───────────────────────────────────────────────────────────────────

--- a/src/agent_bom/constants.py
+++ b/src/agent_bom/constants.py
@@ -1,0 +1,118 @@
+"""Shared constants — single source of truth for AI package catalogs,
+severity classifications, and credential detection patterns.
+
+All compliance modules and graph/model code import from here to avoid
+drift between duplicated definitions.
+"""
+
+from __future__ import annotations
+
+# ── AI/ML Framework Packages ────────────────────────────────────────────────
+# Used by compliance taggers (owasp, atlas, nist_ai_rmf, eu_ai_act,
+# owasp_agentic) to determine if a vulnerability affects an AI/ML component.
+
+AI_PACKAGES: frozenset[str] = frozenset(
+    {
+        # LLM orchestration
+        "langchain",
+        "langchain-core",
+        "langchain-community",
+        "langchain-openai",
+        "langchain-anthropic",
+        "llama-index",
+        "llama-cpp-python",
+        "autogen",
+        "pyautogen",
+        "crewai",
+        "haystack",
+        "haystack-ai",
+        "dspy-ai",
+        "guidance",
+        "semantic-kernel",
+        "pydantic-ai",
+        # LLM clients
+        "openai",
+        "anthropic",
+        "google-generativeai",
+        # Model inference
+        "torch",
+        "torchvision",
+        "torchaudio",
+        "transformers",
+        "diffusers",
+        "tokenizers",
+        # Embedding models
+        "sentence-transformers",
+        # Vector stores / RAG backends
+        "chromadb",
+        "pinecone-client",
+        "weaviate-client",
+        "qdrant-client",
+        "faiss-cpu",
+        "faiss-gpu",
+        "pymilvus",
+        "milvus",
+        "pgvector",
+        "lancedb",
+    }
+)
+
+# Packages directly involved in training data handling and fine-tuning.
+# CVEs here risk training data poisoning (OWASP LLM03).
+TRAINING_DATA_PACKAGES: frozenset[str] = frozenset(
+    {
+        "datasets",
+        "huggingface-hub",
+        "tokenizers",
+        "transformers",
+        "diffusers",
+        "accelerate",
+        "trl",
+        "sentence-transformers",
+        "peft",
+        "torch",
+        "torchvision",
+        "torchaudio",
+        "tensorflow",
+        "tensorflow-gpu",
+        "safetensors",
+        "optimum",
+    }
+)
+
+
+def high_risk_severities() -> frozenset:
+    """Return severity levels considered high-risk.
+
+    Lazy import to avoid circular dependency with models.Severity.
+    """
+    from agent_bom.models import Severity
+
+    return frozenset({Severity.CRITICAL, Severity.HIGH})
+
+
+# ── Credential Detection Patterns ───────────────────────────────────────────
+# Used by models.MCPServer.has_credentials / credential_names and
+# context_graph._is_credential_key.
+
+SENSITIVE_PATTERNS: list[str] = [
+    "key",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "api_key",
+    "apikey",
+    "auth",
+    "private",
+    "connection",
+    "conn_str",
+    "database_url",
+    "db_url",
+]
+
+
+def is_credential_key(name: str) -> bool:
+    """Check if an environment variable name matches credential patterns."""
+    low = name.lower()
+    return any(pat in low for pat in SENSITIVE_PATTERNS)

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -16,29 +16,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
-# ── Credential detection (mirrors models.MCPServer.credential_names) ──────
-
-_SENSITIVE_PATTERNS = [
-    "key",
-    "token",
-    "secret",
-    "password",
-    "credential",
-    "api_key",
-    "apikey",
-    "auth",
-    "private",
-    "connection",
-    "conn_str",
-    "database_url",
-    "db_url",
-]
-
-
-def _is_credential_key(name: str) -> bool:
-    low = name.lower()
-    return any(pat in low for pat in _SENSITIVE_PATTERNS)
-
+from agent_bom.constants import is_credential_key as _is_credential_key
 
 # ── Enums ─────────────────────────────────────────────────────────────────
 

--- a/src/agent_bom/eu_ai_act.py
+++ b/src/agent_bom/eu_ai_act.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from agent_bom.constants import AI_PACKAGES as _AI_PACKAGES
 from agent_bom.models import Severity
 from agent_bom.risk_analyzer import ToolCapability, classify_tool
 
@@ -29,48 +30,6 @@ EU_AI_ACT: dict[str, str] = {
     "ART-15": "Accuracy, Robustness & Cybersecurity",
     "ART-17": "Quality Management System",
 }
-
-# AI/ML framework packages
-_AI_PACKAGES: frozenset[str] = frozenset(
-    {
-        "torch",
-        "torchvision",
-        "torchaudio",
-        "transformers",
-        "diffusers",
-        "tokenizers",
-        "langchain",
-        "langchain-core",
-        "langchain-community",
-        "langchain-openai",
-        "langchain-anthropic",
-        "openai",
-        "anthropic",
-        "google-generativeai",
-        "crewai",
-        "autogen",
-        "pyautogen",
-        "haystack",
-        "haystack-ai",
-        "llama-index",
-        "llama-cpp-python",
-        "dspy-ai",
-        "guidance",
-        "semantic-kernel",
-        "pydantic-ai",
-        "chromadb",
-        "pinecone-client",
-        "weaviate-client",
-        "qdrant-client",
-        "faiss-cpu",
-        "faiss-gpu",
-        "pymilvus",
-        "milvus",
-        "pgvector",
-        "lancedb",
-        "sentence-transformers",
-    }
-)
 
 
 # ─── Tagger ───────────────────────────────────────────────────────────────────

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -224,42 +224,16 @@ class MCPServer:
     @property
     def has_credentials(self) -> bool:
         """Check if env vars suggest credentials are present."""
-        sensitive_patterns = [
-            "key",
-            "token",
-            "secret",
-            "password",
-            "credential",
-            "api_key",
-            "apikey",
-            "auth",
-            "private",
-            "connection",
-            "conn_str",
-            "database_url",
-            "db_url",
-        ]
-        return any(any(pat in k.lower() for pat in sensitive_patterns) for k in self.env)
+        from agent_bom.constants import SENSITIVE_PATTERNS
+
+        return any(any(pat in k.lower() for pat in SENSITIVE_PATTERNS) for k in self.env)
 
     @property
     def credential_names(self) -> list[str]:
         """Return names of env vars that look like credentials."""
-        sensitive_patterns = [
-            "key",
-            "token",
-            "secret",
-            "password",
-            "credential",
-            "api_key",
-            "apikey",
-            "auth",
-            "private",
-            "connection",
-            "conn_str",
-            "database_url",
-            "db_url",
-        ]
-        return [k for k in self.env if any(pat in k.lower() for pat in sensitive_patterns)]
+        from agent_bom.constants import SENSITIVE_PATTERNS
+
+        return [k for k in self.env if any(pat in k.lower() for pat in SENSITIVE_PATTERNS)]
 
 
 @dataclass

--- a/src/agent_bom/nist_ai_rmf.py
+++ b/src/agent_bom/nist_ai_rmf.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from agent_bom.models import Severity
+from agent_bom.constants import AI_PACKAGES as _AI_PACKAGES
+from agent_bom.constants import high_risk_severities
 from agent_bom.risk_analyzer import ToolCapability, classify_tool
 
 if TYPE_CHECKING:
@@ -42,31 +43,7 @@ NIST_AI_RMF: dict[str, str] = {
     "MANAGE-4.1": "Post-deployment monitoring plans implemented",
 }
 
-# AI/ML framework packages — vulnerabilities here map to security testing subcategories
-_AI_PACKAGES: frozenset[str] = frozenset({
-    "torch", "torchvision", "torchaudio",
-    "transformers", "diffusers", "tokenizers",
-    "langchain", "langchain-core", "langchain-community",
-    "langchain-openai", "langchain-anthropic",
-    "openai", "anthropic", "google-generativeai",
-    "crewai", "autogen", "pyautogen",
-    "haystack", "haystack-ai",
-    "llama-index", "llama-cpp-python",
-    "dspy-ai", "guidance",
-    "semantic-kernel",
-    "pydantic-ai",
-    # Vector stores / RAG backends
-    "chromadb", "pinecone-client", "weaviate-client", "qdrant-client",
-    "faiss-cpu", "faiss-gpu", "pymilvus", "milvus",
-    "pgvector", "lancedb",
-    "sentence-transformers",
-})
-
-# Severity levels considered high-risk
-_HIGH_RISK: frozenset[Severity] = frozenset({
-    Severity.CRITICAL,
-    Severity.HIGH,
-})
+_HIGH_RISK = high_risk_severities()
 
 
 # ─── Tagger ───────────────────────────────────────────────────────────────────
@@ -91,7 +68,7 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     """
     tags: set[str] = {
         "GOVERN-1.7",  # always — third-party AI component risk
-        "MAP-3.5",     # always — supply chain risk assessed
+        "MAP-3.5",  # always — supply chain risk assessed
     }
 
     has_exec = False

--- a/src/agent_bom/owasp.py
+++ b/src/agent_bom/owasp.py
@@ -12,7 +12,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from agent_bom.models import Severity
+from agent_bom.constants import (
+    AI_PACKAGES as _AI_PACKAGES,
+)
+from agent_bom.constants import (
+    TRAINING_DATA_PACKAGES as _TRAINING_DATA_PACKAGES,
+)
+from agent_bom.constants import (
+    high_risk_severities,
+)
 from agent_bom.risk_analyzer import ToolCapability, classify_tool
 
 if TYPE_CHECKING:
@@ -34,80 +42,7 @@ OWASP_LLM_TOP10: dict[str, str] = {
     "LLM10": "Unbounded Consumption",
 }
 
-# Package names associated with AI/ML frameworks
-_AI_PACKAGES: frozenset[str] = frozenset(
-    {
-        "torch",
-        "torchvision",
-        "torchaudio",
-        "transformers",
-        "diffusers",
-        "tokenizers",
-        "langchain",
-        "langchain-core",
-        "langchain-community",
-        "langchain-openai",
-        "langchain-anthropic",
-        "openai",
-        "anthropic",
-        "google-generativeai",
-        "crewai",
-        "autogen",
-        "pyautogen",
-        "haystack",
-        "haystack-ai",
-        "llama-index",
-        "llama-cpp-python",
-        "dspy-ai",
-        "guidance",
-        "semantic-kernel",
-        "pydantic-ai",
-        # Vector stores / RAG backends
-        "chromadb",
-        "pinecone-client",
-        "weaviate-client",
-        "qdrant-client",
-        "faiss-cpu",
-        "faiss-gpu",
-        "pymilvus",
-        "milvus",
-        "pgvector",
-        "lancedb",
-        # Embedding models
-        "sentence-transformers",
-    }
-)
-
-# Packages directly involved in training data handling and fine-tuning.
-# CVEs here risk training data poisoning (LLM03).
-_TRAINING_DATA_PACKAGES: frozenset[str] = frozenset(
-    {
-        "datasets",
-        "huggingface-hub",
-        "tokenizers",
-        "transformers",
-        "diffusers",
-        "accelerate",
-        "trl",
-        "sentence-transformers",
-        "peft",
-        "torch",
-        "torchvision",
-        "torchaudio",
-        "tensorflow",
-        "tensorflow-gpu",
-        "safetensors",
-        "optimum",
-    }
-)
-
-# Severity levels considered high-risk for agency/AI-poisoning checks
-_HIGH_RISK_SEVERITIES: frozenset[Severity] = frozenset(
-    {
-        Severity.CRITICAL,
-        Severity.HIGH,
-    }
-)
+_HIGH_RISK_SEVERITIES = high_risk_severities()
 
 
 # ─── Tagger ───────────────────────────────────────────────────────────────────

--- a/src/agent_bom/owasp_agentic.py
+++ b/src/agent_bom/owasp_agentic.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from agent_bom.models import Severity
+from agent_bom.constants import AI_PACKAGES as _AI_PACKAGES
+from agent_bom.constants import high_risk_severities
 from agent_bom.risk_analyzer import ToolCapability, classify_tool
 
 if TYPE_CHECKING:
@@ -34,49 +35,7 @@ OWASP_AGENTIC_TOP10: dict[str, str] = {
     "ASI10": "Rogue Agent Persistence",
 }
 
-# AI/ML framework packages (reused from owasp.py for consistency)
-_AI_PACKAGES: frozenset[str] = frozenset(
-    {
-        "torch",
-        "torchvision",
-        "torchaudio",
-        "transformers",
-        "diffusers",
-        "tokenizers",
-        "langchain",
-        "langchain-core",
-        "langchain-community",
-        "langchain-openai",
-        "langchain-anthropic",
-        "openai",
-        "anthropic",
-        "google-generativeai",
-        "crewai",
-        "autogen",
-        "pyautogen",
-        "haystack",
-        "haystack-ai",
-        "llama-index",
-        "llama-cpp-python",
-        "dspy-ai",
-        "guidance",
-        "semantic-kernel",
-        "pydantic-ai",
-        "chromadb",
-        "pinecone-client",
-        "weaviate-client",
-        "qdrant-client",
-        "faiss-cpu",
-        "faiss-gpu",
-        "pymilvus",
-        "milvus",
-        "pgvector",
-        "lancedb",
-        "sentence-transformers",
-    }
-)
-
-_HIGH_RISK: frozenset[Severity] = frozenset({Severity.CRITICAL, Severity.HIGH})
+_HIGH_RISK = high_risk_severities()
 
 
 # ─── Tagger ───────────────────────────────────────────────────────────────────

--- a/src/agent_bom/owasp_mcp.py
+++ b/src/agent_bom/owasp_mcp.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from agent_bom.models import Severity
+from agent_bom.constants import high_risk_severities
 from agent_bom.risk_analyzer import ToolCapability, classify_tool
 
 if TYPE_CHECKING:
@@ -34,11 +34,7 @@ OWASP_MCP_TOP10: dict[str, str] = {
     "MCP10": "Context Injection & Over-Sharing",
 }
 
-# Severity levels considered high-risk for privilege/poisoning checks
-_HIGH_RISK_SEVERITIES: frozenset[Severity] = frozenset({
-    Severity.CRITICAL,
-    Severity.HIGH,
-})
+_HIGH_RISK_SEVERITIES = high_risk_severities()
 
 
 # ─── Tagger ───────────────────────────────────────────────────────────────────
@@ -74,16 +70,11 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
         tags.add("MCP02")
 
     # Many tools + high severity = scope creep even without explicit elevation
-    if (
-        len(br.exposed_tools) > 5
-        and br.vulnerability.severity in _HIGH_RISK_SEVERITIES
-    ):
+    if len(br.exposed_tools) > 5 and br.vulnerability.severity in _HIGH_RISK_SEVERITIES:
         tags.add("MCP02")
 
     # MCP03 — tool poisoning: unverified server with high-severity CVE
-    has_unverified = any(
-        not s.registry_verified for s in br.affected_servers
-    )
+    has_unverified = any(not s.registry_verified for s in br.affected_servers)
     if has_unverified and br.vulnerability.severity in _HIGH_RISK_SEVERITIES:
         tags.add("MCP03")
 
@@ -110,10 +101,8 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
 
     # MCP07 — insufficient auth: unverified server with stdio (no auth layer)
     from agent_bom.models import TransportType
-    has_no_auth = any(
-        not s.registry_verified and s.transport == TransportType.STDIO
-        for s in br.affected_servers
-    )
+
+    has_no_auth = any(not s.registry_verified and s.transport == TransportType.STDIO for s in br.affected_servers)
     if has_no_auth:
         tags.add("MCP07")
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,144 @@
+"""Tests for shared constants — single source of truth validation."""
+
+from __future__ import annotations
+
+from agent_bom.constants import (
+    AI_PACKAGES,
+    SENSITIVE_PATTERNS,
+    TRAINING_DATA_PACKAGES,
+    high_risk_severities,
+    is_credential_key,
+)
+
+# ---------------------------------------------------------------------------
+# AI_PACKAGES
+# ---------------------------------------------------------------------------
+
+
+class TestAIPackages:
+    def test_contains_llm_orchestration(self):
+        for pkg in ["langchain", "langchain-core", "llama-index", "crewai", "autogen"]:
+            assert pkg in AI_PACKAGES
+
+    def test_contains_llm_clients(self):
+        for pkg in ["openai", "anthropic", "google-generativeai"]:
+            assert pkg in AI_PACKAGES
+
+    def test_contains_model_inference(self):
+        for pkg in ["torch", "transformers", "diffusers", "tokenizers"]:
+            assert pkg in AI_PACKAGES
+
+    def test_contains_rag_backends(self):
+        for pkg in ["chromadb", "pinecone-client", "pymilvus", "qdrant-client", "pgvector", "lancedb"]:
+            assert pkg in AI_PACKAGES
+
+    def test_contains_embeddings(self):
+        assert "sentence-transformers" in AI_PACKAGES
+
+    def test_is_frozenset(self):
+        assert isinstance(AI_PACKAGES, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# TRAINING_DATA_PACKAGES
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingDataPackages:
+    def test_contains_core_training_packages(self):
+        for pkg in ["datasets", "huggingface-hub", "accelerate", "trl", "peft"]:
+            assert pkg in TRAINING_DATA_PACKAGES
+
+    def test_overlaps_with_ai_packages(self):
+        overlap = AI_PACKAGES & TRAINING_DATA_PACKAGES
+        assert "transformers" in overlap
+        assert "torch" in overlap
+
+    def test_is_frozenset(self):
+        assert isinstance(TRAINING_DATA_PACKAGES, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# high_risk_severities
+# ---------------------------------------------------------------------------
+
+
+class TestHighRiskSeverities:
+    def test_returns_frozenset(self):
+        result = high_risk_severities()
+        assert isinstance(result, frozenset)
+
+    def test_contains_critical_and_high(self):
+        from agent_bom.models import Severity
+
+        result = high_risk_severities()
+        assert Severity.CRITICAL in result
+        assert Severity.HIGH in result
+
+    def test_excludes_medium_low_none(self):
+        from agent_bom.models import Severity
+
+        result = high_risk_severities()
+        assert Severity.MEDIUM not in result
+        assert Severity.LOW not in result
+        assert Severity.NONE not in result
+
+
+# ---------------------------------------------------------------------------
+# SENSITIVE_PATTERNS / is_credential_key
+# ---------------------------------------------------------------------------
+
+
+class TestSensitivePatterns:
+    def test_contains_common_patterns(self):
+        for pat in ["key", "token", "secret", "password", "credential"]:
+            assert pat in SENSITIVE_PATTERNS
+
+    def test_contains_database_patterns(self):
+        for pat in ["database_url", "db_url", "conn_str"]:
+            assert pat in SENSITIVE_PATTERNS
+
+    def test_is_credential_key_matches(self):
+        assert is_credential_key("ANTHROPIC_API_KEY")
+        assert is_credential_key("DB_PASSWORD")
+        assert is_credential_key("GITHUB_TOKEN")
+        assert is_credential_key("database_url")
+        assert is_credential_key("OPENAI_SECRET")
+
+    def test_is_credential_key_rejects(self):
+        assert not is_credential_key("LOG_LEVEL")
+        assert not is_credential_key("DEBUG")
+        assert not is_credential_key("PORT")
+        assert not is_credential_key("HOSTNAME")
+
+
+# ---------------------------------------------------------------------------
+# Cross-module consistency — all compliance modules use the same constants
+# ---------------------------------------------------------------------------
+
+
+class TestCrossModuleConsistency:
+    def test_owasp_uses_shared_ai_packages(self):
+        from agent_bom.owasp import _AI_PACKAGES
+
+        assert _AI_PACKAGES is AI_PACKAGES
+
+    def test_atlas_uses_shared_ai_packages(self):
+        from agent_bom.atlas import _AI_PACKAGES
+
+        assert _AI_PACKAGES is AI_PACKAGES
+
+    def test_nist_uses_shared_ai_packages(self):
+        from agent_bom.nist_ai_rmf import _AI_PACKAGES
+
+        assert _AI_PACKAGES is AI_PACKAGES
+
+    def test_eu_ai_act_uses_shared_ai_packages(self):
+        from agent_bom.eu_ai_act import _AI_PACKAGES
+
+        assert _AI_PACKAGES is AI_PACKAGES
+
+    def test_owasp_agentic_uses_shared_ai_packages(self):
+        from agent_bom.owasp_agentic import _AI_PACKAGES
+
+        assert _AI_PACKAGES is AI_PACKAGES

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3435,39 +3435,39 @@ def test_rag_vector_stores_in_ai_packages():
 
 
 def test_owasp_rag_packages_covered():
-    """Vector store / RAG packages are in OWASP _AI_PACKAGES for LLM04 tagging."""
-    from agent_bom.owasp import _AI_PACKAGES
+    """Vector store / RAG packages are in shared AI_PACKAGES for LLM04 tagging."""
+    from agent_bom.constants import AI_PACKAGES
 
     rag_packages = {"chromadb", "pymilvus", "qdrant-client", "sentence-transformers"}
     for pkg in rag_packages:
-        assert pkg in _AI_PACKAGES, f"{pkg} missing from OWASP _AI_PACKAGES"
+        assert pkg in AI_PACKAGES, f"{pkg} missing from AI_PACKAGES"
 
 
 def test_atlas_rag_packages_covered():
-    """Vector store / RAG packages are in ATLAS _AI_PACKAGES."""
-    from agent_bom.atlas import _AI_PACKAGES
+    """Vector store / RAG packages are in shared AI_PACKAGES."""
+    from agent_bom.constants import AI_PACKAGES
 
     rag_packages = {"chromadb", "pymilvus", "qdrant-client", "lancedb"}
     for pkg in rag_packages:
-        assert pkg in _AI_PACKAGES, f"{pkg} missing from ATLAS _AI_PACKAGES"
+        assert pkg in AI_PACKAGES, f"{pkg} missing from AI_PACKAGES"
 
 
 def test_nist_rag_packages_covered():
-    """Vector store / RAG packages are in NIST AI RMF _AI_PACKAGES."""
-    from agent_bom.nist_ai_rmf import _AI_PACKAGES
+    """Vector store / RAG packages are in shared AI_PACKAGES."""
+    from agent_bom.constants import AI_PACKAGES
 
     rag_packages = {"chromadb", "pymilvus", "pgvector"}
     for pkg in rag_packages:
-        assert pkg in _AI_PACKAGES, f"{pkg} missing from NIST _AI_PACKAGES"
+        assert pkg in AI_PACKAGES, f"{pkg} missing from AI_PACKAGES"
 
 
 def test_owasp_training_data_packages_set():
-    """_TRAINING_DATA_PACKAGES contains expected training/fine-tuning packages."""
-    from agent_bom.owasp import _TRAINING_DATA_PACKAGES
+    """TRAINING_DATA_PACKAGES contains expected training/fine-tuning packages."""
+    from agent_bom.constants import TRAINING_DATA_PACKAGES
 
     expected = {"datasets", "transformers", "torch", "accelerate", "trl", "sentence-transformers", "peft", "safetensors"}
     for pkg in expected:
-        assert pkg in _TRAINING_DATA_PACKAGES, f"{pkg} missing from _TRAINING_DATA_PACKAGES"
+        assert pkg in TRAINING_DATA_PACKAGES, f"{pkg} missing from TRAINING_DATA_PACKAGES"
 
 
 # ─── License in SBOM output ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extracts `AI_PACKAGES` (duplicated 5x across compliance modules), `high_risk_severities` (5x), and `SENSITIVE_PATTERNS` (3x across models.py + context_graph.py) into a single `src/agent_bom/constants.py`
- All 6 compliance taggers + models.py + context_graph.py now import from one source of truth
- Eliminates ~300 lines of duplicated definitions and prevents future drift
- Adds 21 new tests in `tests/test_constants.py` validating the shared constants and cross-module consistency

## Test plan
- [x] All 2574 tests pass (`pytest tests/ -x -q`)
- [x] `ruff check src/ tests/` clean
- [x] Cross-module identity tests verify all compliance modules share the exact same `AI_PACKAGES` frozenset