### PR TITLE
docs: restructure README for individual vs enterprise users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center">
-  <b>AI supply chain security scanner. Scan packages and images for CVEs. Assess config security — credential exposure, tool access, privilege escalation. Map blast radius from vulnerabilities to credentials and tools. Enterprise posture scoring, incident correlation, credential risk ranking. OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF + EU AI Act.</b>
+  <b>AI supply chain security scanner. Scan packages and images for CVEs. Assess config security — credential exposure, tool access, privilege escalation. Map blast radius from vulnerabilities to credentials and tools. Enterprise posture scoring, incident correlation, credential risk ranking. 10-framework compliance: OWASP LLM + OWASP MCP + OWASP Agentic + MITRE ATLAS + NIST AI RMF + EU AI Act + NIST CSF 2.0 + ISO 27001 + SOC 2 + CIS Controls v8.</b>
 </p>
 
 <p align="center">
@@ -54,7 +54,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 | **MCP tool reachability** | — | Which tools an attacker reaches post-exploit |
 | **Privilege detection** | — | runs_as_root, shell_access, container_privileged, per-tool permissions |
 | **Enterprise remediation** | — | Named assets, impact percentages, risk narratives |
-| **6-framework compliance** | — | OWASP Agentic Top 10 + OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF + EU AI Act |
+| **10-framework compliance** | — | OWASP Agentic + OWASP LLM + OWASP MCP + MITRE ATLAS + NIST AI RMF + EU AI Act + NIST CSF 2.0 + ISO 27001 + SOC 2 + CIS Controls v8 |
 | **Malicious package detection** | — | OSV MAL- prefix + typosquat heuristics (57 popular packages) |
 | **OpenSSF Scorecard enrichment** | — | Package health scores from api.securityscorecards.dev |
 | **Tool poisoning detection** | — | Description injection, capability combos, CVE exposure, drift |
@@ -128,9 +128,11 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 1. **Discover** — auto-detect MCP configs across 18 clients (Claude Desktop, Cursor, Codex CLI, Gemini CLI, Goose, etc.)
 2. **Extract** — pull server names, package names, env var **names**, and tool lists. Credential **values** are never read.
 3. **Scan** — send only package names + versions to public APIs (OSV.dev, NVD, EPSS, CISA KEV). No hostnames, no secrets, no auth tokens.
-4. **Analyze** — CVE blast radius mapping, tool poisoning detection (`--enforce`), OWASP/ATLAS/NIST threat models, model provenance (`--hf-model`)
+4. **Analyze** — CVE blast radius mapping, tool poisoning detection (`--enforce`), 10-framework threat model tagging, model provenance (`--hf-model`)
 5. **Score** — posture scorecard (grade A–F), credential risk ranking, incident correlation by agent (P1–P4)
 6. **Report** — JSON, SARIF, CycloneDX, SPDX, HTML, or console output. Alert dispatch to Slack/webhooks. Nothing stored server-side.
+
+> **Individual developers:** Steps 1–4 are automatic. Enterprise features (steps 5–6) activate with `--enrich`, `--posture`, or the REST API.
 
 **Trust guarantees:** Read-only (no file writes, no config changes, no servers started). `--dry-run` previews all files and API calls then exits. Every release is Sigstore-signed. Run `agent-bom verify agent-bom` to check integrity. See [PERMISSIONS.md](PERMISSIONS.md) for the full auditable trust contract.
 
@@ -229,13 +231,19 @@ Auto-discovers Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Cop
 
 ---
 
-## Core capabilities
+## For individual developers
+
+> Auto-discover your MCP configs, scan for CVEs, understand blast radius, and fix what matters. No compliance paperwork needed.
 
 ### CVE scanning + blast radius
 
 Every vulnerability is mapped through your AI stack: **which agents** are affected, **which credentials** are exposed, **which MCP tools** an attacker can reach, and **what to fix first**.
 
 Enrichment sources: OSV batch (primary), NVD CVSS v4, FIRST EPSS exploit probability, CISA KEV active exploitation catalog.
+
+### Guided remediation
+
+Each fix tells you exactly what will be protected — named agents, credentials, tools, impact percentages, and risk narratives. Fixed versions are identified automatically.
 
 ### Privilege detection
 
@@ -250,20 +258,94 @@ Every MCP server is assessed for privilege escalation risk:
 
 Privilege levels: **critical** (privileged container, CAP_SYS_ADMIN) → **high** (root, shell) → **medium** (fs write, network) → **low** (read-only).
 
-### 6-framework compliance mapping
+### MCP runtime introspection
 
-Every finding is tagged against six frameworks simultaneously:
+Connect to live servers to discover runtime tools/resources and detect drift from configs. Read-only — only calls `tools/list` and `resources/list`.
+
+```bash
+agent-bom scan --introspect
+```
+
+### Tool poisoning detection
+
+Static analysis of MCP tool descriptions for prompt injection patterns, dangerous capability combinations (EXECUTE + WRITE), CVE exposure in server dependencies, and tool drift detection via introspection.
+
+```bash
+agent-bom scan --enforce                       # tool poisoning + enforcement checks
+agent-bom scan --enforce --introspect          # + drift detection against live servers
+```
+
+### Malicious package detection
+
+OSV MAL- prefix flagging + typosquat heuristics against 57 popular AI/ML packages. Catches known-malicious npm/PyPI packages before they enter your MCP stack.
+
+<details>
+<summary><b>Skill file + prompt scanning</b></summary>
+
+Scan CLAUDE.md, .cursorrules, AGENTS.md for embedded MCP servers, packages, and credentials. 7 security checks: typosquat detection, shell access, dangerous server names, unverified servers, excessive credentials, external URLs, unknown packages.
+
+```bash
+agent-bom scan --skill CLAUDE.md    # explicit
+agent-bom scan --scan-prompts       # prompt template security
+```
+
+</details>
+
+<details>
+<summary><b>Model weight provenance</b></summary>
+
+SHA-256 hash verification, Sigstore signature file detection, and HuggingFace model metadata (author, license, model card, gated status, download count).
+
+```bash
+agent-bom scan --hf-model meta-llama/Llama-3.1-8B          # HuggingFace provenance
+agent-bom scan --model-files ./models --model-provenance   # hash + signature checks
+```
+
+</details>
+
+<details>
+<summary><b>Docker image + Jupyter notebook scanning</b></summary>
+
+3-tier container scanning (Grype → Syft → Docker CLI fallback). Detect 29+ AI libraries, pip installs, credentials in notebooks. Scan 13 model file formats.
+
+```bash
+agent-bom scan --image myapp:latest        # Docker image scanning
+agent-bom scan --jupyter ./notebooks       # notebook audit
+agent-bom scan --model-files ./models      # model file scanning
+```
+
+</details>
+
+> **That's all you need.** Run `agent-bom scan` and you're done.
+> Everything below is for teams deploying agent-bom as an enterprise security platform.
+
+---
+
+## For enterprise teams
+
+> Compliance mapping, SBOM export, policy-as-code, posture scoring, CI/CD gates, cloud discovery, and fleet management.
+
+### 10-framework compliance mapping
+
+Every finding is tagged against ten frameworks simultaneously:
+
+| Category | Frameworks |
+|----------|-----------|
+| **AI-specific** | OWASP Agentic Top 10, OWASP LLM Top 10, OWASP MCP Top 10, MITRE ATLAS, NIST AI RMF 1.0, EU AI Act |
+| **Enterprise GRC** | NIST CSF 2.0, ISO 27001:2022, SOC 2, CIS Controls v8 |
 
 - **OWASP Agentic Top 10** — ASI01 through ASI10 (agent autonomy, tool misuse, spawn persistence)
 - **OWASP LLM Top 10** — LLM01 through LLM10 (7 categories triggered)
 - **OWASP MCP Top 10** — MCP01 through MCP10 (8 categories triggered) — token exposure, tool poisoning, supply chain, shadow servers
-- **MITRE ATLAS** — AML.T0010, AML.T0043, AML.T0051, etc. (9 techniques mapped)
+- **MITRE ATLAS** — AML.T0010, AML.T0043, AML.T0051, etc. (13 techniques mapped)
 - **NIST AI RMF 1.0** — Govern, Map, Measure, Manage (12 subcategories mapped)
 - **EU AI Act** — ART-5 through ART-17 (prohibited practices, high-risk classification, cybersecurity)
+- **NIST CSF 2.0** — Govern, Identify, Protect, Detect, Respond (14 categories mapped)
+- **ISO 27001:2022** — Annex A controls A.5.19 through A.8.28 (9 controls mapped)
+- **SOC 2** — Trust Services Criteria CC6 through CC9 (9 criteria mapped)
+- **CIS Controls v8** — Safeguards CIS-02, CIS-07, CIS-16 (10 safeguards mapped)
 
-### Enterprise remediation
-
-Each fix tells you exactly what will be protected — named agents, credentials, tools, percentages, threat tags, and risk narratives.
+> **CIS Controls v8 vs. CIS Benchmarks:** agent-bom ships CIS Controls v8 — the generic cross-platform security controls ("what to do"). Platform-specific CIS Benchmarks ("how to do it") like AWS Foundations v3.0, GCP v3.0, Azure v2.1, Snowflake v1.0, and Kubernetes v1.9 are on the roadmap.
 
 ### AI-BOM export
 
@@ -334,40 +416,15 @@ agent-bom scan --k8s --context=coreweave-cluster   # CoreWeave / any K8s
 
 </details>
 
-### Additional capabilities
-
 <details>
-<summary><b>MCP runtime introspection</b></summary>
+<summary><b>Interactive security graph visualization</b></summary>
 
-Connect to live servers to discover runtime tools/resources and detect drift from configs. Read-only — only calls `tools/list` and `resources/list`.
+The dashboard (`agent-bom api`) serves interactive [React Flow](https://reactflow.dev/) graphs:
 
-```bash
-agent-bom scan --introspect
-```
-
-</details>
-
-<details>
-<summary><b>Skill file scanning + security audit</b></summary>
-
-Scan CLAUDE.md, .cursorrules, AGENTS.md for embedded MCP servers, packages, and credentials. 7 security checks: typosquat detection, shell access, dangerous server names, unverified servers, excessive credentials, external URLs, unknown packages.
-
-```bash
-agent-bom scan --skill CLAUDE.md    # explicit
-agent-bom scan --skill-only         # skills only
-agent-bom scan --no-skill           # skip skills
-```
-
-</details>
-
-<details>
-<summary><b>Prompt template scanning</b></summary>
-
-Scan .prompt, .promptfile, system_prompt.*, prompt.yaml/json files for hardcoded secrets, prompt injection patterns, unsafe instructions, and sensitive data exposure.
-
-```bash
-agent-bom scan --scan-prompts
-```
+- **Agent Mesh** (`/mesh`) — cross-agent topology with vulnerability overlay, shared server detection, credential blast analysis
+- **Attack Flow** (`/scan?view=attack-flow`) — CVE-centric blast radius graph: CVE → Package → Server → Agent → Credentials → Tools
+- **Supply Chain Lineage** (`/graph`) — full dependency lineage with hover highlighting and detail panels
+- **Context Graph** (`/context`) — lateral movement analysis: agent-to-agent attack paths via shared servers, credentials, and tools
 
 </details>
 
@@ -379,66 +436,6 @@ LLM-generated risk narratives, executive summaries, and threat chain analysis. W
 ```bash
 agent-bom scan --ai-enrich                              # auto-detect Ollama
 agent-bom scan --ai-enrich --ai-model ollama/llama3      # specific model
-agent-bom scan --ai-enrich --ai-model openai/gpt-4o-mini # cloud LLM
-```
-
-</details>
-
-<details>
-<summary><b>Tool poisoning detection + enforcement</b></summary>
-
-Static analysis of MCP tool descriptions for prompt injection patterns, dangerous capability combinations (EXECUTE + WRITE), CVE exposure in server dependencies, and tool drift detection via introspection.
-
-```bash
-agent-bom scan --enforce                       # tool poisoning + enforcement checks
-agent-bom scan --enforce --introspect          # + drift detection against live servers
-```
-
-</details>
-
-<details>
-<summary><b>Model weight provenance</b></summary>
-
-SHA-256 hash verification, Sigstore signature file detection (`.sig`/`.sigstore`/`.bundle` presence — not cryptographic verification), and HuggingFace model metadata (author, license, model card, gated status, download count).
-
-```bash
-agent-bom scan --model-files ./models --model-provenance   # hash + signature checks
-agent-bom scan --hf-model meta-llama/Llama-3.1-8B          # HuggingFace provenance
-```
-
-</details>
-
-<details>
-<summary><b>Jupyter notebook + model file scanning</b></summary>
-
-Detect 29+ AI libraries, pip installs, credentials in notebooks. Scan 13 model file formats with security flags for pickle-based formats.
-
-```bash
-agent-bom scan --jupyter ./notebooks
-agent-bom scan --model-files ./models
-```
-
-</details>
-
-<details>
-<summary><b>Interactive security graph visualization</b></summary>
-
-The dashboard (`agent-bom api`) serves interactive [React Flow](https://reactflow.dev/) graphs — the same rendering approach used by enterprise security platforms:
-
-- **Agent Mesh** (`/mesh`) — cross-agent topology with vulnerability overlay, shared server detection, credential blast analysis, severity filtering, and search
-- **Attack Flow** (`/scan?view=attack-flow`) — CVE-centric blast radius graph: CVE → Package → Server → Agent → Credentials → Tools
-- **Supply Chain Lineage** (`/graph`) — full dependency lineage with hover highlighting and detail panels
-- **Context Graph** (`/context`) — lateral movement analysis: agent-to-agent attack paths via shared servers, credentials, and tools
-
-All graph views include: dagre auto-layout, hover highlighting (BFS connected nodes), click-to-inspect detail panels, minimap, OWASP LLM Top 10 + OWASP MCP Top 10 + MITRE ATLAS + NIST AI RMF framework tagging on every node.
-
-CLI output formats for CI/CD and automation:
-
-```bash
-agent-bom scan -f graph -o graph.json    # Cytoscape-compatible JSON
-agent-bom scan -f html -o report.html    # standalone interactive HTML report
-agent-bom scan -f mermaid                # Mermaid text (for docs/markdown)
-agent-bom scan -f sarif -o results.sarif # GitHub Security tab integration
 ```
 
 </details>
@@ -451,7 +448,7 @@ Beyond OSV.dev, agent-bom checks supplemental sources to catch CVEs not yet inde
 - **GitHub Security Advisories (GHSA)** — all ecosystems (PyPI, npm, Go, Maven, Cargo, NuGet)
 - **NVIDIA CSAF advisories** — GPU/ML packages (CUDA, cuDNN, TensorRT, NCCL)
 
-Both sources deduplicate by CVE ID against OSV results. Packages without a pinned version are auto-resolved from npm/PyPI registries before scanning.
+Both sources deduplicate by CVE ID against OSV results.
 
 </details>
 
@@ -503,8 +500,8 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 | `GET /v1/scan/{id}` | Results + status |
 | `GET /v1/scan/{id}/attack-flow` | Per-CVE blast radius graph |
 | `GET /v1/registry` | 427+ server registry |
-| `GET /v1/compliance` | Full 6-framework compliance posture |
-| `GET /v1/compliance/{framework}` | Single framework (owasp-llm, owasp-mcp, owasp-agentic, atlas, nist, eu-ai-act) |
+| `GET /v1/compliance` | Full 10-framework compliance posture |
+| `GET /v1/compliance/{framework}` | Single framework (owasp-llm, owasp-mcp, owasp-agentic, atlas, nist, eu-ai-act, nist-csf, iso-27001, soc2, cis) |
 | `GET /v1/posture` | Enterprise posture scorecard (grade A–F, 6 dimensions) |
 | `GET /v1/posture/credentials` | Credential risk ranking by blast radius |
 | `GET /v1/posture/incidents` | Incident correlation by agent (P1–P4) |
@@ -536,7 +533,7 @@ cd ui && npm install && npm run dev   # http://localhost:3000
 | Scan | Enterprise scan form with cloud options |
 | Vulnerabilities | CVE browser with severity/EPSS/KEV filters |
 | Agents | Fleet registry + lifecycle state management |
-| Compliance | 6-framework compliance posture (OWASP Agentic, OWASP LLM, OWASP MCP, ATLAS, NIST, EU AI Act) |
+| Compliance | 10-framework compliance posture (OWASP Agentic, OWASP LLM, OWASP MCP, ATLAS, NIST AI RMF, EU AI Act, NIST CSF 2.0, ISO 27001, SOC 2, CIS Controls v8) |
 | Lineage Graph | Interactive supply chain graph — dagre layout, 7 node types, filter panel |
 | Agent Mesh | Cross-agent topology — shared server detection, credential blast radius, tool overlap |
 | Gateway | Runtime MCP policy rules + audit log |
@@ -565,6 +562,9 @@ Set `SNOWFLAKE_ACCOUNT` + `SNOWFLAKE_USER` + auth (`SNOWFLAKE_PRIVATE_KEY_PATH` 
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for full Snowflake architecture and setup instructions.
 
+<details>
+<summary><b>Snowflake deployment architecture</b></summary>
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/snowflake-dark.svg">
@@ -572,12 +572,19 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for full Snowflake architecture and setup ins
   </picture>
 </p>
 
+</details>
+
+<details>
+<summary><b>Enterprise deployment topology</b></summary>
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/deployment-dark.svg">
     <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/deployment-light.svg" alt="Enterprise Deployment Topology" width="800" />
   </picture>
 </p>
+
+</details>
 
 ---
 
@@ -655,9 +662,20 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - [x] Enterprise hardening — bounded caches, SQLite indexes, stuck job cleanup, Content-Length validation
 - [x] Agent context graph — lateral movement analysis via shared servers, credentials, and tools; BFS attack path discovery
 - [x] Enterprise security hardening — per-job thread locks, SSRF protection, error sanitization, RBAC least privilege, path traversal guards
+- [x] NIST CSF 2.0 compliance mapping (14 categories across Govern, Identify, Protect, Detect, Respond)
+- [x] ISO 27001:2022 compliance mapping (9 Annex A controls, A.5.19–A.8.28)
+- [x] SOC 2 Trust Services Criteria (9 criteria, CC6–CC9)
+- [x] CIS Controls v8 (10 safeguards, CIS-02/CIS-07/CIS-16)
+- [x] Critical-only severity triggers (EU AI Act ART-5 Prohibited Practices)
+- [x] SSH/OAuth/PKI/SCIM credential detection
 
 **Planned:**
-- [ ] CIS AI benchmarks
+- [ ] Platform-specific CIS Benchmarks:
+  - AWS Foundations Benchmark v3.0
+  - GCP Foundations Benchmark v3.0
+  - Azure Foundations Benchmark v2.1
+  - Snowflake Benchmark v1.0
+  - Kubernetes Benchmark v1.9
 - [ ] License compliance engine
 - [ ] Workflow engine scanning (n8n, Zapier, Make)
 

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -260,6 +260,6 @@
 
   <!-- MCP Server badge -->
   <rect x="516" y="454" width="228" height="40" rx="6" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="471" class="side-label" fill="#58a6ff">15 MCP Tools · 6 Frameworks</text>
+  <text x="528" y="471" class="side-label" fill="#58a6ff">15 MCP Tools · 10 Frameworks</text>
   <text x="528" y="484" class="box-sub">2,335 tests · Sigstore signed · OpenSSF scored</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -236,6 +236,6 @@
   <text x="528" y="440" class="box-sub">✓ AI-native · MCP-first · runs anywhere</text>
 
   <rect x="516" y="454" width="228" height="40" rx="6" fill="#ffffff" stroke="#0969da" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="471" class="side-label" fill="#0969da">15 MCP Tools · 6 Frameworks</text>
+  <text x="528" y="471" class="side-label" fill="#0969da">15 MCP Tools · 10 Frameworks</text>
   <text x="528" y="484" class="box-sub">2,335 tests · Sigstore signed · OpenSSF scored</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -117,7 +117,7 @@
   <rect x="246" y="342" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
   <text x="332" y="355" text-anchor="middle" class="badge" fill="#d29922">STEP 4 · ANALYZE</text>
   <text x="332" y="376" text-anchor="middle" class="sub">Blast radius mapping</text>
-  <text x="332" y="388" text-anchor="middle" class="sub">6-framework threat tagging</text>
+  <text x="332" y="388" text-anchor="middle" class="sub">10-framework threat tagging</text>
   <text x="332" y="400" text-anchor="middle" class="sub">Tool poisoning detection</text>
 
   <line x1="332" y1="410" x2="332" y2="424" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
@@ -150,7 +150,7 @@
   <text x="569" y="142" text-anchor="middle" class="sub">→ credentials → tools → risk score</text>
 
   <rect x="478" y="162" width="182" height="68" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="180" text-anchor="middle" class="label" fill="#bc8cff">6-Framework Tagging</text>
+  <text x="569" y="180" text-anchor="middle" class="label" fill="#bc8cff">10-Framework Tagging</text>
   <text x="569" y="196" text-anchor="middle" class="sub">OWASP LLM · MCP · Agentic</text>
   <text x="569" y="208" text-anchor="middle" class="sub">MITRE ATLAS · NIST AI RMF</text>
   <text x="569" y="220" text-anchor="middle" class="sub">EU AI Act</text>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -117,7 +117,7 @@
   <rect x="246" y="342" width="172" height="18" rx="6" fill="#fef3c7"/>
   <text x="332" y="355" text-anchor="middle" class="badge" fill="#92400e">STEP 4 · ANALYZE</text>
   <text x="332" y="376" text-anchor="middle" class="sub">Blast radius mapping</text>
-  <text x="332" y="388" text-anchor="middle" class="sub">6-framework threat tagging</text>
+  <text x="332" y="388" text-anchor="middle" class="sub">10-framework threat tagging</text>
   <text x="332" y="400" text-anchor="middle" class="sub">Tool poisoning detection</text>
 
   <line x1="332" y1="410" x2="332" y2="424" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
@@ -150,7 +150,7 @@
   <text x="569" y="142" text-anchor="middle" class="sub">→ credentials → tools → risk score</text>
 
   <rect x="478" y="162" width="182" height="68" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="180" text-anchor="middle" class="label" fill="#5b21b6">6-Framework Tagging</text>
+  <text x="569" y="180" text-anchor="middle" class="label" fill="#5b21b6">10-Framework Tagging</text>
   <text x="569" y="196" text-anchor="middle" class="sub">OWASP LLM · MCP · Agentic</text>
   <text x="569" y="208" text-anchor="middle" class="sub">MITRE ATLAS · NIST AI RMF</text>
   <text x="569" y="220" text-anchor="middle" class="sub">EU AI Act</text>

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -13,8 +13,8 @@ Endpoints:
     GET  /v1/scan/{job_id}/stream      SSE — real-time scan progress
     GET  /v1/agents                    quick agent discovery (no CVE scan)
     DELETE /v1/scan/{job_id}           cancel / discard a job
-    GET  /v1/compliance                full 6-framework compliance posture
-    GET  /v1/compliance/{framework}    single framework (owasp-llm, owasp-mcp, atlas, nist, owasp-agentic, eu-ai-act)
+    GET  /v1/compliance                full 10-framework compliance posture
+    GET  /v1/compliance/{framework}    single framework (owasp-llm, owasp-mcp, owasp-agentic, atlas, nist, eu-ai-act, nist-csf, iso-27001, soc2, cis)
     GET  /v1/malicious/check           malicious package / typosquat check
     GET  /v1/proxy/status              runtime proxy metrics
     GET  /v1/proxy/alerts              recent runtime proxy alerts

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -3206,7 +3206,7 @@ def mcp_server_cmd(transport: str, port: int, host: str):
       policy_check      Evaluate policy rules against scan findings
       registry_lookup   Query the MCP server threat intelligence registry
       generate_sbom     Generate CycloneDX or SPDX SBOM
-      compliance        6-framework compliance posture
+      compliance        10-framework compliance posture
       remediate         Generate actionable remediation plan
       skill_trust       ClawHub-style trust assessment for SKILL.md files
       verify            Package integrity + SLSA provenance verification

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1492,7 +1492,7 @@ _SERVER_CARD_TOOLS = [
     {"name": "generate_sbom", "description": "Generate CycloneDX or SPDX SBOM", "annotations": {"readOnlyHint": True}},
     {
         "name": "compliance",
-        "description": "6-framework compliance posture (OWASP LLM + MCP + Agentic, ATLAS, NIST, EU AI Act)",
+        "description": "10-framework compliance posture (OWASP LLM + MCP + Agentic, ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS)",
         "annotations": {"readOnlyHint": True},
     },
     {"name": "remediate", "description": "Generate actionable remediation plan", "annotations": {"readOnlyHint": True}},


### PR DESCRIPTION
## Summary
- Split "Core capabilities" into **For individual developers** (scanning, remediation, enrichment, privilege detection, tool poisoning, malicious packages) and **For enterprise teams** (10-framework compliance, SBOM, policy-as-code, fleet management, cloud discovery)
- Updated all "6-framework" references to "10-framework" across README, source code (`cli.py`, `mcp_server.py`, `server.py`), and 4 SVG diagrams
- Added NIST CSF 2.0, ISO 27001, SOC 2, CIS Controls v8 framework descriptions with AI-specific vs Enterprise GRC categorization
- Added CIS Controls v8 vs CIS Benchmarks distinction callout and platform-specific CIS Benchmarks roadmap (AWS, GCP, Azure, Snowflake, Kubernetes)
- Wrapped large SVGs (Snowflake, deployment topology) in collapsible `<details>` sections

## Test plan
- [x] `grep -rn "6-framework\|6 Framework" README.md docs/ src/` — zero matches
- [x] `grep -c "NIST CSF\|ISO 27001\|SOC 2\|CIS Controls" README.md` — 13 occurrences
- [x] `pytest tests/ -x -q` — 2625 passed
- [x] `ruff check src/ tests/` — all checks passed