### PR TITLE
fix: stale SVG counts, dependency CVE pins, publish version extraction

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -40,6 +40,9 @@ jobs:
             fi
           else
             VERSION="${HEAD_BRANCH#v}"
+            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+            fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -110,6 +113,9 @@ jobs:
             fi
           else
             VERSION="${HEAD_BRANCH#v}"
+            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+            fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/docs/images/before-after-dark.svg
+++ b/docs/images/before-after-dark.svg
@@ -85,7 +85,7 @@
   </g>
   <g transform="translate(484, 270)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.4"/>
-    <text x="18" y="12" class="bullet">6 compliance frameworks auto-mapped</text>
+    <text x="18" y="12" class="bullet">10 compliance frameworks auto-mapped</text>
   </g>
   <g transform="translate(484, 308)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.4"/>

--- a/docs/images/before-after-light.svg
+++ b/docs/images/before-after-light.svg
@@ -85,7 +85,7 @@
   </g>
   <g transform="translate(484, 270)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.35"/>
-    <text x="18" y="12" class="bullet">6 compliance frameworks auto-mapped</text>
+    <text x="18" y="12" class="bullet">10 compliance frameworks auto-mapped</text>
   </g>
   <g transform="translate(484, 308)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.35"/>

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -150,7 +150,7 @@
   <text x="602" y="233" class="step-num" fill="#d29922">⑤</text>
   <text x="622" y="233" class="step-label">Analyze</text>
   <text x="661" y="252" text-anchor="middle" class="step-detail">Blast radius mapping</text>
-  <text x="661" y="264" text-anchor="middle" class="step-detail">6 compliance frameworks</text>
+  <text x="661" y="264" text-anchor="middle" class="step-detail">10 compliance frameworks</text>
   <text x="661" y="276" text-anchor="middle" class="step-detail">Risk scoring (0-10)</text>
 
   <!-- Flow arrow: engine → outputs -->
@@ -191,13 +191,17 @@
   <text x="278" y="473" class="box-sub">Snowflake · CMMC export · Audit trail · SBOM archive</text>
 
   <!-- Compliance badges row -->
-  <rect x="36" y="488" width="456" height="26" rx="4" fill="#0d1117" stroke="#30363d" stroke-width="0.6"/>
-  <text x="48" y="505" class="badge" fill="#3fb950">OWASP LLM</text>
-  <text x="120" y="505" class="badge" fill="#3fb950">OWASP MCP</text>
-  <text x="195" y="505" class="badge" fill="#3fb950">OWASP Agentic</text>
-  <text x="288" y="505" class="badge" fill="#3fb950">MITRE ATLAS</text>
-  <text x="370" y="505" class="badge" fill="#3fb950">NIST AI RMF</text>
-  <text x="448" y="505" class="badge" fill="#3fb950">EU AI Act</text>
+  <rect x="36" y="488" width="456" height="38" rx="4" fill="#0d1117" stroke="#30363d" stroke-width="0.6"/>
+  <text x="48" y="501" class="badge" fill="#3fb950">OWASP LLM</text>
+  <text x="120" y="501" class="badge" fill="#3fb950">OWASP MCP</text>
+  <text x="195" y="501" class="badge" fill="#3fb950">OWASP Agentic</text>
+  <text x="288" y="501" class="badge" fill="#3fb950">MITRE ATLAS</text>
+  <text x="370" y="501" class="badge" fill="#3fb950">NIST AI RMF</text>
+  <text x="448" y="501" class="badge" fill="#3fb950">EU AI Act</text>
+  <text x="48" y="517" class="badge" fill="#3fb950">NIST CSF</text>
+  <text x="106" y="517" class="badge" fill="#3fb950">ISO 27001</text>
+  <text x="174" y="517" class="badge" fill="#3fb950">SOC 2</text>
+  <text x="222" y="517" class="badge" fill="#3fb950">CIS Controls v8</text>
 
   <!-- ═══ RUNTIME + FLEET (right side panel) ═══ -->
   <rect x="756" y="58" width="186" height="464" rx="8" fill="#161b22" stroke="#bc8cff" stroke-width="0.8" opacity="0.9"/>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -142,7 +142,7 @@
   <text x="602" y="233" class="step-num" fill="#bf8700">⑤</text>
   <text x="622" y="233" class="step-label">Analyze</text>
   <text x="661" y="252" text-anchor="middle" class="step-detail">Blast radius mapping</text>
-  <text x="661" y="264" text-anchor="middle" class="step-detail">6 compliance frameworks</text>
+  <text x="661" y="264" text-anchor="middle" class="step-detail">10 compliance frameworks</text>
   <text x="661" y="276" text-anchor="middle" class="step-detail">Risk scoring (0-10)</text>
 
   <!-- Flow arrow: engine → outputs -->
@@ -176,13 +176,17 @@
   <text x="278" y="461" class="box-label">Governance</text>
   <text x="278" y="473" class="box-sub">Snowflake · CMMC export · Audit trail · SBOM archive</text>
 
-  <rect x="36" y="488" width="456" height="26" rx="4" fill="#ffffff" stroke="#d0d7de" stroke-width="0.6"/>
-  <text x="48" y="505" class="badge" fill="#1a7f37">OWASP LLM</text>
-  <text x="120" y="505" class="badge" fill="#1a7f37">OWASP MCP</text>
-  <text x="195" y="505" class="badge" fill="#1a7f37">OWASP Agentic</text>
-  <text x="288" y="505" class="badge" fill="#1a7f37">MITRE ATLAS</text>
-  <text x="370" y="505" class="badge" fill="#1a7f37">NIST AI RMF</text>
-  <text x="448" y="505" class="badge" fill="#1a7f37">EU AI Act</text>
+  <rect x="36" y="488" width="456" height="38" rx="4" fill="#ffffff" stroke="#d0d7de" stroke-width="0.6"/>
+  <text x="48" y="501" class="badge" fill="#1a7f37">OWASP LLM</text>
+  <text x="120" y="501" class="badge" fill="#1a7f37">OWASP MCP</text>
+  <text x="195" y="501" class="badge" fill="#1a7f37">OWASP Agentic</text>
+  <text x="288" y="501" class="badge" fill="#1a7f37">MITRE ATLAS</text>
+  <text x="370" y="501" class="badge" fill="#1a7f37">NIST AI RMF</text>
+  <text x="448" y="501" class="badge" fill="#1a7f37">EU AI Act</text>
+  <text x="48" y="517" class="badge" fill="#1a7f37">NIST CSF</text>
+  <text x="106" y="517" class="badge" fill="#1a7f37">ISO 27001</text>
+  <text x="174" y="517" class="badge" fill="#1a7f37">SOC 2</text>
+  <text x="222" y="517" class="badge" fill="#1a7f37">CIS Controls v8</text>
 
   <!-- ═══ RUNTIME + FLEET (right side panel) ═══ -->
   <rect x="756" y="58" width="186" height="464" rx="8" fill="#f6f8fa" stroke="#8250df" stroke-width="0.8" opacity="0.9"/>

--- a/docs/images/integration-architecture-dark.svg
+++ b/docs/images/integration-architecture-dark.svg
@@ -109,7 +109,7 @@
     </g>
     <!-- Tag pill -->
     <rect x="16" y="158" width="132" height="22" rx="11" fill="#bc8cff" opacity="0.12"/>
-    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#bc8cff">6 compliance frameworks</text>
+    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#bc8cff">10 compliance frameworks</text>
   </g>
 
   <!-- Arrow 3→4 -->

--- a/docs/images/integration-architecture-light.svg
+++ b/docs/images/integration-architecture-light.svg
@@ -109,7 +109,7 @@
     </g>
     <!-- Tag pill -->
     <rect x="16" y="158" width="132" height="22" rx="11" fill="#bc8cff" opacity="0.1"/>
-    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#8250df">6 compliance frameworks</text>
+    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#8250df">10 compliance frameworks</text>
   </g>
 
   <!-- Arrow 3→4 -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "jsonschema>=4.0",
     # Transitive dep pins — fix known CVEs flagged by OpenSSF/OSV
     "jinja2>=3.1.6",  # GHSA-cpwx-vrp4-4pq7, GHSA-gmj6-6f8f-6699 (sandbox breakout)
-    "werkzeug>=3.1.3",  # GHSA-q34m-jh98-afg2 (debugger RCE)
+    "werkzeug>=3.1.6",  # GHSA-q34m-jh98-afg2 + 8 more Werkzeug advisories
+    "requests>=2.32.4",  # GHSA-9hjg-9r4m-mvj7, GHSA-j8r2-6x86-q33q (session cookie leak)
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Updated "6 compliance frameworks" → "10 compliance frameworks" in 6 SVG files (enterprise-overview, before-after, integration-architecture)
- Added 4 missing framework badges (NIST CSF, ISO 27001, SOC 2, CIS Controls v8) to enterprise-overview SVGs
- Bumped `werkzeug>=3.1.6` fixing 9 GHSAs (incl. debugger RCE) and added `requests>=2.32.4` pin fixing 3 GHSAs
- Fixed publish-registries.yml version extraction: added semver validation + pyproject.toml fallback for `workflow_run` events (root cause of Smithery stuck on v0.38.1)
- Updated GitHub repo description with 10-framework listing

## Test plan
- [x] `grep -rn "6 compliance" docs/images/` — zero matches
- [x] `pip show werkzeug` — 3.1.6
- [x] `pytest tests/ -x -q` — 2625 passed
- [x] `ruff check src/` — all passed