### PR TITLE
feat: SAST scanning via Semgrep wrapper

### DIFF
--- a/src/agent_bom/cis_controls.py
+++ b/src/agent_bom/cis_controls.py
@@ -105,6 +105,14 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.is_kev:
         tags.add("CIS-16.12")
 
+    # CWE-based tagging for SAST findings
+    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
+        from agent_bom.constants import SAST_CWE_MAP
+
+        for cwe in br.vulnerability.cwe_ids:
+            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("cis", []):
+                tags.add(tag)
+
     return sorted(tags)
 
 

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -329,6 +329,21 @@ def main():
 )
 @click.option("--apply-dry-run", is_flag=True, help="Preview what --apply would change without modifying files")
 @click.option(
+    "--code",
+    "code_paths",
+    multiple=True,
+    type=click.Path(exists=True),
+    metavar="PATH",
+    help="Source code directory to scan for security flaws via Semgrep (SAST). Repeatable.",
+)
+@click.option(
+    "--sast-config",
+    default="auto",
+    show_default=True,
+    metavar="CONFIG",
+    help="Semgrep config for --code scans (e.g. 'p/security-audit'). Default: auto.",
+)
+@click.option(
     "--filesystem",
     "filesystem_paths",
     multiple=True,
@@ -529,6 +544,8 @@ def scan(
     remediate_sh_path: Optional[str],
     apply_fixes_flag: bool,
     apply_dry_run: bool,
+    code_paths: tuple,
+    sast_config: str,
     filesystem_paths: tuple,
     jira_url: Optional[str],
     jira_user: Optional[str],
@@ -637,6 +654,8 @@ def scan(
 
             for client, path in get_all_discovery_paths():
                 reads.append(f"  [green]Would read:[/green]   {path}  ({client})")
+        for cp in code_paths:
+            reads.append(f"  [green]Would scan:[/green]   {cp}  (SAST via semgrep)")
         for tf_dir in tf_dirs:
             reads.append(f"  [green]Would read:[/green]   {tf_dir}  (Terraform .tf files)")
         for ap in agent_projects:
@@ -832,6 +851,7 @@ def scan(
         and not agents
         and not images
         and not k8s
+        and not code_paths
         and not tf_dirs
         and not gha_path
         and not agent_projects
@@ -840,7 +860,7 @@ def scan(
     ):
         con.print("\n[yellow]No MCP configurations found.[/yellow]")
         con.print(
-            "  Use --project, --config-dir, --inventory, --image, --k8s, "
+            "  Use --project, --config-dir, --inventory, --image, --k8s, --code, "
             "--tf-dir, --gha, --agent-project, --jupyter, --aws, --azure, --gcp, "
             "--databricks, --snowflake, --nebius, --huggingface, --wandb, "
             "--mlflow, --openai, --ollama, or --scan-prompts to specify a target."
@@ -931,6 +951,34 @@ def scan(
                 agents.append(fs_agent)
             except FilesystemScanError as e:
                 con.print(f"  [yellow]![/yellow] {fs_path}: {e}")
+
+    # Step 1d3: SAST code scan (--code)
+    _sast_data: dict | None = None
+    if not skill_only and code_paths:
+        from agent_bom.sast import SASTScanError, scan_code
+
+        con.print(f"\n[bold blue]Running SAST scan on {len(code_paths)} path(s) via Semgrep...[/bold blue]\n")
+        for code_path in code_paths:
+            try:
+                sast_packages, sast_result = scan_code(code_path, config=sast_config)
+                con.print(
+                    f"  [green]v[/green] {code_path}: {sast_result.total_findings} finding(s) "
+                    f"in {sast_result.files_scanned} file(s) [dim]({sast_result.scan_time_seconds}s)[/dim]"
+                )
+                if sast_packages:
+                    server = MCPServer(name=f"sast:{Path(code_path).name}")
+                    server.packages = sast_packages
+                    sast_agent = Agent(
+                        name=f"code:{Path(code_path).name}",
+                        agent_type=AgentType.CUSTOM,
+                        config_path=code_path,
+                        source="sast",
+                        mcp_servers=[server],
+                    )
+                    agents.append(sast_agent)
+                _sast_data = sast_result.to_dict()
+            except SASTScanError as e:
+                con.print(f"  [yellow]![/yellow] {code_path}: {e}")
 
     # Step 1e: Terraform scan (--tf-dir)
     if not skill_only and tf_dirs:
@@ -1672,6 +1720,8 @@ def scan(
         report.prompt_scan_data = _prompt_scan_data
     if _enforcement_data:
         report.enforcement_data = _enforcement_data
+    if _sast_data:
+        report.sast_data = _sast_data
 
     # ── Context graph: lateral movement analysis ────────────────────
     if context_graph_flag and report.blast_radii:

--- a/src/agent_bom/constants.py
+++ b/src/agent_bom/constants.py
@@ -147,3 +147,62 @@ def is_credential_key(name: str) -> bool:
     """Check if an environment variable name matches credential patterns."""
     low = name.lower()
     return any(pat in low for pat in SENSITIVE_PATTERNS)
+
+
+# ── CWE-to-Compliance Mapping (for SAST findings) ──────────────────────────
+# Maps CWE weakness IDs to applicable compliance framework tags.
+# Used by compliance taggers when processing SAST findings (ecosystem="sast").
+
+SAST_CWE_MAP: dict[str, dict[str, list[str]]] = {
+    "CWE-78": {  # OS Command Injection
+        "owasp_llm": ["LLM02"],
+        "iso_27001": ["A.8.28"],
+        "nist_csf": ["PR.DS-01"],
+        "cis": ["CIS-16.1"],
+    },
+    "CWE-79": {  # Cross-Site Scripting (XSS)
+        "owasp_llm": ["LLM02"],
+        "iso_27001": ["A.8.28"],
+        "nist_csf": ["PR.DS-01"],
+    },
+    "CWE-89": {  # SQL Injection
+        "owasp_llm": ["LLM02"],
+        "iso_27001": ["A.8.28"],
+        "nist_csf": ["PR.DS-01"],
+        "cis": ["CIS-16.1"],
+    },
+    "CWE-22": {  # Path Traversal
+        "iso_27001": ["A.8.28"],
+        "nist_csf": ["PR.DS-01"],
+    },
+    "CWE-327": {  # Broken/Risky Crypto Algorithm
+        "iso_27001": ["A.8.24"],
+        "nist_csf": ["PR.DS-01", "PR.DS-02"],
+        "soc2": ["CC6.1"],
+    },
+    "CWE-502": {  # Deserialization of Untrusted Data
+        "owasp_llm": ["LLM02"],
+        "iso_27001": ["A.8.28"],
+    },
+    "CWE-798": {  # Hardcoded Credentials
+        "owasp_llm": ["LLM06"],
+        "iso_27001": ["A.8.9", "A.8.24"],
+        "nist_csf": ["PR.AA-01"],
+        "soc2": ["CC6.1"],
+        "cis": ["CIS-16.1"],
+    },
+    "CWE-918": {  # Server-Side Request Forgery (SSRF)
+        "iso_27001": ["A.8.28"],
+        "nist_csf": ["DE.CM-01"],
+    },
+    "CWE-611": {  # XXE (XML External Entity)
+        "iso_27001": ["A.8.28"],
+        "nist_csf": ["PR.DS-01"],
+    },
+    "CWE-94": {  # Code Injection
+        "owasp_llm": ["LLM02"],
+        "iso_27001": ["A.8.28"],
+        "nist_csf": ["PR.DS-01"],
+        "cis": ["CIS-16.1"],
+    },
+}

--- a/src/agent_bom/iso_27001.py
+++ b/src/agent_bom/iso_27001.py
@@ -93,6 +93,14 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.fixed_version:
         tags.add("A.8.28")
 
+    # CWE-based tagging for SAST findings
+    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
+        from agent_bom.constants import SAST_CWE_MAP
+
+        for cwe in br.vulnerability.cwe_ids:
+            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("iso_27001", []):
+                tags.add(tag)
+
     return sorted(tags)
 
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1306,7 +1306,41 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("MCP tool error")
             return json.dumps({"error": sanitize_error(exc)})
 
-    # ── Tool 15: context_graph ──────────────────────────────────
+    # ── Tool 16: code_scan ────────────────────────────────────────
+
+    @mcp.tool(annotations=_READ_ONLY)
+    async def code_scan(
+        path: Annotated[str, Field(description="Path to source code directory to scan.")],
+        config: Annotated[
+            str,
+            Field(description="Semgrep config. 'auto' = Semgrep Registry rules. Can be a path or registry string."),
+        ] = "auto",
+    ) -> str:
+        """Run SAST (Static Application Security Testing) on source code via Semgrep.
+
+        Scans for security flaws: SQL injection, XSS, command injection,
+        hardcoded credentials, insecure deserialization, path traversal, etc.
+        Returns findings with CWE classifications and severity levels.
+
+        Requires ``semgrep`` on PATH (``pip install semgrep``).
+        """
+        try:
+            scan_path = _safe_path(path)
+        except ValueError as exc:
+            return json.dumps({"error": sanitize_error(exc)})
+
+        try:
+            from agent_bom.sast import SASTScanError, scan_code
+
+            _packages, sast_result = scan_code(str(scan_path), config=config)
+            return _truncate_response(json.dumps(sast_result.to_dict(), indent=2))
+        except SASTScanError as exc:
+            return json.dumps({"error": sanitize_error(exc)})
+        except Exception as exc:
+            logger.error("code_scan error: %s", exc)
+            return json.dumps({"error": sanitize_error(exc)})
+
+    # ── Tool 17: context_graph ──────────────────────────────────
 
     @mcp.tool(annotations=_READ_ONLY)
     async def context_graph(

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -350,6 +350,7 @@ class AIBOMReport:
     vex_data: Optional[dict] = None  # Serialized VEX document
     toxic_combinations: Optional[list] = None  # Serialized ToxicCombination list
     prioritized_findings: Optional[list] = None  # Priority-ordered findings
+    sast_data: Optional[dict] = None  # Serialized SAST scan results (Semgrep)
 
     def __post_init__(self):
         if not self.tool_version:

--- a/src/agent_bom/nist_csf.py
+++ b/src/agent_bom/nist_csf.py
@@ -129,6 +129,14 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.is_kev:
         tags.add("RS.MI-02")
 
+    # CWE-based tagging for SAST findings
+    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
+        from agent_bom.constants import SAST_CWE_MAP
+
+        for cwe in br.vulnerability.cwe_ids:
+            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("nist_csf", []):
+                tags.add(tag)
+
     return sorted(tags)
 
 

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1542,6 +1542,9 @@ def to_json(report: AIBOMReport) -> dict:
     if report.prioritized_findings:
         result["prioritized_findings"] = report.prioritized_findings
 
+    if report.sast_data:
+        result["sast"] = report.sast_data
+
     # Posture scorecard
     from agent_bom.posture import (
         compute_credential_risk_ranking,

--- a/src/agent_bom/owasp.py
+++ b/src/agent_bom/owasp.py
@@ -89,6 +89,14 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.package.name.lower() in _AI_PACKAGES and br.vulnerability.severity in _HIGH_RISK_SEVERITIES:
         tags.add("LLM04")
 
+    # CWE-based tagging for SAST findings
+    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
+        from agent_bom.constants import SAST_CWE_MAP
+
+        for cwe in br.vulnerability.cwe_ids:
+            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("owasp_llm", []):
+                tags.add(tag)
+
     return sorted(tags)
 
 

--- a/src/agent_bom/sast.py
+++ b/src/agent_bom/sast.py
@@ -1,0 +1,346 @@
+"""SAST scanning via Semgrep — static analysis for source code.
+
+Runs Semgrep with SARIF output, normalizes findings into the agent-bom
+data model (Package + Vulnerability objects), and provides structured
+results for detailed file-level reporting.
+
+Pattern mirrors ``image.py`` (Grype wrapper): subprocess → JSON parse →
+normalize to internal data model → flow through standard pipeline.
+
+Usage::
+
+    from agent_bom.sast import scan_code, SASTScanError
+    packages, sast_result = scan_code("/path/to/project")
+
+If Semgrep is not installed, raises SASTScanError with install guidance.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from agent_bom.models import Package, Severity, Vulnerability
+
+_logger = logging.getLogger(__name__)
+
+
+class SASTScanError(Exception):
+    """Raised when SAST scanning fails."""
+
+
+# ── Data models ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SASTFinding:
+    """A single SAST finding with file location metadata."""
+
+    rule_id: str
+    message: str
+    severity: Severity
+    file_path: str
+    start_line: int
+    end_line: int
+    start_col: int = 0
+    end_col: int = 0
+    cwe_ids: list[str] = field(default_factory=list)
+    owasp_ids: list[str] = field(default_factory=list)
+    rule_url: Optional[str] = None
+    snippet: Optional[str] = None
+
+
+@dataclass
+class SASTResult:
+    """Aggregated SAST scan results."""
+
+    findings: list[SASTFinding] = field(default_factory=list)
+    files_scanned: int = 0
+    rules_loaded: int = 0
+    scan_time_seconds: float = 0.0
+    semgrep_version: Optional[str] = None
+    config_used: str = "auto"
+
+    @property
+    def total_findings(self) -> int:
+        return len(self.findings)
+
+    @property
+    def critical_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.CRITICAL)
+
+    @property
+    def high_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == Severity.HIGH)
+
+    def to_dict(self) -> dict:
+        """Serialize for AIBOMReport.sast_data."""
+        return {
+            "total_findings": self.total_findings,
+            "files_scanned": self.files_scanned,
+            "rules_loaded": self.rules_loaded,
+            "scan_time_seconds": self.scan_time_seconds,
+            "semgrep_version": self.semgrep_version,
+            "config_used": self.config_used,
+            "severity_counts": {
+                "critical": self.critical_count,
+                "high": self.high_count,
+                "medium": sum(1 for f in self.findings if f.severity == Severity.MEDIUM),
+                "low": sum(1 for f in self.findings if f.severity == Severity.LOW),
+            },
+            "findings": [
+                {
+                    "rule_id": f.rule_id,
+                    "message": f.message,
+                    "severity": f.severity.value,
+                    "file_path": f.file_path,
+                    "start_line": f.start_line,
+                    "end_line": f.end_line,
+                    "cwe_ids": f.cwe_ids,
+                    "owasp_ids": f.owasp_ids,
+                    "rule_url": f.rule_url,
+                    "snippet": f.snippet,
+                }
+                for f in self.findings
+            ],
+        }
+
+
+# ── Semgrep severity mapping ───────────────────────────────────────────────
+
+_SARIF_LEVEL_MAP: dict[str, Severity] = {
+    "error": Severity.HIGH,
+    "warning": Severity.MEDIUM,
+    "note": Severity.LOW,
+    "none": Severity.NONE,
+}
+
+
+# ── Internal helpers ────────────────────────────────────────────────────────
+
+
+def _semgrep_available() -> bool:
+    return shutil.which("semgrep") is not None
+
+
+def _get_semgrep_version() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["semgrep", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def _parse_sarif_findings(sarif: dict) -> tuple[list[SASTFinding], int, int]:
+    """Parse Semgrep SARIF output into SASTFinding objects.
+
+    Returns (findings, rules_loaded, files_scanned).
+    """
+    findings: list[SASTFinding] = []
+    files_seen: set[str] = set()
+    rules_loaded = 0
+
+    for run in sarif.get("runs", []):
+        driver = run.get("tool", {}).get("driver", {})
+        rules = {r["id"]: r for r in driver.get("rules", [])}
+        rules_loaded = max(rules_loaded, len(rules))
+
+        for result in run.get("results", []):
+            rule_id = result.get("ruleId", "unknown")
+            level = result.get("level", "warning")
+            message = result.get("message", {}).get("text", "")
+
+            # Extract location
+            locations = result.get("locations", [])
+            if not locations:
+                continue
+            loc = locations[0].get("physicalLocation", {})
+            artifact = loc.get("artifactLocation", {}).get("uri", "")
+            region = loc.get("region", {})
+            start_line = region.get("startLine", 0)
+            end_line = region.get("endLine", start_line)
+            start_col = region.get("startColumn", 0)
+            end_col = region.get("endColumn", 0)
+            snippet_obj = region.get("snippet", {})
+            snippet = snippet_obj.get("text") if snippet_obj else None
+
+            files_seen.add(artifact)
+
+            severity = _SARIF_LEVEL_MAP.get(level, Severity.MEDIUM)
+
+            # Extract CWE IDs and OWASP tags from rule metadata
+            rule_meta = rules.get(rule_id, {})
+            rule_props = rule_meta.get("properties", {})
+            tags = rule_props.get("tags", [])
+            cwe_ids = [t for t in tags if t.upper().startswith("CWE-")]
+            owasp_ids = [t for t in tags if ":" in t and t[0] == "A"]
+
+            rule_url = rule_meta.get("helpUri")
+
+            findings.append(
+                SASTFinding(
+                    rule_id=rule_id,
+                    message=message[:500],
+                    severity=severity,
+                    file_path=artifact,
+                    start_line=start_line,
+                    end_line=end_line,
+                    start_col=start_col,
+                    end_col=end_col,
+                    cwe_ids=cwe_ids,
+                    owasp_ids=owasp_ids,
+                    rule_url=rule_url,
+                    snippet=snippet[:200] if snippet else None,
+                )
+            )
+
+    return findings, rules_loaded, len(files_seen)
+
+
+def _findings_to_packages(findings: list[SASTFinding]) -> list[Package]:
+    """Convert SAST findings into Package objects for the standard pipeline.
+
+    Groups findings by file path.  Each unique file becomes a synthetic
+    ``Package(ecosystem="sast")``, and each finding becomes a ``Vulnerability``
+    on that package.  This allows SAST findings to flow through the standard
+    ``scan_agents → BlastRadius → compliance tagging`` pipeline.
+    """
+    file_findings: dict[str, list[SASTFinding]] = {}
+    for f in findings:
+        file_findings.setdefault(f.file_path, []).append(f)
+
+    packages: list[Package] = []
+    for file_path, file_finds in file_findings.items():
+        vulns: list[Vulnerability] = []
+        seen_ids: set[str] = set()
+        for finding in file_finds:
+            vid = f"{finding.rule_id}:{finding.start_line}"
+            if vid in seen_ids:
+                continue
+            seen_ids.add(vid)
+
+            vulns.append(
+                Vulnerability(
+                    id=finding.rule_id,
+                    summary=finding.message,
+                    severity=finding.severity,
+                    cwe_ids=finding.cwe_ids,
+                    references=[finding.rule_url] if finding.rule_url else [],
+                )
+            )
+
+        if vulns:
+            packages.append(
+                Package(
+                    name=file_path,
+                    version="0.0.0",
+                    ecosystem="sast",
+                    vulnerabilities=vulns,
+                    is_direct=True,
+                )
+            )
+
+    return packages
+
+
+# ── Public API ──────────────────────────────────────────────────────────────
+
+
+def scan_code(
+    path: str,
+    config: str = "auto",
+    timeout: int = 600,
+) -> tuple[list[Package], SASTResult]:
+    """Run Semgrep SAST scan on source code.
+
+    Args:
+        path: Directory or file to scan.
+        config: Semgrep config (default ``"auto"`` = Semgrep Registry).
+                Can be a path to custom rules YAML or registry string.
+        timeout: Subprocess timeout in seconds.
+
+    Returns:
+        Tuple of (packages_with_vulns, structured_sast_result).
+
+    Raises:
+        SASTScanError: If Semgrep is not installed or scan fails.
+    """
+    if not _semgrep_available():
+        raise SASTScanError(
+            "semgrep not found on PATH. Install with: pip install semgrep (or see https://semgrep.dev/docs/getting-started/)"
+        )
+
+    resolved = Path(path).resolve()
+    if not resolved.exists():
+        raise SASTScanError(f"Path does not exist: {path}")
+
+    start = time.monotonic()
+
+    cmd = [
+        "semgrep",
+        "--sarif",
+        "--config",
+        config,
+        "--quiet",
+        str(resolved),
+    ]
+
+    _logger.info("Running SAST scan: %s", " ".join(cmd))
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        raise SASTScanError("semgrep not found on PATH")
+    except subprocess.TimeoutExpired:
+        raise SASTScanError(f"semgrep timed out after {timeout}s scanning {path}")
+
+    # Semgrep exit codes: 0 = clean, 1 = findings found (both are success)
+    # Exit code 2+ = actual error
+    if result.returncode > 1:
+        stderr = result.stderr.strip()
+        raise SASTScanError(f"semgrep exited {result.returncode}: {stderr[:300]}")
+
+    try:
+        sarif = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise SASTScanError(f"semgrep produced invalid SARIF output: {e}")
+
+    elapsed = time.monotonic() - start
+
+    findings, rules_loaded, files_scanned = _parse_sarif_findings(sarif)
+    packages = _findings_to_packages(findings)
+
+    sast_result = SASTResult(
+        findings=findings,
+        files_scanned=files_scanned,
+        rules_loaded=rules_loaded,
+        scan_time_seconds=round(elapsed, 2),
+        semgrep_version=_get_semgrep_version(),
+        config_used=config,
+    )
+
+    _logger.info(
+        "SAST scan complete: %d finding(s) in %d file(s) (%d rules, %.1fs)",
+        sast_result.total_findings,
+        files_scanned,
+        rules_loaded,
+        elapsed,
+    )
+
+    return packages, sast_result

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -496,7 +496,8 @@ async def scan_packages(packages: list[Package]) -> int:
         except Exception as exc:
             console.print(f"  [yellow]⚠[/yellow] Version resolution skipped: {exc}")
 
-    scannable = [p for p in packages if p.version not in ("unknown", "latest")]
+    # SAST packages already carry vulns from Semgrep — skip OSV query for them
+    scannable = [p for p in packages if p.version not in ("unknown", "latest") and p.ecosystem != "sast"]
 
     if not scannable:
         return 0

--- a/src/agent_bom/soc2.py
+++ b/src/agent_bom/soc2.py
@@ -95,6 +95,14 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.fixed_version:
         tags.add("CC8.1")
 
+    # CWE-based tagging for SAST findings
+    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
+        from agent_bom.constants import SAST_CWE_MAP
+
+        for cwe in br.vulnerability.cwe_ids:
+            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("soc2", []):
+                tags.add(tag)
+
     return sorted(tags)
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -57,13 +57,13 @@ def test_create_mcp_server_returns_object():
     assert server.name == "agent-bom"
 
 
-def test_mcp_server_has_fifteen_tools():
-    """Server should register exactly 15 tools."""
+def test_mcp_server_has_sixteen_tools():
+    """Server should register exactly 16 tools."""
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
     tools = _run(server.list_tools())
-    assert len(tools) == 15
+    assert len(tools) == 16
 
 
 def test_mcp_server_tool_names():
@@ -88,6 +88,7 @@ def test_mcp_server_tool_names():
         "inventory",
         "diff",
         "marketplace_check",
+        "code_scan",
         "context_graph",
     }
 

--- a/tests/test_sast.py
+++ b/tests/test_sast.py
@@ -1,0 +1,498 @@
+"""Tests for SAST scanning module (Semgrep wrapper)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_bom.models import Severity
+from agent_bom.sast import (
+    SASTFinding,
+    SASTResult,
+    SASTScanError,
+    _findings_to_packages,
+    _parse_sarif_findings,
+    scan_code,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+SAMPLE_SARIF = {
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "semgrep",
+                    "rules": [
+                        {
+                            "id": "python.lang.security.audit.eval-detected",
+                            "shortDescription": {"text": "Detected use of eval()"},
+                            "helpUri": "https://semgrep.dev/r/python.lang.security.audit.eval-detected",
+                            "defaultConfiguration": {"level": "error"},
+                            "properties": {
+                                "tags": ["CWE-94", "A03:2021"],
+                            },
+                        },
+                        {
+                            "id": "python.lang.security.audit.hardcoded-password",
+                            "shortDescription": {"text": "Hardcoded password"},
+                            "helpUri": "https://semgrep.dev/r/python.lang.security.audit.hardcoded-password",
+                            "defaultConfiguration": {"level": "warning"},
+                            "properties": {
+                                "tags": ["CWE-798"],
+                            },
+                        },
+                    ],
+                }
+            },
+            "results": [
+                {
+                    "ruleId": "python.lang.security.audit.eval-detected",
+                    "level": "error",
+                    "message": {"text": "Detected use of eval(). This can be dangerous."},
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "src/utils.py"},
+                                "region": {
+                                    "startLine": 42,
+                                    "endLine": 42,
+                                    "startColumn": 5,
+                                    "endColumn": 30,
+                                    "snippet": {"text": "result = eval(user_input)"},
+                                },
+                            }
+                        }
+                    ],
+                },
+                {
+                    "ruleId": "python.lang.security.audit.hardcoded-password",
+                    "level": "warning",
+                    "message": {"text": "Hardcoded password detected."},
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "src/config.py"},
+                                "region": {
+                                    "startLine": 10,
+                                    "endLine": 10,
+                                    "startColumn": 1,
+                                    "endColumn": 40,
+                                },
+                            }
+                        }
+                    ],
+                },
+            ],
+        }
+    ],
+}
+
+EMPTY_SARIF = {
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {"driver": {"name": "semgrep", "rules": []}},
+            "results": [],
+        }
+    ],
+}
+
+
+# ── SARIF parsing tests ────────────────────────────────────────────────────
+
+
+def test_parse_sarif_happy_path():
+    """Semgrep SARIF output is parsed into SASTFinding objects."""
+    findings, rules_loaded, files_scanned = _parse_sarif_findings(SAMPLE_SARIF)
+
+    assert len(findings) == 2
+    assert rules_loaded == 2
+    assert files_scanned == 2
+
+    eval_finding = findings[0]
+    assert eval_finding.rule_id == "python.lang.security.audit.eval-detected"
+    assert eval_finding.severity == Severity.HIGH  # "error" → HIGH
+    assert eval_finding.file_path == "src/utils.py"
+    assert eval_finding.start_line == 42
+    assert "CWE-94" in eval_finding.cwe_ids
+    assert eval_finding.snippet == "result = eval(user_input)"
+    assert eval_finding.rule_url == "https://semgrep.dev/r/python.lang.security.audit.eval-detected"
+
+    pw_finding = findings[1]
+    assert pw_finding.severity == Severity.MEDIUM  # "warning" → MEDIUM
+    assert pw_finding.file_path == "src/config.py"
+    assert "CWE-798" in pw_finding.cwe_ids
+
+
+def test_parse_sarif_empty():
+    """Empty SARIF with no results returns empty findings."""
+    findings, rules_loaded, files_scanned = _parse_sarif_findings(EMPTY_SARIF)
+    assert findings == []
+    assert files_scanned == 0
+
+
+def test_parse_sarif_no_location():
+    """Results without locations are skipped."""
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"rules": []}},
+                "results": [
+                    {
+                        "ruleId": "test-rule",
+                        "level": "warning",
+                        "message": {"text": "No location"},
+                        "locations": [],
+                    }
+                ],
+            }
+        ]
+    }
+    findings, _, _ = _parse_sarif_findings(sarif)
+    assert findings == []
+
+
+# ── Severity mapping ───────────────────────────────────────────────────────
+
+
+def test_severity_mapping():
+    """SARIF levels map to correct Severity enums."""
+    from agent_bom.sast import _SARIF_LEVEL_MAP
+
+    assert _SARIF_LEVEL_MAP["error"] == Severity.HIGH
+    assert _SARIF_LEVEL_MAP["warning"] == Severity.MEDIUM
+    assert _SARIF_LEVEL_MAP["note"] == Severity.LOW
+    assert _SARIF_LEVEL_MAP["none"] == Severity.NONE
+
+
+# ── Findings → Packages ───────────────────────────────────────────────────
+
+
+def test_findings_to_packages():
+    """SAST findings are grouped by file into Package objects."""
+    findings = [
+        SASTFinding(
+            rule_id="rule-a",
+            message="Issue A",
+            severity=Severity.HIGH,
+            file_path="src/app.py",
+            start_line=10,
+            end_line=10,
+            cwe_ids=["CWE-89"],
+        ),
+        SASTFinding(
+            rule_id="rule-b",
+            message="Issue B",
+            severity=Severity.MEDIUM,
+            file_path="src/app.py",
+            start_line=20,
+            end_line=20,
+            cwe_ids=["CWE-79"],
+        ),
+        SASTFinding(
+            rule_id="rule-c",
+            message="Issue C",
+            severity=Severity.LOW,
+            file_path="src/utils.py",
+            start_line=5,
+            end_line=5,
+        ),
+    ]
+
+    packages = _findings_to_packages(findings)
+    assert len(packages) == 2  # two files
+
+    app_pkg = next(p for p in packages if p.name == "src/app.py")
+    assert app_pkg.ecosystem == "sast"
+    assert app_pkg.version == "0.0.0"
+    assert len(app_pkg.vulnerabilities) == 2
+    assert app_pkg.vulnerabilities[0].id == "rule-a"
+    assert app_pkg.vulnerabilities[0].cwe_ids == ["CWE-89"]
+
+    utils_pkg = next(p for p in packages if p.name == "src/utils.py")
+    assert len(utils_pkg.vulnerabilities) == 1
+
+
+def test_findings_to_packages_dedup():
+    """Duplicate findings (same rule + line) in a file are deduplicated."""
+    findings = [
+        SASTFinding(
+            rule_id="rule-a",
+            message="Issue A",
+            severity=Severity.HIGH,
+            file_path="src/app.py",
+            start_line=10,
+            end_line=10,
+        ),
+        SASTFinding(
+            rule_id="rule-a",
+            message="Issue A duplicate",
+            severity=Severity.HIGH,
+            file_path="src/app.py",
+            start_line=10,
+            end_line=10,
+        ),
+    ]
+
+    packages = _findings_to_packages(findings)
+    assert len(packages) == 1
+    assert len(packages[0].vulnerabilities) == 1
+
+
+def test_findings_to_packages_empty():
+    """Empty findings list returns empty packages list."""
+    assert _findings_to_packages([]) == []
+
+
+# ── SASTResult ─────────────────────────────────────────────────────────────
+
+
+def test_sast_result_counts():
+    """SASTResult severity counts are computed correctly."""
+    result = SASTResult(
+        findings=[
+            SASTFinding(rule_id="a", message="", severity=Severity.CRITICAL, file_path="f", start_line=1, end_line=1),
+            SASTFinding(rule_id="b", message="", severity=Severity.HIGH, file_path="f", start_line=2, end_line=2),
+            SASTFinding(rule_id="c", message="", severity=Severity.HIGH, file_path="f", start_line=3, end_line=3),
+            SASTFinding(rule_id="d", message="", severity=Severity.MEDIUM, file_path="f", start_line=4, end_line=4),
+        ],
+        files_scanned=1,
+        rules_loaded=4,
+    )
+    assert result.total_findings == 4
+    assert result.critical_count == 1
+    assert result.high_count == 2
+
+    d = result.to_dict()
+    assert d["severity_counts"]["critical"] == 1
+    assert d["severity_counts"]["high"] == 2
+    assert d["severity_counts"]["medium"] == 1
+    assert d["severity_counts"]["low"] == 0
+    assert len(d["findings"]) == 4
+
+
+def test_sast_result_to_dict_fields():
+    """SASTResult.to_dict() includes all expected fields."""
+    result = SASTResult(
+        findings=[],
+        files_scanned=10,
+        rules_loaded=50,
+        scan_time_seconds=1.5,
+        semgrep_version="1.50.0",
+        config_used="p/security-audit",
+    )
+    d = result.to_dict()
+    assert d["files_scanned"] == 10
+    assert d["rules_loaded"] == 50
+    assert d["scan_time_seconds"] == 1.5
+    assert d["semgrep_version"] == "1.50.0"
+    assert d["config_used"] == "p/security-audit"
+
+
+# ── scan_code() ────────────────────────────────────────────────────────────
+
+
+def test_semgrep_not_installed(monkeypatch):
+    """scan_code raises SASTScanError when semgrep is not on PATH."""
+    monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: None)
+    with pytest.raises(SASTScanError, match="semgrep not found"):
+        scan_code("/tmp/fake-project")
+
+
+def test_scan_code_invalid_path(monkeypatch):
+    """Non-existent path raises SASTScanError."""
+    monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
+    with pytest.raises(SASTScanError, match="does not exist"):
+        scan_code("/nonexistent/path/abc123")
+
+
+def test_scan_code_timeout(monkeypatch, tmp_path):
+    """Subprocess timeout raises SASTScanError."""
+    monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
+    monkeypatch.setattr(
+        "agent_bom.sast.subprocess.run",
+        MagicMock(side_effect=subprocess.TimeoutExpired(cmd="semgrep", timeout=600)),
+    )
+    with pytest.raises(SASTScanError, match="timed out"):
+        scan_code(str(tmp_path))
+
+
+def test_scan_code_semgrep_error(monkeypatch, tmp_path):
+    """Semgrep exit code >= 2 raises SASTScanError."""
+    monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
+    mock_result = MagicMock()
+    mock_result.returncode = 2
+    mock_result.stderr = "Fatal error: bad config"
+    monkeypatch.setattr("agent_bom.sast.subprocess.run", MagicMock(return_value=mock_result))
+    with pytest.raises(SASTScanError, match="semgrep exited 2"):
+        scan_code(str(tmp_path))
+
+
+def test_scan_code_invalid_json(monkeypatch, tmp_path):
+    """Invalid JSON from semgrep raises SASTScanError."""
+    monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "not valid json"
+    monkeypatch.setattr("agent_bom.sast.subprocess.run", MagicMock(return_value=mock_result))
+    with pytest.raises(SASTScanError, match="invalid SARIF"):
+        scan_code(str(tmp_path))
+
+
+def test_scan_code_happy_path(monkeypatch, tmp_path):
+    """scan_code returns packages and SASTResult when Semgrep finds issues."""
+    monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
+    monkeypatch.setattr("agent_bom.sast._get_semgrep_version", lambda: "1.50.0")
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1  # findings found
+    mock_result.stdout = json.dumps(SAMPLE_SARIF)
+    monkeypatch.setattr("agent_bom.sast.subprocess.run", MagicMock(return_value=mock_result))
+
+    packages, sast_result = scan_code(str(tmp_path))
+
+    assert len(packages) == 2
+    assert sast_result.total_findings == 2
+    assert sast_result.files_scanned == 2
+    assert sast_result.semgrep_version == "1.50.0"
+    assert sast_result.config_used == "auto"
+
+    # Verify packages have correct ecosystem
+    for pkg in packages:
+        assert pkg.ecosystem == "sast"
+        assert pkg.version == "0.0.0"
+        assert len(pkg.vulnerabilities) > 0
+
+
+def test_scan_code_clean(monkeypatch, tmp_path):
+    """scan_code with no findings returns empty packages."""
+    monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
+    monkeypatch.setattr("agent_bom.sast._get_semgrep_version", lambda: "1.50.0")
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0  # clean, no findings
+    mock_result.stdout = json.dumps(EMPTY_SARIF)
+    monkeypatch.setattr("agent_bom.sast.subprocess.run", MagicMock(return_value=mock_result))
+
+    packages, sast_result = scan_code(str(tmp_path))
+
+    assert packages == []
+    assert sast_result.total_findings == 0
+
+
+# ── CWE mapping ────────────────────────────────────────────────────────────
+
+
+def test_sast_cwe_map_has_common_weaknesses():
+    """SAST_CWE_MAP covers common OWASP Top 10 weakness types."""
+    from agent_bom.constants import SAST_CWE_MAP
+
+    assert "CWE-89" in SAST_CWE_MAP  # SQL injection
+    assert "CWE-79" in SAST_CWE_MAP  # XSS
+    assert "CWE-798" in SAST_CWE_MAP  # hardcoded creds
+    assert "CWE-78" in SAST_CWE_MAP  # OS command injection
+    assert "CWE-22" in SAST_CWE_MAP  # path traversal
+
+
+def test_sast_cwe_map_frameworks():
+    """CWE mappings include expected framework keys."""
+    from agent_bom.constants import SAST_CWE_MAP
+
+    sql_inj = SAST_CWE_MAP["CWE-89"]
+    assert "iso_27001" in sql_inj
+    assert "nist_csf" in sql_inj
+    assert "owasp_llm" in sql_inj
+
+    hardcoded = SAST_CWE_MAP["CWE-798"]
+    assert "soc2" in hardcoded
+    assert "owasp_llm" in hardcoded
+
+
+# ── OSV skip guard ─────────────────────────────────────────────────────────
+
+
+def test_sast_packages_skip_osv():
+    """Packages with ecosystem='sast' should be excluded from scannable list."""
+    from agent_bom.models import Package
+
+    packages = [
+        Package(name="express", version="4.18.2", ecosystem="npm"),
+        Package(name="src/utils.py", version="0.0.0", ecosystem="sast"),
+        Package(name="flask", version="3.0.0", ecosystem="pypi"),
+    ]
+
+    # Replicate the guard from scanners/__init__.py
+    scannable = [p for p in packages if p.version not in ("unknown", "latest") and p.ecosystem != "sast"]
+    assert len(scannable) == 2
+    assert all(p.ecosystem != "sast" for p in scannable)
+
+
+# ── Compliance tagging with CWE ────────────────────────────────────────────
+
+
+def test_iso_27001_sast_cwe_tagging():
+    """ISO 27001 tagger adds A.8.28 for SAST findings with CWE-89."""
+    from agent_bom.iso_27001 import tag_blast_radius
+    from agent_bom.models import BlastRadius, Package, Vulnerability
+
+    br = BlastRadius(
+        vulnerability=Vulnerability(
+            id="python.lang.security.audit.sql-injection",
+            summary="SQL injection detected",
+            severity=Severity.HIGH,
+            cwe_ids=["CWE-89"],
+        ),
+        package=Package(name="src/db.py", version="0.0.0", ecosystem="sast"),
+        affected_servers=[],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+    tags = tag_blast_radius(br)
+    assert "A.8.28" in tags  # CWE-89 → A.8.28 (secure coding)
+
+
+def test_owasp_llm_sast_cwe_tagging():
+    """OWASP LLM tagger adds LLM02 for SAST findings with CWE-78."""
+    from agent_bom.models import BlastRadius, Package, Vulnerability
+    from agent_bom.owasp import tag_blast_radius
+
+    br = BlastRadius(
+        vulnerability=Vulnerability(
+            id="python.lang.security.audit.os-command-injection",
+            summary="OS command injection",
+            severity=Severity.HIGH,
+            cwe_ids=["CWE-78"],
+        ),
+        package=Package(name="src/shell.py", version="0.0.0", ecosystem="sast"),
+        affected_servers=[],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+    tags = tag_blast_radius(br)
+    assert "LLM02" in tags  # CWE-78 → LLM02 (insecure output handling)
+
+
+# ── CLI integration ────────────────────────────────────────────────────────
+
+
+def test_cli_code_flag():
+    """--code flag appears in CLI help."""
+    from click.testing import CliRunner
+
+    from agent_bom.cli import scan as scan_cmd
+
+    runner = CliRunner()
+    result = runner.invoke(scan_cmd, ["--help"])
+    assert "--code" in result.output
+    assert "--sast-config" in result.output
+    assert "SAST" in result.output or "Semgrep" in result.output


### PR DESCRIPTION
## Summary
- Adds static application security testing (SAST) by wrapping Semgrep via subprocess, following the same pattern as Grype for container scanning
- New `sast.py` module parses Semgrep SARIF output into `SASTFinding`/`SASTResult` dataclasses, converts findings to synthetic `Package(ecosystem="sast")` objects that flow through the existing BlastRadius pipeline
- CLI gets `--code PATH` (repeatable) and `--sast-config` options; MCP server gets `code_scan` tool (#16)
- CWE-based compliance mapping: 10 common CWEs (SQL injection, XSS, hardcoded creds, SSRF, etc.) routed to tags in 5 compliance frameworks (OWASP LLM, ISO 27001, NIST CSF, SOC 2, CIS Controls)
- OSV skip guard ensures SAST packages bypass vulnerability database queries (they already carry findings from Semgrep)

## Test plan
- [x] 22 new tests in `tests/test_sast.py` — SARIF parsing, error handling, CWE mapping, compliance tagging, CLI integration
- [x] Full suite passes (2,647 passed, 13 skipped)
- [x] ruff + ruff-format clean
- [ ] Manual: `pip install semgrep && agent-bom scan --code src/` to verify end-to-end