### PR TITLE
fix: Phase 2 hardening — config centralization, HMAC fix, inventory ingestion

### DIFF
--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -33,6 +33,9 @@ from typing import TYPE_CHECKING, Optional
 import httpx
 from rich.console import Console
 
+from agent_bom.config import AI_CACHE_MAX_ENTRIES as _MAX_AI_CACHE
+from agent_bom.config import OLLAMA_BASE_URL
+
 if TYPE_CHECKING:
     from agent_bom.ai_schemas import MCPConfigSecurityAnalysis
     from agent_bom.models import AIBOMReport, BlastRadius
@@ -43,7 +46,6 @@ console = Console(stderr=True)
 logger = logging.getLogger(__name__)
 
 # Simple in-memory cache: hash(prompt) -> response (bounded)
-_MAX_AI_CACHE = 1_000
 _cache: dict[str, str] = {}
 
 
@@ -56,7 +58,6 @@ def _ai_cache_put(key: str, value: str) -> None:
 
 
 DEFAULT_MODEL = "openai/gpt-4o-mini"
-OLLAMA_BASE_URL = "http://localhost:11434"
 OLLAMA_DEFAULT_MODEL = "llama3.2"
 HF_DEFAULT_MODEL = "meta-llama/Llama-3.1-8B-Instruct"
 
@@ -112,7 +113,7 @@ def _get_ollama_models() -> list[str]:
         if resp.status_code == 200:
             data = resp.json()
             return [m["name"] for m in data.get("models", [])]
-    except Exception:
+    except (httpx.HTTPError, ValueError, KeyError):
         pass
     return []
 
@@ -363,7 +364,7 @@ async def _call_ollama_structured(
     if key in _cache:
         try:
             return schema_cls.model_validate_json(_cache[key])
-        except Exception:
+        except (json.JSONDecodeError, ValueError, AttributeError):
             pass
 
     try:
@@ -418,14 +419,14 @@ async def _call_llm_structured(
         # Try direct JSON parse
         try:
             return schema_cls.model_validate_json(raw)
-        except Exception:
+        except (json.JSONDecodeError, ValueError):
             pass
         # Try extracting from markdown/braces
         parsed = _parse_json_response(raw)
         if parsed:
             try:
                 return schema_cls.model_validate(parsed)
-            except Exception:
+            except (ValueError, TypeError):
                 pass
     return None
 

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -27,10 +27,21 @@ from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
-_HMAC_DEFAULT = "agent-bom-default-audit-key"
-_HMAC_KEY = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY", _HMAC_DEFAULT).encode()
-if os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") is None:
-    logger.warning("AGENT_BOM_AUDIT_HMAC_KEY not set — audit log HMAC uses default key (not tamper-proof in production)")
+# HMAC key for audit log tamper detection.  When unset, an ephemeral
+# per-process key is generated — signatures verify within the same process
+# but provide no cross-restart integrity.  Production deployments MUST set
+# AGENT_BOM_AUDIT_HMAC_KEY for meaningful tamper detection.
+_HMAC_ENV_KEY = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY")
+if _HMAC_ENV_KEY is not None:
+    _HMAC_KEY = _HMAC_ENV_KEY.encode()
+else:
+    import secrets as _secrets
+
+    _HMAC_KEY = _secrets.token_bytes(32)
+    logger.warning(
+        "AGENT_BOM_AUDIT_HMAC_KEY not set — audit log HMAC uses ephemeral key "
+        "(signatures will not survive process restart; set env var for production)"
+    )
 
 
 @dataclass

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -44,6 +44,9 @@ from enum import Enum
 from typing import Any
 
 from agent_bom import __version__
+from agent_bom.config import API_JOB_TTL_SECONDS as _JOB_TTL_SECONDS
+from agent_bom.config import API_MAX_CONCURRENT_JOBS as _MAX_CONCURRENT_JOBS
+from agent_bom.config import API_MAX_IN_MEMORY_JOBS as _MAX_IN_MEMORY_JOBS
 from agent_bom.security import sanitize_error
 
 _logger = logging.getLogger(__name__)
@@ -389,11 +392,6 @@ class MaxBodySizeMiddleware(BaseHTTPMiddleware):
                     content={"detail": f"Request body too large (max {self._max_bytes // (1024 * 1024)}MB)"},
                 )
         return await call_next(request)
-
-
-_MAX_CONCURRENT_JOBS = 10
-_JOB_TTL_SECONDS = 3600  # 1 hour
-_MAX_IN_MEMORY_JOBS = 200  # Bounded eviction ceiling for _jobs dict
 
 
 def configure_api(

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -77,6 +77,75 @@ def _make_console(quiet: bool = False, output_format: str = "console", no_color:
     return Console(no_color=no_color)
 
 
+def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list:
+    """Build Agent objects from parsed inventory dict (JSON or CSV)."""
+    from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+
+    agents = []
+    for agent_data in inventory_data.get("agents", []):
+        mcp_servers = []
+        for server_data in agent_data.get("mcp_servers", []):
+            # Parse pre-populated tools (e.g. from Snowflake/cloud inventory)
+            tools = []
+            for tool_data in server_data.get("tools", []):
+                if isinstance(tool_data, str):
+                    tools.append(MCPTool(name=tool_data, description=""))
+                elif isinstance(tool_data, dict):
+                    tools.append(
+                        MCPTool(
+                            name=tool_data.get("name", ""),
+                            description=tool_data.get("description", ""),
+                            input_schema=tool_data.get("input_schema"),
+                        )
+                    )
+
+            # Parse pre-known packages (e.g. from cloud asset scan)
+            packages = []
+            for pkg_data in server_data.get("packages", []):
+                if isinstance(pkg_data, str):
+                    if "@" in pkg_data:
+                        name, version = pkg_data.rsplit("@", 1)
+                    else:
+                        name, version = pkg_data, "unknown"
+                    packages.append(Package(name=name, version=version, ecosystem="unknown"))
+                elif isinstance(pkg_data, dict):
+                    packages.append(
+                        Package(
+                            name=pkg_data.get("name", ""),
+                            version=pkg_data.get("version", "unknown"),
+                            ecosystem=pkg_data.get("ecosystem", "unknown"),
+                            purl=pkg_data.get("purl"),
+                        )
+                    )
+
+            server = MCPServer(
+                name=server_data.get("name", ""),
+                command=server_data.get("command", ""),
+                args=server_data.get("args", []),
+                env=sanitize_env_vars(server_data.get("env", {})),
+                transport=TransportType(server_data.get("transport", "stdio")),
+                url=server_data.get("url"),
+                config_path=agent_data.get("config_path"),
+                working_dir=server_data.get("working_dir"),
+                mcp_version=server_data.get("mcp_version"),
+                tools=tools,
+                packages=packages,
+            )
+            mcp_servers.append(server)
+
+        agent = Agent(
+            name=agent_data.get("name", "unknown"),
+            agent_type=AgentType(agent_data.get("agent_type", agent_data.get("type", "custom"))),
+            config_path=agent_data.get("config_path", source_path),
+            mcp_servers=mcp_servers,
+            version=agent_data.get("version"),
+            source=agent_data.get("source", inventory_data.get("source")),
+        )
+        agents.append(agent)
+
+    return agents
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="agent-bom", message="agent-bom %(version)s")
 def main():
@@ -102,7 +171,7 @@ def main():
 @main.command()
 @click.option("--project", "-p", type=click.Path(exists=True), help="Project directory to scan")
 @click.option("--config-dir", type=click.Path(exists=True), help="Custom agent config directory to scan")
-@click.option("--inventory", type=click.Path(exists=True), help="Manual inventory JSON file")
+@click.option("--inventory", type=str, default=None, help="Inventory file (JSON or CSV). Use '-' for stdin.")
 @click.option("--output", "-o", type=str, help="Output file path (use '-' for stdout)")
 @click.option(
     "--open", "open_report", is_flag=True, default=False, help="Auto-open HTML/graph-html report in default browser after generation"
@@ -756,74 +825,13 @@ def scan(
         agents = []  # skill-only: no agent discovery
 
     if not skill_only and inventory:
-        con.print(f"\n[bold blue]Loading inventory from {inventory}...[/bold blue]\n")
-        from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
+        label = "stdin" if inventory == "-" else inventory
+        con.print(f"\n[bold blue]Loading inventory from {label}...[/bold blue]\n")
 
-        with open(inventory) as f:
-            inventory_data = json.load(f)
+        from agent_bom.inventory import load_inventory
 
-        agents = []
-        for agent_data in inventory_data.get("agents", []):
-            mcp_servers = []
-            for server_data in agent_data.get("mcp_servers", []):
-                # Parse pre-populated tools (e.g. from Snowflake/cloud inventory)
-                tools = []
-                for tool_data in server_data.get("tools", []):
-                    if isinstance(tool_data, str):
-                        tools.append(MCPTool(name=tool_data, description=""))
-                    elif isinstance(tool_data, dict):
-                        tools.append(
-                            MCPTool(
-                                name=tool_data.get("name", ""),
-                                description=tool_data.get("description", ""),
-                                input_schema=tool_data.get("input_schema"),
-                            )
-                        )
-
-                # Parse pre-known packages (e.g. from cloud asset scan)
-                packages = []
-                for pkg_data in server_data.get("packages", []):
-                    if isinstance(pkg_data, str):
-                        # Accept "name@version" shorthand
-                        if "@" in pkg_data:
-                            name, version = pkg_data.rsplit("@", 1)
-                        else:
-                            name, version = pkg_data, "unknown"
-                        packages.append(Package(name=name, version=version, ecosystem="unknown"))
-                    elif isinstance(pkg_data, dict):
-                        packages.append(
-                            Package(
-                                name=pkg_data.get("name", ""),
-                                version=pkg_data.get("version", "unknown"),
-                                ecosystem=pkg_data.get("ecosystem", "unknown"),
-                                purl=pkg_data.get("purl"),
-                            )
-                        )
-
-                server = MCPServer(
-                    name=server_data.get("name", ""),
-                    command=server_data.get("command", ""),
-                    args=server_data.get("args", []),
-                    env=sanitize_env_vars(server_data.get("env", {})),
-                    transport=TransportType(server_data.get("transport", "stdio")),
-                    url=server_data.get("url"),
-                    config_path=agent_data.get("config_path"),
-                    working_dir=server_data.get("working_dir"),
-                    mcp_version=server_data.get("mcp_version"),
-                    tools=tools,
-                    packages=packages,
-                )
-                mcp_servers.append(server)
-
-            agent = Agent(
-                name=agent_data.get("name", "unknown"),
-                agent_type=AgentType(agent_data.get("agent_type", agent_data.get("type", "custom"))),
-                config_path=agent_data.get("config_path", inventory),
-                mcp_servers=mcp_servers,
-                version=agent_data.get("version"),
-                source=agent_data.get("source", inventory_data.get("source")),
-            )
-            agents.append(agent)
+        inventory_data = load_inventory(inventory)
+        agents = _build_agents_from_inventory(inventory_data, inventory)
 
         con.print(f"  [green]✓[/green] Loaded {len(agents)} agent(s) from inventory")
     elif not skill_only and config_dir:

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -35,6 +35,11 @@ def _int(env_key: str, default: int) -> int:
         return default
 
 
+def _str(env_key: str, default: str) -> str:
+    """Read a string from *env_key*, falling back to *default*."""
+    return os.environ.get(env_key, default)
+
+
 # ── EPSS Thresholds ─────────────────────────────────────────────────────────
 # EPSS (Exploit Prediction Scoring System) probability thresholds.
 # Source: https://www.first.org/epss/
@@ -128,3 +133,70 @@ SERVER_RISK_REGISTRY_MEDIUM_FLOOR = _float("AGENT_BOM_SERVER_REG_MEDIUM", 3.0)
 SERVER_RISK_CRITICAL_THRESHOLD = _float("AGENT_BOM_SERVER_CRITICAL", 9.0)
 SERVER_RISK_HIGH_THRESHOLD = _float("AGENT_BOM_SERVER_HIGH", 7.0)
 SERVER_RISK_MEDIUM_THRESHOLD = _float("AGENT_BOM_SERVER_MEDIUM", 4.0)
+
+
+# ── HTTP Client ───────────────────────────────────────────────────────────
+# Used by http_client.create_client() and request_with_retry().
+#
+# Defaults: 3 retries with 1s initial backoff (doubles each retry, capped
+# at 30s).  30s per-request timeout covers most external APIs; NVD can be
+# slow so operators may raise this.
+
+HTTP_MAX_RETRIES = _int("AGENT_BOM_HTTP_MAX_RETRIES", 3)
+HTTP_INITIAL_BACKOFF = _float("AGENT_BOM_HTTP_INITIAL_BACKOFF", 1.0)
+HTTP_MAX_BACKOFF = _float("AGENT_BOM_HTTP_MAX_BACKOFF", 30.0)
+HTTP_DEFAULT_TIMEOUT = _float("AGENT_BOM_HTTP_DEFAULT_TIMEOUT", 30.0)
+
+
+# ── Scanner Batching ──────────────────────────────────────────────────────
+# Used by scanners/__init__.py for OSV batch API concurrency.
+#
+# 10 concurrent requests with 500ms delay between batches keeps us well
+# under OSV.dev's rate limit while still being fast for large inventories.
+
+SCANNER_MAX_CONCURRENT = _int("AGENT_BOM_SCANNER_MAX_CONCURRENT", 10)
+SCANNER_BATCH_DELAY = _float("AGENT_BOM_SCANNER_BATCH_DELAY", 0.5)
+
+
+# ── AI Enrichment ─────────────────────────────────────────────────────────
+# Used by ai_enrich.py for LLM-powered risk narratives.
+#
+# Cache bounded at 1,000 entries (sha256 keyed) to prevent unbounded memory
+# growth during large scans.  Ollama default URL assumes local Docker/native
+# install.
+
+AI_CACHE_MAX_ENTRIES = _int("AGENT_BOM_AI_CACHE_MAX", 1_000)
+OLLAMA_BASE_URL = _str("AGENT_BOM_OLLAMA_URL", "http://localhost:11434")
+
+
+# ── Enrichment Cache ──────────────────────────────────────────────────────
+# Used by enrichment.py for persistent NVD + EPSS disk cache.
+#
+# 7-day TTL balances freshness vs. API rate limits.  10,000 entries covers
+# most enterprise scans without unbounded disk/memory growth.
+
+ENRICHMENT_TTL_SECONDS = _int("AGENT_BOM_ENRICHMENT_TTL", 604_800)
+ENRICHMENT_MAX_CACHE_ENTRIES = _int("AGENT_BOM_ENRICHMENT_MAX_CACHE", 10_000)
+
+
+# ── API Server Limits ─────────────────────────────────────────────────────
+# Used by api/server.py for the REST API job queue.
+#
+# 10 concurrent scan jobs prevents resource exhaustion on shared hosts.
+# 1-hour TTL auto-cleans completed jobs.  200 in-memory ceiling triggers
+# LRU eviction for long-running API instances.
+
+API_MAX_CONCURRENT_JOBS = _int("AGENT_BOM_API_MAX_JOBS", 10)
+API_JOB_TTL_SECONDS = _int("AGENT_BOM_API_JOB_TTL", 3_600)
+API_MAX_IN_MEMORY_JOBS = _int("AGENT_BOM_API_MAX_MEMORY_JOBS", 200)
+
+
+# ── MCP Server Limits ────────────────────────────────────────────────────
+# Used by mcp_server.py for file-size and response-size guards.
+#
+# 50 MB max file size prevents accidental ingestion of large binaries.
+# 500,000 char response cap keeps MCP tool responses within typical
+# LLM context windows.
+
+MCP_MAX_FILE_SIZE = _int("AGENT_BOM_MCP_MAX_FILE_SIZE", 50 * 1024 * 1024)
+MCP_MAX_RESPONSE_CHARS = _int("AGENT_BOM_MCP_MAX_RESPONSE", 500_000)

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -373,7 +373,7 @@ def parse_codex_config(config_path: str) -> list[MCPServer]:
     """
     try:
         data = toml.load(config_path)
-    except Exception:
+    except Exception:  # noqa: BLE001 — toml libraries raise varied error types
         return []
 
     mcp_section = data.get("mcp_servers", {})
@@ -426,7 +426,7 @@ def parse_goose_config(config_path: str) -> list[MCPServer]:
     try:
         with open(config_path) as f:
             data = yaml.safe_load(f)
-    except Exception:
+    except (OSError, ValueError):
         return []
 
     if not isinstance(data, dict):
@@ -479,7 +479,7 @@ def parse_snowflake_connections(config_path: str) -> list[MCPServer]:
     """
     try:
         data = toml.load(config_path)
-    except Exception:
+    except Exception:  # noqa: BLE001 — toml libraries raise varied error types
         return []
 
     if not isinstance(data, dict):
@@ -532,7 +532,7 @@ def parse_cortex_code_metadata(config_path: str) -> dict:
     try:
         with open(config_path) as f:
             data = json.load(f)
-    except Exception:
+    except (json.JSONDecodeError, OSError, ValueError):
         return {}
 
     if not isinstance(data, dict):
@@ -775,7 +775,7 @@ def _parse_docker_mcp_catalog(
 
     try:
         catalog_data = yaml.safe_load(catalog_path.read_text())
-    except Exception:
+    except (OSError, ValueError):
         return []
 
     registry = catalog_data.get("registry", {})
@@ -852,7 +852,7 @@ def discover_docker_mcp() -> Optional[Agent]:
 
     try:
         registry_data = yaml.safe_load(registry_path.read_text())
-    except Exception:
+    except (OSError, ValueError):
         return None
 
     if not registry_data or not isinstance(registry_data, dict):
@@ -937,7 +937,7 @@ def discover_compose_mcp_servers(project_dir: Optional[str] = None) -> Optional[
 
     try:
         compose_data = yaml.safe_load(compose_path.read_text())
-    except Exception:
+    except (OSError, ValueError):
         return None
 
     if not compose_data or not isinstance(compose_data, dict):

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -13,6 +13,8 @@ from typing import Optional
 import httpx
 from rich.console import Console
 
+from agent_bom.config import ENRICHMENT_MAX_CACHE_ENTRIES as _MAX_ENRICHMENT_CACHE_ENTRIES
+from agent_bom.config import ENRICHMENT_TTL_SECONDS as _ENRICHMENT_TTL
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Vulnerability
 
@@ -31,13 +33,11 @@ _kev_cache_time: Optional[datetime] = None
 # ─── Persistent enrichment cache (NVD + EPSS) ──────────────────────────────
 
 _ENRICHMENT_CACHE_DIR = Path.home() / ".agent-bom"
-_ENRICHMENT_TTL = 604_800  # 7 days
 
 # Module-level in-memory mirrors (loaded lazily from disk)
 _nvd_file_cache: dict[str, dict] = {}
 _epss_file_cache: dict[str, dict] = {}
 _enrichment_cache_loaded = False
-_MAX_ENRICHMENT_CACHE_ENTRIES = 10_000  # Prevent unbounded memory growth
 
 
 def _evict_oldest(cache: dict[str, dict], max_entries: int) -> None:
@@ -70,7 +70,7 @@ def _load_enrichment_cache() -> None:
                 _nvd_file_cache.update(fresh)
             else:
                 _epss_file_cache.update(fresh)
-        except Exception:  # noqa: BLE001
+        except (OSError, json.JSONDecodeError, ValueError):
             _logger.debug("Failed to load enrichment cache %s", name)
 
 
@@ -80,7 +80,7 @@ def _save_enrichment_cache() -> None:
     for name, data in [("nvd_cache.json", _nvd_file_cache), ("epss_cache.json", _epss_file_cache)]:
         try:
             (_ENRICHMENT_CACHE_DIR / name).write_text(json.dumps(data))
-        except Exception:  # noqa: BLE001
+        except OSError:
             _logger.debug("Failed to save %s cache", name)
 
 

--- a/src/agent_bom/http_client.py
+++ b/src/agent_bom/http_client.py
@@ -8,12 +8,18 @@ from typing import Any, Optional
 
 import httpx
 
+from agent_bom.config import (
+    HTTP_INITIAL_BACKOFF as INITIAL_BACKOFF,
+)
+from agent_bom.config import (
+    HTTP_MAX_BACKOFF as MAX_BACKOFF,
+)
+from agent_bom.config import (
+    HTTP_MAX_RETRIES as MAX_RETRIES,
+)
+
 logger = logging.getLogger(__name__)
 
-# Retry configuration
-MAX_RETRIES = 3
-INITIAL_BACKOFF = 1.0  # seconds
-MAX_BACKOFF = 30.0
 RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
 
@@ -47,11 +53,11 @@ def _safe_url(url: str) -> str:  # noqa: PLW0108
             )
         )
         return _sanitize_for_log(safe)
-    except Exception:
+    except (ValueError, AttributeError):
         return "<redacted-url>"
 
 
-def create_client(timeout: float = 30.0, max_redirects: int = 5) -> httpx.AsyncClient:
+def create_client(timeout: float | None = None, max_redirects: int = 5) -> httpx.AsyncClient:
     """Create an httpx.AsyncClient with connection-level retries.
 
     Uses httpx's built-in transport retry for connection failures (DNS, TCP reset).
@@ -61,6 +67,10 @@ def create_client(timeout: float = 30.0, max_redirects: int = 5) -> httpx.AsyncC
         timeout: Per-request timeout in seconds.
         max_redirects: Maximum number of HTTP redirects to follow (default 5).
     """
+    from agent_bom.config import HTTP_DEFAULT_TIMEOUT
+
+    if timeout is None:
+        timeout = HTTP_DEFAULT_TIMEOUT
     transport = httpx.AsyncHTTPTransport(retries=2)
     return httpx.AsyncClient(
         timeout=timeout,

--- a/src/agent_bom/inventory.py
+++ b/src/agent_bom/inventory.py
@@ -1,0 +1,181 @@
+"""Enterprise inventory ingestion — JSON and CSV formats, stdin support.
+
+Supports:
+- **JSON**: Full inventory schema (``agents[]`` → ``mcp_servers[]`` → ``packages[]``)
+- **CSV**:  Flat format for CMDB/spreadsheet export
+- **Stdin**: ``--inventory -`` reads from stdin (auto-detects JSON vs CSV)
+
+CSV format (required columns: ``name``, ``version``, ``ecosystem``)::
+
+    name,version,ecosystem,server_name,agent_name,env_keys
+    langchain,0.1.0,pypi,ai-server,prod-agent,OPENAI_API_KEY;SLACK_TOKEN
+    express,4.18.2,npm,api-server,prod-agent,
+    fastapi,0.104.0,pypi,ai-server,prod-agent,
+
+Minimal 3-column CSV also works::
+
+    name,version,ecosystem
+    langchain,0.1.0,pypi
+    fastapi,0.104.0,pypi
+
+Usage::
+
+    from agent_bom.inventory import load_inventory
+
+    data = load_inventory("fleet.csv")       # CSV file
+    data = load_inventory("inventory.json")  # JSON file
+    data = load_inventory("-")               # stdin (auto-detect)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import sys
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+# Required CSV columns for package scanning.
+_CSV_REQUIRED_COLUMNS = frozenset({"name", "version", "ecosystem"})
+
+
+def load_inventory(source: str) -> dict:
+    """Load inventory from a file path or stdin (``-``).
+
+    Auto-detects JSON vs CSV:
+    - ``.csv`` extension → CSV parser
+    - stdin: first non-whitespace char ``{`` or ``[`` → JSON, else CSV
+    - everything else → JSON
+
+    Returns:
+        Dictionary matching the inventory schema (``{"agents": [...]}``)
+
+    Raises:
+        FileNotFoundError: If *source* is a path that does not exist.
+        ValueError: If the file is empty or has missing required columns.
+    """
+    if source == "-":
+        return _load_from_stdin()
+
+    from pathlib import Path
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"Inventory file not found: {source}")
+
+    if path.suffix.lower() == ".csv":
+        with open(path, newline="", encoding="utf-8") as fp:
+            return _load_csv_inventory(fp)
+
+    with open(path, encoding="utf-8") as fp:
+        return _load_json_inventory(fp)
+
+
+def _load_from_stdin() -> dict:
+    """Read inventory from stdin, auto-detecting format."""
+    content = sys.stdin.read()
+    if not content.strip():
+        raise ValueError("Empty input on stdin")
+
+    fmt = _detect_format(content)
+    if fmt == "json":
+        return json.loads(content)
+
+    return _load_csv_inventory(io.StringIO(content))
+
+
+def _detect_format(content: str) -> str:
+    """Detect whether *content* is JSON or CSV based on first non-whitespace character."""
+    stripped = content.lstrip()
+    if stripped and stripped[0] in ("{", "["):
+        return "json"
+    return "csv"
+
+
+def _load_json_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
+    """Parse JSON inventory from a file-like object."""
+    return json.load(fp)
+
+
+def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
+    """Parse CSV inventory into the standard inventory schema.
+
+    Groups rows by ``(agent_name, server_name)`` to build the full
+    ``agents[] → mcp_servers[] → packages[]`` hierarchy.
+    """
+    reader = csv.DictReader(fp)
+
+    if not reader.fieldnames:
+        raise ValueError("CSV file is empty or has no header row")
+
+    # Normalise header names (strip whitespace, lowercase for matching).
+    # Maps lowercase-stripped → raw fieldname as DictReader uses it.
+    normalised = {h.strip().lower(): h for h in reader.fieldnames}
+    missing = _CSV_REQUIRED_COLUMNS - set(normalised)
+    if missing:
+        raise ValueError(f"CSV missing required columns: {', '.join(sorted(missing))}")
+
+    # Map normalised names back to actual header strings for DictReader access
+    col_name = normalised["name"]
+    col_version = normalised["version"]
+    col_ecosystem = normalised["ecosystem"]
+    col_server = normalised.get("server_name", "")
+    col_agent = normalised.get("agent_name", "")
+    col_env = normalised.get("env_keys", "")
+
+    # Group rows by (agent, server)
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for row in reader:
+        agent = (row.get(col_agent) or "").strip() or "inventory-agent"
+        server = (row.get(col_server) or "").strip() or "inventory-server"
+        groups[(agent, server)].append(row)
+
+    # Build inventory structure
+    agents_by_name: dict[str, dict] = {}
+    for (agent_name, server_name), rows in groups.items():
+        packages = []
+        env: dict[str, str] = {}
+        for row in rows:
+            name = (row.get(col_name) or "").strip()
+            version = (row.get(col_version) or "").strip()
+            ecosystem = (row.get(col_ecosystem) or "").strip()
+            if not name or not version:
+                continue
+            packages.append(
+                {
+                    "name": name,
+                    "version": version,
+                    "ecosystem": ecosystem or "unknown",
+                }
+            )
+            # Parse semicolon-separated env key names (values always redacted)
+            if col_env:
+                for key in (row.get(col_env) or "").split(";"):
+                    key = key.strip()
+                    if key:
+                        env[key] = "REDACTED"
+
+        if not packages:
+            continue
+
+        server_def = {
+            "name": server_name,
+            "packages": packages,
+            "env": env,
+        }
+
+        if agent_name not in agents_by_name:
+            agents_by_name[agent_name] = {
+                "name": agent_name,
+                "agent_type": "custom",
+                "mcp_servers": [],
+            }
+        agents_by_name[agent_name]["mcp_servers"].append(server_def)
+
+    if not agents_by_name:
+        raise ValueError("CSV produced no valid inventory entries (check name/version columns)")
+
+    return {"agents": list(agents_by_name.values())}

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -39,12 +39,11 @@ from typing import Annotated, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from agent_bom.config import MCP_MAX_FILE_SIZE as _MAX_FILE_SIZE
+from agent_bom.config import MCP_MAX_RESPONSE_CHARS as _MAX_RESPONSE_CHARS
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
-
-# Maximum file size for SBOM/skill file reads (50 MB)
-_MAX_FILE_SIZE = 50 * 1024 * 1024
 
 # ---------------------------------------------------------------------------
 # Input validation helpers
@@ -54,10 +53,6 @@ _VALID_ECOSYSTEMS = frozenset({"npm", "pypi", "go", "cargo", "maven", "nuget", "
 
 _CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
 _GHSA_RE = re.compile(r"^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$", re.IGNORECASE)
-
-# Max chars in a tool response — prevents multi-MB payloads from overwhelming
-# MCP clients with limited context windows.
-_MAX_RESPONSE_CHARS = 500_000
 
 
 def _validate_ecosystem(ecosystem: str) -> str:

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -13,6 +13,8 @@ import hashlib
 import logging
 import platform
 
+import httpx
+
 logger = logging.getLogger(__name__)
 
 
@@ -70,7 +72,7 @@ async def _push_async(push_url: str, results: dict, api_key: str | None = None) 
                 return True
             logger.warning("Push failed: HTTP %d — %s", resp.status_code, resp.text[:200])
             return False
-        except Exception:
+        except (httpx.HTTPError, ValueError, OSError):
             logger.exception("Push to %s failed", push_url)
             return False
 

--- a/src/agent_bom/registry.py
+++ b/src/agent_bom/registry.py
@@ -44,7 +44,7 @@ def _load_registry() -> dict:
     """Load the bundled MCP registry JSON."""
     try:
         return json.loads(_REGISTRY_PATH.read_text()).get("servers", {})
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         return {}
 
 
@@ -52,7 +52,7 @@ def _load_registry_full() -> dict:
     """Load the full registry JSON (including metadata keys)."""
     try:
         return json.loads(_REGISTRY_PATH.read_text())
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         return {"servers": {}}
 
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -13,11 +13,17 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from agent_bom.atlas import tag_blast_radius as tag_atlas_techniques
 from agent_bom.cis_controls import tag_blast_radius as tag_cis_controls
+from agent_bom.config import (
+    SCANNER_BATCH_DELAY as BATCH_DELAY_SECONDS,
+)
+from agent_bom.config import (
+    SCANNER_MAX_CONCURRENT as MAX_CONCURRENT_REQUESTS,
+)
 
 # Single source of truth for AI/ML package catalog — imported from constants.
 # Vulnerabilities in these carry elevated risk because they run inside AI
 # agents that have credentials and tool access.
-from agent_bom.constants import AI_PACKAGES as _AI_FRAMEWORK_PACKAGES  # noqa: E402
+from agent_bom.constants import AI_PACKAGES as _AI_FRAMEWORK_PACKAGES
 from agent_bom.eu_ai_act import tag_blast_radius as tag_eu_ai_act
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.iso_27001 import tag_blast_radius as tag_iso_27001
@@ -46,10 +52,6 @@ ECOSYSTEM_MAP = {
     "nuget": "NuGet",
     "rubygems": "RubyGems",
 }
-
-# Rate limiting: max concurrent API requests + delay between batches
-MAX_CONCURRENT_REQUESTS = 10
-BATCH_DELAY_SECONDS = 0.5  # 500ms between OSV batch calls
 
 
 def _get_api_semaphore() -> asyncio.Semaphore:

--- a/src/agent_bom/smithery.py
+++ b/src/agent_bom/smithery.py
@@ -99,8 +99,11 @@ async def search_smithery(
 
     async with create_client(timeout=15.0) as client:
         resp = await request_with_retry(
-            client, "GET", f"{_API_BASE}/servers",
-            headers=headers, params=params,
+            client,
+            "GET",
+            f"{_API_BASE}/servers",
+            headers=headers,
+            params=params,
         )
 
         if resp is None:
@@ -113,16 +116,18 @@ async def search_smithery(
         data = resp.json()
         servers = []
         for s in data.get("servers", []):
-            servers.append(SmitheryServer(
-                qualified_name=s.get("qualifiedName", ""),
-                display_name=s.get("displayName", ""),
-                description=s.get("description", ""),
-                verified=s.get("verified", False),
-                use_count=s.get("useCount", 0),
-                remote=s.get("remote", False),
-                is_deployed=s.get("isDeployed", False),
-                homepage=s.get("homepage", ""),
-            ))
+            servers.append(
+                SmitheryServer(
+                    qualified_name=s.get("qualifiedName", ""),
+                    display_name=s.get("displayName", ""),
+                    description=s.get("description", ""),
+                    verified=s.get("verified", False),
+                    use_count=s.get("useCount", 0),
+                    remote=s.get("remote", False),
+                    is_deployed=s.get("isDeployed", False),
+                    homepage=s.get("homepage", ""),
+                )
+            )
 
         pagination = data.get("pagination", {})
         return SmitherySearchResult(
@@ -158,7 +163,9 @@ async def get_smithery_server(
 
     async with create_client(timeout=15.0) as client:
         resp = await request_with_retry(
-            client, "GET", f"{_REGISTRY_BASE}/servers/{qualified_name}",
+            client,
+            "GET",
+            f"{_REGISTRY_BASE}/servers/{qualified_name}",
             headers=headers,
         )
 
@@ -225,23 +232,27 @@ async def smithery_lookup(
 
     logger.info(
         "Smithery: resolved %s → %s (verified=%s, uses=%d)",
-        server.name, best.display_name, best.verified, best.use_count,
+        server.name,
+        best.display_name,
+        best.verified,
+        best.use_count,
     )
 
-    return [Package(
-        name=best.qualified_name,
-        version="latest",
-        ecosystem="smithery",
-        purl=f"pkg:smithery/{best.qualified_name}",
-        is_direct=True,
-        resolved_from_registry=True,
-        auto_risk_level=risk_level,
-        auto_risk_justification=(
-            f"Smithery: {'verified' if best.verified else 'unverified'}, "
-            f"{best.use_count} installs"
-            + (", security scan FAILED" if best.security_scan_passed is False else "")
-        ),
-    )]
+    return [
+        Package(
+            name=best.qualified_name,
+            version="latest",
+            ecosystem="smithery",
+            purl=f"pkg:smithery/{best.qualified_name}",
+            is_direct=True,
+            resolved_from_registry=True,
+            auto_risk_level=risk_level,
+            auto_risk_justification=(
+                f"Smithery: {'verified' if best.verified else 'unverified'}, "
+                f"{best.use_count} installs" + (", security scan FAILED" if best.security_scan_passed is False else "")
+            ),
+        )
+    ]
 
 
 def smithery_lookup_sync(
@@ -282,7 +293,7 @@ async def sync_from_smithery(
     # Load local registry
     try:
         local_data = json.loads(_REGISTRY_PATH.read_text())
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         local_data = {"servers": {}}
 
     local_servers = local_data.get("servers", {})
@@ -294,7 +305,9 @@ async def sync_from_smithery(
     async with create_client(timeout=30.0) as client:
         for page in range(1, max_pages + 1):
             resp = await request_with_retry(
-                client, "GET", f"{_API_BASE}/servers",
+                client,
+                "GET",
+                f"{_API_BASE}/servers",
                 headers=headers,
                 params={"page": page, "pageSize": page_size},
             )
@@ -354,14 +367,16 @@ async def sync_from_smithery(
                     local_servers[qn] = entry
 
                 result.added += 1
-                result.details.append({
-                    "server": qn,
-                    "display_name": display,
-                    "verified": verified,
-                    "use_count": use_count,
-                    "risk_level": risk,
-                    "status": "added",
-                })
+                result.details.append(
+                    {
+                        "server": qn,
+                        "display_name": display,
+                        "verified": verified,
+                        "use_count": use_count,
+                        "risk_level": risk,
+                        "status": "added",
+                    }
+                )
 
             pagination = data.get("pagination", {})
             if page >= pagination.get("totalPages", 1):

--- a/tests/test_hardening_phase2.py
+++ b/tests/test_hardening_phase2.py
@@ -1,0 +1,482 @@
+"""Tests for Phase 2 production hardening.
+
+Covers:
+- config.py expansion (15 new constants, _str() helper, env overrides)
+- Audit HMAC ephemeral key (no hardcoded default)
+- Exception narrowing (consumer modules use specific types)
+- inventory.py (JSON, CSV, stdin, auto-detect, error cases)
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import textwrap
+from unittest.mock import patch
+
+import pytest
+
+# ── Config Expansion ────────────────────────────────────────────────────────
+
+
+class TestConfigDefaults:
+    """Verify all 15 new constants have correct defaults."""
+
+    def test_http_max_retries(self):
+        from agent_bom.config import HTTP_MAX_RETRIES
+
+        assert HTTP_MAX_RETRIES == 3
+
+    def test_http_initial_backoff(self):
+        from agent_bom.config import HTTP_INITIAL_BACKOFF
+
+        assert HTTP_INITIAL_BACKOFF == 1.0
+
+    def test_http_max_backoff(self):
+        from agent_bom.config import HTTP_MAX_BACKOFF
+
+        assert HTTP_MAX_BACKOFF == 30.0
+
+    def test_http_default_timeout(self):
+        from agent_bom.config import HTTP_DEFAULT_TIMEOUT
+
+        assert HTTP_DEFAULT_TIMEOUT == 30.0
+
+    def test_scanner_max_concurrent(self):
+        from agent_bom.config import SCANNER_MAX_CONCURRENT
+
+        assert SCANNER_MAX_CONCURRENT == 10
+
+    def test_scanner_batch_delay(self):
+        from agent_bom.config import SCANNER_BATCH_DELAY
+
+        assert SCANNER_BATCH_DELAY == 0.5
+
+    def test_ai_cache_max_entries(self):
+        from agent_bom.config import AI_CACHE_MAX_ENTRIES
+
+        assert AI_CACHE_MAX_ENTRIES == 1_000
+
+    def test_ollama_base_url(self):
+        from agent_bom.config import OLLAMA_BASE_URL
+
+        assert OLLAMA_BASE_URL == "http://localhost:11434"
+
+    def test_enrichment_ttl_seconds(self):
+        from agent_bom.config import ENRICHMENT_TTL_SECONDS
+
+        assert ENRICHMENT_TTL_SECONDS == 604_800
+
+    def test_enrichment_max_cache(self):
+        from agent_bom.config import ENRICHMENT_MAX_CACHE_ENTRIES
+
+        assert ENRICHMENT_MAX_CACHE_ENTRIES == 10_000
+
+    def test_api_max_concurrent_jobs(self):
+        from agent_bom.config import API_MAX_CONCURRENT_JOBS
+
+        assert API_MAX_CONCURRENT_JOBS == 10
+
+    def test_api_job_ttl_seconds(self):
+        from agent_bom.config import API_JOB_TTL_SECONDS
+
+        assert API_JOB_TTL_SECONDS == 3_600
+
+    def test_api_max_in_memory_jobs(self):
+        from agent_bom.config import API_MAX_IN_MEMORY_JOBS
+
+        assert API_MAX_IN_MEMORY_JOBS == 200
+
+    def test_mcp_max_file_size(self):
+        from agent_bom.config import MCP_MAX_FILE_SIZE
+
+        assert MCP_MAX_FILE_SIZE == 50 * 1024 * 1024
+
+    def test_mcp_max_response_chars(self):
+        from agent_bom.config import MCP_MAX_RESPONSE_CHARS
+
+        assert MCP_MAX_RESPONSE_CHARS == 500_000
+
+
+class TestConfigHelpers:
+    """Test _float(), _int(), _str() helpers."""
+
+    def test_str_helper_returns_default(self):
+        from agent_bom.config import _str
+
+        assert _str("AGENT_BOM_TEST_NONEXISTENT_KEY_XYZ", "fallback") == "fallback"
+
+    def test_str_helper_reads_env(self):
+        from agent_bom.config import _str
+
+        with patch.dict(os.environ, {"AGENT_BOM_TEST_STR_KEY": "custom_val"}):
+            assert _str("AGENT_BOM_TEST_STR_KEY", "default") == "custom_val"
+
+    def test_int_helper_returns_default_on_invalid(self):
+        from agent_bom.config import _int
+
+        with patch.dict(os.environ, {"AGENT_BOM_TEST_BAD_INT": "not_a_number"}):
+            assert _int("AGENT_BOM_TEST_BAD_INT", 42) == 42
+
+    def test_float_helper_returns_default_on_invalid(self):
+        from agent_bom.config import _float
+
+        with patch.dict(os.environ, {"AGENT_BOM_TEST_BAD_FLOAT": "xyz"}):
+            assert _float("AGENT_BOM_TEST_BAD_FLOAT", 3.14) == 3.14
+
+
+class TestConfigConsumerImports:
+    """Verify consumer modules import from config (not hardcoded)."""
+
+    def test_http_client_uses_config_retries(self):
+        from agent_bom import config
+        from agent_bom.http_client import MAX_RETRIES
+
+        assert MAX_RETRIES == config.HTTP_MAX_RETRIES
+
+    def test_http_client_uses_config_backoff(self):
+        from agent_bom import config
+        from agent_bom.http_client import INITIAL_BACKOFF, MAX_BACKOFF
+
+        assert INITIAL_BACKOFF == config.HTTP_INITIAL_BACKOFF
+        assert MAX_BACKOFF == config.HTTP_MAX_BACKOFF
+
+    def test_scanners_uses_config_concurrency(self):
+        from agent_bom import config
+        from agent_bom.scanners import BATCH_DELAY_SECONDS, MAX_CONCURRENT_REQUESTS
+
+        assert MAX_CONCURRENT_REQUESTS == config.SCANNER_MAX_CONCURRENT
+        assert BATCH_DELAY_SECONDS == config.SCANNER_BATCH_DELAY
+
+
+# ── Audit HMAC ──────────────────────────────────────────────────────────────
+
+
+class TestAuditHMAC:
+    """Verify HMAC key is ephemeral (no hardcoded default)."""
+
+    def test_no_hardcoded_hmac_default_in_source(self):
+        """Source code must NOT contain a static HMAC key string."""
+        import inspect
+
+        from agent_bom.api import audit_log
+
+        source = inspect.getsource(audit_log)
+        assert "agent-bom-default-audit-key" not in source
+
+    def test_ephemeral_key_is_bytes(self):
+        from agent_bom.api.audit_log import _HMAC_KEY
+
+        assert isinstance(_HMAC_KEY, bytes)
+        assert len(_HMAC_KEY) >= 16  # At least 128-bit
+
+    def test_sign_verify_roundtrip(self):
+        from agent_bom.api.audit_log import AuditEntry
+
+        entry = AuditEntry(action="scan", actor="test", resource="job/test-1")
+        entry.sign()
+        assert entry.hmac_signature
+        assert entry.verify()
+
+    def test_tampered_entry_fails_verify(self):
+        from agent_bom.api.audit_log import AuditEntry
+
+        entry = AuditEntry(action="scan", actor="test", resource="job/test-1")
+        entry.sign()
+        entry.action = "tampered"
+        assert not entry.verify()
+
+    def test_in_memory_log_signs_on_append(self):
+        from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog
+
+        log = InMemoryAuditLog()
+        entry = AuditEntry(action="test_action", actor="ci")
+        assert entry.hmac_signature == ""
+        log.append(entry)
+        assert entry.hmac_signature != ""
+        assert entry.verify()
+
+    def test_in_memory_integrity_check(self):
+        from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog
+
+        log = InMemoryAuditLog()
+        for i in range(5):
+            log.append(AuditEntry(action="scan", actor=f"user-{i}"))
+        verified, tampered = log.verify_integrity()
+        assert verified == 5
+        assert tampered == 0
+
+    def test_env_var_hmac_key_used(self):
+        """When AGENT_BOM_AUDIT_HMAC_KEY is set, it should be used."""
+        import importlib
+
+        from agent_bom.api import audit_log
+
+        with patch.dict(os.environ, {"AGENT_BOM_AUDIT_HMAC_KEY": "test-secret-key-42"}):
+            importlib.reload(audit_log)
+            assert audit_log._HMAC_KEY == b"test-secret-key-42"
+
+        # Reload again without env var to restore ephemeral key
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            importlib.reload(audit_log)
+            assert isinstance(audit_log._HMAC_KEY, bytes)
+
+
+# ── Exception Narrowing ────────────────────────────────────────────────────
+
+
+class TestExceptionNarrowing:
+    """Verify critical except clauses use specific types."""
+
+    def test_http_client_url_sanitizer_catches_value_error(self):
+        from agent_bom.http_client import _safe_url
+
+        # Should not raise — handles ValueError/AttributeError gracefully
+        result = _safe_url("not://a[valid/url")
+        assert isinstance(result, str)
+
+    def test_enrichment_cache_handles_corrupt_json(self, tmp_path):
+        """Enrichment cache load should handle corrupt JSON gracefully."""
+        import agent_bom.enrichment as enrich_mod
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        (cache_dir / "nvd_cache.json").write_text("this is not json{{{")
+
+        # Temporarily swap cache dir and reset loaded flag
+        orig_dir = enrich_mod._ENRICHMENT_CACHE_DIR
+        orig_loaded = enrich_mod._enrichment_cache_loaded
+        try:
+            enrich_mod._ENRICHMENT_CACHE_DIR = cache_dir
+            enrich_mod._enrichment_cache_loaded = False
+            # Should not raise — the narrowed except handles it
+            enrich_mod._load_enrichment_cache()
+        finally:
+            enrich_mod._ENRICHMENT_CACHE_DIR = orig_dir
+            enrich_mod._enrichment_cache_loaded = orig_loaded
+
+    def test_registry_handles_corrupt_json(self, tmp_path):
+        """Registry _load_registry should handle corrupt JSON files."""
+        from agent_bom.registry import _load_registry
+
+        bad_file = tmp_path / "registry.json"
+        bad_file.write_text("{corrupt json!!")
+
+        with patch.object(
+            __import__("agent_bom.registry", fromlist=["_REGISTRY_PATH"]),
+            "_REGISTRY_PATH",
+            bad_file,
+        ):
+            result = _load_registry()
+            assert result == {}
+
+    def test_push_imports_httpx(self):
+        """push.py should import httpx at module level for exception handling."""
+        import agent_bom.push as push_mod
+
+        assert hasattr(push_mod, "httpx")
+
+
+# ── Inventory Module ────────────────────────────────────────────────────────
+
+
+class TestInventoryDetectFormat:
+    """Test auto-detection of JSON vs CSV content."""
+
+    def test_detect_json_object(self):
+        from agent_bom.inventory import _detect_format
+
+        assert _detect_format('{"agents": []}') == "json"
+
+    def test_detect_json_array(self):
+        from agent_bom.inventory import _detect_format
+
+        assert _detect_format("[1, 2, 3]") == "json"
+
+    def test_detect_json_with_whitespace(self):
+        from agent_bom.inventory import _detect_format
+
+        assert _detect_format("  \n  { }") == "json"
+
+    def test_detect_csv(self):
+        from agent_bom.inventory import _detect_format
+
+        assert _detect_format("name,version,ecosystem\n") == "csv"
+
+    def test_detect_csv_plain_text(self):
+        from agent_bom.inventory import _detect_format
+
+        assert _detect_format("some,data,here") == "csv"
+
+
+class TestInventoryCSV:
+    """Test CSV inventory loading."""
+
+    def test_minimal_3_column_csv(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = "name,version,ecosystem\nlangchain,0.1.0,pypi\nfastapi,0.104.0,pypi\n"
+        result = _load_csv_inventory(io.StringIO(csv_data))
+
+        assert "agents" in result
+        agents = result["agents"]
+        assert len(agents) == 1
+        agent = agents[0]
+        assert agent["name"] == "inventory-agent"
+        assert len(agent["mcp_servers"]) == 1
+        server = agent["mcp_servers"][0]
+        assert server["name"] == "inventory-server"
+        assert len(server["packages"]) == 2
+
+    def test_full_column_csv(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = textwrap.dedent("""\
+            name,version,ecosystem,server_name,agent_name,env_keys
+            langchain,0.1.0,pypi,ai-server,prod-agent,OPENAI_API_KEY;SLACK_TOKEN
+            express,4.18.2,npm,api-server,prod-agent,
+            fastapi,0.104.0,pypi,ai-server,prod-agent,
+        """)
+        result = _load_csv_inventory(io.StringIO(csv_data))
+
+        agents = result["agents"]
+        assert len(agents) == 1
+        agent = agents[0]
+        assert agent["name"] == "prod-agent"
+        # Two servers: ai-server and api-server
+        server_names = {s["name"] for s in agent["mcp_servers"]}
+        assert server_names == {"ai-server", "api-server"}
+
+    def test_agent_server_grouping(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = textwrap.dedent("""\
+            name,version,ecosystem,agent_name,server_name
+            pkg-a,1.0,pypi,agent-1,server-1
+            pkg-b,2.0,npm,agent-2,server-2
+        """)
+        result = _load_csv_inventory(io.StringIO(csv_data))
+
+        agents = result["agents"]
+        assert len(agents) == 2
+        agent_names = {a["name"] for a in agents}
+        assert agent_names == {"agent-1", "agent-2"}
+
+    def test_default_agent_server_names(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = "name,version,ecosystem\nfoo,1.0,pip\n"
+        result = _load_csv_inventory(io.StringIO(csv_data))
+
+        agent = result["agents"][0]
+        assert agent["name"] == "inventory-agent"
+        assert agent["mcp_servers"][0]["name"] == "inventory-server"
+
+    def test_env_keys_parsed(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = "name,version,ecosystem,env_keys\nfoo,1.0,pypi,API_KEY;SECRET\n"
+        result = _load_csv_inventory(io.StringIO(csv_data))
+
+        env = result["agents"][0]["mcp_servers"][0]["env"]
+        assert env == {"API_KEY": "REDACTED", "SECRET": "REDACTED"}
+
+    def test_missing_required_columns_raises(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = "name,version\nfoo,1.0\n"
+        with pytest.raises(ValueError, match="missing required columns"):
+            _load_csv_inventory(io.StringIO(csv_data))
+
+    def test_empty_csv_raises(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        with pytest.raises(ValueError, match="empty"):
+            _load_csv_inventory(io.StringIO(""))
+
+    def test_rows_with_empty_name_skipped(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = "name,version,ecosystem\n,1.0,pypi\nfoo,2.0,pypi\n"
+        result = _load_csv_inventory(io.StringIO(csv_data))
+        pkgs = result["agents"][0]["mcp_servers"][0]["packages"]
+        assert len(pkgs) == 1
+        assert pkgs[0]["name"] == "foo"
+
+    def test_ecosystem_defaults_to_unknown(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = "name,version,ecosystem\nfoo,1.0,\n"
+        result = _load_csv_inventory(io.StringIO(csv_data))
+        pkg = result["agents"][0]["mcp_servers"][0]["packages"][0]
+        assert pkg["ecosystem"] == "unknown"
+
+    def test_case_insensitive_headers(self):
+        from agent_bom.inventory import _load_csv_inventory
+
+        csv_data = "Name, Version, Ecosystem\nfoo,1.0,pypi\n"
+        result = _load_csv_inventory(io.StringIO(csv_data))
+        assert len(result["agents"]) == 1
+
+
+class TestInventoryJSON:
+    """Test JSON inventory loading."""
+
+    def test_json_file_loading(self, tmp_path):
+        from agent_bom.inventory import load_inventory
+
+        data = {"agents": [{"name": "test", "mcp_servers": []}]}
+        json_file = tmp_path / "inventory.json"
+        json_file.write_text(json.dumps(data))
+
+        result = load_inventory(str(json_file))
+        assert result == data
+
+    def test_csv_file_detected_by_extension(self, tmp_path):
+        from agent_bom.inventory import load_inventory
+
+        csv_file = tmp_path / "inventory.csv"
+        csv_file.write_text("name,version,ecosystem\nfoo,1.0,pypi\n")
+
+        result = load_inventory(str(csv_file))
+        assert "agents" in result
+        assert len(result["agents"]) == 1
+
+
+class TestInventoryFileErrors:
+    """Test error handling for file loading."""
+
+    def test_file_not_found(self):
+        from agent_bom.inventory import load_inventory
+
+        with pytest.raises(FileNotFoundError, match="not found"):
+            load_inventory("/nonexistent/path/inventory.json")
+
+
+class TestInventoryStdin:
+    """Test stdin inventory loading."""
+
+    def test_stdin_json(self):
+        from agent_bom.inventory import _load_from_stdin
+
+        data = json.dumps({"agents": [{"name": "stdin-agent", "mcp_servers": []}]})
+        with patch("sys.stdin", io.StringIO(data)):
+            result = _load_from_stdin()
+        assert result["agents"][0]["name"] == "stdin-agent"
+
+    def test_stdin_csv(self):
+        from agent_bom.inventory import _load_from_stdin
+
+        csv_data = "name,version,ecosystem\nfoo,1.0,pypi\n"
+        with patch("sys.stdin", io.StringIO(csv_data)):
+            result = _load_from_stdin()
+        assert "agents" in result
+
+    def test_stdin_empty_raises(self):
+        from agent_bom.inventory import _load_from_stdin
+
+        with patch("sys.stdin", io.StringIO("   ")):
+            with pytest.raises(ValueError, match="Empty input"):
+                _load_from_stdin()

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -161,7 +161,7 @@ class TestPushResults:
 
     def test_push_network_error(self):
         mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_client.post = AsyncMock(side_effect=OSError("Connection refused"))
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 


### PR DESCRIPTION
## Summary

- **Config centralization**: 15 new env-overridable constants in `config.py` (HTTP, scanner, AI, enrichment, API, MCP); 6 consumer modules rewired via aliased imports — zero downstream changes
- **HMAC security fix**: Replaced hardcoded `agent-bom-default-audit-key` with ephemeral `secrets.token_bytes(32)` per-process key; production deployments set `AGENT_BOM_AUDIT_HMAC_KEY`
- **Exception narrowing**: ~20 bare `except Exception:` clauses narrowed to specific types across 8 modules (ai_enrich, discovery, enrichment, http_client, registry, push, smithery)
- **Inventory ingestion**: New `inventory.py` module supporting JSON, CSV (3-col minimal + full 6-col), and stdin with auto-detection; `--inventory -` pipes from stdin
- **CSV bug fix**: Test-driven fix for header whitespace normalization (preserves raw DictReader keys)

## Test plan

- [x] 54 new tests in `test_hardening_phase2.py` covering all changes
- [x] All 2,738 existing tests pass (13 skipped)
- [x] `ruff check` + `ruff format` clean
- [x] Fixed existing `test_push_network_error` to use `OSError` instead of bare `Exception`