### PR TITLE
docs: align stale numbers — 16 tools, 2,700+ tests, add code_scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ agent-bom mcp-server                    # stdio
 agent-bom mcp-server --transport sse    # remote
 ```
 
-15 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`, `marketplace_check`, `context_graph`
+16 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`, `marketplace_check`, `code_scan`, `context_graph`
 
 ### Cloud UI
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -282,6 +282,6 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine |
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (15 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (16 tools) |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">15 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">16 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">15 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">16 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/data-flow-dark.svg
+++ b/docs/images/data-flow-dark.svg
@@ -158,7 +158,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d29922">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,335 automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,700+ automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d29922">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/data-flow-light.svg
+++ b/docs/images/data-flow-light.svg
@@ -151,7 +151,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#fffbeb" stroke="#d97706" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d97706">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,335 automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,700+ automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d97706">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -265,5 +265,5 @@
   <!-- MCP Server badge -->
   <rect x="516" y="454" width="228" height="40" rx="6" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6" opacity="0.7"/>
   <text x="528" y="471" class="side-label" fill="#58a6ff">15 MCP Tools · 10 Frameworks</text>
-  <text x="528" y="484" class="box-sub">2,335 tests · Sigstore signed · OpenSSF scored</text>
+  <text x="528" y="484" class="box-sub">2,700+ tests · Sigstore signed · OpenSSF scored</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -241,5 +241,5 @@
 
   <rect x="516" y="454" width="228" height="40" rx="6" fill="#ffffff" stroke="#0969da" stroke-width="0.6" opacity="0.7"/>
   <text x="528" y="471" class="side-label" fill="#0969da">15 MCP Tools · 10 Frameworks</text>
-  <text x="528" y="484" class="box-sub">2,335 tests · Sigstore signed · OpenSSF scored</text>
+  <text x="528" y="484" class="box-sub">2,700+ tests · Sigstore signed · OpenSSF scored</text>
 </svg>

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">15 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">16 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">15 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">16 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -212,7 +212,7 @@
 
   <rect x="720" y="346" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
   <text x="813" y="364" text-anchor="middle" class="label" fill="#3fb950">MCP Server</text>
-  <text x="813" y="378" text-anchor="middle" class="sub">15 tools · stdio + SSE transport</text>
+  <text x="813" y="378" text-anchor="middle" class="sub">16 tools · stdio + SSE transport</text>
 
   <rect x="720" y="396" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
   <text x="813" y="414" text-anchor="middle" class="label" fill="#3fb950">Observability</text>
@@ -230,5 +230,5 @@
   <!-- ═══ Bottom Bar: Trust + Data Flow ═══ -->
   <rect x="20" y="570" width="900" height="38" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
   <text x="470" y="586" text-anchor="middle" class="badge" fill="#8b949e">TRUST MODEL</text>
-  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,335 tests</text>
+  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,700+ tests</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -212,7 +212,7 @@
 
   <rect x="720" y="346" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
   <text x="813" y="364" text-anchor="middle" class="label" fill="#065f46">MCP Server</text>
-  <text x="813" y="378" text-anchor="middle" class="sub">15 tools · stdio + SSE transport</text>
+  <text x="813" y="378" text-anchor="middle" class="sub">16 tools · stdio + SSE transport</text>
 
   <rect x="720" y="396" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
   <text x="813" y="414" text-anchor="middle" class="label" fill="#065f46">Observability</text>
@@ -230,5 +230,5 @@
   <!-- ═══ Bottom Bar: Trust + Data Flow ═══ -->
   <rect x="20" y="570" width="900" height="38" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
   <text x="470" y="586" text-anchor="middle" class="badge" fill="#475569">TRUST MODEL</text>
-  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,335 tests</text>
+  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,700+ tests</text>
 </svg>

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   pypi: https://pypi.org/project/agent-bom/
   smithery: https://smithery.ai/server/agent-bom/agent-bom
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 2099
+  tests: 2700
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -93,7 +93,7 @@ docker run -p 8080:8080 agent-bom-sse
 # Connect: { "type": "sse", "url": "http://localhost:8080/sse" }
 ```
 
-## Available MCP Tools (15 tools)
+## Available MCP Tools (16 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -109,6 +109,7 @@ docker run -p 8080:8080 agent-bom-sse
 | `policy_check` | Evaluate results against security policy |
 | `diff` | Compare two scan reports (new/resolved/persistent) |
 | `marketplace_check` | Pre-install trust check with registry cross-reference |
+| `code_scan` | SAST scanning via Semgrep with CWE-based compliance mapping |
 | `where` | Show MCP client config discovery paths |
 | `inventory` | List discovered agents, servers, packages |
 | `context_graph` | Agent context graph with lateral movement analysis |
@@ -182,6 +183,6 @@ installation or self-host your own instance.
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: 99/100 quality score
 - **Sigstore signed**: `agent-bom verify agent-bom@0.49.0`
-- **2,099 tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
+- **2,700+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -4,7 +4,7 @@ Start with:
     agent-bom mcp-server              # stdio (for Claude Desktop, Cursor, etc.)
     agent-bom mcp-server --sse        # SSE transport (for remote clients)
 
-Tools (15):
+Tools (16):
     scan              — Full discovery → scan → output pipeline
     check             — Check a specific package for CVEs before installing
     blast_radius      — Look up blast radius for a specific CVE
@@ -19,6 +19,7 @@ Tools (15):
     inventory         — List agents/servers without CVE scanning
     diff              — Compare scan against baseline for new/resolved vulns
     marketplace_check — Pre-install trust check with registry cross-reference
+    code_scan         — SAST scanning via Semgrep with CWE-based compliance mapping
     context_graph     — Agent context graph with lateral movement analysis
 
 Resources (2):


### PR DESCRIPTION
## Summary

- Fix stale test count (2,335 → 2,700+) across 6 SVG diagrams
- Fix stale tool count (15 → 16) across 6 SVG diagrams + 3 docs
- Add missing `code_scan` tool to MCP server docstring, README, SKILL.md
- Use approximate test count (2,700+) to avoid per-PR documentation churn

## Test plan

- [x] `grep -r "15 tools"` returns zero matches in docs/src
- [x] `grep -r "2,335"` returns zero matches in docs
- [x] `test_mcp_server_has_sixteen_tools` passes
- [x] `ruff check` clean