### PR TITLE
fix: update Dockerfile.sse tool count from 14 to 16

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 14 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 16 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f Dockerfile.sse -t agent-bom-sse .


### PR DESCRIPTION
## Summary
- Stale comment in Dockerfile.sse referenced 14 MCP tools; actual count is 16 (code_scan + context_graph added in recent PRs)

## Test plan
- [x] No code changes, comment-only fix