### PR TITLE
docs: redesign README diagrams — clean minimal architecture

### DIFF
--- a/docs/images/blast-radius-dark.svg
+++ b/docs/images/blast-radius-dark.svg
@@ -1,167 +1,94 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 440" fill="none">
-  <style>
-    .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
-    .subtitle { font: 400 11px system-ui, sans-serif; fill: #8b949e; }
-    .phase-label { font: 700 9px system-ui, sans-serif; letter-spacing: 0.1em; }
-    .node-name { font: 600 11px system-ui, sans-serif; }
-    .node-detail { font: 400 9px system-ui, sans-serif; fill: #8b949e; }
-    .badge { font: 700 8px 'SF Mono', monospace; }
-    .tag { font: 600 8.5px 'SF Mono', monospace; }
-    .flow-line { stroke-width: 2; fill: none; }
-    .dim-line { stroke: #30363d; stroke-width: 1; fill: none; }
-  </style>
-  <defs>
-    <marker id="arr-red" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <path d="M0 0L10 3.5L0 7Z" fill="#ef4444"/>
-    </marker>
-    <marker id="arr-gray" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <path d="M0 0L10 3.5L0 7Z" fill="#484f58"/>
-    </marker>
-    <linearGradient id="glow-red" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ef4444" stop-opacity="0.15"/>
-      <stop offset="100%" stop-color="#ef4444" stop-opacity="0"/>
-    </linearGradient>
-  </defs>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 360" fill="none">
   <!-- Background -->
-  <rect width="880" height="440" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <rect width="880" height="360" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="440" y="30" text-anchor="middle" class="title">Blast Radius — How a CVE propagates through the AI stack</text>
-  <text x="440" y="48" text-anchor="middle" class="subtitle">agent-bom traces every vulnerability to the agents, credentials, and tools it can reach</text>
+  <text x="440" y="32" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">How a CVE propagates through your AI stack</text>
 
-  <!-- ═══ CVE Origin (left) ═══ -->
-  <text x="90" y="80" text-anchor="middle" class="phase-label" fill="#ef4444">VULNERABILITY</text>
+  <!-- ─── CHAIN: CVE → Package → Server → Agent ─── -->
 
-  <rect x="24" y="92" width="132" height="64" rx="10" fill="#1c0a0a" stroke="#ef4444" stroke-width="2"/>
-  <text x="90" y="112" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" font-weight="700" fill="#f87171">CVE-2025-1234</text>
-  <text x="90" y="128" text-anchor="middle" class="node-detail">better-sqlite3@9.0</text>
-  <text x="90" y="144" text-anchor="middle" class="badge" fill="#ef4444">CRITICAL 9.8 · KEV</text>
+  <!-- Node 1: CVE -->
+  <rect x="30" y="56" width="160" height="80" rx="14" fill="#2d1215" stroke="#f87171" stroke-width="2.5"/>
+  <text x="110" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#f87171" letter-spacing="0.08em">VULNERABILITY</text>
+  <text x="110" y="112" text-anchor="middle" font-family="monospace" font-size="13" font-weight="700" fill="#fca5a5">CVE-2025-1234</text>
+  <text x="110" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#f87171">CRITICAL 9.8 | KEV</text>
 
-  <!-- ═══ Arrow: CVE → Package ═══ -->
-  <line x1="156" y1="124" x2="192" y2="124" class="flow-line" stroke="#ef4444" marker-end="url(#arr-red)"/>
+  <!-- Arrow -->
+  <path d="M190 96 L220 96" stroke="#f87171" stroke-width="3" stroke-linecap="round"/>
+  <path d="M214 90 L224 96 L214 102" fill="#f87171"/>
 
-  <!-- ═══ Package ═══ -->
-  <text x="274" y="80" text-anchor="middle" class="phase-label" fill="#3fb950">PACKAGE</text>
+  <!-- Node 2: Package -->
+  <rect x="228" y="56" width="160" height="80" rx="14" fill="#0a2118" stroke="#34d399" stroke-width="2"/>
+  <text x="308" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.08em">PACKAGE</text>
+  <text x="308" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#6ee7b7">better-sqlite3</text>
+  <text x="308" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#34d399">npm v9.0.0</text>
 
-  <rect x="200" y="92" width="148" height="64" rx="10" fill="#0a1612" stroke="#3fb950" stroke-width="1.5"/>
-  <text x="274" y="112" text-anchor="middle" class="node-name" fill="#7ee787">better-sqlite3</text>
-  <text x="274" y="128" text-anchor="middle" class="node-detail">npm · v9.0.0</text>
-  <rect x="236" y="134" width="76" height="14" rx="3" fill="#1c0a0a" stroke="#ef4444" stroke-width="0.8"/>
-  <text x="274" y="144" text-anchor="middle" class="badge" fill="#f87171">1 CRITICAL</text>
+  <!-- Arrow -->
+  <path d="M388 96 L418 96" stroke="#f87171" stroke-width="3" stroke-linecap="round"/>
+  <path d="M412 90 L422 96 L412 102" fill="#f87171"/>
 
-  <!-- ═══ Arrow: Package → Server ═══ -->
-  <line x1="348" y1="124" x2="384" y2="124" class="flow-line" stroke="#ef4444" marker-end="url(#arr-red)"/>
+  <!-- Node 3: MCP Server -->
+  <rect x="426" y="56" width="160" height="80" rx="14" fill="#1a1028" stroke="#a78bfa" stroke-width="2"/>
+  <text x="506" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">MCP SERVER</text>
+  <text x="506" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#c4b5fd">sqlite-mcp</text>
+  <text x="506" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a78bfa">unverified | 3 tools</text>
 
-  <!-- ═══ MCP Server ═══ -->
-  <text x="466" y="80" text-anchor="middle" class="phase-label" fill="#a78bfa">MCP SERVER</text>
+  <!-- Arrow -->
+  <path d="M586 96 L616 96" stroke="#f87171" stroke-width="3" stroke-linecap="round"/>
+  <path d="M610 90 L620 96 L610 102" fill="#f87171"/>
 
-  <rect x="392" y="92" width="148" height="64" rx="10" fill="#120d1b" stroke="#a78bfa" stroke-width="1.5"/>
-  <text x="466" y="112" text-anchor="middle" class="node-name" fill="#c4b5fd">sqlite-mcp</text>
-  <text x="466" y="128" text-anchor="middle" class="node-detail">Unverified · 3 tools</text>
-  <rect x="422" y="134" width="88" height="14" rx="3" fill="#1c0a0a" stroke="#ef4444" stroke-width="0.8"/>
-  <text x="466" y="144" text-anchor="middle" class="badge" fill="#f87171">COMPROMISED</text>
+  <!-- Node 4: Agent -->
+  <rect x="624" y="56" width="160" height="80" rx="14" fill="#0c1a2e" stroke="#60a5fa" stroke-width="2"/>
+  <text x="704" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.08em">AI AGENT</text>
+  <text x="704" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#93c5fd">Cursor IDE</text>
+  <text x="704" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#60a5fa">4 servers | 12 tools</text>
 
-  <!-- ═══ Arrow: Server → Agent ═══ -->
-  <line x1="540" y1="124" x2="576" y2="124" class="flow-line" stroke="#ef4444" marker-end="url(#arr-red)"/>
+  <!-- Red propagation glow line -->
+  <rect x="30" y="142" width="754" height="3" rx="1.5" fill="#f87171" opacity="0.15"/>
 
-  <!-- ═══ AI Agent ═══ -->
-  <text x="658" y="80" text-anchor="middle" class="phase-label" fill="#58a6ff">AI AGENT</text>
+  <!-- ─── IMPACT ─── -->
+  <text x="440" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#e6edf3">What an attacker can reach</text>
 
-  <rect x="584" y="92" width="148" height="64" rx="10" fill="#0d1521" stroke="#1f6feb" stroke-width="1.5"/>
-  <text x="658" y="112" text-anchor="middle" class="node-name" fill="#58a6ff">Cursor IDE</text>
-  <text x="658" y="128" text-anchor="middle" class="node-detail">4 servers · 12 tools</text>
-  <rect x="614" y="134" width="88" height="14" rx="3" fill="#1c0a0a" stroke="#ef4444" stroke-width="0.8"/>
-  <text x="658" y="144" text-anchor="middle" class="badge" fill="#f87171">AT RISK</text>
+  <!-- Credentials -->
+  <text x="48" y="210" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24" letter-spacing="0.08em">CREDENTIALS EXPOSED</text>
 
-  <!-- ═══ Propagation glow bar ═══ -->
-  <rect x="24" y="166" width="708" height="4" rx="2" fill="url(#glow-red)"/>
-  <rect x="24" y="166" width="708" height="4" rx="2" fill="#ef4444" opacity="0.08"/>
+  <rect x="48" y="220" width="136" height="40" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="116" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fbbf24">ANTHROPIC_KEY</text>
 
-  <!-- ═══ What the attacker reaches (bottom section) ═══ -->
-  <text x="440" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#e6edf3">What an attacker can reach</text>
+  <rect x="196" y="220" width="136" height="40" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="264" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fbbf24">DB_URL</text>
 
-  <!-- Row 1: Credentials -->
-  <text x="60" y="236" class="phase-label" fill="#f59e0b">CREDENTIALS EXPOSED</text>
+  <rect x="344" y="220" width="136" height="40" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="412" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fbbf24">AWS_SECRET</text>
 
-  <rect x="60" y="246" width="120" height="38" rx="7" fill="#1a1508" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="120" y="262" text-anchor="middle" class="node-name" fill="#fbbf24">ANTHROPIC_KEY</text>
-  <text x="120" y="276" text-anchor="middle" class="node-detail">API access</text>
+  <!-- Tools -->
+  <text x="48" y="288" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#9ca3af" letter-spacing="0.08em">TOOLS REACHABLE</text>
 
-  <rect x="196" y="246" width="120" height="38" rx="7" fill="#1a1508" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="256" y="262" text-anchor="middle" class="node-name" fill="#fbbf24">DB_URL</text>
-  <text x="256" y="276" text-anchor="middle" class="node-detail">Database connection</text>
+  <rect x="48" y="298" width="100" height="36" rx="8" fill="#161b22" stroke="#4b5563" stroke-width="1.2"/>
+  <text x="98" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#d1d5db">query_db</text>
 
-  <rect x="332" y="246" width="120" height="38" rx="7" fill="#1a1508" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="392" y="262" text-anchor="middle" class="node-name" fill="#fbbf24">AWS_SECRET</text>
-  <text x="392" y="276" text-anchor="middle" class="node-detail">Cloud access</text>
+  <rect x="160" y="298" width="100" height="36" rx="8" fill="#161b22" stroke="#4b5563" stroke-width="1.2"/>
+  <text x="210" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#d1d5db">read_file</text>
 
-  <!-- Row 2: Tools reachable -->
-  <text x="60" y="310" class="phase-label" fill="#d29922">TOOLS REACHABLE</text>
+  <rect x="272" y="298" width="100" height="36" rx="8" fill="#161b22" stroke="#4b5563" stroke-width="1.2"/>
+  <text x="322" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#d1d5db">write_file</text>
 
-  <rect x="60" y="320" width="90" height="32" rx="6" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="105" y="340" text-anchor="middle" class="tag" fill="#e3b341">query_db</text>
+  <rect x="384" y="298" width="100" height="36" rx="8" fill="#2d1215" stroke="#f87171" stroke-width="2"/>
+  <text x="434" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fca5a5">run_shell</text>
 
-  <rect x="164" y="320" width="90" height="32" rx="6" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="209" y="340" text-anchor="middle" class="tag" fill="#e3b341">read_file</text>
+  <!-- Impact summary -->
+  <rect x="560" y="196" width="290" height="146" rx="14" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+  <text x="705" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#e6edf3">Impact Summary</text>
 
-  <rect x="268" y="320" width="90" height="32" rx="6" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="313" y="340" text-anchor="middle" class="tag" fill="#e3b341">write_file</text>
+  <text x="588" y="250" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#f87171">1</text>
+  <text x="616" y="248" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#8b949e">agent compromised</text>
 
-  <rect x="372" y="320" width="90" height="32" rx="6" fill="#161b22" stroke="#ef4444" stroke-width="1.5"/>
-  <text x="417" y="340" text-anchor="middle" class="tag" fill="#f87171">run_shell</text>
+  <text x="588" y="280" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#fbbf24">3</text>
+  <text x="616" y="278" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#8b949e">credentials exposed</text>
 
-  <!-- Row 3: Threat tags -->
-  <text x="60" y="376" class="phase-label" fill="#a78bfa">THREAT FRAMEWORKS TRIGGERED</text>
+  <text x="588" y="310" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#9ca3af">4</text>
+  <text x="616" y="308" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#8b949e">tools reachable (incl. RCE)</text>
 
-  <rect x="60" y="386" width="60" height="20" rx="4" fill="#1e1536" stroke="#8b5cf6" stroke-width="0.8"/>
-  <text x="90" y="400" text-anchor="middle" class="tag" fill="#c4b5fd">LLM02</text>
-
-  <rect x="130" y="386" width="60" height="20" rx="4" fill="#1e1536" stroke="#8b5cf6" stroke-width="0.8"/>
-  <text x="160" y="400" text-anchor="middle" class="tag" fill="#c4b5fd">LLM05</text>
-
-  <rect x="200" y="386" width="60" height="20" rx="4" fill="#1e1536" stroke="#8b5cf6" stroke-width="0.8"/>
-  <text x="230" y="400" text-anchor="middle" class="tag" fill="#c4b5fd">LLM06</text>
-
-  <rect x="270" y="386" width="60" height="20" rx="4" fill="#1e1536" stroke="#8b5cf6" stroke-width="0.8"/>
-  <text x="300" y="400" text-anchor="middle" class="tag" fill="#c4b5fd">LLM08</text>
-
-  <rect x="348" y="386" width="82" height="20" rx="4" fill="#0c1a1a" stroke="#22d3ee" stroke-width="0.8"/>
-  <text x="389" y="400" text-anchor="middle" class="tag" fill="#67e8f9">AML.T0010</text>
-
-  <rect x="440" y="386" width="82" height="20" rx="4" fill="#0c1a1a" stroke="#22d3ee" stroke-width="0.8"/>
-  <text x="481" y="400" text-anchor="middle" class="tag" fill="#67e8f9">AML.T0062</text>
-
-  <!-- ═══ Impact Summary (right panel) ═══ -->
-  <rect x="560" y="220" width="296" height="196" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="708" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#e6edf3">Impact Summary</text>
-
-  <!-- Metric rows -->
-  <text x="584" y="272" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#ef4444">1</text>
-  <text x="608" y="268" class="node-name" fill="#8b949e">agent affected</text>
-  <text x="608" y="280" class="node-detail">Cursor IDE (100% of env)</text>
-
-  <line x1="580" y1="290" x2="840" y2="290" class="dim-line"/>
-
-  <text x="584" y="312" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#f59e0b">3</text>
-  <text x="608" y="308" class="node-name" fill="#8b949e">credentials exposed</text>
-  <text x="608" y="320" class="node-detail">ANTHROPIC_KEY, DB_URL, AWS_SECRET</text>
-
-  <line x1="580" y1="330" x2="840" y2="330" class="dim-line"/>
-
-  <text x="584" y="352" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#d29922">4</text>
-  <text x="608" y="348" class="node-name" fill="#8b949e">tools reachable</text>
-  <text x="608" y="360" class="node-detail">incl. run_shell (RCE risk)</text>
-
-  <line x1="580" y1="370" x2="840" y2="370" class="dim-line"/>
-
-  <text x="584" y="392" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#a78bfa">6</text>
-  <text x="608" y="388" class="node-name" fill="#8b949e">threat categories</text>
-  <text x="608" y="400" class="node-detail">4 OWASP LLM + 2 ATLAS + ASI + EU</text>
-
-  <!-- Remediation callout -->
-  <rect x="580" y="406" width="260" height="2" rx="1" fill="#3fb950" opacity="0.5"/>
-
-  <!-- Fix label -->
-  <text x="710" y="424" text-anchor="middle" font-family="'SF Mono', monospace" font-size="9" font-weight="600" fill="#3fb950">FIX: upgrade better-sqlite3 → 11.7.0</text>
+  <rect x="560" y="324" width="290" height="2" rx="1" fill="#34d399" opacity="0.4"/>
+  <text x="705" y="344" text-anchor="middle" font-family="monospace" font-size="11" font-weight="700" fill="#34d399">FIX: upgrade better-sqlite3 to 11.7.0</text>
 </svg>

--- a/docs/images/blast-radius-light.svg
+++ b/docs/images/blast-radius-light.svg
@@ -1,157 +1,95 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 440" fill="none">
-  <style>
-    .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #1f2328; }
-    .subtitle { font: 400 11px system-ui, sans-serif; fill: #656d76; }
-    .phase-label { font: 700 9px system-ui, sans-serif; letter-spacing: 0.1em; }
-    .node-name { font: 600 11px system-ui, sans-serif; }
-    .node-detail { font: 400 9px system-ui, sans-serif; fill: #656d76; }
-    .badge { font: 700 8px 'SF Mono', monospace; }
-    .tag { font: 600 8.5px 'SF Mono', monospace; }
-    .flow-line { stroke-width: 2; fill: none; }
-    .dim-line { stroke: #d1d9e0; stroke-width: 1; fill: none; }
-  </style>
-  <defs>
-    <marker id="arr-red" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <path d="M0 0L10 3.5L0 7Z" fill="#cf222e"/>
-    </marker>
-    <linearGradient id="glow-red" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#cf222e" stop-opacity="0.1"/>
-      <stop offset="100%" stop-color="#cf222e" stop-opacity="0"/>
-    </linearGradient>
-  </defs>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 360" fill="none">
   <!-- Background -->
-  <rect width="880" height="440" rx="12" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
+  <rect width="880" height="360" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="440" y="30" text-anchor="middle" class="title">Blast Radius — How a CVE propagates through the AI stack</text>
-  <text x="440" y="48" text-anchor="middle" class="subtitle">agent-bom traces every vulnerability to the agents, credentials, and tools it can reach</text>
+  <text x="440" y="32" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">How a CVE propagates through your AI stack</text>
 
-  <!-- ═══ CVE Origin ═══ -->
-  <text x="90" y="80" text-anchor="middle" class="phase-label" fill="#cf222e">VULNERABILITY</text>
+  <!-- ─── CHAIN: CVE → Package → Server → Agent ─── -->
 
-  <rect x="24" y="92" width="132" height="64" rx="10" fill="#ffebe9" stroke="#cf222e" stroke-width="2"/>
-  <text x="90" y="112" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" font-weight="700" fill="#a40e26">CVE-2025-1234</text>
-  <text x="90" y="128" text-anchor="middle" class="node-detail">better-sqlite3@9.0</text>
-  <text x="90" y="144" text-anchor="middle" class="badge" fill="#cf222e">CRITICAL 9.8 · KEV</text>
+  <!-- Node 1: CVE -->
+  <rect x="30" y="56" width="160" height="80" rx="14" fill="#fef2f2" stroke="#ef4444" stroke-width="2.5"/>
+  <text x="110" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#dc2626" letter-spacing="0.08em">VULNERABILITY</text>
+  <text x="110" y="112" text-anchor="middle" font-family="monospace" font-size="13" font-weight="700" fill="#991b1b">CVE-2025-1234</text>
+  <text x="110" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#b91c1c">CRITICAL 9.8 | KEV</text>
 
-  <line x1="156" y1="124" x2="192" y2="124" class="flow-line" stroke="#cf222e" marker-end="url(#arr-red)"/>
+  <!-- Arrow -->
+  <path d="M190 96 L220 96" stroke="#ef4444" stroke-width="3" stroke-linecap="round"/>
+  <path d="M214 90 L224 96 L214 102" fill="#ef4444"/>
 
-  <!-- ═══ Package ═══ -->
-  <text x="274" y="80" text-anchor="middle" class="phase-label" fill="#1a7f37">PACKAGE</text>
+  <!-- Node 2: Package -->
+  <rect x="228" y="56" width="160" height="80" rx="14" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
+  <text x="308" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#16a34a" letter-spacing="0.08em">PACKAGE</text>
+  <text x="308" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#15803d">better-sqlite3</text>
+  <text x="308" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#166534">npm v9.0.0</text>
 
-  <rect x="200" y="92" width="148" height="64" rx="10" fill="#dafbe1" stroke="#1a7f37" stroke-width="1.5"/>
-  <text x="274" y="112" text-anchor="middle" class="node-name" fill="#116329">better-sqlite3</text>
-  <text x="274" y="128" text-anchor="middle" class="node-detail">npm · v9.0.0</text>
-  <rect x="236" y="134" width="76" height="14" rx="3" fill="#ffebe9" stroke="#cf222e" stroke-width="0.8"/>
-  <text x="274" y="144" text-anchor="middle" class="badge" fill="#cf222e">1 CRITICAL</text>
+  <!-- Arrow -->
+  <path d="M388 96 L418 96" stroke="#ef4444" stroke-width="3" stroke-linecap="round"/>
+  <path d="M412 90 L422 96 L412 102" fill="#ef4444"/>
 
-  <line x1="348" y1="124" x2="384" y2="124" class="flow-line" stroke="#cf222e" marker-end="url(#arr-red)"/>
+  <!-- Node 3: MCP Server -->
+  <rect x="426" y="56" width="160" height="80" rx="14" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
+  <text x="506" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">MCP SERVER</text>
+  <text x="506" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#6d28d9">sqlite-mcp</text>
+  <text x="506" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">unverified | 3 tools</text>
 
-  <!-- ═══ MCP Server ═══ -->
-  <text x="466" y="80" text-anchor="middle" class="phase-label" fill="#8250df">MCP SERVER</text>
+  <!-- Arrow -->
+  <path d="M586 96 L616 96" stroke="#ef4444" stroke-width="3" stroke-linecap="round"/>
+  <path d="M610 90 L620 96 L610 102" fill="#ef4444"/>
 
-  <rect x="392" y="92" width="148" height="64" rx="10" fill="#fbefff" stroke="#8250df" stroke-width="1.5"/>
-  <text x="466" y="112" text-anchor="middle" class="node-name" fill="#6639ba">sqlite-mcp</text>
-  <text x="466" y="128" text-anchor="middle" class="node-detail">Unverified · 3 tools</text>
-  <rect x="422" y="134" width="88" height="14" rx="3" fill="#ffebe9" stroke="#cf222e" stroke-width="0.8"/>
-  <text x="466" y="144" text-anchor="middle" class="badge" fill="#cf222e">COMPROMISED</text>
+  <!-- Node 4: Agent -->
+  <rect x="624" y="56" width="160" height="80" rx="14" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="704" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#2563eb" letter-spacing="0.08em">AI AGENT</text>
+  <text x="704" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#1d4ed8">Cursor IDE</text>
+  <text x="704" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#2563eb">4 servers | 12 tools</text>
 
-  <line x1="540" y1="124" x2="576" y2="124" class="flow-line" stroke="#cf222e" marker-end="url(#arr-red)"/>
+  <!-- Red propagation glow line -->
+  <rect x="30" y="142" width="754" height="3" rx="1.5" fill="#ef4444" opacity="0.15"/>
 
-  <!-- ═══ AI Agent ═══ -->
-  <text x="658" y="80" text-anchor="middle" class="phase-label" fill="#0969da">AI AGENT</text>
+  <!-- ─── IMPACT: What attacker reaches ─── -->
+  <text x="440" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#0f172a">What an attacker can reach</text>
 
-  <rect x="584" y="92" width="148" height="64" rx="10" fill="#ddf4ff" stroke="#0969da" stroke-width="1.5"/>
-  <text x="658" y="112" text-anchor="middle" class="node-name" fill="#0550ae">Cursor IDE</text>
-  <text x="658" y="128" text-anchor="middle" class="node-detail">4 servers · 12 tools</text>
-  <rect x="614" y="134" width="88" height="14" rx="3" fill="#ffebe9" stroke="#cf222e" stroke-width="0.8"/>
-  <text x="658" y="144" text-anchor="middle" class="badge" fill="#cf222e">AT RISK</text>
+  <!-- Credentials row -->
+  <text x="48" y="210" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#d97706" letter-spacing="0.08em">CREDENTIALS EXPOSED</text>
 
-  <!-- Propagation glow -->
-  <rect x="24" y="166" width="708" height="4" rx="2" fill="url(#glow-red)"/>
-  <rect x="24" y="166" width="708" height="4" rx="2" fill="#cf222e" opacity="0.06"/>
+  <rect x="48" y="220" width="136" height="40" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="116" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#92400e">ANTHROPIC_KEY</text>
 
-  <!-- ═══ What attacker reaches ═══ -->
-  <text x="440" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1f2328">What an attacker can reach</text>
+  <rect x="196" y="220" width="136" height="40" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="264" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#92400e">DB_URL</text>
 
-  <!-- Credentials -->
-  <text x="60" y="236" class="phase-label" fill="#bf8700">CREDENTIALS EXPOSED</text>
+  <rect x="344" y="220" width="136" height="40" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="412" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#92400e">AWS_SECRET</text>
 
-  <rect x="60" y="246" width="120" height="38" rx="7" fill="#fff8c5" stroke="#bf8700" stroke-width="1.2"/>
-  <text x="120" y="262" text-anchor="middle" class="node-name" fill="#7d4e00">ANTHROPIC_KEY</text>
-  <text x="120" y="276" text-anchor="middle" class="node-detail">API access</text>
+  <!-- Tools row -->
+  <text x="48" y="288" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#78716c" letter-spacing="0.08em">TOOLS REACHABLE</text>
 
-  <rect x="196" y="246" width="120" height="38" rx="7" fill="#fff8c5" stroke="#bf8700" stroke-width="1.2"/>
-  <text x="256" y="262" text-anchor="middle" class="node-name" fill="#7d4e00">DB_URL</text>
-  <text x="256" y="276" text-anchor="middle" class="node-detail">Database connection</text>
+  <rect x="48" y="298" width="100" height="36" rx="8" fill="#f8fafc" stroke="#d1d5db" stroke-width="1.2"/>
+  <text x="98" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#374151">query_db</text>
 
-  <rect x="332" y="246" width="120" height="38" rx="7" fill="#fff8c5" stroke="#bf8700" stroke-width="1.2"/>
-  <text x="392" y="262" text-anchor="middle" class="node-name" fill="#7d4e00">AWS_SECRET</text>
-  <text x="392" y="276" text-anchor="middle" class="node-detail">Cloud access</text>
+  <rect x="160" y="298" width="100" height="36" rx="8" fill="#f8fafc" stroke="#d1d5db" stroke-width="1.2"/>
+  <text x="210" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#374151">read_file</text>
 
-  <!-- Tools -->
-  <text x="60" y="310" class="phase-label" fill="#9a6700">TOOLS REACHABLE</text>
+  <rect x="272" y="298" width="100" height="36" rx="8" fill="#f8fafc" stroke="#d1d5db" stroke-width="1.2"/>
+  <text x="322" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#374151">write_file</text>
 
-  <rect x="60" y="320" width="90" height="32" rx="6" fill="#f6f8fa" stroke="#9a6700" stroke-width="1"/>
-  <text x="105" y="340" text-anchor="middle" class="tag" fill="#7d4e00">query_db</text>
+  <rect x="384" y="298" width="100" height="36" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <text x="434" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#dc2626">run_shell</text>
 
-  <rect x="164" y="320" width="90" height="32" rx="6" fill="#f6f8fa" stroke="#9a6700" stroke-width="1"/>
-  <text x="209" y="340" text-anchor="middle" class="tag" fill="#7d4e00">read_file</text>
+  <!-- Impact summary box -->
+  <rect x="560" y="196" width="290" height="146" rx="14" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="705" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#0f172a">Impact Summary</text>
 
-  <rect x="268" y="320" width="90" height="32" rx="6" fill="#f6f8fa" stroke="#9a6700" stroke-width="1"/>
-  <text x="313" y="340" text-anchor="middle" class="tag" fill="#7d4e00">write_file</text>
+  <text x="588" y="250" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#ef4444">1</text>
+  <text x="616" y="248" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#64748b">agent compromised</text>
 
-  <rect x="372" y="320" width="90" height="32" rx="6" fill="#ffebe9" stroke="#cf222e" stroke-width="1.5"/>
-  <text x="417" y="340" text-anchor="middle" class="tag" fill="#a40e26">run_shell</text>
+  <text x="588" y="280" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#f59e0b">3</text>
+  <text x="616" y="278" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#64748b">credentials exposed</text>
 
-  <!-- Threat tags -->
-  <text x="60" y="376" class="phase-label" fill="#8250df">THREAT FRAMEWORKS TRIGGERED</text>
+  <text x="588" y="310" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#78716c">4</text>
+  <text x="616" y="308" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#64748b">tools reachable (incl. RCE)</text>
 
-  <rect x="60" y="386" width="60" height="20" rx="4" fill="#fbefff" stroke="#8250df" stroke-width="0.8"/>
-  <text x="90" y="400" text-anchor="middle" class="tag" fill="#6639ba">LLM02</text>
-
-  <rect x="130" y="386" width="60" height="20" rx="4" fill="#fbefff" stroke="#8250df" stroke-width="0.8"/>
-  <text x="160" y="400" text-anchor="middle" class="tag" fill="#6639ba">LLM05</text>
-
-  <rect x="200" y="386" width="60" height="20" rx="4" fill="#fbefff" stroke="#8250df" stroke-width="0.8"/>
-  <text x="230" y="400" text-anchor="middle" class="tag" fill="#6639ba">LLM06</text>
-
-  <rect x="270" y="386" width="60" height="20" rx="4" fill="#fbefff" stroke="#8250df" stroke-width="0.8"/>
-  <text x="300" y="400" text-anchor="middle" class="tag" fill="#6639ba">LLM08</text>
-
-  <rect x="348" y="386" width="82" height="20" rx="4" fill="#ddf4ff" stroke="#0969da" stroke-width="0.8"/>
-  <text x="389" y="400" text-anchor="middle" class="tag" fill="#0550ae">AML.T0010</text>
-
-  <rect x="440" y="386" width="82" height="20" rx="4" fill="#ddf4ff" stroke="#0969da" stroke-width="0.8"/>
-  <text x="481" y="400" text-anchor="middle" class="tag" fill="#0550ae">AML.T0062</text>
-
-  <!-- ═══ Impact Summary ═══ -->
-  <rect x="560" y="220" width="296" height="196" rx="10" fill="#f6f8fa" stroke="#d1d9e0" stroke-width="1"/>
-  <text x="708" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#1f2328">Impact Summary</text>
-
-  <text x="584" y="272" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#cf222e">1</text>
-  <text x="608" y="268" class="node-name" fill="#656d76">agent affected</text>
-  <text x="608" y="280" class="node-detail">Cursor IDE (100% of env)</text>
-
-  <line x1="580" y1="290" x2="840" y2="290" class="dim-line"/>
-
-  <text x="584" y="312" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#bf8700">3</text>
-  <text x="608" y="308" class="node-name" fill="#656d76">credentials exposed</text>
-  <text x="608" y="320" class="node-detail">ANTHROPIC_KEY, DB_URL, AWS_SECRET</text>
-
-  <line x1="580" y1="330" x2="840" y2="330" class="dim-line"/>
-
-  <text x="584" y="352" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#9a6700">4</text>
-  <text x="608" y="348" class="node-name" fill="#656d76">tools reachable</text>
-  <text x="608" y="360" class="node-detail">incl. run_shell (RCE risk)</text>
-
-  <line x1="580" y1="370" x2="840" y2="370" class="dim-line"/>
-
-  <text x="584" y="392" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#8250df">6</text>
-  <text x="608" y="388" class="node-name" fill="#656d76">threat categories</text>
-  <text x="608" y="400" class="node-detail">4 OWASP LLM + 2 ATLAS + ASI + EU</text>
-
-  <rect x="580" y="406" width="260" height="2" rx="1" fill="#1a7f37" opacity="0.4"/>
-  <text x="710" y="424" text-anchor="middle" font-family="'SF Mono', monospace" font-size="9" font-weight="600" fill="#1a7f37">FIX: upgrade better-sqlite3 → 11.7.0</text>
+  <!-- Fix footer -->
+  <rect x="560" y="324" width="290" height="2" rx="1" fill="#22c55e" opacity="0.4"/>
+  <text x="705" y="344" text-anchor="middle" font-family="monospace" font-size="11" font-weight="700" fill="#16a34a">FIX: upgrade better-sqlite3 to 11.7.0</text>
 </svg>

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -1,269 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" fill="none">
-  <style>
-    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
-    .subtitle { font: 400 10px system-ui, sans-serif; fill: #8b949e; }
-    .section-title { font: 700 9px system-ui, sans-serif; letter-spacing: 0.08em; }
-    .box-label { font: 600 10px system-ui, sans-serif; fill: #e6edf3; }
-    .box-sub { font: 400 8px system-ui, sans-serif; fill: #8b949e; }
-    .step-num { font: 700 11px system-ui, sans-serif; }
-    .step-label { font: 600 10px system-ui, sans-serif; fill: #e6edf3; }
-    .step-detail { font: 400 8px system-ui, sans-serif; fill: #8b949e; }
-    .badge { font: 600 8px system-ui, sans-serif; }
-    .side-title { font: 700 9px system-ui, sans-serif; letter-spacing: 0.06em; }
-    .side-label { font: 500 8.5px system-ui, sans-serif; fill: #c9d1d9; }
-    .side-sub { font: 400 7.5px system-ui, sans-serif; fill: #8b949e; }
-  </style>
-  <defs>
-    <marker id="arr-blue" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#58a6ff" opacity="0.7"/>
-    </marker>
-    <marker id="arr-amber" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#d29922" opacity="0.7"/>
-    </marker>
-    <marker id="arr-green" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#3fb950" opacity="0.7"/>
-    </marker>
-    <linearGradient id="flow-grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#58a6ff" stop-opacity="0.15"/>
-      <stop offset="100%" stop-color="#58a6ff" stop-opacity="0"/>
-    </linearGradient>
-  </defs>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
   <!-- Background -->
-  <rect width="960" height="540" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <rect width="880" height="420" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
-  <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" class="title">agent-bom — AI Supply Chain Security Scanner</text>
-  <text x="480" y="42" text-anchor="middle" class="subtitle">Read-only analysis · No agents deployed · No code execution · Local or CI/CD</text>
+  <!-- ─── ROW 1: INPUT SOURCES ─── -->
+  <rect x="30" y="24" width="820" height="90" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.2" opacity="0.9"/>
+  <text x="440" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.1em">INPUT SOURCES</text>
 
-  <!-- ═══ INPUT SOURCES (top lane) ═══ -->
-  <rect x="24" y="58" width="720" height="110" rx="8" fill="#161b22" stroke="#58a6ff" stroke-width="0.8" opacity="0.9"/>
-  <text x="40" y="74" class="section-title" fill="#58a6ff">INPUT SOURCES</text>
+  <rect x="52" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="112" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">MCP Configs</text>
 
-  <!-- Input box 1: MCP Configs -->
-  <rect x="36" y="82" width="108" height="76" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <circle cx="90" cy="104" r="12" fill="none" stroke="#58a6ff" stroke-width="1.2" opacity="0.7"/>
-  <text x="90" y="108" text-anchor="middle" class="step-num" fill="#58a6ff">⚙</text>
-  <text x="90" y="126" text-anchor="middle" class="box-label">MCP Configs</text>
-  <text x="90" y="137" text-anchor="middle" class="box-sub">18 clients · auto-detect</text>
-  <text x="90" y="148" text-anchor="middle" class="box-sub">Claude · Cursor · Codex</text>
+  <rect x="184" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="244" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">Containers</text>
 
-  <!-- Input box 2: Containers -->
-  <rect x="152" y="82" width="108" height="76" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <circle cx="206" cy="104" r="12" fill="none" stroke="#58a6ff" stroke-width="1.2" opacity="0.7"/>
-  <text x="206" y="108" text-anchor="middle" class="step-num" fill="#58a6ff">🐳</text>
-  <text x="206" y="126" text-anchor="middle" class="box-label">Containers</text>
-  <text x="206" y="137" text-anchor="middle" class="box-sub">Docker Hub · ECR · GCR</text>
-  <text x="206" y="148" text-anchor="middle" class="box-sub">OCI deep scan</text>
+  <rect x="316" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="376" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">Kubernetes</text>
 
-  <!-- Input box 3: Kubernetes -->
-  <rect x="268" y="82" width="108" height="76" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <circle cx="322" cy="104" r="12" fill="none" stroke="#58a6ff" stroke-width="1.2" opacity="0.7"/>
-  <text x="322" y="108" text-anchor="middle" class="step-num" fill="#58a6ff">☸</text>
-  <text x="322" y="126" text-anchor="middle" class="box-label">Kubernetes</text>
-  <text x="322" y="137" text-anchor="middle" class="box-sub">Multi-namespace</text>
-  <text x="322" y="148" text-anchor="middle" class="box-sub">Pod image discovery</text>
+  <rect x="448" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="508" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">Cloud APIs</text>
 
-  <!-- Input box 4: SBOMs -->
-  <rect x="384" y="82" width="108" height="76" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <circle cx="438" cy="104" r="12" fill="none" stroke="#58a6ff" stroke-width="1.2" opacity="0.7"/>
-  <text x="438" y="108" text-anchor="middle" class="step-num" fill="#58a6ff">📋</text>
-  <text x="438" y="126" text-anchor="middle" class="box-label">SBOMs</text>
-  <text x="438" y="137" text-anchor="middle" class="box-sub">CycloneDX · SPDX</text>
-  <text x="438" y="148" text-anchor="middle" class="box-sub">Vendor-provided</text>
+  <rect x="580" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="640" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">SBOMs</text>
 
-  <!-- Input box 5: Cloud -->
-  <rect x="500" y="82" width="108" height="76" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <circle cx="554" cy="104" r="12" fill="none" stroke="#58a6ff" stroke-width="1.2" opacity="0.7"/>
-  <text x="554" y="108" text-anchor="middle" class="step-num" fill="#58a6ff">☁</text>
-  <text x="554" y="126" text-anchor="middle" class="box-label">Cloud</text>
-  <text x="554" y="137" text-anchor="middle" class="box-sub">Snowflake · AWS</text>
-  <text x="554" y="148" text-anchor="middle" class="box-sub">Azure · GCP</text>
+  <rect x="712" y="56" width="126" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="775" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">AI Frameworks</text>
 
-  <!-- Input box 6: AI Frameworks -->
-  <rect x="616" y="82" width="116" height="76" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <circle cx="674" cy="104" r="12" fill="none" stroke="#58a6ff" stroke-width="1.2" opacity="0.7"/>
-  <text x="674" y="108" text-anchor="middle" class="step-num" fill="#58a6ff">🤖</text>
-  <text x="674" y="126" text-anchor="middle" class="box-label">AI Frameworks</text>
-  <text x="674" y="137" text-anchor="middle" class="box-sub">LangChain · CrewAI</text>
-  <text x="674" y="148" text-anchor="middle" class="box-sub">70+ packages tracked</text>
+  <!-- Arrow down -->
+  <path d="M440 114 L440 136" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M434 130 L440 140 L446 130" fill="#4b5563"/>
 
-  <!-- Flow arrow: inputs → engine -->
-  <line x1="384" y1="170" x2="384" y2="192" stroke="#58a6ff" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-blue)" opacity="0.6"/>
+  <!-- ─── ROW 2: SCANNER ENGINE ─── -->
+  <rect x="30" y="144" width="620" height="110" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.2" opacity="0.9"/>
+  <text x="340" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.1em">SCANNER ENGINE</text>
 
-  <!-- ═══ SCANNER ENGINE (middle lane) ═══ -->
-  <rect x="24" y="196" width="720" height="108" rx="8" fill="#161b22" stroke="#d29922" stroke-width="0.8" opacity="0.9"/>
-  <text x="40" y="212" class="section-title" fill="#d29922">SCANNER ENGINE</text>
-  <text x="280" y="212" class="subtitle">read-only · no agents · local execution</text>
+  <rect x="46" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="91" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Discover</text>
+  <text x="91" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">18 clients</text>
 
-  <!-- Step 1: Discover -->
-  <rect x="36" y="220" width="128" height="72" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8" opacity="0.7"/>
-  <rect x="36" y="220" width="128" height="18" rx="6" fill="#d29922" opacity="0.12"/>
-  <text x="48" y="233" class="step-num" fill="#d29922">①</text>
-  <text x="68" y="233" class="step-label">Discover</text>
-  <text x="100" y="252" text-anchor="middle" class="step-detail">Auto-detect configs</text>
-  <text x="100" y="264" text-anchor="middle" class="step-detail">18 MCP clients</text>
-  <text x="100" y="276" text-anchor="middle" class="step-detail">Docker · Compose · K8s</text>
+  <path d="M140 208 L152 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+  <path d="M148 204 L155 208 L148 212" fill="#f59e0b"/>
 
-  <!-- Arrow 1→2 -->
-  <line x1="166" y1="256" x2="178" y2="256" stroke="#d29922" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="160" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="205" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Extract</text>
+  <text x="205" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">packages</text>
 
-  <!-- Step 2: Extract -->
-  <rect x="182" y="220" width="118" height="72" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8" opacity="0.7"/>
-  <rect x="182" y="220" width="118" height="18" rx="6" fill="#d29922" opacity="0.12"/>
-  <text x="194" y="233" class="step-num" fill="#d29922">②</text>
-  <text x="214" y="233" class="step-label">Extract</text>
-  <text x="241" y="252" text-anchor="middle" class="step-detail">Packages + versions</text>
-  <text x="241" y="264" text-anchor="middle" class="step-detail">Lock files · registries</text>
-  <text x="241" y="276" text-anchor="middle" class="step-detail">PURLs · credentials</text>
+  <path d="M254 208 L266 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+  <path d="M262 204 L269 208 L262 212" fill="#f59e0b"/>
 
-  <!-- Arrow 2→3 -->
-  <line x1="302" y1="256" x2="314" y2="256" stroke="#d29922" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="274" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="319" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Scan</text>
+  <text x="319" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">OSV + Grype</text>
 
-  <!-- Step 3: Scan -->
-  <rect x="318" y="220" width="118" height="72" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8" opacity="0.7"/>
-  <rect x="318" y="220" width="118" height="18" rx="6" fill="#d29922" opacity="0.12"/>
-  <text x="330" y="233" class="step-num" fill="#d29922">③</text>
-  <text x="350" y="233" class="step-label">Scan</text>
-  <text x="377" y="252" text-anchor="middle" class="step-detail">OSV.dev batch API</text>
-  <text x="377" y="264" text-anchor="middle" class="step-detail">Grype for images</text>
-  <text x="377" y="276" text-anchor="middle" class="step-detail">Typosquat detection</text>
+  <path d="M368 208 L380 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+  <path d="M376 204 L383 208 L376 212" fill="#f59e0b"/>
 
-  <!-- Arrow 3→4 -->
-  <line x1="438" y1="256" x2="450" y2="256" stroke="#d29922" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="388" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="433" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Enrich</text>
+  <text x="433" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">NVD + EPSS</text>
 
-  <!-- Step 4: Enrich -->
-  <rect x="454" y="220" width="118" height="72" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8" opacity="0.7"/>
-  <rect x="454" y="220" width="118" height="18" rx="6" fill="#d29922" opacity="0.12"/>
-  <text x="466" y="233" class="step-num" fill="#d29922">④</text>
-  <text x="486" y="233" class="step-label">Enrich</text>
-  <text x="513" y="252" text-anchor="middle" class="step-detail">NVD CVSS scores</text>
-  <text x="513" y="264" text-anchor="middle" class="step-detail">FIRST EPSS probability</text>
-  <text x="513" y="276" text-anchor="middle" class="step-detail">CISA KEV + CWEs</text>
+  <path d="M482 208 L494 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+  <path d="M490 204 L497 208 L490 212" fill="#f59e0b"/>
 
-  <!-- Arrow 4→5 -->
-  <line x1="574" y1="256" x2="586" y2="256" stroke="#d29922" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="502" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="547" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Analyze</text>
+  <text x="547" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">blast radius</text>
 
-  <!-- Step 5: Analyze -->
-  <rect x="590" y="220" width="142" height="72" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8" opacity="0.7"/>
-  <rect x="590" y="220" width="142" height="18" rx="6" fill="#d29922" opacity="0.12"/>
-  <text x="602" y="233" class="step-num" fill="#d29922">⑤</text>
-  <text x="622" y="233" class="step-label">Analyze</text>
-  <text x="661" y="252" text-anchor="middle" class="step-detail">Blast radius mapping</text>
-  <text x="661" y="264" text-anchor="middle" class="step-detail">10 compliance frameworks</text>
-  <text x="661" y="276" text-anchor="middle" class="step-detail">Risk scoring (0-10)</text>
+  <!-- ─── SIDEBAR: RUNTIME ─── -->
+  <rect x="666" y="144" width="184" height="110" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.2" opacity="0.9"/>
+  <text x="758" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.1em">RUNTIME</text>
 
-  <!-- Flow arrow: engine → outputs -->
-  <line x1="384" y1="306" x2="384" y2="328" stroke="#d29922" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-green)" opacity="0.6"/>
+  <text x="688" y="190" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">MCP Proxy</text>
+  <text x="688" y="208" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Protection Engine</text>
+  <text x="688" y="226" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Fleet Management</text>
+  <text x="688" y="244" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Alert Pipeline</text>
 
-  <!-- ═══ OUTPUTS (bottom-left lane) ═══ -->
-  <rect x="24" y="332" width="480" height="190" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="0.8" opacity="0.9"/>
-  <text x="40" y="348" class="section-title" fill="#3fb950">OUTPUTS + INTEGRATIONS</text>
+  <path d="M596 208 L666 208" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="6 4" opacity="0.6"/>
 
-  <!-- Output row 1: Formats -->
-  <rect x="36" y="356" width="222" height="38" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <text x="48" y="373" class="box-label">Report Formats</text>
-  <text x="48" y="385" class="box-sub">JSON · SARIF · CycloneDX · SPDX · HTML · SVG · Badge</text>
+  <!-- Arrow down -->
+  <path d="M340 254 L340 276" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M334 270 L340 280 L346 270" fill="#4b5563"/>
 
-  <!-- Output row 2: Dashboard -->
-  <rect x="266" y="356" width="228" height="38" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <text x="278" y="373" class="box-label">Security Dashboard</text>
-  <text x="278" y="385" class="box-sub">13-page Next.js UI · REST API · SSE streaming</text>
+  <!-- ─── ROW 3: OUTPUTS ─── -->
+  <rect x="30" y="284" width="820" height="108" rx="12" fill="#161b22" stroke="#059669" stroke-width="1.2" opacity="0.9"/>
+  <text x="440" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.1em">OUTPUTS</text>
 
-  <!-- Output row 3: CI/CD -->
-  <rect x="36" y="400" width="222" height="38" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <text x="48" y="417" class="box-label">CI/CD Pipeline Gates</text>
-  <text x="48" y="429" class="box-sub">GitHub Actions · GitLab CI · SARIF upload · fail gates</text>
+  <rect x="46" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="101" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">JSON / SARIF</text>
 
-  <!-- Output row 4: Observability -->
-  <rect x="266" y="400" width="228" height="38" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <text x="278" y="417" class="box-label">Observability</text>
-  <text x="278" y="429" class="box-sub">Prometheus · OpenTelemetry · Grafana · Pushgateway</text>
+  <rect x="168" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="223" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">CycloneDX</text>
 
-  <!-- Output row 5: Notifications -->
-  <rect x="36" y="444" width="222" height="38" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <text x="48" y="461" class="box-label">Alert Pipeline</text>
-  <text x="48" y="473" class="box-sub">Slack · Jira · Webhooks · auto-trigger on scan</text>
+  <rect x="290" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="345" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Dashboard</text>
 
-  <!-- Output row 6: Governance -->
-  <rect x="266" y="444" width="228" height="38" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
-  <text x="278" y="461" class="box-label">Governance</text>
-  <text x="278" y="473" class="box-sub">Snowflake · CMMC export · Audit trail · SBOM archive</text>
+  <rect x="412" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="467" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">REST API</text>
 
-  <!-- Compliance badges row -->
-  <rect x="36" y="488" width="456" height="38" rx="4" fill="#0d1117" stroke="#30363d" stroke-width="0.6"/>
-  <text x="48" y="501" class="badge" fill="#3fb950">OWASP LLM</text>
-  <text x="120" y="501" class="badge" fill="#3fb950">OWASP MCP</text>
-  <text x="195" y="501" class="badge" fill="#3fb950">OWASP Agentic</text>
-  <text x="288" y="501" class="badge" fill="#3fb950">MITRE ATLAS</text>
-  <text x="370" y="501" class="badge" fill="#3fb950">NIST AI RMF</text>
-  <text x="448" y="501" class="badge" fill="#3fb950">EU AI Act</text>
-  <text x="48" y="517" class="badge" fill="#3fb950">NIST CSF</text>
-  <text x="106" y="517" class="badge" fill="#3fb950">ISO 27001</text>
-  <text x="174" y="517" class="badge" fill="#3fb950">SOC 2</text>
-  <text x="222" y="517" class="badge" fill="#3fb950">CIS Controls v8</text>
+  <rect x="534" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="589" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">MCP Server</text>
 
-  <!-- ═══ RUNTIME + FLEET (right side panel) ═══ -->
-  <rect x="756" y="58" width="186" height="464" rx="8" fill="#161b22" stroke="#bc8cff" stroke-width="0.8" opacity="0.9"/>
-  <text x="772" y="74" class="section-title" fill="#bc8cff">RUNTIME + FLEET</text>
+  <rect x="656" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="711" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Slack / Jira</text>
 
-  <!-- Runtime: Protect -->
-  <rect x="768" y="82" width="162" height="72" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="100" class="side-label" fill="#bc8cff">⛨ Runtime Protection</text>
-  <text x="780" y="114" class="side-sub">Tool drift detector</text>
-  <text x="780" y="125" class="side-sub">Argument analyzer</text>
-  <text x="780" y="136" class="side-sub">Credential leak detector</text>
-  <text x="780" y="147" class="side-sub">Rate limiter · Sequence analyzer</text>
-
-  <!-- Runtime: Fleet -->
-  <rect x="768" y="162" width="162" height="68" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="180" class="side-label" fill="#bc8cff">🏢 Fleet Management</text>
-  <text x="780" y="194" class="side-sub">Multi-tenant agent registry</text>
-  <text x="780" y="205" class="side-sub">Trust scoring per agent</text>
-  <text x="780" y="216" class="side-sub">Lifecycle: discover → approve</text>
-
-  <!-- Runtime: Alerts -->
-  <rect x="768" y="238" width="162" height="56" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="256" class="side-label" fill="#bc8cff">🔔 Alert Pipeline</text>
-  <text x="780" y="270" class="side-sub">Webhook · Slack · in-memory</text>
-  <text x="780" y="281" class="side-sub">Auto-trigger on scan + runtime</text>
-
-  <!-- Runtime: Mesh -->
-  <rect x="768" y="302" width="162" height="56" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="320" class="side-label" fill="#bc8cff">🕸 Agent Mesh</text>
-  <text x="780" y="334" class="side-sub">Cross-agent topology map</text>
-  <text x="780" y="345" class="side-sub">Shared server detection</text>
-
-  <!-- Runtime: Proxy -->
-  <rect x="768" y="366" width="162" height="56" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="384" class="side-label" fill="#bc8cff">🛡 MCP Proxy</text>
-  <text x="780" y="398" class="side-sub">Stdio intercept · policy enforce</text>
-  <text x="780" y="409" class="side-sub">Replay detection · audit log</text>
-
-  <!-- Runtime: Enforcement -->
-  <rect x="768" y="430" width="162" height="56" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="448" class="side-label" fill="#bc8cff">🔒 Enforcement</text>
-  <text x="780" y="462" class="side-sub">Tool poisoning detection</text>
-  <text x="780" y="473" class="side-sub">Permission scanning · drift</text>
-
-  <!-- Horizontal connector: Engine → Runtime panel -->
-  <line x1="744" y1="250" x2="756" y2="250" stroke="#bc8cff" stroke-width="1.2" stroke-dasharray="3 3" opacity="0.5"/>
-
-  <!-- External data sources (bottom bar) -->
-  <rect x="516" y="332" width="228" height="62" rx="6" fill="#161b22" stroke="#6e7681" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="348" class="section-title" fill="#6e7681">PUBLIC DATA SOURCES</text>
-  <text x="528" y="364" class="box-sub">OSV.dev · NVD/NIST · FIRST EPSS</text>
-  <text x="528" y="376" class="box-sub">CISA KEV · MCP Registry (427+) · Grype DB</text>
-  <text x="528" y="388" class="box-sub">No auth required · No user data sent</text>
-
-  <!-- Why agent-bom footer -->
-  <rect x="516" y="400" width="228" height="48" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.6"/>
-  <text x="528" y="416" class="side-label" fill="#e6edf3">vs Wiz / Snyk / Prisma</text>
-  <text x="528" y="429" class="box-sub">✓ Free + open source (Apache-2.0)</text>
-  <text x="528" y="440" class="box-sub">✓ AI-native · MCP-first · runs anywhere</text>
-
-  <!-- MCP Server badge -->
-  <rect x="516" y="454" width="228" height="40" rx="6" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="471" class="side-label" fill="#58a6ff">16 MCP Tools · 10 Frameworks</text>
-  <text x="528" y="484" class="box-sub">2,800+ tests · Sigstore signed · OpenSSF scored</text>
+  <!-- ─── FOOTER: COMPLIANCE ─── -->
+  <rect x="30" y="396" width="820" height="2" rx="1" fill="#21262d"/>
+  <text x="440" y="415" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e" letter-spacing="0.05em">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -1,245 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" fill="none">
-  <style>
-    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #1f2328; }
-    .subtitle { font: 400 10px system-ui, sans-serif; fill: #656d76; }
-    .section-title { font: 700 9px system-ui, sans-serif; letter-spacing: 0.08em; }
-    .box-label { font: 600 10px system-ui, sans-serif; fill: #1f2328; }
-    .box-sub { font: 400 8px system-ui, sans-serif; fill: #656d76; }
-    .step-num { font: 700 11px system-ui, sans-serif; }
-    .step-label { font: 600 10px system-ui, sans-serif; fill: #1f2328; }
-    .step-detail { font: 400 8px system-ui, sans-serif; fill: #656d76; }
-    .badge { font: 600 8px system-ui, sans-serif; }
-    .side-title { font: 700 9px system-ui, sans-serif; letter-spacing: 0.06em; }
-    .side-label { font: 500 8.5px system-ui, sans-serif; fill: #1f2328; }
-    .side-sub { font: 400 7.5px system-ui, sans-serif; fill: #656d76; }
-  </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
   <defs>
-    <marker id="arr-blue" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#0969da" opacity="0.7"/>
-    </marker>
-    <marker id="arr-amber" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#bf8700" opacity="0.7"/>
-    </marker>
-    <marker id="arr-green" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#1a7f37" opacity="0.7"/>
+    <marker id="arrow-down" viewBox="0 0 10 10" refX="5" refY="10" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0L5 10L10 0" fill="none" stroke="#94a3b8" stroke-width="2"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="960" height="540" rx="12" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <rect width="880" height="420" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
-  <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" class="title">agent-bom — AI Supply Chain Security Scanner</text>
-  <text x="480" y="42" text-anchor="middle" class="subtitle">Read-only analysis · No agents deployed · No code execution · Local or CI/CD</text>
+  <!-- ─── ROW 1: INPUT SOURCES ─── -->
+  <rect x="30" y="24" width="820" height="90" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.2"/>
+  <text x="440" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#3b82f6" letter-spacing="0.1em">INPUT SOURCES</text>
 
-  <!-- ═══ INPUT SOURCES (top lane) ═══ -->
-  <rect x="24" y="58" width="720" height="110" rx="8" fill="#f6f8fa" stroke="#0969da" stroke-width="0.8" opacity="0.9"/>
-  <text x="40" y="74" class="section-title" fill="#0969da">INPUT SOURCES</text>
+  <!-- Source pills -->
+  <rect x="52" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="112" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">MCP Configs</text>
 
-  <!-- Input box 1: MCP Configs -->
-  <rect x="36" y="82" width="108" height="76" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <circle cx="90" cy="104" r="12" fill="none" stroke="#0969da" stroke-width="1.2" opacity="0.7"/>
-  <text x="90" y="108" text-anchor="middle" class="step-num" fill="#0969da">⚙</text>
-  <text x="90" y="126" text-anchor="middle" class="box-label">MCP Configs</text>
-  <text x="90" y="137" text-anchor="middle" class="box-sub">18 clients · auto-detect</text>
-  <text x="90" y="148" text-anchor="middle" class="box-sub">Claude · Cursor · Codex</text>
+  <rect x="184" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="244" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">Containers</text>
 
-  <!-- Input box 2: Containers -->
-  <rect x="152" y="82" width="108" height="76" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <circle cx="206" cy="104" r="12" fill="none" stroke="#0969da" stroke-width="1.2" opacity="0.7"/>
-  <text x="206" y="108" text-anchor="middle" class="step-num" fill="#0969da">🐳</text>
-  <text x="206" y="126" text-anchor="middle" class="box-label">Containers</text>
-  <text x="206" y="137" text-anchor="middle" class="box-sub">Docker Hub · ECR · GCR</text>
-  <text x="206" y="148" text-anchor="middle" class="box-sub">OCI deep scan</text>
+  <rect x="316" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="376" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">Kubernetes</text>
 
-  <!-- Input box 3: Kubernetes -->
-  <rect x="268" y="82" width="108" height="76" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <circle cx="322" cy="104" r="12" fill="none" stroke="#0969da" stroke-width="1.2" opacity="0.7"/>
-  <text x="322" y="108" text-anchor="middle" class="step-num" fill="#0969da">☸</text>
-  <text x="322" y="126" text-anchor="middle" class="box-label">Kubernetes</text>
-  <text x="322" y="137" text-anchor="middle" class="box-sub">Multi-namespace</text>
-  <text x="322" y="148" text-anchor="middle" class="box-sub">Pod image discovery</text>
+  <rect x="448" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="508" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">Cloud APIs</text>
 
-  <!-- Input box 4: SBOMs -->
-  <rect x="384" y="82" width="108" height="76" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <circle cx="438" cy="104" r="12" fill="none" stroke="#0969da" stroke-width="1.2" opacity="0.7"/>
-  <text x="438" y="108" text-anchor="middle" class="step-num" fill="#0969da">📋</text>
-  <text x="438" y="126" text-anchor="middle" class="box-label">SBOMs</text>
-  <text x="438" y="137" text-anchor="middle" class="box-sub">CycloneDX · SPDX</text>
-  <text x="438" y="148" text-anchor="middle" class="box-sub">Vendor-provided</text>
+  <rect x="580" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="640" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">SBOMs</text>
 
-  <!-- Input box 5: Cloud -->
-  <rect x="500" y="82" width="108" height="76" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <circle cx="554" cy="104" r="12" fill="none" stroke="#0969da" stroke-width="1.2" opacity="0.7"/>
-  <text x="554" y="108" text-anchor="middle" class="step-num" fill="#0969da">☁</text>
-  <text x="554" y="126" text-anchor="middle" class="box-label">Cloud</text>
-  <text x="554" y="137" text-anchor="middle" class="box-sub">Snowflake · AWS</text>
-  <text x="554" y="148" text-anchor="middle" class="box-sub">Azure · GCP</text>
+  <rect x="712" y="56" width="126" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="775" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">AI Frameworks</text>
 
-  <!-- Input box 6: AI Frameworks -->
-  <rect x="616" y="82" width="116" height="76" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <circle cx="674" cy="104" r="12" fill="none" stroke="#0969da" stroke-width="1.2" opacity="0.7"/>
-  <text x="674" y="108" text-anchor="middle" class="step-num" fill="#0969da">🤖</text>
-  <text x="674" y="126" text-anchor="middle" class="box-label">AI Frameworks</text>
-  <text x="674" y="137" text-anchor="middle" class="box-sub">LangChain · CrewAI</text>
-  <text x="674" y="148" text-anchor="middle" class="box-sub">70+ packages tracked</text>
+  <!-- Arrow down -->
+  <path d="M440 114 L440 136" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M434 130 L440 140 L446 130" fill="#94a3b8"/>
 
-  <!-- Flow arrow: inputs → engine -->
-  <line x1="384" y1="170" x2="384" y2="192" stroke="#0969da" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-blue)" opacity="0.6"/>
+  <!-- ─── ROW 2: SCANNER ENGINE ─── -->
+  <rect x="30" y="144" width="620" height="110" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="1.2"/>
+  <text x="340" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.1em">SCANNER ENGINE</text>
 
-  <!-- ═══ SCANNER ENGINE (middle lane) ═══ -->
-  <rect x="24" y="196" width="720" height="108" rx="8" fill="#f6f8fa" stroke="#bf8700" stroke-width="0.8" opacity="0.9"/>
-  <text x="40" y="212" class="section-title" fill="#bf8700">SCANNER ENGINE</text>
-  <text x="280" y="212" class="subtitle">read-only · no agents · local execution</text>
+  <!-- Pipeline stages -->
+  <rect x="46" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="91" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Discover</text>
+  <text x="91" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">18 clients</text>
 
-  <!-- Step 1: Discover -->
-  <rect x="36" y="220" width="128" height="72" rx="6" fill="#ffffff" stroke="#bf8700" stroke-width="0.8" opacity="0.7"/>
-  <rect x="36" y="220" width="128" height="18" rx="6" fill="#bf8700" opacity="0.08"/>
-  <text x="48" y="233" class="step-num" fill="#bf8700">①</text>
-  <text x="68" y="233" class="step-label">Discover</text>
-  <text x="100" y="252" text-anchor="middle" class="step-detail">Auto-detect configs</text>
-  <text x="100" y="264" text-anchor="middle" class="step-detail">18 MCP clients</text>
-  <text x="100" y="276" text-anchor="middle" class="step-detail">Docker · Compose · K8s</text>
+  <path d="M140 208 L152 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
+  <path d="M148 204 L155 208 L148 212" fill="#d97706"/>
 
-  <line x1="166" y1="256" x2="178" y2="256" stroke="#bf8700" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="160" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="205" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Extract</text>
+  <text x="205" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">packages</text>
 
-  <!-- Step 2: Extract -->
-  <rect x="182" y="220" width="118" height="72" rx="6" fill="#ffffff" stroke="#bf8700" stroke-width="0.8" opacity="0.7"/>
-  <rect x="182" y="220" width="118" height="18" rx="6" fill="#bf8700" opacity="0.08"/>
-  <text x="194" y="233" class="step-num" fill="#bf8700">②</text>
-  <text x="214" y="233" class="step-label">Extract</text>
-  <text x="241" y="252" text-anchor="middle" class="step-detail">Packages + versions</text>
-  <text x="241" y="264" text-anchor="middle" class="step-detail">Lock files · registries</text>
-  <text x="241" y="276" text-anchor="middle" class="step-detail">PURLs · credentials</text>
+  <path d="M254 208 L266 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
+  <path d="M262 204 L269 208 L262 212" fill="#d97706"/>
 
-  <line x1="302" y1="256" x2="314" y2="256" stroke="#bf8700" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="274" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="319" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Scan</text>
+  <text x="319" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">OSV + Grype</text>
 
-  <!-- Step 3: Scan -->
-  <rect x="318" y="220" width="118" height="72" rx="6" fill="#ffffff" stroke="#bf8700" stroke-width="0.8" opacity="0.7"/>
-  <rect x="318" y="220" width="118" height="18" rx="6" fill="#bf8700" opacity="0.08"/>
-  <text x="330" y="233" class="step-num" fill="#bf8700">③</text>
-  <text x="350" y="233" class="step-label">Scan</text>
-  <text x="377" y="252" text-anchor="middle" class="step-detail">OSV.dev batch API</text>
-  <text x="377" y="264" text-anchor="middle" class="step-detail">Grype for images</text>
-  <text x="377" y="276" text-anchor="middle" class="step-detail">Typosquat detection</text>
+  <path d="M368 208 L380 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
+  <path d="M376 204 L383 208 L376 212" fill="#d97706"/>
 
-  <line x1="438" y1="256" x2="450" y2="256" stroke="#bf8700" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="388" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="433" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Enrich</text>
+  <text x="433" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">NVD + EPSS</text>
 
-  <!-- Step 4: Enrich -->
-  <rect x="454" y="220" width="118" height="72" rx="6" fill="#ffffff" stroke="#bf8700" stroke-width="0.8" opacity="0.7"/>
-  <rect x="454" y="220" width="118" height="18" rx="6" fill="#bf8700" opacity="0.08"/>
-  <text x="466" y="233" class="step-num" fill="#bf8700">④</text>
-  <text x="486" y="233" class="step-label">Enrich</text>
-  <text x="513" y="252" text-anchor="middle" class="step-detail">NVD CVSS scores</text>
-  <text x="513" y="264" text-anchor="middle" class="step-detail">FIRST EPSS probability</text>
-  <text x="513" y="276" text-anchor="middle" class="step-detail">CISA KEV + CWEs</text>
+  <path d="M482 208 L494 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
+  <path d="M490 204 L497 208 L490 212" fill="#d97706"/>
 
-  <line x1="574" y1="256" x2="586" y2="256" stroke="#bf8700" stroke-width="1.2" marker-end="url(#arr-amber)" opacity="0.5"/>
+  <rect x="502" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="547" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Analyze</text>
+  <text x="547" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">blast radius</text>
 
-  <!-- Step 5: Analyze -->
-  <rect x="590" y="220" width="142" height="72" rx="6" fill="#ffffff" stroke="#bf8700" stroke-width="0.8" opacity="0.7"/>
-  <rect x="590" y="220" width="142" height="18" rx="6" fill="#bf8700" opacity="0.08"/>
-  <text x="602" y="233" class="step-num" fill="#bf8700">⑤</text>
-  <text x="622" y="233" class="step-label">Analyze</text>
-  <text x="661" y="252" text-anchor="middle" class="step-detail">Blast radius mapping</text>
-  <text x="661" y="264" text-anchor="middle" class="step-detail">10 compliance frameworks</text>
-  <text x="661" y="276" text-anchor="middle" class="step-detail">Risk scoring (0-10)</text>
+  <!-- ─── SIDEBAR: RUNTIME ─── -->
+  <rect x="666" y="144" width="184" height="110" rx="12" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.2"/>
+  <text x="758" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.1em">RUNTIME</text>
 
-  <!-- Flow arrow: engine → outputs -->
-  <line x1="384" y1="306" x2="384" y2="328" stroke="#bf8700" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#arr-green)" opacity="0.6"/>
+  <text x="688" y="190" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">MCP Proxy</text>
+  <text x="688" y="208" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Protection Engine</text>
+  <text x="688" y="226" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Fleet Management</text>
+  <text x="688" y="244" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Alert Pipeline</text>
 
-  <!-- ═══ OUTPUTS (bottom-left lane) ═══ -->
-  <rect x="24" y="332" width="480" height="190" rx="8" fill="#f6f8fa" stroke="#1a7f37" stroke-width="0.8" opacity="0.9"/>
-  <text x="40" y="348" class="section-title" fill="#1a7f37">OUTPUTS + INTEGRATIONS</text>
+  <!-- Dotted connector to runtime -->
+  <path d="M596 208 L666 208" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
 
-  <rect x="36" y="356" width="222" height="38" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <text x="48" y="373" class="box-label">Report Formats</text>
-  <text x="48" y="385" class="box-sub">JSON · SARIF · CycloneDX · SPDX · HTML · SVG · Badge</text>
+  <!-- Arrow down from engine -->
+  <path d="M340 254 L340 276" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M334 270 L340 280 L346 270" fill="#94a3b8"/>
 
-  <rect x="266" y="356" width="228" height="38" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <text x="278" y="373" class="box-label">Security Dashboard</text>
-  <text x="278" y="385" class="box-sub">13-page Next.js UI · REST API · SSE streaming</text>
+  <!-- ─── ROW 3: OUTPUTS ─── -->
+  <rect x="30" y="284" width="820" height="108" rx="12" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="440" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.1em">OUTPUTS</text>
 
-  <rect x="36" y="400" width="222" height="38" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <text x="48" y="417" class="box-label">CI/CD Pipeline Gates</text>
-  <text x="48" y="429" class="box-sub">GitHub Actions · GitLab CI · SARIF upload · fail gates</text>
+  <rect x="46" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="101" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">JSON / SARIF</text>
 
-  <rect x="266" y="400" width="228" height="38" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <text x="278" y="417" class="box-label">Observability</text>
-  <text x="278" y="429" class="box-sub">Prometheus · OpenTelemetry · Grafana · Pushgateway</text>
+  <rect x="168" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="223" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">CycloneDX</text>
 
-  <rect x="36" y="444" width="222" height="38" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <text x="48" y="461" class="box-label">Alert Pipeline</text>
-  <text x="48" y="473" class="box-sub">Slack · Jira · Webhooks · auto-trigger on scan</text>
+  <rect x="290" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="345" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Dashboard</text>
 
-  <rect x="266" y="444" width="228" height="38" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
-  <text x="278" y="461" class="box-label">Governance</text>
-  <text x="278" y="473" class="box-sub">Snowflake · CMMC export · Audit trail · SBOM archive</text>
+  <rect x="412" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="467" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">REST API</text>
 
-  <rect x="36" y="488" width="456" height="38" rx="4" fill="#ffffff" stroke="#d0d7de" stroke-width="0.6"/>
-  <text x="48" y="501" class="badge" fill="#1a7f37">OWASP LLM</text>
-  <text x="120" y="501" class="badge" fill="#1a7f37">OWASP MCP</text>
-  <text x="195" y="501" class="badge" fill="#1a7f37">OWASP Agentic</text>
-  <text x="288" y="501" class="badge" fill="#1a7f37">MITRE ATLAS</text>
-  <text x="370" y="501" class="badge" fill="#1a7f37">NIST AI RMF</text>
-  <text x="448" y="501" class="badge" fill="#1a7f37">EU AI Act</text>
-  <text x="48" y="517" class="badge" fill="#1a7f37">NIST CSF</text>
-  <text x="106" y="517" class="badge" fill="#1a7f37">ISO 27001</text>
-  <text x="174" y="517" class="badge" fill="#1a7f37">SOC 2</text>
-  <text x="222" y="517" class="badge" fill="#1a7f37">CIS Controls v8</text>
+  <rect x="534" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="589" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">MCP Server</text>
 
-  <!-- ═══ RUNTIME + FLEET (right side panel) ═══ -->
-  <rect x="756" y="58" width="186" height="464" rx="8" fill="#f6f8fa" stroke="#8250df" stroke-width="0.8" opacity="0.9"/>
-  <text x="772" y="74" class="section-title" fill="#8250df">RUNTIME + FLEET</text>
+  <rect x="656" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="711" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Slack / Jira</text>
 
-  <rect x="768" y="82" width="162" height="72" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="100" class="side-label" fill="#8250df">⛨ Runtime Protection</text>
-  <text x="780" y="114" class="side-sub">Tool drift detector</text>
-  <text x="780" y="125" class="side-sub">Argument analyzer</text>
-  <text x="780" y="136" class="side-sub">Credential leak detector</text>
-  <text x="780" y="147" class="side-sub">Rate limiter · Sequence analyzer</text>
-
-  <rect x="768" y="162" width="162" height="68" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="180" class="side-label" fill="#8250df">🏢 Fleet Management</text>
-  <text x="780" y="194" class="side-sub">Multi-tenant agent registry</text>
-  <text x="780" y="205" class="side-sub">Trust scoring per agent</text>
-  <text x="780" y="216" class="side-sub">Lifecycle: discover → approve</text>
-
-  <rect x="768" y="238" width="162" height="56" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="256" class="side-label" fill="#8250df">🔔 Alert Pipeline</text>
-  <text x="780" y="270" class="side-sub">Webhook · Slack · in-memory</text>
-  <text x="780" y="281" class="side-sub">Auto-trigger on scan + runtime</text>
-
-  <rect x="768" y="302" width="162" height="56" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="320" class="side-label" fill="#8250df">🕸 Agent Mesh</text>
-  <text x="780" y="334" class="side-sub">Cross-agent topology map</text>
-  <text x="780" y="345" class="side-sub">Shared server detection</text>
-
-  <rect x="768" y="366" width="162" height="56" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="384" class="side-label" fill="#8250df">🛡 MCP Proxy</text>
-  <text x="780" y="398" class="side-sub">Stdio intercept · policy enforce</text>
-  <text x="780" y="409" class="side-sub">Replay detection · audit log</text>
-
-  <rect x="768" y="430" width="162" height="56" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.6" opacity="0.8"/>
-  <text x="780" y="448" class="side-label" fill="#8250df">🔒 Enforcement</text>
-  <text x="780" y="462" class="side-sub">Tool poisoning detection</text>
-  <text x="780" y="473" class="side-sub">Permission scanning · drift</text>
-
-  <line x1="744" y1="250" x2="756" y2="250" stroke="#8250df" stroke-width="1.2" stroke-dasharray="3 3" opacity="0.5"/>
-
-  <!-- External data sources -->
-  <rect x="516" y="332" width="228" height="62" rx="6" fill="#f6f8fa" stroke="#afb8c1" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="348" class="section-title" fill="#656d76">PUBLIC DATA SOURCES</text>
-  <text x="528" y="364" class="box-sub">OSV.dev · NVD/NIST · FIRST EPSS</text>
-  <text x="528" y="376" class="box-sub">CISA KEV · MCP Registry (427+) · Grype DB</text>
-  <text x="528" y="388" class="box-sub">No auth required · No user data sent</text>
-
-  <rect x="516" y="400" width="228" height="48" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.6"/>
-  <text x="528" y="416" class="side-label" fill="#1f2328">vs Wiz / Snyk / Prisma</text>
-  <text x="528" y="429" class="box-sub">✓ Free + open source (Apache-2.0)</text>
-  <text x="528" y="440" class="box-sub">✓ AI-native · MCP-first · runs anywhere</text>
-
-  <rect x="516" y="454" width="228" height="40" rx="6" fill="#ffffff" stroke="#0969da" stroke-width="0.6" opacity="0.7"/>
-  <text x="528" y="471" class="side-label" fill="#0969da">16 MCP Tools · 10 Frameworks</text>
-  <text x="528" y="484" class="box-sub">2,800+ tests · Sigstore signed · OpenSSF scored</text>
+  <!-- ─── FOOTER: COMPLIANCE ─── -->
+  <rect x="30" y="396" width="820" height="2" rx="1" fill="#e2e8f0"/>
+  <text x="440" y="415" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b" letter-spacing="0.05em">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -1,234 +1,117 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 620" fill="none">
-  <style>
-    .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
-    .subtitle { font: 400 10px system-ui, sans-serif; fill: #8b949e; }
-    .phase { font: 700 9px system-ui, sans-serif; letter-spacing: 0.1em; }
-    .label { font: 600 11px system-ui, sans-serif; }
-    .sub { font: 400 9px system-ui, sans-serif; fill: #8b949e; }
-    .badge { font: 600 8px system-ui, sans-serif; }
-    .data-label { font: 500 8px monospace; }
-    .note { font: 400 9px system-ui, sans-serif; fill: #6e7681; }
-  </style>
-  <defs>
-    <marker id="a" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#6e7681"/>
-    </marker>
-    <marker id="ab" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#58a6ff"/>
-    </marker>
-    <marker id="ag" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#3fb950"/>
-    </marker>
-    <marker id="ar" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#f85149"/>
-    </marker>
-    <marker id="ap" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#bc8cff"/>
-    </marker>
-  </defs>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 400" fill="none">
   <!-- Background -->
-  <rect width="940" height="620" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <rect width="880" height="400" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="470" y="28" text-anchor="middle" class="title">Enterprise Scan Workflow — Architecture &amp; Data Flow</text>
-  <text x="470" y="44" text-anchor="middle" class="subtitle">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
+  <text x="440" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Enterprise Scan Workflow</text>
+  <text x="440" y="48" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
 
-  <!-- ═══ COLUMN 1: Input Sources (x=20, w=180) ═══ -->
-  <rect x="20" y="60" width="180" height="498" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1.2"/>
-  <text x="110" y="78" text-anchor="middle" class="phase" fill="#58a6ff">INPUT SOURCES</text>
+  <!-- ─── COLUMN 1: INPUTS ─── -->
+  <rect x="20" y="64" width="190" height="300" rx="12" fill="#161b22" stroke="#3b82f6" stroke-width="1.5" opacity="0.95"/>
+  <text x="115" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.08em">INPUT SOURCES</text>
 
-  <rect x="32" y="88" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="106" text-anchor="middle" class="label" fill="#58a6ff">MCP Configs</text>
-  <text x="110" y="120" text-anchor="middle" class="sub">18 clients auto-discovered</text>
+  <rect x="34" y="98" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="115" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">MCP Configs (18)</text>
 
-  <rect x="32" y="138" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="156" text-anchor="middle" class="label" fill="#58a6ff">Docker Images</text>
-  <text x="110" y="170" text-anchor="middle" class="sub">Grype / Syft / Docker CLI</text>
+  <rect x="34" y="140" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="115" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Docker Images</text>
 
-  <rect x="32" y="188" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="206" text-anchor="middle" class="label" fill="#58a6ff">Kubernetes</text>
-  <text x="110" y="220" text-anchor="middle" class="sub">Multi-namespace pod scan</text>
+  <rect x="34" y="182" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="115" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Kubernetes</text>
 
-  <rect x="32" y="238" width="156" height="52" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="256" text-anchor="middle" class="label" fill="#58a6ff">Cloud APIs</text>
-  <text x="110" y="270" text-anchor="middle" class="sub">AWS Bedrock · Snowflake Cortex</text>
-  <text x="110" y="282" text-anchor="middle" class="sub">Azure AI · GCP Vertex · Databricks</text>
+  <rect x="34" y="224" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="115" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Cloud APIs</text>
 
-  <rect x="32" y="298" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="316" text-anchor="middle" class="label" fill="#58a6ff">SBOMs</text>
-  <text x="110" y="330" text-anchor="middle" class="sub">CycloneDX / SPDX import</text>
+  <rect x="34" y="266" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="115" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">SBOMs / IaC</text>
 
-  <rect x="32" y="348" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="366" text-anchor="middle" class="label" fill="#58a6ff">IaC + CI/CD</text>
-  <text x="110" y="380" text-anchor="middle" class="sub">Terraform · GitHub Actions</text>
+  <rect x="34" y="308" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="115" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">AI Frameworks</text>
 
-  <rect x="32" y="398" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="416" text-anchor="middle" class="label" fill="#58a6ff">AI Frameworks</text>
-  <text x="110" y="430" text-anchor="middle" class="sub">LangChain · CrewAI · ADK</text>
+  <!-- Arrow 1→2 -->
+  <path d="M210 214 L234 214" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M229 209 L238 214 L229 219" fill="#60a5fa"/>
 
-  <rect x="32" y="448" width="156" height="42" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="466" text-anchor="middle" class="label" fill="#58a6ff">SaaS Connectors</text>
-  <text x="110" y="480" text-anchor="middle" class="sub">Jira · Slack · ServiceNow</text>
+  <!-- ─── COLUMN 2: PIPELINE ─── -->
+  <rect x="240" y="64" width="190" height="300" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.5" opacity="0.95"/>
+  <text x="335" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.08em">SCANNER PIPELINE</text>
 
-  <rect x="32" y="498" width="156" height="50" rx="6" fill="#161b22" stroke="#1f6feb" stroke-width="0.8"/>
-  <text x="110" y="516" text-anchor="middle" class="badge" fill="#58a6ff">EXTRACTED DATA</text>
-  <text x="110" y="530" text-anchor="middle" class="data-label" fill="#8b949e">packages · versions · PURLs</text>
-  <text x="110" y="542" text-anchor="middle" class="data-label" fill="#8b949e">env var names · tool lists</text>
+  <rect x="254" y="100" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Discover + Extract</text>
 
-  <!-- Arrow: Sources → Pipeline -->
-  <line x1="200" y1="310" x2="228" y2="310" stroke="#58a6ff" stroke-width="2" marker-end="url(#ab)"/>
+  <path d="M335 138 L335 148" stroke="#f59e0b" stroke-width="1.5"/>
+  <path d="M330 144 L335 152 L340 144" fill="#f59e0b"/>
 
-  <!-- ═══ COLUMN 2: Scanner Pipeline (x=232, w=200) ═══ -->
-  <rect x="232" y="60" width="200" height="498" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1.2"/>
-  <text x="332" y="78" text-anchor="middle" class="phase" fill="#d29922">SCANNER PIPELINE</text>
-  <text x="332" y="92" text-anchor="middle" class="sub">read-only · local execution</text>
+  <rect x="254" y="156" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">CVE Scan</text>
 
-  <!-- Step 1 -->
-  <rect x="246" y="104" width="172" height="58" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
-  <rect x="246" y="104" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
-  <text x="332" y="117" text-anchor="middle" class="badge" fill="#d29922">STEP 1 · DISCOVER</text>
-  <text x="332" y="138" text-anchor="middle" class="sub">Auto-detect agent configs</text>
-  <text x="332" y="150" text-anchor="middle" class="sub">Parse packages + credentials</text>
+  <path d="M335 194 L335 204" stroke="#f59e0b" stroke-width="1.5"/>
+  <path d="M330 200 L335 208 L340 200" fill="#f59e0b"/>
 
-  <line x1="332" y1="162" x2="332" y2="176" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="254" y="212" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="236" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Enrich</text>
 
-  <!-- Step 2 -->
-  <rect x="246" y="180" width="172" height="58" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
-  <rect x="246" y="180" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
-  <text x="332" y="193" text-anchor="middle" class="badge" fill="#d29922">STEP 2 · CVE SCAN</text>
-  <text x="332" y="214" text-anchor="middle" class="sub">OSV.dev batch API</text>
-  <text x="332" y="226" text-anchor="middle" class="sub">Grype for container images</text>
+  <path d="M335 250 L335 260" stroke="#f59e0b" stroke-width="1.5"/>
+  <path d="M330 256 L335 264 L340 256" fill="#f59e0b"/>
 
-  <line x1="332" y1="238" x2="332" y2="252" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="254" y="268" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="292" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Analyze + Tag</text>
 
-  <!-- Step 3 -->
-  <rect x="246" y="256" width="172" height="68" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
-  <rect x="246" y="256" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
-  <text x="332" y="269" text-anchor="middle" class="badge" fill="#d29922">STEP 3 · ENRICH</text>
-  <text x="332" y="290" text-anchor="middle" class="sub">NVD CVSS v3.1/v4.0 scoring</text>
-  <text x="332" y="302" text-anchor="middle" class="sub">FIRST EPSS exploit probability</text>
-  <text x="332" y="314" text-anchor="middle" class="sub">CISA KEV + GHSA + NVIDIA CSAF</text>
+  <rect x="254" y="316" width="162" height="34" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
+  <text x="335" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">read-only | local execution</text>
 
-  <line x1="332" y1="324" x2="332" y2="338" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
+  <!-- Arrow 2→3 -->
+  <path d="M430 214 L454 214" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M449 209 L458 214 L449 219" fill="#fbbf24"/>
 
-  <!-- Step 4 -->
-  <rect x="246" y="342" width="172" height="68" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
-  <rect x="246" y="342" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
-  <text x="332" y="355" text-anchor="middle" class="badge" fill="#d29922">STEP 4 · ANALYZE</text>
-  <text x="332" y="376" text-anchor="middle" class="sub">Blast radius mapping</text>
-  <text x="332" y="388" text-anchor="middle" class="sub">10-framework threat tagging</text>
-  <text x="332" y="400" text-anchor="middle" class="sub">Tool poisoning detection</text>
+  <!-- ─── COLUMN 3: ANALYSIS ─── -->
+  <rect x="460" y="64" width="190" height="300" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.5" opacity="0.95"/>
+  <text x="555" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">ANALYSIS</text>
 
-  <line x1="332" y1="410" x2="332" y2="424" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="474" y="98" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="555" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Blast Radius Engine</text>
 
-  <!-- Step 5 -->
-  <rect x="246" y="428" width="172" height="58" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
-  <rect x="246" y="428" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
-  <text x="332" y="441" text-anchor="middle" class="badge" fill="#d29922">STEP 5 · CONTEXT GRAPH</text>
-  <text x="332" y="462" text-anchor="middle" class="sub">Lateral movement paths</text>
-  <text x="332" y="474" text-anchor="middle" class="sub">Shared server/credential analysis</text>
+  <rect x="474" y="140" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="555" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">10-Framework Tagging</text>
 
-  <line x1="332" y1="486" x2="332" y2="500" stroke="#d29922" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="474" y="182" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="555" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Posture Scorecard</text>
 
-  <!-- Step 6 -->
-  <rect x="246" y="504" width="172" height="46" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
-  <rect x="246" y="504" width="172" height="18" rx="6" fill="#d29922" opacity="0.15"/>
-  <text x="332" y="517" text-anchor="middle" class="badge" fill="#d29922">STEP 6 · REPORT</text>
-  <text x="332" y="536" text-anchor="middle" class="sub">Generate outputs + alerts</text>
+  <rect x="474" y="224" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="555" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Incident Correlation</text>
 
-  <!-- Arrow: Pipeline → Analysis -->
-  <line x1="432" y1="310" x2="460" y2="310" stroke="#d29922" stroke-width="2" marker-end="url(#a)"/>
+  <rect x="474" y="266" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="555" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Context Graph</text>
 
-  <!-- ═══ COLUMN 3: Analysis Output (x=464, w=210) ═══ -->
-  <rect x="464" y="60" width="210" height="498" rx="8" fill="#161b22" stroke="#bc8cff" stroke-width="1.2"/>
-  <text x="569" y="78" text-anchor="middle" class="phase" fill="#bc8cff">ANALYSIS + SCORING</text>
+  <rect x="474" y="308" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="555" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Policy Evaluation</text>
 
-  <rect x="478" y="96" width="182" height="58" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="114" text-anchor="middle" class="label" fill="#bc8cff">Blast Radius Engine</text>
-  <text x="569" y="130" text-anchor="middle" class="sub">CVE → pkg → server → agent</text>
-  <text x="569" y="142" text-anchor="middle" class="sub">→ credentials → tools → risk score</text>
+  <!-- Arrow 3→4 -->
+  <path d="M650 214 L674 214" stroke="#a78bfa" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M669 209 L678 214 L669 219" fill="#a78bfa"/>
 
-  <rect x="478" y="162" width="182" height="68" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="180" text-anchor="middle" class="label" fill="#bc8cff">10-Framework Tagging</text>
-  <text x="569" y="196" text-anchor="middle" class="sub">OWASP LLM · MCP · Agentic</text>
-  <text x="569" y="208" text-anchor="middle" class="sub">MITRE ATLAS · NIST AI RMF</text>
-  <text x="569" y="220" text-anchor="middle" class="sub">EU AI Act</text>
+  <!-- ─── COLUMN 4: OUTPUTS ─── -->
+  <rect x="680" y="64" width="182" height="300" rx="12" fill="#161b22" stroke="#10b981" stroke-width="1.5" opacity="0.95"/>
+  <text x="771" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.08em">OUTPUTS</text>
 
-  <rect x="478" y="238" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="256" text-anchor="middle" class="label" fill="#bc8cff">Posture Scorecard</text>
-  <text x="569" y="272" text-anchor="middle" class="sub">Grade A–F · 6 dimensions</text>
-  <text x="569" y="282" text-anchor="middle" class="sub">Weighted enterprise score</text>
+  <rect x="694" y="98" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="771" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Console + HTML</text>
 
-  <rect x="478" y="294" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="312" text-anchor="middle" class="label" fill="#bc8cff">Incident Correlation</text>
-  <text x="569" y="328" text-anchor="middle" class="sub">P1–P4 priority by agent</text>
-  <text x="569" y="338" text-anchor="middle" class="sub">SOC-ready incident summaries</text>
+  <rect x="694" y="140" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="771" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">SARIF + SBOM</text>
 
-  <rect x="478" y="350" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="368" text-anchor="middle" class="label" fill="#bc8cff">Credential Risk Ranking</text>
-  <text x="569" y="384" text-anchor="middle" class="sub">Blast radius severity tiers</text>
-  <text x="569" y="394" text-anchor="middle" class="sub">Cross-agent aggregation</text>
+  <rect x="694" y="182" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="771" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">REST API + SSE</text>
 
-  <rect x="478" y="406" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="424" text-anchor="middle" class="label" fill="#bc8cff">Context Graph</text>
-  <text x="569" y="440" text-anchor="middle" class="sub">Lateral movement BFS paths</text>
-  <text x="569" y="450" text-anchor="middle" class="sub">Shared servers + credentials</text>
+  <rect x="694" y="224" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="771" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Dashboard (15 pages)</text>
 
-  <rect x="478" y="462" width="182" height="48" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="480" text-anchor="middle" class="label" fill="#bc8cff">Policy Evaluation</text>
-  <text x="569" y="496" text-anchor="middle" class="sub">16 rule conditions</text>
-  <text x="569" y="506" text-anchor="middle" class="sub">fail / warn / info gates</text>
+  <rect x="694" y="266" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="771" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">MCP Server (16 tools)</text>
 
-  <rect x="478" y="518" width="182" height="32" rx="6" fill="#161b22" stroke="#bc8cff" stroke-width="0.8"/>
-  <text x="569" y="538" text-anchor="middle" class="badge" fill="#bc8cff">Remediation: named assets + fix priority</text>
+  <rect x="694" y="308" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="771" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Slack / Jira / Webhooks</text>
 
-  <!-- Arrow: Analysis → Outputs -->
-  <line x1="674" y1="310" x2="702" y2="310" stroke="#bc8cff" stroke-width="2" marker-end="url(#ap)"/>
-
-  <!-- ═══ COLUMN 4: Outputs (x=706, w=214) ═══ -->
-  <rect x="706" y="60" width="214" height="498" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1.2"/>
-  <text x="813" y="78" text-anchor="middle" class="phase" fill="#3fb950">DEPLOYMENT SURFACES</text>
-
-  <rect x="720" y="96" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="114" text-anchor="middle" class="label" fill="#3fb950">Console + HTML Report</text>
-  <text x="813" y="128" text-anchor="middle" class="sub">Rich tables · interactive dashboard</text>
-
-  <rect x="720" y="146" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="164" text-anchor="middle" class="label" fill="#3fb950">SARIF + SBOM Export</text>
-  <text x="813" y="178" text-anchor="middle" class="sub">CycloneDX 1.6 · SPDX 3.0 · GitHub</text>
-
-  <rect x="720" y="196" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="214" text-anchor="middle" class="label" fill="#3fb950">REST API + SSE</text>
-  <text x="813" y="228" text-anchor="middle" class="sub">FastAPI :8422 · live streaming</text>
-
-  <rect x="720" y="246" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="264" text-anchor="middle" class="label" fill="#3fb950">Next.js Dashboard</text>
-  <text x="813" y="278" text-anchor="middle" class="sub">15 pages · React Flow graphs</text>
-
-  <rect x="720" y="296" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="314" text-anchor="middle" class="label" fill="#3fb950">CI/CD Pipeline Gate</text>
-  <text x="813" y="328" text-anchor="middle" class="sub">GitHub Actions · --fail-on-severity</text>
-
-  <rect x="720" y="346" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="364" text-anchor="middle" class="label" fill="#3fb950">MCP Server</text>
-  <text x="813" y="378" text-anchor="middle" class="sub">16 tools · stdio + SSE transport</text>
-
-  <rect x="720" y="396" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="414" text-anchor="middle" class="label" fill="#3fb950">Observability</text>
-  <text x="813" y="428" text-anchor="middle" class="sub">Prometheus · OpenTelemetry</text>
-
-  <rect x="720" y="446" width="186" height="42" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="464" text-anchor="middle" class="label" fill="#3fb950">Alert Pipeline</text>
-  <text x="813" y="478" text-anchor="middle" class="sub">Slack · Jira · Vanta · Drata</text>
-
-  <rect x="720" y="496" width="186" height="60" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
-  <text x="813" y="514" text-anchor="middle" class="label" fill="#3fb950">Snowflake Deployment</text>
-  <text x="813" y="528" text-anchor="middle" class="sub">Snowpark Container Services</text>
-  <text x="813" y="540" text-anchor="middle" class="sub">Streamlit · Native App</text>
-
-  <!-- ═══ Bottom Bar: Trust + Data Flow ═══ -->
-  <rect x="20" y="570" width="900" height="38" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="470" y="586" text-anchor="middle" class="badge" fill="#8b949e">TRUST MODEL</text>
-  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,800+ tests</text>
+  <!-- ─── FOOTER ─── -->
+  <text x="440" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only | Agentless | Never stores credentials | Only package names sent to APIs | Sigstore signed</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -1,234 +1,117 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 620" fill="none">
-  <style>
-    .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #0f172a; }
-    .subtitle { font: 400 10px system-ui, sans-serif; fill: #64748b; }
-    .phase { font: 700 9px system-ui, sans-serif; letter-spacing: 0.1em; }
-    .label { font: 600 11px system-ui, sans-serif; }
-    .sub { font: 400 9px system-ui, sans-serif; fill: #64748b; }
-    .badge { font: 600 8px system-ui, sans-serif; }
-    .data-label { font: 500 8px monospace; }
-    .note { font: 400 9px system-ui, sans-serif; fill: #94a3b8; }
-  </style>
-  <defs>
-    <marker id="a" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#94a3b8"/>
-    </marker>
-    <marker id="ab" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#2563eb"/>
-    </marker>
-    <marker id="ag" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#059669"/>
-    </marker>
-    <marker id="ar" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#dc2626"/>
-    </marker>
-    <marker id="ap" viewBox="0 0 8 6" refX="8" refY="3" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L8 3L0 6Z" fill="#7c3aed"/>
-    </marker>
-  </defs>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 400" fill="none">
   <!-- Background -->
-  <rect width="940" height="620" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <rect width="880" height="400" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="470" y="28" text-anchor="middle" class="title">Enterprise Scan Workflow — Architecture &amp; Data Flow</text>
-  <text x="470" y="44" text-anchor="middle" class="subtitle">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
+  <text x="440" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Enterprise Scan Workflow</text>
+  <text x="440" y="48" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
 
-  <!-- ═══ COLUMN 1: Input Sources (x=20, w=180) ═══ -->
-  <rect x="20" y="60" width="180" height="498" rx="8" fill="#f0f9ff" stroke="#2563eb" stroke-width="1.2"/>
-  <text x="110" y="78" text-anchor="middle" class="phase" fill="#2563eb">INPUT SOURCES</text>
+  <!-- ─── COLUMN 1: INPUTS ─── -->
+  <rect x="20" y="64" width="190" height="300" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="115" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#3b82f6" letter-spacing="0.08em">INPUT SOURCES</text>
 
-  <rect x="32" y="88" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="106" text-anchor="middle" class="label" fill="#1e40af">MCP Configs</text>
-  <text x="110" y="120" text-anchor="middle" class="sub">18 clients auto-discovered</text>
+  <rect x="34" y="98" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="115" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Configs (18)</text>
 
-  <rect x="32" y="138" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="156" text-anchor="middle" class="label" fill="#1e40af">Docker Images</text>
-  <text x="110" y="170" text-anchor="middle" class="sub">Grype / Syft / Docker CLI</text>
+  <rect x="34" y="140" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="115" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Docker Images</text>
 
-  <rect x="32" y="188" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="206" text-anchor="middle" class="label" fill="#1e40af">Kubernetes</text>
-  <text x="110" y="220" text-anchor="middle" class="sub">Multi-namespace pod scan</text>
+  <rect x="34" y="182" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="115" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Kubernetes</text>
 
-  <rect x="32" y="238" width="156" height="52" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="256" text-anchor="middle" class="label" fill="#1e40af">Cloud APIs</text>
-  <text x="110" y="270" text-anchor="middle" class="sub">AWS Bedrock · Snowflake Cortex</text>
-  <text x="110" y="282" text-anchor="middle" class="sub">Azure AI · GCP Vertex · Databricks</text>
+  <rect x="34" y="224" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="115" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Cloud APIs</text>
 
-  <rect x="32" y="298" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="316" text-anchor="middle" class="label" fill="#1e40af">SBOMs</text>
-  <text x="110" y="330" text-anchor="middle" class="sub">CycloneDX / SPDX import</text>
+  <rect x="34" y="266" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="115" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">SBOMs / IaC</text>
 
-  <rect x="32" y="348" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="366" text-anchor="middle" class="label" fill="#1e40af">IaC + CI/CD</text>
-  <text x="110" y="380" text-anchor="middle" class="sub">Terraform · GitHub Actions</text>
+  <rect x="34" y="308" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="115" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">AI Frameworks</text>
 
-  <rect x="32" y="398" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="416" text-anchor="middle" class="label" fill="#1e40af">AI Frameworks</text>
-  <text x="110" y="430" text-anchor="middle" class="sub">LangChain · CrewAI · ADK</text>
+  <!-- Arrow 1→2 -->
+  <path d="M210 214 L234 214" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M229 209 L238 214 L229 219" fill="#3b82f6"/>
 
-  <rect x="32" y="448" width="156" height="42" rx="6" fill="#ffffff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="110" y="466" text-anchor="middle" class="label" fill="#1e40af">SaaS Connectors</text>
-  <text x="110" y="480" text-anchor="middle" class="sub">Jira · Slack · ServiceNow</text>
+  <!-- ─── COLUMN 2: PIPELINE ─── -->
+  <rect x="240" y="64" width="190" height="300" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="335" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.08em">SCANNER PIPELINE</text>
 
-  <rect x="32" y="498" width="156" height="50" rx="6" fill="#eff6ff" stroke="#2563eb" stroke-width="0.8"/>
-  <text x="110" y="516" text-anchor="middle" class="badge" fill="#2563eb">EXTRACTED DATA</text>
-  <text x="110" y="530" text-anchor="middle" class="data-label" fill="#475569">packages · versions · PURLs</text>
-  <text x="110" y="542" text-anchor="middle" class="data-label" fill="#475569">env var names · tool lists</text>
+  <rect x="254" y="100" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Discover + Extract</text>
 
-  <!-- Arrow: Sources → Pipeline -->
-  <line x1="200" y1="310" x2="228" y2="310" stroke="#2563eb" stroke-width="2" marker-end="url(#ab)"/>
+  <path d="M335 138 L335 148" stroke="#d97706" stroke-width="1.5"/>
+  <path d="M330 144 L335 152 L340 144" fill="#d97706"/>
 
-  <!-- ═══ COLUMN 2: Scanner Pipeline (x=232, w=200) ═══ -->
-  <rect x="232" y="60" width="200" height="498" rx="8" fill="#fffbeb" stroke="#d97706" stroke-width="1.2"/>
-  <text x="332" y="78" text-anchor="middle" class="phase" fill="#d97706">SCANNER PIPELINE</text>
-  <text x="332" y="92" text-anchor="middle" class="sub">read-only · local execution</text>
+  <rect x="254" y="156" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">CVE Scan</text>
 
-  <!-- Step 1 -->
-  <rect x="246" y="104" width="172" height="58" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
-  <rect x="246" y="104" width="172" height="18" rx="6" fill="#fef3c7"/>
-  <text x="332" y="117" text-anchor="middle" class="badge" fill="#92400e">STEP 1 · DISCOVER</text>
-  <text x="332" y="138" text-anchor="middle" class="sub">Auto-detect agent configs</text>
-  <text x="332" y="150" text-anchor="middle" class="sub">Parse packages + credentials</text>
+  <path d="M335 194 L335 204" stroke="#d97706" stroke-width="1.5"/>
+  <path d="M330 200 L335 208 L340 200" fill="#d97706"/>
 
-  <line x1="332" y1="162" x2="332" y2="176" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="254" y="212" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="236" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Enrich</text>
 
-  <!-- Step 2 -->
-  <rect x="246" y="180" width="172" height="58" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
-  <rect x="246" y="180" width="172" height="18" rx="6" fill="#fef3c7"/>
-  <text x="332" y="193" text-anchor="middle" class="badge" fill="#92400e">STEP 2 · CVE SCAN</text>
-  <text x="332" y="214" text-anchor="middle" class="sub">OSV.dev batch API</text>
-  <text x="332" y="226" text-anchor="middle" class="sub">Grype for container images</text>
+  <path d="M335 250 L335 260" stroke="#d97706" stroke-width="1.5"/>
+  <path d="M330 256 L335 264 L340 256" fill="#d97706"/>
 
-  <line x1="332" y1="238" x2="332" y2="252" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="254" y="268" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="335" y="292" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Analyze + Tag</text>
 
-  <!-- Step 3 -->
-  <rect x="246" y="256" width="172" height="68" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
-  <rect x="246" y="256" width="172" height="18" rx="6" fill="#fef3c7"/>
-  <text x="332" y="269" text-anchor="middle" class="badge" fill="#92400e">STEP 3 · ENRICH</text>
-  <text x="332" y="290" text-anchor="middle" class="sub">NVD CVSS v3.1/v4.0 scoring</text>
-  <text x="332" y="302" text-anchor="middle" class="sub">FIRST EPSS exploit probability</text>
-  <text x="332" y="314" text-anchor="middle" class="sub">CISA KEV + GHSA + NVIDIA CSAF</text>
+  <rect x="254" y="316" width="162" height="34" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
+  <text x="335" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#92400e">read-only | local execution</text>
 
-  <line x1="332" y1="324" x2="332" y2="338" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
+  <!-- Arrow 2→3 -->
+  <path d="M430 214 L454 214" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M449 209 L458 214 L449 219" fill="#d97706"/>
 
-  <!-- Step 4 -->
-  <rect x="246" y="342" width="172" height="68" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
-  <rect x="246" y="342" width="172" height="18" rx="6" fill="#fef3c7"/>
-  <text x="332" y="355" text-anchor="middle" class="badge" fill="#92400e">STEP 4 · ANALYZE</text>
-  <text x="332" y="376" text-anchor="middle" class="sub">Blast radius mapping</text>
-  <text x="332" y="388" text-anchor="middle" class="sub">10-framework threat tagging</text>
-  <text x="332" y="400" text-anchor="middle" class="sub">Tool poisoning detection</text>
+  <!-- ─── COLUMN 3: ANALYSIS ─── -->
+  <rect x="460" y="64" width="190" height="300" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="555" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">ANALYSIS</text>
 
-  <line x1="332" y1="410" x2="332" y2="424" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="474" y="98" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="555" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Blast Radius Engine</text>
 
-  <!-- Step 5 -->
-  <rect x="246" y="428" width="172" height="58" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
-  <rect x="246" y="428" width="172" height="18" rx="6" fill="#fef3c7"/>
-  <text x="332" y="441" text-anchor="middle" class="badge" fill="#92400e">STEP 5 · CONTEXT GRAPH</text>
-  <text x="332" y="462" text-anchor="middle" class="sub">Lateral movement paths</text>
-  <text x="332" y="474" text-anchor="middle" class="sub">Shared server/credential analysis</text>
+  <rect x="474" y="140" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="555" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">10-Framework Tagging</text>
 
-  <line x1="332" y1="486" x2="332" y2="500" stroke="#d97706" stroke-width="1.5" marker-end="url(#a)"/>
+  <rect x="474" y="182" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="555" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Posture Scorecard</text>
 
-  <!-- Step 6 -->
-  <rect x="246" y="504" width="172" height="46" rx="6" fill="#ffffff" stroke="#fbbf24" stroke-width="1"/>
-  <rect x="246" y="504" width="172" height="18" rx="6" fill="#fef3c7"/>
-  <text x="332" y="517" text-anchor="middle" class="badge" fill="#92400e">STEP 6 · REPORT</text>
-  <text x="332" y="536" text-anchor="middle" class="sub">Generate outputs + alerts</text>
+  <rect x="474" y="224" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="555" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Incident Correlation</text>
 
-  <!-- Arrow: Pipeline → Analysis -->
-  <line x1="432" y1="310" x2="460" y2="310" stroke="#d97706" stroke-width="2" marker-end="url(#a)"/>
+  <rect x="474" y="266" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="555" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Context Graph</text>
 
-  <!-- ═══ COLUMN 3: Analysis Output (x=464, w=210) ═══ -->
-  <rect x="464" y="60" width="210" height="498" rx="8" fill="#faf5ff" stroke="#7c3aed" stroke-width="1.2"/>
-  <text x="569" y="78" text-anchor="middle" class="phase" fill="#7c3aed">ANALYSIS + SCORING</text>
+  <rect x="474" y="308" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="555" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Policy Evaluation</text>
 
-  <rect x="478" y="96" width="182" height="58" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="114" text-anchor="middle" class="label" fill="#5b21b6">Blast Radius Engine</text>
-  <text x="569" y="130" text-anchor="middle" class="sub">CVE → pkg → server → agent</text>
-  <text x="569" y="142" text-anchor="middle" class="sub">→ credentials → tools → risk score</text>
+  <!-- Arrow 3→4 -->
+  <path d="M650 214 L674 214" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M669 209 L678 214 L669 219" fill="#7c3aed"/>
 
-  <rect x="478" y="162" width="182" height="68" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="180" text-anchor="middle" class="label" fill="#5b21b6">10-Framework Tagging</text>
-  <text x="569" y="196" text-anchor="middle" class="sub">OWASP LLM · MCP · Agentic</text>
-  <text x="569" y="208" text-anchor="middle" class="sub">MITRE ATLAS · NIST AI RMF</text>
-  <text x="569" y="220" text-anchor="middle" class="sub">EU AI Act</text>
+  <!-- ─── COLUMN 4: OUTPUTS ─── -->
+  <rect x="680" y="64" width="182" height="300" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/>
+  <text x="771" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.08em">OUTPUTS</text>
 
-  <rect x="478" y="238" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="256" text-anchor="middle" class="label" fill="#5b21b6">Posture Scorecard</text>
-  <text x="569" y="272" text-anchor="middle" class="sub">Grade A–F · 6 dimensions</text>
-  <text x="569" y="282" text-anchor="middle" class="sub">Weighted enterprise score</text>
+  <rect x="694" y="98" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="771" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Console + HTML</text>
 
-  <rect x="478" y="294" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="312" text-anchor="middle" class="label" fill="#5b21b6">Incident Correlation</text>
-  <text x="569" y="328" text-anchor="middle" class="sub">P1–P4 priority by agent</text>
-  <text x="569" y="338" text-anchor="middle" class="sub">SOC-ready incident summaries</text>
+  <rect x="694" y="140" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="771" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">SARIF + SBOM</text>
 
-  <rect x="478" y="350" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="368" text-anchor="middle" class="label" fill="#5b21b6">Credential Risk Ranking</text>
-  <text x="569" y="384" text-anchor="middle" class="sub">Blast radius severity tiers</text>
-  <text x="569" y="394" text-anchor="middle" class="sub">Cross-agent aggregation</text>
+  <rect x="694" y="182" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="771" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">REST API + SSE</text>
 
-  <rect x="478" y="406" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="424" text-anchor="middle" class="label" fill="#5b21b6">Context Graph</text>
-  <text x="569" y="440" text-anchor="middle" class="sub">Lateral movement BFS paths</text>
-  <text x="569" y="450" text-anchor="middle" class="sub">Shared servers + credentials</text>
+  <rect x="694" y="224" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="771" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Dashboard (15 pages)</text>
 
-  <rect x="478" y="462" width="182" height="48" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="569" y="480" text-anchor="middle" class="label" fill="#5b21b6">Policy Evaluation</text>
-  <text x="569" y="496" text-anchor="middle" class="sub">16 rule conditions</text>
-  <text x="569" y="506" text-anchor="middle" class="sub">fail / warn / info gates</text>
+  <rect x="694" y="266" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="771" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">MCP Server (16 tools)</text>
 
-  <rect x="478" y="518" width="182" height="32" rx="6" fill="#f5f3ff" stroke="#7c3aed" stroke-width="0.8"/>
-  <text x="569" y="538" text-anchor="middle" class="badge" fill="#7c3aed">Remediation: named assets + fix priority</text>
+  <rect x="694" y="308" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="771" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Slack / Jira / Webhooks</text>
 
-  <!-- Arrow: Analysis → Outputs -->
-  <line x1="674" y1="310" x2="702" y2="310" stroke="#7c3aed" stroke-width="2" marker-end="url(#ap)"/>
-
-  <!-- ═══ COLUMN 4: Outputs (x=706, w=214) ═══ -->
-  <rect x="706" y="60" width="214" height="498" rx="8" fill="#ecfdf5" stroke="#059669" stroke-width="1.2"/>
-  <text x="813" y="78" text-anchor="middle" class="phase" fill="#059669">DEPLOYMENT SURFACES</text>
-
-  <rect x="720" y="96" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="114" text-anchor="middle" class="label" fill="#065f46">Console + HTML Report</text>
-  <text x="813" y="128" text-anchor="middle" class="sub">Rich tables · interactive dashboard</text>
-
-  <rect x="720" y="146" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="164" text-anchor="middle" class="label" fill="#065f46">SARIF + SBOM Export</text>
-  <text x="813" y="178" text-anchor="middle" class="sub">CycloneDX 1.6 · SPDX 3.0 · GitHub</text>
-
-  <rect x="720" y="196" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="214" text-anchor="middle" class="label" fill="#065f46">REST API + SSE</text>
-  <text x="813" y="228" text-anchor="middle" class="sub">FastAPI :8422 · live streaming</text>
-
-  <rect x="720" y="246" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="264" text-anchor="middle" class="label" fill="#065f46">Next.js Dashboard</text>
-  <text x="813" y="278" text-anchor="middle" class="sub">15 pages · React Flow graphs</text>
-
-  <rect x="720" y="296" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="314" text-anchor="middle" class="label" fill="#065f46">CI/CD Pipeline Gate</text>
-  <text x="813" y="328" text-anchor="middle" class="sub">GitHub Actions · --fail-on-severity</text>
-
-  <rect x="720" y="346" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="364" text-anchor="middle" class="label" fill="#065f46">MCP Server</text>
-  <text x="813" y="378" text-anchor="middle" class="sub">16 tools · stdio + SSE transport</text>
-
-  <rect x="720" y="396" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="414" text-anchor="middle" class="label" fill="#065f46">Observability</text>
-  <text x="813" y="428" text-anchor="middle" class="sub">Prometheus · OpenTelemetry</text>
-
-  <rect x="720" y="446" width="186" height="42" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="464" text-anchor="middle" class="label" fill="#065f46">Alert Pipeline</text>
-  <text x="813" y="478" text-anchor="middle" class="sub">Slack · Jira · Vanta · Drata</text>
-
-  <rect x="720" y="496" width="186" height="60" rx="6" fill="#ffffff" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="813" y="514" text-anchor="middle" class="label" fill="#065f46">Snowflake Deployment</text>
-  <text x="813" y="528" text-anchor="middle" class="sub">Snowpark Container Services</text>
-  <text x="813" y="540" text-anchor="middle" class="sub">Streamlit · Native App</text>
-
-  <!-- ═══ Bottom Bar: Trust + Data Flow ═══ -->
-  <rect x="20" y="570" width="900" height="38" rx="8" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="470" y="586" text-anchor="middle" class="badge" fill="#475569">TRUST MODEL</text>
-  <text x="470" y="600" text-anchor="middle" class="note">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · --dry-run preview · Sigstore signed · 2,800+ tests</text>
+  <!-- ─── FOOTER ─── -->
+  <text x="440" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only | Agentless | Never stores credentials | Only package names sent to APIs | Sigstore signed</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -1,170 +1,98 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" fill="none">
-  <style>
-    .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
-    .subtitle { font: 400 10px system-ui, sans-serif; fill: #8b949e; }
-    .phase { font: 700 9px system-ui, sans-serif; letter-spacing: 0.08em; }
-    .label { font: 600 9.5px system-ui, sans-serif; fill: #e6edf3; }
-    .sub { font: 400 8.5px system-ui, sans-serif; fill: #8b949e; }
-    .badge { font: 600 7.5px system-ui, sans-serif; }
-    .note { font: 400 8.5px system-ui, sans-serif; fill: #6e7681; }
-    .num { font: 700 20px system-ui, sans-serif; }
-  </style>
-  <defs>
-    <marker id="arr" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L10 4L0 8Z" fill="#30363d"/>
-    </marker>
-  </defs>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 280" fill="none">
   <!-- Background -->
-  <rect width="960" height="400" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <rect width="880" height="280" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="30" text-anchor="middle" class="title">Scanner Architecture</text>
-  <text x="480" y="46" text-anchor="middle" class="subtitle">7-stage pipeline from discovery to actionable output</text>
+  <text x="440" y="30" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scanner Pipeline</text>
+  <text x="440" y="50" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">7-stage pipeline from discovery to actionable output</text>
 
-  <!-- ═══ PIPELINE STAGES — equal width 114px, gap 12px ═══ -->
+  <!-- ─── STAGE 1: DISCOVER ─── -->
+  <rect x="18" y="70" width="104" height="120" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="18" y="70" width="104" height="30" rx="12" fill="#2563eb"/>
+  <rect x="18" y="88" width="104" height="12" fill="#2563eb"/>
+  <text x="70" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
+  <text x="70" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">18</text>
+  <text x="70" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">MCP clients</text>
+  <text x="70" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ Docker + K8s + Cloud</text>
 
-  <!-- Stage 1: DISCOVER -->
-  <rect x="22" y="66" width="114" height="148" rx="8" fill="#0d1117" stroke="#58a6ff" stroke-width="1"/>
-  <rect x="22" y="66" width="114" height="26" rx="8" fill="#58a6ff"/>
-  <rect x="22" y="80" width="114" height="12" fill="#58a6ff"/>
-  <text x="79" y="84" text-anchor="middle" class="phase" fill="#ffffff">DISCOVER</text>
-  <text x="79" y="114" text-anchor="middle" class="num" fill="#58a6ff">18</text>
-  <text x="79" y="130" text-anchor="middle" class="label">MCP clients</text>
-  <text x="79" y="148" text-anchor="middle" class="sub">Containers · Cloud</text>
-  <text x="79" y="162" text-anchor="middle" class="sub">SBOMs · Lock files</text>
-  <text x="79" y="176" text-anchor="middle" class="sub">AI frameworks</text>
+  <path d="M122 130 L136 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M132 125 L140 130 L132 135" fill="#4b5563"/>
 
-  <!-- Arrow 1→2 -->
-  <line x1="136" y1="140" x2="152" y2="140" stroke="#30363d" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 2: EXTRACT ─── -->
+  <rect x="142" y="70" width="104" height="120" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="142" y="70" width="104" height="30" rx="12" fill="#2563eb"/>
+  <rect x="142" y="88" width="104" height="12" fill="#2563eb"/>
+  <text x="194" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
+  <text x="194" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">11</text>
+  <text x="194" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">ecosystems</text>
+  <text x="194" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">packages + versions</text>
 
-  <!-- Stage 2: EXTRACT -->
-  <rect x="158" y="66" width="114" height="148" rx="8" fill="#0d1117" stroke="#58a6ff" stroke-width="1"/>
-  <rect x="158" y="66" width="114" height="26" rx="8" fill="#58a6ff"/>
-  <rect x="158" y="80" width="114" height="12" fill="#58a6ff"/>
-  <text x="215" y="84" text-anchor="middle" class="phase" fill="#ffffff">EXTRACT</text>
-  <text x="215" y="114" text-anchor="middle" class="num" fill="#58a6ff">11</text>
-  <text x="215" y="130" text-anchor="middle" class="label">ecosystems</text>
-  <text x="215" y="148" text-anchor="middle" class="sub">Lock files · Registries</text>
-  <text x="215" y="162" text-anchor="middle" class="sub">Transitive resolution</text>
-  <text x="215" y="176" text-anchor="middle" class="sub">Deduplication</text>
+  <path d="M246 130 L260 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M256 125 L264 130 L256 135" fill="#4b5563"/>
 
-  <!-- Arrow 2→3 -->
-  <line x1="272" y1="140" x2="288" y2="140" stroke="#30363d" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 3: SCAN ─── -->
+  <rect x="266" y="70" width="104" height="120" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="266" y="70" width="104" height="30" rx="12" fill="#d97706"/>
+  <rect x="266" y="88" width="104" height="12" fill="#d97706"/>
+  <text x="318" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
+  <text x="318" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#fbbf24">8</text>
+  <text x="318" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fcd34d">vuln sources</text>
+  <text x="318" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OSV + Grype + GHSA</text>
 
-  <!-- Stage 3: SCAN -->
-  <rect x="294" y="66" width="114" height="148" rx="8" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
-  <rect x="294" y="66" width="114" height="26" rx="8" fill="#d29922"/>
-  <rect x="294" y="80" width="114" height="12" fill="#d29922"/>
-  <text x="351" y="84" text-anchor="middle" class="phase" fill="#ffffff">SCAN</text>
-  <text x="351" y="114" text-anchor="middle" class="num" fill="#d29922">8</text>
-  <text x="351" y="130" text-anchor="middle" class="label">vuln sources</text>
-  <text x="351" y="148" text-anchor="middle" class="sub">OSV · Grype · GHSA</text>
-  <text x="351" y="162" text-anchor="middle" class="sub">Typosquat detection</text>
-  <text x="351" y="176" text-anchor="middle" class="sub">Malicious pkg detect</text>
+  <path d="M370 130 L384 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M380 125 L388 130 L380 135" fill="#4b5563"/>
 
-  <!-- Arrow 3→4 -->
-  <line x1="408" y1="140" x2="424" y2="140" stroke="#30363d" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 4: ENRICH ─── -->
+  <rect x="390" y="70" width="104" height="120" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="390" y="70" width="104" height="30" rx="12" fill="#d97706"/>
+  <rect x="390" y="88" width="104" height="12" fill="#d97706"/>
+  <text x="442" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
+  <text x="442" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#fbbf24">5</text>
+  <text x="442" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fcd34d">enrichment APIs</text>
+  <text x="442" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVD + EPSS + KEV</text>
 
-  <!-- Stage 4: ENRICH -->
-  <rect x="430" y="66" width="114" height="148" rx="8" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
-  <rect x="430" y="66" width="114" height="26" rx="8" fill="#d29922"/>
-  <rect x="430" y="80" width="114" height="12" fill="#d29922"/>
-  <text x="487" y="84" text-anchor="middle" class="phase" fill="#ffffff">ENRICH</text>
-  <text x="487" y="114" text-anchor="middle" class="num" fill="#d29922">5</text>
-  <text x="487" y="130" text-anchor="middle" class="label">enrichment APIs</text>
-  <text x="487" y="148" text-anchor="middle" class="sub">NVD CVSS · EPSS</text>
-  <text x="487" y="162" text-anchor="middle" class="sub">CISA KEV · CWE</text>
-  <text x="487" y="176" text-anchor="middle" class="sub">OpenSSF Scorecard</text>
+  <path d="M494 130 L508 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M504 125 L512 130 L504 135" fill="#4b5563"/>
 
-  <!-- Arrow 4→5 -->
-  <line x1="544" y1="140" x2="560" y2="140" stroke="#30363d" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 5: ANALYZE ─── -->
+  <rect x="514" y="70" width="104" height="120" rx="12" fill="#2d1215" stroke="#f87171" stroke-width="2"/>
+  <rect x="514" y="70" width="104" height="30" rx="12" fill="#dc2626"/>
+  <rect x="514" y="88" width="104" height="12" fill="#dc2626"/>
+  <text x="566" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
+  <text x="566" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#fca5a5">Blast radius</text>
+  <text x="566" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#fca5a5">mapping</text>
+  <text x="566" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CVE → agent → creds</text>
 
-  <!-- Stage 5: ANALYZE -->
-  <rect x="566" y="66" width="114" height="148" rx="8" fill="#0d1117" stroke="#f85149" stroke-width="1"/>
-  <rect x="566" y="66" width="114" height="26" rx="8" fill="#f85149"/>
-  <rect x="566" y="80" width="114" height="12" fill="#f85149"/>
-  <text x="623" y="84" text-anchor="middle" class="phase" fill="#ffffff">ANALYZE</text>
-  <text x="623" y="112" text-anchor="middle" class="label">Blast radius mapping</text>
-  <text x="623" y="130" text-anchor="middle" class="sub">CVE → server → creds</text>
-  <text x="623" y="148" text-anchor="middle" class="sub">Tool capability scoring</text>
-  <text x="623" y="162" text-anchor="middle" class="sub">AI risk elevation</text>
-  <text x="623" y="176" text-anchor="middle" class="sub">Risk score 0–10</text>
+  <path d="M618 130 L632 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M628 125 L636 130 L628 135" fill="#4b5563"/>
 
-  <!-- Arrow 5→6 -->
-  <line x1="680" y1="140" x2="696" y2="140" stroke="#30363d" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 6: COMPLY ─── -->
+  <rect x="638" y="70" width="104" height="120" rx="12" fill="#1a1028" stroke="#a78bfa" stroke-width="2"/>
+  <rect x="638" y="70" width="104" height="30" rx="12" fill="#7c3aed"/>
+  <rect x="638" y="88" width="104" height="12" fill="#7c3aed"/>
+  <text x="690" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
+  <text x="690" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#a78bfa">10</text>
+  <text x="690" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#c4b5fd">frameworks</text>
+  <text x="690" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP + ATLAS + NIST</text>
 
-  <!-- Stage 6: COMPLY -->
-  <rect x="702" y="66" width="114" height="148" rx="8" fill="#0d1117" stroke="#bc8cff" stroke-width="1"/>
-  <rect x="702" y="66" width="114" height="26" rx="8" fill="#bc8cff"/>
-  <rect x="702" y="80" width="114" height="12" fill="#bc8cff"/>
-  <text x="759" y="84" text-anchor="middle" class="phase" fill="#ffffff">COMPLY</text>
-  <text x="759" y="114" text-anchor="middle" class="num" fill="#bc8cff">10</text>
-  <text x="759" y="130" text-anchor="middle" class="label">frameworks</text>
-  <text x="759" y="148" text-anchor="middle" class="sub">OWASP LLM/MCP/Agent</text>
-  <text x="759" y="162" text-anchor="middle" class="sub">ATLAS · NIST AI · EU AI</text>
-  <text x="759" y="176" text-anchor="middle" class="sub">CSF · ISO · SOC 2 · CIS</text>
+  <path d="M742 130 L756 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M752 125 L760 130 L752 135" fill="#4b5563"/>
 
-  <!-- Arrow 6→7 -->
-  <line x1="816" y1="140" x2="832" y2="140" stroke="#30363d" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 7: OUTPUT ─── -->
+  <rect x="762" y="70" width="104" height="120" rx="12" fill="#0a2118" stroke="#34d399" stroke-width="2"/>
+  <rect x="762" y="70" width="104" height="30" rx="12" fill="#059669"/>
+  <rect x="762" y="88" width="104" height="12" fill="#059669"/>
+  <text x="814" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
+  <text x="814" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Reports + APIs</text>
+  <text x="814" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">+ MCP Server</text>
+  <text x="814" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">13 output formats</text>
 
-  <!-- Stage 7: OUTPUT -->
-  <rect x="838" y="66" width="106" height="148" rx="8" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
-  <rect x="838" y="66" width="106" height="26" rx="8" fill="#3fb950"/>
-  <rect x="838" y="80" width="106" height="12" fill="#3fb950"/>
-  <text x="891" y="84" text-anchor="middle" class="phase" fill="#ffffff">OUTPUT</text>
-  <text x="891" y="112" text-anchor="middle" class="label">Reports &amp; APIs</text>
-  <text x="891" y="130" text-anchor="middle" class="sub">JSON · SARIF · HTML</text>
-  <text x="891" y="148" text-anchor="middle" class="sub">CycloneDX · SPDX</text>
-  <text x="891" y="162" text-anchor="middle" class="sub">REST · SSE · MCP</text>
-  <text x="891" y="176" text-anchor="middle" class="sub">Slack · Jira · Webhooks</text>
+  <!-- ─── EXTERNAL APIs BAR ─── -->
+  <rect x="18" y="210" width="848" height="50" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="440" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.08em">EXTERNAL APIs</text>
 
-  <!-- ═══ EXTERNAL APIs (bottom panel) — no connector lines ═══ -->
-  <rect x="22" y="238" width="922" height="64" rx="8" fill="#161b22" stroke="#30363d" stroke-width="0.8"/>
-  <text x="483" y="258" text-anchor="middle" class="phase" fill="#8b949e">EXTERNAL APIs &amp; DATABASES</text>
+  <text x="440" y="250" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  MCP Registry  |  OpenSSF Scorecard</text>
 
-  <!-- Badges row -->
-  <rect x="36" y="268" width="56" height="18" rx="4" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6"/>
-  <text x="64" y="280" text-anchor="middle" class="badge" fill="#58a6ff">OSV.dev</text>
-  <rect x="100" y="268" width="42" height="18" rx="4" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6"/>
-  <text x="121" y="280" text-anchor="middle" class="badge" fill="#58a6ff">NVD</text>
-  <rect x="150" y="268" width="66" height="18" rx="4" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6"/>
-  <text x="183" y="280" text-anchor="middle" class="badge" fill="#58a6ff">FIRST EPSS</text>
-  <rect x="224" y="268" width="60" height="18" rx="4" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6"/>
-  <text x="254" y="280" text-anchor="middle" class="badge" fill="#58a6ff">CISA KEV</text>
-  <rect x="292" y="268" width="62" height="18" rx="4" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6"/>
-  <text x="323" y="280" text-anchor="middle" class="badge" fill="#58a6ff">Grype DB</text>
-  <rect x="362" y="268" width="72" height="18" rx="4" fill="#0d1117" stroke="#58a6ff" stroke-width="0.6"/>
-  <text x="398" y="280" text-anchor="middle" class="badge" fill="#58a6ff">GitHub GHSA</text>
-
-  <rect x="462" y="268" width="78" height="18" rx="4" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6"/>
-  <text x="501" y="280" text-anchor="middle" class="badge" fill="#bc8cff">MCP Registry</text>
-  <rect x="548" y="268" width="62" height="18" rx="4" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6"/>
-  <text x="579" y="280" text-anchor="middle" class="badge" fill="#bc8cff">Smithery</text>
-  <rect x="618" y="268" width="76" height="18" rx="4" fill="#0d1117" stroke="#bc8cff" stroke-width="0.6"/>
-  <text x="656" y="280" text-anchor="middle" class="badge" fill="#bc8cff">HuggingFace</text>
-
-  <rect x="722" y="268" width="50" height="18" rx="4" fill="#0d1117" stroke="#d29922" stroke-width="0.6"/>
-  <text x="747" y="280" text-anchor="middle" class="badge" fill="#d29922">Grype</text>
-  <rect x="780" y="268" width="40" height="18" rx="4" fill="#0d1117" stroke="#d29922" stroke-width="0.6"/>
-  <text x="800" y="280" text-anchor="middle" class="badge" fill="#d29922">Syft</text>
-  <rect x="828" y="268" width="96" height="18" rx="4" fill="#0d1117" stroke="#3fb950" stroke-width="0.6"/>
-  <text x="876" y="280" text-anchor="middle" class="badge" fill="#3fb950">OpenSSF Scorecard</text>
-
-  <!-- ═══ KEY METRICS BAR ═══ -->
-  <rect x="22" y="322" width="922" height="30" rx="6" fill="#161b22" stroke="#30363d" stroke-width="0.6"/>
-  <text x="90" y="341" text-anchor="middle" class="badge" fill="#8b949e">18 MCP clients</text>
-  <text x="175" y="341" text-anchor="middle" class="badge" fill="#30363d">|</text>
-  <text x="265" y="341" text-anchor="middle" class="badge" fill="#8b949e">11 package ecosystems</text>
-  <text x="360" y="341" text-anchor="middle" class="badge" fill="#30363d">|</text>
-  <text x="450" y="341" text-anchor="middle" class="badge" fill="#8b949e">8 vulnerability sources</text>
-  <text x="540" y="341" text-anchor="middle" class="badge" fill="#30363d">|</text>
-  <text x="640" y="341" text-anchor="middle" class="badge" fill="#8b949e">10 compliance frameworks</text>
-  <text x="740" y="341" text-anchor="middle" class="badge" fill="#30363d">|</text>
-  <text x="815" y="341" text-anchor="middle" class="badge" fill="#8b949e">16 MCP tools</text>
-  <text x="870" y="341" text-anchor="middle" class="badge" fill="#30363d">|</text>
-  <text x="920" y="341" text-anchor="middle" class="badge" fill="#8b949e">13 formats</text>
-
-  <!-- ═══ FOOTER NOTE ═══ -->
-  <text x="480" y="378" text-anchor="middle" class="note">Read-only analysis · No agents deployed · No code execution · Runs locally or in CI/CD</text>
+  <!-- Footer -->
+  <text x="440" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only analysis  |  No agents deployed  |  No code execution  |  Runs locally or in CI/CD</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -1,170 +1,104 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" fill="none">
-  <style>
-    .title { font: 700 15px system-ui, -apple-system, sans-serif; fill: #0f172a; }
-    .subtitle { font: 400 10px system-ui, sans-serif; fill: #64748b; }
-    .phase { font: 700 9px system-ui, sans-serif; letter-spacing: 0.08em; }
-    .label { font: 600 9.5px system-ui, sans-serif; fill: #334155; }
-    .sub { font: 400 8.5px system-ui, sans-serif; fill: #64748b; }
-    .badge { font: 600 7.5px system-ui, sans-serif; }
-    .note { font: 400 8.5px system-ui, sans-serif; fill: #94a3b8; }
-    .num { font: 700 20px system-ui, sans-serif; }
-  </style>
-  <defs>
-    <marker id="arr" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-      <path d="M0 0L10 4L0 8Z" fill="#cbd5e1"/>
-    </marker>
-  </defs>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 280" fill="none">
   <!-- Background -->
-  <rect width="960" height="400" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+  <rect width="880" height="280" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="30" text-anchor="middle" class="title">Scanner Architecture</text>
-  <text x="480" y="46" text-anchor="middle" class="subtitle">7-stage pipeline from discovery to actionable output</text>
+  <text x="440" y="30" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scanner Pipeline</text>
+  <text x="440" y="50" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">7-stage pipeline from discovery to actionable output</text>
 
-  <!-- ═══ PIPELINE STAGES — equal width 114px, gap 12px ═══ -->
+  <!-- ─── STAGE 1: DISCOVER ─── -->
+  <rect x="18" y="70" width="104" height="120" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="18" y="70" width="104" height="30" rx="12" fill="#3b82f6"/>
+  <rect x="18" y="88" width="104" height="12" fill="#3b82f6"/>
+  <text x="70" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
+  <text x="70" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">18</text>
+  <text x="70" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">MCP clients</text>
+  <text x="70" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ Docker + K8s + Cloud</text>
 
-  <!-- Stage 1: DISCOVER -->
-  <rect x="22" y="66" width="114" height="148" rx="8" fill="#eff6ff" stroke="#2563eb" stroke-width="1"/>
-  <rect x="22" y="66" width="114" height="26" rx="8" fill="#2563eb"/>
-  <rect x="22" y="80" width="114" height="12" fill="#2563eb"/>
-  <text x="79" y="84" text-anchor="middle" class="phase" fill="#ffffff">DISCOVER</text>
-  <text x="79" y="114" text-anchor="middle" class="num" fill="#2563eb">18</text>
-  <text x="79" y="130" text-anchor="middle" class="label">MCP clients</text>
-  <text x="79" y="148" text-anchor="middle" class="sub">Containers · Cloud</text>
-  <text x="79" y="162" text-anchor="middle" class="sub">SBOMs · Lock files</text>
-  <text x="79" y="176" text-anchor="middle" class="sub">AI frameworks</text>
+  <!-- Arrow -->
+  <path d="M122 130 L136 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M132 125 L140 130 L132 135" fill="#94a3b8"/>
 
-  <!-- Arrow 1→2 -->
-  <line x1="136" y1="140" x2="152" y2="140" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 2: EXTRACT ─── -->
+  <rect x="142" y="70" width="104" height="120" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="142" y="70" width="104" height="30" rx="12" fill="#3b82f6"/>
+  <rect x="142" y="88" width="104" height="12" fill="#3b82f6"/>
+  <text x="194" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
+  <text x="194" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">11</text>
+  <text x="194" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">ecosystems</text>
+  <text x="194" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">packages + versions</text>
 
-  <!-- Stage 2: EXTRACT -->
-  <rect x="158" y="66" width="114" height="148" rx="8" fill="#eff6ff" stroke="#2563eb" stroke-width="1"/>
-  <rect x="158" y="66" width="114" height="26" rx="8" fill="#2563eb"/>
-  <rect x="158" y="80" width="114" height="12" fill="#2563eb"/>
-  <text x="215" y="84" text-anchor="middle" class="phase" fill="#ffffff">EXTRACT</text>
-  <text x="215" y="114" text-anchor="middle" class="num" fill="#2563eb">11</text>
-  <text x="215" y="130" text-anchor="middle" class="label">ecosystems</text>
-  <text x="215" y="148" text-anchor="middle" class="sub">Lock files · Registries</text>
-  <text x="215" y="162" text-anchor="middle" class="sub">Transitive resolution</text>
-  <text x="215" y="176" text-anchor="middle" class="sub">Deduplication</text>
+  <!-- Arrow -->
+  <path d="M246 130 L260 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M256 125 L264 130 L256 135" fill="#94a3b8"/>
 
-  <!-- Arrow 2→3 -->
-  <line x1="272" y1="140" x2="288" y2="140" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 3: SCAN ─── -->
+  <rect x="266" y="70" width="104" height="120" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="266" y="70" width="104" height="30" rx="12" fill="#f59e0b"/>
+  <rect x="266" y="88" width="104" height="12" fill="#f59e0b"/>
+  <text x="318" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
+  <text x="318" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#d97706">8</text>
+  <text x="318" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#92400e">vuln sources</text>
+  <text x="318" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OSV + Grype + GHSA</text>
 
-  <!-- Stage 3: SCAN -->
-  <rect x="294" y="66" width="114" height="148" rx="8" fill="#fef9ec" stroke="#d97706" stroke-width="1"/>
-  <rect x="294" y="66" width="114" height="26" rx="8" fill="#d97706"/>
-  <rect x="294" y="80" width="114" height="12" fill="#d97706"/>
-  <text x="351" y="84" text-anchor="middle" class="phase" fill="#ffffff">SCAN</text>
-  <text x="351" y="114" text-anchor="middle" class="num" fill="#d97706">8</text>
-  <text x="351" y="130" text-anchor="middle" class="label">vuln sources</text>
-  <text x="351" y="148" text-anchor="middle" class="sub">OSV · Grype · GHSA</text>
-  <text x="351" y="162" text-anchor="middle" class="sub">Typosquat detection</text>
-  <text x="351" y="176" text-anchor="middle" class="sub">Malicious pkg detect</text>
+  <!-- Arrow -->
+  <path d="M370 130 L384 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M380 125 L388 130 L380 135" fill="#94a3b8"/>
 
-  <!-- Arrow 3→4 -->
-  <line x1="408" y1="140" x2="424" y2="140" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 4: ENRICH ─── -->
+  <rect x="390" y="70" width="104" height="120" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="390" y="70" width="104" height="30" rx="12" fill="#f59e0b"/>
+  <rect x="390" y="88" width="104" height="12" fill="#f59e0b"/>
+  <text x="442" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
+  <text x="442" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#d97706">5</text>
+  <text x="442" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#92400e">enrichment APIs</text>
+  <text x="442" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVD + EPSS + KEV</text>
 
-  <!-- Stage 4: ENRICH -->
-  <rect x="430" y="66" width="114" height="148" rx="8" fill="#fef9ec" stroke="#d97706" stroke-width="1"/>
-  <rect x="430" y="66" width="114" height="26" rx="8" fill="#d97706"/>
-  <rect x="430" y="80" width="114" height="12" fill="#d97706"/>
-  <text x="487" y="84" text-anchor="middle" class="phase" fill="#ffffff">ENRICH</text>
-  <text x="487" y="114" text-anchor="middle" class="num" fill="#d97706">5</text>
-  <text x="487" y="130" text-anchor="middle" class="label">enrichment APIs</text>
-  <text x="487" y="148" text-anchor="middle" class="sub">NVD CVSS · EPSS</text>
-  <text x="487" y="162" text-anchor="middle" class="sub">CISA KEV · CWE</text>
-  <text x="487" y="176" text-anchor="middle" class="sub">OpenSSF Scorecard</text>
+  <!-- Arrow -->
+  <path d="M494 130 L508 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M504 125 L512 130 L504 135" fill="#94a3b8"/>
 
-  <!-- Arrow 4→5 -->
-  <line x1="544" y1="140" x2="560" y2="140" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 5: ANALYZE ─── -->
+  <rect x="514" y="70" width="104" height="120" rx="12" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <rect x="514" y="70" width="104" height="30" rx="12" fill="#ef4444"/>
+  <rect x="514" y="88" width="104" height="12" fill="#ef4444"/>
+  <text x="566" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
+  <text x="566" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#dc2626">Blast radius</text>
+  <text x="566" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#dc2626">mapping</text>
+  <text x="566" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CVE → agent → creds</text>
 
-  <!-- Stage 5: ANALYZE -->
-  <rect x="566" y="66" width="114" height="148" rx="8" fill="#fef2f2" stroke="#dc2626" stroke-width="1"/>
-  <rect x="566" y="66" width="114" height="26" rx="8" fill="#dc2626"/>
-  <rect x="566" y="80" width="114" height="12" fill="#dc2626"/>
-  <text x="623" y="84" text-anchor="middle" class="phase" fill="#ffffff">ANALYZE</text>
-  <text x="623" y="112" text-anchor="middle" class="label">Blast radius mapping</text>
-  <text x="623" y="130" text-anchor="middle" class="sub">CVE → server → creds</text>
-  <text x="623" y="148" text-anchor="middle" class="sub">Tool capability scoring</text>
-  <text x="623" y="162" text-anchor="middle" class="sub">AI risk elevation</text>
-  <text x="623" y="176" text-anchor="middle" class="sub">Risk score 0–10</text>
+  <!-- Arrow -->
+  <path d="M618 130 L632 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M628 125 L636 130 L628 135" fill="#94a3b8"/>
 
-  <!-- Arrow 5→6 -->
-  <line x1="680" y1="140" x2="696" y2="140" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 6: COMPLY ─── -->
+  <rect x="638" y="70" width="104" height="120" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
+  <rect x="638" y="70" width="104" height="30" rx="12" fill="#8b5cf6"/>
+  <rect x="638" y="88" width="104" height="12" fill="#8b5cf6"/>
+  <text x="690" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
+  <text x="690" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#7c3aed">10</text>
+  <text x="690" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6d28d9">frameworks</text>
+  <text x="690" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP + ATLAS + NIST</text>
 
-  <!-- Stage 6: COMPLY -->
-  <rect x="702" y="66" width="114" height="148" rx="8" fill="#f5f3ff" stroke="#7c3aed" stroke-width="1"/>
-  <rect x="702" y="66" width="114" height="26" rx="8" fill="#7c3aed"/>
-  <rect x="702" y="80" width="114" height="12" fill="#7c3aed"/>
-  <text x="759" y="84" text-anchor="middle" class="phase" fill="#ffffff">COMPLY</text>
-  <text x="759" y="114" text-anchor="middle" class="num" fill="#7c3aed">10</text>
-  <text x="759" y="130" text-anchor="middle" class="label">frameworks</text>
-  <text x="759" y="148" text-anchor="middle" class="sub">OWASP LLM/MCP/Agent</text>
-  <text x="759" y="162" text-anchor="middle" class="sub">ATLAS · NIST AI · EU AI</text>
-  <text x="759" y="176" text-anchor="middle" class="sub">CSF · ISO · SOC 2 · CIS</text>
+  <!-- Arrow -->
+  <path d="M742 130 L756 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M752 125 L760 130 L752 135" fill="#94a3b8"/>
 
-  <!-- Arrow 6→7 -->
-  <line x1="816" y1="140" x2="832" y2="140" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- ─── STAGE 7: OUTPUT ─── -->
+  <rect x="762" y="70" width="104" height="120" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+  <rect x="762" y="70" width="104" height="30" rx="12" fill="#10b981"/>
+  <rect x="762" y="88" width="104" height="12" fill="#10b981"/>
+  <text x="814" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
+  <text x="814" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#059669">Reports + APIs</text>
+  <text x="814" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#059669">+ MCP Server</text>
+  <text x="814" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">13 output formats</text>
 
-  <!-- Stage 7: OUTPUT -->
-  <rect x="838" y="66" width="106" height="148" rx="8" fill="#f0fdf4" stroke="#16a34a" stroke-width="1"/>
-  <rect x="838" y="66" width="106" height="26" rx="8" fill="#16a34a"/>
-  <rect x="838" y="80" width="106" height="12" fill="#16a34a"/>
-  <text x="891" y="84" text-anchor="middle" class="phase" fill="#ffffff">OUTPUT</text>
-  <text x="891" y="112" text-anchor="middle" class="label">Reports &amp; APIs</text>
-  <text x="891" y="130" text-anchor="middle" class="sub">JSON · SARIF · HTML</text>
-  <text x="891" y="148" text-anchor="middle" class="sub">CycloneDX · SPDX</text>
-  <text x="891" y="162" text-anchor="middle" class="sub">REST · SSE · MCP</text>
-  <text x="891" y="176" text-anchor="middle" class="sub">Slack · Jira · Webhooks</text>
+  <!-- ─── EXTERNAL APIs BAR ─── -->
+  <rect x="18" y="210" width="848" height="50" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="440" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#64748b" letter-spacing="0.08em">EXTERNAL APIs</text>
 
-  <!-- ═══ EXTERNAL APIs (bottom panel) — no connector lines ═══ -->
-  <rect x="22" y="238" width="922" height="64" rx="8" fill="#f8fafc" stroke="#cbd5e1" stroke-width="0.8"/>
-  <text x="483" y="258" text-anchor="middle" class="phase" fill="#64748b">EXTERNAL APIs &amp; DATABASES</text>
+  <text x="440" y="250" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#475569">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  MCP Registry  |  OpenSSF Scorecard</text>
 
-  <!-- Badges row — evenly spaced -->
-  <rect x="36" y="268" width="56" height="18" rx="4" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.6"/>
-  <text x="64" y="280" text-anchor="middle" class="badge" fill="#2563eb">OSV.dev</text>
-  <rect x="100" y="268" width="42" height="18" rx="4" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.6"/>
-  <text x="121" y="280" text-anchor="middle" class="badge" fill="#2563eb">NVD</text>
-  <rect x="150" y="268" width="66" height="18" rx="4" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.6"/>
-  <text x="183" y="280" text-anchor="middle" class="badge" fill="#2563eb">FIRST EPSS</text>
-  <rect x="224" y="268" width="60" height="18" rx="4" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.6"/>
-  <text x="254" y="280" text-anchor="middle" class="badge" fill="#2563eb">CISA KEV</text>
-  <rect x="292" y="268" width="62" height="18" rx="4" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.6"/>
-  <text x="323" y="280" text-anchor="middle" class="badge" fill="#2563eb">Grype DB</text>
-  <rect x="362" y="268" width="72" height="18" rx="4" fill="#dbeafe" stroke="#93c5fd" stroke-width="0.6"/>
-  <text x="398" y="280" text-anchor="middle" class="badge" fill="#2563eb">GitHub GHSA</text>
-
-  <rect x="462" y="268" width="78" height="18" rx="4" fill="#f3e8ff" stroke="#c4b5fd" stroke-width="0.6"/>
-  <text x="501" y="280" text-anchor="middle" class="badge" fill="#7c3aed">MCP Registry</text>
-  <rect x="548" y="268" width="62" height="18" rx="4" fill="#f3e8ff" stroke="#c4b5fd" stroke-width="0.6"/>
-  <text x="579" y="280" text-anchor="middle" class="badge" fill="#7c3aed">Smithery</text>
-  <rect x="618" y="268" width="76" height="18" rx="4" fill="#f3e8ff" stroke="#c4b5fd" stroke-width="0.6"/>
-  <text x="656" y="280" text-anchor="middle" class="badge" fill="#7c3aed">HuggingFace</text>
-
-  <rect x="722" y="268" width="50" height="18" rx="4" fill="#fef9ec" stroke="#fcd34d" stroke-width="0.6"/>
-  <text x="747" y="280" text-anchor="middle" class="badge" fill="#d97706">Grype</text>
-  <rect x="780" y="268" width="40" height="18" rx="4" fill="#fef9ec" stroke="#fcd34d" stroke-width="0.6"/>
-  <text x="800" y="280" text-anchor="middle" class="badge" fill="#d97706">Syft</text>
-  <rect x="828" y="268" width="96" height="18" rx="4" fill="#dcfce7" stroke="#86efac" stroke-width="0.6"/>
-  <text x="876" y="280" text-anchor="middle" class="badge" fill="#16a34a">OpenSSF Scorecard</text>
-
-  <!-- ═══ KEY METRICS BAR ═══ -->
-  <rect x="22" y="322" width="922" height="30" rx="6" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="0.6"/>
-  <text x="90" y="341" text-anchor="middle" class="badge" fill="#475569">18 MCP clients</text>
-  <text x="175" y="341" text-anchor="middle" class="badge" fill="#cbd5e1">|</text>
-  <text x="265" y="341" text-anchor="middle" class="badge" fill="#475569">11 package ecosystems</text>
-  <text x="360" y="341" text-anchor="middle" class="badge" fill="#cbd5e1">|</text>
-  <text x="450" y="341" text-anchor="middle" class="badge" fill="#475569">8 vulnerability sources</text>
-  <text x="540" y="341" text-anchor="middle" class="badge" fill="#cbd5e1">|</text>
-  <text x="640" y="341" text-anchor="middle" class="badge" fill="#475569">10 compliance frameworks</text>
-  <text x="740" y="341" text-anchor="middle" class="badge" fill="#cbd5e1">|</text>
-  <text x="815" y="341" text-anchor="middle" class="badge" fill="#475569">16 MCP tools</text>
-  <text x="870" y="341" text-anchor="middle" class="badge" fill="#cbd5e1">|</text>
-  <text x="920" y="341" text-anchor="middle" class="badge" fill="#475569">13 formats</text>
-
-  <!-- ═══ FOOTER NOTE ═══ -->
-  <text x="480" y="378" text-anchor="middle" class="note">Read-only analysis · No agents deployed · No code execution · Runs locally or in CI/CD</text>
+  <!-- Footer -->
+  <text x="440" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only analysis  |  No agents deployed  |  No code execution  |  Runs locally or in CI/CD</text>
 </svg>


### PR DESCRIPTION
## Summary
- Redesigned all 8 README SVG diagrams (4 light + 4 dark) with clean, modern architecture visuals
- Replaced dense text-heavy infographic panels (~1536 lines) with minimal diagrams (~738 lines)
- Large shapes, bold labels, thick arrows, generous whitespace — readable at GitHub rendering width
- Diagrams: enterprise overview, blast radius propagation, scanner pipeline, enterprise scan workflow

## What changed
- **enterprise-overview**: 3-band horizontal flow (sources → engine → outputs) + runtime sidebar
- **blast-radius**: Clean 4-node chain (CVE → Package → Server → Agent) + impact summary
- **scanner-architecture**: 7 colored stage cards in horizontal pipeline
- **scan-workflow**: 4-column layout (inputs → pipeline → analysis → outputs)

## Test plan
- [x] All 8 SVGs validate as valid XML
- [x] All 24 deploy/metrics tests pass
- [x] Light and dark mode variants are consistent