### PR TITLE
docs: comprehensive diagram redesign showing full capability scope

### DIFF
--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -1,107 +1,164 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
-  <!-- Background -->
-  <rect width="880" height="420" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 580" fill="none">
+  <rect width="960" height="580" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
-  <!-- ─── ROW 1: INPUT SOURCES ─── -->
-  <rect x="30" y="24" width="820" height="90" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.2" opacity="0.9"/>
-  <text x="440" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.1em">INPUT SOURCES</text>
+  <!-- ─── ROW 1: DISCOVERY & INPUT SOURCES ─── -->
+  <rect x="20" y="16" width="920" height="164" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.2"/>
+  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.1em">DISCOVERY &amp; INPUT SOURCES</text>
 
-  <rect x="52" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="112" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">MCP Configs</text>
+  <rect x="34" y="48" width="168" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Local Agents</text>
+  <text x="118" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#60a5fa">18</text>
+  <text x="118" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#93c5fd">MCP clients auto-detected</text>
+  <text x="118" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Claude · Cursor · Codex · Gemini</text>
+  <text x="118" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Goose · Windsurf · Zed + 11 more</text>
+  <text x="118" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">+ Docker Compose discovery</text>
 
-  <rect x="184" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="244" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">Containers</text>
+  <rect x="214" y="48" width="146" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="287" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Containers</text>
+  <text x="287" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">Docker Images</text>
+  <text x="287" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Grype / Syft / Docker CLI</text>
+  <text x="287" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Multi-arch · Private registry</text>
+  <text x="287" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">Kubernetes</text>
+  <text x="287" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">All namespaces · Pod images</text>
+  <text x="287" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">EKS · GKE · AKS · CoreWeave</text>
 
-  <rect x="316" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="376" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">Kubernetes</text>
+  <rect x="372" y="48" width="194" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="469" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Cloud Providers</text>
+  <text x="469" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#60a5fa">8</text>
+  <text x="469" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#93c5fd">platforms scanned</text>
+  <text x="469" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">AWS Bedrock · Lambda · ECS · EKS</text>
+  <text x="469" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Azure AI · GCP Vertex · Snowflake</text>
+  <text x="469" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Databricks · Nebius GPU Cloud</text>
+  <text x="469" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">Cortex Agents · Snowpark · Bedrock</text>
 
-  <rect x="448" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="508" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">Cloud APIs</text>
+  <rect x="578" y="48" width="146" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="651" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">AI Platforms</text>
+  <text x="651" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">HuggingFace</text>
+  <text x="651" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Models · Spaces · Inference</text>
+  <text x="651" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">MLflow · W&amp;B · Ollama</text>
+  <text x="651" y="136" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Model provenance + hashes</text>
+  <text x="651" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">13 model file formats</text>
+  <text x="651" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Sigstore signature checks</text>
 
-  <rect x="580" y="56" width="120" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="640" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">SBOMs</text>
+  <rect x="736" y="48" width="192" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="832" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Code &amp; Config</text>
+  <text x="832" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">7 package ecosystems</text>
+  <text x="832" y="102" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">npm · pip · Go · Cargo · Maven</text>
+  <text x="832" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">SBOMs · IaC · SAST</text>
+  <text x="832" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CycloneDX · SPDX · Terraform</text>
+  <text x="832" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">GitHub Actions · Notebooks</text>
+  <text x="832" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Skill files · Prompt templates</text>
 
-  <rect x="712" y="56" width="126" height="44" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="775" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#93c5fd">AI Frameworks</text>
+  <path d="M480 180 L480 200" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M474 194 L480 204 L486 194" fill="#4b5563"/>
 
-  <!-- Arrow down -->
-  <path d="M440 114 L440 136" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M434 130 L440 140 L446 130" fill="#4b5563"/>
+  <!-- ─── ROW 2: ANALYSIS ENGINE ─── -->
+  <rect x="20" y="208" width="700" height="172" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.2"/>
+  <text x="370" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.1em">ANALYSIS ENGINE</text>
 
-  <!-- ─── ROW 2: SCANNER ENGINE ─── -->
-  <rect x="30" y="144" width="620" height="110" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.2" opacity="0.9"/>
-  <text x="340" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.1em">SCANNER ENGINE</text>
+  <rect x="34" y="240" width="148" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="108" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">7 Vuln Sources</text>
+  <text x="108" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">OSV · NVD · EPSS · KEV</text>
+  <text x="108" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">GHSA · NVIDIA · Grype</text>
 
-  <rect x="46" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="91" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Discover</text>
-  <text x="91" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">18 clients</text>
+  <path d="M186 268 L198 268" stroke="#f59e0b" stroke-width="2"/>
+  <path d="M194 264 L201 268 L194 272" fill="#f59e0b"/>
 
-  <path d="M140 208 L152 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
-  <path d="M148 204 L155 208 L148 212" fill="#f59e0b"/>
+  <rect x="204" y="240" width="148" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="278" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">Blast Radius</text>
+  <text x="278" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">CVE → pkg → server → agent</text>
+  <text x="278" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">→ credentials → tools</text>
 
-  <rect x="160" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="205" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Extract</text>
-  <text x="205" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">packages</text>
+  <path d="M356 268 L368 268" stroke="#f59e0b" stroke-width="2"/>
+  <path d="M364 264 L371 268 L364 272" fill="#f59e0b"/>
 
-  <path d="M254 208 L266 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
-  <path d="M262 204 L269 208 L262 212" fill="#f59e0b"/>
+  <rect x="374" y="240" width="148" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="448" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">10 Frameworks</text>
+  <text x="448" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">OWASP LLM + MCP + Agentic</text>
+  <text x="448" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">ATLAS · NIST · EU AI Act +4</text>
 
-  <rect x="274" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="319" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Scan</text>
-  <text x="319" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">OSV + Grype</text>
+  <path d="M526 268 L538 268" stroke="#f59e0b" stroke-width="2"/>
+  <path d="M534 264 L541 268 L534 272" fill="#f59e0b"/>
 
-  <path d="M368 208 L380 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
-  <path d="M376 204 L383 208 L376 212" fill="#f59e0b"/>
+  <rect x="544" y="240" width="160" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="624" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">Context Graph</text>
+  <text x="624" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Lateral movement analysis</text>
+  <text x="624" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">BFS attack paths</text>
 
-  <rect x="388" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="433" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Enrich</text>
-  <text x="433" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">NVD + EPSS</text>
+  <rect x="34" y="306" width="148" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="108" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Posture Scorecard</text>
+  <text x="108" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Grade A-F · 6 dimensions</text>
+  <text x="108" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Weighted enterprise scoring</text>
 
-  <path d="M482 208 L494 208" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
-  <path d="M490 204 L497 208 L490 212" fill="#f59e0b"/>
+  <rect x="204" y="306" width="148" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="278" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Incident Correlation</text>
+  <text x="278" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">P1-P4 priority by agent</text>
+  <text x="278" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">SOC-ready OCSF format</text>
 
-  <rect x="502" y="178" width="90" height="60" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="547" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#fbbf24">Analyze</text>
-  <text x="547" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">blast radius</text>
+  <rect x="374" y="306" width="148" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="448" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Credential Ranking</text>
+  <text x="448" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Risk tiers by blast radius</text>
+  <text x="448" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Cross-agent aggregation</text>
+
+  <rect x="544" y="306" width="160" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="624" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Toxic Combos</text>
+  <text x="624" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">KEV+creds · RCE+exec</text>
+  <text x="624" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Malicious pkg · Typosquat</text>
 
   <!-- ─── SIDEBAR: RUNTIME ─── -->
-  <rect x="666" y="144" width="184" height="110" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.2" opacity="0.9"/>
-  <text x="758" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.1em">RUNTIME</text>
+  <rect x="736" y="208" width="204" height="172" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.2"/>
+  <text x="838" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.1em">RUNTIME PROTECTION</text>
 
-  <text x="688" y="190" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">MCP Proxy</text>
-  <text x="688" y="208" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Protection Engine</text>
-  <text x="688" y="226" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Fleet Management</text>
-  <text x="688" y="244" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Alert Pipeline</text>
+  <rect x="748" y="240" width="180" height="44" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="838" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#c4b5fd">MCP Proxy</text>
+  <text x="838" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">JSON-RPC intercept · audit log</text>
 
-  <path d="M596 208 L666 208" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="6 4" opacity="0.6"/>
+  <rect x="748" y="292" width="180" height="44" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="838" y="310" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#c4b5fd">5 Detectors</text>
+  <text x="838" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Drift · Creds · Rate · Sequence · Args</text>
 
-  <!-- Arrow down -->
-  <path d="M340 254 L340 276" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M334 270 L340 280 L346 270" fill="#4b5563"/>
+  <rect x="748" y="344" width="86" height="30" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="791" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#c4b5fd">Fleet Mgmt</text>
+
+  <rect x="842" y="344" width="86" height="30" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="885" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#c4b5fd">Alerts</text>
+
+  <path d="M704 294 L736 294" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
+
+  <path d="M370 380 L370 402" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M364 396 L370 406 L376 396" fill="#4b5563"/>
 
   <!-- ─── ROW 3: OUTPUTS ─── -->
-  <rect x="30" y="284" width="820" height="108" rx="12" fill="#161b22" stroke="#059669" stroke-width="1.2" opacity="0.9"/>
-  <text x="440" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.1em">OUTPUTS</text>
+  <rect x="20" y="410" width="920" height="84" rx="12" fill="#0a2118" stroke="#059669" stroke-width="1.2"/>
+  <text x="480" y="430" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT</text>
 
-  <rect x="46" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="101" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">JSON / SARIF</text>
+  <rect x="34" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="82" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">CLI</text>
 
-  <rect x="168" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="223" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">CycloneDX</text>
+  <rect x="140" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="188" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">REST API</text>
 
-  <rect x="290" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="345" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Dashboard</text>
+  <rect x="246" y="442" width="114" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="303" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">MCP (16 tools)</text>
 
-  <rect x="412" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="467" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">REST API</text>
+  <rect x="370" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="418" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">Dashboard</text>
 
-  <rect x="534" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="589" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">MCP Server</text>
+  <rect x="476" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="524" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">SARIF / SBOM</text>
 
-  <rect x="656" y="318" width="110" height="44" rx="10" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="711" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Slack / Jira</text>
+  <rect x="582" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="630" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">GitHub Action</text>
 
-  <!-- ─── FOOTER: COMPLIANCE ─── -->
-  <rect x="30" y="396" width="820" height="2" rx="1" fill="#21262d"/>
-  <text x="440" y="415" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e" letter-spacing="0.05em">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+  <rect x="688" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="736" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">Docker / Helm</text>
+
+  <rect x="794" y="442" width="134" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
+  <text x="861" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">Slack · Jira · Webhooks</text>
+
+  <!-- ─── FOOTER ─── -->
+  <rect x="20" y="504" width="920" height="2" rx="1" fill="#21262d"/>
+  <text x="480" y="524" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  427+ server registry  |  7 vuln sources  |  10 compliance frameworks  |  16 MCP tools  |  2,868 tests</text>
+  <text x="480" y="546" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  OpenSSF scored  |  Apache 2.0</text>
+  <text x="480" y="568" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#34d399">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -1,116 +1,164 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" fill="none">
-  <defs>
-    <marker id="arrow-down" viewBox="0 0 10 10" refX="5" refY="10" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M0 0L5 10L10 0" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 580" fill="none">
+  <rect width="960" height="580" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
-  <!-- Background -->
-  <rect width="880" height="420" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <!-- ─── ROW 1: DISCOVERY & INPUT SOURCES ─── -->
+  <rect x="20" y="16" width="920" height="164" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.2"/>
+  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#2563eb" letter-spacing="0.1em">DISCOVERY &amp; INPUT SOURCES</text>
 
-  <!-- ─── ROW 1: INPUT SOURCES ─── -->
-  <rect x="30" y="24" width="820" height="90" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.2"/>
-  <text x="440" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#3b82f6" letter-spacing="0.1em">INPUT SOURCES</text>
+  <rect x="34" y="48" width="168" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Local Agents</text>
+  <text x="118" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#3b82f6">18</text>
+  <text x="118" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#1e40af">MCP clients auto-detected</text>
+  <text x="118" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Claude · Cursor · Codex · Gemini</text>
+  <text x="118" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Goose · Windsurf · Zed + 11 more</text>
+  <text x="118" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">+ Docker Compose discovery</text>
 
-  <!-- Source pills -->
-  <rect x="52" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="112" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">MCP Configs</text>
+  <rect x="214" y="48" width="146" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="287" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Containers</text>
+  <text x="287" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">Docker Images</text>
+  <text x="287" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Grype / Syft / Docker CLI</text>
+  <text x="287" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Multi-arch · Private registry</text>
+  <text x="287" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">Kubernetes</text>
+  <text x="287" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">All namespaces · Pod images</text>
+  <text x="287" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">EKS · GKE · AKS · CoreWeave</text>
 
-  <rect x="184" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="244" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">Containers</text>
+  <rect x="372" y="48" width="194" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="469" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Cloud Providers</text>
+  <text x="469" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#3b82f6">8</text>
+  <text x="469" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#1e40af">platforms scanned</text>
+  <text x="469" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">AWS Bedrock · Lambda · ECS · EKS</text>
+  <text x="469" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Azure AI · GCP Vertex · Snowflake</text>
+  <text x="469" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Databricks · Nebius GPU Cloud</text>
+  <text x="469" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">Cortex Agents · Snowpark · Bedrock</text>
 
-  <rect x="316" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="376" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">Kubernetes</text>
+  <rect x="578" y="48" width="146" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="651" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">AI Platforms</text>
+  <text x="651" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">HuggingFace</text>
+  <text x="651" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Models · Spaces · Inference</text>
+  <text x="651" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">MLflow · W&amp;B · Ollama</text>
+  <text x="651" y="136" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Model provenance + hashes</text>
+  <text x="651" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">13 model file formats</text>
+  <text x="651" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Sigstore signature checks</text>
 
-  <rect x="448" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="508" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">Cloud APIs</text>
+  <rect x="736" y="48" width="192" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="832" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Code &amp; Config</text>
+  <text x="832" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">7 package ecosystems</text>
+  <text x="832" y="102" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">npm · pip · Go · Cargo · Maven</text>
+  <text x="832" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">SBOMs · IaC · SAST</text>
+  <text x="832" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CycloneDX · SPDX · Terraform</text>
+  <text x="832" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">GitHub Actions · Notebooks</text>
+  <text x="832" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Skill files · Prompt templates</text>
 
-  <rect x="580" y="56" width="120" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="640" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">SBOMs</text>
+  <path d="M480 180 L480 200" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M474 194 L480 204 L486 194" fill="#94a3b8"/>
 
-  <rect x="712" y="56" width="126" height="44" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="775" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af">AI Frameworks</text>
+  <!-- ─── ROW 2: ANALYSIS ENGINE ─── -->
+  <rect x="20" y="208" width="700" height="172" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="1.2"/>
+  <text x="370" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.1em">ANALYSIS ENGINE</text>
 
-  <!-- Arrow down -->
-  <path d="M440 114 L440 136" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M434 130 L440 140 L446 130" fill="#94a3b8"/>
+  <rect x="34" y="240" width="148" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="108" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">7 Vuln Sources</text>
+  <text x="108" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">OSV · NVD · EPSS · KEV</text>
+  <text x="108" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">GHSA · NVIDIA · Grype</text>
 
-  <!-- ─── ROW 2: SCANNER ENGINE ─── -->
-  <rect x="30" y="144" width="620" height="110" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="1.2"/>
-  <text x="340" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.1em">SCANNER ENGINE</text>
+  <path d="M186 268 L198 268" stroke="#d97706" stroke-width="2"/>
+  <path d="M194 264 L201 268 L194 272" fill="#d97706"/>
 
-  <!-- Pipeline stages -->
-  <rect x="46" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="91" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Discover</text>
-  <text x="91" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">18 clients</text>
+  <rect x="204" y="240" width="148" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="278" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">Blast Radius</text>
+  <text x="278" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">CVE → pkg → server → agent</text>
+  <text x="278" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">→ credentials → tools</text>
 
-  <path d="M140 208 L152 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
-  <path d="M148 204 L155 208 L148 212" fill="#d97706"/>
+  <path d="M356 268 L368 268" stroke="#d97706" stroke-width="2"/>
+  <path d="M364 264 L371 268 L364 272" fill="#d97706"/>
 
-  <rect x="160" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="205" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Extract</text>
-  <text x="205" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">packages</text>
+  <rect x="374" y="240" width="148" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="448" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">10 Frameworks</text>
+  <text x="448" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">OWASP LLM + MCP + Agentic</text>
+  <text x="448" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">ATLAS · NIST · EU AI Act +4</text>
 
-  <path d="M254 208 L266 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
-  <path d="M262 204 L269 208 L262 212" fill="#d97706"/>
+  <path d="M526 268 L538 268" stroke="#d97706" stroke-width="2"/>
+  <path d="M534 264 L541 268 L534 272" fill="#d97706"/>
 
-  <rect x="274" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="319" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Scan</text>
-  <text x="319" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">OSV + Grype</text>
+  <rect x="544" y="240" width="160" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="624" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">Context Graph</text>
+  <text x="624" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Lateral movement analysis</text>
+  <text x="624" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">BFS attack paths</text>
 
-  <path d="M368 208 L380 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
-  <path d="M376 204 L383 208 L376 212" fill="#d97706"/>
+  <rect x="34" y="306" width="148" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="108" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Posture Scorecard</text>
+  <text x="108" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Grade A-F · 6 dimensions</text>
+  <text x="108" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Weighted enterprise scoring</text>
 
-  <rect x="388" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="433" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Enrich</text>
-  <text x="433" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">NVD + EPSS</text>
+  <rect x="204" y="306" width="148" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="278" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Incident Correlation</text>
+  <text x="278" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">P1-P4 priority by agent</text>
+  <text x="278" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">SOC-ready OCSF format</text>
 
-  <path d="M482 208 L494 208" stroke="#d97706" stroke-width="2" stroke-linecap="round"/>
-  <path d="M490 204 L497 208 L490 212" fill="#d97706"/>
+  <rect x="374" y="306" width="148" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="448" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Credential Ranking</text>
+  <text x="448" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Risk tiers by blast radius</text>
+  <text x="448" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Cross-agent aggregation</text>
 
-  <rect x="502" y="178" width="90" height="60" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="547" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#92400e">Analyze</text>
-  <text x="547" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a16207">blast radius</text>
+  <rect x="544" y="306" width="160" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="624" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Toxic Combos</text>
+  <text x="624" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">KEV+creds · RCE+exec</text>
+  <text x="624" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Malicious pkg · Typosquat</text>
 
   <!-- ─── SIDEBAR: RUNTIME ─── -->
-  <rect x="666" y="144" width="184" height="110" rx="12" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.2"/>
-  <text x="758" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.1em">RUNTIME</text>
+  <rect x="736" y="208" width="204" height="172" rx="12" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1.2"/>
+  <text x="838" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.1em">RUNTIME PROTECTION</text>
 
-  <text x="688" y="190" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">MCP Proxy</text>
-  <text x="688" y="208" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Protection Engine</text>
-  <text x="688" y="226" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Fleet Management</text>
-  <text x="688" y="244" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Alert Pipeline</text>
+  <rect x="748" y="240" width="180" height="44" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="838" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#6d28d9">MCP Proxy</text>
+  <text x="838" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">JSON-RPC intercept · audit log</text>
 
-  <!-- Dotted connector to runtime -->
-  <path d="M596 208 L666 208" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <rect x="748" y="292" width="180" height="44" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="838" y="310" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#6d28d9">5 Detectors</text>
+  <text x="838" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Drift · Creds · Rate · Sequence · Args</text>
 
-  <!-- Arrow down from engine -->
-  <path d="M340 254 L340 276" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M334 270 L340 280 L346 270" fill="#94a3b8"/>
+  <rect x="748" y="344" width="86" height="30" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="791" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6d28d9">Fleet Mgmt</text>
+
+  <rect x="842" y="344" width="86" height="30" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="885" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6d28d9">Alerts</text>
+
+  <path d="M704 294 L736 294" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
+
+  <path d="M370 380 L370 402" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M364 396 L370 406 L376 396" fill="#94a3b8"/>
 
   <!-- ─── ROW 3: OUTPUTS ─── -->
-  <rect x="30" y="284" width="820" height="108" rx="12" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="440" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.1em">OUTPUTS</text>
+  <rect x="20" y="410" width="920" height="84" rx="12" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="480" y="430" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT</text>
 
-  <rect x="46" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="101" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">JSON / SARIF</text>
+  <rect x="34" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="82" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">CLI</text>
 
-  <rect x="168" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="223" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">CycloneDX</text>
+  <rect x="140" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="188" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API</text>
 
-  <rect x="290" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="345" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Dashboard</text>
+  <rect x="246" y="442" width="114" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="303" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (16 tools)</text>
 
-  <rect x="412" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="467" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">REST API</text>
+  <rect x="370" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="418" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard</text>
 
-  <rect x="534" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="589" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">MCP Server</text>
+  <rect x="476" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="524" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">SARIF / SBOM</text>
 
-  <rect x="656" y="318" width="110" height="44" rx="10" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="711" y="345" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Slack / Jira</text>
+  <rect x="582" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="630" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">GitHub Action</text>
 
-  <!-- ─── FOOTER: COMPLIANCE ─── -->
-  <rect x="30" y="396" width="820" height="2" rx="1" fill="#e2e8f0"/>
-  <text x="440" y="415" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b" letter-spacing="0.05em">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+  <rect x="688" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="736" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">Docker / Helm</text>
+
+  <rect x="794" y="442" width="134" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="861" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">Slack · Jira · Webhooks</text>
+
+  <!-- ─── FOOTER ─── -->
+  <rect x="20" y="504" width="920" height="2" rx="1" fill="#e2e8f0"/>
+  <text x="480" y="524" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  427+ server registry  |  7 vuln sources  |  10 compliance frameworks  |  16 MCP tools  |  2,868 tests</text>
+  <text x="480" y="546" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  OpenSSF scored  |  Apache 2.0</text>
+  <text x="480" y="568" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#059669">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -1,117 +1,166 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 400" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 480" fill="none">
   <!-- Background -->
-  <rect width="880" height="400" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+  <rect width="960" height="480" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="440" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Enterprise Scan Workflow</text>
-  <text x="440" y="48" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Enterprise Scan Workflow</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">How agent-bom discovers, scans, analyzes, and reports across your entire AI infrastructure</text>
 
   <!-- ─── COLUMN 1: INPUTS ─── -->
-  <rect x="20" y="64" width="190" height="300" rx="12" fill="#161b22" stroke="#3b82f6" stroke-width="1.5" opacity="0.95"/>
-  <text x="115" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.08em">INPUT SOURCES</text>
+  <rect x="20" y="60" width="200" height="372" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.5"/>
+  <text x="120" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.08em">INPUT SOURCES</text>
 
-  <rect x="34" y="98" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="115" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">MCP Configs (18)</text>
+  <rect x="34" y="94" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">MCP Configs (18 clients)</text>
+  <text x="120" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Claude · Cursor · Codex · Zed + 14</text>
 
-  <rect x="34" y="140" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="115" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Docker Images</text>
+  <rect x="34" y="140" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Docker + K8s</text>
+  <text x="120" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Images · Pods · All namespaces</text>
 
-  <rect x="34" y="182" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="115" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Kubernetes</text>
+  <rect x="34" y="186" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">8 Cloud Providers</text>
+  <text x="120" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">AWS · Azure · GCP · Snowflake + 4</text>
 
-  <rect x="34" y="224" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="115" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Cloud APIs</text>
+  <rect x="34" y="232" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">AI Platforms</text>
+  <text x="120" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">HuggingFace · MLflow · W&amp;B · Ollama</text>
 
-  <rect x="34" y="266" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="115" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">SBOMs / IaC</text>
+  <rect x="34" y="278" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">SBOMs / IaC / SAST</text>
+  <text x="120" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CycloneDX · SPDX · Terraform</text>
 
-  <rect x="34" y="308" width="162" height="34" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="115" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">AI Frameworks</text>
+  <rect x="34" y="324" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">7 Package Ecosystems</text>
+  <text x="120" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">npm · pip · Go · Cargo · Maven + 2</text>
+
+  <rect x="34" y="370" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Code &amp; Models</text>
+  <text x="120" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">SAST · Notebooks · 13 model formats</text>
+
+  <text x="120" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">427+ MCP server registry</text>
 
   <!-- Arrow 1→2 -->
-  <path d="M210 214 L234 214" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M229 209 L238 214 L229 219" fill="#60a5fa"/>
+  <path d="M220 246 L244 246" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M239 241 L248 246 L239 251" fill="#60a5fa"/>
 
   <!-- ─── COLUMN 2: PIPELINE ─── -->
-  <rect x="240" y="64" width="190" height="300" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.5" opacity="0.95"/>
-  <text x="335" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.08em">SCANNER PIPELINE</text>
+  <rect x="250" y="60" width="190" height="372" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.5"/>
+  <text x="345" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.08em">SCANNER PIPELINE</text>
 
-  <rect x="254" y="100" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Discover + Extract</text>
+  <rect x="264" y="96" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Discover + Extract</text>
+  <text x="345" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">11 ecosystems · container layers</text>
 
-  <path d="M335 138 L335 148" stroke="#f59e0b" stroke-width="1.5"/>
-  <path d="M330 144 L335 152 L340 144" fill="#f59e0b"/>
+  <path d="M345 140 L345 150" stroke="#f59e0b" stroke-width="1.5"/>
+  <path d="M340 146 L345 154 L350 146" fill="#f59e0b"/>
 
-  <rect x="254" y="156" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">CVE Scan</text>
+  <rect x="264" y="158" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">CVE Scan</text>
+  <text x="345" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">7 sources: OSV · NVD · GHSA · Grype</text>
 
-  <path d="M335 194 L335 204" stroke="#f59e0b" stroke-width="1.5"/>
-  <path d="M330 200 L335 208 L340 200" fill="#f59e0b"/>
+  <path d="M345 202 L345 212" stroke="#f59e0b" stroke-width="1.5"/>
+  <path d="M340 208 L345 216 L350 208" fill="#f59e0b"/>
 
-  <rect x="254" y="212" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="236" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Enrich</text>
+  <rect x="264" y="220" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="238" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Enrich</text>
+  <text x="345" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">NVD CVSS · EPSS · KEV · OpenSSF</text>
 
-  <path d="M335 250 L335 260" stroke="#f59e0b" stroke-width="1.5"/>
-  <path d="M330 256 L335 264 L340 256" fill="#f59e0b"/>
+  <path d="M345 264 L345 274" stroke="#f59e0b" stroke-width="1.5"/>
+  <path d="M340 270 L345 278 L350 270" fill="#f59e0b"/>
 
-  <rect x="254" y="268" width="162" height="38" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="292" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Analyze + Tag</text>
+  <rect x="264" y="282" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="300" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Analyze + Tag</text>
+  <text x="345" y="316" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Blast radius · 10 frameworks · OCSF</text>
 
-  <rect x="254" y="316" width="162" height="34" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
-  <text x="335" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">read-only | local execution</text>
+  <path d="M345 326 L345 336" stroke="#f59e0b" stroke-width="1.5"/>
+  <path d="M340 332 L345 340 L350 332" fill="#f59e0b"/>
+
+  <rect x="264" y="344" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="362" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Score + Prioritize</text>
+  <text x="345" y="378" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Posture A-F · P1-P4 incidents</text>
+
+  <rect x="264" y="396" width="162" height="28" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
+  <text x="345" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">read-only | local execution</text>
 
   <!-- Arrow 2→3 -->
-  <path d="M430 214 L454 214" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M449 209 L458 214 L449 219" fill="#fbbf24"/>
+  <path d="M440 246 L464 246" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M459 241 L468 246 L459 251" fill="#fbbf24"/>
 
   <!-- ─── COLUMN 3: ANALYSIS ─── -->
-  <rect x="460" y="64" width="190" height="300" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.5" opacity="0.95"/>
-  <text x="555" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">ANALYSIS</text>
+  <rect x="470" y="60" width="200" height="372" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="570" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">ANALYSIS ENGINE</text>
 
-  <rect x="474" y="98" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="555" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Blast Radius Engine</text>
+  <rect x="484" y="94" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="570" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Blast Radius Engine</text>
+  <text x="570" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">CVE → pkg → server → agent → creds</text>
 
-  <rect x="474" y="140" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="555" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">10-Framework Tagging</text>
+  <rect x="484" y="140" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="570" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Context Graph</text>
+  <text x="570" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Lateral movement · BFS attack paths</text>
 
-  <rect x="474" y="182" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="555" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Posture Scorecard</text>
+  <rect x="484" y="186" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="570" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">10-Framework Tagging</text>
+  <text x="570" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">OWASP · ATLAS · NIST · EU AI Act</text>
 
-  <rect x="474" y="224" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="555" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Incident Correlation</text>
+  <rect x="484" y="232" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="570" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Posture Scorecard</text>
+  <text x="570" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Grade A-F · 6 weighted dimensions</text>
 
-  <rect x="474" y="266" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="555" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Context Graph</text>
+  <rect x="484" y="278" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="570" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Incident Correlation</text>
+  <text x="570" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">P1-P4 priority · SOC-ready OCSF</text>
 
-  <rect x="474" y="308" width="162" height="34" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="555" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Policy Evaluation</text>
+  <rect x="484" y="324" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="570" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Credential Ranking</text>
+  <text x="570" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Risk tiers · cross-agent aggregation</text>
+
+  <rect x="484" y="370" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="570" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Toxic Combinations</text>
+  <text x="570" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">KEV+creds · RCE+exec · malicious</text>
+
+  <text x="570" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#a78bfa">Policy-as-code engine</text>
 
   <!-- Arrow 3→4 -->
-  <path d="M650 214 L674 214" stroke="#a78bfa" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M669 209 L678 214 L669 219" fill="#a78bfa"/>
+  <path d="M670 246 L694 246" stroke="#a78bfa" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M689 241 L698 246 L689 251" fill="#a78bfa"/>
 
   <!-- ─── COLUMN 4: OUTPUTS ─── -->
-  <rect x="680" y="64" width="182" height="300" rx="12" fill="#161b22" stroke="#10b981" stroke-width="1.5" opacity="0.95"/>
-  <text x="771" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.08em">OUTPUTS</text>
+  <rect x="700" y="60" width="242" height="372" rx="12" fill="#161b22" stroke="#059669" stroke-width="1.5"/>
+  <text x="821" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.08em">DEPLOYMENT &amp; OUTPUT</text>
 
-  <rect x="694" y="98" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="771" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Console + HTML</text>
+  <rect x="714" y="94" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="767" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">CLI + HTML</text>
 
-  <rect x="694" y="140" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="771" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">SARIF + SBOM</text>
+  <rect x="828" y="94" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="881" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">REST API + SSE</text>
 
-  <rect x="694" y="182" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="771" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">REST API + SSE</text>
+  <rect x="714" y="136" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="767" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">SARIF + SBOM</text>
 
-  <rect x="694" y="224" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="771" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Dashboard (15 pages)</text>
+  <rect x="828" y="136" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="881" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Dashboard (15p)</text>
 
-  <rect x="694" y="266" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="771" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">MCP Server (16 tools)</text>
+  <rect x="714" y="178" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="824" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">MCP Server (16 tools)</text>
 
-  <rect x="694" y="308" width="154" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="771" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Slack / Jira / Webhooks</text>
+  <rect x="714" y="220" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="824" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">GitHub Action (CI/CD)</text>
+
+  <rect x="714" y="262" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="824" y="284" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Docker + Helm Chart</text>
+
+  <rect x="714" y="304" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="824" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Slack / Jira / Webhooks</text>
+
+  <!-- Runtime protection sub-section -->
+  <rect x="714" y="350" width="220" height="74" rx="8" fill="#1a1028" stroke="#7c3aed" stroke-width="1"/>
+  <text x="824" y="370" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa">Runtime Protection</text>
+  <text x="824" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">MCP Proxy · 5 Detectors</text>
+  <text x="824" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Fleet Management · Prometheus</text>
+  <text x="824" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Alert pipeline (webhook · file · callback)</text>
 
   <!-- ─── FOOTER ─── -->
-  <text x="440" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only | Agentless | Never stores credentials | Only package names sent to APIs | Sigstore signed</text>
+  <text x="480" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  7 vuln sources  |  10 frameworks  |  16 MCP tools  |  2,868 tests</text>
+  <text x="480" y="472" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -1,117 +1,166 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 400" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 480" fill="none">
   <!-- Background -->
-  <rect width="880" height="400" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect width="960" height="480" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="440" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Enterprise Scan Workflow</text>
-  <text x="440" y="48" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">How agent-bom discovers, scans, analyzes, and reports across your AI infrastructure</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Enterprise Scan Workflow</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">How agent-bom discovers, scans, analyzes, and reports across your entire AI infrastructure</text>
 
   <!-- ─── COLUMN 1: INPUTS ─── -->
-  <rect x="20" y="64" width="190" height="300" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="115" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#3b82f6" letter-spacing="0.08em">INPUT SOURCES</text>
+  <rect x="20" y="60" width="200" height="372" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="120" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#3b82f6" letter-spacing="0.08em">INPUT SOURCES</text>
 
-  <rect x="34" y="98" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="115" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Configs (18)</text>
+  <rect x="34" y="94" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="120" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Configs (18 clients)</text>
+  <text x="120" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Claude · Cursor · Codex · Zed + 14</text>
 
-  <rect x="34" y="140" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="115" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Docker Images</text>
+  <rect x="34" y="140" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="120" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Docker + K8s</text>
+  <text x="120" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Images · Pods · All namespaces</text>
 
-  <rect x="34" y="182" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="115" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Kubernetes</text>
+  <rect x="34" y="186" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="120" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">8 Cloud Providers</text>
+  <text x="120" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">AWS · Azure · GCP · Snowflake + 4</text>
 
-  <rect x="34" y="224" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="115" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Cloud APIs</text>
+  <rect x="34" y="232" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="120" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">AI Platforms</text>
+  <text x="120" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">HuggingFace · MLflow · W&amp;B · Ollama</text>
 
-  <rect x="34" y="266" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="115" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">SBOMs / IaC</text>
+  <rect x="34" y="278" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="120" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">SBOMs / IaC / SAST</text>
+  <text x="120" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CycloneDX · SPDX · Terraform</text>
 
-  <rect x="34" y="308" width="162" height="34" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="115" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">AI Frameworks</text>
+  <rect x="34" y="324" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="120" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">7 Package Ecosystems</text>
+  <text x="120" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">npm · pip · Go · Cargo · Maven + 2</text>
+
+  <rect x="34" y="370" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="120" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Code &amp; Models</text>
+  <text x="120" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">SAST · Notebooks · 13 model formats</text>
+
+  <text x="120" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">427+ MCP server registry</text>
 
   <!-- Arrow 1→2 -->
-  <path d="M210 214 L234 214" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M229 209 L238 214 L229 219" fill="#3b82f6"/>
+  <path d="M220 246 L244 246" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M239 241 L248 246 L239 251" fill="#3b82f6"/>
 
   <!-- ─── COLUMN 2: PIPELINE ─── -->
-  <rect x="240" y="64" width="190" height="300" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="335" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.08em">SCANNER PIPELINE</text>
+  <rect x="250" y="60" width="190" height="372" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="345" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.08em">SCANNER PIPELINE</text>
 
-  <rect x="254" y="100" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Discover + Extract</text>
+  <rect x="264" y="96" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Discover + Extract</text>
+  <text x="345" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">11 ecosystems · container layers</text>
 
-  <path d="M335 138 L335 148" stroke="#d97706" stroke-width="1.5"/>
-  <path d="M330 144 L335 152 L340 144" fill="#d97706"/>
+  <path d="M345 140 L345 150" stroke="#d97706" stroke-width="1.5"/>
+  <path d="M340 146 L345 154 L350 146" fill="#d97706"/>
 
-  <rect x="254" y="156" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">CVE Scan</text>
+  <rect x="264" y="158" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">CVE Scan</text>
+  <text x="345" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">7 sources: OSV · NVD · GHSA · Grype</text>
 
-  <path d="M335 194 L335 204" stroke="#d97706" stroke-width="1.5"/>
-  <path d="M330 200 L335 208 L340 200" fill="#d97706"/>
+  <path d="M345 202 L345 212" stroke="#d97706" stroke-width="1.5"/>
+  <path d="M340 208 L345 216 L350 208" fill="#d97706"/>
 
-  <rect x="254" y="212" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="236" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Enrich</text>
+  <rect x="264" y="220" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="238" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Enrich</text>
+  <text x="345" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">NVD CVSS · EPSS · KEV · OpenSSF</text>
 
-  <path d="M335 250 L335 260" stroke="#d97706" stroke-width="1.5"/>
-  <path d="M330 256 L335 264 L340 256" fill="#d97706"/>
+  <path d="M345 264 L345 274" stroke="#d97706" stroke-width="1.5"/>
+  <path d="M340 270 L345 278 L350 270" fill="#d97706"/>
 
-  <rect x="254" y="268" width="162" height="38" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="335" y="292" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Analyze + Tag</text>
+  <rect x="264" y="282" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="300" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Analyze + Tag</text>
+  <text x="345" y="316" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Blast radius · 10 frameworks · OCSF</text>
 
-  <rect x="254" y="316" width="162" height="34" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
-  <text x="335" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#92400e">read-only | local execution</text>
+  <path d="M345 326 L345 336" stroke="#d97706" stroke-width="1.5"/>
+  <path d="M340 332 L345 340 L350 332" fill="#d97706"/>
+
+  <rect x="264" y="344" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="345" y="362" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Score + Prioritize</text>
+  <text x="345" y="378" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Posture A-F · P1-P4 incidents</text>
+
+  <rect x="264" y="396" width="162" height="28" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
+  <text x="345" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#92400e">read-only | local execution</text>
 
   <!-- Arrow 2→3 -->
-  <path d="M430 214 L454 214" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M449 209 L458 214 L449 219" fill="#d97706"/>
+  <path d="M440 246 L464 246" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M459 241 L468 246 L459 251" fill="#d97706"/>
 
   <!-- ─── COLUMN 3: ANALYSIS ─── -->
-  <rect x="460" y="64" width="190" height="300" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="1.5"/>
-  <text x="555" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">ANALYSIS</text>
+  <rect x="470" y="60" width="200" height="372" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="570" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">ANALYSIS ENGINE</text>
 
-  <rect x="474" y="98" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="555" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Blast Radius Engine</text>
+  <rect x="484" y="94" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="570" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Blast Radius Engine</text>
+  <text x="570" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">CVE → pkg → server → agent → creds</text>
 
-  <rect x="474" y="140" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="555" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">10-Framework Tagging</text>
+  <rect x="484" y="140" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="570" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Context Graph</text>
+  <text x="570" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Lateral movement · BFS attack paths</text>
 
-  <rect x="474" y="182" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="555" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Posture Scorecard</text>
+  <rect x="484" y="186" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="570" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">10-Framework Tagging</text>
+  <text x="570" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">OWASP · ATLAS · NIST · EU AI Act</text>
 
-  <rect x="474" y="224" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="555" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Incident Correlation</text>
+  <rect x="484" y="232" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="570" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Posture Scorecard</text>
+  <text x="570" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Grade A-F · 6 weighted dimensions</text>
 
-  <rect x="474" y="266" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="555" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Context Graph</text>
+  <rect x="484" y="278" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="570" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Incident Correlation</text>
+  <text x="570" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">P1-P4 priority · SOC-ready OCSF</text>
 
-  <rect x="474" y="308" width="162" height="34" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="555" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Policy Evaluation</text>
+  <rect x="484" y="324" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="570" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Credential Ranking</text>
+  <text x="570" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Risk tiers · cross-agent aggregation</text>
+
+  <rect x="484" y="370" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="570" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Toxic Combinations</text>
+  <text x="570" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">KEV+creds · RCE+exec · malicious</text>
+
+  <text x="570" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#7c3aed">Policy-as-code engine</text>
 
   <!-- Arrow 3→4 -->
-  <path d="M650 214 L674 214" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M669 209 L678 214 L669 219" fill="#7c3aed"/>
+  <path d="M670 246 L694 246" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M689 241 L698 246 L689 251" fill="#7c3aed"/>
 
   <!-- ─── COLUMN 4: OUTPUTS ─── -->
-  <rect x="680" y="64" width="182" height="300" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/>
-  <text x="771" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.08em">OUTPUTS</text>
+  <rect x="700" y="60" width="242" height="372" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/>
+  <text x="821" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.08em">DEPLOYMENT &amp; OUTPUT</text>
 
-  <rect x="694" y="98" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="771" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Console + HTML</text>
+  <rect x="714" y="94" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="767" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">CLI + HTML</text>
 
-  <rect x="694" y="140" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="771" y="162" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">SARIF + SBOM</text>
+  <rect x="828" y="94" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="881" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">REST API + SSE</text>
 
-  <rect x="694" y="182" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="771" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">REST API + SSE</text>
+  <rect x="714" y="136" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="767" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">SARIF + SBOM</text>
 
-  <rect x="694" y="224" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="771" y="246" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Dashboard (15 pages)</text>
+  <rect x="828" y="136" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="881" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Dashboard (15p)</text>
 
-  <rect x="694" y="266" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="771" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">MCP Server (16 tools)</text>
+  <rect x="714" y="178" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="824" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">MCP Server (16 tools)</text>
 
-  <rect x="694" y="308" width="154" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="771" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Slack / Jira / Webhooks</text>
+  <rect x="714" y="220" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="824" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">GitHub Action (CI/CD)</text>
+
+  <rect x="714" y="262" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="824" y="284" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Docker + Helm Chart</text>
+
+  <rect x="714" y="304" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="824" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Slack / Jira / Webhooks</text>
+
+  <!-- Runtime protection sub-section -->
+  <rect x="714" y="350" width="220" height="74" rx="8" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="824" y="370" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed">Runtime Protection</text>
+  <text x="824" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">MCP Proxy · 5 Detectors</text>
+  <text x="824" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Fleet Management · Prometheus</text>
+  <text x="824" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Alert pipeline (webhook · file · callback)</text>
 
   <!-- ─── FOOTER ─── -->
-  <text x="440" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only | Agentless | Never stores credentials | Only package names sent to APIs | Sigstore signed</text>
+  <text x="480" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  7 vuln sources  |  10 frameworks  |  16 MCP tools  |  2,868 tests</text>
+  <text x="480" y="472" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -1,98 +1,142 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 280" fill="none">
-  <!-- Background -->
-  <rect width="880" height="280" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 380" fill="none">
+  <rect width="960" height="380" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="440" y="30" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scanner Pipeline</text>
-  <text x="440" y="50" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">7-stage pipeline from discovery to actionable output</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scanner Pipeline</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">7-stage pipeline from multi-source discovery to actionable security intelligence</text>
 
   <!-- ─── STAGE 1: DISCOVER ─── -->
-  <rect x="18" y="70" width="104" height="120" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="18" y="70" width="104" height="30" rx="12" fill="#2563eb"/>
-  <rect x="18" y="88" width="104" height="12" fill="#2563eb"/>
-  <text x="70" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
-  <text x="70" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">18</text>
-  <text x="70" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">MCP clients</text>
-  <text x="70" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ Docker + K8s + Cloud</text>
+  <rect x="18" y="62" width="120" height="170" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="18" y="62" width="120" height="30" rx="12" fill="#2563eb"/>
+  <rect x="18" y="80" width="120" height="12" fill="#2563eb"/>
+  <text x="78" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
+  <text x="78" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#60a5fa">18</text>
+  <text x="78" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">MCP clients</text>
+  <text x="78" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ Docker images</text>
+  <text x="78" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ Kubernetes pods</text>
+  <text x="78" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ 8 cloud providers</text>
+  <text x="78" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ AI platforms</text>
+  <text x="78" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ SBOMs + IaC</text>
+  <text x="78" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">427+ MCP registry</text>
 
-  <path d="M122 130 L136 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M132 125 L140 130 L132 135" fill="#4b5563"/>
+  <!-- Arrow -->
+  <path d="M138 147 L152 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M148 142 L156 147 L148 152" fill="#4b5563"/>
 
   <!-- ─── STAGE 2: EXTRACT ─── -->
-  <rect x="142" y="70" width="104" height="120" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="142" y="70" width="104" height="30" rx="12" fill="#2563eb"/>
-  <rect x="142" y="88" width="104" height="12" fill="#2563eb"/>
-  <text x="194" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
-  <text x="194" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">11</text>
-  <text x="194" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">ecosystems</text>
-  <text x="194" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">packages + versions</text>
+  <rect x="158" y="62" width="120" height="170" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="158" y="62" width="120" height="30" rx="12" fill="#2563eb"/>
+  <rect x="158" y="80" width="120" height="12" fill="#2563eb"/>
+  <text x="218" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
+  <text x="218" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#60a5fa">11</text>
+  <text x="218" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">ecosystems</text>
+  <text x="218" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">npm · pip · Go · Cargo</text>
+  <text x="218" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Maven · NuGet · Ruby</text>
+  <text x="218" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Container layers</text>
+  <text x="218" y="188" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Model files (13 fmts)</text>
+  <text x="218" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">SAST via Semgrep</text>
+  <text x="218" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">CycloneDX + SPDX</text>
 
-  <path d="M246 130 L260 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M256 125 L264 130 L256 135" fill="#4b5563"/>
+  <!-- Arrow -->
+  <path d="M278 147 L292 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M288 142 L296 147 L288 152" fill="#4b5563"/>
 
   <!-- ─── STAGE 3: SCAN ─── -->
-  <rect x="266" y="70" width="104" height="120" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="266" y="70" width="104" height="30" rx="12" fill="#d97706"/>
-  <rect x="266" y="88" width="104" height="12" fill="#d97706"/>
-  <text x="318" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
-  <text x="318" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#fbbf24">8</text>
-  <text x="318" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fcd34d">vuln sources</text>
-  <text x="318" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OSV + Grype + GHSA</text>
+  <rect x="298" y="62" width="120" height="170" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="298" y="62" width="120" height="30" rx="12" fill="#d97706"/>
+  <rect x="298" y="80" width="120" height="12" fill="#d97706"/>
+  <text x="358" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
+  <text x="358" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#fbbf24">7</text>
+  <text x="358" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#fcd34d">vuln sources</text>
+  <text x="358" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OSV.dev batch API</text>
+  <text x="358" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Grype DB + GHSA</text>
+  <text x="358" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVD / NIST CVEs</text>
+  <text x="358" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVIDIA GPU CVEs</text>
+  <text x="358" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CISA KEV catalog</text>
+  <text x="358" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#fbbf24">Malicious + typosquat</text>
 
-  <path d="M370 130 L384 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M380 125 L388 130 L380 135" fill="#4b5563"/>
+  <!-- Arrow -->
+  <path d="M418 147 L432 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M428 142 L436 147 L428 152" fill="#4b5563"/>
 
   <!-- ─── STAGE 4: ENRICH ─── -->
-  <rect x="390" y="70" width="104" height="120" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="390" y="70" width="104" height="30" rx="12" fill="#d97706"/>
-  <rect x="390" y="88" width="104" height="12" fill="#d97706"/>
-  <text x="442" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
-  <text x="442" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#fbbf24">5</text>
-  <text x="442" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fcd34d">enrichment APIs</text>
-  <text x="442" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVD + EPSS + KEV</text>
+  <rect x="438" y="62" width="120" height="170" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="438" y="62" width="120" height="30" rx="12" fill="#d97706"/>
+  <rect x="438" y="80" width="120" height="12" fill="#d97706"/>
+  <text x="498" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
+  <text x="498" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#fbbf24">5</text>
+  <text x="498" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#fcd34d">enrichment APIs</text>
+  <text x="498" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVD CVSS v3.1/v4</text>
+  <text x="498" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">FIRST EPSS scores</text>
+  <text x="498" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CISA KEV status</text>
+  <text x="498" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OpenSSF Scorecard</text>
+  <text x="498" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">AI risk classification</text>
+  <text x="498" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#fbbf24">False positive reduction</text>
 
-  <path d="M494 130 L508 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M504 125 L512 130 L504 135" fill="#4b5563"/>
+  <!-- Arrow -->
+  <path d="M558 147 L572 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M568 142 L576 147 L568 152" fill="#4b5563"/>
 
   <!-- ─── STAGE 5: ANALYZE ─── -->
-  <rect x="514" y="70" width="104" height="120" rx="12" fill="#2d1215" stroke="#f87171" stroke-width="2"/>
-  <rect x="514" y="70" width="104" height="30" rx="12" fill="#dc2626"/>
-  <rect x="514" y="88" width="104" height="12" fill="#dc2626"/>
-  <text x="566" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
-  <text x="566" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#fca5a5">Blast radius</text>
-  <text x="566" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#fca5a5">mapping</text>
-  <text x="566" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CVE → agent → creds</text>
+  <rect x="578" y="62" width="120" height="170" rx="12" fill="#2d1215" stroke="#f87171" stroke-width="2"/>
+  <rect x="578" y="62" width="120" height="30" rx="12" fill="#dc2626"/>
+  <rect x="578" y="80" width="120" height="12" fill="#dc2626"/>
+  <text x="638" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
+  <text x="638" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fca5a5">Blast Radius</text>
+  <text x="638" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CVE → pkg → server</text>
+  <text x="638" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">→ agent → credentials</text>
+  <text x="638" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fca5a5">Context Graph</text>
+  <text x="638" y="174" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Lateral movement</text>
+  <text x="638" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">BFS attack paths</text>
+  <text x="638" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Toxic combinations</text>
+  <text x="638" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#f87171">Posture scorecard A-F</text>
 
-  <path d="M618 130 L632 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M628 125 L636 130 L628 135" fill="#4b5563"/>
+  <!-- Arrow -->
+  <path d="M698 147 L712 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M708 142 L716 147 L708 152" fill="#4b5563"/>
 
   <!-- ─── STAGE 6: COMPLY ─── -->
-  <rect x="638" y="70" width="104" height="120" rx="12" fill="#1a1028" stroke="#a78bfa" stroke-width="2"/>
-  <rect x="638" y="70" width="104" height="30" rx="12" fill="#7c3aed"/>
-  <rect x="638" y="88" width="104" height="12" fill="#7c3aed"/>
-  <text x="690" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
-  <text x="690" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#a78bfa">10</text>
-  <text x="690" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#c4b5fd">frameworks</text>
-  <text x="690" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP + ATLAS + NIST</text>
+  <rect x="718" y="62" width="120" height="170" rx="12" fill="#1a1028" stroke="#a78bfa" stroke-width="2"/>
+  <rect x="718" y="62" width="120" height="30" rx="12" fill="#7c3aed"/>
+  <rect x="718" y="80" width="120" height="12" fill="#7c3aed"/>
+  <text x="778" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
+  <text x="778" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#a78bfa">10</text>
+  <text x="778" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#c4b5fd">frameworks</text>
+  <text x="778" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP LLM Top 10</text>
+  <text x="778" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP MCP Top 10</text>
+  <text x="778" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP Agentic</text>
+  <text x="778" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">MITRE ATLAS + NIST</text>
+  <text x="778" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">EU AI Act + ISO 27001</text>
+  <text x="778" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">SOC 2 + CIS v8</text>
+  <text x="778" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Policy-as-code engine</text>
 
-  <path d="M742 130 L756 130" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M752 125 L760 130 L752 135" fill="#4b5563"/>
+  <!-- Arrow -->
+  <path d="M838 147 L852 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M848 142 L856 147 L848 152" fill="#4b5563"/>
 
   <!-- ─── STAGE 7: OUTPUT ─── -->
-  <rect x="762" y="70" width="104" height="120" rx="12" fill="#0a2118" stroke="#34d399" stroke-width="2"/>
-  <rect x="762" y="70" width="104" height="30" rx="12" fill="#059669"/>
-  <rect x="762" y="88" width="104" height="12" fill="#059669"/>
-  <text x="814" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
-  <text x="814" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Reports + APIs</text>
-  <text x="814" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">+ MCP Server</text>
-  <text x="814" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">13 output formats</text>
+  <rect x="858" y="62" width="88" height="170" rx="12" fill="#0a2118" stroke="#34d399" stroke-width="2"/>
+  <rect x="858" y="62" width="88" height="30" rx="12" fill="#059669"/>
+  <rect x="858" y="80" width="88" height="12" fill="#059669"/>
+  <text x="902" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
+  <text x="902" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">CLI + HTML</text>
+  <text x="902" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">REST API</text>
+  <text x="902" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">MCP Server</text>
+  <text x="902" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Dashboard</text>
+  <text x="902" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">SARIF + SBOM</text>
+  <text x="902" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">GitHub Action</text>
+  <text x="902" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Docker/Helm</text>
 
   <!-- ─── EXTERNAL APIs BAR ─── -->
-  <rect x="18" y="210" width="848" height="50" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="440" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.08em">EXTERNAL APIs</text>
+  <rect x="18" y="250" width="928" height="50" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="480" y="270" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.08em">EXTERNAL APIs</text>
+  <text x="480" y="290" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  NVIDIA  |  MCP Registry  |  OpenSSF Scorecard</text>
 
-  <text x="440" y="250" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  MCP Registry  |  OpenSSF Scorecard</text>
+  <!-- ─── RUNTIME BAR ─── -->
+  <rect x="18" y="310" width="928" height="40" rx="10" fill="#1a1028" stroke="#7c3aed" stroke-width="1"/>
+  <text x="480" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">RUNTIME PROTECTION</text>
+  <text x="480" y="344" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a78bfa">MCP Proxy  |  5 Detectors (drift · creds · rate · sequence · args)  |  Fleet Management  |  Alert Pipeline  |  Prometheus Metrics</text>
 
   <!-- Footer -->
-  <text x="440" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only analysis  |  No agents deployed  |  No code execution  |  Runs locally or in CI/CD</text>
+  <text x="480" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -1,104 +1,142 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 280" fill="none">
-  <!-- Background -->
-  <rect width="880" height="280" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 380" fill="none">
+  <rect width="960" height="380" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="440" y="30" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scanner Pipeline</text>
-  <text x="440" y="50" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">7-stage pipeline from discovery to actionable output</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scanner Pipeline</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">7-stage pipeline from multi-source discovery to actionable security intelligence</text>
 
   <!-- ─── STAGE 1: DISCOVER ─── -->
-  <rect x="18" y="70" width="104" height="120" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="18" y="70" width="104" height="30" rx="12" fill="#3b82f6"/>
-  <rect x="18" y="88" width="104" height="12" fill="#3b82f6"/>
-  <text x="70" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
-  <text x="70" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">18</text>
-  <text x="70" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">MCP clients</text>
-  <text x="70" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ Docker + K8s + Cloud</text>
+  <rect x="18" y="62" width="120" height="170" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="18" y="62" width="120" height="30" rx="12" fill="#3b82f6"/>
+  <rect x="18" y="80" width="120" height="12" fill="#3b82f6"/>
+  <text x="78" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
+  <text x="78" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#3b82f6">18</text>
+  <text x="78" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">MCP clients</text>
+  <text x="78" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ Docker images</text>
+  <text x="78" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ Kubernetes pods</text>
+  <text x="78" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ 8 cloud providers</text>
+  <text x="78" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ AI platforms</text>
+  <text x="78" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ SBOMs + IaC</text>
+  <text x="78" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">427+ MCP registry</text>
 
   <!-- Arrow -->
-  <path d="M122 130 L136 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M132 125 L140 130 L132 135" fill="#94a3b8"/>
+  <path d="M138 147 L152 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M148 142 L156 147 L148 152" fill="#94a3b8"/>
 
   <!-- ─── STAGE 2: EXTRACT ─── -->
-  <rect x="142" y="70" width="104" height="120" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="142" y="70" width="104" height="30" rx="12" fill="#3b82f6"/>
-  <rect x="142" y="88" width="104" height="12" fill="#3b82f6"/>
-  <text x="194" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
-  <text x="194" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">11</text>
-  <text x="194" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">ecosystems</text>
-  <text x="194" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">packages + versions</text>
+  <rect x="158" y="62" width="120" height="170" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="158" y="62" width="120" height="30" rx="12" fill="#3b82f6"/>
+  <rect x="158" y="80" width="120" height="12" fill="#3b82f6"/>
+  <text x="218" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
+  <text x="218" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#3b82f6">11</text>
+  <text x="218" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">ecosystems</text>
+  <text x="218" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">npm · pip · Go · Cargo</text>
+  <text x="218" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Maven · NuGet · Ruby</text>
+  <text x="218" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Container layers</text>
+  <text x="218" y="188" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Model files (13 fmts)</text>
+  <text x="218" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">SAST via Semgrep</text>
+  <text x="218" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">CycloneDX + SPDX</text>
 
   <!-- Arrow -->
-  <path d="M246 130 L260 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M256 125 L264 130 L256 135" fill="#94a3b8"/>
+  <path d="M278 147 L292 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M288 142 L296 147 L288 152" fill="#94a3b8"/>
 
   <!-- ─── STAGE 3: SCAN ─── -->
-  <rect x="266" y="70" width="104" height="120" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="266" y="70" width="104" height="30" rx="12" fill="#f59e0b"/>
-  <rect x="266" y="88" width="104" height="12" fill="#f59e0b"/>
-  <text x="318" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
-  <text x="318" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#d97706">8</text>
-  <text x="318" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#92400e">vuln sources</text>
-  <text x="318" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OSV + Grype + GHSA</text>
+  <rect x="298" y="62" width="120" height="170" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="298" y="62" width="120" height="30" rx="12" fill="#f59e0b"/>
+  <rect x="298" y="80" width="120" height="12" fill="#f59e0b"/>
+  <text x="358" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
+  <text x="358" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#d97706">7</text>
+  <text x="358" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#92400e">vuln sources</text>
+  <text x="358" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OSV.dev batch API</text>
+  <text x="358" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Grype DB + GHSA</text>
+  <text x="358" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVD / NIST CVEs</text>
+  <text x="358" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVIDIA GPU CVEs</text>
+  <text x="358" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CISA KEV catalog</text>
+  <text x="358" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Malicious + typosquat</text>
 
   <!-- Arrow -->
-  <path d="M370 130 L384 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M380 125 L388 130 L380 135" fill="#94a3b8"/>
+  <path d="M418 147 L432 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M428 142 L436 147 L428 152" fill="#94a3b8"/>
 
   <!-- ─── STAGE 4: ENRICH ─── -->
-  <rect x="390" y="70" width="104" height="120" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="390" y="70" width="104" height="30" rx="12" fill="#f59e0b"/>
-  <rect x="390" y="88" width="104" height="12" fill="#f59e0b"/>
-  <text x="442" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
-  <text x="442" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#d97706">5</text>
-  <text x="442" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#92400e">enrichment APIs</text>
-  <text x="442" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVD + EPSS + KEV</text>
+  <rect x="438" y="62" width="120" height="170" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="438" y="62" width="120" height="30" rx="12" fill="#f59e0b"/>
+  <rect x="438" y="80" width="120" height="12" fill="#f59e0b"/>
+  <text x="498" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
+  <text x="498" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#d97706">5</text>
+  <text x="498" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#92400e">enrichment APIs</text>
+  <text x="498" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVD CVSS v3.1/v4</text>
+  <text x="498" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">FIRST EPSS scores</text>
+  <text x="498" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CISA KEV status</text>
+  <text x="498" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OpenSSF Scorecard</text>
+  <text x="498" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">AI risk classification</text>
+  <text x="498" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">False positive reduction</text>
 
   <!-- Arrow -->
-  <path d="M494 130 L508 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M504 125 L512 130 L504 135" fill="#94a3b8"/>
+  <path d="M558 147 L572 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M568 142 L576 147 L568 152" fill="#94a3b8"/>
 
   <!-- ─── STAGE 5: ANALYZE ─── -->
-  <rect x="514" y="70" width="104" height="120" rx="12" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
-  <rect x="514" y="70" width="104" height="30" rx="12" fill="#ef4444"/>
-  <rect x="514" y="88" width="104" height="12" fill="#ef4444"/>
-  <text x="566" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
-  <text x="566" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#dc2626">Blast radius</text>
-  <text x="566" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#dc2626">mapping</text>
-  <text x="566" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CVE → agent → creds</text>
+  <rect x="578" y="62" width="120" height="170" rx="12" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <rect x="578" y="62" width="120" height="30" rx="12" fill="#ef4444"/>
+  <rect x="578" y="80" width="120" height="12" fill="#ef4444"/>
+  <text x="638" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
+  <text x="638" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#dc2626">Blast Radius</text>
+  <text x="638" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CVE → pkg → server</text>
+  <text x="638" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">→ agent → credentials</text>
+  <text x="638" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#dc2626">Context Graph</text>
+  <text x="638" y="174" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Lateral movement</text>
+  <text x="638" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">BFS attack paths</text>
+  <text x="638" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Toxic combinations</text>
+  <text x="638" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#ef4444">Posture scorecard A-F</text>
 
   <!-- Arrow -->
-  <path d="M618 130 L632 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M628 125 L636 130 L628 135" fill="#94a3b8"/>
+  <path d="M698 147 L712 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M708 142 L716 147 L708 152" fill="#94a3b8"/>
 
   <!-- ─── STAGE 6: COMPLY ─── -->
-  <rect x="638" y="70" width="104" height="120" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
-  <rect x="638" y="70" width="104" height="30" rx="12" fill="#8b5cf6"/>
-  <rect x="638" y="88" width="104" height="12" fill="#8b5cf6"/>
-  <text x="690" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
-  <text x="690" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#7c3aed">10</text>
-  <text x="690" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6d28d9">frameworks</text>
-  <text x="690" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP + ATLAS + NIST</text>
+  <rect x="718" y="62" width="120" height="170" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
+  <rect x="718" y="62" width="120" height="30" rx="12" fill="#8b5cf6"/>
+  <rect x="718" y="80" width="120" height="12" fill="#8b5cf6"/>
+  <text x="778" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
+  <text x="778" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#7c3aed">10</text>
+  <text x="778" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6d28d9">frameworks</text>
+  <text x="778" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP LLM Top 10</text>
+  <text x="778" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP MCP Top 10</text>
+  <text x="778" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP Agentic</text>
+  <text x="778" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">MITRE ATLAS + NIST</text>
+  <text x="778" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">EU AI Act + ISO 27001</text>
+  <text x="778" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">SOC 2 + CIS v8</text>
+  <text x="778" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Policy-as-code engine</text>
 
   <!-- Arrow -->
-  <path d="M742 130 L756 130" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M752 125 L760 130 L752 135" fill="#94a3b8"/>
+  <path d="M838 147 L852 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M848 142 L856 147 L848 152" fill="#94a3b8"/>
 
   <!-- ─── STAGE 7: OUTPUT ─── -->
-  <rect x="762" y="70" width="104" height="120" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
-  <rect x="762" y="70" width="104" height="30" rx="12" fill="#10b981"/>
-  <rect x="762" y="88" width="104" height="12" fill="#10b981"/>
-  <text x="814" y="91" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
-  <text x="814" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#059669">Reports + APIs</text>
-  <text x="814" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#059669">+ MCP Server</text>
-  <text x="814" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">13 output formats</text>
+  <rect x="858" y="62" width="88" height="170" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+  <rect x="858" y="62" width="88" height="30" rx="12" fill="#10b981"/>
+  <rect x="858" y="80" width="88" height="12" fill="#10b981"/>
+  <text x="902" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
+  <text x="902" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">CLI + HTML</text>
+  <text x="902" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">REST API</text>
+  <text x="902" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">MCP Server</text>
+  <text x="902" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">Dashboard</text>
+  <text x="902" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">SARIF + SBOM</text>
+  <text x="902" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">GitHub Action</text>
+  <text x="902" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">Docker/Helm</text>
 
   <!-- ─── EXTERNAL APIs BAR ─── -->
-  <rect x="18" y="210" width="848" height="50" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="440" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#64748b" letter-spacing="0.08em">EXTERNAL APIs</text>
+  <rect x="18" y="250" width="928" height="50" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="480" y="270" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#64748b" letter-spacing="0.08em">EXTERNAL APIs</text>
+  <text x="480" y="290" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#475569">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  NVIDIA  |  MCP Registry  |  OpenSSF Scorecard</text>
 
-  <text x="440" y="250" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#475569">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  MCP Registry  |  OpenSSF Scorecard</text>
+  <!-- ─── RUNTIME BAR ─── -->
+  <rect x="18" y="310" width="928" height="40" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="480" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">RUNTIME PROTECTION</text>
+  <text x="480" y="344" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">MCP Proxy  |  5 Detectors (drift · creds · rate · sequence · args)  |  Fleet Management  |  Alert Pipeline  |  Prometheus Metrics</text>
 
   <!-- Footer -->
-  <text x="440" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only analysis  |  No agents deployed  |  No code execution  |  Runs locally or in CI/CD</text>
+  <text x="480" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
 </svg>


### PR DESCRIPTION
## Summary
- Redesigned all 6 architecture diagrams (enterprise-overview, scanner-architecture, scan-workflow in light+dark) to showcase the complete feature set
- Each diagram now shows: 18 MCP clients, 8 cloud providers, Docker/K8s, AI platforms (HuggingFace/MLflow/W&B/Ollama), 7 package ecosystems, SBOMs/IaC/SAST, 7 vuln sources, blast radius + context graph, 10 compliance frameworks, posture scorecard, incident correlation, credential ranking, toxic combos, runtime protection with MCP proxy and 5 detectors, and all deployment outputs
- Key numbers footer on each diagram for at-a-glance impact

## Test plan
- [ ] Verify SVGs render correctly on GitHub (light + dark mode)
- [ ] Check enterprise-overview shows all 5 input categories with detail
- [ ] Check scanner-architecture shows expanded 7-stage pipeline with runtime bar
- [ ] Check scan-workflow shows full 4-column layout with comprehensive content