### PR TITLE
docs: definitive diagram redesign — full depth + proprietary vs external

### DIFF
--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -1,164 +1,221 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 580" fill="none">
-  <rect width="960" height="580" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 740" fill="none">
+  <rect width="960" height="740" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
-  <!-- ─── ROW 1: DISCOVERY & INPUT SOURCES ─── -->
-  <rect x="20" y="16" width="920" height="164" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.2"/>
-  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.1em">DISCOVERY &amp; INPUT SOURCES</text>
+  <!-- ─── ROW 1: MULTI-SOURCE DISCOVERY ─── -->
+  <rect x="20" y="16" width="920" height="200" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.2"/>
+  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.1em">MULTI-SOURCE DISCOVERY</text>
 
-  <rect x="34" y="48" width="168" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Local Agents</text>
-  <text x="118" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#60a5fa">18</text>
-  <text x="118" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#93c5fd">MCP clients auto-detected</text>
-  <text x="118" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Claude · Cursor · Codex · Gemini</text>
-  <text x="118" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Goose · Windsurf · Zed + 11 more</text>
-  <text x="118" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">+ Docker Compose discovery</text>
+  <rect x="34" y="48" width="168" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">MCP Agents</text>
+  <text x="118" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">18</text>
+  <text x="118" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">clients auto-detected</text>
+  <text x="118" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Claude · Cursor · Codex · Gemini</text>
+  <text x="118" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Goose · Windsurf · Zed · Cline</text>
+  <text x="118" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Snowflake CLI · Roo + 8 more</text>
+  <text x="118" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">427+ server threat registry</text>
+  <text x="118" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">+ MCP Registry + Smithery.ai</text>
+  <text x="118" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Docker Compose discovery</text>
 
-  <rect x="214" y="48" width="146" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="287" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Containers</text>
-  <text x="287" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">Docker Images</text>
-  <text x="287" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Grype / Syft / Docker CLI</text>
-  <text x="287" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Multi-arch · Private registry</text>
-  <text x="287" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">Kubernetes</text>
-  <text x="287" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">All namespaces · Pod images</text>
-  <text x="287" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">EKS · GKE · AKS · CoreWeave</text>
+  <rect x="214" y="48" width="148" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="288" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Infrastructure</text>
+  <text x="288" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">Docker Images</text>
+  <text x="288" y="100" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Grype · Syft · Docker CLI</text>
+  <text x="288" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Multi-arch · Private registry</text>
+  <text x="288" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">Kubernetes</text>
+  <text x="288" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">All namespaces · Pod images</text>
+  <text x="288" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">EKS · GKE · AKS · CoreWeave</text>
+  <text x="288" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">Terraform IaC</text>
+  <text x="288" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Bedrock · SageMaker · Azure AI</text>
+  <text x="288" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Filesystem / disk snapshots</text>
 
-  <rect x="372" y="48" width="194" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="469" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Cloud Providers</text>
-  <text x="469" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#60a5fa">8</text>
-  <text x="469" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#93c5fd">platforms scanned</text>
-  <text x="469" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">AWS Bedrock · Lambda · ECS · EKS</text>
-  <text x="469" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Azure AI · GCP Vertex · Snowflake</text>
-  <text x="469" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Databricks · Nebius GPU Cloud</text>
-  <text x="469" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">Cortex Agents · Snowpark · Bedrock</text>
+  <rect x="374" y="48" width="194" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="471" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Cloud &amp; AI Providers</text>
+  <text x="471" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">11</text>
+  <text x="471" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">platform integrations</text>
+  <text x="471" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">AWS Bedrock · Lambda · ECS · EKS</text>
+  <text x="471" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Azure AI · GCP Vertex · Snowflake</text>
+  <text x="471" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Databricks · Nebius GPU Cloud</text>
+  <text x="471" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">HuggingFace · MLflow · W&amp;B</text>
+  <text x="471" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OpenAI Assistants · Ollama</text>
+  <text x="471" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">Governance + Observability</text>
+  <text x="471" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Cortex telemetry · agent health</text>
 
-  <rect x="578" y="48" width="146" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="651" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">AI Platforms</text>
-  <text x="651" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">HuggingFace</text>
-  <text x="651" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Models · Spaces · Inference</text>
-  <text x="651" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">MLflow · W&amp;B · Ollama</text>
-  <text x="651" y="136" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Model provenance + hashes</text>
-  <text x="651" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">13 model file formats</text>
-  <text x="651" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Sigstore signature checks</text>
+  <rect x="580" y="48" width="160" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="660" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">AI/ML Deep Scan</text>
+  <text x="660" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">10 agent frameworks</text>
+  <text x="660" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">LangChain · CrewAI · AutoGen</text>
+  <text x="660" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OpenAI SDK · Google ADK + 5</text>
+  <text x="660" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">12 model file formats</text>
+  <text x="660" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">GGUF · SafeTensors · ONNX</text>
+  <text x="660" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">PyTorch · TF · CoreML + 6</text>
+  <text x="660" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Sigstore + SLSA provenance</text>
+  <text x="660" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Jupyter notebook scanning</text>
+  <text x="660" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">GitHub Actions scanning</text>
 
-  <rect x="736" y="48" width="192" height="120" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="832" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Code &amp; Config</text>
-  <text x="832" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">7 package ecosystems</text>
-  <text x="832" y="102" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">npm · pip · Go · Cargo · Maven</text>
-  <text x="832" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#93c5fd">SBOMs · IaC · SAST</text>
-  <text x="832" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CycloneDX · SPDX · Terraform</text>
-  <text x="832" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">GitHub Actions · Notebooks</text>
-  <text x="832" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Skill files · Prompt templates</text>
+  <rect x="752" y="48" width="176" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="840" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Code &amp; Supply Chain</text>
+  <text x="840" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">7 package ecosystems</text>
+  <text x="840" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">npm · pip · Go · Cargo · Maven</text>
+  <text x="840" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NuGet · Ruby + transitive deps</text>
+  <text x="840" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">SBOMs · SAST · Integrity</text>
+  <text x="840" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">CycloneDX · SPDX ingestion</text>
+  <text x="840" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Semgrep SAST (CWE mapping)</text>
+  <text x="840" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">npm/PyPI SHA integrity</text>
+  <text x="840" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">SLSA + PEP 740 attestations</text>
+  <text x="840" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">deps.dev transitive resolution</text>
 
-  <path d="M480 180 L480 200" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M474 194 L480 204 L486 194" fill="#4b5563"/>
+  <path d="M480 216 L480 236" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M474 230 L480 240 L486 230" fill="#4b5563"/>
 
-  <!-- ─── ROW 2: ANALYSIS ENGINE ─── -->
-  <rect x="20" y="208" width="700" height="172" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.2"/>
-  <text x="370" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.1em">ANALYSIS ENGINE</text>
+  <!-- ─── ROW 2: PROPRIETARY ANALYSIS ENGINE ─── -->
+  <rect x="20" y="244" width="700" height="242" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.2"/>
+  <text x="370" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.1em">PROPRIETARY ANALYSIS ENGINE — 70+ MODULES</text>
 
-  <rect x="34" y="240" width="148" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="108" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">7 Vuln Sources</text>
-  <text x="108" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">OSV · NVD · EPSS · KEV</text>
-  <text x="108" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">GHSA · NVIDIA · Grype</text>
+  <rect x="34" y="276" width="214" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="141" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Vuln Intelligence</text>
+  <text x="141" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">OSV · GHSA · NVIDIA · Snyk · Grype</text>
+  <text x="141" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">NVD CVSS · EPSS · KEV · Scorecard</text>
 
-  <path d="M186 268 L198 268" stroke="#f59e0b" stroke-width="2"/>
-  <path d="M194 264 L201 268 L194 272" fill="#f59e0b"/>
+  <path d="M252 304 L264 304" stroke="#f59e0b" stroke-width="2"/>
+  <path d="M260 300 L267 304 L260 308" fill="#f59e0b"/>
 
-  <rect x="204" y="240" width="148" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="278" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">Blast Radius</text>
-  <text x="278" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">CVE → pkg → server → agent</text>
-  <text x="278" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">→ credentials → tools</text>
+  <rect x="270" y="276" width="200" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="370" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Blast Radius Engine</text>
+  <text x="370" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">CVE → pkg → server → agent → creds → tools</text>
+  <text x="370" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">Configurable weighted risk scoring</text>
 
-  <path d="M356 268 L368 268" stroke="#f59e0b" stroke-width="2"/>
-  <path d="M364 264 L371 268 L364 272" fill="#f59e0b"/>
+  <path d="M474 304 L486 304" stroke="#f59e0b" stroke-width="2"/>
+  <path d="M482 300 L489 304 L482 308" fill="#f59e0b"/>
 
-  <rect x="374" y="240" width="148" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="448" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">10 Frameworks</text>
-  <text x="448" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">OWASP LLM + MCP + Agentic</text>
-  <text x="448" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">ATLAS · NIST · EU AI Act +4</text>
+  <rect x="492" y="276" width="212" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="598" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Context Graph + BFS</text>
+  <text x="598" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">Lateral movement attack paths</text>
+  <text x="598" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">PageRank · Betweenness centrality</text>
 
-  <path d="M526 268 L538 268" stroke="#f59e0b" stroke-width="2"/>
-  <path d="M534 264 L541 268 L534 272" fill="#f59e0b"/>
+  <rect x="34" y="342" width="130" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="99" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">10 Frameworks</text>
+  <text x="99" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">OWASP LLM+MCP+Agentic</text>
+  <text x="99" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">ATLAS · NIST · EU AI +4</text>
 
-  <rect x="544" y="240" width="160" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="624" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#fbbf24">Context Graph</text>
-  <text x="624" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Lateral movement analysis</text>
-  <text x="624" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">BFS attack paths</text>
+  <rect x="172" y="342" width="130" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="237" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Posture Score</text>
+  <text x="237" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Grade A-F · 6 dimensions</text>
+  <text x="237" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Weighted enterprise score</text>
 
-  <rect x="34" y="306" width="148" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="108" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Posture Scorecard</text>
-  <text x="108" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Grade A-F · 6 dimensions</text>
-  <text x="108" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Weighted enterprise scoring</text>
+  <rect x="310" y="342" width="130" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="375" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Incidents</text>
+  <text x="375" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">P1-P4 priority by agent</text>
+  <text x="375" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">SOC-ready OCSF v1.1</text>
 
-  <rect x="204" y="306" width="148" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="278" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Incident Correlation</text>
-  <text x="278" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">P1-P4 priority by agent</text>
-  <text x="278" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">SOC-ready OCSF format</text>
+  <rect x="448" y="342" width="124" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="510" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Toxic Combos</text>
+  <text x="510" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">KEV+creds · RCE+exec</text>
+  <text x="510" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Malicious · Typosquat</text>
 
-  <rect x="374" y="306" width="148" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="448" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Credential Ranking</text>
-  <text x="448" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Risk tiers by blast radius</text>
-  <text x="448" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Cross-agent aggregation</text>
+  <rect x="580" y="342" width="124" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
+  <text x="642" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Cred Ranking</text>
+  <text x="642" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Risk tiers by exposure</text>
+  <text x="642" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Cross-agent aggregation</text>
 
-  <rect x="544" y="306" width="160" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="624" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Toxic Combos</text>
-  <text x="624" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">KEV+creds · RCE+exec</text>
-  <text x="624" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Malicious pkg · Typosquat</text>
+  <rect x="34" y="408" width="164" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
+  <text x="116" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Policy-as-Code Engine</text>
+  <text x="116" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">YAML rules · pass/fail/warn</text>
 
-  <!-- ─── SIDEBAR: RUNTIME ─── -->
-  <rect x="736" y="208" width="204" height="172" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.2"/>
-  <text x="838" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.1em">RUNTIME PROTECTION</text>
+  <rect x="206" y="408" width="120" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
+  <text x="266" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">License Policy</text>
+  <text x="266" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">SPDX · block/warn rules</text>
 
-  <rect x="748" y="240" width="180" height="44" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="838" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#c4b5fd">MCP Proxy</text>
-  <text x="838" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">JSON-RPC intercept · audit log</text>
+  <rect x="334" y="408" width="108" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
+  <text x="388" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">VEX / OpenVEX</text>
+  <text x="388" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Exploit status mgmt</text>
 
-  <rect x="748" y="292" width="180" height="44" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="838" y="310" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#c4b5fd">5 Detectors</text>
-  <text x="838" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Drift · Creds · Rate · Sequence · Args</text>
+  <rect x="450" y="408" width="120" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
+  <text x="510" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Risk Analyzer</text>
+  <text x="510" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">7 tool capabilities · 8 combos</text>
 
-  <rect x="748" y="344" width="86" height="30" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="791" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#c4b5fd">Fleet Mgmt</text>
+  <rect x="578" y="408" width="128" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
+  <text x="642" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">CVSS 3.1 Compute</text>
+  <text x="642" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">AV/AC/PR/UI/S/C/I/A</text>
 
-  <rect x="842" y="344" width="86" height="30" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="885" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#c4b5fd">Alerts</text>
+  <text x="370" y="474" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" font-weight="600" fill="#d97706">+ AI enrichment (Ollama/HuggingFace/litellm) · Baseline comparison · Trend tracking · Multi-source correlation · OTel trace ingest</text>
 
-  <path d="M704 294 L736 294" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <!-- ─── SIDEBAR: RUNTIME PROTECTION ─── -->
+  <rect x="736" y="244" width="204" height="242" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.2"/>
+  <text x="838" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.1em">RUNTIME PROTECTION</text>
 
-  <path d="M370 380 L370 402" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M364 396 L370 406 L376 396" fill="#4b5563"/>
+  <rect x="748" y="278" width="180" height="52" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="838" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#c4b5fd">MCP Stdio Proxy</text>
+  <text x="838" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">JSON-RPC intercept · audit log</text>
+  <text x="838" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Policy enforce · replay detect</text>
 
-  <!-- ─── ROW 3: OUTPUTS ─── -->
-  <rect x="20" y="410" width="920" height="84" rx="12" fill="#0a2118" stroke="#059669" stroke-width="1.2"/>
-  <text x="480" y="430" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT</text>
+  <rect x="748" y="336" width="180" height="40" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="838" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#c4b5fd">4 Inline Scanners</text>
+  <text x="838" y="366" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Injection · PII · Secrets · Payloads</text>
 
-  <rect x="34" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="82" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">CLI</text>
+  <rect x="748" y="382" width="180" height="40" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="838" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#c4b5fd">5 Detectors</text>
+  <text x="838" y="412" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Drift · Creds · Rate · Seq · Args</text>
 
-  <rect x="140" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="188" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">REST API</text>
+  <rect x="748" y="428" width="86" height="28" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="791" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#c4b5fd">Fleet Mgmt</text>
 
-  <rect x="246" y="442" width="114" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="303" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">MCP (16 tools)</text>
+  <rect x="842" y="428" width="86" height="28" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
+  <text x="885" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#c4b5fd">Trust Score</text>
 
-  <rect x="370" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="418" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">Dashboard</text>
+  <rect x="748" y="462" width="180" height="18" rx="4" fill="#1a1028" stroke="#7c3aed" stroke-width="0.5"/>
+  <text x="838" y="475" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Alerts · Dedup · Slack/Webhook/File</text>
 
-  <rect x="476" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="524" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">SARIF / SBOM</text>
+  <path d="M704 360 L736 360" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
 
-  <rect x="582" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="630" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">GitHub Action</text>
+  <path d="M370 486 L370 506" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M364 500 L370 510 L376 500" fill="#4b5563"/>
 
-  <rect x="688" y="442" width="96" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="736" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">Docker / Helm</text>
+  <!-- ─── ROW 3: DEPLOYMENT & OUTPUT ─── -->
+  <rect x="20" y="514" width="920" height="84" rx="12" fill="#0a2118" stroke="#059669" stroke-width="1.2"/>
+  <text x="480" y="534" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT — 13+ FORMATS</text>
 
-  <rect x="794" y="442" width="134" height="38" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1.2"/>
-  <text x="861" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#6ee7b7">Slack · Jira · Webhooks</text>
+  <rect x="30" y="544" width="78" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="69" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">CLI</text>
+
+  <rect x="114" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="157" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">REST API</text>
+  <text x="157" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">25+ endpoints</text>
+
+  <rect x="206" y="544" width="96" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="254" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">MCP Server</text>
+  <text x="254" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">16 tools</text>
+
+  <rect x="308" y="544" width="78" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="347" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Dashboard</text>
+
+  <rect x="392" y="544" width="90" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="437" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">SARIF/SBOM</text>
+
+  <rect x="488" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="531" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">GH Action</text>
+
+  <rect x="580" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="623" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Docker/Helm</text>
+
+  <rect x="672" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="715" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Prometheus</text>
+  <text x="715" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">OTLP · OCSF</text>
+
+  <rect x="764" y="544" width="168" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
+  <text x="848" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Slack · Jira · ServiceNow</text>
+  <text x="848" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">Drata · Vanta · Webhooks</text>
+
+  <!-- ─── ROW 4: INFRASTRUCTURE BAR ─── -->
+  <rect x="20" y="606" width="920" height="36" rx="8" fill="#161b22" stroke="#30363d" stroke-width="0.8"/>
+  <text x="480" y="622" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e" letter-spacing="0.06em">INFRASTRUCTURE</text>
+  <text x="480" y="636" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Storage: SQLite · PostgreSQL · Snowflake  |  Auth: RBAC · scrypt API keys · HMAC audit log  |  Scheduler: cron · backoff  |  Cache: SQLite WAL · 7-day TTL</text>
 
   <!-- ─── FOOTER ─── -->
-  <rect x="20" y="504" width="920" height="2" rx="1" fill="#21262d"/>
-  <text x="480" y="524" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  427+ server registry  |  7 vuln sources  |  10 compliance frameworks  |  16 MCP tools  |  2,868 tests</text>
-  <text x="480" y="546" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  OpenSSF scored  |  Apache 2.0</text>
-  <text x="480" y="568" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#34d399">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+  <rect x="20" y="652" width="920" height="2" rx="1" fill="#21262d"/>
+  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">18 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
+  <text x="480" y="694" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  SLSA provenance  |  OpenSSF scored  |  Apache 2.0</text>
+  <text x="480" y="716" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#34d399">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+
+  <rect x="20" y="728" width="920" height="2" rx="1" fill="#fbbf24" opacity="0.3"/>
+  <text x="480" y="738" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#d97706">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime dependencies beyond stdlib for core analysis</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -1,164 +1,232 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 580" fill="none">
-  <rect width="960" height="580" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 740" fill="none">
+  <rect width="960" height="740" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
-  <!-- ─── ROW 1: DISCOVERY & INPUT SOURCES ─── -->
-  <rect x="20" y="16" width="920" height="164" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.2"/>
-  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#2563eb" letter-spacing="0.1em">DISCOVERY &amp; INPUT SOURCES</text>
+  <!-- ─── ROW 1: MULTI-SOURCE DISCOVERY ─── -->
+  <rect x="20" y="16" width="920" height="200" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.2"/>
+  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#2563eb" letter-spacing="0.1em">MULTI-SOURCE DISCOVERY</text>
 
-  <rect x="34" y="48" width="168" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Local Agents</text>
-  <text x="118" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#3b82f6">18</text>
-  <text x="118" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#1e40af">MCP clients auto-detected</text>
-  <text x="118" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Claude · Cursor · Codex · Gemini</text>
-  <text x="118" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Goose · Windsurf · Zed + 11 more</text>
-  <text x="118" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">+ Docker Compose discovery</text>
+  <!-- Box 1: MCP Agents -->
+  <rect x="34" y="48" width="168" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">MCP Agents</text>
+  <text x="118" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">18</text>
+  <text x="118" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">clients auto-detected</text>
+  <text x="118" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Claude · Cursor · Codex · Gemini</text>
+  <text x="118" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Goose · Windsurf · Zed · Cline</text>
+  <text x="118" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Snowflake CLI · Roo + 8 more</text>
+  <text x="118" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">427+ server threat registry</text>
+  <text x="118" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">+ MCP Registry + Smithery.ai</text>
+  <text x="118" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Docker Compose discovery</text>
 
-  <rect x="214" y="48" width="146" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="287" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Containers</text>
-  <text x="287" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">Docker Images</text>
-  <text x="287" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Grype / Syft / Docker CLI</text>
-  <text x="287" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Multi-arch · Private registry</text>
-  <text x="287" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">Kubernetes</text>
-  <text x="287" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">All namespaces · Pod images</text>
-  <text x="287" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">EKS · GKE · AKS · CoreWeave</text>
+  <!-- Box 2: Infrastructure -->
+  <rect x="214" y="48" width="148" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="288" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Infrastructure</text>
+  <text x="288" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">Docker Images</text>
+  <text x="288" y="100" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Grype · Syft · Docker CLI</text>
+  <text x="288" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Multi-arch · Private registry</text>
+  <text x="288" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">Kubernetes</text>
+  <text x="288" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">All namespaces · Pod images</text>
+  <text x="288" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">EKS · GKE · AKS · CoreWeave</text>
+  <text x="288" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">Terraform IaC</text>
+  <text x="288" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Bedrock · SageMaker · Azure AI</text>
+  <text x="288" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Filesystem / disk snapshots</text>
 
-  <rect x="372" y="48" width="194" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="469" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Cloud Providers</text>
-  <text x="469" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="24" font-weight="800" fill="#3b82f6">8</text>
-  <text x="469" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#1e40af">platforms scanned</text>
-  <text x="469" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">AWS Bedrock · Lambda · ECS · EKS</text>
-  <text x="469" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Azure AI · GCP Vertex · Snowflake</text>
-  <text x="469" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Databricks · Nebius GPU Cloud</text>
-  <text x="469" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">Cortex Agents · Snowpark · Bedrock</text>
+  <!-- Box 3: Cloud & AI Providers -->
+  <rect x="374" y="48" width="194" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="471" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Cloud &amp; AI Providers</text>
+  <text x="471" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">11</text>
+  <text x="471" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">platform integrations</text>
+  <text x="471" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">AWS Bedrock · Lambda · ECS · EKS</text>
+  <text x="471" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Azure AI · GCP Vertex · Snowflake</text>
+  <text x="471" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Databricks · Nebius GPU Cloud</text>
+  <text x="471" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">HuggingFace · MLflow · W&amp;B</text>
+  <text x="471" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OpenAI Assistants · Ollama</text>
+  <text x="471" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">Governance + Observability</text>
+  <text x="471" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Cortex telemetry · agent health</text>
 
-  <rect x="578" y="48" width="146" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="651" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">AI Platforms</text>
-  <text x="651" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">HuggingFace</text>
-  <text x="651" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Models · Spaces · Inference</text>
-  <text x="651" y="120" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">MLflow · W&amp;B · Ollama</text>
-  <text x="651" y="136" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Model provenance + hashes</text>
-  <text x="651" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">13 model file formats</text>
-  <text x="651" y="160" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Sigstore signature checks</text>
+  <!-- Box 4: AI/ML Deep Scan -->
+  <rect x="580" y="48" width="160" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="660" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">AI/ML Deep Scan</text>
+  <text x="660" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">10 agent frameworks</text>
+  <text x="660" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">LangChain · CrewAI · AutoGen</text>
+  <text x="660" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OpenAI SDK · Google ADK + 5</text>
+  <text x="660" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">12 model file formats</text>
+  <text x="660" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">GGUF · SafeTensors · ONNX</text>
+  <text x="660" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">PyTorch · TF · CoreML + 6</text>
+  <text x="660" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Sigstore + SLSA provenance</text>
+  <text x="660" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Jupyter notebook scanning</text>
+  <text x="660" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">GitHub Actions scanning</text>
 
-  <rect x="736" y="48" width="192" height="120" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="832" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Code &amp; Config</text>
-  <text x="832" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">7 package ecosystems</text>
-  <text x="832" y="102" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">npm · pip · Go · Cargo · Maven</text>
-  <text x="832" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1e40af">SBOMs · IaC · SAST</text>
-  <text x="832" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CycloneDX · SPDX · Terraform</text>
-  <text x="832" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">GitHub Actions · Notebooks</text>
-  <text x="832" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Skill files · Prompt templates</text>
+  <!-- Box 5: Code & Supply Chain -->
+  <rect x="752" y="48" width="176" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
+  <text x="840" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Code &amp; Supply Chain</text>
+  <text x="840" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">7 package ecosystems</text>
+  <text x="840" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">npm · pip · Go · Cargo · Maven</text>
+  <text x="840" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NuGet · Ruby + transitive deps</text>
+  <text x="840" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">SBOMs · SAST · Integrity</text>
+  <text x="840" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">CycloneDX · SPDX ingestion</text>
+  <text x="840" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Semgrep SAST (CWE mapping)</text>
+  <text x="840" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">npm/PyPI SHA integrity</text>
+  <text x="840" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">SLSA + PEP 740 attestations</text>
+  <text x="840" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">deps.dev transitive resolution</text>
 
-  <path d="M480 180 L480 200" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M474 194 L480 204 L486 194" fill="#94a3b8"/>
+  <!-- Arrow down -->
+  <path d="M480 216 L480 236" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M474 230 L480 240 L486 230" fill="#94a3b8"/>
 
-  <!-- ─── ROW 2: ANALYSIS ENGINE ─── -->
-  <rect x="20" y="208" width="700" height="172" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="1.2"/>
-  <text x="370" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.1em">ANALYSIS ENGINE</text>
+  <!-- ─── ROW 2: PROPRIETARY ANALYSIS ENGINE ─── -->
+  <rect x="20" y="244" width="700" height="242" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="1.2"/>
+  <text x="370" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.1em">PROPRIETARY ANALYSIS ENGINE — 70+ MODULES</text>
 
-  <rect x="34" y="240" width="148" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="108" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">7 Vuln Sources</text>
-  <text x="108" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">OSV · NVD · EPSS · KEV</text>
-  <text x="108" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">GHSA · NVIDIA · Grype</text>
+  <!-- Row 2a: Vulnerability Intelligence -->
+  <rect x="34" y="276" width="214" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="141" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Vuln Intelligence</text>
+  <text x="141" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">OSV · GHSA · NVIDIA · Snyk · Grype</text>
+  <text x="141" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">NVD CVSS · EPSS · KEV · Scorecard</text>
 
-  <path d="M186 268 L198 268" stroke="#d97706" stroke-width="2"/>
-  <path d="M194 264 L201 268 L194 272" fill="#d97706"/>
+  <path d="M252 304 L264 304" stroke="#d97706" stroke-width="2"/>
+  <path d="M260 300 L267 304 L260 308" fill="#d97706"/>
 
-  <rect x="204" y="240" width="148" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="278" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">Blast Radius</text>
-  <text x="278" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">CVE → pkg → server → agent</text>
-  <text x="278" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">→ credentials → tools</text>
+  <rect x="270" y="276" width="200" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="370" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Blast Radius Engine</text>
+  <text x="370" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">CVE → pkg → server → agent → creds → tools</text>
+  <text x="370" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">Configurable weighted risk scoring</text>
 
-  <path d="M356 268 L368 268" stroke="#d97706" stroke-width="2"/>
-  <path d="M364 264 L371 268 L364 272" fill="#d97706"/>
+  <path d="M474 304 L486 304" stroke="#d97706" stroke-width="2"/>
+  <path d="M482 300 L489 304 L482 308" fill="#d97706"/>
 
-  <rect x="374" y="240" width="148" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="448" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">10 Frameworks</text>
-  <text x="448" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">OWASP LLM + MCP + Agentic</text>
-  <text x="448" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">ATLAS · NIST · EU AI Act +4</text>
+  <rect x="492" y="276" width="212" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="598" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Context Graph + BFS</text>
+  <text x="598" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">Lateral movement attack paths</text>
+  <text x="598" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">PageRank · Betweenness centrality</text>
 
-  <path d="M526 268 L538 268" stroke="#d97706" stroke-width="2"/>
-  <path d="M534 264 L541 268 L534 272" fill="#d97706"/>
+  <!-- Row 2b: More analysis capabilities -->
+  <rect x="34" y="342" width="130" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="99" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">10 Frameworks</text>
+  <text x="99" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">OWASP LLM+MCP+Agentic</text>
+  <text x="99" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">ATLAS · NIST · EU AI +4</text>
 
-  <rect x="544" y="240" width="160" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="624" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#92400e">Context Graph</text>
-  <text x="624" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Lateral movement analysis</text>
-  <text x="624" y="286" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">BFS attack paths</text>
+  <rect x="172" y="342" width="130" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="237" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Posture Score</text>
+  <text x="237" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Grade A-F · 6 dimensions</text>
+  <text x="237" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Weighted enterprise score</text>
 
-  <rect x="34" y="306" width="148" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="108" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Posture Scorecard</text>
-  <text x="108" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Grade A-F · 6 dimensions</text>
-  <text x="108" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Weighted enterprise scoring</text>
+  <rect x="310" y="342" width="130" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="375" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Incidents</text>
+  <text x="375" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">P1-P4 priority by agent</text>
+  <text x="375" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">SOC-ready OCSF v1.1</text>
 
-  <rect x="204" y="306" width="148" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="278" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Incident Correlation</text>
-  <text x="278" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">P1-P4 priority by agent</text>
-  <text x="278" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">SOC-ready OCSF format</text>
+  <rect x="448" y="342" width="124" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="510" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Toxic Combos</text>
+  <text x="510" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">KEV+creds · RCE+exec</text>
+  <text x="510" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Malicious · Typosquat</text>
 
-  <rect x="374" y="306" width="148" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="448" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Credential Ranking</text>
-  <text x="448" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Risk tiers by blast radius</text>
-  <text x="448" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Cross-agent aggregation</text>
+  <rect x="580" y="342" width="124" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
+  <text x="642" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Cred Ranking</text>
+  <text x="642" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Risk tiers by exposure</text>
+  <text x="642" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Cross-agent aggregation</text>
 
-  <rect x="544" y="306" width="160" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="624" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Toxic Combos</text>
-  <text x="624" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">KEV+creds · RCE+exec</text>
-  <text x="624" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Malicious pkg · Typosquat</text>
+  <!-- Row 2c: Policy + VEX + License + Risk Analyzer -->
+  <rect x="34" y="408" width="164" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
+  <text x="116" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Policy-as-Code Engine</text>
+  <text x="116" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">YAML rules · pass/fail/warn</text>
 
-  <!-- ─── SIDEBAR: RUNTIME ─── -->
-  <rect x="736" y="208" width="204" height="172" rx="12" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1.2"/>
-  <text x="838" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.1em">RUNTIME PROTECTION</text>
+  <rect x="206" y="408" width="120" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
+  <text x="266" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">License Policy</text>
+  <text x="266" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">SPDX · block/warn rules</text>
 
-  <rect x="748" y="240" width="180" height="44" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="838" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#6d28d9">MCP Proxy</text>
-  <text x="838" y="274" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">JSON-RPC intercept · audit log</text>
+  <rect x="334" y="408" width="108" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
+  <text x="388" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">VEX / OpenVEX</text>
+  <text x="388" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Exploit status mgmt</text>
 
-  <rect x="748" y="292" width="180" height="44" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="838" y="310" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#6d28d9">5 Detectors</text>
-  <text x="838" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Drift · Creds · Rate · Sequence · Args</text>
+  <rect x="450" y="408" width="120" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
+  <text x="510" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Risk Analyzer</text>
+  <text x="510" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">7 tool capabilities · 8 combos</text>
 
-  <rect x="748" y="344" width="86" height="30" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="791" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6d28d9">Fleet Mgmt</text>
+  <rect x="578" y="408" width="128" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
+  <text x="642" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">CVSS 3.1 Compute</text>
+  <text x="642" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">AV/AC/PR/UI/S/C/I/A</text>
 
-  <rect x="842" y="344" width="86" height="30" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="885" y="364" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6d28d9">Alerts</text>
+  <text x="370" y="474" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" font-weight="600" fill="#d97706">+ AI enrichment (Ollama/HuggingFace/litellm) · Baseline comparison · Trend tracking · Multi-source correlation · OTel trace ingest</text>
 
-  <path d="M704 294 L736 294" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <!-- ─── SIDEBAR: RUNTIME PROTECTION ─── -->
+  <rect x="736" y="244" width="204" height="242" rx="12" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1.2"/>
+  <text x="838" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.1em">RUNTIME PROTECTION</text>
 
-  <path d="M370 380 L370 402" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M364 396 L370 406 L376 396" fill="#94a3b8"/>
+  <rect x="748" y="278" width="180" height="52" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="838" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">MCP Stdio Proxy</text>
+  <text x="838" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">JSON-RPC intercept · audit log</text>
+  <text x="838" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Policy enforce · replay detect</text>
 
-  <!-- ─── ROW 3: OUTPUTS ─── -->
-  <rect x="20" y="410" width="920" height="84" rx="12" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="480" y="430" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT</text>
+  <rect x="748" y="336" width="180" height="40" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="838" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">4 Inline Scanners</text>
+  <text x="838" y="366" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Injection · PII · Secrets · Payloads</text>
 
-  <rect x="34" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="82" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">CLI</text>
+  <rect x="748" y="382" width="180" height="40" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="838" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">5 Detectors</text>
+  <text x="838" y="412" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Drift · Creds · Rate · Seq · Args</text>
 
-  <rect x="140" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="188" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API</text>
+  <rect x="748" y="428" width="86" height="28" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="791" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6d28d9">Fleet Mgmt</text>
 
-  <rect x="246" y="442" width="114" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="303" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (16 tools)</text>
+  <rect x="842" y="428" width="86" height="28" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="885" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6d28d9">Trust Score</text>
 
-  <rect x="370" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="418" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard</text>
+  <rect x="748" y="462" width="180" height="18" rx="4" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="0.5"/>
+  <text x="838" y="475" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Alerts · Dedup · Slack/Webhook/File</text>
 
-  <rect x="476" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="524" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">SARIF / SBOM</text>
+  <path d="M704 360 L736 360" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
 
-  <rect x="582" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="630" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">GitHub Action</text>
+  <!-- Arrow down -->
+  <path d="M370 486 L370 506" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M364 500 L370 510 L376 500" fill="#94a3b8"/>
 
-  <rect x="688" y="442" width="96" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="736" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">Docker / Helm</text>
+  <!-- ─── ROW 3: DEPLOYMENT & OUTPUT ─── -->
+  <rect x="20" y="514" width="920" height="84" rx="12" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.2"/>
+  <text x="480" y="534" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT — 13+ FORMATS</text>
 
-  <rect x="794" y="442" width="134" height="38" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="861" y="466" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#065f46">Slack · Jira · Webhooks</text>
+  <rect x="30" y="544" width="78" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="69" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">CLI</text>
+
+  <rect x="114" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="157" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">REST API</text>
+  <text x="157" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">25+ endpoints</text>
+
+  <rect x="206" y="544" width="96" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="254" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">MCP Server</text>
+  <text x="254" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">16 tools</text>
+
+  <rect x="308" y="544" width="78" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="347" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Dashboard</text>
+
+  <rect x="392" y="544" width="90" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="437" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">SARIF/SBOM</text>
+
+  <rect x="488" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="531" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">GH Action</text>
+
+  <rect x="580" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="623" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Docker/Helm</text>
+
+  <rect x="672" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="715" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Prometheus</text>
+  <text x="715" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">OTLP · OCSF</text>
+
+  <rect x="764" y="544" width="168" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
+  <text x="848" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Slack · Jira · ServiceNow</text>
+  <text x="848" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">Drata · Vanta · Webhooks</text>
+
+  <!-- ─── ROW 4: INFRASTRUCTURE BAR ─── -->
+  <rect x="20" y="606" width="920" height="36" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.8"/>
+  <text x="480" y="622" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#475569" letter-spacing="0.06em">INFRASTRUCTURE</text>
+  <text x="480" y="636" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Storage: SQLite · PostgreSQL · Snowflake  |  Auth: RBAC · scrypt API keys · HMAC audit log  |  Scheduler: cron · backoff  |  Cache: SQLite WAL · 7-day TTL</text>
 
   <!-- ─── FOOTER ─── -->
-  <rect x="20" y="504" width="920" height="2" rx="1" fill="#e2e8f0"/>
-  <text x="480" y="524" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  427+ server registry  |  7 vuln sources  |  10 compliance frameworks  |  16 MCP tools  |  2,868 tests</text>
-  <text x="480" y="546" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  OpenSSF scored  |  Apache 2.0</text>
-  <text x="480" y="568" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#059669">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+  <rect x="20" y="652" width="920" height="2" rx="1" fill="#e2e8f0"/>
+  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">18 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
+  <text x="480" y="694" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  SLSA provenance  |  OpenSSF scored  |  Apache 2.0</text>
+  <text x="480" y="716" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#059669">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+
+  <!-- Proprietary label -->
+  <rect x="20" y="728" width="920" height="2" rx="1" fill="#fbbf24" opacity="0.4"/>
+  <text x="480" y="738" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#d97706">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime dependencies beyond stdlib for core analysis</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -1,166 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 480" fill="none">
-  <!-- Background -->
-  <rect width="960" height="480" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" fill="none">
+  <rect width="960" height="620" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Enterprise Scan Workflow</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">How agent-bom discovers, scans, analyzes, and reports across your entire AI infrastructure</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scan Workflow — End-to-End Data Flow</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">From multi-source discovery to actionable intelligence across agents, containers, cloud, and AI/ML infrastructure</text>
 
-  <!-- ─── COLUMN 1: INPUTS ─── -->
-  <rect x="20" y="60" width="200" height="372" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.5"/>
-  <text x="120" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.08em">INPUT SOURCES</text>
+  <!-- ═══ COLUMN 1: INPUTS ═══ -->
+  <rect x="14" y="58" width="220" height="14" rx="4" fill="#1f6feb"/>
+  <text x="124" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">DISCOVERY INPUTS</text>
 
-  <rect x="34" y="94" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">MCP Configs (18 clients)</text>
-  <text x="120" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Claude · Cursor · Codex · Zed + 14</text>
+  <!-- MCP Agents -->
+  <rect x="14" y="78" width="220" height="76" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
+  <text x="24" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">MCP Agent Ecosystem</text>
+  <text x="24" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">18 client configs (Claude, Cursor, Windsurf…)</text>
+  <text x="24" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">427+ MCP registry packages</text>
+  <text x="24" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Tool permission + capability analysis</text>
+  <text x="24" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">discovery/__init__.py · mcp_registry.py</text>
 
-  <rect x="34" y="140" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Docker + K8s</text>
-  <text x="120" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Images · Pods · All namespaces</text>
+  <!-- Infrastructure -->
+  <rect x="14" y="160" width="220" height="76" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
+  <text x="24" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">Infrastructure</text>
+  <text x="24" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Docker images (Grype → Syft → Docker CLI)</text>
+  <text x="24" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Kubernetes pods + namespaces (kubectl)</text>
+  <text x="24" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Terraform state files (HCL parser)</text>
+  <text x="24" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">image.py · k8s.py · parsers/__init__.py</text>
 
-  <rect x="34" y="186" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">8 Cloud Providers</text>
-  <text x="120" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">AWS · Azure · GCP · Snowflake + 4</text>
+  <!-- Cloud & AI -->
+  <rect x="14" y="242" width="220" height="88" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
+  <text x="24" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">Cloud + AI Providers (11)</text>
+  <text x="24" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AWS · Azure · GCP · Snowflake · Databricks</text>
+  <text x="24" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Nebius · HuggingFace · W&amp;B · MLflow</text>
+  <text x="24" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OpenAI · Ollama (local models)</text>
+  <text x="24" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">10 agent frameworks (AST detection)</text>
+  <text x="24" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">cloud/ · ai_frameworks.py · models.py</text>
 
-  <rect x="34" y="232" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">AI Platforms</text>
-  <text x="120" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">HuggingFace · MLflow · W&amp;B · Ollama</text>
+  <!-- Code & Supply Chain -->
+  <rect x="14" y="336" width="220" height="88" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
+  <text x="24" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">Code + Supply Chain</text>
+  <text x="24" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">7 ecosystems: npm pip Go Cargo Maven NuGet Ruby</text>
+  <text x="24" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SBOM ingest: CycloneDX + SPDX</text>
+  <text x="24" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SAST: Semgrep rules (code_scan.py)</text>
+  <text x="24" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">12 model file formats (GGUF, SafeTensors…)</text>
+  <text x="24" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">parsers/ · sbom.py · code_scan.py · integrity.py</text>
 
-  <rect x="34" y="278" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">SBOMs / IaC / SAST</text>
-  <text x="120" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CycloneDX · SPDX · Terraform</text>
+  <!-- ═══ Arrow Column 1→2 ═══ -->
+  <path d="M240 250 L254 250" stroke="#484f58" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M250 245 L258 250 L250 255" fill="#484f58"/>
 
-  <rect x="34" y="324" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">7 Package Ecosystems</text>
-  <text x="120" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">npm · pip · Go · Cargo · Maven + 2</text>
+  <!-- ═══ COLUMN 2: SCANNING + ENRICHMENT ═══ -->
+  <rect x="260" y="58" width="220" height="14" rx="4" fill="#d29922"/>
+  <text x="370" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">SCANNING + ENRICHMENT</text>
 
-  <rect x="34" y="370" width="172" height="38" rx="8" fill="#0d1117" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#93c5fd">Code &amp; Models</text>
-  <text x="120" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">SAST · Notebooks · 13 model formats</text>
+  <!-- Vuln Scanning -->
+  <rect x="260" y="78" width="220" height="100" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
+  <text x="270" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">Vulnerability Scanning (9 sources)</text>
+  <text x="270" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OSV.dev batch API (primary)</text>
+  <text x="270" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">GHSA · NVD/NIST CVEs · Grype DB</text>
+  <text x="270" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NVIDIA CSAF (GPU vulns) · Snyk</text>
+  <text x="270" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Malicious + typosquat detection</text>
+  <text x="270" y="158" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#e3b341">PROPRIETARY orchestrator + EXTERNAL APIs</text>
+  <text x="270" y="170" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">scanners/__init__.py · nvidia.py</text>
 
-  <text x="120" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">427+ MCP server registry</text>
+  <!-- Enrichment -->
+  <rect x="260" y="184" width="220" height="100" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
+  <text x="270" y="200" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">Enrichment Pipeline</text>
+  <text x="270" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CVSS 3.1 computation (PROPRIETARY)</text>
+  <text x="270" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NVD CVSS v3.1/v4 (EXTERNAL)</text>
+  <text x="270" y="238" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">FIRST EPSS probability scores</text>
+  <text x="270" y="250" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CISA KEV active exploitation status</text>
+  <text x="270" y="262" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OpenSSF Scorecard health metrics</text>
+  <text x="270" y="276" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">cvss.py · scanners/__init__.py</text>
 
-  <!-- Arrow 1→2 -->
-  <path d="M220 246 L244 246" stroke="#60a5fa" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M239 241 L248 246 L239 251" fill="#60a5fa"/>
+  <!-- False Positive + AI -->
+  <rect x="260" y="290" width="220" height="76" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
+  <text x="270" y="306" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">Intelligence Layer (PROPRIETARY)</text>
+  <text x="270" y="320" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AI risk classification (7 categories)</text>
+  <text x="270" y="332" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">False positive reduction engine</text>
+  <text x="270" y="344" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Conditional OWASP tagging</text>
+  <text x="270" y="358" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">scanners/__init__.py · vex.py</text>
 
-  <!-- ─── COLUMN 2: PIPELINE ─── -->
-  <rect x="250" y="60" width="190" height="372" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.5"/>
-  <text x="345" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.08em">SCANNER PIPELINE</text>
+  <!-- VEX -->
+  <rect x="260" y="372" width="220" height="52" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
+  <text x="270" y="388" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">VEX / Suppression (PROPRIETARY)</text>
+  <text x="270" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OpenVEX status tracking</text>
+  <text x="270" y="414" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Credential ranking + prioritization</text>
 
-  <rect x="264" y="96" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Discover + Extract</text>
-  <text x="345" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">11 ecosystems · container layers</text>
+  <!-- ═══ Arrow Column 2→3 ═══ -->
+  <path d="M486 250 L500 250" stroke="#484f58" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M496 245 L504 250 L496 255" fill="#484f58"/>
 
-  <path d="M345 140 L345 150" stroke="#f59e0b" stroke-width="1.5"/>
-  <path d="M340 146 L345 154 L350 146" fill="#f59e0b"/>
+  <!-- ═══ COLUMN 3: ANALYSIS ═══ -->
+  <rect x="506" y="58" width="220" height="14" rx="4" fill="#da3633"/>
+  <text x="616" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">PROPRIETARY ANALYSIS</text>
 
-  <rect x="264" y="158" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">CVE Scan</text>
-  <text x="345" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">7 sources: OSV · NVD · GHSA · Grype</text>
+  <!-- Blast Radius -->
+  <rect x="506" y="78" width="220" height="76" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1"/>
+  <text x="516" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#f85149">Blast Radius Engine</text>
+  <text x="516" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CVE → package → server → agent → creds</text>
+  <text x="516" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Multi-hop propagation modeling</text>
+  <text x="516" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Exposure surface calculation</text>
+  <text x="516" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#f85149">blast_radius.py</text>
 
-  <path d="M345 202 L345 212" stroke="#f59e0b" stroke-width="1.5"/>
-  <path d="M340 208 L345 216 L350 208" fill="#f59e0b"/>
+  <!-- Context Graph -->
+  <rect x="506" y="160" width="220" height="76" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1"/>
+  <text x="516" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#f85149">Context Graph + BFS</text>
+  <text x="516" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Lateral movement path discovery</text>
+  <text x="516" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Attack surface visualization (ReactFlow)</text>
+  <text x="516" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Dependency graph traversal</text>
+  <text x="516" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#f85149">context_graph.py</text>
 
-  <rect x="264" y="220" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="238" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Enrich</text>
-  <text x="345" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">NVD CVSS · EPSS · KEV · OpenSSF</text>
+  <!-- Risk Analysis -->
+  <rect x="506" y="242" width="220" height="88" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1"/>
+  <text x="516" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#f85149">Risk Analyzer</text>
+  <text x="516" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">7 tool capabilities (READ→ADMIN)</text>
+  <text x="516" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">8 dangerous combination patterns</text>
+  <text x="516" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Toxic combo detection</text>
+  <text x="516" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Incident correlation engine</text>
+  <text x="516" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#f85149">risk_analyzer.py · incidents.py</text>
 
-  <path d="M345 264 L345 274" stroke="#f59e0b" stroke-width="1.5"/>
-  <path d="M340 270 L345 278 L350 270" fill="#f59e0b"/>
+  <!-- Compliance -->
+  <rect x="506" y="336" width="220" height="88" rx="8" fill="#161b22" stroke="#a371f7" stroke-width="1"/>
+  <text x="516" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a371f7">Compliance + Policy (10 frameworks)</text>
+  <text x="516" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP LLM/MCP/Agentic Top 10</text>
+  <text x="516" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MITRE ATLAS · NIST AI RMF · EU AI Act</text>
+  <text x="516" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">ISO 27001 · SOC 2 · CIS v8</text>
+  <text x="516" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Policy-as-code + License policy (SPDX)</text>
+  <text x="516" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">compliance.py · policy.py · license.py</text>
 
-  <rect x="264" y="282" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="300" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Analyze + Tag</text>
-  <text x="345" y="316" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Blast radius · 10 frameworks · OCSF</text>
+  <!-- ═══ Arrow Column 3→4 ═══ -->
+  <path d="M732 250 L746 250" stroke="#484f58" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M742 245 L750 250 L742 255" fill="#484f58"/>
 
-  <path d="M345 326 L345 336" stroke="#f59e0b" stroke-width="1.5"/>
-  <path d="M340 332 L345 340 L350 332" fill="#f59e0b"/>
+  <!-- ═══ COLUMN 4: OUTPUTS ═══ -->
+  <rect x="752" y="58" width="194" height="14" rx="4" fill="#238636"/>
+  <text x="849" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">OUTPUTS + DELIVERY</text>
 
-  <rect x="264" y="344" width="162" height="44" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="362" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#fbbf24">Score + Prioritize</text>
-  <text x="345" y="378" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Posture A-F · P1-P4 incidents</text>
+  <!-- Formats -->
+  <rect x="752" y="78" width="194" height="88" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="762" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">13+ Output Formats</text>
+  <text x="762" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">JSON · Console (rich) · HTML report</text>
+  <text x="762" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CycloneDX · SPDX · SARIF</text>
+  <text x="762" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SVG badges · Mermaid diagrams</text>
+  <text x="762" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Cytoscape · ReactFlow (attack flow)</text>
+  <text x="762" y="158" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">output/__init__.py</text>
 
-  <rect x="264" y="396" width="162" height="28" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
-  <text x="345" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#d97706">read-only | local execution</text>
+  <!-- APIs -->
+  <rect x="752" y="172" width="194" height="76" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="762" y="188" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">APIs + Services</text>
+  <text x="762" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">REST API (25+ endpoints)</text>
+  <text x="762" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MCP Server (16 tools)</text>
+  <text x="762" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Next.js Dashboard (15 sections)</text>
+  <text x="762" y="240" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">api.py · mcp_server.py · dashboard/</text>
 
-  <!-- Arrow 2→3 -->
-  <path d="M440 246 L464 246" stroke="#fbbf24" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M459 241 L468 246 L459 251" fill="#fbbf24"/>
+  <!-- CI/CD -->
+  <rect x="752" y="254" width="194" height="76" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="762" y="270" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">CI/CD + Deployment</text>
+  <text x="762" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">GitHub Action (Marketplace)</text>
+  <text x="762" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Docker Hub · GHCR · Railway SSE</text>
+  <text x="762" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Helm chart · K8s manifests</text>
+  <text x="762" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">action.yml · deploy/ · Dockerfiles</text>
 
-  <!-- ─── COLUMN 3: ANALYSIS ─── -->
-  <rect x="470" y="60" width="200" height="372" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.5"/>
-  <text x="570" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">ANALYSIS ENGINE</text>
+  <!-- Observability -->
+  <rect x="752" y="336" width="194" height="64" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="762" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">Observability + SIEM</text>
+  <text x="762" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Prometheus metrics (/metrics)</text>
+  <text x="762" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OCSF + OTLP telemetry</text>
+  <text x="762" y="392" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">proxy.py · ocsf.py</text>
 
-  <rect x="484" y="94" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="570" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Blast Radius Engine</text>
-  <text x="570" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">CVE → pkg → server → agent → creds</text>
+  <!-- Integrations -->
+  <rect x="752" y="406" width="194" height="52" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="762" y="422" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">Enterprise Integrations</text>
+  <text x="762" y="436" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Slack · Jira · ServiceNow</text>
+  <text x="762" y="448" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Drata · Vanta · Webhooks</text>
 
-  <rect x="484" y="140" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="570" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Context Graph</text>
-  <text x="570" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Lateral movement · BFS attack paths</text>
+  <!-- ═══ RUNTIME BAR ═══ -->
+  <rect x="14" y="470" width="932" height="52" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="1"/>
+  <text x="480" y="488" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a371f7" letter-spacing="0.08em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
+  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a371f7">4 Inline Scanners (prompt injection · PII · secrets · payloads)  |  5 Detectors (drift · creds · rate · sequence · args)</text>
+  <text x="480" y="514" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Fleet Management · Trust Scoring (5 dimensions) · Alert Pipeline · Replay Protection</text>
 
-  <rect x="484" y="186" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="570" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">10-Framework Tagging</text>
-  <text x="570" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">OWASP · ATLAS · NIST · EU AI Act</text>
+  <!-- ═══ INFRA BAR ═══ -->
+  <rect x="14" y="530" width="932" height="36" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="480" y="553" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#3fb950">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
 
-  <rect x="484" y="232" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="570" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Posture Scorecard</text>
-  <text x="570" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Grade A-F · 6 weighted dimensions</text>
-
-  <rect x="484" y="278" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="570" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Incident Correlation</text>
-  <text x="570" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">P1-P4 priority · SOC-ready OCSF</text>
-
-  <rect x="484" y="324" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="570" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Credential Ranking</text>
-  <text x="570" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Risk tiers · cross-agent aggregation</text>
-
-  <rect x="484" y="370" width="172" height="38" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="570" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#c4b5fd">Toxic Combinations</text>
-  <text x="570" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">KEV+creds · RCE+exec · malicious</text>
-
-  <text x="570" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#a78bfa">Policy-as-code engine</text>
-
-  <!-- Arrow 3→4 -->
-  <path d="M670 246 L694 246" stroke="#a78bfa" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M689 241 L698 246 L689 251" fill="#a78bfa"/>
-
-  <!-- ─── COLUMN 4: OUTPUTS ─── -->
-  <rect x="700" y="60" width="242" height="372" rx="12" fill="#161b22" stroke="#059669" stroke-width="1.5"/>
-  <text x="821" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.08em">DEPLOYMENT &amp; OUTPUT</text>
-
-  <rect x="714" y="94" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="767" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">CLI + HTML</text>
-
-  <rect x="828" y="94" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="881" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">REST API + SSE</text>
-
-  <rect x="714" y="136" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="767" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">SARIF + SBOM</text>
-
-  <rect x="828" y="136" width="106" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="881" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Dashboard (15p)</text>
-
-  <rect x="714" y="178" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="824" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">MCP Server (16 tools)</text>
-
-  <rect x="714" y="220" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="824" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">GitHub Action (CI/CD)</text>
-
-  <rect x="714" y="262" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="824" y="284" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Docker + Helm Chart</text>
-
-  <rect x="714" y="304" width="220" height="34" rx="8" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="824" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6ee7b7">Slack / Jira / Webhooks</text>
-
-  <!-- Runtime protection sub-section -->
-  <rect x="714" y="350" width="220" height="74" rx="8" fill="#1a1028" stroke="#7c3aed" stroke-width="1"/>
-  <text x="824" y="370" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa">Runtime Protection</text>
-  <text x="824" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">MCP Proxy · 5 Detectors</text>
-  <text x="824" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Fleet Management · Prometheus</text>
-  <text x="824" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Alert pipeline (webhook · file · callback)</text>
-
-  <!-- ─── FOOTER ─── -->
-  <text x="480" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  7 vuln sources  |  10 frameworks  |  16 MCP tools  |  2,868 tests</text>
-  <text x="480" y="472" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
+  <!-- Footer -->
+  <text x="480" y="584" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">~70 proprietary modules  |  ~15 hybrid  |  ~22 external  |  107 total  |  2,868+ tests  |  0 runtime deps for core</text>
+  <text x="480" y="602" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#484f58">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -1,166 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 480" fill="none">
-  <!-- Background -->
-  <rect width="960" height="480" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" fill="none">
+  <rect width="960" height="620" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Enterprise Scan Workflow</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">How agent-bom discovers, scans, analyzes, and reports across your entire AI infrastructure</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scan Workflow — End-to-End Data Flow</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">From multi-source discovery to actionable intelligence across agents, containers, cloud, and AI/ML infrastructure</text>
 
-  <!-- ─── COLUMN 1: INPUTS ─── -->
-  <rect x="20" y="60" width="200" height="372" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="120" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#3b82f6" letter-spacing="0.08em">INPUT SOURCES</text>
+  <!-- ═══ COLUMN 1: INPUTS ═══ -->
+  <rect x="14" y="58" width="220" height="14" rx="4" fill="#3b82f6"/>
+  <text x="124" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">DISCOVERY INPUTS</text>
 
-  <rect x="34" y="94" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="120" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Configs (18 clients)</text>
-  <text x="120" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Claude · Cursor · Codex · Zed + 14</text>
+  <!-- MCP Agents -->
+  <rect x="14" y="78" width="220" height="76" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="24" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">MCP Agent Ecosystem</text>
+  <text x="24" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">18 client configs (Claude, Cursor, Windsurf…)</text>
+  <text x="24" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">427+ MCP registry packages</text>
+  <text x="24" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Tool permission + capability analysis</text>
+  <text x="24" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">discovery/__init__.py · mcp_registry.py</text>
 
-  <rect x="34" y="140" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="120" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Docker + K8s</text>
-  <text x="120" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Images · Pods · All namespaces</text>
+  <!-- Infrastructure -->
+  <rect x="14" y="160" width="220" height="76" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="24" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">Infrastructure</text>
+  <text x="24" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Docker images (Grype → Syft → Docker CLI)</text>
+  <text x="24" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Kubernetes pods + namespaces (kubectl)</text>
+  <text x="24" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Terraform state files (HCL parser)</text>
+  <text x="24" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">image.py · k8s.py · parsers/__init__.py</text>
 
-  <rect x="34" y="186" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="120" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">8 Cloud Providers</text>
-  <text x="120" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">AWS · Azure · GCP · Snowflake + 4</text>
+  <!-- Cloud & AI -->
+  <rect x="14" y="242" width="220" height="88" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="24" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">Cloud + AI Providers (11)</text>
+  <text x="24" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AWS · Azure · GCP · Snowflake · Databricks</text>
+  <text x="24" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Nebius · HuggingFace · W&amp;B · MLflow</text>
+  <text x="24" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OpenAI · Ollama (local models)</text>
+  <text x="24" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">10 agent frameworks (AST detection)</text>
+  <text x="24" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">cloud/ · ai_frameworks.py · models.py</text>
 
-  <rect x="34" y="232" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="120" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">AI Platforms</text>
-  <text x="120" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">HuggingFace · MLflow · W&amp;B · Ollama</text>
+  <!-- Code & Supply Chain -->
+  <rect x="14" y="336" width="220" height="88" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="24" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">Code + Supply Chain</text>
+  <text x="24" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">7 ecosystems: npm pip Go Cargo Maven NuGet Ruby</text>
+  <text x="24" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SBOM ingest: CycloneDX + SPDX</text>
+  <text x="24" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SAST: Semgrep rules (code_scan.py)</text>
+  <text x="24" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">12 model file formats (GGUF, SafeTensors…)</text>
+  <text x="24" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">parsers/ · sbom.py · code_scan.py · integrity.py</text>
 
-  <rect x="34" y="278" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="120" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">SBOMs / IaC / SAST</text>
-  <text x="120" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CycloneDX · SPDX · Terraform</text>
+  <!-- ═══ Arrow Column 1→2 ═══ -->
+  <path d="M240 250 L254 250" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M250 245 L258 250 L250 255" fill="#94a3b8"/>
 
-  <rect x="34" y="324" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="120" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">7 Package Ecosystems</text>
-  <text x="120" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">npm · pip · Go · Cargo · Maven + 2</text>
+  <!-- ═══ COLUMN 2: SCANNING + ENRICHMENT ═══ -->
+  <rect x="260" y="58" width="220" height="14" rx="4" fill="#f59e0b"/>
+  <text x="370" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">SCANNING + ENRICHMENT</text>
 
-  <rect x="34" y="370" width="172" height="38" rx="8" fill="#ffffff" stroke="#93c5fd" stroke-width="1"/>
-  <text x="120" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1e40af">Code &amp; Models</text>
-  <text x="120" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">SAST · Notebooks · 13 model formats</text>
+  <!-- Vuln Scanning -->
+  <rect x="260" y="78" width="220" height="100" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <text x="270" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Vulnerability Scanning (9 sources)</text>
+  <text x="270" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OSV.dev batch API (primary)</text>
+  <text x="270" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">GHSA · NVD/NIST CVEs · Grype DB</text>
+  <text x="270" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NVIDIA CSAF (GPU vulns) · Snyk</text>
+  <text x="270" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Malicious + typosquat detection</text>
+  <text x="270" y="158" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#d97706">PROPRIETARY orchestrator + EXTERNAL APIs</text>
+  <text x="270" y="170" font-family="system-ui, sans-serif" font-size="7.5" fill="#d97706">scanners/__init__.py · nvidia.py</text>
 
-  <text x="120" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">427+ MCP server registry</text>
+  <!-- Enrichment -->
+  <rect x="260" y="184" width="220" height="100" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <text x="270" y="200" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Enrichment Pipeline</text>
+  <text x="270" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CVSS 3.1 computation (PROPRIETARY)</text>
+  <text x="270" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NVD CVSS v3.1/v4 (EXTERNAL)</text>
+  <text x="270" y="238" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">FIRST EPSS probability scores</text>
+  <text x="270" y="250" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CISA KEV active exploitation status</text>
+  <text x="270" y="262" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OpenSSF Scorecard health metrics</text>
+  <text x="270" y="276" font-family="system-ui, sans-serif" font-size="7.5" fill="#d97706">cvss.py · scanners/__init__.py</text>
 
-  <!-- Arrow 1→2 -->
-  <path d="M220 246 L244 246" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M239 241 L248 246 L239 251" fill="#3b82f6"/>
+  <!-- False Positive + AI -->
+  <rect x="260" y="290" width="220" height="76" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <text x="270" y="306" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Intelligence Layer (PROPRIETARY)</text>
+  <text x="270" y="320" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AI risk classification (7 categories)</text>
+  <text x="270" y="332" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">False positive reduction engine</text>
+  <text x="270" y="344" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Conditional OWASP tagging</text>
+  <text x="270" y="358" font-family="system-ui, sans-serif" font-size="7.5" fill="#d97706">scanners/__init__.py · vex.py</text>
 
-  <!-- ─── COLUMN 2: PIPELINE ─── -->
-  <rect x="250" y="60" width="190" height="372" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="345" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.08em">SCANNER PIPELINE</text>
+  <!-- VEX -->
+  <rect x="260" y="372" width="220" height="52" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <text x="270" y="388" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">VEX / Suppression (PROPRIETARY)</text>
+  <text x="270" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OpenVEX status tracking</text>
+  <text x="270" y="414" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Credential ranking + prioritization</text>
 
-  <rect x="264" y="96" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="114" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Discover + Extract</text>
-  <text x="345" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">11 ecosystems · container layers</text>
+  <!-- ═══ Arrow Column 2→3 ═══ -->
+  <path d="M486 250 L500 250" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M496 245 L504 250 L496 255" fill="#94a3b8"/>
 
-  <path d="M345 140 L345 150" stroke="#d97706" stroke-width="1.5"/>
-  <path d="M340 146 L345 154 L350 146" fill="#d97706"/>
+  <!-- ═══ COLUMN 3: ANALYSIS ═══ -->
+  <rect x="506" y="58" width="220" height="14" rx="4" fill="#ef4444"/>
+  <text x="616" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">PROPRIETARY ANALYSIS</text>
 
-  <rect x="264" y="158" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">CVE Scan</text>
-  <text x="345" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">7 sources: OSV · NVD · GHSA · Grype</text>
+  <!-- Blast Radius -->
+  <rect x="506" y="78" width="220" height="76" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+  <text x="516" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#991b1b">Blast Radius Engine</text>
+  <text x="516" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CVE → package → server → agent → creds</text>
+  <text x="516" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Multi-hop propagation modeling</text>
+  <text x="516" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Exposure surface calculation</text>
+  <text x="516" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#ef4444">blast_radius.py</text>
 
-  <path d="M345 202 L345 212" stroke="#d97706" stroke-width="1.5"/>
-  <path d="M340 208 L345 216 L350 208" fill="#d97706"/>
+  <!-- Context Graph -->
+  <rect x="506" y="160" width="220" height="76" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+  <text x="516" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#991b1b">Context Graph + BFS</text>
+  <text x="516" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Lateral movement path discovery</text>
+  <text x="516" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Attack surface visualization (ReactFlow)</text>
+  <text x="516" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Dependency graph traversal</text>
+  <text x="516" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#ef4444">context_graph.py</text>
 
-  <rect x="264" y="220" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="238" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Enrich</text>
-  <text x="345" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">NVD CVSS · EPSS · KEV · OpenSSF</text>
+  <!-- Risk Analysis -->
+  <rect x="506" y="242" width="220" height="88" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+  <text x="516" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#991b1b">Risk Analyzer</text>
+  <text x="516" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">7 tool capabilities (READ→ADMIN)</text>
+  <text x="516" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">8 dangerous combination patterns</text>
+  <text x="516" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Toxic combo detection</text>
+  <text x="516" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Incident correlation engine</text>
+  <text x="516" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#ef4444">risk_analyzer.py · incidents.py</text>
 
-  <path d="M345 264 L345 274" stroke="#d97706" stroke-width="1.5"/>
-  <path d="M340 270 L345 278 L350 270" fill="#d97706"/>
+  <!-- Compliance -->
+  <rect x="506" y="336" width="220" height="88" rx="8" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1"/>
+  <text x="516" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">Compliance + Policy (10 frameworks)</text>
+  <text x="516" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP LLM/MCP/Agentic Top 10</text>
+  <text x="516" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MITRE ATLAS · NIST AI RMF · EU AI Act</text>
+  <text x="516" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">ISO 27001 · SOC 2 · CIS v8</text>
+  <text x="516" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Policy-as-code + License policy (SPDX)</text>
+  <text x="516" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b5cf6">compliance.py · policy.py · license.py</text>
 
-  <rect x="264" y="282" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="300" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Analyze + Tag</text>
-  <text x="345" y="316" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Blast radius · 10 frameworks · OCSF</text>
+  <!-- ═══ Arrow Column 3→4 ═══ -->
+  <path d="M732 250 L746 250" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M742 245 L750 250 L742 255" fill="#94a3b8"/>
 
-  <path d="M345 326 L345 336" stroke="#d97706" stroke-width="1.5"/>
-  <path d="M340 332 L345 340 L350 332" fill="#d97706"/>
+  <!-- ═══ COLUMN 4: OUTPUTS ═══ -->
+  <rect x="752" y="58" width="194" height="14" rx="4" fill="#10b981"/>
+  <text x="849" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">OUTPUTS + DELIVERY</text>
 
-  <rect x="264" y="344" width="162" height="44" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="345" y="362" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#92400e">Score + Prioritize</text>
-  <text x="345" y="378" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a16207">Posture A-F · P1-P4 incidents</text>
+  <!-- Formats -->
+  <rect x="752" y="78" width="194" height="88" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="762" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">13+ Output Formats</text>
+  <text x="762" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">JSON · Console (rich) · HTML report</text>
+  <text x="762" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CycloneDX · SPDX · SARIF</text>
+  <text x="762" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SVG badges · Mermaid diagrams</text>
+  <text x="762" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Cytoscape · ReactFlow (attack flow)</text>
+  <text x="762" y="158" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">output/__init__.py</text>
 
-  <rect x="264" y="396" width="162" height="28" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
-  <text x="345" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#92400e">read-only | local execution</text>
+  <!-- APIs -->
+  <rect x="752" y="172" width="194" height="76" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="762" y="188" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">APIs + Services</text>
+  <text x="762" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">REST API (25+ endpoints)</text>
+  <text x="762" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MCP Server (16 tools)</text>
+  <text x="762" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Next.js Dashboard (15 sections)</text>
+  <text x="762" y="240" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">api.py · mcp_server.py · dashboard/</text>
 
-  <!-- Arrow 2→3 -->
-  <path d="M440 246 L464 246" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M459 241 L468 246 L459 251" fill="#d97706"/>
+  <!-- CI/CD -->
+  <rect x="752" y="254" width="194" height="76" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="762" y="270" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">CI/CD + Deployment</text>
+  <text x="762" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">GitHub Action (Marketplace)</text>
+  <text x="762" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Docker Hub · GHCR · Railway SSE</text>
+  <text x="762" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Helm chart · K8s manifests</text>
+  <text x="762" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">action.yml · deploy/ · Dockerfiles</text>
 
-  <!-- ─── COLUMN 3: ANALYSIS ─── -->
-  <rect x="470" y="60" width="200" height="372" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="1.5"/>
-  <text x="570" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">ANALYSIS ENGINE</text>
+  <!-- Observability -->
+  <rect x="752" y="336" width="194" height="64" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="762" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">Observability + SIEM</text>
+  <text x="762" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Prometheus metrics (/metrics)</text>
+  <text x="762" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OCSF + OTLP telemetry</text>
+  <text x="762" y="392" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">proxy.py · ocsf.py</text>
 
-  <rect x="484" y="94" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="570" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Blast Radius Engine</text>
-  <text x="570" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">CVE → pkg → server → agent → creds</text>
+  <!-- Integrations -->
+  <rect x="752" y="406" width="194" height="52" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="762" y="422" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">Enterprise Integrations</text>
+  <text x="762" y="436" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Slack · Jira · ServiceNow</text>
+  <text x="762" y="448" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Drata · Vanta · Webhooks</text>
 
-  <rect x="484" y="140" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="570" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Context Graph</text>
-  <text x="570" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Lateral movement · BFS attack paths</text>
+  <!-- ═══ RUNTIME BAR ═══ -->
+  <rect x="14" y="470" width="932" height="52" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="480" y="488" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
+  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">4 Inline Scanners (prompt injection · PII · secrets · payloads)  |  5 Detectors (drift · creds · rate · sequence · args)</text>
+  <text x="480" y="514" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b5cf6">Fleet Management · Trust Scoring (5 dimensions) · Alert Pipeline · Replay Protection</text>
 
-  <rect x="484" y="186" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="570" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">10-Framework Tagging</text>
-  <text x="570" y="216" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">OWASP · ATLAS · NIST · EU AI Act</text>
+  <!-- ═══ INFRA BAR ═══ -->
+  <rect x="14" y="530" width="932" height="36" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="480" y="553" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#15803d">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
 
-  <rect x="484" y="232" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="570" y="248" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Posture Scorecard</text>
-  <text x="570" y="262" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Grade A-F · 6 weighted dimensions</text>
-
-  <rect x="484" y="278" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="570" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Incident Correlation</text>
-  <text x="570" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">P1-P4 priority · SOC-ready OCSF</text>
-
-  <rect x="484" y="324" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="570" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Credential Ranking</text>
-  <text x="570" y="354" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Risk tiers · cross-agent aggregation</text>
-
-  <rect x="484" y="370" width="172" height="38" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="570" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#6d28d9">Toxic Combinations</text>
-  <text x="570" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">KEV+creds · RCE+exec · malicious</text>
-
-  <text x="570" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#7c3aed">Policy-as-code engine</text>
-
-  <!-- Arrow 3→4 -->
-  <path d="M670 246 L694 246" stroke="#7c3aed" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M689 241 L698 246 L689 251" fill="#7c3aed"/>
-
-  <!-- ─── COLUMN 4: OUTPUTS ─── -->
-  <rect x="700" y="60" width="242" height="372" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="1.5"/>
-  <text x="821" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.08em">DEPLOYMENT &amp; OUTPUT</text>
-
-  <rect x="714" y="94" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="767" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">CLI + HTML</text>
-
-  <rect x="828" y="94" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="881" y="116" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">REST API + SSE</text>
-
-  <rect x="714" y="136" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="767" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">SARIF + SBOM</text>
-
-  <rect x="828" y="136" width="106" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="881" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Dashboard (15p)</text>
-
-  <rect x="714" y="178" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="824" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">MCP Server (16 tools)</text>
-
-  <rect x="714" y="220" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="824" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">GitHub Action (CI/CD)</text>
-
-  <rect x="714" y="262" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="824" y="284" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Docker + Helm Chart</text>
-
-  <rect x="714" y="304" width="220" height="34" rx="8" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="824" y="326" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#065f46">Slack / Jira / Webhooks</text>
-
-  <!-- Runtime protection sub-section -->
-  <rect x="714" y="350" width="220" height="74" rx="8" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="824" y="370" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed">Runtime Protection</text>
-  <text x="824" y="386" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">MCP Proxy · 5 Detectors</text>
-  <text x="824" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Fleet Management · Prometheus</text>
-  <text x="824" y="414" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Alert pipeline (webhook · file · callback)</text>
-
-  <!-- ─── FOOTER ─── -->
-  <text x="480" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">18 MCP clients  |  8 cloud providers  |  7 ecosystems  |  7 vuln sources  |  10 frameworks  |  16 MCP tools  |  2,868 tests</text>
-  <text x="480" y="472" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
+  <!-- Footer -->
+  <text x="480" y="584" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#475569">~70 proprietary modules  |  ~15 hybrid  |  ~22 external  |  107 total  |  2,868+ tests  |  0 runtime deps for core</text>
+  <text x="480" y="602" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -1,142 +1,188 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 380" fill="none">
-  <rect width="960" height="380" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+  <rect width="960" height="520" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scanner Pipeline</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">7-stage pipeline from multi-source discovery to actionable security intelligence</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scanner Pipeline — 7-Stage Architecture</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">Proprietary analysis engine with external intelligence feeds · 70+ modules · zero runtime dependencies for core</text>
 
   <!-- ─── STAGE 1: DISCOVER ─── -->
-  <rect x="18" y="62" width="120" height="170" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="18" y="62" width="120" height="30" rx="12" fill="#2563eb"/>
-  <rect x="18" y="80" width="120" height="12" fill="#2563eb"/>
-  <text x="78" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
-  <text x="78" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#60a5fa">18</text>
-  <text x="78" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">MCP clients</text>
-  <text x="78" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ Docker images</text>
-  <text x="78" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ Kubernetes pods</text>
-  <text x="78" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ 8 cloud providers</text>
-  <text x="78" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ AI platforms</text>
-  <text x="78" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">+ SBOMs + IaC</text>
-  <text x="78" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">427+ MCP registry</text>
+  <rect x="14" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#1f6feb" stroke-width="2"/>
+  <rect x="14" y="62" width="122" height="26" rx="10" fill="#1f6feb"/>
+  <rect x="14" y="78" width="122" height="10" fill="#1f6feb"/>
+  <text x="75" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① DISCOVER</text>
+  <text x="75" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">PROPRIETARY</text>
+  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">18 MCP clients</text>
+  <text x="75" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Docker / K8s / Terraform</text>
+  <text x="75" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">11 cloud+AI providers</text>
+  <text x="75" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">10 agent frameworks</text>
+  <text x="75" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">12 model file formats</text>
+  <text x="75" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Jupyter · GH Actions</text>
+  <text x="75" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Filesystem + lockfiles</text>
+  <text x="75" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL</text>
+  <text x="75" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">MCP Registry (427+)</text>
+  <text x="75" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Docker Hub API</text>
+  <text x="75" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">kubectl CLI</text>
+  <text x="75" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">discovery/__init__.py</text>
+  <text x="75" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">k8s.py · image.py</text>
 
-  <!-- Arrow -->
-  <path d="M138 147 L152 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M148 142 L156 147 L148 152" fill="#4b5563"/>
+  <!-- Arrow 1→2 -->
+  <path d="M136 170 L148 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
+  <path d="M145 166 L151 170 L145 174" fill="#484f58"/>
 
   <!-- ─── STAGE 2: EXTRACT ─── -->
-  <rect x="158" y="62" width="120" height="170" rx="12" fill="#0c1a2e" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="158" y="62" width="120" height="30" rx="12" fill="#2563eb"/>
-  <rect x="158" y="80" width="120" height="12" fill="#2563eb"/>
-  <text x="218" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
-  <text x="218" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#60a5fa">11</text>
-  <text x="218" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">ecosystems</text>
-  <text x="218" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">npm · pip · Go · Cargo</text>
-  <text x="218" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Maven · NuGet · Ruby</text>
-  <text x="218" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Container layers</text>
-  <text x="218" y="188" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Model files (13 fmts)</text>
-  <text x="218" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">SAST via Semgrep</text>
-  <text x="218" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#60a5fa">CycloneDX + SPDX</text>
+  <rect x="152" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#1f6feb" stroke-width="2"/>
+  <rect x="152" y="62" width="122" height="26" rx="10" fill="#1f6feb"/>
+  <rect x="152" y="78" width="122" height="10" fill="#1f6feb"/>
+  <text x="213" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">② EXTRACT</text>
+  <text x="213" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">PROPRIETARY</text>
+  <text x="213" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">7 ecosystems parser</text>
+  <text x="213" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">npm·pip·Go·Cargo·Maven</text>
+  <text x="213" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NuGet · Ruby gems</text>
+  <text x="213" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AST framework detect</text>
+  <text x="213" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Model file inspection</text>
+  <text x="213" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SBOM ingest CDX+SPDX</text>
+  <text x="213" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Container layer extract</text>
+  <text x="213" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL</text>
+  <text x="213" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Syft (fallback scanner)</text>
+  <text x="213" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Semgrep (SAST rules)</text>
+  <text x="213" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">cosign (sig verify)</text>
+  <text x="213" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">parsers/__init__.py</text>
+  <text x="213" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">sbom.py · code_scan.py</text>
 
-  <!-- Arrow -->
-  <path d="M278 147 L292 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M288 142 L296 147 L288 152" fill="#4b5563"/>
+  <!-- Arrow 2→3 -->
+  <path d="M274 170 L286 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
+  <path d="M283 166 L289 170 L283 174" fill="#484f58"/>
 
   <!-- ─── STAGE 3: SCAN ─── -->
-  <rect x="298" y="62" width="120" height="170" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="298" y="62" width="120" height="30" rx="12" fill="#d97706"/>
-  <rect x="298" y="80" width="120" height="12" fill="#d97706"/>
-  <text x="358" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
-  <text x="358" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#fbbf24">7</text>
-  <text x="358" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#fcd34d">vuln sources</text>
-  <text x="358" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OSV.dev batch API</text>
-  <text x="358" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Grype DB + GHSA</text>
-  <text x="358" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVD / NIST CVEs</text>
-  <text x="358" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVIDIA GPU CVEs</text>
-  <text x="358" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CISA KEV catalog</text>
-  <text x="358" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#fbbf24">Malicious + typosquat</text>
+  <rect x="290" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#d29922" stroke-width="2"/>
+  <rect x="290" y="62" width="122" height="26" rx="10" fill="#d29922"/>
+  <rect x="290" y="78" width="122" height="10" fill="#d29922"/>
+  <text x="351" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">③ SCAN</text>
+  <text x="351" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341">PROPRIETARY</text>
+  <text x="351" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OSV batch orchestrator</text>
+  <text x="351" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Malicious pkg detect</text>
+  <text x="351" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Typosquat detection</text>
+  <text x="351" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Snyk cross-reference</text>
+  <text x="351" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NVIDIA CSAF parser</text>
+  <text x="351" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL APIs</text>
+  <text x="351" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OSV.dev batch API</text>
+  <text x="351" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">GHSA advisories</text>
+  <text x="351" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Grype DB (fallback)</text>
+  <text x="351" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NVD / NIST CVE feed</text>
+  <text x="351" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NVIDIA CSAF feed</text>
+  <text x="351" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">scanners/__init__.py</text>
+  <text x="351" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">image.py · nvidia.py</text>
 
-  <!-- Arrow -->
-  <path d="M418 147 L432 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M428 142 L436 147 L428 152" fill="#4b5563"/>
+  <!-- Arrow 3→4 -->
+  <path d="M412 170 L424 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
+  <path d="M421 166 L427 170 L421 174" fill="#484f58"/>
 
   <!-- ─── STAGE 4: ENRICH ─── -->
-  <rect x="438" y="62" width="120" height="170" rx="12" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="438" y="62" width="120" height="30" rx="12" fill="#d97706"/>
-  <rect x="438" y="80" width="120" height="12" fill="#d97706"/>
-  <text x="498" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
-  <text x="498" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#fbbf24">5</text>
-  <text x="498" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#fcd34d">enrichment APIs</text>
-  <text x="498" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">NVD CVSS v3.1/v4</text>
-  <text x="498" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">FIRST EPSS scores</text>
-  <text x="498" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CISA KEV status</text>
-  <text x="498" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OpenSSF Scorecard</text>
-  <text x="498" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">AI risk classification</text>
-  <text x="498" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#fbbf24">False positive reduction</text>
+  <rect x="428" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#d29922" stroke-width="2"/>
+  <rect x="428" y="62" width="122" height="26" rx="10" fill="#d29922"/>
+  <rect x="428" y="78" width="122" height="10" fill="#d29922"/>
+  <text x="489" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">④ ENRICH</text>
+  <text x="489" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341">PROPRIETARY</text>
+  <text x="489" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CVSS 3.1 computation</text>
+  <text x="489" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AI risk classification</text>
+  <text x="489" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">False positive reducer</text>
+  <text x="489" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Conditional OWASP tag</text>
+  <text x="489" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Credential ranking</text>
+  <text x="489" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">VEX/OpenVEX engine</text>
+  <text x="489" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL APIs</text>
+  <text x="489" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NVD CVSS v3.1/v4</text>
+  <text x="489" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">FIRST EPSS scores</text>
+  <text x="489" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">CISA KEV catalog</text>
+  <text x="489" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OpenSSF Scorecard</text>
+  <text x="489" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">scanners/__init__.py</text>
+  <text x="489" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">cvss.py · vex.py</text>
 
-  <!-- Arrow -->
-  <path d="M558 147 L572 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M568 142 L576 147 L568 152" fill="#4b5563"/>
+  <!-- Arrow 4→5 -->
+  <path d="M550 170 L562 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
+  <path d="M559 166 L565 170 L559 174" fill="#484f58"/>
 
   <!-- ─── STAGE 5: ANALYZE ─── -->
-  <rect x="578" y="62" width="120" height="170" rx="12" fill="#2d1215" stroke="#f87171" stroke-width="2"/>
-  <rect x="578" y="62" width="120" height="30" rx="12" fill="#dc2626"/>
-  <rect x="578" y="80" width="120" height="12" fill="#dc2626"/>
-  <text x="638" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
-  <text x="638" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fca5a5">Blast Radius</text>
-  <text x="638" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">CVE → pkg → server</text>
-  <text x="638" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">→ agent → credentials</text>
-  <text x="638" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#fca5a5">Context Graph</text>
-  <text x="638" y="174" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Lateral movement</text>
-  <text x="638" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">BFS attack paths</text>
-  <text x="638" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Toxic combinations</text>
-  <text x="638" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#f87171">Posture scorecard A-F</text>
+  <rect x="566" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#f85149" stroke-width="2"/>
+  <rect x="566" y="62" width="122" height="26" rx="10" fill="#da3633"/>
+  <rect x="566" y="78" width="122" height="10" fill="#da3633"/>
+  <text x="627" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑤ ANALYZE</text>
+  <text x="627" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149">100% PROPRIETARY</text>
+  <text x="627" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Blast Radius engine</text>
+  <text x="627" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Context Graph + BFS</text>
+  <text x="627" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Lateral movement paths</text>
+  <text x="627" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Toxic combo detector</text>
+  <text x="627" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Risk Analyzer (7 caps)</text>
+  <text x="627" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">8 dangerous patterns</text>
+  <text x="627" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Posture scorecard A-F</text>
+  <text x="627" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Incident correlation</text>
+  <text x="627" y="214" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Fleet trust scoring</text>
+  <text x="627" y="226" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Dependency graph walk</text>
+  <text x="627" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#f85149">blast_radius.py</text>
+  <text x="627" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#f85149">context_graph.py</text>
 
-  <!-- Arrow -->
-  <path d="M698 147 L712 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M708 142 L716 147 L708 152" fill="#4b5563"/>
+  <!-- Arrow 5→6 -->
+  <path d="M688 170 L700 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
+  <path d="M697 166 L703 170 L697 174" fill="#484f58"/>
 
   <!-- ─── STAGE 6: COMPLY ─── -->
-  <rect x="718" y="62" width="120" height="170" rx="12" fill="#1a1028" stroke="#a78bfa" stroke-width="2"/>
-  <rect x="718" y="62" width="120" height="30" rx="12" fill="#7c3aed"/>
-  <rect x="718" y="80" width="120" height="12" fill="#7c3aed"/>
-  <text x="778" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
-  <text x="778" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#a78bfa">10</text>
-  <text x="778" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#c4b5fd">frameworks</text>
-  <text x="778" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP LLM Top 10</text>
-  <text x="778" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP MCP Top 10</text>
-  <text x="778" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">OWASP Agentic</text>
-  <text x="778" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">MITRE ATLAS + NIST</text>
-  <text x="778" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">EU AI Act + ISO 27001</text>
-  <text x="778" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">SOC 2 + CIS v8</text>
-  <text x="778" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a78bfa">Policy-as-code engine</text>
+  <rect x="704" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="2"/>
+  <rect x="704" y="62" width="122" height="26" rx="10" fill="#8b5cf6"/>
+  <rect x="704" y="78" width="122" height="10" fill="#8b5cf6"/>
+  <text x="765" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑥ COMPLY</text>
+  <text x="765" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#a371f7">100% PROPRIETARY</text>
+  <text x="765" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">10 compliance frameworks</text>
+  <text x="765" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP LLM Top 10</text>
+  <text x="765" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP MCP Top 10</text>
+  <text x="765" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP Agentic Security</text>
+  <text x="765" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MITRE ATLAS · NIST</text>
+  <text x="765" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">EU AI Act · ISO 27001</text>
+  <text x="765" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SOC 2 · CIS v8</text>
+  <text x="765" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Policy-as-code engine</text>
+  <text x="765" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">License policy (SPDX)</text>
+  <text x="765" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Auto-remediation</text>
+  <text x="765" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a371f7">compliance.py</text>
+  <text x="765" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a371f7">policy.py · license.py</text>
 
-  <!-- Arrow -->
-  <path d="M838 147 L852 147" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M848 142 L856 147 L848 152" fill="#4b5563"/>
+  <!-- Arrow 6→7 -->
+  <path d="M826 170 L838 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
+  <path d="M835 166 L841 170 L835 174" fill="#484f58"/>
 
   <!-- ─── STAGE 7: OUTPUT ─── -->
-  <rect x="858" y="62" width="88" height="170" rx="12" fill="#0a2118" stroke="#34d399" stroke-width="2"/>
-  <rect x="858" y="62" width="88" height="30" rx="12" fill="#059669"/>
-  <rect x="858" y="80" width="88" height="12" fill="#059669"/>
-  <text x="902" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
-  <text x="902" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">CLI + HTML</text>
-  <text x="902" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">REST API</text>
-  <text x="902" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">MCP Server</text>
-  <text x="902" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Dashboard</text>
-  <text x="902" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">SARIF + SBOM</text>
-  <text x="902" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">GitHub Action</text>
-  <text x="902" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Docker/Helm</text>
+  <rect x="842" y="62" width="104" height="220" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="2"/>
+  <rect x="842" y="62" width="104" height="26" rx="10" fill="#238636"/>
+  <rect x="842" y="78" width="104" height="10" fill="#238636"/>
+  <text x="894" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑦ OUTPUT</text>
+  <text x="894" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#3fb950">13+ FORMATS</text>
+  <text x="894" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">JSON · Console · HTML</text>
+  <text x="894" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CycloneDX · SPDX</text>
+  <text x="894" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SARIF (GitHub native)</text>
+  <text x="894" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SVG badges · Mermaid</text>
+  <text x="894" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Cytoscape · ReactFlow</text>
+  <text x="894" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Attack flow graphs</text>
+  <text x="894" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">REST API (25+ routes)</text>
+  <text x="894" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MCP Server (16 tools)</text>
+  <text x="894" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Next.js Dashboard</text>
+  <text x="894" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Prometheus · OCSF</text>
+  <text x="894" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">output/__init__.py</text>
+  <text x="894" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">api.py · mcp_server.py</text>
 
-  <!-- ─── EXTERNAL APIs BAR ─── -->
-  <rect x="18" y="250" width="928" height="50" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="480" y="270" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.08em">EXTERNAL APIs</text>
-  <text x="480" y="290" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  NVIDIA  |  MCP Registry  |  OpenSSF Scorecard</text>
+  <!-- ─── EXTERNAL INTELLIGENCE BAR ─── -->
+  <rect x="14" y="300" width="932" height="52" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="480" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.08em">9 EXTERNAL INTELLIGENCE SOURCES</text>
+  <text x="480" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#8b949e">OSV.dev Batch  ·  GHSA  ·  NVD/NIST  ·  FIRST EPSS  ·  CISA KEV  ·  NVIDIA CSAF  ·  Grype DB  ·  OpenSSF Scorecard  ·  MCP Registry (427+)</text>
 
-  <!-- ─── RUNTIME BAR ─── -->
-  <rect x="18" y="310" width="928" height="40" rx="10" fill="#1a1028" stroke="#7c3aed" stroke-width="1"/>
-  <text x="480" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">RUNTIME PROTECTION</text>
-  <text x="480" y="344" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a78bfa">MCP Proxy  |  5 Detectors (drift · creds · rate · sequence · args)  |  Fleet Management  |  Alert Pipeline  |  Prometheus Metrics</text>
+  <!-- ─── INTEGRATIONS BAR ─── -->
+  <rect x="14" y="362" width="932" height="52" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="1"/>
+  <text x="480" y="380" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a371f7" letter-spacing="0.08em">RUNTIME PROTECTION + DELIVERY</text>
+  <text x="480" y="396" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a371f7">MCP Stdio Proxy · 4 Inline Scanners · 5 Detectors · Fleet Mgmt · Trust Scoring · Alert Pipeline</text>
+  <text x="480" y="406" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">GitHub Action · Docker/Helm · Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+
+  <!-- ─── INFRASTRUCTURE BAR ─── -->
+  <rect x="14" y="424" width="932" height="42" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="480" y="442" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950" letter-spacing="0.08em">INFRASTRUCTURE</text>
+  <text x="480" y="456" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#3fb950">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
 
   <!-- Footer -->
-  <text x="480" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
+  <text x="480" y="486" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime deps for core</text>
+  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#484f58">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -1,142 +1,188 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 380" fill="none">
-  <rect width="960" height="380" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+  <rect width="960" height="520" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scanner Pipeline</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">7-stage pipeline from multi-source discovery to actionable security intelligence</text>
+  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scanner Pipeline — 7-Stage Architecture</text>
+  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">Proprietary analysis engine with external intelligence feeds · 70+ modules · zero runtime dependencies for core</text>
 
   <!-- ─── STAGE 1: DISCOVER ─── -->
-  <rect x="18" y="62" width="120" height="170" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="18" y="62" width="120" height="30" rx="12" fill="#3b82f6"/>
-  <rect x="18" y="80" width="120" height="12" fill="#3b82f6"/>
-  <text x="78" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">DISCOVER</text>
-  <text x="78" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#3b82f6">18</text>
-  <text x="78" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">MCP clients</text>
-  <text x="78" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ Docker images</text>
-  <text x="78" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ Kubernetes pods</text>
-  <text x="78" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ 8 cloud providers</text>
-  <text x="78" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ AI platforms</text>
-  <text x="78" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">+ SBOMs + IaC</text>
-  <text x="78" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">427+ MCP registry</text>
+  <rect x="14" y="62" width="122" height="220" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="14" y="62" width="122" height="26" rx="10" fill="#3b82f6"/>
+  <rect x="14" y="78" width="122" height="10" fill="#3b82f6"/>
+  <text x="75" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① DISCOVER</text>
+  <text x="75" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">PROPRIETARY</text>
+  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">18 MCP clients</text>
+  <text x="75" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Docker / K8s / Terraform</text>
+  <text x="75" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">11 cloud+AI providers</text>
+  <text x="75" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">10 agent frameworks</text>
+  <text x="75" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">12 model file formats</text>
+  <text x="75" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Jupyter · GH Actions</text>
+  <text x="75" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Filesystem + lockfiles</text>
+  <text x="75" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL</text>
+  <text x="75" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">MCP Registry (427+)</text>
+  <text x="75" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Docker Hub API</text>
+  <text x="75" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">kubectl CLI</text>
+  <text x="75" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">discovery/__init__.py</text>
+  <text x="75" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">k8s.py · image.py</text>
 
-  <!-- Arrow -->
-  <path d="M138 147 L152 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M148 142 L156 147 L148 152" fill="#94a3b8"/>
+  <!-- Arrow 1→2 -->
+  <path d="M136 170 L148 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M145 166 L151 170 L145 174" fill="#94a3b8"/>
 
   <!-- ─── STAGE 2: EXTRACT ─── -->
-  <rect x="158" y="62" width="120" height="170" rx="12" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="158" y="62" width="120" height="30" rx="12" fill="#3b82f6"/>
-  <rect x="158" y="80" width="120" height="12" fill="#3b82f6"/>
-  <text x="218" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">EXTRACT</text>
-  <text x="218" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#3b82f6">11</text>
-  <text x="218" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">ecosystems</text>
-  <text x="218" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">npm · pip · Go · Cargo</text>
-  <text x="218" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Maven · NuGet · Ruby</text>
-  <text x="218" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Container layers</text>
-  <text x="218" y="188" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Model files (13 fmts)</text>
-  <text x="218" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">SAST via Semgrep</text>
-  <text x="218" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#3b82f6">CycloneDX + SPDX</text>
+  <rect x="152" y="62" width="122" height="220" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="152" y="62" width="122" height="26" rx="10" fill="#3b82f6"/>
+  <rect x="152" y="78" width="122" height="10" fill="#3b82f6"/>
+  <text x="213" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">② EXTRACT</text>
+  <text x="213" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">PROPRIETARY</text>
+  <text x="213" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">7 ecosystems parser</text>
+  <text x="213" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">npm·pip·Go·Cargo·Maven</text>
+  <text x="213" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NuGet · Ruby gems</text>
+  <text x="213" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AST framework detect</text>
+  <text x="213" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Model file inspection</text>
+  <text x="213" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SBOM ingest CDX+SPDX</text>
+  <text x="213" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Container layer extract</text>
+  <text x="213" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL</text>
+  <text x="213" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Syft (fallback scanner)</text>
+  <text x="213" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Semgrep (SAST rules)</text>
+  <text x="213" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">cosign (sig verify)</text>
+  <text x="213" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">parsers/__init__.py</text>
+  <text x="213" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">sbom.py · code_scan.py</text>
 
-  <!-- Arrow -->
-  <path d="M278 147 L292 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M288 142 L296 147 L288 152" fill="#94a3b8"/>
+  <!-- Arrow 2→3 -->
+  <path d="M274 170 L286 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M283 166 L289 170 L283 174" fill="#94a3b8"/>
 
   <!-- ─── STAGE 3: SCAN ─── -->
-  <rect x="298" y="62" width="120" height="170" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="298" y="62" width="120" height="30" rx="12" fill="#f59e0b"/>
-  <rect x="298" y="80" width="120" height="12" fill="#f59e0b"/>
-  <text x="358" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">SCAN</text>
-  <text x="358" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#d97706">7</text>
-  <text x="358" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#92400e">vuln sources</text>
-  <text x="358" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OSV.dev batch API</text>
-  <text x="358" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Grype DB + GHSA</text>
-  <text x="358" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVD / NIST CVEs</text>
-  <text x="358" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVIDIA GPU CVEs</text>
-  <text x="358" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CISA KEV catalog</text>
-  <text x="358" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">Malicious + typosquat</text>
+  <rect x="290" y="62" width="122" height="220" rx="10" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="290" y="62" width="122" height="26" rx="10" fill="#f59e0b"/>
+  <rect x="290" y="78" width="122" height="10" fill="#f59e0b"/>
+  <text x="351" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">③ SCAN</text>
+  <text x="351" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e">PROPRIETARY</text>
+  <text x="351" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OSV batch orchestrator</text>
+  <text x="351" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Malicious pkg detect</text>
+  <text x="351" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Typosquat detection</text>
+  <text x="351" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Snyk cross-reference</text>
+  <text x="351" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NVIDIA CSAF parser</text>
+  <text x="351" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL APIs</text>
+  <text x="351" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OSV.dev batch API</text>
+  <text x="351" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">GHSA advisories</text>
+  <text x="351" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Grype DB (fallback)</text>
+  <text x="351" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NVD / NIST CVE feed</text>
+  <text x="351" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NVIDIA CSAF feed</text>
+  <text x="351" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">scanners/__init__.py</text>
+  <text x="351" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">image.py · nvidia.py</text>
 
-  <!-- Arrow -->
-  <path d="M418 147 L432 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M428 142 L436 147 L428 152" fill="#94a3b8"/>
+  <!-- Arrow 3→4 -->
+  <path d="M412 170 L424 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M421 166 L427 170 L421 174" fill="#94a3b8"/>
 
   <!-- ─── STAGE 4: ENRICH ─── -->
-  <rect x="438" y="62" width="120" height="170" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="438" y="62" width="120" height="30" rx="12" fill="#f59e0b"/>
-  <rect x="438" y="80" width="120" height="12" fill="#f59e0b"/>
-  <text x="498" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ENRICH</text>
-  <text x="498" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#d97706">5</text>
-  <text x="498" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#92400e">enrichment APIs</text>
-  <text x="498" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">NVD CVSS v3.1/v4</text>
-  <text x="498" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">FIRST EPSS scores</text>
-  <text x="498" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CISA KEV status</text>
-  <text x="498" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OpenSSF Scorecard</text>
-  <text x="498" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">AI risk classification</text>
-  <text x="498" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#d97706">False positive reduction</text>
+  <rect x="428" y="62" width="122" height="220" rx="10" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="428" y="62" width="122" height="26" rx="10" fill="#f59e0b"/>
+  <rect x="428" y="78" width="122" height="10" fill="#f59e0b"/>
+  <text x="489" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">④ ENRICH</text>
+  <text x="489" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e">PROPRIETARY</text>
+  <text x="489" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CVSS 3.1 computation</text>
+  <text x="489" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AI risk classification</text>
+  <text x="489" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">False positive reducer</text>
+  <text x="489" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Conditional OWASP tag</text>
+  <text x="489" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Credential ranking</text>
+  <text x="489" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">VEX/OpenVEX engine</text>
+  <text x="489" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL APIs</text>
+  <text x="489" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NVD CVSS v3.1/v4</text>
+  <text x="489" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">FIRST EPSS scores</text>
+  <text x="489" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">CISA KEV catalog</text>
+  <text x="489" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OpenSSF Scorecard</text>
+  <text x="489" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">scanners/__init__.py</text>
+  <text x="489" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">cvss.py · vex.py</text>
 
-  <!-- Arrow -->
-  <path d="M558 147 L572 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M568 142 L576 147 L568 152" fill="#94a3b8"/>
+  <!-- Arrow 4→5 -->
+  <path d="M550 170 L562 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M559 166 L565 170 L559 174" fill="#94a3b8"/>
 
   <!-- ─── STAGE 5: ANALYZE ─── -->
-  <rect x="578" y="62" width="120" height="170" rx="12" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
-  <rect x="578" y="62" width="120" height="30" rx="12" fill="#ef4444"/>
-  <rect x="578" y="80" width="120" height="12" fill="#ef4444"/>
-  <text x="638" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">ANALYZE</text>
-  <text x="638" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#dc2626">Blast Radius</text>
-  <text x="638" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">CVE → pkg → server</text>
-  <text x="638" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">→ agent → credentials</text>
-  <text x="638" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#dc2626">Context Graph</text>
-  <text x="638" y="174" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Lateral movement</text>
-  <text x="638" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">BFS attack paths</text>
-  <text x="638" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Toxic combinations</text>
-  <text x="638" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#ef4444">Posture scorecard A-F</text>
+  <rect x="566" y="62" width="122" height="220" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <rect x="566" y="62" width="122" height="26" rx="10" fill="#ef4444"/>
+  <rect x="566" y="78" width="122" height="10" fill="#ef4444"/>
+  <text x="627" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑤ ANALYZE</text>
+  <text x="627" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b">100% PROPRIETARY</text>
+  <text x="627" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Blast Radius engine</text>
+  <text x="627" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Context Graph + BFS</text>
+  <text x="627" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Lateral movement paths</text>
+  <text x="627" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Toxic combo detector</text>
+  <text x="627" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Risk Analyzer (7 caps)</text>
+  <text x="627" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">8 dangerous patterns</text>
+  <text x="627" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Posture scorecard A-F</text>
+  <text x="627" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Incident correlation</text>
+  <text x="627" y="214" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Fleet trust scoring</text>
+  <text x="627" y="226" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Dependency graph walk</text>
+  <text x="627" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#ef4444">blast_radius.py</text>
+  <text x="627" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#ef4444">context_graph.py</text>
 
-  <!-- Arrow -->
-  <path d="M698 147 L712 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M708 142 L716 147 L708 152" fill="#94a3b8"/>
+  <!-- Arrow 5→6 -->
+  <path d="M688 170 L700 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M697 166 L703 170 L697 174" fill="#94a3b8"/>
 
   <!-- ─── STAGE 6: COMPLY ─── -->
-  <rect x="718" y="62" width="120" height="170" rx="12" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
-  <rect x="718" y="62" width="120" height="30" rx="12" fill="#8b5cf6"/>
-  <rect x="718" y="80" width="120" height="12" fill="#8b5cf6"/>
-  <text x="778" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">COMPLY</text>
-  <text x="778" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="22" font-weight="800" fill="#7c3aed">10</text>
-  <text x="778" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6d28d9">frameworks</text>
-  <text x="778" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP LLM Top 10</text>
-  <text x="778" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP MCP Top 10</text>
-  <text x="778" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">OWASP Agentic</text>
-  <text x="778" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">MITRE ATLAS + NIST</text>
-  <text x="778" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">EU AI Act + ISO 27001</text>
-  <text x="778" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">SOC 2 + CIS v8</text>
-  <text x="778" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">Policy-as-code engine</text>
+  <rect x="704" y="62" width="122" height="220" rx="10" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
+  <rect x="704" y="62" width="122" height="26" rx="10" fill="#8b5cf6"/>
+  <rect x="704" y="78" width="122" height="10" fill="#8b5cf6"/>
+  <text x="765" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑥ COMPLY</text>
+  <text x="765" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#6d28d9">100% PROPRIETARY</text>
+  <text x="765" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">10 compliance frameworks</text>
+  <text x="765" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP LLM Top 10</text>
+  <text x="765" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP MCP Top 10</text>
+  <text x="765" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP Agentic Security</text>
+  <text x="765" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MITRE ATLAS · NIST</text>
+  <text x="765" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">EU AI Act · ISO 27001</text>
+  <text x="765" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SOC 2 · CIS v8</text>
+  <text x="765" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Policy-as-code engine</text>
+  <text x="765" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">License policy (SPDX)</text>
+  <text x="765" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Auto-remediation</text>
+  <text x="765" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#8b5cf6">compliance.py</text>
+  <text x="765" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#8b5cf6">policy.py · license.py</text>
 
-  <!-- Arrow -->
-  <path d="M838 147 L852 147" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M848 142 L856 147 L848 152" fill="#94a3b8"/>
+  <!-- Arrow 6→7 -->
+  <path d="M826 170 L838 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
+  <path d="M835 166 L841 170 L835 174" fill="#94a3b8"/>
 
   <!-- ─── STAGE 7: OUTPUT ─── -->
-  <rect x="858" y="62" width="88" height="170" rx="12" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
-  <rect x="858" y="62" width="88" height="30" rx="12" fill="#10b981"/>
-  <rect x="858" y="80" width="88" height="12" fill="#10b981"/>
-  <text x="902" y="83" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#ffffff">OUTPUT</text>
-  <text x="902" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">CLI + HTML</text>
-  <text x="902" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">REST API</text>
-  <text x="902" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">MCP Server</text>
-  <text x="902" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">Dashboard</text>
-  <text x="902" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">SARIF + SBOM</text>
-  <text x="902" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">GitHub Action</text>
-  <text x="902" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#059669">Docker/Helm</text>
+  <rect x="842" y="62" width="104" height="220" rx="10" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+  <rect x="842" y="62" width="104" height="26" rx="10" fill="#10b981"/>
+  <rect x="842" y="78" width="104" height="10" fill="#10b981"/>
+  <text x="894" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑦ OUTPUT</text>
+  <text x="894" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#065f46">13+ FORMATS</text>
+  <text x="894" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">JSON · Console · HTML</text>
+  <text x="894" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CycloneDX · SPDX</text>
+  <text x="894" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SARIF (GitHub native)</text>
+  <text x="894" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SVG badges · Mermaid</text>
+  <text x="894" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Cytoscape · ReactFlow</text>
+  <text x="894" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Attack flow graphs</text>
+  <text x="894" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">REST API (25+ routes)</text>
+  <text x="894" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MCP Server (16 tools)</text>
+  <text x="894" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Next.js Dashboard</text>
+  <text x="894" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Prometheus · OCSF</text>
+  <text x="894" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#10b981">output/__init__.py</text>
+  <text x="894" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#10b981">api.py · mcp_server.py</text>
 
-  <!-- ─── EXTERNAL APIs BAR ─── -->
-  <rect x="18" y="250" width="928" height="50" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="480" y="270" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#64748b" letter-spacing="0.08em">EXTERNAL APIs</text>
-  <text x="480" y="290" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#475569">OSV.dev  |  NVD/NIST  |  FIRST EPSS  |  CISA KEV  |  Grype DB  |  GHSA  |  NVIDIA  |  MCP Registry  |  OpenSSF Scorecard</text>
+  <!-- ─── EXTERNAL INTELLIGENCE BAR ─── -->
+  <rect x="14" y="300" width="932" height="52" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="480" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#475569" letter-spacing="0.08em">9 EXTERNAL INTELLIGENCE SOURCES</text>
+  <text x="480" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#64748b">OSV.dev Batch  ·  GHSA  ·  NVD/NIST  ·  FIRST EPSS  ·  CISA KEV  ·  NVIDIA CSAF  ·  Grype DB  ·  OpenSSF Scorecard  ·  MCP Registry (427+)</text>
 
-  <!-- ─── RUNTIME BAR ─── -->
-  <rect x="18" y="310" width="928" height="40" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="480" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">RUNTIME PROTECTION</text>
-  <text x="480" y="344" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">MCP Proxy  |  5 Detectors (drift · creds · rate · sequence · args)  |  Fleet Management  |  Alert Pipeline  |  Prometheus Metrics</text>
+  <!-- ─── INTEGRATIONS BAR ─── -->
+  <rect x="14" y="362" width="932" height="52" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="480" y="380" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">RUNTIME PROTECTION + DELIVERY</text>
+  <text x="480" y="396" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">MCP Stdio Proxy · 4 Inline Scanners · 5 Detectors · Fleet Mgmt · Trust Scoring · Alert Pipeline</text>
+  <text x="480" y="406" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b5cf6">GitHub Action · Docker/Helm · Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+
+  <!-- ─── INFRASTRUCTURE BAR ─── -->
+  <rect x="14" y="424" width="932" height="42" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="480" y="442" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#166534" letter-spacing="0.08em">INFRASTRUCTURE</text>
+  <text x="480" y="456" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#15803d">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
 
   <!-- Footer -->
-  <text x="480" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Only package names sent to APIs  |  Sigstore signed  |  Apache 2.0</text>
+  <text x="480" y="486" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#475569">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime deps for core</text>
+  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>


### PR DESCRIPTION
## Summary

- Redesigned all 6 README SVGs (enterprise-overview, scanner-architecture, scan-workflow — light + dark) based on a thorough 107-module codebase audit
- Every diagram now shows the full depth: 18 MCP clients, 11 cloud/AI providers, 10 agent frameworks, 12 model file formats, 7 ecosystems, 9 vuln sources, 4 inline scanners, 5 detectors, 10 compliance frameworks, 13+ output formats
- Clear **PROPRIETARY vs EXTERNAL** labels at every stage — Stage 5 (Analyze) and Stage 6 (Comply) marked "100% PROPRIETARY"
- Source file references in each section so readers can trace diagrams to code
- Footer with accurate module breakdown: ~70 proprietary | ~15 hybrid | ~22 external | 0 runtime deps for core

## Test plan

- [ ] Verify all 6 SVGs render correctly on GitHub (light + dark mode)
- [ ] Confirm no broken XML/SVG syntax
- [ ] Visual review of enterprise-overview, scanner-architecture, scan-workflow