### PR TITLE
chore: bump version 0.50.0 → 0.51.0

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           agent-bom scan --sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.50.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.51.0"}},"results":[]}]}' > results.sarif
           fi
       - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         if: always()

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.50.0
+ARG VERSION=0.51.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.50.0
+ARG VERSION=0.51.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.50.0"
+  --version "0.51.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.50.0
-git push origin v0.50.0
+git tag v0.51.0
+git push origin v0.51.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
   </picture>
 </p>
 
-1. **Discover** — auto-detect MCP configs across 18 clients (Claude Desktop, Cursor, Codex CLI, Gemini CLI, Goose, etc.)
+1. **Discover** — auto-detect MCP configs across 20 clients (Claude Desktop, Cursor, JetBrains AI, Junie, Codex CLI, Gemini CLI, Goose, etc.)
 2. **Extract** — pull server names, package names, env var **names**, and tool lists. Credential **values** are never read.
 3. **Scan** — send only package names + versions to public APIs (OSV.dev, NVD, EPSS, CISA KEV). NVD status tracking (Analyzed/Modified/Rejected) with remediation links.
 4. **Analyze** — CVE blast radius mapping, per-CVE compliance tagging across 10 frameworks, tool poisoning detection (`--enforce`), model provenance
@@ -94,7 +94,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 ```mermaid
 graph TB
     subgraph Input["Input Sources"]
-        MCP["MCP Configs\n18 Clients"]
+        MCP["MCP Configs\n20 Clients"]
         Docker["Docker Images"]
         K8s["Kubernetes"]
         Cloud["Cloud APIs\nAWS / Azure / GCP / Snowflake"]
@@ -148,7 +148,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full set of architectur
 |---|---|---|
 | Package CVE detection | Yes | Yes — OSV + NVD CVSS v4 + EPSS + CISA KEV + GHSA + NVIDIA CSAF + NVD status tracking |
 | SBOM generation | Yes (Syft) | Yes — CycloneDX 1.6, SPDX 3.0, SARIF |
-| **AI agent discovery** | — | 18 MCP clients + Docker Compose auto-discovered |
+| **AI agent discovery** | — | 20 MCP clients + Docker Compose auto-discovered |
 | **Blast radius mapping** | — | CVE → package → server → agent → credentials → tools |
 | **Credential exposure** | — | Which secrets leak per vulnerability, per agent |
 | **MCP tool reachability** | — | Which tools an attacker reaches post-exploit |
@@ -199,7 +199,7 @@ Auto-discovers Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Cop
 
 | Source | How |
 |--------|-----|
-| MCP configs | Auto-discover (18 clients + Docker Compose) |
+| MCP configs | Auto-discover (20 clients + Docker Compose) |
 | Docker images | Grype / Syft / Docker CLI fallback |
 | Kubernetes | kubectl across namespaces |
 | Cloud providers | AWS, Azure, GCP, Databricks, Snowflake, Nebius |
@@ -228,7 +228,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.50.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.51.0` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -490,7 +490,7 @@ Both sources deduplicate by CVE ID against OSV results.
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.50.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.51.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Opt-in MCP traffic audit (per-server) |
@@ -502,7 +502,7 @@ Both sources deduplicate by CVE ID against OSV results.
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.50.0
+- uses: msaad00/agent-bom@v0.51.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -630,7 +630,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 | **AI frameworks** | Dependency scan | LangChain, LlamaIndex, AutoGen, PyTorch, JAX, TensorFlow |
 | **Inference servers** | `--image` | vLLM, Triton, TGI, llama.cpp |
 | **MLOps** | Dependency scan | MLflow, W&B, Ray, ClearML |
-| **MCP ecosystem** | Auto-discovery + registry | 18 clients, 427+ servers |
+| **MCP ecosystem** | Auto-discovery + registry | 20 clients, 427+ servers |
 | **LLM providers** | API key + SDK detection | OpenAI, Anthropic, Cohere, Mistral |
 | **IaC + CI/CD** | `--tf-dir`, `--gha` | Terraform AI resources, GitHub Actions |
 
@@ -644,7 +644,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.50.0` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.51.0` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 
@@ -656,7 +656,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - [x] Cloud AI inventory — AWS Bedrock, Azure AI Foundry, GCP Vertex, Snowflake Cortex, Databricks, Nebius
 - [x] Tool poisoning / prompt injection detection — `--enforce` with description injection, capability combos, CVE exposure, drift
 - [x] Model weight provenance — SHA-256 hash, Sigstore file detection, HuggingFace metadata (`--model-provenance`, `--hf-model`)
-- [x] 18 MCP client discovery — Codex CLI, Gemini CLI, Goose, Snowflake CLI, full Cortex Code (CoCo) coverage
+- [x] 20 MCP client discovery — JetBrains AI, Junie, Codex CLI, Gemini CLI, Goose, Snowflake CLI, full Cortex Code (CoCo) coverage
 - [x] K8s AI workload discovery — `--k8s --all-namespaces` with pod-level scanning
 - [x] OWASP MCP Top 10 compliance mapping — MCP01–MCP10 risk tagging
 - [x] Malicious package detection — OSV MAL- prefix flagging + typosquat heuristics

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: AI supply chain security scanner — scan containers, MCP servers, and AI agents for CVEs, credential exposure, and compliance violations
 version: 0.1.0
-appVersion: "0.50.0"
+appVersion: "0.51.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: msaad02/agent-bom
-  tag: "0.50.0"
+  tag: "0.51.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: msaad02/agent-bom-runtime
-  tag: "0.50.0"
+  tag: "0.51.0"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.50.0
+- uses: msaad00/agent-bom@v0.51.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -212,7 +212,7 @@
 
   <!-- ─── FOOTER ─── -->
   <rect x="20" y="652" width="920" height="2" rx="1" fill="#21262d"/>
-  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">18 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
+  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">20 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
   <text x="480" y="694" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  SLSA provenance  |  OpenSSF scored  |  Apache 2.0</text>
   <text x="480" y="716" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#34d399">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
 

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -222,7 +222,7 @@
 
   <!-- ─── FOOTER ─── -->
   <rect x="20" y="652" width="920" height="2" rx="1" fill="#e2e8f0"/>
-  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">18 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
+  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">20 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
   <text x="480" y="694" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  SLSA provenance  |  OpenSSF scored  |  Apache 2.0</text>
   <text x="480" y="716" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#059669">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
 

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -11,7 +11,7 @@
   <rect x="14" y="78" width="122" height="10" fill="#1f6feb"/>
   <text x="75" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① DISCOVER</text>
   <text x="75" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">PROPRIETARY</text>
-  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">18 MCP clients</text>
+  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">20 MCP clients</text>
   <text x="75" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Docker / K8s / Terraform</text>
   <text x="75" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">11 cloud+AI providers</text>
   <text x="75" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">10 agent frameworks</text>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -11,7 +11,7 @@
   <rect x="14" y="78" width="122" height="10" fill="#3b82f6"/>
   <text x="75" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① DISCOVER</text>
   <text x="75" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">PROPRIETARY</text>
-  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">18 MCP clients</text>
+  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">20 MCP clients</text>
   <text x="75" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Docker / K8s / Terraform</text>
   <text x="75" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">11 cloud+AI providers</text>
   <text x="75" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">10 agent frameworks</text>

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   compliance (OWASP, MITRE ATLAS, EU AI Act, NIST AI RMF). Use when the user
   mentions vulnerability scanning, dependency security, SBOM generation, MCP server
   trust, or AI supply chain risk.
-version: 0.50.0
+version: 0.51.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Docker for container
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.50.0
+    docker: ghcr.io/msaad00/agent-bom:0.51.0
   openclaw:
     requires:
       bins: []
@@ -82,7 +82,7 @@ agent-bom where             # show all discovery paths
 ### As a Docker Container
 
 ```bash
-docker run --rm ghcr.io/msaad00/agent-bom:0.50.0 scan
+docker run --rm ghcr.io/msaad00/agent-bom:0.51.0 scan
 ```
 
 ### Self-Hosted SSE Server
@@ -182,7 +182,7 @@ installation or self-host your own instance.
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: 99/100 quality score
-- **Sigstore signed**: `agent-bom verify agent-bom@0.50.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.51.0`
 - **2,700+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.50.0
+ARG VERSION=0.51.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.50.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.51.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.50.0": {
+        "ghcr.io/msaad00/agent-bom:v0.51.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.50.0"
+version = "0.51.0"
 description = "AI supply chain security scanner — CVEs, blast radius, credential exposure, 10-framework compliance (OWASP LLM/MCP/Agentic + MITRE ATLAS + NIST AI RMF + EU AI Act + NIST CSF + ISO 27001 + SOC 2 + CIS). 18 MCP clients, 16 tools, GPU/container/K8s scanning."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.50.0"
+    __version__ = "0.51.0"

--- a/tests/test_api_pipeline_events.py
+++ b/tests/test_api_pipeline_events.py
@@ -1,4 +1,4 @@
-"""Tests for structured scan pipeline SSE events (v0.50.0)."""
+"""Tests for structured scan pipeline SSE events (v0.51.0)."""
 
 from __future__ import annotations
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.50.0"
+    assert __version__ == "0.51.0"
 
 
 def test_report_version_matches():
@@ -2933,7 +2933,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.50.0"
+    assert data["version"] == "0.51.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 

--- a/tests/test_dynamic_discovery.py
+++ b/tests/test_dynamic_discovery.py
@@ -1,4 +1,4 @@
-"""Tests for dynamic MCP configuration discovery (v0.50.0)."""
+"""Tests for dynamic MCP configuration discovery (v0.51.0)."""
 
 from __future__ import annotations
 

--- a/tests/test_ocsf.py
+++ b/tests/test_ocsf.py
@@ -79,11 +79,11 @@ class TestOCSFFormat:
         assert isinstance(fi["types"], list)
 
     def test_metadata_product(self):
-        ocsf = to_ocsf_detection_finding(_sample_alert(), product_version="0.50.0")
+        ocsf = to_ocsf_detection_finding(_sample_alert(), product_version="0.51.0")
         meta = ocsf["metadata"]
         assert meta["product"]["name"] == "agent-bom"
         assert meta["product"]["vendor_name"] == "msaad00"
-        assert meta["product"]["version"] == "0.50.0"
+        assert meta["product"]["version"] == "0.51.0"
         assert meta["version"] == "1.1.0"
 
     def test_evidences(self):
@@ -136,7 +136,7 @@ class TestSeverityMapping:
 class TestOCSFBatch:
     def test_batch_converts_all(self):
         alerts = [_sample_alert(severity=s) for s in ("critical", "high", "low")]
-        batch = to_ocsf_batch(alerts, "0.50.0")
+        batch = to_ocsf_batch(alerts, "0.51.0")
         assert len(batch) == 3
         assert all(b["class_uid"] == 2004 for b in batch)
 


### PR DESCRIPTION
## Summary

- Version bump across 22 files for v0.51.0 release
- Update MCP client count 18 → 20 in README, Mermaid diagrams, and SVGs (JetBrains AI + Junie from #175)

## After merge

```bash
git tag v0.51.0 && git push origin v0.51.0
```

This triggers: PyPI publish, Docker Hub, GHCR, Sigstore signing, SLSA provenance, GitHub Release.

## Test plan

- [x] All 2,885 tests passing
- [x] Version strings consistent across all 22 files