### PR TITLE
feat: redesign README diagrams as real architecture visuals

### DIFF
--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -1,221 +1,387 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 740" fill="none">
-  <rect width="960" height="740" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" fill="none">
+  <defs>
+    <marker id="eo-arr" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#484f58"/></marker>
+    <marker id="eo-arr-b" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#1f6feb"/></marker>
+    <marker id="eo-arr-a" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#d29922"/></marker>
+    <marker id="eo-arr-r" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#f85149"/></marker>
+    <marker id="eo-arr-g" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#3fb950"/></marker>
+    <marker id="eo-arr-p" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#a371f7"/></marker>
+  </defs>
 
-  <!-- ─── ROW 1: MULTI-SOURCE DISCOVERY ─── -->
-  <rect x="20" y="16" width="920" height="200" rx="12" fill="#161b22" stroke="#1d4ed8" stroke-width="1.2"/>
-  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.1em">MULTI-SOURCE DISCOVERY</text>
+  <rect width="960" height="700" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
-  <rect x="34" y="48" width="168" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">MCP Agents</text>
-  <text x="118" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">18</text>
-  <text x="118" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">clients auto-detected</text>
-  <text x="118" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Claude · Cursor · Codex · Gemini</text>
-  <text x="118" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Goose · Windsurf · Zed · Cline</text>
-  <text x="118" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Snowflake CLI · Roo + 8 more</text>
-  <text x="118" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">427+ server threat registry</text>
-  <text x="118" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">+ MCP Registry + Smithery.ai</text>
-  <text x="118" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Docker Compose discovery</text>
+  <!-- Title -->
+  <text x="480" y="24" text-anchor="middle" font-family="system-ui, sans-serif" font-size="15" font-weight="700" fill="#e6edf3">Enterprise Architecture — 4-Layer System Overview</text>
+  <text x="480" y="40" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#8b949e">Multi-source discovery → analysis → output with runtime protection sidecar</text>
 
-  <rect x="214" y="48" width="148" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="288" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Infrastructure</text>
-  <text x="288" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">Docker Images</text>
-  <text x="288" y="100" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Grype · Syft · Docker CLI</text>
-  <text x="288" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Multi-arch · Private registry</text>
-  <text x="288" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">Kubernetes</text>
-  <text x="288" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">All namespaces · Pod images</text>
-  <text x="288" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">EKS · GKE · AKS · CoreWeave</text>
-  <text x="288" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">Terraform IaC</text>
-  <text x="288" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Bedrock · SageMaker · Azure AI</text>
-  <text x="288" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Filesystem / disk snapshots</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 1: MULTI-SOURCE DISCOVERY (8 input nodes → merge node)        -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="52" width="750" height="120" rx="10" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
+  <text x="389" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff" letter-spacing="0.08em">LAYER 1 — MULTI-SOURCE DISCOVERY</text>
 
-  <rect x="374" y="48" width="194" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="471" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Cloud &amp; AI Providers</text>
-  <text x="471" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#60a5fa">11</text>
-  <text x="471" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">platform integrations</text>
-  <text x="471" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">AWS Bedrock · Lambda · ECS · EKS</text>
-  <text x="471" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Azure AI · GCP Vertex · Snowflake</text>
-  <text x="471" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Databricks · Nebius GPU Cloud</text>
-  <text x="471" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">HuggingFace · MLflow · W&amp;B</text>
-  <text x="471" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OpenAI Assistants · Ollama</text>
-  <text x="471" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">Governance + Observability</text>
-  <text x="471" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Cortex telemetry · agent health</text>
+  <!-- Input nodes row 1 -->
+  <rect x="24" y="78" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="68" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">MCP Agents</text>
+  <text x="68" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">20 clients</text>
 
-  <rect x="580" y="48" width="160" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="660" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">AI/ML Deep Scan</text>
-  <text x="660" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">10 agent frameworks</text>
-  <text x="660" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">LangChain · CrewAI · AutoGen</text>
-  <text x="660" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OpenAI SDK · Google ADK + 5</text>
-  <text x="660" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">12 model file formats</text>
-  <text x="660" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">GGUF · SafeTensors · ONNX</text>
-  <text x="660" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">PyTorch · TF · CoreML + 6</text>
-  <text x="660" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Sigstore + SLSA provenance</text>
-  <text x="660" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Jupyter notebook scanning</text>
-  <text x="660" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">GitHub Actions scanning</text>
+  <rect x="118" y="78" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="162" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">Docker / K8s</text>
+  <text x="162" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">Images + Pods</text>
 
-  <rect x="752" y="48" width="176" height="156" rx="10" fill="#0d1117" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="840" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#93c5fd">Code &amp; Supply Chain</text>
-  <text x="840" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">7 package ecosystems</text>
-  <text x="840" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">npm · pip · Go · Cargo · Maven</text>
-  <text x="840" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NuGet · Ruby + transitive deps</text>
-  <text x="840" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#93c5fd">SBOMs · SAST · Integrity</text>
-  <text x="840" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">CycloneDX · SPDX ingestion</text>
-  <text x="840" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Semgrep SAST (CWE mapping)</text>
-  <text x="840" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">npm/PyPI SHA integrity</text>
-  <text x="840" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">SLSA + PEP 740 attestations</text>
-  <text x="840" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#60a5fa">deps.dev transitive resolution</text>
+  <rect x="212" y="78" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="256" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">Cloud / AI</text>
+  <text x="256" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">11 providers</text>
 
-  <path d="M480 216 L480 236" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M474 230 L480 240 L486 230" fill="#4b5563"/>
+  <rect x="306" y="78" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="350" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">AI/ML Models</text>
+  <text x="350" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">10 fwks · 12 fmts</text>
 
-  <!-- ─── ROW 2: PROPRIETARY ANALYSIS ENGINE ─── -->
-  <rect x="20" y="244" width="700" height="242" rx="12" fill="#161b22" stroke="#d97706" stroke-width="1.2"/>
-  <text x="370" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24" letter-spacing="0.1em">PROPRIETARY ANALYSIS ENGINE — 70+ MODULES</text>
+  <!-- Input nodes row 2 -->
+  <rect x="24" y="122" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="68" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">Code / Pkgs</text>
+  <text x="68" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">7 ecosystems</text>
 
-  <rect x="34" y="276" width="214" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="141" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Vuln Intelligence</text>
-  <text x="141" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">OSV · GHSA · NVIDIA · Snyk · Grype</text>
-  <text x="141" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">NVD CVSS · EPSS · KEV · Scorecard</text>
+  <rect x="118" y="122" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="162" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">SBOM Ingest</text>
+  <text x="162" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">CDX + SPDX</text>
 
-  <path d="M252 304 L264 304" stroke="#f59e0b" stroke-width="2"/>
-  <path d="M260 300 L267 304 L260 308" fill="#f59e0b"/>
+  <rect x="212" y="122" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="256" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">Integrity</text>
+  <text x="256" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">SHA · SLSA · PEP 740</text>
 
-  <rect x="270" y="276" width="200" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="370" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Blast Radius Engine</text>
-  <text x="370" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">CVE → pkg → server → agent → creds → tools</text>
-  <text x="370" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">Configurable weighted risk scoring</text>
+  <rect x="306" y="122" width="88" height="36" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1.2"/>
+  <text x="350" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#58a6ff">Filesystem</text>
+  <text x="350" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#1f6feb">Lockfiles + AST</text>
 
-  <path d="M474 304 L486 304" stroke="#f59e0b" stroke-width="2"/>
-  <path d="M482 300 L489 304 L482 308" fill="#f59e0b"/>
+  <!-- Merge/Extract node -->
+  <rect x="430" y="90" width="110" height="54" rx="8" fill="#1f6feb" stroke="#58a6ff" stroke-width="1.5"/>
+  <text x="485" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">Extract +</text>
+  <text x="485" y="126" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">Parse</text>
+  <text x="485" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a5d8ff">Syft · Semgrep ext</text>
 
-  <rect x="492" y="276" width="212" height="56" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="598" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fbbf24">Context Graph + BFS</text>
-  <text x="598" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">Lateral movement attack paths</text>
-  <text x="598" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#d97706">PageRank · Betweenness centrality</text>
+  <!-- Converging arrows from 8 nodes to Extract -->
+  <path d="M112 96 L430 110" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M206 96 L430 112" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M300 96 L430 114" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M394 96 L430 116" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M112 140 L430 120" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M206 140 L430 122" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M300 140 L430 124" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M394 140 L430 126" stroke="#1f6feb" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
 
-  <rect x="34" y="342" width="130" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="99" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">10 Frameworks</text>
-  <text x="99" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">OWASP LLM+MCP+Agentic</text>
-  <text x="99" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">ATLAS · NIST · EU AI +4</text>
+  <!-- Extract output arrow down to Layer 2 -->
+  <path d="M485 144 L485 180" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#eo-arr)"/>
 
-  <rect x="172" y="342" width="130" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="237" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Posture Score</text>
-  <text x="237" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Grade A-F · 6 dimensions</text>
-  <text x="237" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Weighted enterprise score</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION SIDEBAR (right column, spans layers 1-2)         -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="776" y="52" width="170" height="304" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="1.5"/>
+  <text x="861" y="70" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#d2a8ff" letter-spacing="0.06em">RUNTIME PROTECTION</text>
 
-  <rect x="310" y="342" width="130" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="375" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Incidents</text>
-  <text x="375" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">P1-P4 priority by agent</text>
-  <text x="375" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">SOC-ready OCSF v1.1</text>
+  <rect x="786" y="80" width="150" height="36" rx="6" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="861" y="96" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#d2a8ff">MCP Stdio Proxy</text>
+  <text x="861" y="108" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a371f7">JSON-RPC intercept · audit</text>
 
-  <rect x="448" y="342" width="124" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="510" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Toxic Combos</text>
-  <text x="510" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">KEV+creds · RCE+exec</text>
-  <text x="510" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Malicious · Typosquat</text>
+  <!-- Arrow down inside sidebar -->
+  <path d="M861 116 L861 126" stroke="#a371f7" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="580" y="342" width="124" height="56" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="1"/>
-  <text x="642" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Cred Ranking</text>
-  <text x="642" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Risk tiers by exposure</text>
-  <text x="642" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Cross-agent aggregation</text>
+  <rect x="786" y="130" width="72" height="28" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="822" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#d2a8ff">Injection</text>
+  <rect x="864" y="130" width="72" height="28" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="900" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#d2a8ff">PII</text>
+  <rect x="786" y="164" width="72" height="28" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="822" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#d2a8ff">Secrets</text>
+  <rect x="864" y="164" width="72" height="28" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="900" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#d2a8ff">Payloads</text>
 
-  <rect x="34" y="408" width="164" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
-  <text x="116" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Policy-as-Code Engine</text>
-  <text x="116" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">YAML rules · pass/fail/warn</text>
+  <!-- Arrow down to detectors -->
+  <path d="M861 192 L861 202" stroke="#a371f7" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="206" y="408" width="120" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
-  <text x="266" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">License Policy</text>
-  <text x="266" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">SPDX · block/warn rules</text>
+  <rect x="786" y="206" width="150" height="28" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="861" y="224" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#d2a8ff">5 Detectors</text>
 
-  <rect x="334" y="408" width="108" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
-  <text x="388" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">VEX / OpenVEX</text>
-  <text x="388" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">Exploit status mgmt</text>
+  <rect x="786" y="240" width="46" height="20" rx="4" fill="#161b22" stroke="#a371f7" stroke-width="0.8"/>
+  <text x="809" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#d2a8ff">Drift</text>
+  <rect x="836" y="240" width="46" height="20" rx="4" fill="#161b22" stroke="#a371f7" stroke-width="0.8"/>
+  <text x="859" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#d2a8ff">Creds</text>
+  <rect x="886" y="240" width="46" height="20" rx="4" fill="#161b22" stroke="#a371f7" stroke-width="0.8"/>
+  <text x="909" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#d2a8ff">Rate</text>
+  <rect x="806" y="264" width="46" height="20" rx="4" fill="#161b22" stroke="#a371f7" stroke-width="0.8"/>
+  <text x="829" y="278" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#d2a8ff">Seq</text>
+  <rect x="856" y="264" width="46" height="20" rx="4" fill="#161b22" stroke="#a371f7" stroke-width="0.8"/>
+  <text x="879" y="278" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#d2a8ff">Args</text>
 
-  <rect x="450" y="408" width="120" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
-  <text x="510" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">Risk Analyzer</text>
-  <text x="510" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">7 tool capabilities · 8 combos</text>
+  <!-- Arrow down to fleet/trust -->
+  <path d="M861 284 L861 294" stroke="#a371f7" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="578" y="408" width="128" height="42" rx="8" fill="#1c1917" stroke="#d97706" stroke-width="0.8"/>
-  <text x="642" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24">CVSS 3.1 Compute</text>
-  <text x="642" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">AV/AC/PR/UI/S/C/I/A</text>
+  <rect x="786" y="298" width="72" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="822" y="313" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#d2a8ff">Fleet Mgmt</text>
+  <rect x="864" y="298" width="72" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="900" y="313" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#d2a8ff">Trust Score</text>
 
-  <text x="370" y="474" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" font-weight="600" fill="#d97706">+ AI enrichment (Ollama/HuggingFace/litellm) · Baseline comparison · Trend tracking · Multi-source correlation · OTel trace ingest</text>
+  <rect x="786" y="326" width="150" height="20" rx="4" fill="#a371f7" opacity="0.2"/>
+  <text x="861" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#d2a8ff">Slack · Jira · Webhooks</text>
 
-  <!-- ─── SIDEBAR: RUNTIME PROTECTION ─── -->
-  <rect x="736" y="244" width="204" height="242" rx="12" fill="#161b22" stroke="#7c3aed" stroke-width="1.2"/>
-  <text x="838" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.1em">RUNTIME PROTECTION</text>
+  <!-- Dashed arrow from sidebar into Layer 2 -->
+  <path d="M776 240 L764 240" stroke="#a371f7" stroke-width="1.2" fill="none" stroke-dasharray="4 3" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="748" y="278" width="180" height="52" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="838" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#c4b5fd">MCP Stdio Proxy</text>
-  <text x="838" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">JSON-RPC intercept · audit log</text>
-  <text x="838" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Policy enforce · replay detect</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 2: PROPRIETARY ANALYSIS ENGINE (3 rows of connected nodes)    -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="182" width="750" height="174" rx="10" fill="#161b22" stroke="#d29922" stroke-width="1"/>
+  <text x="389" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341" letter-spacing="0.08em">LAYER 2 — PROPRIETARY ANALYSIS ENGINE (70+ modules)</text>
 
-  <rect x="748" y="336" width="180" height="40" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="838" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#c4b5fd">4 Inline Scanners</text>
-  <text x="838" y="366" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Injection · PII · Secrets · Payloads</text>
+  <!-- Row 2a: Scan + Enrich pipeline -->
+  <rect x="24" y="208" width="88" height="36" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.2"/>
+  <text x="68" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">Vuln Scan</text>
+  <text x="68" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d29922">9 sources</text>
 
-  <rect x="748" y="382" width="180" height="40" rx="8" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="838" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#c4b5fd">5 Detectors</text>
-  <text x="838" y="412" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Drift · Creds · Rate · Seq · Args</text>
+  <path d="M112 226 L126 226" stroke="#d29922" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="748" y="428" width="86" height="28" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="791" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#c4b5fd">Fleet Mgmt</text>
+  <rect x="130" y="208" width="88" height="36" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.2"/>
+  <text x="174" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">CVSS 3.1</text>
+  <text x="174" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d29922">Compute</text>
 
-  <rect x="842" y="428" width="86" height="28" rx="6" fill="#0d1117" stroke="#7c3aed" stroke-width="1"/>
-  <text x="885" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#c4b5fd">Trust Score</text>
+  <path d="M218 226 L232 226" stroke="#d29922" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="748" y="462" width="180" height="18" rx="4" fill="#1a1028" stroke="#7c3aed" stroke-width="0.5"/>
-  <text x="838" y="475" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a78bfa">Alerts · Dedup · Slack/Webhook/File</text>
+  <rect x="236" y="208" width="74" height="36" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.2"/>
+  <text x="273" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">EPSS</text>
+  <text x="273" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d29922">Scores</text>
 
-  <path d="M704 360 L736 360" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <path d="M310 226 L322 226" stroke="#d29922" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <path d="M370 486 L370 506" stroke="#4b5563" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M364 500 L370 510 L376 500" fill="#4b5563"/>
+  <rect x="326" y="208" width="74" height="36" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.2"/>
+  <text x="363" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">KEV</text>
+  <text x="363" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d29922">CISA</text>
 
-  <!-- ─── ROW 3: DEPLOYMENT & OUTPUT ─── -->
-  <rect x="20" y="514" width="920" height="84" rx="12" fill="#0a2118" stroke="#059669" stroke-width="1.2"/>
-  <text x="480" y="534" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT — 13+ FORMATS</text>
+  <path d="M400 226 L412 226" stroke="#d29922" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="30" y="544" width="78" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="69" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">CLI</text>
+  <rect x="416" y="208" width="88" height="36" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="460" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">AI Risk</text>
+  <text x="460" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d29922">Classify</text>
 
-  <rect x="114" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="157" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">REST API</text>
-  <text x="157" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">25+ endpoints</text>
+  <path d="M504 226 L516 226" stroke="#d29922" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="206" y="544" width="96" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="254" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">MCP Server</text>
-  <text x="254" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">16 tools</text>
+  <rect x="520" y="208" width="100" height="36" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="570" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">FP Reduction</text>
+  <text x="570" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d29922">Malware · Typosquat</text>
 
-  <rect x="308" y="544" width="78" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="347" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Dashboard</text>
+  <path d="M620 226 L636 226" stroke="#d29922" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="392" y="544" width="90" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="437" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">SARIF/SBOM</text>
+  <rect x="640" y="208" width="112" height="36" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="696" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">OpenSSF Score</text>
+  <text x="696" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d29922">Health metrics</text>
 
-  <rect x="488" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="531" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">GH Action</text>
+  <!-- Row 2b: Deep Analysis (connected with arrows) -->
+  <rect x="24" y="256" width="110" height="36" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="79" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Blast Radius</text>
+  <text x="79" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#f85149">6-hop chain</text>
 
-  <rect x="580" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="623" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Docker/Helm</text>
+  <path d="M134 274 L148 274" stroke="#f85149" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
 
-  <rect x="672" y="544" width="86" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="715" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Prometheus</text>
-  <text x="715" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">OTLP · OCSF</text>
+  <rect x="152" y="256" width="110" height="36" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="207" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Context Graph</text>
+  <text x="207" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#f85149">BFS · PageRank</text>
 
-  <rect x="764" y="544" width="168" height="34" rx="6" fill="#0d1117" stroke="#10b981" stroke-width="1"/>
-  <text x="848" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#6ee7b7">Slack · Jira · ServiceNow</text>
-  <text x="848" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#34d399">Drata · Vanta · Webhooks</text>
+  <path d="M262 274 L276 274" stroke="#f85149" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
 
-  <!-- ─── ROW 4: INFRASTRUCTURE BAR ─── -->
-  <rect x="20" y="606" width="920" height="36" rx="8" fill="#161b22" stroke="#30363d" stroke-width="0.8"/>
-  <text x="480" y="622" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e" letter-spacing="0.06em">INFRASTRUCTURE</text>
-  <text x="480" y="636" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Storage: SQLite · PostgreSQL · Snowflake  |  Auth: RBAC · scrypt API keys · HMAC audit log  |  Scheduler: cron · backoff  |  Cache: SQLite WAL · 7-day TTL</text>
+  <rect x="280" y="256" width="98" height="36" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="329" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Risk Analyzer</text>
+  <text x="329" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#f85149">7 capabilities</text>
 
-  <!-- ─── FOOTER ─── -->
-  <rect x="20" y="652" width="920" height="2" rx="1" fill="#21262d"/>
-  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">20 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
-  <text x="480" y="694" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#6e7681">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  SLSA provenance  |  OpenSSF scored  |  Apache 2.0</text>
-  <text x="480" y="716" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#34d399">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+  <path d="M378 274 L392 274" stroke="#f85149" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
 
-  <rect x="20" y="728" width="920" height="2" rx="1" fill="#fbbf24" opacity="0.3"/>
-  <text x="480" y="738" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#d97706">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime dependencies beyond stdlib for core analysis</text>
+  <rect x="396" y="256" width="98" height="36" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="445" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Toxic Combos</text>
+  <text x="445" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#f85149">8 patterns</text>
+
+  <path d="M494 274 L508 274" stroke="#f85149" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
+
+  <rect x="512" y="256" width="110" height="36" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="567" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Posture Score</text>
+  <text x="567" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#f85149">A-F · 6 dims</text>
+
+  <path d="M622 274 L636 274" stroke="#f85149" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
+
+  <rect x="640" y="256" width="112" height="36" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="696" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Incidents</text>
+  <text x="696" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#f85149">P1-P4 · OCSF</text>
+
+  <!-- Vertical arrows from scan row to analysis row -->
+  <path d="M68 244 L68 256" stroke="#484f58" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M460 244 L445 256" stroke="#484f58" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M570 244 L567 256" stroke="#484f58" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+
+  <!-- Row 2c: Compliance & Policy -->
+  <rect x="24" y="304" width="100" height="36" rx="6" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="74" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#d2a8ff">OWASP LLM</text>
+  <text x="74" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a371f7">+ MCP + Agentic</text>
+
+  <path d="M124 322 L136 322" stroke="#a371f7" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="140" y="304" width="82" height="36" rx="6" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="181" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#d2a8ff">MITRE ATLAS</text>
+  <text x="181" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a371f7">Tactics</text>
+
+  <path d="M222 322 L234 322" stroke="#a371f7" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="238" y="304" width="74" height="36" rx="6" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="275" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#d2a8ff">NIST</text>
+  <text x="275" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a371f7">AI RMF · CSF</text>
+
+  <path d="M312 322 L324 322" stroke="#a371f7" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="328" y="304" width="68" height="36" rx="6" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="362" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#d2a8ff">EU AI</text>
+  <text x="362" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a371f7">Act</text>
+
+  <path d="M396 322 L408 322" stroke="#a371f7" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="412" y="304" width="68" height="36" rx="6" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="446" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#d2a8ff">SOC 2</text>
+  <text x="446" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a371f7">CIS v8</text>
+
+  <path d="M480 322 L492 322" stroke="#a371f7" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="496" y="304" width="90" height="36" rx="6" fill="#0d1117" stroke="#a371f7" stroke-width="1.2"/>
+  <text x="541" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#d2a8ff">License Policy</text>
+  <text x="541" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a371f7">SPDX rules</text>
+
+  <path d="M586 322 L598 322" stroke="#a371f7" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="602" y="304" width="150" height="36" rx="6" fill="#a371f7" stroke="#d2a8ff" stroke-width="1.5"/>
+  <text x="677" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">Policy-as-Code Engine</text>
+  <text x="677" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#e9d5ff">YAML rules · pass/fail/warn</text>
+
+  <!-- Vertical arrow from analysis to compliance -->
+  <path d="M696 292 L696 304" stroke="#484f58" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+
+  <!-- Arrow down from Layer 2 to Layer 3 -->
+  <path d="M389 356 L389 380" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#eo-arr)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 3: DEPLOYMENT & OUTPUT (output nodes connected to delivery)   -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="382" width="932" height="140" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="480" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#7ee787" letter-spacing="0.08em">LAYER 3 — OUTPUT &amp; DEPLOYMENT (13+ formats)</text>
+
+  <!-- Output format nodes -->
+  <rect x="24" y="408" width="72" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="60" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">JSON</text>
+
+  <rect x="102" y="408" width="72" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="138" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">SARIF</text>
+
+  <rect x="180" y="408" width="72" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="216" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">CycloneDX</text>
+
+  <rect x="258" y="408" width="72" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="294" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">SPDX</text>
+
+  <rect x="336" y="408" width="72" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="372" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">HTML</text>
+
+  <rect x="414" y="408" width="72" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="450" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">SVG</text>
+
+  <rect x="492" y="408" width="72" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="528" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">OCSF</text>
+
+  <rect x="570" y="408" width="88" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="614" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">Prometheus</text>
+
+  <!-- Delivery channel nodes -->
+  <rect x="24" y="452" width="96" height="30" rx="5" fill="#3fb950" stroke="#7ee787" stroke-width="1.5"/>
+  <text x="72" y="471" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">CLI</text>
+
+  <path d="M120 467 L134 467" stroke="#3fb950" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="138" y="452" width="96" height="30" rx="5" fill="#3fb950" stroke="#7ee787" stroke-width="1.5"/>
+  <text x="186" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">REST API</text>
+  <text x="186" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d1fae5">25+ endpoints</text>
+
+  <path d="M234 467 L248 467" stroke="#3fb950" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="252" y="452" width="96" height="30" rx="5" fill="#3fb950" stroke="#7ee787" stroke-width="1.5"/>
+  <text x="300" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">MCP Server</text>
+  <text x="300" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d1fae5">16 tools</text>
+
+  <path d="M348 467 L362 467" stroke="#3fb950" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="366" y="452" width="96" height="30" rx="5" fill="#3fb950" stroke="#7ee787" stroke-width="1.5"/>
+  <text x="414" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">Dashboard</text>
+  <text x="414" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d1fae5">15 sections</text>
+
+  <path d="M462 467 L476 467" stroke="#3fb950" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="480" y="452" width="96" height="30" rx="5" fill="#3fb950" stroke="#7ee787" stroke-width="1.5"/>
+  <text x="528" y="471" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">GH Action</text>
+
+  <path d="M576 467 L590 467" stroke="#3fb950" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="594" y="452" width="96" height="30" rx="5" fill="#3fb950" stroke="#7ee787" stroke-width="1.5"/>
+  <text x="642" y="471" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">Docker / Helm</text>
+
+  <!-- Vertical arrows from formats to delivery -->
+  <path d="M60 438 L72 452" stroke="#484f58" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M216 438 L300 452" stroke="#484f58" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M450 438 L528 452" stroke="#484f58" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+
+  <!-- Alert delivery -->
+  <rect x="710" y="452" width="226" height="30" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="823" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">Alert Channels</text>
+  <text x="823" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3fb950">Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+
+  <!-- Delivery to alerts arrow -->
+  <path d="M690 467 L710 467" stroke="#3fb950" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <!-- Arrow: runtime protection to alert channels -->
+  <path d="M861 346 L861 370 L823 370 L823 452" stroke="#a371f7" stroke-width="1.2" fill="none" stroke-dasharray="4 3" marker-end="url(#eo-arr-p)"/>
+
+  <!-- Pipeline arrow down from format row -->
+  <path d="M389 496 L389 520" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#eo-arr)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  EXTERNAL INTELLIGENCE FEEDS (dashed bottom band)                    -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="522" width="932" height="52" rx="8" fill="#161b22" stroke="#484f58" stroke-width="1" stroke-dasharray="5 3"/>
+  <text x="480" y="540" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e" letter-spacing="0.06em">EXTERNAL INTELLIGENCE FEEDS — 9 sources feed into Layer 2</text>
+
+  <rect x="28" y="550" width="80" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="68" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">OSV.dev</text>
+  <rect x="116" y="550" width="65" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="148" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">GHSA</text>
+  <rect x="189" y="550" width="75" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="226" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">NVD/NIST</text>
+  <rect x="272" y="550" width="65" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="304" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">EPSS</text>
+  <rect x="345" y="550" width="65" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="377" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">CISA KEV</text>
+  <rect x="418" y="550" width="90" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="463" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">NVIDIA CSAF</text>
+  <rect x="516" y="550" width="70" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="551" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">Grype DB</text>
+  <rect x="594" y="550" width="70" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="629" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">OpenSSF</text>
+  <rect x="672" y="550" width="90" height="16" rx="3" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="717" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">MCP Registry</text>
+
+  <!-- Dashed arrows from external feeds up to Layer 2 -->
+  <path d="M300 522 L300 356" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#eo-arr)"/>
+  <path d="M500 522 L500 356" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#eo-arr)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 4: INFRASTRUCTURE BAR                                         -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="586" width="932" height="46" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="480" y="604" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#7ee787" letter-spacing="0.06em">LAYER 4 — INFRASTRUCTURE</text>
+  <text x="480" y="622" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#3fb950">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway SSE · Helm</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  FOOTER                                                               -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <text x="480" y="654" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#8b949e">20 MCP clients · 11 providers · 10 agent fwks · 12 model formats · 7 ecosystems · 427+ registry · 107 modules · 2,900+ tests</text>
+  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#484f58">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
+  <text x="480" y="690" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" font-weight="600" fill="#d29922">~70 proprietary · ~15 hybrid · ~22 external · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -1,232 +1,388 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 740" fill="none">
-  <rect width="960" height="740" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 700" fill="none">
+  <defs>
+    <marker id="eo-arr" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#94a3b8"/></marker>
+    <marker id="eo-arr-b" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#3b82f6"/></marker>
+    <marker id="eo-arr-a" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#f59e0b"/></marker>
+    <marker id="eo-arr-r" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/></marker>
+    <marker id="eo-arr-g" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/></marker>
+    <marker id="eo-arr-p" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#8b5cf6"/></marker>
+  </defs>
 
-  <!-- ─── ROW 1: MULTI-SOURCE DISCOVERY ─── -->
-  <rect x="20" y="16" width="920" height="200" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.2"/>
-  <text x="480" y="36" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#2563eb" letter-spacing="0.1em">MULTI-SOURCE DISCOVERY</text>
+  <rect width="960" height="700" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
-  <!-- Box 1: MCP Agents -->
-  <rect x="34" y="48" width="168" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="118" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">MCP Agents</text>
-  <text x="118" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">18</text>
-  <text x="118" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">clients auto-detected</text>
-  <text x="118" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Claude · Cursor · Codex · Gemini</text>
-  <text x="118" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Goose · Windsurf · Zed · Cline</text>
-  <text x="118" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Snowflake CLI · Roo + 8 more</text>
-  <text x="118" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">427+ server threat registry</text>
-  <text x="118" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">+ MCP Registry + Smithery.ai</text>
-  <text x="118" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Docker Compose discovery</text>
+  <!-- Title -->
+  <text x="480" y="24" text-anchor="middle" font-family="system-ui, sans-serif" font-size="15" font-weight="700" fill="#0f172a">Enterprise Architecture — 4-Layer System Overview</text>
+  <text x="480" y="40" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#64748b">Multi-source discovery → analysis → output with runtime protection sidecar</text>
 
-  <!-- Box 2: Infrastructure -->
-  <rect x="214" y="48" width="148" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="288" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Infrastructure</text>
-  <text x="288" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">Docker Images</text>
-  <text x="288" y="100" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Grype · Syft · Docker CLI</text>
-  <text x="288" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Multi-arch · Private registry</text>
-  <text x="288" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">Kubernetes</text>
-  <text x="288" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">All namespaces · Pod images</text>
-  <text x="288" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">EKS · GKE · AKS · CoreWeave</text>
-  <text x="288" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">Terraform IaC</text>
-  <text x="288" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Bedrock · SageMaker · Azure AI</text>
-  <text x="288" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Filesystem / disk snapshots</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 1: MULTI-SOURCE DISCOVERY (8 input nodes → merge node)        -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="52" width="750" height="120" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <text x="389" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#2563eb" letter-spacing="0.08em">LAYER 1 — MULTI-SOURCE DISCOVERY</text>
 
-  <!-- Box 3: Cloud & AI Providers -->
-  <rect x="374" y="48" width="194" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="471" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Cloud &amp; AI Providers</text>
-  <text x="471" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="26" font-weight="800" fill="#3b82f6">11</text>
-  <text x="471" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">platform integrations</text>
-  <text x="471" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">AWS Bedrock · Lambda · ECS · EKS</text>
-  <text x="471" y="134" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Azure AI · GCP Vertex · Snowflake</text>
-  <text x="471" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Databricks · Nebius GPU Cloud</text>
-  <text x="471" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">HuggingFace · MLflow · W&amp;B</text>
-  <text x="471" y="170" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OpenAI Assistants · Ollama</text>
-  <text x="471" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">Governance + Observability</text>
-  <text x="471" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Cortex telemetry · agent health</text>
+  <!-- Input nodes row 1 -->
+  <rect x="24" y="78" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="68" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">MCP Agents</text>
+  <text x="68" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">20 clients</text>
 
-  <!-- Box 4: AI/ML Deep Scan -->
-  <rect x="580" y="48" width="160" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="660" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">AI/ML Deep Scan</text>
-  <text x="660" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">10 agent frameworks</text>
-  <text x="660" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">LangChain · CrewAI · AutoGen</text>
-  <text x="660" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OpenAI SDK · Google ADK + 5</text>
-  <text x="660" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">12 model file formats</text>
-  <text x="660" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">GGUF · SafeTensors · ONNX</text>
-  <text x="660" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">PyTorch · TF · CoreML + 6</text>
-  <text x="660" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Sigstore + SLSA provenance</text>
-  <text x="660" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Jupyter notebook scanning</text>
-  <text x="660" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">GitHub Actions scanning</text>
+  <rect x="118" y="78" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="162" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">Docker / K8s</text>
+  <text x="162" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">Images + Pods</text>
 
-  <!-- Box 5: Code & Supply Chain -->
-  <rect x="752" y="48" width="176" height="156" rx="10" fill="#ffffff" stroke="#93c5fd" stroke-width="1.2"/>
-  <text x="840" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="12" font-weight="700" fill="#1e40af">Code &amp; Supply Chain</text>
-  <text x="840" y="86" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">7 package ecosystems</text>
-  <text x="840" y="98" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">npm · pip · Go · Cargo · Maven</text>
-  <text x="840" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NuGet · Ruby + transitive deps</text>
-  <text x="840" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#1e40af">SBOMs · SAST · Integrity</text>
-  <text x="840" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">CycloneDX · SPDX ingestion</text>
-  <text x="840" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Semgrep SAST (CWE mapping)</text>
-  <text x="840" y="164" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">npm/PyPI SHA integrity</text>
-  <text x="840" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">SLSA + PEP 740 attestations</text>
-  <text x="840" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#3b82f6">deps.dev transitive resolution</text>
+  <rect x="212" y="78" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="256" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">Cloud / AI</text>
+  <text x="256" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">11 providers</text>
 
-  <!-- Arrow down -->
-  <path d="M480 216 L480 236" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M474 230 L480 240 L486 230" fill="#94a3b8"/>
+  <rect x="306" y="78" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="350" y="93" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">AI/ML Models</text>
+  <text x="350" y="107" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">10 fwks · 12 fmts</text>
 
-  <!-- ─── ROW 2: PROPRIETARY ANALYSIS ENGINE ─── -->
-  <rect x="20" y="244" width="700" height="242" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="1.2"/>
-  <text x="370" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#d97706" letter-spacing="0.1em">PROPRIETARY ANALYSIS ENGINE — 70+ MODULES</text>
+  <!-- Input nodes row 2 -->
+  <rect x="24" y="122" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="68" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">Code / Pkgs</text>
+  <text x="68" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">7 ecosystems</text>
 
-  <!-- Row 2a: Vulnerability Intelligence -->
-  <rect x="34" y="276" width="214" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="141" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Vuln Intelligence</text>
-  <text x="141" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">OSV · GHSA · NVIDIA · Snyk · Grype</text>
-  <text x="141" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">NVD CVSS · EPSS · KEV · Scorecard</text>
+  <rect x="118" y="122" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="162" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">SBOM Ingest</text>
+  <text x="162" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">CDX + SPDX</text>
 
-  <path d="M252 304 L264 304" stroke="#d97706" stroke-width="2"/>
-  <path d="M260 300 L267 304 L260 308" fill="#d97706"/>
+  <rect x="212" y="122" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="256" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">Integrity</text>
+  <text x="256" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">SHA · SLSA · PEP 740</text>
 
-  <rect x="270" y="276" width="200" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="370" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Blast Radius Engine</text>
-  <text x="370" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">CVE → pkg → server → agent → creds → tools</text>
-  <text x="370" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">Configurable weighted risk scoring</text>
+  <rect x="306" y="122" width="88" height="36" rx="6" fill="#fff" stroke="#3b82f6" stroke-width="1.2"/>
+  <text x="350" y="137" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#1e40af">Filesystem</text>
+  <text x="350" y="151" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">Lockfiles + AST</text>
 
-  <path d="M474 304 L486 304" stroke="#d97706" stroke-width="2"/>
-  <path d="M482 300 L489 304 L482 308" fill="#d97706"/>
+  <!-- Merge/Extract node -->
+  <rect x="430" y="90" width="110" height="54" rx="8" fill="#3b82f6" stroke="#1d4ed8" stroke-width="1.5"/>
+  <text x="485" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">Extract +</text>
+  <text x="485" y="126" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">Parse</text>
+  <text x="485" y="140" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#dbeafe">Syft · Semgrep ext</text>
 
-  <rect x="492" y="276" width="212" height="56" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="598" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#92400e">Context Graph + BFS</text>
-  <text x="598" y="308" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">Lateral movement attack paths</text>
-  <text x="598" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a16207">PageRank · Betweenness centrality</text>
+  <!-- Converging arrows from 8 nodes to Extract -->
+  <path d="M112 96 L430 110" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M206 96 L430 112" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M300 96 L430 114" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M394 96 L430 116" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M112 140 L430 120" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M206 140 L430 122" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M300 140 L430 124" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
+  <path d="M394 140 L430 126" stroke="#3b82f6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-b)"/>
 
-  <!-- Row 2b: More analysis capabilities -->
-  <rect x="34" y="342" width="130" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="99" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">10 Frameworks</text>
-  <text x="99" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">OWASP LLM+MCP+Agentic</text>
-  <text x="99" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">ATLAS · NIST · EU AI +4</text>
+  <!-- Extract output arrow down to Layer 2 -->
+  <path d="M485 144 L485 180" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#eo-arr)"/>
 
-  <rect x="172" y="342" width="130" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="237" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Posture Score</text>
-  <text x="237" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Grade A-F · 6 dimensions</text>
-  <text x="237" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Weighted enterprise score</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION SIDEBAR (right column, spans layers 1-2)         -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="776" y="52" width="170" height="304" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1.5"/>
+  <text x="861" y="70" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#7c3aed" letter-spacing="0.06em">RUNTIME PROTECTION</text>
 
-  <rect x="310" y="342" width="130" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="375" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Incidents</text>
-  <text x="375" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">P1-P4 priority by agent</text>
-  <text x="375" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">SOC-ready OCSF v1.1</text>
+  <rect x="786" y="80" width="150" height="36" rx="6" fill="#fff" stroke="#8b5cf6" stroke-width="1.2"/>
+  <text x="861" y="96" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#6d28d9">MCP Stdio Proxy</text>
+  <text x="861" y="108" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7c3aed">JSON-RPC intercept · audit</text>
 
-  <rect x="448" y="342" width="124" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="510" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Toxic Combos</text>
-  <text x="510" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">KEV+creds · RCE+exec</text>
-  <text x="510" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Malicious · Typosquat</text>
+  <!-- Arrow down inside sidebar -->
+  <path d="M861 116 L861 126" stroke="#8b5cf6" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="580" y="342" width="124" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <text x="642" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Cred Ranking</text>
-  <text x="642" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Risk tiers by exposure</text>
-  <text x="642" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Cross-agent aggregation</text>
+  <rect x="786" y="130" width="72" height="28" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="822" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#6d28d9">Injection</text>
+  <rect x="864" y="130" width="72" height="28" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="900" y="148" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#6d28d9">PII</text>
+  <rect x="786" y="164" width="72" height="28" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="822" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#6d28d9">Secrets</text>
+  <rect x="864" y="164" width="72" height="28" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="900" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#6d28d9">Payloads</text>
 
-  <!-- Row 2c: Policy + VEX + License + Risk Analyzer -->
-  <rect x="34" y="408" width="164" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
-  <text x="116" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Policy-as-Code Engine</text>
-  <text x="116" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">YAML rules · pass/fail/warn</text>
+  <!-- Arrow down to detectors -->
+  <path d="M861 192 L861 202" stroke="#8b5cf6" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="206" y="408" width="120" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
-  <text x="266" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">License Policy</text>
-  <text x="266" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">SPDX · block/warn rules</text>
+  <rect x="786" y="206" width="150" height="28" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="861" y="224" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#6d28d9">5 Detectors</text>
+  <text x="861" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6" fill="#8b5cf6" dy="20" visibility="hidden">_</text>
 
-  <rect x="334" y="408" width="108" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
-  <text x="388" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">VEX / OpenVEX</text>
-  <text x="388" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">Exploit status mgmt</text>
+  <rect x="786" y="240" width="46" height="20" rx="4" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="0.8"/>
+  <text x="809" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#6d28d9">Drift</text>
+  <rect x="836" y="240" width="46" height="20" rx="4" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="0.8"/>
+  <text x="859" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#6d28d9">Creds</text>
+  <rect x="886" y="240" width="46" height="20" rx="4" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="0.8"/>
+  <text x="909" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#6d28d9">Rate</text>
+  <rect x="806" y="264" width="46" height="20" rx="4" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="0.8"/>
+  <text x="829" y="278" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#6d28d9">Seq</text>
+  <rect x="856" y="264" width="46" height="20" rx="4" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="0.8"/>
+  <text x="879" y="278" text-anchor="middle" font-family="system-ui, sans-serif" font-size="6.5" fill="#6d28d9">Args</text>
 
-  <rect x="450" y="408" width="120" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
-  <text x="510" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Risk Analyzer</text>
-  <text x="510" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">7 tool capabilities · 8 combos</text>
+  <!-- Arrow down to fleet/trust -->
+  <path d="M861 284 L861 294" stroke="#8b5cf6" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="578" y="408" width="128" height="42" rx="8" fill="#fff7ed" stroke="#d97706" stroke-width="0.8"/>
-  <text x="642" y="424" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">CVSS 3.1 Compute</text>
-  <text x="642" y="438" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a16207">AV/AC/PR/UI/S/C/I/A</text>
+  <rect x="786" y="298" width="72" height="22" rx="5" fill="#fff" stroke="#7c3aed" stroke-width="1.2"/>
+  <text x="822" y="313" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#6d28d9">Fleet Mgmt</text>
+  <rect x="864" y="298" width="72" height="22" rx="5" fill="#fff" stroke="#7c3aed" stroke-width="1.2"/>
+  <text x="900" y="313" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#6d28d9">Trust Score</text>
 
-  <text x="370" y="474" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" font-weight="600" fill="#d97706">+ AI enrichment (Ollama/HuggingFace/litellm) · Baseline comparison · Trend tracking · Multi-source correlation · OTel trace ingest</text>
+  <rect x="786" y="326" width="150" height="20" rx="4" fill="#ede9fe"/>
+  <text x="861" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="600" fill="#7c3aed">Slack · Jira · Webhooks</text>
 
-  <!-- ─── SIDEBAR: RUNTIME PROTECTION ─── -->
-  <rect x="736" y="244" width="204" height="242" rx="12" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1.2"/>
-  <text x="838" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.1em">RUNTIME PROTECTION</text>
+  <!-- Dashed arrow from sidebar into Layer 2 -->
+  <path d="M776 240 L764 240" stroke="#8b5cf6" stroke-width="1.2" fill="none" stroke-dasharray="4 3" marker-end="url(#eo-arr-p)"/>
 
-  <rect x="748" y="278" width="180" height="52" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="838" y="294" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">MCP Stdio Proxy</text>
-  <text x="838" y="306" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">JSON-RPC intercept · audit log</text>
-  <text x="838" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Policy enforce · replay detect</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 2: PROPRIETARY ANALYSIS ENGINE (3 rows of connected nodes)    -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="182" width="750" height="174" rx="10" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <text x="389" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#d97706" letter-spacing="0.08em">LAYER 2 — PROPRIETARY ANALYSIS ENGINE (70+ modules)</text>
 
-  <rect x="748" y="336" width="180" height="40" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="838" y="352" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">4 Inline Scanners</text>
-  <text x="838" y="366" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Injection · PII · Secrets · Payloads</text>
+  <!-- Row 2a: Scan + Enrich pipeline -->
+  <rect x="24" y="208" width="88" height="36" rx="6" fill="#fff" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="68" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">Vuln Scan</text>
+  <text x="68" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a16207">9 sources</text>
 
-  <rect x="748" y="382" width="180" height="40" rx="8" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="838" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">5 Detectors</text>
-  <text x="838" y="412" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Drift · Creds · Rate · Seq · Args</text>
+  <path d="M112 226 L126 226" stroke="#f59e0b" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="748" y="428" width="86" height="28" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="791" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6d28d9">Fleet Mgmt</text>
+  <rect x="130" y="208" width="88" height="36" rx="6" fill="#fff" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="174" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">CVSS 3.1</text>
+  <text x="174" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a16207">Compute</text>
 
-  <rect x="842" y="428" width="86" height="28" rx="6" fill="#ffffff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="885" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6d28d9">Trust Score</text>
+  <path d="M218 226 L232 226" stroke="#f59e0b" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="748" y="462" width="180" height="18" rx="4" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="0.5"/>
-  <text x="838" y="475" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#7c3aed">Alerts · Dedup · Slack/Webhook/File</text>
+  <rect x="236" y="208" width="74" height="36" rx="6" fill="#fff" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="273" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">EPSS</text>
+  <text x="273" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a16207">Scores</text>
 
-  <path d="M704 360 L736 360" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <path d="M310 226 L322 226" stroke="#f59e0b" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <!-- Arrow down -->
-  <path d="M370 486 L370 506" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M364 500 L370 510 L376 500" fill="#94a3b8"/>
+  <rect x="326" y="208" width="74" height="36" rx="6" fill="#fff" stroke="#f59e0b" stroke-width="1.2"/>
+  <text x="363" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">KEV</text>
+  <text x="363" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a16207">CISA</text>
 
-  <!-- ─── ROW 3: DEPLOYMENT & OUTPUT ─── -->
-  <rect x="20" y="514" width="920" height="84" rx="12" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.2"/>
-  <text x="480" y="534" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#059669" letter-spacing="0.1em">DEPLOYMENT &amp; OUTPUT — 13+ FORMATS</text>
+  <path d="M400 226 L412 226" stroke="#f59e0b" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="30" y="544" width="78" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="69" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">CLI</text>
+  <rect x="416" y="208" width="88" height="36" rx="6" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="460" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">AI Risk</text>
+  <text x="460" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a16207">Classify</text>
 
-  <rect x="114" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="157" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">REST API</text>
-  <text x="157" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">25+ endpoints</text>
+  <path d="M504 226 L516 226" stroke="#f59e0b" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="206" y="544" width="96" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="254" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">MCP Server</text>
-  <text x="254" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">16 tools</text>
+  <rect x="520" y="208" width="100" height="36" rx="6" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="570" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">FP Reduction</text>
+  <text x="570" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a16207">Malware · Typosquat</text>
 
-  <rect x="308" y="544" width="78" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="347" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Dashboard</text>
+  <path d="M620 226 L636 226" stroke="#f59e0b" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-a)"/>
 
-  <rect x="392" y="544" width="90" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="437" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">SARIF/SBOM</text>
+  <rect x="640" y="208" width="112" height="36" rx="6" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="696" y="223" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">OpenSSF Score</text>
+  <text x="696" y="237" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#a16207">Health metrics</text>
 
-  <rect x="488" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="531" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">GH Action</text>
+  <!-- Row 2b: Deep Analysis (connected with arrows) -->
+  <rect x="24" y="256" width="110" height="36" rx="6" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="79" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Blast Radius</text>
+  <text x="79" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#dc2626">6-hop chain</text>
 
-  <rect x="580" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="623" y="566" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Docker/Helm</text>
+  <path d="M134 274 L148 274" stroke="#ef4444" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
 
-  <rect x="672" y="544" width="86" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="715" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Prometheus</text>
-  <text x="715" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">OTLP · OCSF</text>
+  <rect x="152" y="256" width="110" height="36" rx="6" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="207" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Context Graph</text>
+  <text x="207" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#dc2626">BFS · PageRank</text>
 
-  <rect x="764" y="544" width="168" height="34" rx="6" fill="#ffffff" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="848" y="560" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#065f46">Slack · Jira · ServiceNow</text>
-  <text x="848" y="572" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#059669">Drata · Vanta · Webhooks</text>
+  <path d="M262 274 L276 274" stroke="#ef4444" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
 
-  <!-- ─── ROW 4: INFRASTRUCTURE BAR ─── -->
-  <rect x="20" y="606" width="920" height="36" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="0.8"/>
-  <text x="480" y="622" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#475569" letter-spacing="0.06em">INFRASTRUCTURE</text>
-  <text x="480" y="636" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Storage: SQLite · PostgreSQL · Snowflake  |  Auth: RBAC · scrypt API keys · HMAC audit log  |  Scheduler: cron · backoff  |  Cache: SQLite WAL · 7-day TTL</text>
+  <rect x="280" y="256" width="98" height="36" rx="6" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="329" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Risk Analyzer</text>
+  <text x="329" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#dc2626">7 capabilities</text>
 
-  <!-- ─── FOOTER ─── -->
-  <rect x="20" y="652" width="920" height="2" rx="1" fill="#e2e8f0"/>
-  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#64748b">20 MCP clients  |  11 providers  |  10 agent frameworks  |  12 model formats  |  7 ecosystems  |  427+ registry  |  9 vuln sources  |  10 frameworks  |  107 modules  |  2,868+ tests</text>
-  <text x="480" y="694" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only  |  Agentless  |  Never stores credentials  |  Sigstore signed  |  SLSA provenance  |  OpenSSF scored  |  Apache 2.0</text>
-  <text x="480" y="716" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#059669">OWASP LLM + MCP + Agentic  |  MITRE ATLAS  |  NIST AI RMF + CSF 2.0  |  EU AI Act  |  ISO 27001  |  SOC 2  |  CIS v8</text>
+  <path d="M378 274 L392 274" stroke="#ef4444" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
 
-  <!-- Proprietary label -->
-  <rect x="20" y="728" width="920" height="2" rx="1" fill="#fbbf24" opacity="0.4"/>
-  <text x="480" y="738" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#d97706">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime dependencies beyond stdlib for core analysis</text>
+  <rect x="396" y="256" width="98" height="36" rx="6" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="445" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Toxic Combos</text>
+  <text x="445" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#dc2626">8 patterns</text>
+
+  <path d="M494 274 L508 274" stroke="#ef4444" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
+
+  <rect x="512" y="256" width="110" height="36" rx="6" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="567" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Posture Score</text>
+  <text x="567" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#dc2626">A-F · 6 dims</text>
+
+  <path d="M622 274 L636 274" stroke="#ef4444" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-r)"/>
+
+  <rect x="640" y="256" width="112" height="36" rx="6" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="696" y="271" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Incidents</text>
+  <text x="696" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#dc2626">P1-P4 · OCSF</text>
+
+  <!-- Vertical arrows from scan row to analysis row -->
+  <path d="M68 244 L68 256" stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M460 244 L445 256" stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M570 244 L567 256" stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+
+  <!-- Row 2c: Compliance & Policy -->
+  <rect x="24" y="304" width="100" height="36" rx="6" fill="#fff" stroke="#8b5cf6" stroke-width="1.2"/>
+  <text x="74" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#6d28d9">OWASP LLM</text>
+  <text x="74" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7c3aed">+ MCP + Agentic</text>
+
+  <path d="M124 322 L136 322" stroke="#8b5cf6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="140" y="304" width="82" height="36" rx="6" fill="#fff" stroke="#8b5cf6" stroke-width="1.2"/>
+  <text x="181" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#6d28d9">MITRE ATLAS</text>
+  <text x="181" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7c3aed">Tactics</text>
+
+  <path d="M222 322 L234 322" stroke="#8b5cf6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="238" y="304" width="74" height="36" rx="6" fill="#fff" stroke="#8b5cf6" stroke-width="1.2"/>
+  <text x="275" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#6d28d9">NIST</text>
+  <text x="275" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7c3aed">AI RMF · CSF</text>
+
+  <path d="M312 322 L324 322" stroke="#8b5cf6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="328" y="304" width="68" height="36" rx="6" fill="#fff" stroke="#8b5cf6" stroke-width="1.2"/>
+  <text x="362" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#6d28d9">EU AI</text>
+  <text x="362" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7c3aed">Act</text>
+
+  <path d="M396 322 L408 322" stroke="#8b5cf6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="412" y="304" width="68" height="36" rx="6" fill="#fff" stroke="#8b5cf6" stroke-width="1.2"/>
+  <text x="446" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#6d28d9">SOC 2</text>
+  <text x="446" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7c3aed">CIS v8</text>
+
+  <path d="M480 322 L492 322" stroke="#8b5cf6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="496" y="304" width="90" height="36" rx="6" fill="#fff" stroke="#8b5cf6" stroke-width="1.2"/>
+  <text x="541" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#6d28d9">License Policy</text>
+  <text x="541" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7c3aed">SPDX rules</text>
+
+  <path d="M586 322 L598 322" stroke="#8b5cf6" stroke-width="1.2" fill="none" marker-end="url(#eo-arr-p)"/>
+
+  <rect x="602" y="304" width="150" height="36" rx="6" fill="#8b5cf6" stroke="#6d28d9" stroke-width="1.5"/>
+  <text x="677" y="319" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">Policy-as-Code Engine</text>
+  <text x="677" y="333" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#e9d5ff">YAML rules · pass/fail/warn</text>
+
+  <!-- Vertical arrow from analysis to compliance -->
+  <path d="M696 292 L696 304" stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+
+  <!-- Arrow down from Layer 2 to Layer 3 -->
+  <path d="M389 356 L389 380" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#eo-arr)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 3: DEPLOYMENT & OUTPUT (output nodes connected to delivery)   -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="382" width="932" height="140" rx="10" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="480" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#059669" letter-spacing="0.08em">LAYER 3 — OUTPUT &amp; DEPLOYMENT (13+ formats)</text>
+
+  <!-- Output format nodes -->
+  <rect x="24" y="408" width="72" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="60" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">JSON</text>
+
+  <rect x="102" y="408" width="72" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="138" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">SARIF</text>
+
+  <rect x="180" y="408" width="72" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="216" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">CycloneDX</text>
+
+  <rect x="258" y="408" width="72" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="294" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">SPDX</text>
+
+  <rect x="336" y="408" width="72" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="372" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">HTML</text>
+
+  <rect x="414" y="408" width="72" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="450" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">SVG</text>
+
+  <rect x="492" y="408" width="72" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="528" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">OCSF</text>
+
+  <rect x="570" y="408" width="88" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="614" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">Prometheus</text>
+
+  <!-- Delivery channel nodes -->
+  <rect x="24" y="452" width="96" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1.5"/>
+  <text x="72" y="471" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">CLI</text>
+
+  <path d="M120 467 L134 467" stroke="#10b981" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="138" y="452" width="96" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1.5"/>
+  <text x="186" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">REST API</text>
+  <text x="186" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d1fae5">25+ endpoints</text>
+
+  <path d="M234 467 L248 467" stroke="#10b981" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="252" y="452" width="96" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1.5"/>
+  <text x="300" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">MCP Server</text>
+  <text x="300" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d1fae5">16 tools</text>
+
+  <path d="M348 467 L362 467" stroke="#10b981" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="366" y="452" width="96" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1.5"/>
+  <text x="414" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">Dashboard</text>
+  <text x="414" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d1fae5">15 sections</text>
+
+  <path d="M462 467 L476 467" stroke="#10b981" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="480" y="452" width="96" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1.5"/>
+  <text x="528" y="471" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">GH Action</text>
+
+  <path d="M576 467 L590 467" stroke="#10b981" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <rect x="594" y="452" width="96" height="30" rx="5" fill="#10b981" stroke="#059669" stroke-width="1.5"/>
+  <text x="642" y="471" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#fff">Docker / Helm</text>
+
+  <!-- Vertical arrows from formats to delivery -->
+  <path d="M60 438 L72 452" stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M216 438 L300 452" stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+  <path d="M450 438 L528 452" stroke="#94a3b8" stroke-width="1" fill="none" stroke-dasharray="3 2"/>
+
+  <!-- Alert delivery -->
+  <rect x="710" y="452" width="226" height="30" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="823" y="465" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">Alert Channels</text>
+  <text x="823" y="477" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#059669">Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+
+  <!-- Delivery to alerts arrow -->
+  <path d="M690 467 L710 467" stroke="#10b981" stroke-width="1.5" fill="none" marker-end="url(#eo-arr-g)"/>
+
+  <!-- Arrow: runtime protection to alert channels -->
+  <path d="M861 346 L861 370 L823 370 L823 452" stroke="#8b5cf6" stroke-width="1.2" fill="none" stroke-dasharray="4 3" marker-end="url(#eo-arr-p)"/>
+
+  <!-- Pipeline arrow down from format row -->
+  <path d="M389 496 L389 520" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#eo-arr)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  EXTERNAL INTELLIGENCE FEEDS (dashed bottom band)                    -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="522" width="932" height="52" rx="8" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="5 3"/>
+  <text x="480" y="540" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#475569" letter-spacing="0.06em">EXTERNAL INTELLIGENCE FEEDS — 9 sources feed into Layer 2</text>
+
+  <rect x="28" y="550" width="80" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="68" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">OSV.dev</text>
+  <rect x="116" y="550" width="65" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="148" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">GHSA</text>
+  <rect x="189" y="550" width="75" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="226" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">NVD/NIST</text>
+  <rect x="272" y="550" width="65" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="304" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">EPSS</text>
+  <rect x="345" y="550" width="65" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="377" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">CISA KEV</text>
+  <rect x="418" y="550" width="90" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="463" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">NVIDIA CSAF</text>
+  <rect x="516" y="550" width="70" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="551" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">Grype DB</text>
+  <rect x="594" y="550" width="70" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="629" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">OpenSSF</text>
+  <rect x="672" y="550" width="90" height="16" rx="3" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="717" y="562" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">MCP Registry</text>
+
+  <!-- Dashed arrows from external feeds up to Layer 2 -->
+  <path d="M300 522 L300 356" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#eo-arr)"/>
+  <path d="M500 522 L500 356" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#eo-arr)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  LAYER 4: INFRASTRUCTURE BAR                                         -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="586" width="932" height="46" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="480" y="604" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#166534" letter-spacing="0.06em">LAYER 4 — INFRASTRUCTURE</text>
+  <text x="480" y="622" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#15803d">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway SSE · Helm</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!--  FOOTER                                                               -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <text x="480" y="654" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#475569">20 MCP clients · 11 providers · 10 agent fwks · 12 model formats · 7 ecosystems · 427+ registry · 107 modules · 2,900+ tests</text>
+  <text x="480" y="672" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#94a3b8">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
+  <text x="480" y="690" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" font-weight="600" fill="#d97706">~70 proprietary · ~15 hybrid · ~22 external · 0 runtime deps</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -1,189 +1,262 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" fill="none">
-  <rect width="960" height="620" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 680" fill="none">
+  <defs>
+    <marker id="d-arrow-gray" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#484f58"/></marker>
+    <marker id="d-arrow-blue" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#58a6ff"/></marker>
+    <marker id="d-arrow-amber" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#e3b341"/></marker>
+    <marker id="d-arrow-red" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#f85149"/></marker>
+    <marker id="d-arrow-green" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#3fb950"/></marker>
+  </defs>
+
+  <rect width="960" height="680" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scan Workflow — End-to-End Data Flow</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">From multi-source discovery to actionable intelligence across agents, containers, cloud, and AI/ML infrastructure</text>
+  <text x="480" y="24" text-anchor="middle" font-family="system-ui, sans-serif" font-size="15" font-weight="700" fill="#e6edf3">Scan Workflow — End-to-End Data Flow</text>
+  <text x="480" y="40" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#8b949e">Proprietary analysis engine · 70+ modules · 20 MCP clients · 11 cloud providers · zero runtime deps</text>
 
-  <!-- ═══ COLUMN 1: INPUTS ═══ -->
-  <rect x="14" y="58" width="220" height="14" rx="4" fill="#1f6feb"/>
-  <text x="124" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">DISCOVERY INPUTS</text>
+  <!-- ═══ COLUMN 1: DISCOVERY ═══ -->
+  <rect x="14" y="52" width="148" height="418" rx="10" fill="#161b22" stroke="#1f6feb" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="88" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff" letter-spacing="0.08em">DISCOVERY</text>
 
-  <!-- MCP Agents -->
-  <rect x="14" y="78" width="220" height="76" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
-  <text x="24" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">MCP Agent Ecosystem</text>
-  <text x="24" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">18 client configs (Claude, Cursor, Windsurf…)</text>
-  <text x="24" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">427+ MCP registry packages</text>
-  <text x="24" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Tool permission + capability analysis</text>
-  <text x="24" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">discovery/__init__.py · mcp_registry.py</text>
+  <rect x="24" y="80" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="96" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">MCP Agents</text>
+  <text x="88" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">20 clients · 427+ registry</text>
 
-  <!-- Infrastructure -->
-  <rect x="14" y="160" width="220" height="76" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
-  <text x="24" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">Infrastructure</text>
-  <text x="24" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Docker images (Grype → Syft → Docker CLI)</text>
-  <text x="24" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Kubernetes pods + namespaces (kubectl)</text>
-  <text x="24" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Terraform state files (HCL parser)</text>
-  <text x="24" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">image.py · k8s.py · parsers/__init__.py</text>
+  <rect x="24" y="128" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">Containers</text>
+  <text x="88" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">Docker · K8s · Terraform</text>
 
-  <!-- Cloud & AI -->
-  <rect x="14" y="242" width="220" height="88" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
-  <text x="24" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">Cloud + AI Providers (11)</text>
-  <text x="24" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AWS · Azure · GCP · Snowflake · Databricks</text>
-  <text x="24" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Nebius · HuggingFace · W&amp;B · MLflow</text>
-  <text x="24" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OpenAI · Ollama (local models)</text>
-  <text x="24" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">10 agent frameworks (AST detection)</text>
-  <text x="24" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">cloud/ · ai_frameworks.py · models.py</text>
+  <rect x="24" y="176" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">Cloud + AI</text>
+  <text x="88" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">11 providers · 10 frameworks</text>
 
-  <!-- Code & Supply Chain -->
-  <rect x="14" y="336" width="220" height="88" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
-  <text x="24" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#58a6ff">Code + Supply Chain</text>
-  <text x="24" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">7 ecosystems: npm pip Go Cargo Maven NuGet Ruby</text>
-  <text x="24" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SBOM ingest: CycloneDX + SPDX</text>
-  <text x="24" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SAST: Semgrep rules (code_scan.py)</text>
-  <text x="24" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">12 model file formats (GGUF, SafeTensors…)</text>
-  <text x="24" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#58a6ff">parsers/ · sbom.py · code_scan.py · integrity.py</text>
+  <rect x="24" y="224" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">Code + Supply Chain</text>
+  <text x="88" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">7 ecosystems · SBOM · SAST</text>
 
-  <!-- ═══ Arrow Column 1→2 ═══ -->
-  <path d="M240 250 L254 250" stroke="#484f58" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M250 245 L258 250 L250 255" fill="#484f58"/>
+  <rect x="24" y="272" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">AI/ML Models</text>
+  <text x="88" y="302" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">12 formats · Jupyter · GH Actions</text>
 
-  <!-- ═══ COLUMN 2: SCANNING + ENRICHMENT ═══ -->
-  <rect x="260" y="58" width="220" height="14" rx="4" fill="#d29922"/>
-  <text x="370" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">SCANNING + ENRICHMENT</text>
+  <rect x="24" y="320" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="336" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">SBOM Ingest</text>
+  <text x="88" y="350" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">CycloneDX · SPDX</text>
 
-  <!-- Vuln Scanning -->
-  <rect x="260" y="78" width="220" height="100" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="270" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">Vulnerability Scanning (9 sources)</text>
-  <text x="270" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OSV.dev batch API (primary)</text>
-  <text x="270" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">GHSA · NVD/NIST CVEs · Grype DB</text>
-  <text x="270" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NVIDIA CSAF (GPU vulns) · Snyk</text>
-  <text x="270" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Malicious + typosquat detection</text>
-  <text x="270" y="158" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#e3b341">PROPRIETARY orchestrator + EXTERNAL APIs</text>
-  <text x="270" y="170" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">scanners/__init__.py · nvidia.py</text>
+  <rect x="24" y="368" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">Integrity Verify</text>
+  <text x="88" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">cosign · Sigstore · SHA-256</text>
 
-  <!-- Enrichment -->
-  <rect x="260" y="184" width="220" height="100" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="270" y="200" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">Enrichment Pipeline</text>
-  <text x="270" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CVSS 3.1 computation (PROPRIETARY)</text>
-  <text x="270" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NVD CVSS v3.1/v4 (EXTERNAL)</text>
-  <text x="270" y="238" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">FIRST EPSS probability scores</text>
-  <text x="270" y="250" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CISA KEV active exploitation status</text>
-  <text x="270" y="262" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OpenSSF Scorecard health metrics</text>
-  <text x="270" y="276" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">cvss.py · scanners/__init__.py</text>
+  <rect x="24" y="416" width="128" height="38" rx="8" fill="#0d1117" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="88" y="432" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">Filesystem</text>
+  <text x="88" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b949e">Lockfiles · node_modules</text>
 
-  <!-- False Positive + AI -->
-  <rect x="260" y="290" width="220" height="76" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="270" y="306" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">Intelligence Layer (PROPRIETARY)</text>
-  <text x="270" y="320" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AI risk classification (7 categories)</text>
-  <text x="270" y="332" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">False positive reduction engine</text>
-  <text x="270" y="344" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Conditional OWASP tagging</text>
-  <text x="270" y="358" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">scanners/__init__.py · vex.py</text>
+  <!-- Arrows: Discovery → Extract -->
+  <path d="M152 99 L170 99 L170 240 L186 240" stroke="#1f6feb" stroke-width="1.5" fill="none" marker-end="url(#d-arrow-blue)"/>
+  <path d="M152 147 L174 147 L174 240 L186 240" stroke="#1f6feb" stroke-width="1.5" fill="none"/>
+  <path d="M152 195 L178 195 L178 240 L186 240" stroke="#1f6feb" stroke-width="1.5" fill="none"/>
+  <path d="M152 243 L186 243" stroke="#1f6feb" stroke-width="1.5" fill="none"/>
+  <path d="M152 291 L178 291 L178 246 L186 246" stroke="#1f6feb" stroke-width="1.5" fill="none"/>
+  <path d="M152 339 L174 339 L174 248 L186 248" stroke="#1f6feb" stroke-width="1.5" fill="none"/>
+  <path d="M152 387 L170 387 L170 250 L186 250" stroke="#1f6feb" stroke-width="1.5" fill="none"/>
+  <path d="M152 435 L166 435 L166 252 L186 252" stroke="#1f6feb" stroke-width="1.5" fill="none"/>
 
-  <!-- VEX -->
-  <rect x="260" y="372" width="220" height="52" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="270" y="388" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#e3b341">VEX / Suppression (PROPRIETARY)</text>
-  <text x="270" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OpenVEX status tracking</text>
-  <text x="270" y="414" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Credential ranking + prioritization</text>
+  <!-- ═══ COLUMN 2: EXTRACT ═══ -->
+  <rect x="188" y="175" width="140" height="142" rx="10" fill="#161b22" stroke="#1f6feb" stroke-width="1.5"/>
+  <text x="258" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff" letter-spacing="0.06em">EXTRACT + PARSE</text>
+  <text x="258" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">PROPRIETARY</text>
 
-  <!-- ═══ Arrow Column 2→3 ═══ -->
-  <path d="M486 250 L500 250" stroke="#484f58" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M496 245 L504 250 L496 255" fill="#484f58"/>
+  <rect x="198" y="212" width="120" height="24" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="258" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">Package Parser (7 eco)</text>
 
-  <!-- ═══ COLUMN 3: ANALYSIS ═══ -->
-  <rect x="506" y="58" width="220" height="14" rx="4" fill="#da3633"/>
-  <text x="616" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">PROPRIETARY ANALYSIS</text>
+  <rect x="198" y="242" width="120" height="24" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="258" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">AST Framework Detect</text>
 
-  <!-- Blast Radius -->
-  <rect x="506" y="78" width="220" height="76" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1"/>
-  <text x="516" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#f85149">Blast Radius Engine</text>
-  <text x="516" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CVE → package → server → agent → creds</text>
-  <text x="516" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Multi-hop propagation modeling</text>
-  <text x="516" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Exposure surface calculation</text>
-  <text x="516" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#f85149">blast_radius.py</text>
+  <rect x="198" y="272" width="120" height="24" rx="6" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="258" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">Model File Inspector</text>
 
-  <!-- Context Graph -->
-  <rect x="506" y="160" width="220" height="76" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1"/>
-  <text x="516" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#f85149">Context Graph + BFS</text>
-  <text x="516" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Lateral movement path discovery</text>
-  <text x="516" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Attack surface visualization (ReactFlow)</text>
-  <text x="516" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Dependency graph traversal</text>
-  <text x="516" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#f85149">context_graph.py</text>
+  <path d="M328 246 L352 246" stroke="#484f58" stroke-width="2" fill="none" marker-end="url(#d-arrow-gray)"/>
 
-  <!-- Risk Analysis -->
-  <rect x="506" y="242" width="220" height="88" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1"/>
-  <text x="516" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#f85149">Risk Analyzer</text>
-  <text x="516" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">7 tool capabilities (READ→ADMIN)</text>
-  <text x="516" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">8 dangerous combination patterns</text>
-  <text x="516" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Toxic combo detection</text>
-  <text x="516" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Incident correlation engine</text>
-  <text x="516" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#f85149">risk_analyzer.py · incidents.py</text>
+  <!-- ═══ COLUMN 3: SCAN + ENRICH ═══ -->
+  <rect x="354" y="80" width="178" height="330" rx="10" fill="#161b22" stroke="#d29922" stroke-width="1.5"/>
+  <text x="443" y="97" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341" letter-spacing="0.06em">SCAN + ENRICH</text>
 
-  <!-- Compliance -->
-  <rect x="506" y="336" width="220" height="88" rx="8" fill="#161b22" stroke="#a371f7" stroke-width="1"/>
-  <text x="516" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a371f7">Compliance + Policy (10 frameworks)</text>
-  <text x="516" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP LLM/MCP/Agentic Top 10</text>
-  <text x="516" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MITRE ATLAS · NIST AI RMF · EU AI Act</text>
-  <text x="516" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">ISO 27001 · SOC 2 · CIS v8</text>
-  <text x="516" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Policy-as-code + License policy (SPDX)</text>
-  <text x="516" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">compliance.py · policy.py · license.py</text>
+  <rect x="364" y="106" width="158" height="28" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="443" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341">Vuln Scanner</text>
 
-  <!-- ═══ Arrow Column 3→4 ═══ -->
-  <path d="M732 250 L746 250" stroke="#484f58" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M742 245 L750 250 L742 255" fill="#484f58"/>
+  <rect x="364" y="142" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="401" y="157" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">OSV.dev batch</text>
+  <rect x="447" y="142" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="484" y="157" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">GHSA</text>
+  <rect x="364" y="170" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="401" y="185" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">NVD / NIST</text>
+  <rect x="447" y="170" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="484" y="185" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">Grype DB</text>
+  <rect x="364" y="198" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="401" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">NVIDIA CSAF</text>
+  <rect x="447" y="198" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="484" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">Snyk</text>
 
-  <!-- ═══ COLUMN 4: OUTPUTS ═══ -->
-  <rect x="752" y="58" width="194" height="14" rx="4" fill="#238636"/>
-  <text x="849" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">OUTPUTS + DELIVERY</text>
+  <rect x="364" y="232" width="158" height="28" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="443" y="250" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341">Enrichment Pipeline</text>
 
-  <!-- Formats -->
-  <rect x="752" y="78" width="194" height="88" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="762" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">13+ Output Formats</text>
-  <text x="762" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">JSON · Console (rich) · HTML report</text>
-  <text x="762" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CycloneDX · SPDX · SARIF</text>
-  <text x="762" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SVG badges · Mermaid diagrams</text>
-  <text x="762" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Cytoscape · ReactFlow (attack flow)</text>
-  <text x="762" y="158" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">output/__init__.py</text>
+  <rect x="364" y="268" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="401" y="283" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">CVSS 3.1</text>
+  <rect x="447" y="268" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="484" y="283" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">EPSS scores</text>
+  <rect x="364" y="296" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="401" y="311" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">CISA KEV</text>
+  <rect x="447" y="296" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="484" y="311" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">OpenSSF</text>
 
-  <!-- APIs -->
-  <rect x="752" y="172" width="194" height="76" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="762" y="188" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">APIs + Services</text>
-  <text x="762" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">REST API (25+ endpoints)</text>
-  <text x="762" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MCP Server (16 tools)</text>
-  <text x="762" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Next.js Dashboard (15 sections)</text>
-  <text x="762" y="240" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">api.py · mcp_server.py · dashboard/</text>
+  <rect x="364" y="326" width="158" height="28" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="443" y="344" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341">AI Risk + FP Reduction</text>
 
-  <!-- CI/CD -->
-  <rect x="752" y="254" width="194" height="76" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="762" y="270" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">CI/CD + Deployment</text>
-  <text x="762" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">GitHub Action (Marketplace)</text>
-  <text x="762" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Docker Hub · GHCR · Railway SSE</text>
-  <text x="762" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Helm chart · K8s manifests</text>
-  <text x="762" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">action.yml · deploy/ · Dockerfiles</text>
+  <rect x="364" y="362" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="401" y="377" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">OWASP tags</text>
+  <rect x="447" y="362" width="75" height="22" rx="5" fill="#1c1917" stroke="#d29922" stroke-width="1"/>
+  <text x="484" y="377" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#e3b341">VEX engine</text>
 
-  <!-- Observability -->
-  <rect x="752" y="336" width="194" height="64" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="762" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">Observability + SIEM</text>
-  <text x="762" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Prometheus metrics (/metrics)</text>
-  <text x="762" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OCSF + OTLP telemetry</text>
-  <text x="762" y="392" font-family="system-ui, sans-serif" font-size="7.5" fill="#3fb950">proxy.py · ocsf.py</text>
+  <line x1="443" y1="134" x2="443" y2="142" stroke="#d29922" stroke-width="1" marker-end="url(#d-arrow-amber)"/>
+  <line x1="443" y1="220" x2="443" y2="232" stroke="#d29922" stroke-width="1" marker-end="url(#d-arrow-amber)"/>
+  <line x1="443" y1="260" x2="443" y2="268" stroke="#d29922" stroke-width="1" marker-end="url(#d-arrow-amber)"/>
+  <line x1="443" y1="318" x2="443" y2="326" stroke="#d29922" stroke-width="1" marker-end="url(#d-arrow-amber)"/>
+  <line x1="443" y1="354" x2="443" y2="362" stroke="#d29922" stroke-width="1" marker-end="url(#d-arrow-amber)"/>
 
-  <!-- Integrations -->
-  <rect x="752" y="406" width="194" height="52" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="762" y="422" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950">Enterprise Integrations</text>
-  <text x="762" y="436" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Slack · Jira · ServiceNow</text>
-  <text x="762" y="448" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Drata · Vanta · Webhooks</text>
+  <path d="M532 246 L556 246" stroke="#484f58" stroke-width="2" fill="none" marker-end="url(#d-arrow-gray)"/>
+
+  <!-- ═══ COLUMN 4: ANALYSIS ═══ -->
+  <rect x="558" y="80" width="170" height="330" rx="10" fill="#161b22" stroke="#f85149" stroke-width="1.5"/>
+  <text x="643" y="97" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149" letter-spacing="0.06em">PROPRIETARY ANALYSIS</text>
+
+  <rect x="568" y="106" width="150" height="36" rx="7" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="643" y="121" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149">Blast Radius Engine</text>
+  <text x="643" y="133" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">CVE → pkg → server → agent → creds</text>
+
+  <rect x="568" y="150" width="150" height="36" rx="7" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="643" y="165" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149">Context Graph + BFS</text>
+  <text x="643" y="177" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">Lateral movement · attack paths</text>
+
+  <rect x="568" y="194" width="150" height="36" rx="7" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="643" y="209" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149">Risk Analyzer</text>
+  <text x="643" y="221" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">7 caps · 8 dangerous combos</text>
+
+  <rect x="568" y="238" width="150" height="28" rx="7" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="643" y="256" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149">Toxic Combo Detector</text>
+
+  <rect x="568" y="274" width="150" height="28" rx="7" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="643" y="292" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149">Posture Scorecard A-F</text>
+
+  <rect x="568" y="310" width="150" height="36" rx="7" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+  <text x="643" y="325" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#a371f7">Compliance (10 fwks)</text>
+  <text x="643" y="337" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">OWASP · MITRE · NIST · EU AI Act</text>
+
+  <rect x="568" y="354" width="150" height="28" rx="7" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+  <text x="643" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#a371f7">Policy-as-Code Engine</text>
+
+  <text x="643" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#f85149">Fleet trust scoring · Incidents</text>
+
+  <line x1="643" y1="142" x2="643" y2="150" stroke="#f85149" stroke-width="1" marker-end="url(#d-arrow-red)"/>
+  <line x1="643" y1="186" x2="643" y2="194" stroke="#f85149" stroke-width="1" marker-end="url(#d-arrow-red)"/>
+  <line x1="643" y1="230" x2="643" y2="238" stroke="#f85149" stroke-width="1" marker-end="url(#d-arrow-red)"/>
+  <line x1="643" y1="266" x2="643" y2="274" stroke="#f85149" stroke-width="1" marker-end="url(#d-arrow-red)"/>
+  <line x1="643" y1="302" x2="643" y2="310" stroke="#f85149" stroke-width="1" marker-end="url(#d-arrow-red)"/>
+  <line x1="643" y1="346" x2="643" y2="354" stroke="#a371f7" stroke-width="1"/>
+
+  <path d="M728 246 L748 246" stroke="#484f58" stroke-width="2" fill="none" marker-end="url(#d-arrow-gray)"/>
+
+  <!-- ═══ COLUMN 5: OUTPUTS ═══ -->
+  <rect x="750" y="80" width="196" height="382" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="848" y="97" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#3fb950" letter-spacing="0.06em">OUTPUTS + DELIVERY</text>
+
+  <rect x="760" y="106" width="90" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="805" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">JSON</text>
+  <rect x="856" y="106" width="80" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="896" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">Console</text>
+  <rect x="760" y="136" width="90" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="805" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">CycloneDX</text>
+  <rect x="856" y="136" width="80" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="896" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">SPDX</text>
+  <rect x="760" y="166" width="90" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="805" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">SARIF</text>
+  <rect x="856" y="166" width="80" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="896" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">HTML</text>
+  <rect x="760" y="196" width="90" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="805" y="212" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">Mermaid</text>
+  <rect x="856" y="196" width="80" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="896" y="212" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">SVG badges</text>
+  <rect x="760" y="226" width="90" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="805" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">ReactFlow</text>
+  <rect x="856" y="226" width="80" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="896" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">Cytoscape</text>
+
+  <line x1="760" y1="262" x2="936" y2="262" stroke="#238636" stroke-width="1"/>
+
+  <rect x="760" y="270" width="176" height="28" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="848" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#3fb950">REST API — 25+ endpoints</text>
+  <rect x="760" y="304" width="176" height="28" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="848" y="322" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#3fb950">MCP Server — 16 tools</text>
+  <rect x="760" y="338" width="176" height="28" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="848" y="356" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#3fb950">Dashboard — 15 sections</text>
+
+  <rect x="760" y="372" width="85" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="802" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">GH Action</text>
+  <rect x="851" y="372" width="85" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="893" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">Docker/Helm</text>
+  <rect x="760" y="402" width="85" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="802" y="418" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">Prometheus</text>
+  <rect x="851" y="402" width="85" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="893" y="418" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">OCSF/OTLP</text>
+  <rect x="760" y="432" width="176" height="24" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1.2"/>
+  <text x="848" y="448" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#3fb950">Slack · Jira · ServiceNow · Drata · Vanta</text>
+
+  <!-- ═══ EXTERNAL APIs ═══ -->
+  <rect x="354" y="420" width="374" height="54" rx="8" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="5 3"/>
+  <text x="541" y="436" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#8b949e" letter-spacing="0.06em">EXTERNAL INTELLIGENCE (9 sources)</text>
+  <text x="541" y="450" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#8b949e">OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype · OpenSSF · MCP Registry</text>
+  <path d="M443 420 L443 410" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#d-arrow-gray)"/>
 
   <!-- ═══ RUNTIME BAR ═══ -->
-  <rect x="14" y="470" width="932" height="52" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="1"/>
-  <text x="480" y="488" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a371f7" letter-spacing="0.08em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
-  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a371f7">4 Inline Scanners (prompt injection · PII · secrets · payloads)  |  5 Detectors (drift · creds · rate · sequence · args)</text>
-  <text x="480" y="514" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">Fleet Management · Trust Scoring (5 dimensions) · Alert Pipeline · Replay Protection</text>
+  <rect x="14" y="490" width="932" height="82" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="1.5"/>
+  <text x="480" y="508" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a371f7" letter-spacing="0.06em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
+
+  <rect x="28" y="516" width="130" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="93" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Prompt Injection</text>
+  <rect x="166" y="516" width="90" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="211" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">PII Detection</text>
+  <rect x="264" y="516" width="100" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="314" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Secret Scanner</text>
+  <rect x="372" y="516" width="112" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="428" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Payload Scanner</text>
+  <rect x="492" y="516" width="80" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="532" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Drift Detect</text>
+  <rect x="580" y="516" width="80" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="620" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Rate Limit</text>
+  <rect x="668" y="516" width="80" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="708" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Sequence</text>
+  <rect x="756" y="516" width="80" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="796" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Args Guard</text>
+  <rect x="844" y="516" width="92" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="890" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#a371f7">Cred Detect</text>
+
+  <text x="480" y="558" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#a371f7">Fleet Management · Trust Scoring (5 dims) · Alert Pipeline · Replay Protection</text>
 
   <!-- ═══ INFRA BAR ═══ -->
-  <rect x="14" y="530" width="932" height="36" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="480" y="553" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#3fb950">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
+  <rect x="14" y="584" width="932" height="40" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <rect x="28" y="594" width="110" height="20" rx="5" fill="#0d1117" stroke="#238636" stroke-width="1"/>
+  <text x="83" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">SQLite (WAL)</text>
+  <rect x="146" y="594" width="100" height="20" rx="5" fill="#0d1117" stroke="#238636" stroke-width="1"/>
+  <text x="196" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">PostgreSQL</text>
+  <rect x="254" y="594" width="100" height="20" rx="5" fill="#0d1117" stroke="#238636" stroke-width="1"/>
+  <text x="304" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">Snowflake</text>
+  <rect x="380" y="594" width="130" height="20" rx="5" fill="#0d1117" stroke="#238636" stroke-width="1"/>
+  <text x="445" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">RBAC + scrypt KDF</text>
+  <rect x="518" y="594" width="160" height="20" rx="5" fill="#0d1117" stroke="#238636" stroke-width="1"/>
+  <text x="598" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">HMAC-SHA256 audit log</text>
+  <rect x="686" y="594" width="90" height="20" rx="5" fill="#0d1117" stroke="#238636" stroke-width="1"/>
+  <text x="731" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">Scheduler</text>
+  <rect x="784" y="594" width="148" height="20" rx="5" fill="#0d1117" stroke="#238636" stroke-width="1"/>
+  <text x="858" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">Cache · Rate Limiter</text>
 
   <!-- Footer -->
-  <text x="480" y="584" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">~70 proprietary modules  |  ~15 hybrid  |  ~22 external  |  107 total  |  2,868+ tests  |  0 runtime deps for core</text>
-  <text x="480" y="602" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#484f58">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
+  <text x="480" y="648" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#8b949e">~70 proprietary modules · ~15 hybrid · ~22 external · 107 total · 2,900+ tests · 0 runtime deps</text>
+  <text x="480" y="666" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#484f58">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -1,189 +1,343 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" fill="none">
-  <rect width="960" height="620" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 680" fill="none">
+  <defs>
+    <marker id="arrow-gray" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#94a3b8"/></marker>
+    <marker id="arrow-blue" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#3b82f6"/></marker>
+    <marker id="arrow-amber" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#f59e0b"/></marker>
+    <marker id="arrow-red" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#ef4444"/></marker>
+    <marker id="arrow-green" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#10b981"/></marker>
+  </defs>
+
+  <rect width="960" height="680" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scan Workflow — End-to-End Data Flow</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">From multi-source discovery to actionable intelligence across agents, containers, cloud, and AI/ML infrastructure</text>
+  <text x="480" y="24" text-anchor="middle" font-family="system-ui, sans-serif" font-size="15" font-weight="700" fill="#0f172a">Scan Workflow — End-to-End Data Flow</text>
+  <text x="480" y="40" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#64748b">Proprietary analysis engine · 70+ modules · 20 MCP clients · 11 cloud providers · zero runtime deps</text>
 
-  <!-- ═══ COLUMN 1: INPUTS ═══ -->
-  <rect x="14" y="58" width="220" height="14" rx="4" fill="#3b82f6"/>
-  <text x="124" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">DISCOVERY INPUTS</text>
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  COLUMN 1: DISCOVERY INPUTS (x: 14–160)                           -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="52" width="148" height="418" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1" stroke-dasharray="4 2"/>
+  <text x="88" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af" letter-spacing="0.08em">DISCOVERY</text>
 
-  <!-- MCP Agents -->
-  <rect x="14" y="78" width="220" height="76" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="24" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">MCP Agent Ecosystem</text>
-  <text x="24" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">18 client configs (Claude, Cursor, Windsurf…)</text>
-  <text x="24" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">427+ MCP registry packages</text>
-  <text x="24" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Tool permission + capability analysis</text>
-  <text x="24" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">discovery/__init__.py · mcp_registry.py</text>
+  <!-- Node: MCP Agents -->
+  <rect x="24" y="80" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="96" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">MCP Agents</text>
+  <text x="88" y="110" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">20 clients · 427+ registry</text>
 
-  <!-- Infrastructure -->
-  <rect x="14" y="160" width="220" height="76" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="24" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">Infrastructure</text>
-  <text x="24" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Docker images (Grype → Syft → Docker CLI)</text>
-  <text x="24" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Kubernetes pods + namespaces (kubectl)</text>
-  <text x="24" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Terraform state files (HCL parser)</text>
-  <text x="24" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">image.py · k8s.py · parsers/__init__.py</text>
+  <!-- Node: Docker / Containers -->
+  <rect x="24" y="128" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">Containers</text>
+  <text x="88" y="158" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">Docker · K8s · Terraform</text>
 
-  <!-- Cloud & AI -->
-  <rect x="14" y="242" width="220" height="88" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="24" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">Cloud + AI Providers (11)</text>
-  <text x="24" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AWS · Azure · GCP · Snowflake · Databricks</text>
-  <text x="24" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Nebius · HuggingFace · W&amp;B · MLflow</text>
-  <text x="24" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OpenAI · Ollama (local models)</text>
-  <text x="24" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">10 agent frameworks (AST detection)</text>
-  <text x="24" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">cloud/ · ai_frameworks.py · models.py</text>
+  <!-- Node: Cloud + AI -->
+  <rect x="24" y="176" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">Cloud + AI</text>
+  <text x="88" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">11 providers · 10 frameworks</text>
 
-  <!-- Code & Supply Chain -->
-  <rect x="14" y="336" width="220" height="88" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
-  <text x="24" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#1e40af">Code + Supply Chain</text>
-  <text x="24" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">7 ecosystems: npm pip Go Cargo Maven NuGet Ruby</text>
-  <text x="24" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SBOM ingest: CycloneDX + SPDX</text>
-  <text x="24" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SAST: Semgrep rules (code_scan.py)</text>
-  <text x="24" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">12 model file formats (GGUF, SafeTensors…)</text>
-  <text x="24" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#3b82f6">parsers/ · sbom.py · code_scan.py · integrity.py</text>
+  <!-- Node: Code / Supply Chain -->
+  <rect x="24" y="224" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">Code + Supply Chain</text>
+  <text x="88" y="254" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">7 ecosystems · SBOM · SAST</text>
 
-  <!-- ═══ Arrow Column 1→2 ═══ -->
-  <path d="M240 250 L254 250" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M250 245 L258 250 L250 255" fill="#94a3b8"/>
+  <!-- Node: AI/ML Models -->
+  <rect x="24" y="272" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">AI/ML Models</text>
+  <text x="88" y="302" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">12 formats · Jupyter · GH Actions</text>
 
-  <!-- ═══ COLUMN 2: SCANNING + ENRICHMENT ═══ -->
-  <rect x="260" y="58" width="220" height="14" rx="4" fill="#f59e0b"/>
-  <text x="370" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">SCANNING + ENRICHMENT</text>
+  <!-- Node: SBOMs -->
+  <rect x="24" y="320" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="336" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">SBOM Ingest</text>
+  <text x="88" y="350" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">CycloneDX · SPDX</text>
 
-  <!-- Vuln Scanning -->
-  <rect x="260" y="78" width="220" height="100" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
-  <text x="270" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Vulnerability Scanning (9 sources)</text>
-  <text x="270" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OSV.dev batch API (primary)</text>
-  <text x="270" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">GHSA · NVD/NIST CVEs · Grype DB</text>
-  <text x="270" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NVIDIA CSAF (GPU vulns) · Snyk</text>
-  <text x="270" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Malicious + typosquat detection</text>
-  <text x="270" y="158" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#d97706">PROPRIETARY orchestrator + EXTERNAL APIs</text>
-  <text x="270" y="170" font-family="system-ui, sans-serif" font-size="7.5" fill="#d97706">scanners/__init__.py · nvidia.py</text>
+  <!-- Node: Integrity -->
+  <rect x="24" y="368" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="384" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">Integrity Verify</text>
+  <text x="88" y="398" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">cosign · Sigstore · SHA-256</text>
 
-  <!-- Enrichment -->
-  <rect x="260" y="184" width="220" height="100" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
-  <text x="270" y="200" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Enrichment Pipeline</text>
-  <text x="270" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CVSS 3.1 computation (PROPRIETARY)</text>
-  <text x="270" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NVD CVSS v3.1/v4 (EXTERNAL)</text>
-  <text x="270" y="238" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">FIRST EPSS probability scores</text>
-  <text x="270" y="250" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CISA KEV active exploitation status</text>
-  <text x="270" y="262" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OpenSSF Scorecard health metrics</text>
-  <text x="270" y="276" font-family="system-ui, sans-serif" font-size="7.5" fill="#d97706">cvss.py · scanners/__init__.py</text>
+  <!-- Node: Filesystem -->
+  <rect x="24" y="416" width="128" height="38" rx="8" fill="#ffffff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="88" y="432" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">Filesystem</text>
+  <text x="88" y="446" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#64748b">Lockfiles · node_modules</text>
 
-  <!-- False Positive + AI -->
-  <rect x="260" y="290" width="220" height="76" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
-  <text x="270" y="306" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">Intelligence Layer (PROPRIETARY)</text>
-  <text x="270" y="320" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AI risk classification (7 categories)</text>
-  <text x="270" y="332" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">False positive reduction engine</text>
-  <text x="270" y="344" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Conditional OWASP tagging</text>
-  <text x="270" y="358" font-family="system-ui, sans-serif" font-size="7.5" fill="#d97706">scanners/__init__.py · vex.py</text>
+  <!-- ── Arrows: Discovery → Extract (converging) ── -->
+  <path d="M152 99 L170 99 L170 240 L186 240" stroke="#3b82f6" stroke-width="1.5" fill="none" marker-end="url(#arrow-blue)"/>
+  <path d="M152 147 L174 147 L174 240 L186 240" stroke="#3b82f6" stroke-width="1.5" fill="none"/>
+  <path d="M152 195 L178 195 L178 240 L186 240" stroke="#3b82f6" stroke-width="1.5" fill="none"/>
+  <path d="M152 243 L186 243" stroke="#3b82f6" stroke-width="1.5" fill="none"/>
+  <path d="M152 291 L178 291 L178 246 L186 246" stroke="#3b82f6" stroke-width="1.5" fill="none"/>
+  <path d="M152 339 L174 339 L174 248 L186 248" stroke="#3b82f6" stroke-width="1.5" fill="none"/>
+  <path d="M152 387 L170 387 L170 250 L186 250" stroke="#3b82f6" stroke-width="1.5" fill="none"/>
+  <path d="M152 435 L166 435 L166 252 L186 252" stroke="#3b82f6" stroke-width="1.5" fill="none"/>
 
-  <!-- VEX -->
-  <rect x="260" y="372" width="220" height="52" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
-  <text x="270" y="388" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#92400e">VEX / Suppression (PROPRIETARY)</text>
-  <text x="270" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OpenVEX status tracking</text>
-  <text x="270" y="414" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Credential ranking + prioritization</text>
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  COLUMN 2: EXTRACT + PARSE (x: 188–326)                          -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="188" y="175" width="140" height="142" rx="10" fill="#eff6ff" stroke="#93c5fd" stroke-width="1.5"/>
+  <text x="258" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af" letter-spacing="0.06em">EXTRACT + PARSE</text>
+  <text x="258" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#1e40af">PROPRIETARY</text>
 
-  <!-- ═══ Arrow Column 2→3 ═══ -->
-  <path d="M486 250 L500 250" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M496 245 L504 250 L496 255" fill="#94a3b8"/>
+  <rect x="198" y="212" width="120" height="24" rx="6" fill="#dbeafe" stroke="#93c5fd" stroke-width="1"/>
+  <text x="258" y="228" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#1e40af">Package Parser (7 eco)</text>
 
-  <!-- ═══ COLUMN 3: ANALYSIS ═══ -->
-  <rect x="506" y="58" width="220" height="14" rx="4" fill="#ef4444"/>
-  <text x="616" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">PROPRIETARY ANALYSIS</text>
+  <rect x="198" y="242" width="120" height="24" rx="6" fill="#dbeafe" stroke="#93c5fd" stroke-width="1"/>
+  <text x="258" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#1e40af">AST Framework Detect</text>
+
+  <rect x="198" y="272" width="120" height="24" rx="6" fill="#dbeafe" stroke="#93c5fd" stroke-width="1"/>
+  <text x="258" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#1e40af">Model File Inspector</text>
+
+  <!-- Arrow: Extract → Scan -->
+  <path d="M328 246 L352 246" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow-gray)"/>
+
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  COLUMN 3: SCAN + ENRICH (x: 354–530)                            -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="354" y="80" width="178" height="330" rx="10" fill="#fffbeb" stroke="#fde68a" stroke-width="1.5"/>
+  <text x="443" y="97" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e" letter-spacing="0.06em">SCAN + ENRICH</text>
+
+  <!-- Vulnerability Scanner -->
+  <rect x="364" y="106" width="158" height="28" rx="6" fill="#ffffff" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="443" y="124" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e">Vuln Scanner</text>
+
+  <!-- Sub-nodes for scan sources -->
+  <rect x="364" y="142" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="401" y="157" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">OSV.dev batch</text>
+
+  <rect x="447" y="142" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="484" y="157" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">GHSA</text>
+
+  <rect x="364" y="170" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="401" y="185" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">NVD / NIST</text>
+
+  <rect x="447" y="170" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="484" y="185" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">Grype DB</text>
+
+  <rect x="364" y="198" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="401" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">NVIDIA CSAF</text>
+
+  <rect x="447" y="198" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="484" y="213" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">Snyk</text>
+
+  <!-- Enrichment Pipeline -->
+  <rect x="364" y="232" width="158" height="28" rx="6" fill="#ffffff" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="443" y="250" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e">Enrichment Pipeline</text>
+
+  <rect x="364" y="268" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="401" y="283" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">CVSS 3.1</text>
+
+  <rect x="447" y="268" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="484" y="283" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">EPSS scores</text>
+
+  <rect x="364" y="296" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="401" y="311" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">CISA KEV</text>
+
+  <rect x="447" y="296" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="484" y="311" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">OpenSSF</text>
+
+  <!-- Intelligence layer -->
+  <rect x="364" y="326" width="158" height="28" rx="6" fill="#ffffff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="443" y="344" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e">AI Risk + FP Reduction</text>
+
+  <rect x="364" y="362" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="401" y="377" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">OWASP tags</text>
+
+  <rect x="447" y="362" width="75" height="22" rx="5" fill="#fef3c7" stroke="#fcd34d" stroke-width="1"/>
+  <text x="484" y="377" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#92400e">VEX engine</text>
+
+  <!-- Internal arrows within scan column -->
+  <line x1="443" y1="134" x2="443" y2="142" stroke="#d97706" stroke-width="1" marker-end="url(#arrow-amber)"/>
+  <line x1="443" y1="220" x2="443" y2="232" stroke="#d97706" stroke-width="1" marker-end="url(#arrow-amber)"/>
+  <line x1="443" y1="260" x2="443" y2="268" stroke="#d97706" stroke-width="1" marker-end="url(#arrow-amber)"/>
+  <line x1="443" y1="318" x2="443" y2="326" stroke="#d97706" stroke-width="1" marker-end="url(#arrow-amber)"/>
+  <line x1="443" y1="354" x2="443" y2="362" stroke="#d97706" stroke-width="1" marker-end="url(#arrow-amber)"/>
+
+  <!-- Arrow: Scan → Analysis -->
+  <path d="M532 246 L556 246" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow-gray)"/>
+
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  COLUMN 4: PROPRIETARY ANALYSIS (x: 558–726)                     -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="558" y="80" width="170" height="330" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="1.5"/>
+  <text x="643" y="97" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b" letter-spacing="0.06em">PROPRIETARY ANALYSIS</text>
 
   <!-- Blast Radius -->
-  <rect x="506" y="78" width="220" height="76" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
-  <text x="516" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#991b1b">Blast Radius Engine</text>
-  <text x="516" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CVE → package → server → agent → creds</text>
-  <text x="516" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Multi-hop propagation modeling</text>
-  <text x="516" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Exposure surface calculation</text>
-  <text x="516" y="146" font-family="system-ui, sans-serif" font-size="7.5" fill="#ef4444">blast_radius.py</text>
+  <rect x="568" y="106" width="150" height="36" rx="7" fill="#ffffff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="643" y="121" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b">Blast Radius Engine</text>
+  <text x="643" y="133" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">CVE → pkg → server → agent → creds</text>
 
   <!-- Context Graph -->
-  <rect x="506" y="160" width="220" height="76" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
-  <text x="516" y="176" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#991b1b">Context Graph + BFS</text>
-  <text x="516" y="190" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Lateral movement path discovery</text>
-  <text x="516" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Attack surface visualization (ReactFlow)</text>
-  <text x="516" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Dependency graph traversal</text>
-  <text x="516" y="228" font-family="system-ui, sans-serif" font-size="7.5" fill="#ef4444">context_graph.py</text>
+  <rect x="568" y="150" width="150" height="36" rx="7" fill="#ffffff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="643" y="165" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b">Context Graph + BFS</text>
+  <text x="643" y="177" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">Lateral movement · attack paths</text>
 
-  <!-- Risk Analysis -->
-  <rect x="506" y="242" width="220" height="88" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
-  <text x="516" y="258" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#991b1b">Risk Analyzer</text>
-  <text x="516" y="272" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">7 tool capabilities (READ→ADMIN)</text>
-  <text x="516" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">8 dangerous combination patterns</text>
-  <text x="516" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Toxic combo detection</text>
-  <text x="516" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Incident correlation engine</text>
-  <text x="516" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#ef4444">risk_analyzer.py · incidents.py</text>
+  <!-- Risk Analyzer -->
+  <rect x="568" y="194" width="150" height="36" rx="7" fill="#ffffff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="643" y="209" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b">Risk Analyzer</text>
+  <text x="643" y="221" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">7 caps · 8 dangerous combos</text>
+
+  <!-- Toxic Combos -->
+  <rect x="568" y="238" width="150" height="28" rx="7" fill="#ffffff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="643" y="256" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b">Toxic Combo Detector</text>
+
+  <!-- Posture Score -->
+  <rect x="568" y="274" width="150" height="28" rx="7" fill="#ffffff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="643" y="292" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b">Posture Scorecard A-F</text>
 
   <!-- Compliance -->
-  <rect x="506" y="336" width="220" height="88" rx="8" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1"/>
-  <text x="516" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9">Compliance + Policy (10 frameworks)</text>
-  <text x="516" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP LLM/MCP/Agentic Top 10</text>
-  <text x="516" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MITRE ATLAS · NIST AI RMF · EU AI Act</text>
-  <text x="516" y="390" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">ISO 27001 · SOC 2 · CIS v8</text>
-  <text x="516" y="402" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Policy-as-code + License policy (SPDX)</text>
-  <text x="516" y="416" font-family="system-ui, sans-serif" font-size="7.5" fill="#8b5cf6">compliance.py · policy.py · license.py</text>
+  <rect x="568" y="310" width="150" height="36" rx="7" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="643" y="325" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#6d28d9">Compliance (10 fwks)</text>
+  <text x="643" y="337" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">OWASP · MITRE · NIST · EU AI Act</text>
 
-  <!-- ═══ Arrow Column 3→4 ═══ -->
-  <path d="M732 250 L746 250" stroke="#94a3b8" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M742 245 L750 250 L742 255" fill="#94a3b8"/>
+  <!-- Policy Engine -->
+  <rect x="568" y="354" width="150" height="28" rx="7" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="643" y="372" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#6d28d9">Policy-as-Code Engine</text>
 
-  <!-- ═══ COLUMN 4: OUTPUTS ═══ -->
-  <rect x="752" y="58" width="194" height="14" rx="4" fill="#10b981"/>
-  <text x="849" y="69" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fff">OUTPUTS + DELIVERY</text>
+  <!-- Fleet Trust -->
+  <rect x="568" y="390" width="150" height="12" rx="4" fill="#fef2f2" stroke="none"/>
+  <text x="643" y="400" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#991b1b">Fleet trust scoring · Incidents</text>
 
-  <!-- Formats -->
-  <rect x="752" y="78" width="194" height="88" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="762" y="94" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">13+ Output Formats</text>
-  <text x="762" y="108" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">JSON · Console (rich) · HTML report</text>
-  <text x="762" y="120" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CycloneDX · SPDX · SARIF</text>
-  <text x="762" y="132" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SVG badges · Mermaid diagrams</text>
-  <text x="762" y="144" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Cytoscape · ReactFlow (attack flow)</text>
-  <text x="762" y="158" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">output/__init__.py</text>
+  <!-- Internal arrows within analysis column -->
+  <line x1="643" y1="142" x2="643" y2="150" stroke="#ef4444" stroke-width="1" marker-end="url(#arrow-red)"/>
+  <line x1="643" y1="186" x2="643" y2="194" stroke="#ef4444" stroke-width="1" marker-end="url(#arrow-red)"/>
+  <line x1="643" y1="230" x2="643" y2="238" stroke="#ef4444" stroke-width="1" marker-end="url(#arrow-red)"/>
+  <line x1="643" y1="266" x2="643" y2="274" stroke="#ef4444" stroke-width="1" marker-end="url(#arrow-red)"/>
+  <line x1="643" y1="302" x2="643" y2="310" stroke="#ef4444" stroke-width="1" marker-end="url(#arrow-red)"/>
+  <line x1="643" y1="346" x2="643" y2="354" stroke="#8b5cf6" stroke-width="1"/>
 
-  <!-- APIs -->
-  <rect x="752" y="172" width="194" height="76" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="762" y="188" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">APIs + Services</text>
-  <text x="762" y="202" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">REST API (25+ endpoints)</text>
-  <text x="762" y="214" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MCP Server (16 tools)</text>
-  <text x="762" y="226" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Next.js Dashboard (15 sections)</text>
-  <text x="762" y="240" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">api.py · mcp_server.py · dashboard/</text>
+  <!-- Arrow: Analysis → Output -->
+  <path d="M728 246 L748 246" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow-gray)"/>
 
-  <!-- CI/CD -->
-  <rect x="752" y="254" width="194" height="76" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="762" y="270" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">CI/CD + Deployment</text>
-  <text x="762" y="284" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">GitHub Action (Marketplace)</text>
-  <text x="762" y="296" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Docker Hub · GHCR · Railway SSE</text>
-  <text x="762" y="308" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Helm chart · K8s manifests</text>
-  <text x="762" y="322" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">action.yml · deploy/ · Dockerfiles</text>
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  COLUMN 5: OUTPUTS (x: 750–946)                                  -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="750" y="80" width="196" height="382" rx="10" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1.5"/>
+  <text x="848" y="97" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#065f46" letter-spacing="0.06em">OUTPUTS + DELIVERY</text>
 
-  <!-- Observability -->
-  <rect x="752" y="336" width="194" height="64" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="762" y="352" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">Observability + SIEM</text>
-  <text x="762" y="366" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Prometheus metrics (/metrics)</text>
-  <text x="762" y="378" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OCSF + OTLP telemetry</text>
-  <text x="762" y="392" font-family="system-ui, sans-serif" font-size="7.5" fill="#10b981">proxy.py · ocsf.py</text>
+  <!-- Output format nodes -->
+  <rect x="760" y="106" width="90" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="805" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">JSON</text>
 
-  <!-- Integrations -->
-  <rect x="752" y="406" width="194" height="52" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
-  <text x="762" y="422" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#065f46">Enterprise Integrations</text>
-  <text x="762" y="436" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Slack · Jira · ServiceNow</text>
-  <text x="762" y="448" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Drata · Vanta · Webhooks</text>
+  <rect x="856" y="106" width="80" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="896" y="122" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">Console</text>
 
-  <!-- ═══ RUNTIME BAR ═══ -->
-  <rect x="14" y="470" width="932" height="52" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="480" y="488" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
-  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">4 Inline Scanners (prompt injection · PII · secrets · payloads)  |  5 Detectors (drift · creds · rate · sequence · args)</text>
-  <text x="480" y="514" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b5cf6">Fleet Management · Trust Scoring (5 dimensions) · Alert Pipeline · Replay Protection</text>
+  <rect x="760" y="136" width="90" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="805" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">CycloneDX</text>
 
-  <!-- ═══ INFRA BAR ═══ -->
-  <rect x="14" y="530" width="932" height="36" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
-  <text x="480" y="553" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#15803d">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
+  <rect x="856" y="136" width="80" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="896" y="152" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">SPDX</text>
 
-  <!-- Footer -->
-  <text x="480" y="584" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#475569">~70 proprietary modules  |  ~15 hybrid  |  ~22 external  |  107 total  |  2,868+ tests  |  0 runtime deps for core</text>
-  <text x="480" y="602" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
+  <rect x="760" y="166" width="90" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="805" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">SARIF</text>
+
+  <rect x="856" y="166" width="80" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="896" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">HTML</text>
+
+  <rect x="760" y="196" width="90" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="805" y="212" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">Mermaid</text>
+
+  <rect x="856" y="196" width="80" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="896" y="212" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">SVG badges</text>
+
+  <rect x="760" y="226" width="90" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="805" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">ReactFlow</text>
+
+  <rect x="856" y="226" width="80" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="896" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">Cytoscape</text>
+
+  <!-- Delivery channels -->
+  <line x1="760" y1="262" x2="936" y2="262" stroke="#a7f3d0" stroke-width="1"/>
+
+  <rect x="760" y="270" width="176" height="28" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.5"/>
+  <text x="848" y="288" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#065f46">REST API — 25+ endpoints</text>
+
+  <rect x="760" y="304" width="176" height="28" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.5"/>
+  <text x="848" y="322" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#065f46">MCP Server — 16 tools</text>
+
+  <rect x="760" y="338" width="176" height="28" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.5"/>
+  <text x="848" y="356" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#065f46">Dashboard — 15 sections</text>
+
+  <rect x="760" y="372" width="85" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="802" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">GH Action</text>
+
+  <rect x="851" y="372" width="85" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="893" y="388" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">Docker/Helm</text>
+
+  <rect x="760" y="402" width="85" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="802" y="418" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">Prometheus</text>
+
+  <rect x="851" y="402" width="85" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="893" y="418" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">OCSF/OTLP</text>
+
+  <rect x="760" y="432" width="176" height="24" rx="6" fill="#ffffff" stroke="#10b981" stroke-width="1.2"/>
+  <text x="848" y="448" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">Slack · Jira · ServiceNow · Drata · Vanta</text>
+
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  EXTERNAL APIs (dashed border — shows these are NOT proprietary)  -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="354" y="420" width="374" height="54" rx="8" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="5 3"/>
+  <text x="541" y="436" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#64748b" letter-spacing="0.06em">EXTERNAL INTELLIGENCE (9 sources)</text>
+  <text x="541" y="450" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#64748b">OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype · OpenSSF · MCP Registry</text>
+
+  <!-- Dashed arrows from external to scan column -->
+  <path d="M443 420 L443 410" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#arrow-gray)"/>
+
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION BAR                                           -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="490" width="932" height="82" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1.5"/>
+  <text x="480" y="508" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9" letter-spacing="0.06em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
+
+  <!-- Runtime sub-nodes -->
+  <rect x="28" y="516" width="130" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="93" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Prompt Injection</text>
+
+  <rect x="166" y="516" width="90" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="211" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">PII Detection</text>
+
+  <rect x="264" y="516" width="100" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="314" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Secret Scanner</text>
+
+  <rect x="372" y="516" width="112" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="428" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Payload Scanner</text>
+
+  <rect x="492" y="516" width="80" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="532" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Drift Detect</text>
+
+  <rect x="580" y="516" width="80" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="620" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Rate Limit</text>
+
+  <rect x="668" y="516" width="80" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="708" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Sequence</text>
+
+  <rect x="756" y="516" width="80" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="796" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Args Guard</text>
+
+  <rect x="844" y="516" width="92" height="22" rx="5" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
+  <text x="890" y="531" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" fill="#6d28d9">Cred Detect</text>
+
+  <text x="480" y="558" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#7c3aed">Fleet Management · Trust Scoring (5 dims) · Alert Pipeline · Replay Protection</text>
+
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  INFRASTRUCTURE BAR                                                -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="584" width="932" height="40" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <rect x="28" y="594" width="110" height="20" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="83" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#166534">SQLite (WAL)</text>
+  <rect x="146" y="594" width="100" height="20" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="196" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#166534">PostgreSQL</text>
+  <rect x="254" y="594" width="100" height="20" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="304" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#166534">Snowflake</text>
+  <rect x="380" y="594" width="130" height="20" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="445" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#166534">RBAC + scrypt KDF</text>
+  <rect x="518" y="594" width="160" height="20" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="598" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#166534">HMAC-SHA256 audit log</text>
+  <rect x="686" y="594" width="90" height="20" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="731" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#166534">Scheduler</text>
+  <rect x="784" y="594" width="148" height="20" rx="5" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="858" y="608" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#166534">Cache · Rate Limiter</text>
+
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <!--  FOOTER                                                            -->
+  <!-- ════════════════════════════════════════════════════════════════════ -->
+  <text x="480" y="648" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#475569">~70 proprietary modules · ~15 hybrid · ~22 external · 107 total · 2,900+ tests · 0 runtime deps</text>
+  <text x="480" y="666" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#94a3b8">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -1,188 +1,247 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
-  <rect width="960" height="520" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" fill="none">
+  <defs>
+    <marker id="sa-arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#484f58"/></marker>
+    <marker id="sa-arrow-b" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#1f6feb"/></marker>
+    <marker id="sa-arrow-a" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#d29922"/></marker>
+  </defs>
+
+  <rect width="960" height="540" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">Scanner Pipeline — 7-Stage Architecture</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#8b949e">Proprietary analysis engine with external intelligence feeds · 70+ modules · zero runtime dependencies for core</text>
+  <text x="480" y="24" text-anchor="middle" font-family="system-ui, sans-serif" font-size="15" font-weight="700" fill="#e6edf3">Scanner Pipeline — 7-Stage Architecture</text>
+  <text x="480" y="40" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#8b949e">Proprietary engine with external intelligence feeds · each arrow is a real data handoff</text>
 
-  <!-- ─── STAGE 1: DISCOVER ─── -->
-  <rect x="14" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#1f6feb" stroke-width="2"/>
-  <rect x="14" y="62" width="122" height="26" rx="10" fill="#1f6feb"/>
-  <rect x="14" y="78" width="122" height="10" fill="#1f6feb"/>
-  <text x="75" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① DISCOVER</text>
-  <text x="75" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">PROPRIETARY</text>
-  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">20 MCP clients</text>
-  <text x="75" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Docker / K8s / Terraform</text>
-  <text x="75" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">11 cloud+AI providers</text>
-  <text x="75" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">10 agent frameworks</text>
-  <text x="75" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">12 model file formats</text>
-  <text x="75" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Jupyter · GH Actions</text>
-  <text x="75" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Filesystem + lockfiles</text>
-  <text x="75" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL</text>
-  <text x="75" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">MCP Registry (427+)</text>
-  <text x="75" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Docker Hub API</text>
-  <text x="75" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">kubectl CLI</text>
-  <text x="75" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">discovery/__init__.py</text>
-  <text x="75" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">k8s.py · image.py</text>
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  MAIN PIPELINE — 7 stages connected by arrows                    -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- Stage 1: DISCOVER -->
+  <rect x="14" y="56" width="118" height="32" rx="8" fill="#1f6feb" stroke="none"/>
+  <text x="73" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① Discover</text>
+
+  <!-- Discover sub-nodes -->
+  <rect x="14" y="96" width="118" height="196" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
+  <rect x="22" y="104" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="73" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">MCP (20 clients)</text>
+  <rect x="22" y="132" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="73" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">Docker / K8s</text>
+  <rect x="22" y="160" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="73" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">Cloud (11 provs)</text>
+  <rect x="22" y="188" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="73" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">AI/ML (10 fwks)</text>
+  <rect x="22" y="216" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="73" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">Code (7 eco)</text>
+  <rect x="22" y="244" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="73" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">Filesystem</text>
+  <rect x="22" y="272" width="102" height="12" rx="3" fill="#1f6feb" opacity="0.2"/>
+  <text x="73" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#58a6ff">PROPRIETARY</text>
 
   <!-- Arrow 1→2 -->
-  <path d="M136 170 L148 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
-  <path d="M145 166 L151 170 L145 174" fill="#484f58"/>
+  <path d="M132 180 L146 180" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 2: EXTRACT ─── -->
-  <rect x="152" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#1f6feb" stroke-width="2"/>
-  <rect x="152" y="62" width="122" height="26" rx="10" fill="#1f6feb"/>
-  <rect x="152" y="78" width="122" height="10" fill="#1f6feb"/>
-  <text x="213" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">② EXTRACT</text>
-  <text x="213" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#58a6ff">PROPRIETARY</text>
-  <text x="213" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">7 ecosystems parser</text>
-  <text x="213" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">npm·pip·Go·Cargo·Maven</text>
-  <text x="213" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NuGet · Ruby gems</text>
-  <text x="213" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AST framework detect</text>
-  <text x="213" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Model file inspection</text>
-  <text x="213" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SBOM ingest CDX+SPDX</text>
-  <text x="213" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Container layer extract</text>
-  <text x="213" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL</text>
-  <text x="213" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Syft (fallback scanner)</text>
-  <text x="213" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Semgrep (SAST rules)</text>
-  <text x="213" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">cosign (sig verify)</text>
-  <text x="213" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">parsers/__init__.py</text>
-  <text x="213" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#58a6ff">sbom.py · code_scan.py</text>
+  <!-- Stage 2: EXTRACT -->
+  <rect x="148" y="56" width="118" height="32" rx="8" fill="#1f6feb" stroke="none"/>
+  <text x="207" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">② Extract</text>
+
+  <rect x="148" y="96" width="118" height="196" rx="8" fill="#161b22" stroke="#1f6feb" stroke-width="1"/>
+  <rect x="156" y="104" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="207" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">Pkg Parser</text>
+  <rect x="156" y="132" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="207" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">AST Detect</text>
+  <rect x="156" y="160" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="207" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">Model Inspector</text>
+  <rect x="156" y="188" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="207" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">SBOM Ingest</text>
+  <rect x="156" y="216" width="102" height="22" rx="5" fill="#0d1117" stroke="#1f6feb" stroke-width="1"/>
+  <text x="207" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#58a6ff">Container Layers</text>
+  <!-- External tools -->
+  <rect x="156" y="248" width="48" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="180" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">Syft</text>
+  <rect x="210" y="248" width="48" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="234" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">Semgrep</text>
+  <rect x="156" y="272" width="102" height="12" rx="3" fill="#1f6feb" opacity="0.2"/>
+  <text x="207" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#58a6ff">PROPRIETARY + ext</text>
 
   <!-- Arrow 2→3 -->
-  <path d="M274 170 L286 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
-  <path d="M283 166 L289 170 L283 174" fill="#484f58"/>
+  <path d="M266 180 L280 180" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 3: SCAN ─── -->
-  <rect x="290" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#d29922" stroke-width="2"/>
-  <rect x="290" y="62" width="122" height="26" rx="10" fill="#d29922"/>
-  <rect x="290" y="78" width="122" height="10" fill="#d29922"/>
-  <text x="351" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">③ SCAN</text>
-  <text x="351" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341">PROPRIETARY</text>
-  <text x="351" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OSV batch orchestrator</text>
-  <text x="351" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Malicious pkg detect</text>
-  <text x="351" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Typosquat detection</text>
-  <text x="351" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Snyk cross-reference</text>
-  <text x="351" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">NVIDIA CSAF parser</text>
-  <text x="351" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL APIs</text>
-  <text x="351" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OSV.dev batch API</text>
-  <text x="351" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">GHSA advisories</text>
-  <text x="351" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">Grype DB (fallback)</text>
-  <text x="351" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NVD / NIST CVE feed</text>
-  <text x="351" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NVIDIA CSAF feed</text>
-  <text x="351" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">scanners/__init__.py</text>
-  <text x="351" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">image.py · nvidia.py</text>
+  <!-- Stage 3: SCAN -->
+  <rect x="282" y="56" width="118" height="32" rx="8" fill="#d29922" stroke="none"/>
+  <text x="341" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">③ Scan</text>
+
+  <rect x="282" y="96" width="118" height="196" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
+  <rect x="290" y="104" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="341" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">OSV.dev batch</text>
+  <rect x="290" y="132" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="341" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">GHSA</text>
+  <rect x="290" y="160" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="341" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">NVD / NIST</text>
+  <rect x="290" y="188" width="48" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="314" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">Grype</text>
+  <rect x="344" y="188" width="48" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="368" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">NVIDIA</text>
+  <rect x="290" y="216" width="48" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="314" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">Snyk</text>
+  <rect x="344" y="216" width="48" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="368" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#e3b341">Malware</text>
+  <rect x="290" y="244" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="341" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">Typosquat Detect</text>
+  <rect x="290" y="272" width="102" height="12" rx="3" fill="#d29922" opacity="0.2"/>
+  <text x="341" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#e3b341">9 SOURCES</text>
 
   <!-- Arrow 3→4 -->
-  <path d="M412 170 L424 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
-  <path d="M421 166 L427 170 L421 174" fill="#484f58"/>
+  <path d="M400 180 L414 180" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 4: ENRICH ─── -->
-  <rect x="428" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#d29922" stroke-width="2"/>
-  <rect x="428" y="62" width="122" height="26" rx="10" fill="#d29922"/>
-  <rect x="428" y="78" width="122" height="10" fill="#d29922"/>
-  <text x="489" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">④ ENRICH</text>
-  <text x="489" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#e3b341">PROPRIETARY</text>
-  <text x="489" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CVSS 3.1 computation</text>
-  <text x="489" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">AI risk classification</text>
-  <text x="489" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">False positive reducer</text>
-  <text x="489" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Conditional OWASP tag</text>
-  <text x="489" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Credential ranking</text>
-  <text x="489" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">VEX/OpenVEX engine</text>
-  <text x="489" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e">EXTERNAL APIs</text>
-  <text x="489" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">NVD CVSS v3.1/v4</text>
-  <text x="489" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">FIRST EPSS scores</text>
-  <text x="489" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">CISA KEV catalog</text>
-  <text x="489" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#8b949e">OpenSSF Scorecard</text>
-  <text x="489" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">scanners/__init__.py</text>
-  <text x="489" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#e3b341">cvss.py · vex.py</text>
+  <!-- Stage 4: ENRICH -->
+  <rect x="416" y="56" width="118" height="32" rx="8" fill="#d29922" stroke="none"/>
+  <text x="475" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">④ Enrich</text>
+
+  <rect x="416" y="96" width="118" height="196" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1"/>
+  <rect x="424" y="104" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="475" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">CVSS 3.1 Compute</text>
+  <rect x="424" y="132" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="475" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">EPSS Scores</text>
+  <rect x="424" y="160" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="475" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">CISA KEV</text>
+  <rect x="424" y="188" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
+  <text x="475" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#e3b341">OpenSSF Score</text>
+  <rect x="424" y="216" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="475" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">AI Risk Classify</text>
+  <rect x="424" y="244" width="102" height="22" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="1.5"/>
+  <text x="475" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#e3b341">FP Reduction</text>
+  <rect x="424" y="272" width="102" height="12" rx="3" fill="#d29922" opacity="0.2"/>
+  <text x="475" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#e3b341">PROPRIETARY + ext</text>
 
   <!-- Arrow 4→5 -->
-  <path d="M550 170 L562 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
-  <path d="M559 166 L565 170 L559 174" fill="#484f58"/>
+  <path d="M534 180 L548 180" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 5: ANALYZE ─── -->
-  <rect x="566" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#f85149" stroke-width="2"/>
-  <rect x="566" y="62" width="122" height="26" rx="10" fill="#da3633"/>
-  <rect x="566" y="78" width="122" height="10" fill="#da3633"/>
-  <text x="627" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑤ ANALYZE</text>
-  <text x="627" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#f85149">100% PROPRIETARY</text>
-  <text x="627" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Blast Radius engine</text>
-  <text x="627" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Context Graph + BFS</text>
-  <text x="627" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Lateral movement paths</text>
-  <text x="627" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Toxic combo detector</text>
-  <text x="627" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Risk Analyzer (7 caps)</text>
-  <text x="627" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">8 dangerous patterns</text>
-  <text x="627" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Posture scorecard A-F</text>
-  <text x="627" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Incident correlation</text>
-  <text x="627" y="214" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Fleet trust scoring</text>
-  <text x="627" y="226" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Dependency graph walk</text>
-  <text x="627" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#f85149">blast_radius.py</text>
-  <text x="627" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#f85149">context_graph.py</text>
+  <!-- Stage 5: ANALYZE -->
+  <rect x="550" y="56" width="118" height="32" rx="8" fill="#f85149" stroke="none"/>
+  <text x="609" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑤ Analyze</text>
+
+  <rect x="550" y="96" width="118" height="196" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1"/>
+  <rect x="558" y="104" width="102" height="22" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="609" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Blast Radius</text>
+  <rect x="558" y="132" width="102" height="22" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="609" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Context Graph</text>
+  <rect x="558" y="160" width="102" height="22" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="609" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Risk Analyzer</text>
+  <rect x="558" y="188" width="102" height="22" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="609" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Toxic Combos</text>
+  <rect x="558" y="216" width="102" height="22" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="609" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Posture Score</text>
+  <rect x="558" y="244" width="102" height="22" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="1.5"/>
+  <text x="609" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#ff7b72">Incidents</text>
+  <rect x="558" y="272" width="102" height="12" rx="3" fill="#f85149" opacity="0.2"/>
+  <text x="609" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#ff7b72">100% PROPRIETARY</text>
+
+  <!-- Cross-connections within analyze (BFS) -->
+  <path d="M660 115 Q668 130 660 143" stroke="#f85149" stroke-width="1" fill="none" stroke-dasharray="2 2"/>
+  <path d="M660 147 Q668 162 660 175" stroke="#f85149" stroke-width="1" fill="none" stroke-dasharray="2 2"/>
 
   <!-- Arrow 5→6 -->
-  <path d="M688 170 L700 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
-  <path d="M697 166 L703 170 L697 174" fill="#484f58"/>
+  <path d="M668 180 L682 180" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 6: COMPLY ─── -->
-  <rect x="704" y="62" width="122" height="220" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="2"/>
-  <rect x="704" y="62" width="122" height="26" rx="10" fill="#8b5cf6"/>
-  <rect x="704" y="78" width="122" height="10" fill="#8b5cf6"/>
-  <text x="765" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑥ COMPLY</text>
-  <text x="765" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#a371f7">100% PROPRIETARY</text>
-  <text x="765" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">10 compliance frameworks</text>
-  <text x="765" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP LLM Top 10</text>
-  <text x="765" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP MCP Top 10</text>
-  <text x="765" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">OWASP Agentic Security</text>
-  <text x="765" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MITRE ATLAS · NIST</text>
-  <text x="765" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">EU AI Act · ISO 27001</text>
-  <text x="765" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SOC 2 · CIS v8</text>
-  <text x="765" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Policy-as-code engine</text>
-  <text x="765" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">License policy (SPDX)</text>
-  <text x="765" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Auto-remediation</text>
-  <text x="765" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a371f7">compliance.py</text>
-  <text x="765" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#a371f7">policy.py · license.py</text>
+  <!-- Stage 6: COMPLY -->
+  <rect x="684" y="56" width="118" height="32" rx="8" fill="#a371f7" stroke="none"/>
+  <text x="743" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑥ Comply</text>
+
+  <rect x="684" y="96" width="118" height="196" rx="8" fill="#161b22" stroke="#a371f7" stroke-width="1"/>
+  <rect x="692" y="104" width="102" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="743" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#d2a8ff">OWASP LLM</text>
+  <rect x="692" y="132" width="102" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="743" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#d2a8ff">OWASP MCP</text>
+  <rect x="692" y="160" width="102" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="743" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#d2a8ff">MITRE ATLAS</text>
+  <rect x="692" y="188" width="48" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="716" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#d2a8ff">NIST</text>
+  <rect x="746" y="188" width="48" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="770" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#d2a8ff">EU AI</text>
+  <rect x="692" y="216" width="48" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="716" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#d2a8ff">SOC 2</text>
+  <rect x="746" y="216" width="48" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1"/>
+  <text x="770" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#d2a8ff">CIS v8</text>
+  <rect x="692" y="244" width="102" height="22" rx="5" fill="#0d1117" stroke="#a371f7" stroke-width="1.5"/>
+  <text x="743" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#d2a8ff">Policy Engine</text>
+  <rect x="692" y="272" width="102" height="12" rx="3" fill="#a371f7" opacity="0.2"/>
+  <text x="743" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#d2a8ff">100% PROPRIETARY</text>
 
   <!-- Arrow 6→7 -->
-  <path d="M826 170 L838 170" stroke="#484f58" stroke-width="2" stroke-linecap="round"/>
-  <path d="M835 166 L841 170 L835 174" fill="#484f58"/>
+  <path d="M802 180 L816 180" stroke="#484f58" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 7: OUTPUT ─── -->
-  <rect x="842" y="62" width="104" height="220" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="2"/>
-  <rect x="842" y="62" width="104" height="26" rx="10" fill="#238636"/>
-  <rect x="842" y="78" width="104" height="10" fill="#238636"/>
-  <text x="894" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑦ OUTPUT</text>
-  <text x="894" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#3fb950">13+ FORMATS</text>
-  <text x="894" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">JSON · Console · HTML</text>
-  <text x="894" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">CycloneDX · SPDX</text>
-  <text x="894" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SARIF (GitHub native)</text>
-  <text x="894" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">SVG badges · Mermaid</text>
-  <text x="894" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Cytoscape · ReactFlow</text>
-  <text x="894" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Attack flow graphs</text>
-  <text x="894" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">REST API (25+ routes)</text>
-  <text x="894" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">MCP Server (16 tools)</text>
-  <text x="894" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Next.js Dashboard</text>
-  <text x="894" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#c9d1d9">Prometheus · OCSF</text>
-  <text x="894" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">output/__init__.py</text>
-  <text x="894" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">api.py · mcp_server.py</text>
+  <!-- Stage 7: OUTPUT -->
+  <rect x="818" y="56" width="128" height="32" rx="8" fill="#3fb950" stroke="none"/>
+  <text x="882" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑦ Output</text>
 
-  <!-- ─── EXTERNAL INTELLIGENCE BAR ─── -->
-  <rect x="14" y="300" width="932" height="52" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1"/>
-  <text x="480" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#8b949e" letter-spacing="0.08em">9 EXTERNAL INTELLIGENCE SOURCES</text>
-  <text x="480" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#8b949e">OSV.dev Batch  ·  GHSA  ·  NVD/NIST  ·  FIRST EPSS  ·  CISA KEV  ·  NVIDIA CSAF  ·  Grype DB  ·  OpenSSF Scorecard  ·  MCP Registry (427+)</text>
+  <rect x="818" y="96" width="128" height="196" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <rect x="826" y="104" width="56" height="20" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="854" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#7ee787">JSON</text>
+  <rect x="886" y="104" width="52" height="20" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="912" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#7ee787">SARIF</text>
+  <rect x="826" y="128" width="56" height="20" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="854" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#7ee787">CDX</text>
+  <rect x="886" y="128" width="52" height="20" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="912" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#7ee787">SPDX</text>
+  <rect x="826" y="152" width="56" height="20" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="854" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#7ee787">HTML</text>
+  <rect x="886" y="152" width="52" height="20" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="912" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#7ee787">SVG</text>
+  <rect x="826" y="180" width="112" height="22" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="882" y="195" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">REST API (25+)</text>
+  <rect x="826" y="206" width="112" height="22" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="882" y="221" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">MCP Server (16)</text>
+  <rect x="826" y="232" width="112" height="22" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1.5"/>
+  <text x="882" y="247" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#7ee787">Dashboard (15)</text>
+  <rect x="826" y="258" width="112" height="22" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
+  <text x="882" y="273" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#7ee787">Prometheus/OCSF</text>
+  <rect x="826" y="272" width="112" height="12" rx="3" fill="#3fb950" opacity="0.2"/>
+  <text x="882" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#7ee787">13+ FORMATS</text>
 
-  <!-- ─── INTEGRATIONS BAR ─── -->
-  <rect x="14" y="362" width="932" height="52" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="1"/>
-  <text x="480" y="380" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#a371f7" letter-spacing="0.08em">RUNTIME PROTECTION + DELIVERY</text>
-  <text x="480" y="396" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a371f7">MCP Stdio Proxy · 4 Inline Scanners · 5 Detectors · Fleet Mgmt · Trust Scoring · Alert Pipeline</text>
-  <text x="480" y="406" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b949e">GitHub Action · Docker/Helm · Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  EXTERNAL FEEDS (dashed boxes below pipeline)                     -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="310" width="932" height="54" rx="8" fill="#161b22" stroke="#484f58" stroke-width="1" stroke-dasharray="5 3"/>
+  <text x="480" y="328" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#8b949e" letter-spacing="0.06em">EXTERNAL INTELLIGENCE FEEDS — 9 sources feed into stages ③ ④</text>
 
-  <!-- ─── INFRASTRUCTURE BAR ─── -->
-  <rect x="14" y="424" width="932" height="42" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="480" y="442" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#3fb950" letter-spacing="0.08em">INFRASTRUCTURE</text>
-  <text x="480" y="456" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#3fb950">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
+  <rect x="28" y="338" width="80" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="68" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">OSV.dev</text>
+  <rect x="116" y="338" width="65" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="148" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">GHSA</text>
+  <rect x="189" y="338" width="75" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="226" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">NVD/NIST</text>
+  <rect x="272" y="338" width="65" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="304" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">EPSS</text>
+  <rect x="345" y="338" width="65" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="377" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">CISA KEV</text>
+  <rect x="418" y="338" width="90" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="463" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">NVIDIA CSAF</text>
+  <rect x="516" y="338" width="70" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="551" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">Grype DB</text>
+  <rect x="594" y="338" width="70" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="629" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">OpenSSF</text>
+  <rect x="672" y="338" width="90" height="18" rx="4" fill="#0d1117" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="717" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#8b949e">MCP Registry</text>
+
+  <!-- Dashed arrows from external feeds up to pipeline stages 3 and 4 -->
+  <path d="M341 310 L341 296" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#sa-arrow)"/>
+  <path d="M475 310 L475 296" stroke="#484f58" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#sa-arrow)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION BAR                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="378" width="932" height="56" rx="10" fill="#161b22" stroke="#a371f7" stroke-width="1.5"/>
+  <text x="480" y="396" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#d2a8ff" letter-spacing="0.06em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
+  <text x="480" y="412" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#a371f7">4 Inline Scanners (injection · PII · secrets · payloads) · 5 Detectors · Fleet Mgmt · Trust Score · Alerts</text>
+  <text x="480" y="426" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#8b949e">Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  INFRASTRUCTURE BAR                                                -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="446" width="932" height="40" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
+  <text x="480" y="464" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#7ee787">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache</text>
+  <text x="480" y="478" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3fb950">GH Action · Docker Hub · GHCR · Railway SSE · Helm · K8s manifests</text>
 
   <!-- Footer -->
-  <text x="480" y="486" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#8b949e">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime deps for core</text>
-  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#484f58">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
+  <text x="480" y="510" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#8b949e">~70 proprietary · ~15 hybrid · ~22 external · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <text x="480" y="528" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#484f58">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -1,188 +1,247 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
-  <rect width="960" height="520" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" fill="none">
+  <defs>
+    <marker id="sa-arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#94a3b8"/></marker>
+    <marker id="sa-arrow-b" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#3b82f6"/></marker>
+    <marker id="sa-arrow-a" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="9" markerHeight="7" orient="auto-start-reverse"><polygon points="0 0, 10 3.5, 0 7" fill="#f59e0b"/></marker>
+  </defs>
+
+  <rect width="960" height="540" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
 
   <!-- Title -->
-  <text x="480" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">Scanner Pipeline — 7-Stage Architecture</text>
-  <text x="480" y="46" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">Proprietary analysis engine with external intelligence feeds · 70+ modules · zero runtime dependencies for core</text>
+  <text x="480" y="24" text-anchor="middle" font-family="system-ui, sans-serif" font-size="15" font-weight="700" fill="#0f172a">Scanner Pipeline — 7-Stage Architecture</text>
+  <text x="480" y="40" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#64748b">Proprietary engine with external intelligence feeds · each arrow is a real data handoff</text>
 
-  <!-- ─── STAGE 1: DISCOVER ─── -->
-  <rect x="14" y="62" width="122" height="220" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="14" y="62" width="122" height="26" rx="10" fill="#3b82f6"/>
-  <rect x="14" y="78" width="122" height="10" fill="#3b82f6"/>
-  <text x="75" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① DISCOVER</text>
-  <text x="75" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">PROPRIETARY</text>
-  <text x="75" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">20 MCP clients</text>
-  <text x="75" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Docker / K8s / Terraform</text>
-  <text x="75" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">11 cloud+AI providers</text>
-  <text x="75" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">10 agent frameworks</text>
-  <text x="75" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">12 model file formats</text>
-  <text x="75" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Jupyter · GH Actions</text>
-  <text x="75" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Filesystem + lockfiles</text>
-  <text x="75" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL</text>
-  <text x="75" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">MCP Registry (427+)</text>
-  <text x="75" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Docker Hub API</text>
-  <text x="75" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">kubectl CLI</text>
-  <text x="75" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">discovery/__init__.py</text>
-  <text x="75" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">k8s.py · image.py</text>
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  MAIN PIPELINE — 7 stages connected by arrows                    -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- Stage 1: DISCOVER -->
+  <rect x="14" y="56" width="118" height="32" rx="8" fill="#3b82f6" stroke="none"/>
+  <text x="73" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">① Discover</text>
+
+  <!-- Discover sub-nodes -->
+  <rect x="14" y="96" width="118" height="196" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <rect x="22" y="104" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="73" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">MCP (20 clients)</text>
+  <rect x="22" y="132" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="73" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">Docker / K8s</text>
+  <rect x="22" y="160" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="73" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">Cloud (11 provs)</text>
+  <rect x="22" y="188" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="73" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">AI/ML (10 fwks)</text>
+  <rect x="22" y="216" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="73" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">Code (7 eco)</text>
+  <rect x="22" y="244" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="73" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">Filesystem</text>
+  <rect x="22" y="272" width="102" height="12" rx="3" fill="#dbeafe"/>
+  <text x="73" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">PROPRIETARY</text>
 
   <!-- Arrow 1→2 -->
-  <path d="M136 170 L148 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
-  <path d="M145 166 L151 170 L145 174" fill="#94a3b8"/>
+  <path d="M132 180 L146 180" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 2: EXTRACT ─── -->
-  <rect x="152" y="62" width="122" height="220" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
-  <rect x="152" y="62" width="122" height="26" rx="10" fill="#3b82f6"/>
-  <rect x="152" y="78" width="122" height="10" fill="#3b82f6"/>
-  <text x="213" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">② EXTRACT</text>
-  <text x="213" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#1e40af">PROPRIETARY</text>
-  <text x="213" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">7 ecosystems parser</text>
-  <text x="213" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">npm·pip·Go·Cargo·Maven</text>
-  <text x="213" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NuGet · Ruby gems</text>
-  <text x="213" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AST framework detect</text>
-  <text x="213" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Model file inspection</text>
-  <text x="213" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SBOM ingest CDX+SPDX</text>
-  <text x="213" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Container layer extract</text>
-  <text x="213" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL</text>
-  <text x="213" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Syft (fallback scanner)</text>
-  <text x="213" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Semgrep (SAST rules)</text>
-  <text x="213" y="242" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">cosign (sig verify)</text>
-  <text x="213" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">parsers/__init__.py</text>
-  <text x="213" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#3b82f6">sbom.py · code_scan.py</text>
+  <!-- Stage 2: EXTRACT -->
+  <rect x="148" y="56" width="118" height="32" rx="8" fill="#3b82f6" stroke="none"/>
+  <text x="207" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">② Extract</text>
+
+  <rect x="148" y="96" width="118" height="196" rx="8" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+  <rect x="156" y="104" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="207" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">Pkg Parser</text>
+  <rect x="156" y="132" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="207" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">AST Detect</text>
+  <rect x="156" y="160" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="207" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">Model Inspector</text>
+  <rect x="156" y="188" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="207" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">SBOM Ingest</text>
+  <rect x="156" y="216" width="102" height="22" rx="5" fill="#fff" stroke="#3b82f6" stroke-width="1"/>
+  <text x="207" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#1e40af">Container Layers</text>
+  <!-- External tools -->
+  <rect x="156" y="248" width="48" height="18" rx="4" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="180" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">Syft</text>
+  <rect x="210" y="248" width="48" height="18" rx="4" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="234" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">Semgrep</text>
+  <rect x="156" y="272" width="102" height="12" rx="3" fill="#dbeafe"/>
+  <text x="207" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#3b82f6">PROPRIETARY + ext</text>
 
   <!-- Arrow 2→3 -->
-  <path d="M274 170 L286 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
-  <path d="M283 166 L289 170 L283 174" fill="#94a3b8"/>
+  <path d="M266 180 L280 180" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 3: SCAN ─── -->
-  <rect x="290" y="62" width="122" height="220" rx="10" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="290" y="62" width="122" height="26" rx="10" fill="#f59e0b"/>
-  <rect x="290" y="78" width="122" height="10" fill="#f59e0b"/>
-  <text x="351" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">③ SCAN</text>
-  <text x="351" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e">PROPRIETARY</text>
-  <text x="351" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OSV batch orchestrator</text>
-  <text x="351" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Malicious pkg detect</text>
-  <text x="351" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Typosquat detection</text>
-  <text x="351" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Snyk cross-reference</text>
-  <text x="351" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">NVIDIA CSAF parser</text>
-  <text x="351" y="182" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL APIs</text>
-  <text x="351" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OSV.dev batch API</text>
-  <text x="351" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">GHSA advisories</text>
-  <text x="351" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">Grype DB (fallback)</text>
-  <text x="351" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NVD / NIST CVE feed</text>
-  <text x="351" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NVIDIA CSAF feed</text>
-  <text x="351" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">scanners/__init__.py</text>
-  <text x="351" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">image.py · nvidia.py</text>
+  <!-- Stage 3: SCAN -->
+  <rect x="282" y="56" width="118" height="32" rx="8" fill="#f59e0b" stroke="none"/>
+  <text x="341" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">③ Scan</text>
+
+  <rect x="282" y="96" width="118" height="196" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <rect x="290" y="104" width="102" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="341" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">OSV.dev batch</text>
+  <rect x="290" y="132" width="102" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="341" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">GHSA</text>
+  <rect x="290" y="160" width="102" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="341" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">NVD / NIST</text>
+  <rect x="290" y="188" width="48" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="314" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">Grype</text>
+  <rect x="344" y="188" width="48" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="368" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">NVIDIA</text>
+  <rect x="290" y="216" width="48" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="314" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">Snyk</text>
+  <rect x="344" y="216" width="48" height="22" rx="5" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="368" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="700" fill="#92400e">Malware</text>
+  <rect x="290" y="244" width="102" height="22" rx="5" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="341" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">Typosquat Detect</text>
+  <rect x="290" y="272" width="102" height="12" rx="3" fill="#fef3c7"/>
+  <text x="341" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d97706">9 SOURCES</text>
 
   <!-- Arrow 3→4 -->
-  <path d="M412 170 L424 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
-  <path d="M421 166 L427 170 L421 174" fill="#94a3b8"/>
+  <path d="M400 180 L414 180" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 4: ENRICH ─── -->
-  <rect x="428" y="62" width="122" height="220" rx="10" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-  <rect x="428" y="62" width="122" height="26" rx="10" fill="#f59e0b"/>
-  <rect x="428" y="78" width="122" height="10" fill="#f59e0b"/>
-  <text x="489" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">④ ENRICH</text>
-  <text x="489" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#92400e">PROPRIETARY</text>
-  <text x="489" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CVSS 3.1 computation</text>
-  <text x="489" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">AI risk classification</text>
-  <text x="489" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">False positive reducer</text>
-  <text x="489" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Conditional OWASP tag</text>
-  <text x="489" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Credential ranking</text>
-  <text x="489" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">VEX/OpenVEX engine</text>
-  <text x="489" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#64748b">EXTERNAL APIs</text>
-  <text x="489" y="208" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">NVD CVSS v3.1/v4</text>
-  <text x="489" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">FIRST EPSS scores</text>
-  <text x="489" y="232" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">CISA KEV catalog</text>
-  <text x="489" y="244" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#64748b">OpenSSF Scorecard</text>
-  <text x="489" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">scanners/__init__.py</text>
-  <text x="489" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#d97706">cvss.py · vex.py</text>
+  <!-- Stage 4: ENRICH -->
+  <rect x="416" y="56" width="118" height="32" rx="8" fill="#f59e0b" stroke="none"/>
+  <text x="475" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">④ Enrich</text>
+
+  <rect x="416" y="96" width="118" height="196" rx="8" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <rect x="424" y="104" width="102" height="22" rx="5" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="475" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">CVSS 3.1 Compute</text>
+  <rect x="424" y="132" width="102" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="475" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">EPSS Scores</text>
+  <rect x="424" y="160" width="102" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="475" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">CISA KEV</text>
+  <rect x="424" y="188" width="102" height="22" rx="5" fill="#fff" stroke="#f59e0b" stroke-width="1"/>
+  <text x="475" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#92400e">OpenSSF Score</text>
+  <rect x="424" y="216" width="102" height="22" rx="5" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="475" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">AI Risk Classify</text>
+  <rect x="424" y="244" width="102" height="22" rx="5" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+  <text x="475" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#92400e">FP Reduction</text>
+  <rect x="424" y="272" width="102" height="12" rx="3" fill="#fef3c7"/>
+  <text x="475" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#d97706">PROPRIETARY + ext</text>
 
   <!-- Arrow 4→5 -->
-  <path d="M550 170 L562 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
-  <path d="M559 166 L565 170 L559 174" fill="#94a3b8"/>
+  <path d="M534 180 L548 180" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 5: ANALYZE ─── -->
-  <rect x="566" y="62" width="122" height="220" rx="10" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
-  <rect x="566" y="62" width="122" height="26" rx="10" fill="#ef4444"/>
-  <rect x="566" y="78" width="122" height="10" fill="#ef4444"/>
-  <text x="627" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑤ ANALYZE</text>
-  <text x="627" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#991b1b">100% PROPRIETARY</text>
-  <text x="627" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Blast Radius engine</text>
-  <text x="627" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Context Graph + BFS</text>
-  <text x="627" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Lateral movement paths</text>
-  <text x="627" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Toxic combo detector</text>
-  <text x="627" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Risk Analyzer (7 caps)</text>
-  <text x="627" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">8 dangerous patterns</text>
-  <text x="627" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Posture scorecard A-F</text>
-  <text x="627" y="202" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Incident correlation</text>
-  <text x="627" y="214" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Fleet trust scoring</text>
-  <text x="627" y="226" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Dependency graph walk</text>
-  <text x="627" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#ef4444">blast_radius.py</text>
-  <text x="627" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#ef4444">context_graph.py</text>
+  <!-- Stage 5: ANALYZE -->
+  <rect x="550" y="56" width="118" height="32" rx="8" fill="#ef4444" stroke="none"/>
+  <text x="609" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑤ Analyze</text>
+
+  <rect x="550" y="96" width="118" height="196" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+  <rect x="558" y="104" width="102" height="22" rx="5" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="609" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Blast Radius</text>
+  <rect x="558" y="132" width="102" height="22" rx="5" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="609" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Context Graph</text>
+  <rect x="558" y="160" width="102" height="22" rx="5" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="609" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Risk Analyzer</text>
+  <rect x="558" y="188" width="102" height="22" rx="5" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="609" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Toxic Combos</text>
+  <rect x="558" y="216" width="102" height="22" rx="5" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="609" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Posture Score</text>
+  <rect x="558" y="244" width="102" height="22" rx="5" fill="#fff" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="609" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#991b1b">Incidents</text>
+  <rect x="558" y="272" width="102" height="12" rx="3" fill="#fee2e2"/>
+  <text x="609" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#ef4444">100% PROPRIETARY</text>
+
+  <!-- Cross-connections within analyze (BFS) -->
+  <path d="M660 115 Q668 130 660 143" stroke="#ef4444" stroke-width="1" fill="none" stroke-dasharray="2 2"/>
+  <path d="M660 147 Q668 162 660 175" stroke="#ef4444" stroke-width="1" fill="none" stroke-dasharray="2 2"/>
 
   <!-- Arrow 5→6 -->
-  <path d="M688 170 L700 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
-  <path d="M697 166 L703 170 L697 174" fill="#94a3b8"/>
+  <path d="M668 180 L682 180" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 6: COMPLY ─── -->
-  <rect x="704" y="62" width="122" height="220" rx="10" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
-  <rect x="704" y="62" width="122" height="26" rx="10" fill="#8b5cf6"/>
-  <rect x="704" y="78" width="122" height="10" fill="#8b5cf6"/>
-  <text x="765" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑥ COMPLY</text>
-  <text x="765" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#6d28d9">100% PROPRIETARY</text>
-  <text x="765" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">10 compliance frameworks</text>
-  <text x="765" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP LLM Top 10</text>
-  <text x="765" y="144" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP MCP Top 10</text>
-  <text x="765" y="156" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">OWASP Agentic Security</text>
-  <text x="765" y="168" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MITRE ATLAS · NIST</text>
-  <text x="765" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">EU AI Act · ISO 27001</text>
-  <text x="765" y="192" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SOC 2 · CIS v8</text>
-  <text x="765" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Policy-as-code engine</text>
-  <text x="765" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">License policy (SPDX)</text>
-  <text x="765" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Auto-remediation</text>
-  <text x="765" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#8b5cf6">compliance.py</text>
-  <text x="765" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#8b5cf6">policy.py · license.py</text>
+  <!-- Stage 6: COMPLY -->
+  <rect x="684" y="56" width="118" height="32" rx="8" fill="#8b5cf6" stroke="none"/>
+  <text x="743" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑥ Comply</text>
+
+  <rect x="684" y="96" width="118" height="196" rx="8" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1"/>
+  <rect x="692" y="104" width="102" height="22" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="743" y="119" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#6d28d9">OWASP LLM</text>
+  <rect x="692" y="132" width="102" height="22" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="743" y="147" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#6d28d9">OWASP MCP</text>
+  <rect x="692" y="160" width="102" height="22" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="743" y="175" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#6d28d9">MITRE ATLAS</text>
+  <rect x="692" y="188" width="48" height="22" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="716" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#6d28d9">NIST</text>
+  <rect x="746" y="188" width="48" height="22" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="770" y="203" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#6d28d9">EU AI</text>
+  <rect x="692" y="216" width="48" height="22" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="716" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#6d28d9">SOC 2</text>
+  <rect x="746" y="216" width="48" height="22" rx="5" fill="#fff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="770" y="231" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#6d28d9">CIS v8</text>
+  <rect x="692" y="244" width="102" height="22" rx="5" fill="#fff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="743" y="259" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#6d28d9">Policy Engine</text>
+  <rect x="692" y="272" width="102" height="12" rx="3" fill="#ede9fe"/>
+  <text x="743" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" font-weight="700" fill="#8b5cf6">100% PROPRIETARY</text>
 
   <!-- Arrow 6→7 -->
-  <path d="M826 170 L838 170" stroke="#94a3b8" stroke-width="2" stroke-linecap="round"/>
-  <path d="M835 166 L841 170 L835 174" fill="#94a3b8"/>
+  <path d="M802 180 L816 180" stroke="#94a3b8" stroke-width="2.5" fill="none" marker-end="url(#sa-arrow)"/>
 
-  <!-- ─── STAGE 7: OUTPUT ─── -->
-  <rect x="842" y="62" width="104" height="220" rx="10" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
-  <rect x="842" y="62" width="104" height="26" rx="10" fill="#10b981"/>
-  <rect x="842" y="78" width="104" height="10" fill="#10b981"/>
-  <text x="894" y="82" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑦ OUTPUT</text>
-  <text x="894" y="104" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#065f46">13+ FORMATS</text>
-  <text x="894" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">JSON · Console · HTML</text>
-  <text x="894" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">CycloneDX · SPDX</text>
-  <text x="894" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SARIF (GitHub native)</text>
-  <text x="894" y="154" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">SVG badges · Mermaid</text>
-  <text x="894" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Cytoscape · ReactFlow</text>
-  <text x="894" y="178" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Attack flow graphs</text>
-  <text x="894" y="194" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">REST API (25+ routes)</text>
-  <text x="894" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">MCP Server (16 tools)</text>
-  <text x="894" y="218" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Next.js Dashboard</text>
-  <text x="894" y="230" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8.5" fill="#334155">Prometheus · OCSF</text>
-  <text x="894" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#10b981">output/__init__.py</text>
-  <text x="894" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#10b981">api.py · mcp_server.py</text>
+  <!-- Stage 7: OUTPUT -->
+  <rect x="818" y="56" width="128" height="32" rx="8" fill="#10b981" stroke="none"/>
+  <text x="882" y="76" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#fff">⑦ Output</text>
 
-  <!-- ─── EXTERNAL INTELLIGENCE BAR ─── -->
-  <rect x="14" y="300" width="932" height="52" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="480" y="318" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#475569" letter-spacing="0.08em">9 EXTERNAL INTELLIGENCE SOURCES</text>
-  <text x="480" y="338" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#64748b">OSV.dev Batch  ·  GHSA  ·  NVD/NIST  ·  FIRST EPSS  ·  CISA KEV  ·  NVIDIA CSAF  ·  Grype DB  ·  OpenSSF Scorecard  ·  MCP Registry (427+)</text>
+  <rect x="818" y="96" width="128" height="196" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <rect x="826" y="104" width="56" height="20" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="854" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#065f46">JSON</text>
+  <rect x="886" y="104" width="52" height="20" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="912" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#065f46">SARIF</text>
+  <rect x="826" y="128" width="56" height="20" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="854" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#065f46">CDX</text>
+  <rect x="886" y="128" width="52" height="20" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="912" y="142" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#065f46">SPDX</text>
+  <rect x="826" y="152" width="56" height="20" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="854" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#065f46">HTML</text>
+  <rect x="886" y="152" width="52" height="20" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="912" y="166" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7.5" font-weight="600" fill="#065f46">SVG</text>
+  <rect x="826" y="180" width="112" height="22" rx="5" fill="#fff" stroke="#059669" stroke-width="1.5"/>
+  <text x="882" y="195" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">REST API (25+)</text>
+  <rect x="826" y="206" width="112" height="22" rx="5" fill="#fff" stroke="#059669" stroke-width="1.5"/>
+  <text x="882" y="221" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">MCP Server (16)</text>
+  <rect x="826" y="232" width="112" height="22" rx="5" fill="#fff" stroke="#059669" stroke-width="1.5"/>
+  <text x="882" y="247" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="700" fill="#065f46">Dashboard (15)</text>
+  <rect x="826" y="258" width="112" height="22" rx="5" fill="#fff" stroke="#10b981" stroke-width="1"/>
+  <text x="882" y="273" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" font-weight="600" fill="#065f46">Prometheus/OCSF</text>
+  <rect x="826" y="272" width="112" height="12" rx="3" fill="#d1fae5"/>
+  <text x="882" y="282" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#10b981">13+ FORMATS</text>
 
-  <!-- ─── INTEGRATIONS BAR ─── -->
-  <rect x="14" y="362" width="932" height="52" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="480" y="380" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">RUNTIME PROTECTION + DELIVERY</text>
-  <text x="480" y="396" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">MCP Stdio Proxy · 4 Inline Scanners · 5 Detectors · Fleet Mgmt · Trust Scoring · Alert Pipeline</text>
-  <text x="480" y="406" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#8b5cf6">GitHub Action · Docker/Helm · Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  EXTERNAL FEEDS (dashed boxes below pipeline)                     -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="310" width="932" height="54" rx="8" fill="#f8fafc" stroke="#94a3b8" stroke-width="1" stroke-dasharray="5 3"/>
+  <text x="480" y="328" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#475569" letter-spacing="0.06em">EXTERNAL INTELLIGENCE FEEDS — 9 sources feed into stages ③ ④</text>
 
-  <!-- ─── INFRASTRUCTURE BAR ─── -->
-  <rect x="14" y="424" width="932" height="42" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
-  <text x="480" y="442" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#166534" letter-spacing="0.08em">INFRASTRUCTURE</text>
-  <text x="480" y="456" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#15803d">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit log  |  Scheduler · Cache</text>
+  <rect x="28" y="338" width="80" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="68" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">OSV.dev</text>
+  <rect x="116" y="338" width="65" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="148" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">GHSA</text>
+  <rect x="189" y="338" width="75" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="226" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">NVD/NIST</text>
+  <rect x="272" y="338" width="65" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="304" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">EPSS</text>
+  <rect x="345" y="338" width="65" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="377" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">CISA KEV</text>
+  <rect x="418" y="338" width="90" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="463" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">NVIDIA CSAF</text>
+  <rect x="516" y="338" width="70" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="551" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">Grype DB</text>
+  <rect x="594" y="338" width="70" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="629" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">OpenSSF</text>
+  <rect x="672" y="338" width="90" height="18" rx="4" fill="#fff" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="717" y="351" text-anchor="middle" font-family="system-ui, sans-serif" font-size="7" fill="#64748b">MCP Registry</text>
+
+  <!-- Dashed arrows from external feeds up to pipeline stages 3 and 4 -->
+  <path d="M341 310 L341 296" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#sa-arrow)"/>
+  <path d="M475 310 L475 296" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 2" marker-end="url(#sa-arrow)"/>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION BAR                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="378" width="932" height="56" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="1.5"/>
+  <text x="480" y="396" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#6d28d9" letter-spacing="0.06em">RUNTIME PROTECTION — MCP STDIO PROXY</text>
+  <text x="480" y="412" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#7c3aed">4 Inline Scanners (injection · PII · secrets · payloads) · 5 Detectors · Fleet Mgmt · Trust Score · Alerts</text>
+  <text x="480" y="426" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#8b5cf6">Slack · Jira · ServiceNow · Drata · Vanta · Webhooks</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!--  INFRASTRUCTURE BAR                                                -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <rect x="14" y="446" width="932" height="40" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+  <text x="480" y="464" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#166534">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache</text>
+  <text x="480" y="478" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#15803d">GH Action · Docker Hub · GHCR · Railway SSE · Helm · K8s manifests</text>
 
   <!-- Footer -->
-  <text x="480" y="486" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#475569">~70 proprietary modules  |  ~15 hybrid modules  |  ~22 external integrations  |  0 runtime deps for core</text>
-  <text x="480" y="504" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
+  <text x="480" y="510" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#475569">~70 proprietary · ~15 hybrid · ~22 external · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <text x="480" y="528" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#94a3b8">Read-only · Agentless · Never stores credentials · Only package names sent to APIs · Sigstore signed · Apache 2.0</text>
 </svg>


### PR DESCRIPTION
## Summary
- Redesigned all 6 README SVG diagrams from text-box layouts into real architecture diagrams with SVG arrow paths, marker arrowheads, converging data flows, and connected component nodes
- **scan-workflow** (light + dark): 5-column flow with 8 discovery inputs converging into Extract, horizontal pipeline through Scan → Enrich → Analyze → Output
- **scanner-architecture** (light + dark): 7-stage pipeline with sub-node columns, horizontal stage arrows, cross-connection curves, external intelligence feeds bar
- **enterprise-overview** (light + dark): 4-layer system overview with runtime protection sidebar, 3 analysis rows (scan/enrich, deep analysis, compliance), delivery channel chain

## Test plan
- [ ] Verify all 6 SVGs render correctly on GitHub README (light + dark mode toggle)
- [ ] Check arrow markers and paths display properly
- [ ] Confirm `<picture>` tags in README still match the updated filenames