### PR TITLE
feat: story-driven diagram redesign (Wiz/Snyk-inspired)

### DIFF
--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -1,209 +1,179 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 700" fill="none">
   <defs>
-    <marker id="eo-ah" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#484f58"/></marker>
-    <marker id="eo-ah-b" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#1f6feb"/></marker>
-    <marker id="eo-ah-p" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#a371f7"/></marker>
-
-    <!-- Icon: Search/Discover -->
-    <symbol id="eo-search" viewBox="0 0 24 24">
-      <circle cx="10" cy="10" r="7" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-    </symbol>
-    <!-- Icon: Shield -->
-    <symbol id="eo-shield" viewBox="0 0 24 24">
-      <path d="M12 2L3 7V12C3 17.5 7 21.5 12 23C17 21.5 21 17.5 21 12V7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M8 12L11 15L16 9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    </symbol>
-    <!-- Icon: Graph -->
-    <symbol id="eo-graph" viewBox="0 0 24 24">
-      <circle cx="12" cy="5" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="5" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="19" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="12" y1="8" x2="5" y2="16" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="12" y1="8" x2="19" y2="16" stroke="currentColor" stroke-width="1.5"/>
-    </symbol>
-    <!-- Icon: Document -->
-    <symbol id="eo-doc" viewBox="0 0 24 24">
-      <rect x="4" y="2" width="16" height="20" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="8" y1="8" x2="16" y2="8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="12" x2="14" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="16" x2="12" y2="16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-    </symbol>
-    <!-- Icon: Lock -->
-    <symbol id="eo-lock" viewBox="0 0 24 24">
-      <rect x="5" y="11" width="14" height="10" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
-      <path d="M8 11V7C8 4.8 9.8 3 12 3S16 4.8 16 7V11" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
-    </symbol>
+    <marker id="eo-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#484f58"/>
+    </marker>
+    <marker id="eo-a-p" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#a371f7"/>
+    </marker>
   </defs>
 
-  <rect width="1200" height="560" rx="16" fill="#0d1117"/>
+  <rect width="1200" height="700" rx="20" fill="#0d1117"/>
 
   <!-- Title -->
-  <text x="600" y="36" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" font-weight="700" fill="#e6edf3">Enterprise Architecture</text>
-  <text x="600" y="56" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#8b949e">4-layer system — multi-source discovery through analysis to actionable output</text>
+  <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#e6edf3">Enterprise Architecture</text>
+  <text x="600" y="68" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" fill="#484f58">Multi-source discovery  →  analysis  →  output  with runtime protection sidecar</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 1: DISCOVER (top row of input blocks)                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="76" width="900" height="96" rx="12" fill="#161b22" stroke="#1f3a5f" stroke-width="2"/>
-  <use href="#eo-search" x="56" y="86" width="24" height="24" color="#58a6ff"/>
-  <text x="94" y="102" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#58a6ff">Discovery Layer</text>
-  <text x="260" y="102" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">8 source types · auto-detected · agentless</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 1: DISCOVERY                                     -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="100" width="840" height="120" rx="18" fill="#161b22" stroke="#1f3a5f" stroke-width="2"/>
+  <text x="100" y="128" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#58a6ff">Discovery Layer</text>
+  <text x="280" y="128" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#58a6ff">8 source types · auto-detected · agentless</text>
 
-  <!-- Input blocks -->
-  <rect x="56" y="116" width="120" height="42" rx="8" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="116" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">MCP Agents</text>
-  <text x="116" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">20 clients</text>
+  <!-- Source blocks — clean rounded pills -->
+  <rect x="80" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
+  <text x="134" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">MCP Agents</text>
+  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">20 clients</text>
 
-  <rect x="186" y="116" width="120" height="42" rx="8" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="246" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Containers</text>
-  <text x="246" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Docker · K8s</text>
+  <rect x="198" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
+  <text x="252" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Containers</text>
+  <text x="252" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Docker · K8s</text>
 
-  <rect x="316" y="116" width="120" height="42" rx="8" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="376" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Cloud + AI</text>
-  <text x="376" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">11 providers</text>
+  <rect x="316" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
+  <text x="370" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Cloud + AI</text>
+  <text x="370" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">11 providers</text>
 
-  <rect x="446" y="116" width="120" height="42" rx="8" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="506" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Code / Pkgs</text>
-  <text x="506" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">7 ecosystems</text>
+  <rect x="434" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
+  <text x="488" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Code / Pkgs</text>
+  <text x="488" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">7 ecosystems</text>
 
-  <rect x="576" y="116" width="120" height="42" rx="8" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="636" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">AI/ML Models</text>
-  <text x="636" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">12 formats</text>
+  <rect x="552" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
+  <text x="606" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">AI/ML Models</text>
+  <text x="606" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">12 formats</text>
 
-  <rect x="706" y="116" width="120" height="42" rx="8" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="766" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">SBOMs</text>
-  <text x="766" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">CDX · SPDX</text>
+  <rect x="670" y="148" width="90" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
+  <text x="715" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">SBOMs</text>
+  <text x="715" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">CDX · SPDX</text>
 
-  <rect x="836" y="116" width="92" height="42" rx="8" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="882" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Filesystem</text>
+  <rect x="770" y="148" width="110" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
+  <text x="825" y="170" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Filesystem</text>
 
   <!-- Arrow Layer 1 → Layer 2 -->
-  <path d="M490 172 L490 196" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#eo-ah)"/>
+  <path d="M480 220 L480 252" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#eo-a)"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  RUNTIME PROTECTION SIDEBAR                                       -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="960" y="76" width="200" height="276" rx="12" fill="#150e1a" stroke="#3f1f5f" stroke-width="2"/>
-  <use href="#eo-lock" x="976" y="86" width="24" height="24" color="#d2a8ff"/>
-  <text x="1014" y="102" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#d2a8ff">Runtime</text>
-  <text x="1014" y="118" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#d2a8ff">Protection</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION SIDEBAR                             -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="940" y="100" width="200" height="320" rx="18" fill="#161b22" stroke="#3f1f5f" stroke-width="2"/>
+  <text x="1040" y="132" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#d2a8ff">Runtime</text>
+  <text x="1040" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#d2a8ff">Protection</text>
 
-  <rect x="976" y="132" width="168" height="32" rx="6" fill="#21262d" stroke="#4f1f7f" stroke-width="1.5"/>
-  <text x="1060" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#d2a8ff">MCP Stdio Proxy</text>
+  <rect x="964" y="170" width="152" height="32" rx="8" fill="#21262d" stroke="#4f1f7f" stroke-width="1.5"/>
+  <text x="1040" y="191" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#d2a8ff">MCP Stdio Proxy</text>
 
-  <text x="1060" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#a371f7">4 Inline Scanners</text>
-  <text x="1060" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Injection · PII · Secrets · Payloads</text>
+  <text x="1040" y="224" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#a371f7">4 Inline Scanners</text>
+  <text x="1040" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Injection · PII · Secrets · Payloads</text>
 
-  <text x="1060" y="220" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#a371f7">5 Detectors</text>
-  <text x="1060" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Drift · Creds · Rate · Seq · Args</text>
+  <text x="1040" y="268" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#a371f7">5 Detectors</text>
+  <text x="1040" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Drift · Creds · Rate · Seq · Args</text>
 
-  <rect x="976" y="252" width="80" height="26" rx="6" fill="#1f0f3f" stroke="#3f1f5f" stroke-width="1"/>
-  <text x="1016" y="269" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#d2a8ff">Fleet Mgmt</text>
+  <text x="1040" y="316" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#a371f7">Fleet Mgmt · Trust Score</text>
+  <text x="1040" y="336" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Replay · Dedup · Integrity</text>
 
-  <rect x="1064" y="252" width="80" height="26" rx="6" fill="#1f0f3f" stroke="#3f1f5f" stroke-width="1"/>
-  <text x="1104" y="269" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#d2a8ff">Trust Score</text>
-
-  <text x="1060" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Replay Protect · Alert Pipeline</text>
-  <text x="1060" y="314" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Dedup · Payload Integrity</text>
-
-  <text x="1060" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">Slack · Jira · ServiceNow</text>
+  <text x="1040" y="366" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">Slack · Jira · ServiceNow · Webhooks</text>
 
   <!-- Dashed arrow from sidebar into Layer 2 -->
-  <path d="M960 280 L940 280" stroke="#a371f7" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-ah-p)"/>
+  <path d="M940 340 L910 340" stroke="#a371f7" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-a-p)"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 2: ANALYSIS ENGINE (hero block)                            -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="200" width="900" height="152" rx="12" fill="#1a1a0e" stroke="#5f4a1f" stroke-width="2"/>
-  <use href="#eo-graph" x="56" y="210" width="24" height="24" color="#d29922"/>
-  <text x="94" y="226" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#e3b341">Proprietary Analysis Engine</text>
-  <text x="360" y="226" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">70+ modules · 9 vuln sources · 6 enrichments · deep risk intelligence</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 2: PROPRIETARY ANALYSIS ENGINE                   -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="260" width="840" height="160" rx="18" fill="#161b22" stroke="#5f4a1f" stroke-width="2"/>
+  <text x="100" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#e3b341">Proprietary Analysis Engine</text>
+  <text x="400" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#d29922">70+ modules · 9 vuln sources · deep risk intelligence</text>
 
-  <!-- Analysis row 1: Scan + Enrich -->
-  <rect x="56" y="242" width="140" height="36" rx="8" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
-  <text x="126" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#e3b341">Vuln Scan (9 src)</text>
-  <path d="M196 260 L210 260" stroke="#d29922" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="216" y="242" width="140" height="36" rx="8" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
-  <text x="286" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#e3b341">CVSS · EPSS · KEV</text>
-  <path d="M356 260 L370 260" stroke="#d29922" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="376" y="242" width="140" height="36" rx="8" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
-  <text x="446" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#e3b341">AI Risk + FP Reduce</text>
+  <!-- Row 1: Scan + Enrich pipeline -->
+  <rect x="80" y="308" width="130" height="34" rx="10" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
+  <text x="145" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">Vuln Scan (9 src)</text>
 
-  <!-- Analysis row 2: Deep analysis -->
-  <rect x="56" y="290" width="134" height="36" rx="8" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="123" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#ff7b72">Blast Radius</text>
-  <path d="M190 308 L204 308" stroke="#f85149" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="210" y="290" width="134" height="36" rx="8" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="277" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#ff7b72">Context Graph</text>
-  <path d="M344 308 L358 308" stroke="#f85149" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="364" y="290" width="134" height="36" rx="8" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="431" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#ff7b72">Toxic Combos</text>
-  <path d="M498 308 L512 308" stroke="#f85149" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="518" y="290" width="134" height="36" rx="8" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="585" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#ff7b72">Posture A-F</text>
+  <path d="M210 325 L228 325" stroke="#d29922" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="234" y="308" width="130" height="34" rx="10" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
+  <text x="299" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">CVSS · EPSS · KEV</text>
+
+  <path d="M364 325 L382 325" stroke="#d29922" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="388" y="308" width="130" height="34" rx="10" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
+  <text x="453" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">AI Risk + FP Reduce</text>
+
+  <!-- Row 2: Deep analysis -->
+  <rect x="80" y="354" width="120" height="34" rx="10" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
+  <text x="140" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Blast Radius</text>
+
+  <path d="M200 371 L218 371" stroke="#f85149" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="224" y="354" width="120" height="34" rx="10" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
+  <text x="284" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Context Graph</text>
+
+  <path d="M344 371 L362 371" stroke="#f85149" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="368" y="354" width="120" height="34" rx="10" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
+  <text x="428" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Toxic Combos</text>
+
+  <path d="M488 371 L506 371" stroke="#f85149" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="512" y="354" width="120" height="34" rx="10" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
+  <text x="572" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Posture A-F</text>
 
   <!-- Compliance nodes -->
-  <rect x="680" y="242" width="120" height="36" rx="8" fill="#21262d" stroke="#4f1f7f" stroke-width="1.5"/>
-  <text x="740" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#d2a8ff">10 Frameworks</text>
-  <rect x="810" y="242" width="120" height="36" rx="8" fill="#8b5cf6"/>
-  <text x="870" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">Policy Engine</text>
+  <rect x="660" y="308" width="110" height="34" rx="10" fill="#21262d" stroke="#4f1f7f" stroke-width="1.5"/>
+  <text x="715" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#d2a8ff">10 Frameworks</text>
 
-  <rect x="680" y="290" width="250" height="36" rx="8" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="805" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#ff7b72">Incidents (P1-P4) · OCSF Events</text>
+  <rect x="780" y="308" width="110" height="34" rx="10" fill="#8b5cf6"/>
+  <text x="835" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#fff">Policy Engine</text>
 
-  <text x="490" y="344" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">OWASP LLM+MCP · MITRE ATLAS · NIST AI RMF · EU AI Act · SOC 2 · CIS v8 · ISO 27001</text>
+  <rect x="660" y="354" width="230" height="34" rx="10" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
+  <text x="775" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Incidents (P1-P4) · OCSF Events</text>
+
+  <text x="480" y="408" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">OWASP LLM+MCP · MITRE ATLAS · NIST AI RMF · EU AI Act · SOC 2 · CIS v8 · ISO 27001</text>
 
   <!-- Arrow Layer 2 → Layer 3 -->
-  <path d="M490 352 L490 376" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#eo-ah)"/>
+  <path d="M480 420 L480 452" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#eo-a)"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 3: OUTPUT + DELIVERY                                       -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="380" width="1120" height="84" rx="12" fill="#0e1a14" stroke="#1f5f3a" stroke-width="2"/>
-  <use href="#eo-doc" x="56" y="394" width="24" height="24" color="#3fb950"/>
-  <text x="94" y="410" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#7ee787">Output + Deployment</text>
-  <text x="290" y="410" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">13+ formats · 6 delivery channels</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 3: OUTPUT + DELIVERY                             -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="460" width="1080" height="90" rx="18" fill="#161b22" stroke="#1f5f3a" stroke-width="2"/>
+  <text x="120" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#7ee787">Output + Deployment</text>
+  <text x="326" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#3fb950">13+ formats · 6 delivery channels</text>
 
   <!-- Format pills -->
-  <rect x="56" y="424" width="56" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="84" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">JSON</text>
-  <rect x="118" y="424" width="56" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="146" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SARIF</text>
-  <rect x="180" y="424" width="56" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="208" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">CDX</text>
-  <rect x="242" y="424" width="56" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="270" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SPDX</text>
-  <rect x="304" y="424" width="56" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="332" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">HTML</text>
-  <rect x="366" y="424" width="56" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="394" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">OCSF</text>
+  <rect x="80" y="510" width="52" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="106" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">JSON</text>
+  <rect x="140" y="510" width="52" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="166" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SARIF</text>
+  <rect x="200" y="510" width="52" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="226" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">CDX</text>
+  <rect x="260" y="510" width="52" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="286" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SPDX</text>
+  <rect x="320" y="510" width="52" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="346" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">HTML</text>
+  <rect x="380" y="510" width="52" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="406" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">OCSF</text>
 
   <!-- Delivery channels -->
-  <rect x="470" y="424" width="76" height="24" rx="12" fill="#238636"/>
-  <text x="508" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
-  <rect x="554" y="424" width="76" height="24" rx="12" fill="#238636"/>
-  <text x="592" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">REST API</text>
-  <rect x="638" y="424" width="94" height="24" rx="12" fill="#238636"/>
-  <text x="685" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
-  <rect x="740" y="424" width="94" height="24" rx="12" fill="#238636"/>
-  <text x="787" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
-  <rect x="842" y="424" width="94" height="24" rx="12" fill="#238636"/>
-  <text x="889" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
-  <rect x="944" y="424" width="102" height="24" rx="12" fill="#238636"/>
-  <text x="995" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
+  <rect x="480" y="510" width="70" height="24" rx="12" fill="#238636"/>
+  <text x="515" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
+  <rect x="558" y="510" width="78" height="24" rx="12" fill="#238636"/>
+  <text x="597" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">REST API</text>
+  <rect x="644" y="510" width="90" height="24" rx="12" fill="#238636"/>
+  <text x="689" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
+  <rect x="742" y="510" width="90" height="24" rx="12" fill="#238636"/>
+  <text x="787" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
+  <rect x="840" y="510" width="90" height="24" rx="12" fill="#238636"/>
+  <text x="885" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
+  <rect x="938" y="510" width="100" height="24" rx="12" fill="#238636"/>
+  <text x="988" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
 
-  <!-- Alert delivery -->
-  <text x="700" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3fb950">Slack · Jira · ServiceNow · Drata · Vanta · Webhooks · Prometheus</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 4: INFRASTRUCTURE                                -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="566" width="1080" height="44" rx="14" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+  <text x="600" y="594" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#8b949e">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway · Helm</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 4: INFRASTRUCTURE                                          -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="478" width="1120" height="36" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
-  <text x="600" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#8b949e">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway SSE · Helm</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  FOOTER                                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="600" y="540" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#8b949e">20 MCP clients · 11 providers · 10 agent fwks · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  FOOTER                                                 -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <text x="600" y="650" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 11 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -1,209 +1,179 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 700" fill="none">
   <defs>
-    <marker id="eo-ah" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#94a3b8"/></marker>
-    <marker id="eo-ah-b" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#2563eb"/></marker>
-    <marker id="eo-ah-p" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#7c3aed"/></marker>
-
-    <!-- Icon: Search/Discover -->
-    <symbol id="eo-search" viewBox="0 0 24 24">
-      <circle cx="10" cy="10" r="7" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-    </symbol>
-    <!-- Icon: Shield -->
-    <symbol id="eo-shield" viewBox="0 0 24 24">
-      <path d="M12 2L3 7V12C3 17.5 7 21.5 12 23C17 21.5 21 17.5 21 12V7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M8 12L11 15L16 9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    </symbol>
-    <!-- Icon: Graph -->
-    <symbol id="eo-graph" viewBox="0 0 24 24">
-      <circle cx="12" cy="5" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="5" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="19" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="12" y1="8" x2="5" y2="16" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="12" y1="8" x2="19" y2="16" stroke="currentColor" stroke-width="1.5"/>
-    </symbol>
-    <!-- Icon: Document -->
-    <symbol id="eo-doc" viewBox="0 0 24 24">
-      <rect x="4" y="2" width="16" height="20" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="8" y1="8" x2="16" y2="8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="12" x2="14" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="16" x2="12" y2="16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-    </symbol>
-    <!-- Icon: Lock -->
-    <symbol id="eo-lock" viewBox="0 0 24 24">
-      <rect x="5" y="11" width="14" height="10" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
-      <path d="M8 11V7C8 4.8 9.8 3 12 3S16 4.8 16 7V11" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
-    </symbol>
+    <marker id="eo-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#cbd5e1"/>
+    </marker>
+    <marker id="eo-a-p" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#a78bfa"/>
+    </marker>
   </defs>
 
-  <rect width="1200" height="560" rx="16" fill="#ffffff"/>
+  <rect width="1200" height="700" rx="20" fill="#ffffff"/>
 
   <!-- Title -->
-  <text x="600" y="36" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" font-weight="700" fill="#0f172a">Enterprise Architecture</text>
-  <text x="600" y="56" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#64748b">4-layer system — multi-source discovery through analysis to actionable output</text>
+  <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#0f172a">Enterprise Architecture</text>
+  <text x="600" y="68" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" fill="#94a3b8">Multi-source discovery  →  analysis  →  output  with runtime protection sidecar</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 1: DISCOVER (top row of input blocks)                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="76" width="900" height="96" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="2"/>
-  <use href="#eo-search" x="56" y="86" width="24" height="24" color="#2563eb"/>
-  <text x="94" y="102" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#1e40af">Discovery Layer</text>
-  <text x="260" y="102" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">8 source types · auto-detected · agentless</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 1: DISCOVERY                                     -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="100" width="840" height="120" rx="18" fill="#eff6ff" stroke="#dbeafe" stroke-width="2"/>
+  <text x="100" y="128" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#1e40af">Discovery Layer</text>
+  <text x="280" y="128" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#3b82f6">8 source types · auto-detected · agentless</text>
 
-  <!-- Input blocks -->
-  <rect x="56" y="116" width="120" height="42" rx="8" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="116" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Agents</text>
-  <text x="116" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">20 clients</text>
+  <!-- Source blocks — clean rounded pills -->
+  <rect x="80" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="134" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Agents</text>
+  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">20 clients</text>
 
-  <rect x="186" y="116" width="120" height="42" rx="8" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="246" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Containers</text>
-  <text x="246" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">Docker · K8s</text>
+  <rect x="198" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="252" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Containers</text>
+  <text x="252" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">Docker · K8s</text>
 
-  <rect x="316" y="116" width="120" height="42" rx="8" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="376" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Cloud + AI</text>
-  <text x="376" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">11 providers</text>
+  <rect x="316" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="370" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Cloud + AI</text>
+  <text x="370" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">11 providers</text>
 
-  <rect x="446" y="116" width="120" height="42" rx="8" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="506" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Code / Pkgs</text>
-  <text x="506" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">7 ecosystems</text>
+  <rect x="434" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="488" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Code / Pkgs</text>
+  <text x="488" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">7 ecosystems</text>
 
-  <rect x="576" y="116" width="120" height="42" rx="8" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="636" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">AI/ML Models</text>
-  <text x="636" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">12 formats</text>
+  <rect x="552" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="606" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">AI/ML Models</text>
+  <text x="606" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">12 formats</text>
 
-  <rect x="706" y="116" width="120" height="42" rx="8" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="766" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">SBOMs</text>
-  <text x="766" y="150" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">CDX · SPDX</text>
+  <rect x="670" y="148" width="90" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="715" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">SBOMs</text>
+  <text x="715" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">CDX · SPDX</text>
 
-  <rect x="836" y="116" width="92" height="42" rx="8" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="882" y="140" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Filesystem</text>
+  <rect x="770" y="148" width="110" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
+  <text x="825" y="170" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Filesystem</text>
 
   <!-- Arrow Layer 1 → Layer 2 -->
-  <path d="M490 172 L490 196" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#eo-ah)"/>
+  <path d="M480 220 L480 252" stroke="#cbd5e1" stroke-width="3" fill="none" marker-end="url(#eo-a)"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  RUNTIME PROTECTION SIDEBAR                                       -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="960" y="76" width="200" height="276" rx="12" fill="#faf5ff" stroke="#c4b5fd" stroke-width="2"/>
-  <use href="#eo-lock" x="976" y="86" width="24" height="24" color="#7c3aed"/>
-  <text x="1014" y="102" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#6d28d9">Runtime</text>
-  <text x="1014" y="118" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#6d28d9">Protection</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION SIDEBAR                             -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="940" y="100" width="200" height="320" rx="18" fill="#faf5ff" stroke="#e9d5ff" stroke-width="2"/>
+  <text x="1040" y="132" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#6d28d9">Runtime</text>
+  <text x="1040" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#6d28d9">Protection</text>
 
-  <rect x="976" y="132" width="168" height="32" rx="6" fill="#fff" stroke="#a78bfa" stroke-width="1.5"/>
-  <text x="1060" y="152" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#6d28d9">MCP Stdio Proxy</text>
+  <rect x="964" y="170" width="152" height="32" rx="8" fill="#fff" stroke="#c4b5fd" stroke-width="1.5"/>
+  <text x="1040" y="191" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#6d28d9">MCP Stdio Proxy</text>
 
-  <text x="1060" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7c3aed">4 Inline Scanners</text>
-  <text x="1060" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b5cf6">Injection · PII · Secrets · Payloads</text>
+  <text x="1040" y="224" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7c3aed">4 Inline Scanners</text>
+  <text x="1040" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a78bfa">Injection · PII · Secrets · Payloads</text>
 
-  <text x="1060" y="220" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7c3aed">5 Detectors</text>
-  <text x="1060" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b5cf6">Drift · Creds · Rate · Seq · Args</text>
+  <text x="1040" y="268" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7c3aed">5 Detectors</text>
+  <text x="1040" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a78bfa">Drift · Creds · Rate · Seq · Args</text>
 
-  <rect x="976" y="252" width="80" height="26" rx="6" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="1016" y="269" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#6d28d9">Fleet Mgmt</text>
+  <text x="1040" y="316" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7c3aed">Fleet Mgmt · Trust Score</text>
+  <text x="1040" y="336" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a78bfa">Replay · Dedup · Integrity</text>
 
-  <rect x="1064" y="252" width="80" height="26" rx="6" fill="#ede9fe" stroke="#c4b5fd" stroke-width="1"/>
-  <text x="1104" y="269" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#6d28d9">Trust Score</text>
-
-  <text x="1060" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b5cf6">Replay Protect · Alert Pipeline</text>
-  <text x="1060" y="314" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b5cf6">Dedup · Payload Integrity</text>
-
-  <text x="1060" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">Slack · Jira · ServiceNow</text>
+  <text x="1040" y="366" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">Slack · Jira · ServiceNow · Webhooks</text>
 
   <!-- Dashed arrow from sidebar into Layer 2 -->
-  <path d="M960 280 L940 280" stroke="#7c3aed" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-ah-p)"/>
+  <path d="M940 340 L910 340" stroke="#a78bfa" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-a-p)"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 2: ANALYSIS ENGINE (hero block)                            -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="200" width="900" height="152" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="2"/>
-  <use href="#eo-graph" x="56" y="210" width="24" height="24" color="#d97706"/>
-  <text x="94" y="226" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#92400e">Proprietary Analysis Engine</text>
-  <text x="360" y="226" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">70+ modules · 9 vuln sources · 6 enrichments · deep risk intelligence</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 2: PROPRIETARY ANALYSIS ENGINE                   -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="260" width="840" height="160" rx="18" fill="#fffbeb" stroke="#fde68a" stroke-width="2"/>
+  <text x="100" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#92400e">Proprietary Analysis Engine</text>
+  <text x="400" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#d97706">70+ modules · 9 vuln sources · deep risk intelligence</text>
 
-  <!-- Analysis row 1: Scan + Enrich -->
-  <rect x="56" y="242" width="140" height="36" rx="8" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="126" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#92400e">Vuln Scan (9 src)</text>
-  <path d="M196 260 L210 260" stroke="#d97706" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="216" y="242" width="140" height="36" rx="8" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="286" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#92400e">CVSS · EPSS · KEV</text>
-  <path d="M356 260 L370 260" stroke="#d97706" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="376" y="242" width="140" height="36" rx="8" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="446" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#92400e">AI Risk + FP Reduce</text>
+  <!-- Row 1: Scan + Enrich pipeline -->
+  <rect x="80" y="308" width="130" height="34" rx="10" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="145" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">Vuln Scan (9 src)</text>
 
-  <!-- Analysis row 2: Deep analysis -->
-  <rect x="56" y="290" width="134" height="36" rx="8" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="123" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#991b1b">Blast Radius</text>
-  <path d="M190 308 L204 308" stroke="#ef4444" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="210" y="290" width="134" height="36" rx="8" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="277" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#991b1b">Context Graph</text>
-  <path d="M344 308 L358 308" stroke="#ef4444" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="364" y="290" width="134" height="36" rx="8" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="431" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#991b1b">Toxic Combos</text>
-  <path d="M498 308 L512 308" stroke="#ef4444" stroke-width="2" fill="none" marker-end="url(#eo-ah)"/>
-  <rect x="518" y="290" width="134" height="36" rx="8" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="585" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#991b1b">Posture A-F</text>
+  <path d="M210 325 L228 325" stroke="#d97706" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="234" y="308" width="130" height="34" rx="10" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="299" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">CVSS · EPSS · KEV</text>
+
+  <path d="M364 325 L382 325" stroke="#d97706" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="388" y="308" width="130" height="34" rx="10" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
+  <text x="453" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">AI Risk + FP Reduce</text>
+
+  <!-- Row 2: Deep analysis -->
+  <rect x="80" y="354" width="120" height="34" rx="10" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="140" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Blast Radius</text>
+
+  <path d="M200 371 L218 371" stroke="#ef4444" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="224" y="354" width="120" height="34" rx="10" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="284" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Context Graph</text>
+
+  <path d="M344 371 L362 371" stroke="#ef4444" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="368" y="354" width="120" height="34" rx="10" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="428" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Toxic Combos</text>
+
+  <path d="M488 371 L506 371" stroke="#ef4444" stroke-width="2" fill="none" marker-end="url(#eo-a)"/>
+
+  <rect x="512" y="354" width="120" height="34" rx="10" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="572" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Posture A-F</text>
 
   <!-- Compliance nodes -->
-  <rect x="680" y="242" width="120" height="36" rx="8" fill="#fff" stroke="#c4b5fd" stroke-width="1.5"/>
-  <text x="740" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#6d28d9">10 Frameworks</text>
-  <rect x="810" y="242" width="120" height="36" rx="8" fill="#7c3aed"/>
-  <text x="870" y="265" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">Policy Engine</text>
+  <rect x="660" y="308" width="110" height="34" rx="10" fill="#fff" stroke="#c4b5fd" stroke-width="1.5"/>
+  <text x="715" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#6d28d9">10 Frameworks</text>
 
-  <rect x="680" y="290" width="250" height="36" rx="8" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="805" y="313" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#991b1b">Incidents (P1-P4) · OCSF Events</text>
+  <rect x="780" y="308" width="110" height="34" rx="10" fill="#8b5cf6"/>
+  <text x="835" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#fff">Policy Engine</text>
 
-  <text x="490" y="344" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">OWASP LLM+MCP · MITRE ATLAS · NIST AI RMF · EU AI Act · SOC 2 · CIS v8 · ISO 27001</text>
+  <rect x="660" y="354" width="230" height="34" rx="10" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
+  <text x="775" y="376" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Incidents (P1-P4) · OCSF Events</text>
+
+  <text x="480" y="408" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">OWASP LLM+MCP · MITRE ATLAS · NIST AI RMF · EU AI Act · SOC 2 · CIS v8 · ISO 27001</text>
 
   <!-- Arrow Layer 2 → Layer 3 -->
-  <path d="M490 352 L490 376" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#eo-ah)"/>
+  <path d="M480 420 L480 452" stroke="#cbd5e1" stroke-width="3" fill="none" marker-end="url(#eo-a)"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 3: OUTPUT + DELIVERY                                       -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="380" width="1120" height="84" rx="12" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="2"/>
-  <use href="#eo-doc" x="56" y="394" width="24" height="24" color="#059669"/>
-  <text x="94" y="410" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#065f46">Output + Deployment</text>
-  <text x="290" y="410" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">13+ formats · 6 delivery channels</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 3: OUTPUT + DELIVERY                             -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="460" width="1080" height="90" rx="18" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="2"/>
+  <text x="120" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#14532d">Output + Deployment</text>
+  <text x="326" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#16a34a">13+ formats · 6 delivery channels</text>
 
   <!-- Format pills -->
-  <rect x="56" y="424" width="56" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="84" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">JSON</text>
-  <rect x="118" y="424" width="56" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="146" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">SARIF</text>
-  <rect x="180" y="424" width="56" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="208" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">CDX</text>
-  <rect x="242" y="424" width="56" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="270" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">SPDX</text>
-  <rect x="304" y="424" width="56" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="332" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">HTML</text>
-  <rect x="366" y="424" width="56" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="394" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">OCSF</text>
+  <rect x="80" y="510" width="52" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="106" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">JSON</text>
+  <rect x="140" y="510" width="52" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="166" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">SARIF</text>
+  <rect x="200" y="510" width="52" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="226" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">CDX</text>
+  <rect x="260" y="510" width="52" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="286" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">SPDX</text>
+  <rect x="320" y="510" width="52" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="346" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">HTML</text>
+  <rect x="380" y="510" width="52" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="406" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">OCSF</text>
 
   <!-- Delivery channels -->
-  <rect x="470" y="424" width="76" height="24" rx="12" fill="#059669"/>
-  <text x="508" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
-  <rect x="554" y="424" width="76" height="24" rx="12" fill="#059669"/>
-  <text x="592" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">REST API</text>
-  <rect x="638" y="424" width="94" height="24" rx="12" fill="#059669"/>
-  <text x="685" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
-  <rect x="740" y="424" width="94" height="24" rx="12" fill="#059669"/>
-  <text x="787" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
-  <rect x="842" y="424" width="94" height="24" rx="12" fill="#059669"/>
-  <text x="889" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
-  <rect x="944" y="424" width="102" height="24" rx="12" fill="#059669"/>
-  <text x="995" y="440" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
+  <rect x="480" y="510" width="70" height="24" rx="12" fill="#16a34a"/>
+  <text x="515" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
+  <rect x="558" y="510" width="78" height="24" rx="12" fill="#16a34a"/>
+  <text x="597" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">REST API</text>
+  <rect x="644" y="510" width="90" height="24" rx="12" fill="#16a34a"/>
+  <text x="689" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
+  <rect x="742" y="510" width="90" height="24" rx="12" fill="#16a34a"/>
+  <text x="787" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
+  <rect x="840" y="510" width="90" height="24" rx="12" fill="#16a34a"/>
+  <text x="885" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
+  <rect x="938" y="510" width="100" height="24" rx="12" fill="#16a34a"/>
+  <text x="988" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
 
-  <!-- Alert delivery -->
-  <text x="700" y="460" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#059669">Slack · Jira · ServiceNow · Drata · Vanta · Webhooks · Prometheus</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  LAYER 4: INFRASTRUCTURE                                -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="566" width="1080" height="44" rx="14" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="600" y="594" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#475569">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway · Helm</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  LAYER 4: INFRASTRUCTURE                                          -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="478" width="1120" height="36" rx="10" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
-  <text x="600" y="500" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#475569">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway SSE · Helm</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  FOOTER                                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="600" y="540" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#64748b">20 MCP clients · 11 providers · 10 agent fwks · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  FOOTER                                                 -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <text x="600" y="650" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 11 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -1,228 +1,162 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" fill="none">
   <defs>
-    <marker id="ah" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#484f58"/></marker>
-    <marker id="ah-b" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#1f6feb"/></marker>
-    <marker id="ah-a" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#d29922"/></marker>
-    <marker id="ah-r" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#f85149"/></marker>
-    <marker id="ah-g" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#3fb950"/></marker>
-    <marker id="ah-p" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#a371f7"/></marker>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#484f58"/>
+    </marker>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#58a6ff"/>
+    </marker>
+    <linearGradient id="flow-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#58a6ff"/>
+      <stop offset="50%" stop-color="#d29922"/>
+      <stop offset="100%" stop-color="#f85149"/>
+    </linearGradient>
 
-    <!-- Icon: Magnifying glass (Discover) -->
-    <symbol id="icon-discover" viewBox="0 0 24 24">
-      <circle cx="10" cy="10" r="7" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+    <!-- Icon: Radar/Discover -->
+    <symbol id="ico-discover" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="18" stroke="currentColor" stroke-width="2.5" fill="none" opacity="0.3"/>
+      <circle cx="24" cy="24" r="11" stroke="currentColor" stroke-width="2.5" fill="none" opacity="0.6"/>
+      <circle cx="24" cy="24" r="4" fill="currentColor"/>
+      <line x1="24" y1="6" x2="24" y2="2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <line x1="24" y1="46" x2="24" y2="42" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <line x1="6" y1="24" x2="2" y2="24" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <line x1="46" y1="24" x2="42" y2="24" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
     </symbol>
 
-    <!-- Icon: Package/Box (Extract) -->
-    <symbol id="icon-extract" viewBox="0 0 24 24">
-      <path d="M3 8L12 3L21 8V16L12 21L3 16V8Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <line x1="12" y1="12" x2="12" y2="21" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="3" y1="8" x2="12" y2="12" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="21" y1="8" x2="12" y2="12" stroke="currentColor" stroke-width="1.5"/>
+    <!-- Icon: Shield-Scan -->
+    <symbol id="ico-scan" viewBox="0 0 48 48">
+      <path d="M24 4L6 14V24C6 36 14 43 24 46C34 43 42 36 42 24V14L24 4Z" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <path d="M16 24L22 30L34 18" stroke="currentColor" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
 
-    <!-- Icon: Shield with check (Scan) -->
-    <symbol id="icon-scan" viewBox="0 0 24 24">
-      <path d="M12 2L3 7V12C3 17.5 7 21.5 12 23C17 21.5 21 17.5 21 12V7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M8 12L11 15L16 9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    </symbol>
-
-    <!-- Icon: Graph/Network (Analyze) -->
-    <symbol id="icon-analyze" viewBox="0 0 24 24">
-      <circle cx="12" cy="5" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="5" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="19" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="12" y1="8" x2="5" y2="16" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="12" y1="8" x2="19" y2="16" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="8" y1="19" x2="16" y2="19" stroke="currentColor" stroke-width="1.5"/>
-    </symbol>
-
-    <!-- Icon: Clipboard/Output -->
-    <symbol id="icon-output" viewBox="0 0 24 24">
-      <rect x="4" y="4" width="16" height="18" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="8" y1="10" x2="16" y2="10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="14" x2="14" y2="14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="18" x2="12" y2="18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <path d="M9 2H15V4C15 5 14 6 12 6C10 6 9 5 9 4V2Z" stroke="currentColor" stroke-width="1.5" fill="none"/>
+    <!-- Icon: Graph/Analyze -->
+    <symbol id="ico-analyze" viewBox="0 0 48 48">
+      <circle cx="24" cy="10" r="6" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <circle cx="10" cy="38" r="6" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <circle cx="38" cy="38" r="6" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <circle cx="24" cy="10" r="2.5" fill="currentColor"/>
+      <circle cx="10" cy="38" r="2.5" fill="currentColor"/>
+      <circle cx="38" cy="38" r="2.5" fill="currentColor"/>
+      <line x1="24" y1="16" x2="10" y2="32" stroke="currentColor" stroke-width="2"/>
+      <line x1="24" y1="16" x2="38" y2="32" stroke="currentColor" stroke-width="2"/>
+      <line x1="16" y1="38" x2="32" y2="38" stroke="currentColor" stroke-width="2"/>
     </symbol>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="520" rx="16" fill="#0d1117"/>
+  <rect width="1200" height="600" rx="20" fill="#0d1117"/>
 
   <!-- Title -->
-  <text x="600" y="36" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" font-weight="700" fill="#e6edf3">How Agent-BOM Works</text>
-  <text x="600" y="56" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#8b949e">End-to-end scan workflow — from discovery to actionable output</text>
+  <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#e6edf3">How Agent-BOM Works</text>
+  <text x="600" y="68" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" fill="#484f58">Discover everything. Scan for risk. Analyze what matters.</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 1: DISCOVER                                                -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="90" width="200" height="280" rx="12" fill="#161b22" stroke="#1f3a5f" stroke-width="2"/>
-  <use href="#icon-discover" x="120" y="108" width="32" height="32" color="#1f6feb"/>
-  <text x="140" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#58a6ff">Discover</text>
-  <text x="140" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">8 source types · 20 MCP clients</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  THREE HERO BLOCKS                                      -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <!-- Sub-items -->
-  <rect x="56" y="198" width="168" height="28" rx="6" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="140" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#58a6ff">MCP Agent Configs</text>
+  <!-- BLOCK 1: DISCOVER -->
+  <rect x="60" y="110" width="300" height="300" rx="20" fill="#161b22" stroke="#1f3a5f" stroke-width="2"/>
+  <use href="#ico-discover" x="160" y="134" width="56" height="56" color="#2563eb"/>
+  <text x="210" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#58a6ff">Discover</text>
+  <text x="210" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#58a6ff">Auto-detect every component</text>
 
-  <rect x="56" y="234" width="168" height="28" rx="6" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="140" y="253" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#58a6ff">Docker · K8s · Terraform</text>
+  <!-- Discover details — clean list, not boxes -->
+  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">20 MCP clients  ·  11 cloud providers</text>
+  <text x="210" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Docker + K8s  ·  7 code ecosystems</text>
+  <text x="210" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">12 AI/ML formats  ·  SBOM ingest</text>
+  <text x="210" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Integrity verification  ·  Filesystem</text>
 
-  <rect x="56" y="270" width="168" height="28" rx="6" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="140" y="289" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#58a6ff">11 Cloud + AI Providers</text>
+  <rect x="130" y="368" width="160" height="26" rx="13" fill="#1f3a5f"/>
+  <text x="210" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#58a6ff">8 SOURCE TYPES</text>
 
-  <rect x="56" y="306" width="168" height="28" rx="6" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="140" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#58a6ff">Code · SBOMs · Models</text>
+  <!-- ═══ FLOW ARROW 1→2 ═══ -->
+  <path d="M360 260 C420 260, 400 260, 460 260" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+  <text x="410" y="248" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">extract</text>
+  <text x="410" y="275" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">+ parse</text>
 
-  <text x="140" y="358" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b949e">7 ecosystems · 12 model formats</text>
+  <!-- BLOCK 2: SCAN + ENRICH -->
+  <rect x="470" y="110" width="300" height="300" rx="20" fill="#161b22" stroke="#5f4a1f" stroke-width="2"/>
+  <use href="#ico-scan" x="570" y="134" width="56" height="56" color="#d29922"/>
+  <text x="620" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#e3b341">Scan + Enrich</text>
+  <text x="620" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#d29922">Find vulns. Score risk. Tag threats.</text>
 
-  <!-- ═══ Arrow 1→2 (bezier) ═══ -->
-  <path d="M240 230 C275 230, 275 230, 310 230" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#ah)"/>
+  <text x="620" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">OSV  ·  GHSA  ·  NVD  ·  Grype  ·  Snyk</text>
+  <text x="620" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">CVSS 3.1  ·  EPSS  ·  CISA KEV</text>
+  <text x="620" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">AI risk classification  ·  FP reduction</text>
+  <text x="620" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Malware + typosquat detection</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 2: EXTRACT + PARSE                                         -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="320" y="130" width="180" height="200" rx="12" fill="#161b22" stroke="#1f3a5f" stroke-width="2"/>
-  <use href="#icon-extract" x="390" y="148" width="32" height="32" color="#1f6feb"/>
-  <text x="410" y="202" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#58a6ff">Extract</text>
-  <text x="410" y="220" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Parse + normalize</text>
+  <rect x="540" y="368" width="160" height="26" rx="13" fill="#3f2a0f"/>
+  <text x="620" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#e3b341">9 VULN SOURCES</text>
 
-  <rect x="336" y="238" width="148" height="26" rx="6" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="410" y="256" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#58a6ff">Package Parser</text>
+  <!-- ═══ FLOW ARROW 2→3 ═══ -->
+  <path d="M770 260 C830 260, 810 260, 870 260" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+  <text x="820" y="248" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">deep</text>
+  <text x="820" y="275" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">analysis</text>
 
-  <rect x="336" y="270" width="148" height="26" rx="6" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
-  <text x="410" y="288" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#58a6ff">Model Inspector</text>
-
-  <text x="410" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b949e" font-style="italic">+ Syft · Semgrep (optional)</text>
-
-  <!-- ═══ Arrow 2→3 (bezier) ═══ -->
-  <path d="M500 230 C535 230, 535 230, 570 230" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#ah)"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 3: SCAN + ENRICH (hero block — larger)                     -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="580" y="90" width="220" height="280" rx="12" fill="#1a1a0e" stroke="#5f4a1f" stroke-width="2"/>
-  <use href="#icon-scan" x="670" y="108" width="32" height="32" color="#d29922"/>
-  <text x="690" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#e3b341">Scan + Enrich</text>
-  <text x="690" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">9 vuln sources · 6 enrichments</text>
-
-  <rect x="596" y="198" width="188" height="28" rx="6" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
-  <text x="690" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">OSV · GHSA · NVD · Grype</text>
-
-  <rect x="596" y="234" width="188" height="28" rx="6" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
-  <text x="690" y="253" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">CVSS 3.1 · EPSS · KEV</text>
-
-  <rect x="596" y="270" width="188" height="28" rx="6" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
-  <text x="690" y="289" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">AI Risk Classification</text>
-
-  <rect x="596" y="306" width="188" height="28" rx="6" fill="#21262d" stroke="#7f5a1f" stroke-width="1.5"/>
-  <text x="690" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">Malware + Typosquat Detect</text>
-
-  <text x="690" y="358" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b949e">OWASP tagging · FP reduction</text>
-
-  <!-- ═══ Arrow 3→4 (bezier) ═══ -->
-  <path d="M800 230 C835 230, 835 230, 870 230" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#ah)"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 4: ANALYZE (hero block — proprietary)                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="880" y="90" width="280" height="280" rx="12" fill="#1a0e0e" stroke="#5f1f1f" stroke-width="2"/>
-
+  <!-- BLOCK 3: ANALYZE -->
+  <rect x="880" y="110" width="260" height="300" rx="20" fill="#161b22" stroke="#5f1f1f" stroke-width="2"/>
   <!-- Proprietary badge -->
-  <rect x="900" y="100" width="100" height="20" rx="10" fill="#da3633"/>
-  <text x="950" y="114" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">PROPRIETARY</text>
+  <rect x="900" y="124" width="100" height="22" rx="11" fill="#da3633"/>
+  <text x="950" y="139" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">PROPRIETARY</text>
 
-  <use href="#icon-analyze" x="1000" y="108" width="32" height="32" color="#f85149"/>
-  <text x="1020" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#ff7b72">Analyze</text>
-  <text x="1020" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Deep risk intelligence</text>
+  <use href="#ico-analyze" x="982" y="134" width="56" height="56" color="#f85149"/>
+  <text x="1010" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#ff7b72">Analyze</text>
+  <text x="1010" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#f85149">Understand real-world impact</text>
 
-  <!-- Analysis nodes with arrows between them -->
-  <rect x="896" y="198" width="128" height="28" rx="6" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="960" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Blast Radius</text>
+  <text x="1010" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Blast radius (6-hop chains)</text>
+  <text x="1010" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Context graph + attack paths</text>
+  <text x="1010" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Toxic combos · Posture A-F</text>
+  <text x="1010" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">10 compliance frameworks</text>
 
-  <path d="M1024 212 L1036 212" stroke="#f85149" stroke-width="1.5" fill="none" marker-end="url(#ah-r)"/>
+  <rect x="930" y="368" width="160" height="26" rx="13" fill="#3f0f0f"/>
+  <text x="1010" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#ff7b72">70+ MODULES</text>
 
-  <rect x="1040" y="198" width="108" height="28" rx="6" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="1094" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Context Graph</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  OUTPUT ROW — clean horizontal bar                      -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <rect x="896" y="238" width="128" height="28" rx="6" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="960" y="257" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Toxic Combos</text>
+  <!-- Down arrow from Analyze to Output -->
+  <path d="M600 410 L600 446" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
 
-  <path d="M1024 252 L1036 252" stroke="#f85149" stroke-width="1.5" fill="none" marker-end="url(#ah-r)"/>
+  <rect x="60" y="456" width="1080" height="80" rx="16" fill="#161b22" stroke="#1f5f3a" stroke-width="2"/>
 
-  <rect x="1040" y="238" width="108" height="28" rx="6" fill="#21262d" stroke="#7f1f1f" stroke-width="1.5"/>
-  <text x="1094" y="257" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#ff7b72">Posture A-F</text>
+  <text x="120" y="488" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#7ee787">Output</text>
+  <text x="120" y="510" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#3fb950">13+ formats  ·  6 delivery channels</text>
 
-  <rect x="896" y="278" width="252" height="28" rx="6" fill="#21262d" stroke="#4f1f7f" stroke-width="1.5"/>
-  <text x="1022" y="297" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#d2a8ff">10 Compliance Frameworks</text>
+  <!-- Format pills -->
+  <rect x="370" y="476" width="54" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="397" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">JSON</text>
 
-  <rect x="896" y="314" width="252" height="28" rx="6" fill="#21262d" stroke="#4f1f7f" stroke-width="1.5"/>
-  <text x="1022" y="333" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#d2a8ff">Policy-as-Code Engine</text>
+  <rect x="432" y="476" width="54" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="459" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SARIF</text>
 
-  <text x="1022" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b949e">OWASP · MITRE · NIST · EU AI Act</text>
+  <rect x="494" y="476" width="54" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="521" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">CDX</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  OUTPUT BAR (below main pipeline)                                 -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="400" width="1120" height="80" rx="12" fill="#0e1a14" stroke="#1f5f3a" stroke-width="2"/>
-  <use href="#icon-output" x="56" y="418" width="28" height="28" color="#3fb950"/>
-  <text x="105" y="436" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#7ee787">Output</text>
-  <text x="105" y="454" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">13+ formats · 6 delivery channels</text>
+  <rect x="556" y="476" width="54" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="583" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SPDX</text>
 
-  <!-- Output format pills -->
-  <rect x="340" y="414" width="62" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="371" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">JSON</text>
-
-  <rect x="410" y="414" width="62" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="441" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SARIF</text>
-
-  <rect x="480" y="414" width="62" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="511" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">CDX</text>
-
-  <rect x="550" y="414" width="62" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="581" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">SPDX</text>
-
-  <rect x="620" y="414" width="62" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="651" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">HTML</text>
-
-  <rect x="690" y="414" width="62" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
-  <text x="721" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">OCSF</text>
+  <rect x="618" y="476" width="54" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
+  <text x="645" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">HTML</text>
 
   <!-- Delivery channels -->
-  <rect x="340" y="446" width="82" height="24" rx="12" fill="#238636"/>
-  <text x="381" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
+  <rect x="710" y="476" width="64" height="24" rx="12" fill="#238636"/>
+  <text x="742" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
 
-  <rect x="430" y="446" width="82" height="24" rx="12" fill="#238636"/>
-  <text x="471" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">REST API</text>
+  <rect x="782" y="476" width="80" height="24" rx="12" fill="#238636"/>
+  <text x="822" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP (16)</text>
 
-  <rect x="520" y="446" width="100" height="24" rx="12" fill="#238636"/>
-  <text x="570" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
+  <rect x="870" y="476" width="80" height="24" rx="12" fill="#238636"/>
+  <text x="910" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
 
-  <rect x="628" y="446" width="96" height="24" rx="12" fill="#238636"/>
-  <text x="676" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
+  <rect x="958" y="476" width="80" height="24" rx="12" fill="#238636"/>
+  <text x="998" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
 
-  <rect x="732" y="446" width="96" height="24" rx="12" fill="#238636"/>
-  <text x="780" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
+  <rect x="1046" y="476" width="80" height="24" rx="12" fill="#238636"/>
+  <text x="1086" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker</text>
 
-  <rect x="836" y="446" width="102" height="24" rx="12" fill="#238636"/>
-  <text x="887" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
-
-  <!-- Arrow from Analyze down to Output -->
-  <path d="M1020 370 L1020 400" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#ah)"/>
-  <!-- Arrow from Discover down to Output -->
-  <path d="M140 370 L140 400" stroke="#484f58" stroke-width="2" fill="none" stroke-dasharray="6 4"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  EXTERNAL FEEDS (subtle dashed underline)                         -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="690" y="390" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#484f58">External: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
-
-  <!-- Dashed arrows from external label up to Scan block -->
-  <path d="M690 380 L690 372" stroke="#484f58" stroke-width="1" stroke-dasharray="3 3" marker-end="url(#ah)"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  FOOTER                                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="600" y="504" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#8b949e">~70 proprietary modules · 107 total · 2,900+ tests · zero runtime deps · read-only · agentless</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  FOOTER — single line                                   -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  2,900+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -1,228 +1,162 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" fill="none">
   <defs>
-    <marker id="ah" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#94a3b8"/></marker>
-    <marker id="ah-b" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#2563eb"/></marker>
-    <marker id="ah-a" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#d97706"/></marker>
-    <marker id="ah-r" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#dc2626"/></marker>
-    <marker id="ah-g" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#059669"/></marker>
-    <marker id="ah-p" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#7c3aed"/></marker>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#3b82f6"/>
+    </marker>
+    <linearGradient id="flow-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="50%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#ef4444"/>
+    </linearGradient>
 
-    <!-- Icon: Magnifying glass (Discover) -->
-    <symbol id="icon-discover" viewBox="0 0 24 24">
-      <circle cx="10" cy="10" r="7" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="15" y1="15" x2="21" y2="21" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+    <!-- Icon: Radar/Discover -->
+    <symbol id="ico-discover" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="18" stroke="currentColor" stroke-width="2.5" fill="none" opacity="0.3"/>
+      <circle cx="24" cy="24" r="11" stroke="currentColor" stroke-width="2.5" fill="none" opacity="0.6"/>
+      <circle cx="24" cy="24" r="4" fill="currentColor"/>
+      <line x1="24" y1="6" x2="24" y2="2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <line x1="24" y1="46" x2="24" y2="42" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <line x1="6" y1="24" x2="2" y2="24" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      <line x1="46" y1="24" x2="42" y2="24" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
     </symbol>
 
-    <!-- Icon: Package/Box (Extract) -->
-    <symbol id="icon-extract" viewBox="0 0 24 24">
-      <path d="M3 8L12 3L21 8V16L12 21L3 16V8Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <line x1="12" y1="12" x2="12" y2="21" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="3" y1="8" x2="12" y2="12" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="21" y1="8" x2="12" y2="12" stroke="currentColor" stroke-width="1.5"/>
+    <!-- Icon: Shield-Scan -->
+    <symbol id="ico-scan" viewBox="0 0 48 48">
+      <path d="M24 4L6 14V24C6 36 14 43 24 46C34 43 42 36 42 24V14L24 4Z" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <path d="M16 24L22 30L34 18" stroke="currentColor" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
 
-    <!-- Icon: Shield with check (Scan) -->
-    <symbol id="icon-scan" viewBox="0 0 24 24">
-      <path d="M12 2L3 7V12C3 17.5 7 21.5 12 23C17 21.5 21 17.5 21 12V7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M8 12L11 15L16 9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    </symbol>
-
-    <!-- Icon: Graph/Network (Analyze) -->
-    <symbol id="icon-analyze" viewBox="0 0 24 24">
-      <circle cx="12" cy="5" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="5" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <circle cx="19" cy="19" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="12" y1="8" x2="5" y2="16" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="12" y1="8" x2="19" y2="16" stroke="currentColor" stroke-width="1.5"/>
-      <line x1="8" y1="19" x2="16" y2="19" stroke="currentColor" stroke-width="1.5"/>
-    </symbol>
-
-    <!-- Icon: Clipboard/Output -->
-    <symbol id="icon-output" viewBox="0 0 24 24">
-      <rect x="4" y="4" width="16" height="18" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
-      <line x1="8" y1="10" x2="16" y2="10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="14" x2="14" y2="14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="18" x2="12" y2="18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      <path d="M9 2H15V4C15 5 14 6 12 6C10 6 9 5 9 4V2Z" stroke="currentColor" stroke-width="1.5" fill="none"/>
+    <!-- Icon: Graph/Analyze -->
+    <symbol id="ico-analyze" viewBox="0 0 48 48">
+      <circle cx="24" cy="10" r="6" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <circle cx="10" cy="38" r="6" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <circle cx="38" cy="38" r="6" stroke="currentColor" stroke-width="2.5" fill="none"/>
+      <circle cx="24" cy="10" r="2.5" fill="currentColor"/>
+      <circle cx="10" cy="38" r="2.5" fill="currentColor"/>
+      <circle cx="38" cy="38" r="2.5" fill="currentColor"/>
+      <line x1="24" y1="16" x2="10" y2="32" stroke="currentColor" stroke-width="2"/>
+      <line x1="24" y1="16" x2="38" y2="32" stroke="currentColor" stroke-width="2"/>
+      <line x1="16" y1="38" x2="32" y2="38" stroke="currentColor" stroke-width="2"/>
     </symbol>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="520" rx="16" fill="#ffffff"/>
+  <rect width="1200" height="600" rx="20" fill="#ffffff"/>
 
   <!-- Title -->
-  <text x="600" y="36" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" font-weight="700" fill="#0f172a">How Agent-BOM Works</text>
-  <text x="600" y="56" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#64748b">End-to-end scan workflow — from discovery to actionable output</text>
+  <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#0f172a">How Agent-BOM Works</text>
+  <text x="600" y="68" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" fill="#94a3b8">Discover everything. Scan for risk. Analyze what matters.</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 1: DISCOVER                                                -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="90" width="200" height="280" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="2"/>
-  <use href="#icon-discover" x="120" y="108" width="32" height="32" color="#2563eb"/>
-  <text x="140" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#1e40af">Discover</text>
-  <text x="140" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">8 source types · 20 MCP clients</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  THREE HERO BLOCKS                                      -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <!-- Sub-items -->
-  <rect x="56" y="198" width="168" height="28" rx="6" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="140" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#1e40af">MCP Agent Configs</text>
+  <!-- BLOCK 1: DISCOVER -->
+  <rect x="60" y="110" width="300" height="300" rx="20" fill="#eff6ff" stroke="#dbeafe" stroke-width="2"/>
+  <use href="#ico-discover" x="160" y="134" width="56" height="56" color="#2563eb"/>
+  <text x="210" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#1e3a5f">Discover</text>
+  <text x="210" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#3b82f6">Auto-detect every component</text>
 
-  <rect x="56" y="234" width="168" height="28" rx="6" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="140" y="253" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#1e40af">Docker · K8s · Terraform</text>
+  <!-- Discover details — clean list, not boxes -->
+  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">20 MCP clients  ·  11 cloud providers</text>
+  <text x="210" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Docker + K8s  ·  7 code ecosystems</text>
+  <text x="210" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">12 AI/ML formats  ·  SBOM ingest</text>
+  <text x="210" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Integrity verification  ·  Filesystem</text>
 
-  <rect x="56" y="270" width="168" height="28" rx="6" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="140" y="289" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#1e40af">11 Cloud + AI Providers</text>
+  <rect x="130" y="368" width="160" height="26" rx="13" fill="#dbeafe"/>
+  <text x="210" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#1e40af">8 SOURCE TYPES</text>
 
-  <rect x="56" y="306" width="168" height="28" rx="6" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="140" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#1e40af">Code · SBOMs · Models</text>
+  <!-- ═══ FLOW ARROW 1→2 ═══ -->
+  <path d="M360 260 C420 260, 400 260, 460 260" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+  <text x="410" y="248" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">extract</text>
+  <text x="410" y="275" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">+ parse</text>
 
-  <text x="140" y="358" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#64748b">7 ecosystems · 12 model formats</text>
+  <!-- BLOCK 2: SCAN + ENRICH -->
+  <rect x="470" y="110" width="300" height="300" rx="20" fill="#fffbeb" stroke="#fde68a" stroke-width="2"/>
+  <use href="#ico-scan" x="570" y="134" width="56" height="56" color="#d97706"/>
+  <text x="620" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#78350f">Scan + Enrich</text>
+  <text x="620" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#d97706">Find vulns. Score risk. Tag threats.</text>
 
-  <!-- ═══ Arrow 1→2 (bezier) ═══ -->
-  <path d="M240 230 C275 230, 275 230, 310 230" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#ah)"/>
+  <text x="620" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">OSV  ·  GHSA  ·  NVD  ·  Grype  ·  Snyk</text>
+  <text x="620" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">CVSS 3.1  ·  EPSS  ·  CISA KEV</text>
+  <text x="620" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">AI risk classification  ·  FP reduction</text>
+  <text x="620" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Malware + typosquat detection</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 2: EXTRACT + PARSE                                         -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="320" y="130" width="180" height="200" rx="12" fill="#eff6ff" stroke="#bfdbfe" stroke-width="2"/>
-  <use href="#icon-extract" x="390" y="148" width="32" height="32" color="#2563eb"/>
-  <text x="410" y="202" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#1e40af">Extract</text>
-  <text x="410" y="220" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Parse + normalize</text>
+  <rect x="540" y="368" width="160" height="26" rx="13" fill="#fef3c7"/>
+  <text x="620" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#92400e">9 VULN SOURCES</text>
 
-  <rect x="336" y="238" width="148" height="26" rx="6" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="410" y="256" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#1e40af">Package Parser</text>
+  <!-- ═══ FLOW ARROW 2→3 ═══ -->
+  <path d="M770 260 C830 260, 810 260, 870 260" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
+  <text x="820" y="248" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">deep</text>
+  <text x="820" y="275" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">analysis</text>
 
-  <rect x="336" y="270" width="148" height="26" rx="6" fill="#fff" stroke="#93c5fd" stroke-width="1.5"/>
-  <text x="410" y="288" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#1e40af">Model Inspector</text>
-
-  <text x="410" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#64748b" font-style="italic">+ Syft · Semgrep (optional)</text>
-
-  <!-- ═══ Arrow 2→3 (bezier) ═══ -->
-  <path d="M500 230 C535 230, 535 230, 570 230" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#ah)"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 3: SCAN + ENRICH (hero block — larger)                     -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="580" y="90" width="220" height="280" rx="12" fill="#fffbeb" stroke="#fcd34d" stroke-width="2"/>
-  <use href="#icon-scan" x="670" y="108" width="32" height="32" color="#d97706"/>
-  <text x="690" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#92400e">Scan + Enrich</text>
-  <text x="690" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">9 vuln sources · 6 enrichments</text>
-
-  <rect x="596" y="198" width="188" height="28" rx="6" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="690" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">OSV · GHSA · NVD · Grype</text>
-
-  <rect x="596" y="234" width="188" height="28" rx="6" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="690" y="253" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">CVSS 3.1 · EPSS · KEV</text>
-
-  <rect x="596" y="270" width="188" height="28" rx="6" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="690" y="289" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">AI Risk Classification</text>
-
-  <rect x="596" y="306" width="188" height="28" rx="6" fill="#fff" stroke="#fbbf24" stroke-width="1.5"/>
-  <text x="690" y="325" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">Malware + Typosquat Detect</text>
-
-  <text x="690" y="358" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#64748b">OWASP tagging · FP reduction</text>
-
-  <!-- ═══ Arrow 3→4 (bezier) ═══ -->
-  <path d="M800 230 C835 230, 835 230, 870 230" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#ah)"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  BLOCK 4: ANALYZE (hero block — proprietary)                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="880" y="90" width="280" height="280" rx="12" fill="#fef2f2" stroke="#fecaca" stroke-width="2"/>
-
+  <!-- BLOCK 3: ANALYZE -->
+  <rect x="880" y="110" width="260" height="300" rx="20" fill="#fef2f2" stroke="#fecaca" stroke-width="2"/>
   <!-- Proprietary badge -->
-  <rect x="900" y="100" width="100" height="20" rx="10" fill="#dc2626"/>
-  <text x="950" y="114" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">PROPRIETARY</text>
+  <rect x="900" y="124" width="100" height="22" rx="11" fill="#dc2626"/>
+  <text x="950" y="139" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">PROPRIETARY</text>
 
-  <use href="#icon-analyze" x="1000" y="108" width="32" height="32" color="#dc2626"/>
-  <text x="1020" y="162" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#991b1b">Analyze</text>
-  <text x="1020" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Deep risk intelligence</text>
+  <use href="#ico-analyze" x="982" y="134" width="56" height="56" color="#dc2626"/>
+  <text x="1010" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#7f1d1d">Analyze</text>
+  <text x="1010" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#dc2626">Understand real-world impact</text>
 
-  <!-- Analysis nodes with arrows between them -->
-  <rect x="896" y="198" width="128" height="28" rx="6" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="960" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Blast Radius</text>
+  <text x="1010" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Blast radius (6-hop chains)</text>
+  <text x="1010" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Context graph + attack paths</text>
+  <text x="1010" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Toxic combos · Posture A-F</text>
+  <text x="1010" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">10 compliance frameworks</text>
 
-  <path d="M1024 212 L1036 212" stroke="#ef4444" stroke-width="1.5" fill="none" marker-end="url(#ah-r)"/>
+  <rect x="930" y="368" width="160" height="26" rx="13" fill="#fee2e2"/>
+  <text x="1010" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#991b1b">70+ MODULES</text>
 
-  <rect x="1040" y="198" width="108" height="28" rx="6" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="1094" y="217" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Context Graph</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  OUTPUT ROW — clean horizontal bar                      -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <rect x="896" y="238" width="128" height="28" rx="6" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="960" y="257" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Toxic Combos</text>
+  <!-- Down arrow from Analyze to Output -->
+  <path d="M600 410 L600 446" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#arrow)"/>
 
-  <path d="M1024 252 L1036 252" stroke="#ef4444" stroke-width="1.5" fill="none" marker-end="url(#ah-r)"/>
+  <rect x="60" y="456" width="1080" height="80" rx="16" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="2"/>
 
-  <rect x="1040" y="238" width="108" height="28" rx="6" fill="#fff" stroke="#fca5a5" stroke-width="1.5"/>
-  <text x="1094" y="257" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#991b1b">Posture A-F</text>
+  <text x="120" y="488" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#14532d">Output</text>
+  <text x="120" y="510" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#16a34a">13+ formats  ·  6 delivery channels</text>
 
-  <rect x="896" y="278" width="252" height="28" rx="6" fill="#fff" stroke="#c4b5fd" stroke-width="1.5"/>
-  <text x="1022" y="297" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#6d28d9">10 Compliance Frameworks</text>
+  <!-- Format pills -->
+  <rect x="370" y="476" width="54" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="397" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">JSON</text>
 
-  <rect x="896" y="314" width="252" height="28" rx="6" fill="#fff" stroke="#c4b5fd" stroke-width="1.5"/>
-  <text x="1022" y="333" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#6d28d9">Policy-as-Code Engine</text>
+  <rect x="432" y="476" width="54" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="459" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">SARIF</text>
 
-  <text x="1022" y="360" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#64748b">OWASP · MITRE · NIST · EU AI Act</text>
+  <rect x="494" y="476" width="54" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="521" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">CDX</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  OUTPUT BAR (below main pipeline)                                 -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="40" y="400" width="1120" height="80" rx="12" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="2"/>
-  <use href="#icon-output" x="56" y="418" width="28" height="28" color="#059669"/>
-  <text x="105" y="436" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#065f46">Output</text>
-  <text x="105" y="454" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">13+ formats · 6 delivery channels</text>
+  <rect x="556" y="476" width="54" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="583" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">SPDX</text>
 
-  <!-- Output format pills -->
-  <rect x="340" y="414" width="62" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="371" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">JSON</text>
-
-  <rect x="410" y="414" width="62" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="441" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">SARIF</text>
-
-  <rect x="480" y="414" width="62" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="511" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">CDX</text>
-
-  <rect x="550" y="414" width="62" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="581" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">SPDX</text>
-
-  <rect x="620" y="414" width="62" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="651" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">HTML</text>
-
-  <rect x="690" y="414" width="62" height="24" rx="12" fill="#d1fae5" stroke="#6ee7b7" stroke-width="1"/>
-  <text x="721" y="430" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">OCSF</text>
+  <rect x="618" y="476" width="54" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
+  <text x="645" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#166534">HTML</text>
 
   <!-- Delivery channels -->
-  <rect x="340" y="446" width="82" height="24" rx="12" fill="#059669"/>
-  <text x="381" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
+  <rect x="710" y="476" width="64" height="24" rx="12" fill="#16a34a"/>
+  <text x="742" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
 
-  <rect x="430" y="446" width="82" height="24" rx="12" fill="#059669"/>
-  <text x="471" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">REST API</text>
+  <rect x="782" y="476" width="80" height="24" rx="12" fill="#16a34a"/>
+  <text x="822" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP (16)</text>
 
-  <rect x="520" y="446" width="100" height="24" rx="12" fill="#059669"/>
-  <text x="570" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
+  <rect x="870" y="476" width="80" height="24" rx="12" fill="#16a34a"/>
+  <text x="910" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
 
-  <rect x="628" y="446" width="96" height="24" rx="12" fill="#059669"/>
-  <text x="676" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
+  <rect x="958" y="476" width="80" height="24" rx="12" fill="#16a34a"/>
+  <text x="998" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
 
-  <rect x="732" y="446" width="96" height="24" rx="12" fill="#059669"/>
-  <text x="780" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
+  <rect x="1046" y="476" width="80" height="24" rx="12" fill="#16a34a"/>
+  <text x="1086" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker</text>
 
-  <rect x="836" y="446" width="102" height="24" rx="12" fill="#059669"/>
-  <text x="887" y="462" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
-
-  <!-- Arrow from Analyze down to Output -->
-  <path d="M1020 370 L1020 400" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#ah)"/>
-  <!-- Arrow from Discover down to Output -->
-  <path d="M140 370 L140 400" stroke="#94a3b8" stroke-width="2" fill="none" stroke-dasharray="6 4"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  EXTERNAL FEEDS (subtle dashed underline)                         -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="690" y="390" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#94a3b8">External: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
-
-  <!-- Dashed arrows from external label up to Scan block -->
-  <path d="M690 380 L690 372" stroke="#94a3b8" stroke-width="1" stroke-dasharray="3 3" marker-end="url(#ah)"/>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  FOOTER                                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="600" y="504" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#64748b">~70 proprietary modules · 107 total · 2,900+ tests · zero runtime deps · read-only · agentless</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  FOOTER — single line                                   -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  2,900+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -1,200 +1,173 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 480" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 640" fill="none">
   <defs>
-    <marker id="sa-ah" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#484f58"/></marker>
-    <marker id="sa-ah-b" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#1f6feb"/></marker>
-
-    <!-- Icon: Layers/Stack -->
-    <symbol id="icon-layers" viewBox="0 0 24 24">
-      <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M2 12L12 17L22 12" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M2 17L12 22L22 17" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-    </symbol>
-
-    <!-- Icon: Database -->
-    <symbol id="icon-db" viewBox="0 0 24 24">
-      <ellipse cx="12" cy="5" rx="9" ry="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <path d="M3 5V19C3 20.7 7 22 12 22S21 20.7 21 19V5" stroke="currentColor" stroke-width="2" fill="none"/>
-      <path d="M3 12C3 13.7 7 15 12 15S21 13.7 21 12" stroke="currentColor" stroke-width="2" fill="none"/>
-    </symbol>
-
-    <!-- Icon: Lock/Shield -->
-    <symbol id="icon-shield" viewBox="0 0 24 24">
-      <path d="M12 2L3 7V12C3 17.5 7 21.5 12 23C17 21.5 21 17.5 21 12V7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-    </symbol>
+    <marker id="sa-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#484f58"/>
+    </marker>
+    <linearGradient id="pipe-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1f6feb"/>
+      <stop offset="30%" stop-color="#d29922"/>
+      <stop offset="60%" stop-color="#f85149"/>
+      <stop offset="80%" stop-color="#a371f7"/>
+      <stop offset="100%" stop-color="#3fb950"/>
+    </linearGradient>
   </defs>
 
-  <rect width="1200" height="480" rx="16" fill="#0d1117"/>
+  <rect width="1200" height="640" rx="20" fill="#0d1117"/>
 
   <!-- Title -->
-  <text x="600" y="36" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" font-weight="700" fill="#e6edf3">Scanner Architecture</text>
-  <text x="600" y="56" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#8b949e">7-stage pipeline — proprietary engine with external intelligence feeds</text>
+  <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#e6edf3">Scanner Architecture</text>
+  <text x="600" y="68" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" fill="#484f58">7-stage pipeline — from source discovery to actionable output</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  STAGE INDICATORS (numbered circles at top)                       -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  PIPELINE — gradient connected line with stage dots     -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <!-- Stage 1 -->
-  <circle cx="80" cy="88" r="14" fill="#1f6feb"/>
-  <text x="80" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">1</text>
-  <text x="80" y="82" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="0" fill="transparent">_</text>
+  <!-- Pipeline backbone line -->
+  <line x1="100" y1="130" x2="1100" y2="130" stroke="url(#pipe-grad)" stroke-width="4" stroke-linecap="round"/>
 
-  <!-- Stage 2 -->
-  <circle cx="240" cy="88" r="14" fill="#1f6feb"/>
-  <text x="240" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">2</text>
+  <!-- Stage dots + labels -->
+  <!-- 1. Discover -->
+  <circle cx="100" cy="130" r="20" fill="#1f6feb"/>
+  <text x="100" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">1</text>
+  <text x="100" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#58a6ff">Discover</text>
 
-  <!-- Stage 3 -->
-  <circle cx="400" cy="88" r="14" fill="#d29922"/>
-  <text x="400" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">3</text>
+  <!-- 2. Extract -->
+  <circle cx="267" cy="130" r="20" fill="#1f6feb"/>
+  <text x="267" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">2</text>
+  <text x="267" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#58a6ff">Extract</text>
 
-  <!-- Stage 4 -->
-  <circle cx="560" cy="88" r="14" fill="#d29922"/>
-  <text x="560" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">4</text>
+  <!-- 3. Scan -->
+  <circle cx="434" cy="130" r="20" fill="#d29922"/>
+  <text x="434" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">3</text>
+  <text x="434" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#e3b341">Scan</text>
 
-  <!-- Stage 5 -->
-  <circle cx="720" cy="88" r="14" fill="#da3633"/>
-  <text x="720" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">5</text>
+  <!-- 4. Enrich -->
+  <circle cx="600" cy="130" r="20" fill="#d29922"/>
+  <text x="600" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">4</text>
+  <text x="600" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#e3b341">Enrich</text>
 
-  <!-- Stage 6 -->
-  <circle cx="900" cy="88" r="14" fill="#8b5cf6"/>
-  <text x="900" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">6</text>
+  <!-- 5. Analyze -->
+  <circle cx="767" cy="130" r="20" fill="#f85149"/>
+  <text x="767" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">5</text>
+  <text x="767" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#ff7b72">Analyze</text>
 
-  <!-- Stage 7 -->
-  <circle cx="1080" cy="88" r="14" fill="#238636"/>
-  <text x="1080" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">7</text>
+  <!-- 6. Comply -->
+  <circle cx="933" cy="130" r="20" fill="#a371f7"/>
+  <text x="933" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">6</text>
+  <text x="933" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#d2a8ff">Comply</text>
 
-  <!-- Connecting line between stage numbers -->
-  <line x1="94" y1="88" x2="226" y2="88" stroke="#30363d" stroke-width="2"/>
-  <line x1="254" y1="88" x2="386" y2="88" stroke="#30363d" stroke-width="2"/>
-  <line x1="414" y1="88" x2="546" y2="88" stroke="#30363d" stroke-width="2"/>
-  <line x1="574" y1="88" x2="706" y2="88" stroke="#30363d" stroke-width="2"/>
-  <line x1="734" y1="88" x2="886" y2="88" stroke="#30363d" stroke-width="2"/>
-  <line x1="914" y1="88" x2="1066" y2="88" stroke="#30363d" stroke-width="2"/>
+  <!-- 7. Output -->
+  <circle cx="1100" cy="130" r="20" fill="#238636"/>
+  <text x="1100" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">7</text>
+  <text x="1100" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#7ee787">Output</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  STAGE BLOCKS (below the numbered indicators)                     -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  DETAIL CARDS — one per stage, below the pipeline       -->
+  <!--  Clean rounded cards with icon + concise text           -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <!-- Stage 1: Discover -->
-  <rect x="20" y="115" width="120" height="200" rx="10" fill="#161b22" stroke="#1f3a5f" stroke-width="2"/>
-  <text x="80" y="138" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#58a6ff">Discover</text>
-  <text x="80" y="160" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">MCP (20)</text>
-  <text x="80" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Docker/K8s</text>
-  <text x="80" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Cloud (11)</text>
-  <text x="80" y="214" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">AI/ML (10)</text>
-  <text x="80" y="232" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Code (7)</text>
-  <text x="80" y="250" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Filesystem</text>
-  <rect x="32" y="266" width="96" height="16" rx="8" fill="#1f3a5f"/>
-  <text x="80" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#58a6ff">PROPRIETARY</text>
-  <text x="80" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#8b949e">8 source types</text>
+  <!-- Vertical connector lines from pipeline dots to cards -->
+  <line x1="100" y1="150" x2="100" y2="186" stroke="#30363d" stroke-width="2"/>
+  <line x1="267" y1="150" x2="267" y2="186" stroke="#30363d" stroke-width="2"/>
+  <line x1="434" y1="150" x2="434" y2="186" stroke="#30363d" stroke-width="2"/>
+  <line x1="600" y1="150" x2="600" y2="186" stroke="#30363d" stroke-width="2"/>
+  <line x1="767" y1="150" x2="767" y2="186" stroke="#30363d" stroke-width="2"/>
+  <line x1="933" y1="150" x2="933" y2="186" stroke="#30363d" stroke-width="2"/>
+  <line x1="1100" y1="150" x2="1100" y2="186" stroke="#30363d" stroke-width="2"/>
 
-  <!-- Arrow -->
-  <path d="M140 215 C165 215, 165 215, 180 215" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 1: Discover -->
+  <rect x="30" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#1f3a5f" stroke-width="1.5"/>
+  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">MCP (20 clients)</text>
+  <text x="100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Docker / K8s</text>
+  <text x="100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Cloud (11)</text>
+  <text x="100" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">AI/ML (12 fmts)</text>
+  <text x="100" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Code (7 eco)</text>
+  <text x="100" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Filesystem</text>
+  <rect x="48" y="330" width="104" height="16" rx="8" fill="#1f3a5f"/>
+  <text x="100" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#58a6ff">PROPRIETARY</text>
 
-  <!-- Stage 2: Extract -->
-  <rect x="186" y="135" width="108" height="160" rx="10" fill="#161b22" stroke="#1f3a5f" stroke-width="2"/>
-  <text x="240" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#58a6ff">Extract</text>
-  <text x="240" y="182" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Pkg Parser</text>
-  <text x="240" y="200" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">AST Detect</text>
-  <text x="240" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">Model Inspect</text>
-  <text x="240" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">SBOM Ingest</text>
-  <text x="240" y="260" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#484f58" font-style="italic">Syft · Semgrep</text>
-  <rect x="198" y="270" width="84" height="16" rx="8" fill="#1f3a5f"/>
-  <text x="240" y="282" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#58a6ff">PROP + ext</text>
+  <!-- Card 2: Extract -->
+  <rect x="197" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#1f3a5f" stroke-width="1.5"/>
+  <text x="267" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Package Parser</text>
+  <text x="267" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">AST Detect</text>
+  <text x="267" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Model Inspector</text>
+  <text x="267" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">SBOM Ingest</text>
+  <text x="267" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58" font-style="italic">+ Syft · Semgrep</text>
+  <rect x="215" y="318" width="104" height="16" rx="8" fill="#1f3a5f"/>
+  <text x="267" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#58a6ff">PROP + ext</text>
 
-  <!-- Arrow -->
-  <path d="M294 215 C319 215, 319 215, 340 215" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 3: Scan -->
+  <rect x="364" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#5f4a1f" stroke-width="1.5"/>
+  <text x="434" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">OSV.dev</text>
+  <text x="434" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">GHSA · NVD</text>
+  <text x="434" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">Grype · NVIDIA</text>
+  <text x="434" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">Snyk</text>
+  <text x="434" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">Malware Detect</text>
+  <text x="434" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">Typosquat</text>
+  <rect x="382" y="330" width="104" height="16" rx="8" fill="#3f2a0f"/>
+  <text x="434" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#e3b341">9 SOURCES</text>
 
-  <!-- Stage 3: Scan -->
-  <rect x="346" y="115" width="108" height="200" rx="10" fill="#1a1a0e" stroke="#5f4a1f" stroke-width="2"/>
-  <text x="400" y="138" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#e3b341">Scan</text>
-  <text x="400" y="160" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">OSV.dev</text>
-  <text x="400" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">GHSA</text>
-  <text x="400" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">NVD / NIST</text>
-  <text x="400" y="214" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">Grype · NVIDIA</text>
-  <text x="400" y="232" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">Snyk</text>
-  <text x="400" y="250" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#e3b341">Malware Detect</text>
-  <text x="400" y="268" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#e3b341">Typosquat</text>
-  <rect x="358" y="280" width="84" height="16" rx="8" fill="#3f2a0f"/>
-  <text x="400" y="292" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#d29922">9 SOURCES</text>
+  <!-- Card 4: Enrich -->
+  <rect x="530" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#5f4a1f" stroke-width="1.5"/>
+  <text x="600" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">CVSS 3.1</text>
+  <text x="600" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">EPSS Scores</text>
+  <text x="600" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">CISA KEV</text>
+  <text x="600" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d29922">OpenSSF</text>
+  <text x="600" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">AI Risk Classify</text>
+  <text x="600" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#e3b341">FP Reduction</text>
 
-  <!-- Arrow -->
-  <path d="M454 215 C479 215, 479 215, 500 215" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 5: Analyze -->
+  <rect x="697" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#5f1f1f" stroke-width="1.5"/>
+  <rect x="712" y="198" width="68" height="16" rx="8" fill="#da3633"/>
+  <text x="746" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="767" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Blast Radius</text>
+  <text x="767" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Context Graph</text>
+  <text x="767" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Toxic Combos</text>
+  <text x="767" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Posture A-F</text>
+  <text x="767" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Incidents</text>
+  <rect x="715" y="330" width="104" height="16" rx="8" fill="#3f0f0f"/>
+  <text x="767" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#f85149">100% PROP</text>
 
-  <!-- Stage 4: Enrich -->
-  <rect x="506" y="135" width="108" height="160" rx="10" fill="#1a1a0e" stroke="#5f4a1f" stroke-width="2"/>
-  <text x="560" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#e3b341">Enrich</text>
-  <text x="560" y="182" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">CVSS 3.1</text>
-  <text x="560" y="200" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">EPSS Scores</text>
-  <text x="560" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">CISA KEV</text>
-  <text x="560" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d29922">OpenSSF</text>
-  <text x="560" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#e3b341">AI Risk Classify</text>
-  <text x="560" y="276" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#e3b341">FP Reduction</text>
+  <!-- Card 6: Comply -->
+  <rect x="863" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#3f1f5f" stroke-width="1.5"/>
+  <rect x="878" y="198" width="68" height="16" rx="8" fill="#8b5cf6"/>
+  <text x="912" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="933" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">OWASP LLM+MCP</text>
+  <text x="933" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">MITRE ATLAS</text>
+  <text x="933" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">NIST · EU AI Act</text>
+  <text x="933" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">SOC 2 · CIS v8</text>
+  <text x="933" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#d2a8ff">Policy Engine</text>
 
-  <!-- Arrow -->
-  <path d="M614 215 C639 215, 639 215, 660 215" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 7: Output -->
+  <rect x="1030" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#1f5f3a" stroke-width="1.5"/>
+  <text x="1100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">JSON · SARIF</text>
+  <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">CDX · SPDX</text>
+  <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">HTML · SVG</text>
+  <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">REST API (25+)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (16 tools)</text>
+  <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">Dashboard (15)</text>
+  <rect x="1048" y="338" width="104" height="16" rx="8" fill="#0f3f1f"/>
+  <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#7ee787">13+ FORMATS</text>
 
-  <!-- Stage 5: Analyze -->
-  <rect x="666" y="115" width="108" height="200" rx="10" fill="#1a0e0e" stroke="#5f1f1f" stroke-width="2"/>
-  <rect x="676" y="122" width="68" height="16" rx="8" fill="#da3633"/>
-  <text x="710" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
-  <text x="720" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#ff7b72">Analyze</text>
-  <text x="720" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#f85149">Blast Radius</text>
-  <text x="720" y="198" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#f85149">Context Graph</text>
-  <text x="720" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#f85149">Risk Analyzer</text>
-  <text x="720" y="234" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#f85149">Toxic Combos</text>
-  <text x="720" y="252" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#f85149">Posture A-F</text>
-  <text x="720" y="270" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#f85149">Incidents</text>
-  <rect x="678" y="282" width="84" height="16" rx="8" fill="#3f0f0f"/>
-  <text x="720" y="294" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#f85149">100% PROP</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION — full-width bar                    -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="400" width="1080" height="70" rx="16" fill="#161b22" stroke="#3f1f5f" stroke-width="2"/>
+  <text x="120" y="430" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#d2a8ff">Runtime Protection</text>
+  <text x="120" y="452" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#a371f7">MCP Stdio Proxy  ·  4 inline scanners  ·  5 detectors  ·  Fleet mgmt  ·  Trust score  ·  Alert pipeline</text>
 
-  <!-- Arrow -->
-  <path d="M774 215 C799 215, 799 215, 840 215" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  INFRASTRUCTURE — full-width bar                        -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="486" width="1080" height="50" rx="14" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+  <text x="120" y="516" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#8b949e">Infrastructure</text>
+  <text x="260" y="516" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">SQLite · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC audit  |  Docker Hub · GHCR · Railway SSE · Helm</text>
 
-  <!-- Stage 6: Comply -->
-  <rect x="846" y="135" width="108" height="160" rx="10" fill="#150e1a" stroke="#3f1f5f" stroke-width="2"/>
-  <rect x="856" y="142" width="68" height="16" rx="8" fill="#8b5cf6"/>
-  <text x="890" y="154" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
-  <text x="900" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#d2a8ff">Comply</text>
-  <text x="900" y="200" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">OWASP LLM+MCP</text>
-  <text x="900" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">MITRE ATLAS</text>
-  <text x="900" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">NIST · EU AI Act</text>
-  <text x="900" y="254" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">SOC 2 · CIS v8</text>
-  <text x="900" y="276" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#d2a8ff">Policy Engine</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  EXTERNAL FEEDS — subtle bottom line                    -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#484f58">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
-  <!-- Arrow -->
-  <path d="M954 215 C979 215, 979 215, 1020 215" stroke="#484f58" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
-
-  <!-- Stage 7: Output -->
-  <rect x="1026" y="115" width="134" height="200" rx="10" fill="#0e1a14" stroke="#1f5f3a" stroke-width="2"/>
-  <text x="1093" y="138" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#7ee787">Output</text>
-  <text x="1093" y="160" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3fb950">JSON · SARIF</text>
-  <text x="1093" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3fb950">CDX · SPDX</text>
-  <text x="1093" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3fb950">HTML · SVG</text>
-  <text x="1093" y="220" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">REST API (25+)</text>
-  <text x="1093" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">MCP Server (16)</text>
-  <text x="1093" y="256" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#7ee787">Dashboard (15)</text>
-  <text x="1093" y="274" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3fb950">Prometheus · OCSF</text>
-  <rect x="1041" y="286" width="104" height="16" rx="8" fill="#0f3f1f"/>
-  <text x="1093" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#3fb950">13+ FORMATS</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  RUNTIME PROTECTION BAR                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="20" y="340" width="1160" height="52" rx="10" fill="#150e1a" stroke="#3f1f5f" stroke-width="2"/>
-  <use href="#icon-shield" x="40" y="352" width="28" height="28" color="#a371f7"/>
-  <text x="82" y="368" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#d2a8ff">Runtime Protection</text>
-  <text x="82" y="384" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">MCP Stdio Proxy · 4 Inline Scanners · 5 Detectors · Fleet Mgmt · Trust Score · Alert Pipeline</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  INFRASTRUCTURE BAR                                               -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="20" y="404" width="1160" height="36" rx="10" fill="#0e1a14" stroke="#1f5f3a" stroke-width="1.5"/>
-  <use href="#icon-db" x="40" y="410" width="24" height="24" color="#3fb950"/>
-  <text x="78" y="428" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">Infrastructure</text>
-  <text x="192" y="428" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">SQLite · PostgreSQL · Snowflake · RBAC · HMAC audit · Docker Hub · GHCR · Railway SSE · Helm</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  FOOTER                                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="600" y="468" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#8b949e">~70 proprietary · ~15 hybrid · ~22 external · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <!-- Footer -->
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 proprietary  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,900+ tests  ·  0 runtime deps</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -1,200 +1,173 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 480" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 640" fill="none">
   <defs>
-    <marker id="sa-ah" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#94a3b8"/></marker>
-    <marker id="sa-ah-b" viewBox="0 0 12 8" refX="11" refY="4" markerWidth="10" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 L12 4 L0 8 Z" fill="#2563eb"/></marker>
-
-    <!-- Icon: Layers/Stack -->
-    <symbol id="icon-layers" viewBox="0 0 24 24">
-      <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M2 12L12 17L22 12" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-      <path d="M2 17L12 22L22 17" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-    </symbol>
-
-    <!-- Icon: Database -->
-    <symbol id="icon-db" viewBox="0 0 24 24">
-      <ellipse cx="12" cy="5" rx="9" ry="3" stroke="currentColor" stroke-width="2" fill="none"/>
-      <path d="M3 5V19C3 20.7 7 22 12 22S21 20.7 21 19V5" stroke="currentColor" stroke-width="2" fill="none"/>
-      <path d="M3 12C3 13.7 7 15 12 15S21 13.7 21 12" stroke="currentColor" stroke-width="2" fill="none"/>
-    </symbol>
-
-    <!-- Icon: Lock/Shield -->
-    <symbol id="icon-shield" viewBox="0 0 24 24">
-      <path d="M12 2L3 7V12C3 17.5 7 21.5 12 23C17 21.5 21 17.5 21 12V7L12 2Z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/>
-    </symbol>
+    <marker id="sa-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#cbd5e1"/>
+    </marker>
+    <linearGradient id="pipe-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="30%" stop-color="#f59e0b"/>
+      <stop offset="60%" stop-color="#ef4444"/>
+      <stop offset="80%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#10b981"/>
+    </linearGradient>
   </defs>
 
-  <rect width="1200" height="480" rx="16" fill="#ffffff"/>
+  <rect width="1200" height="640" rx="20" fill="#ffffff"/>
 
   <!-- Title -->
-  <text x="600" y="36" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="20" font-weight="700" fill="#0f172a">Scanner Architecture</text>
-  <text x="600" y="56" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#64748b">7-stage pipeline — proprietary engine with external intelligence feeds</text>
+  <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#0f172a">Scanner Architecture</text>
+  <text x="600" y="68" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" fill="#94a3b8">7-stage pipeline — from source discovery to actionable output</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  STAGE INDICATORS (numbered circles at top)                       -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  PIPELINE — gradient connected line with stage dots     -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <!-- Stage 1 -->
-  <circle cx="80" cy="88" r="14" fill="#2563eb"/>
-  <text x="80" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">1</text>
-  <text x="80" y="82" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="0" fill="transparent">_</text>
+  <!-- Pipeline backbone line -->
+  <line x1="100" y1="130" x2="1100" y2="130" stroke="url(#pipe-grad)" stroke-width="4" stroke-linecap="round"/>
 
-  <!-- Stage 2 -->
-  <circle cx="240" cy="88" r="14" fill="#2563eb"/>
-  <text x="240" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">2</text>
+  <!-- Stage dots + labels -->
+  <!-- 1. Discover -->
+  <circle cx="100" cy="130" r="20" fill="#3b82f6"/>
+  <text x="100" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">1</text>
+  <text x="100" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#1e40af">Discover</text>
 
-  <!-- Stage 3 -->
-  <circle cx="400" cy="88" r="14" fill="#d97706"/>
-  <text x="400" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">3</text>
+  <!-- 2. Extract -->
+  <circle cx="267" cy="130" r="20" fill="#3b82f6"/>
+  <text x="267" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">2</text>
+  <text x="267" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#1e40af">Extract</text>
 
-  <!-- Stage 4 -->
-  <circle cx="560" cy="88" r="14" fill="#d97706"/>
-  <text x="560" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">4</text>
+  <!-- 3. Scan -->
+  <circle cx="434" cy="130" r="20" fill="#f59e0b"/>
+  <text x="434" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">3</text>
+  <text x="434" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#92400e">Scan</text>
 
-  <!-- Stage 5 -->
-  <circle cx="720" cy="88" r="14" fill="#dc2626"/>
-  <text x="720" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">5</text>
+  <!-- 4. Enrich -->
+  <circle cx="600" cy="130" r="20" fill="#f59e0b"/>
+  <text x="600" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">4</text>
+  <text x="600" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#92400e">Enrich</text>
 
-  <!-- Stage 6 -->
-  <circle cx="900" cy="88" r="14" fill="#7c3aed"/>
-  <text x="900" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">6</text>
+  <!-- 5. Analyze -->
+  <circle cx="767" cy="130" r="20" fill="#ef4444"/>
+  <text x="767" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">5</text>
+  <text x="767" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#991b1b">Analyze</text>
 
-  <!-- Stage 7 -->
-  <circle cx="1080" cy="88" r="14" fill="#059669"/>
-  <text x="1080" y="93" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="700" fill="#fff">7</text>
+  <!-- 6. Comply -->
+  <circle cx="933" cy="130" r="20" fill="#8b5cf6"/>
+  <text x="933" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">6</text>
+  <text x="933" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#6d28d9">Comply</text>
 
-  <!-- Connecting line between stage numbers -->
-  <line x1="94" y1="88" x2="226" y2="88" stroke="#e2e8f0" stroke-width="2"/>
-  <line x1="254" y1="88" x2="386" y2="88" stroke="#e2e8f0" stroke-width="2"/>
-  <line x1="414" y1="88" x2="546" y2="88" stroke="#e2e8f0" stroke-width="2"/>
-  <line x1="574" y1="88" x2="706" y2="88" stroke="#e2e8f0" stroke-width="2"/>
-  <line x1="734" y1="88" x2="886" y2="88" stroke="#e2e8f0" stroke-width="2"/>
-  <line x1="914" y1="88" x2="1066" y2="88" stroke="#e2e8f0" stroke-width="2"/>
+  <!-- 7. Output -->
+  <circle cx="1100" cy="130" r="20" fill="#10b981"/>
+  <text x="1100" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="#fff">7</text>
+  <text x="1100" y="108" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#065f46">Output</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  STAGE BLOCKS (below the numbered indicators)                     -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  DETAIL CARDS — one per stage, below the pipeline       -->
+  <!--  Clean rounded cards with icon + concise text           -->
+  <!-- ════════════════════════════════════════════════════════ -->
 
-  <!-- Stage 1: Discover -->
-  <rect x="20" y="115" width="120" height="200" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="2"/>
-  <text x="80" y="138" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#1e40af">Discover</text>
-  <text x="80" y="160" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">MCP (20)</text>
-  <text x="80" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">Docker/K8s</text>
-  <text x="80" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">Cloud (11)</text>
-  <text x="80" y="214" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">AI/ML (10)</text>
-  <text x="80" y="232" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">Code (7)</text>
-  <text x="80" y="250" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">Filesystem</text>
-  <rect x="32" y="266" width="96" height="16" rx="8" fill="#dbeafe"/>
-  <text x="80" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#2563eb">PROPRIETARY</text>
-  <text x="80" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#64748b">8 source types</text>
+  <!-- Vertical connector lines from pipeline dots to cards -->
+  <line x1="100" y1="150" x2="100" y2="186" stroke="#e2e8f0" stroke-width="2"/>
+  <line x1="267" y1="150" x2="267" y2="186" stroke="#e2e8f0" stroke-width="2"/>
+  <line x1="434" y1="150" x2="434" y2="186" stroke="#e2e8f0" stroke-width="2"/>
+  <line x1="600" y1="150" x2="600" y2="186" stroke="#e2e8f0" stroke-width="2"/>
+  <line x1="767" y1="150" x2="767" y2="186" stroke="#e2e8f0" stroke-width="2"/>
+  <line x1="933" y1="150" x2="933" y2="186" stroke="#e2e8f0" stroke-width="2"/>
+  <line x1="1100" y1="150" x2="1100" y2="186" stroke="#e2e8f0" stroke-width="2"/>
 
-  <!-- Arrow -->
-  <path d="M140 215 C165 215, 165 215, 180 215" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 1: Discover -->
+  <rect x="30" y="190" width="140" height="160" rx="14" fill="#eff6ff" stroke="#dbeafe" stroke-width="1.5"/>
+  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">MCP (20 clients)</text>
+  <text x="100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Docker / K8s</text>
+  <text x="100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Cloud (11)</text>
+  <text x="100" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">AI/ML (12 fmts)</text>
+  <text x="100" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Code (7 eco)</text>
+  <text x="100" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Filesystem</text>
+  <rect x="48" y="330" width="104" height="16" rx="8" fill="#dbeafe"/>
+  <text x="100" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#1e40af">PROPRIETARY</text>
 
-  <!-- Stage 2: Extract -->
-  <rect x="186" y="135" width="108" height="160" rx="10" fill="#eff6ff" stroke="#bfdbfe" stroke-width="2"/>
-  <text x="240" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#1e40af">Extract</text>
-  <text x="240" y="182" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">Pkg Parser</text>
-  <text x="240" y="200" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">AST Detect</text>
-  <text x="240" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">Model Inspect</text>
-  <text x="240" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#3b82f6">SBOM Ingest</text>
-  <text x="240" y="260" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#94a3b8" font-style="italic">Syft · Semgrep</text>
-  <rect x="198" y="270" width="84" height="16" rx="8" fill="#dbeafe"/>
-  <text x="240" y="282" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#2563eb">PROP + ext</text>
+  <!-- Card 2: Extract -->
+  <rect x="197" y="190" width="140" height="160" rx="14" fill="#eff6ff" stroke="#dbeafe" stroke-width="1.5"/>
+  <text x="267" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Package Parser</text>
+  <text x="267" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">AST Detect</text>
+  <text x="267" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Model Inspector</text>
+  <text x="267" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">SBOM Ingest</text>
+  <text x="267" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8" font-style="italic">+ Syft · Semgrep</text>
+  <rect x="215" y="318" width="104" height="16" rx="8" fill="#dbeafe"/>
+  <text x="267" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#1e40af">PROP + ext</text>
 
-  <!-- Arrow -->
-  <path d="M294 215 C319 215, 319 215, 340 215" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 3: Scan -->
+  <rect x="364" y="190" width="140" height="160" rx="14" fill="#fffbeb" stroke="#fde68a" stroke-width="1.5"/>
+  <text x="434" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">OSV.dev</text>
+  <text x="434" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">GHSA · NVD</text>
+  <text x="434" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">Grype · NVIDIA</text>
+  <text x="434" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">Snyk</text>
+  <text x="434" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">Malware Detect</text>
+  <text x="434" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">Typosquat</text>
+  <rect x="382" y="330" width="104" height="16" rx="8" fill="#fef3c7"/>
+  <text x="434" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#92400e">9 SOURCES</text>
 
-  <!-- Stage 3: Scan -->
-  <rect x="346" y="115" width="108" height="200" rx="10" fill="#fffbeb" stroke="#fcd34d" stroke-width="2"/>
-  <text x="400" y="138" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#92400e">Scan</text>
-  <text x="400" y="160" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">OSV.dev</text>
-  <text x="400" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">GHSA</text>
-  <text x="400" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">NVD / NIST</text>
-  <text x="400" y="214" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">Grype · NVIDIA</text>
-  <text x="400" y="232" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">Snyk</text>
-  <text x="400" y="250" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#92400e">Malware Detect</text>
-  <text x="400" y="268" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#92400e">Typosquat</text>
-  <rect x="358" y="280" width="84" height="16" rx="8" fill="#fef3c7"/>
-  <text x="400" y="292" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#d97706">9 SOURCES</text>
+  <!-- Card 4: Enrich -->
+  <rect x="530" y="190" width="140" height="160" rx="14" fill="#fffbeb" stroke="#fde68a" stroke-width="1.5"/>
+  <text x="600" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">CVSS 3.1</text>
+  <text x="600" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">EPSS Scores</text>
+  <text x="600" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">CISA KEV</text>
+  <text x="600" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#d97706">OpenSSF</text>
+  <text x="600" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">AI Risk Classify</text>
+  <text x="600" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#92400e">FP Reduction</text>
 
-  <!-- Arrow -->
-  <path d="M454 215 C479 215, 479 215, 500 215" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 5: Analyze -->
+  <rect x="697" y="190" width="140" height="160" rx="14" fill="#fef2f2" stroke="#fecaca" stroke-width="1.5"/>
+  <rect x="712" y="198" width="68" height="16" rx="8" fill="#dc2626"/>
+  <text x="746" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="767" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Blast Radius</text>
+  <text x="767" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Context Graph</text>
+  <text x="767" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Toxic Combos</text>
+  <text x="767" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Posture A-F</text>
+  <text x="767" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Incidents</text>
+  <rect x="715" y="330" width="104" height="16" rx="8" fill="#fee2e2"/>
+  <text x="767" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#dc2626">100% PROP</text>
 
-  <!-- Stage 4: Enrich -->
-  <rect x="506" y="135" width="108" height="160" rx="10" fill="#fffbeb" stroke="#fcd34d" stroke-width="2"/>
-  <text x="560" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#92400e">Enrich</text>
-  <text x="560" y="182" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">CVSS 3.1</text>
-  <text x="560" y="200" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">EPSS Scores</text>
-  <text x="560" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">CISA KEV</text>
-  <text x="560" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#d97706">OpenSSF</text>
-  <text x="560" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#92400e">AI Risk Classify</text>
-  <text x="560" y="276" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#92400e">FP Reduction</text>
+  <!-- Card 6: Comply -->
+  <rect x="863" y="190" width="140" height="160" rx="14" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1.5"/>
+  <rect x="878" y="198" width="68" height="16" rx="8" fill="#8b5cf6"/>
+  <text x="912" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="933" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">OWASP LLM+MCP</text>
+  <text x="933" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">MITRE ATLAS</text>
+  <text x="933" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">NIST · EU AI Act</text>
+  <text x="933" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">SOC 2 · CIS v8</text>
+  <text x="933" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#6d28d9">Policy Engine</text>
 
-  <!-- Arrow -->
-  <path d="M614 215 C639 215, 639 215, 660 215" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- Card 7: Output -->
+  <rect x="1030" y="190" width="140" height="160" rx="14" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1.5"/>
+  <text x="1100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">JSON · SARIF</text>
+  <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">CDX · SPDX</text>
+  <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">HTML · SVG</text>
+  <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API (25+)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (16 tools)</text>
+  <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard (15)</text>
+  <rect x="1048" y="338" width="104" height="16" rx="8" fill="#d1fae5"/>
+  <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#065f46">13+ FORMATS</text>
 
-  <!-- Stage 5: Analyze -->
-  <rect x="666" y="115" width="108" height="200" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="2"/>
-  <rect x="676" y="122" width="68" height="16" rx="8" fill="#dc2626"/>
-  <text x="710" y="134" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
-  <text x="720" y="158" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#991b1b">Analyze</text>
-  <text x="720" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#dc2626">Blast Radius</text>
-  <text x="720" y="198" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#dc2626">Context Graph</text>
-  <text x="720" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#dc2626">Risk Analyzer</text>
-  <text x="720" y="234" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#dc2626">Toxic Combos</text>
-  <text x="720" y="252" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#dc2626">Posture A-F</text>
-  <text x="720" y="270" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#dc2626">Incidents</text>
-  <rect x="678" y="282" width="84" height="16" rx="8" fill="#fee2e2"/>
-  <text x="720" y="294" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#dc2626">100% PROP</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  RUNTIME PROTECTION — full-width bar                    -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="400" width="1080" height="70" rx="16" fill="#faf5ff" stroke="#e9d5ff" stroke-width="2"/>
+  <text x="120" y="430" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#6d28d9">Runtime Protection</text>
+  <text x="120" y="452" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#7c3aed">MCP Stdio Proxy  ·  4 inline scanners  ·  5 detectors  ·  Fleet mgmt  ·  Trust score  ·  Alert pipeline</text>
 
-  <!-- Arrow -->
-  <path d="M774 215 C799 215, 799 215, 840 215" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  INFRASTRUCTURE — full-width bar                        -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <rect x="60" y="486" width="1080" height="50" rx="14" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="120" y="516" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#475569">Infrastructure</text>
+  <text x="260" y="516" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">SQLite · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC audit  |  Docker Hub · GHCR · Railway SSE · Helm</text>
 
-  <!-- Stage 6: Comply -->
-  <rect x="846" y="135" width="108" height="160" rx="10" fill="#faf5ff" stroke="#e9d5ff" stroke-width="2"/>
-  <rect x="856" y="142" width="68" height="16" rx="8" fill="#7c3aed"/>
-  <text x="890" y="154" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
-  <text x="900" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#6d28d9">Comply</text>
-  <text x="900" y="200" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#7c3aed">OWASP LLM+MCP</text>
-  <text x="900" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#7c3aed">MITRE ATLAS</text>
-  <text x="900" y="236" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#7c3aed">NIST · EU AI Act</text>
-  <text x="900" y="254" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#7c3aed">SOC 2 · CIS v8</text>
-  <text x="900" y="276" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#6d28d9">Policy Engine</text>
+  <!-- ════════════════════════════════════════════════════════ -->
+  <!--  EXTERNAL FEEDS — subtle bottom line                    -->
+  <!-- ════════════════════════════════════════════════════════ -->
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#94a3b8">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
-  <!-- Arrow -->
-  <path d="M954 215 C979 215, 979 215, 1020 215" stroke="#94a3b8" stroke-width="3" fill="none" marker-end="url(#sa-ah)"/>
-
-  <!-- Stage 7: Output -->
-  <rect x="1026" y="115" width="134" height="200" rx="10" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="2"/>
-  <text x="1093" y="138" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#065f46">Output</text>
-  <text x="1093" y="160" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#059669">JSON · SARIF</text>
-  <text x="1093" y="178" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#059669">CDX · SPDX</text>
-  <text x="1093" y="196" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#059669">HTML · SVG</text>
-  <text x="1093" y="220" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">REST API (25+)</text>
-  <text x="1093" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">MCP Server (16)</text>
-  <text x="1093" y="256" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#065f46">Dashboard (15)</text>
-  <text x="1093" y="274" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#059669">Prometheus · OCSF</text>
-  <rect x="1041" y="286" width="104" height="16" rx="8" fill="#d1fae5"/>
-  <text x="1093" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="600" fill="#059669">13+ FORMATS</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  RUNTIME PROTECTION BAR                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="20" y="340" width="1160" height="52" rx="10" fill="#faf5ff" stroke="#c4b5fd" stroke-width="2"/>
-  <use href="#icon-shield" x="40" y="352" width="28" height="28" color="#7c3aed"/>
-  <text x="82" y="368" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="#6d28d9">Runtime Protection</text>
-  <text x="82" y="384" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">MCP Stdio Proxy · 4 Inline Scanners · 5 Detectors · Fleet Mgmt · Trust Score · Alert Pipeline</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  INFRASTRUCTURE BAR                                               -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <rect x="20" y="404" width="1160" height="36" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
-  <use href="#icon-db" x="40" y="410" width="24" height="24" color="#059669"/>
-  <text x="78" y="428" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#166534">Infrastructure</text>
-  <text x="192" y="428" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#15803d">SQLite · PostgreSQL · Snowflake · RBAC · HMAC audit · Docker Hub · GHCR · Railway SSE · Helm</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!--  FOOTER                                                           -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <text x="600" y="468" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#64748b">~70 proprietary · ~15 hybrid · ~22 external · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <!-- Footer -->
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 proprietary  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,900+ tests  ·  0 runtime deps</text>
 </svg>


### PR DESCRIPTION
## Summary
- Complete tear-down and rebuild of 3 core README diagrams
- Philosophy shift: "tell a story, not list features" — inspired by Wiz, Cyera, Snyk, CrowdStrike
- Previous diagrams had 30-40 cramped boxes with overlapping arrows — now 3-7 clean blocks with 50%+ whitespace

## What changed

| Diagram | Before | After |
|---------|--------|-------|
| scan-workflow | 4 dense blocks with sub-boxes | 3 hero blocks with SVG icons, clean text lists |
| scanner-architecture | 7 cramped stage boxes | Gradient pipeline line with numbered dots, detail cards below |
| enterprise-overview | 40+ boxes, spaghetti arrows | 4 horizontal layers with Runtime sidebar, minimal arrows |

## Design principles applied
- 3-5 large blocks max (not 30-40)
- 50%+ whitespace (generous padding and spacing)
- One clear visual flow direction
- Text lists instead of boxes-in-boxes
- Color = semantic meaning (blue=discover, amber=scan, red=analyze, purple=runtime, green=output)
- Large SVG path icons as visual anchors

## Test plan
- [ ] Verify all 6 SVGs render correctly on GitHub (light + dark)
- [ ] Check `<picture>` tags in README switch correctly between themes
- [ ] Compare visual clarity against previous version