### PR TITLE
fix: replace 'Proprietary' labels with 'Built-in' in diagrams

### DIFF
--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -77,10 +77,10 @@
   <path d="M940 340 L910 340" stroke="#a371f7" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-a-p)"/>
 
   <!-- ════════════════════════════════════════════════════════ -->
-  <!--  LAYER 2: PROPRIETARY ANALYSIS ENGINE                   -->
+  <!--  LAYER 2: DEEP ANALYSIS ENGINE                          -->
   <!-- ════════════════════════════════════════════════════════ -->
   <rect x="60" y="260" width="840" height="160" rx="18" fill="#161b22" stroke="#5f4a1f" stroke-width="2"/>
-  <text x="100" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#e3b341">Proprietary Analysis Engine</text>
+  <text x="100" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#e3b341">Deep Analysis Engine</text>
   <text x="400" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#d29922">70+ modules · 9 vuln sources · deep risk intelligence</text>
 
   <!-- Row 1: Scan + Enrich pipeline -->

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -77,10 +77,10 @@
   <path d="M940 340 L910 340" stroke="#a78bfa" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-a-p)"/>
 
   <!-- ════════════════════════════════════════════════════════ -->
-  <!--  LAYER 2: PROPRIETARY ANALYSIS ENGINE                   -->
+  <!--  LAYER 2: DEEP ANALYSIS ENGINE                          -->
   <!-- ════════════════════════════════════════════════════════ -->
   <rect x="60" y="260" width="840" height="160" rx="18" fill="#fffbeb" stroke="#fde68a" stroke-width="2"/>
-  <text x="100" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#92400e">Proprietary Analysis Engine</text>
+  <text x="100" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#92400e">Deep Analysis Engine</text>
   <text x="400" y="290" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#d97706">70+ modules · 9 vuln sources · deep risk intelligence</text>
 
   <!-- Row 1: Scan + Enrich pipeline -->

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -95,9 +95,9 @@
 
   <!-- BLOCK 3: ANALYZE -->
   <rect x="880" y="110" width="260" height="300" rx="20" fill="#161b22" stroke="#5f1f1f" stroke-width="2"/>
-  <!-- Proprietary badge -->
-  <rect x="900" y="124" width="100" height="22" rx="11" fill="#da3633"/>
-  <text x="950" y="139" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">PROPRIETARY</text>
+  <!-- Built-in badge -->
+  <rect x="900" y="124" width="76" height="22" rx="11" fill="#da3633"/>
+  <text x="938" y="139" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">BUILT-IN</text>
 
   <use href="#ico-analyze" x="982" y="134" width="56" height="56" color="#f85149"/>
   <text x="1010" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#ff7b72">Analyze</text>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -95,9 +95,9 @@
 
   <!-- BLOCK 3: ANALYZE -->
   <rect x="880" y="110" width="260" height="300" rx="20" fill="#fef2f2" stroke="#fecaca" stroke-width="2"/>
-  <!-- Proprietary badge -->
-  <rect x="900" y="124" width="100" height="22" rx="11" fill="#dc2626"/>
-  <text x="950" y="139" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">PROPRIETARY</text>
+  <!-- Built-in badge -->
+  <rect x="900" y="124" width="76" height="22" rx="11" fill="#dc2626"/>
+  <text x="938" y="139" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="700" fill="#fff" letter-spacing="0.06em">BUILT-IN</text>
 
   <use href="#ico-analyze" x="982" y="134" width="56" height="56" color="#dc2626"/>
   <text x="1010" y="216" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#7f1d1d">Analyze</text>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -84,7 +84,7 @@
   <text x="100" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Code (7 eco)</text>
   <text x="100" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Filesystem</text>
   <rect x="48" y="330" width="104" height="16" rx="8" fill="#1f3a5f"/>
-  <text x="100" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#58a6ff">PROPRIETARY</text>
+  <text x="100" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#58a6ff">BUILT-IN</text>
 
   <!-- Card 2: Extract -->
   <rect x="197" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#1f3a5f" stroke-width="1.5"/>
@@ -94,7 +94,7 @@
   <text x="267" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">SBOM Ingest</text>
   <text x="267" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58" font-style="italic">+ Syft · Semgrep</text>
   <rect x="215" y="318" width="104" height="16" rx="8" fill="#1f3a5f"/>
-  <text x="267" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#58a6ff">PROP + ext</text>
+  <text x="267" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#58a6ff">BUILT-IN + ext</text>
 
   <!-- Card 3: Scan -->
   <rect x="364" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#5f4a1f" stroke-width="1.5"/>
@@ -119,19 +119,19 @@
   <!-- Card 5: Analyze -->
   <rect x="697" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#5f1f1f" stroke-width="1.5"/>
   <rect x="712" y="198" width="68" height="16" rx="8" fill="#da3633"/>
-  <text x="746" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="746" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">BUILT-IN</text>
   <text x="767" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Blast Radius</text>
   <text x="767" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Context Graph</text>
   <text x="767" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Toxic Combos</text>
   <text x="767" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Posture A-F</text>
   <text x="767" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#f85149">Incidents</text>
   <rect x="715" y="330" width="104" height="16" rx="8" fill="#3f0f0f"/>
-  <text x="767" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#f85149">100% PROP</text>
+  <text x="767" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#f85149">DEEP ANALYSIS</text>
 
   <!-- Card 6: Comply -->
   <rect x="863" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#3f1f5f" stroke-width="1.5"/>
   <rect x="878" y="198" width="68" height="16" rx="8" fill="#8b5cf6"/>
-  <text x="912" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="912" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">BUILT-IN</text>
   <text x="933" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">OWASP LLM+MCP</text>
   <text x="933" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">MITRE ATLAS</text>
   <text x="933" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#a371f7">NIST · EU AI Act</text>
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#484f58">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 proprietary  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,900+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,900+ tests  ·  0 runtime deps</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -84,7 +84,7 @@
   <text x="100" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Code (7 eco)</text>
   <text x="100" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Filesystem</text>
   <rect x="48" y="330" width="104" height="16" rx="8" fill="#dbeafe"/>
-  <text x="100" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#1e40af">PROPRIETARY</text>
+  <text x="100" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#1e40af">BUILT-IN</text>
 
   <!-- Card 2: Extract -->
   <rect x="197" y="190" width="140" height="160" rx="14" fill="#eff6ff" stroke="#dbeafe" stroke-width="1.5"/>
@@ -94,7 +94,7 @@
   <text x="267" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">SBOM Ingest</text>
   <text x="267" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8" font-style="italic">+ Syft · Semgrep</text>
   <rect x="215" y="318" width="104" height="16" rx="8" fill="#dbeafe"/>
-  <text x="267" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#1e40af">PROP + ext</text>
+  <text x="267" y="330" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#1e40af">BUILT-IN + ext</text>
 
   <!-- Card 3: Scan -->
   <rect x="364" y="190" width="140" height="160" rx="14" fill="#fffbeb" stroke="#fde68a" stroke-width="1.5"/>
@@ -119,19 +119,19 @@
   <!-- Card 5: Analyze -->
   <rect x="697" y="190" width="140" height="160" rx="14" fill="#fef2f2" stroke="#fecaca" stroke-width="1.5"/>
   <rect x="712" y="198" width="68" height="16" rx="8" fill="#dc2626"/>
-  <text x="746" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="746" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">BUILT-IN</text>
   <text x="767" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Blast Radius</text>
   <text x="767" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Context Graph</text>
   <text x="767" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Toxic Combos</text>
   <text x="767" y="298" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Posture A-F</text>
   <text x="767" y="318" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#dc2626">Incidents</text>
   <rect x="715" y="330" width="104" height="16" rx="8" fill="#fee2e2"/>
-  <text x="767" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#dc2626">100% PROP</text>
+  <text x="767" y="342" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#dc2626">DEEP ANALYSIS</text>
 
   <!-- Card 6: Comply -->
   <rect x="863" y="190" width="140" height="160" rx="14" fill="#faf5ff" stroke="#e9d5ff" stroke-width="1.5"/>
   <rect x="878" y="198" width="68" height="16" rx="8" fill="#8b5cf6"/>
-  <text x="912" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">PROPRIETARY</text>
+  <text x="912" y="210" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="7" font-weight="700" fill="#fff" letter-spacing="0.04em">BUILT-IN</text>
   <text x="933" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">OWASP LLM+MCP</text>
   <text x="933" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">MITRE ATLAS</text>
   <text x="933" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#7c3aed">NIST · EU AI Act</text>
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#94a3b8">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 proprietary  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,900+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,900+ tests  ·  0 runtime deps</text>
 </svg>


### PR DESCRIPTION
## Summary
- Replaced all "PROPRIETARY" badges/labels with "BUILT-IN" across all 6 SVG architecture diagrams
- Renamed "Proprietary Analysis Engine" to "Deep Analysis Engine" in enterprise-overview
- Changed "100% PROP" to "DEEP ANALYSIS" and "PROP + ext" to "BUILT-IN + ext" in scanner-architecture
- We're Apache 2.0 open source — "Proprietary" was misleading

## Test plan
- [ ] Verify all 6 SVGs render correctly on GitHub (light + dark mode)
- [ ] Confirm no remaining "proprietary" text in diagram files