### PR TITLE
release: v0.52.0

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           agent-bom scan --sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.51.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.52.0"}},"results":[]}]}' > results.sarif
           fi
       - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         if: always()

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.51.0
+ARG VERSION=0.52.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.51.0
+ARG VERSION=0.52.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.51.0"
+  --version "0.52.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.51.0
-git push origin v0.51.0
+git tag v0.52.0
+git push origin v0.52.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.51.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.52.0` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -490,7 +490,7 @@ Both sources deduplicate by CVE ID against OSV results.
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
-| GitHub Action | `uses: msaad00/agent-bom@v0.51.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.52.0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Opt-in MCP traffic audit (per-server) |
@@ -502,7 +502,7 @@ Both sources deduplicate by CVE ID against OSV results.
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.51.0
+- uses: msaad00/agent-bom@v0.52.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -644,7 +644,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.51.0` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.52.0` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: AI supply chain security scanner — scan containers, MCP servers, and AI agents for CVEs, credential exposure, and compliance violations
 version: 0.1.0
-appVersion: "0.51.0"
+appVersion: "0.52.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: msaad02/agent-bom
-  tag: "0.51.0"
+  tag: "0.52.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: msaad02/agent-bom-runtime
-  tag: "0.51.0"
+  tag: "0.52.0"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.51.0
+- uses: msaad00/agent-bom@v0.52.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   compliance (OWASP, MITRE ATLAS, EU AI Act, NIST AI RMF). Use when the user
   mentions vulnerability scanning, dependency security, SBOM generation, MCP server
   trust, or AI supply chain risk.
-version: 0.51.0
+version: 0.52.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Docker for container
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.51.0
+    docker: ghcr.io/msaad00/agent-bom:0.52.0
   openclaw:
     requires:
       bins: []
@@ -113,7 +113,7 @@ agent-bom where             # show all discovery paths
 ### As a Docker Container
 
 ```bash
-docker run --rm ghcr.io/msaad00/agent-bom:0.51.0 scan
+docker run --rm ghcr.io/msaad00/agent-bom:0.52.0 scan
 ```
 
 ### Self-Hosted SSE Server
@@ -213,7 +213,7 @@ installation or self-host your own instance.
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: [smithery.ai/server/agent-bom](https://smithery.ai/server/agent-bom/agent-bom)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.51.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.52.0`
 - **2,900+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.51.0
+ARG VERSION=0.52.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.51.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.52.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.51.0": {
+        "ghcr.io/msaad00/agent-bom:v0.52.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.51.0"
+version = "0.52.0"
 description = "AI supply chain security scanner — CVEs, blast radius, credential exposure, 10-framework compliance (OWASP LLM/MCP/Agentic + MITRE ATLAS + NIST AI RMF + EU AI Act + NIST CSF + ISO 27001 + SOC 2 + CIS). 18 MCP clients, 16 tools, GPU/container/K8s scanning."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.51.0"
+    __version__ = "0.52.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.51.0"
+    assert __version__ == "0.52.0"
 
 
 def test_report_version_matches():
@@ -2933,7 +2933,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.51.0"
+    assert data["version"] == "0.52.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
Version bump 0.51.0 → 0.52.0 across 15 files after PRs #182, #183, #184 merge.

### What's new in v0.52.0
- **CoreWeave + NVIDIA NIM discovery** (12th cloud provider) — VirtualServer CRDs, KServe InferenceServices, NIM container detection, InfiniBand training jobs
- **ClickHouse analytics backend** — append-only OLAP for vulnerability trends, runtime events, posture snapshots
- **Grafana dashboard** — pre-built 10-panel dashboard with docker-compose (ClickHouse + Grafana)
- **Smithery config properties** — nvdApiKey, clickhouseUrl, snykToken surfaced in configSchema
- **ClawHub metadata accuracy** — file_reads, network_endpoints, optional_env, optional_bins declared
- **scan_metadata table** — scan-level tracking (agent count, vuln count, posture grade, duration)

### Files bumped
pyproject.toml, __init__.py, Dockerfile.mcp, Dockerfile.sse, Dockerfile.runtime, toolhive/server.json, mcp-registry/server.json, SKILL.md, Chart.yaml, values.yaml, README.md, PUBLISHING.md, docs/AI_INFRASTRUCTURE_SCANNING.md, cve-freshness.yml, test_core.py

## Test plan
- [x] All 2,920 tests pass (13 skipped)
- [x] Version assertions in test_core.py updated
- [x] CI version-check alignment validated
- [ ] Merge PRs #182, #183, #184 first, then merge this PR