### PR TITLE
feat: brand-colored integration pills + analytics in architecture diagrams

### DIFF
--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 700" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" fill="none">
   <defs>
     <marker id="eo-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
       <path d="M0 0 L10 5 L0 10 Z" fill="#484f58"/>
@@ -8,7 +8,7 @@
     </marker>
   </defs>
 
-  <rect width="1200" height="700" rx="20" fill="#0d1117"/>
+  <rect width="1200" height="760" rx="20" fill="#0d1117"/>
 
   <!-- Title -->
   <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#e6edf3">Enterprise Architecture</text>
@@ -32,7 +32,7 @@
 
   <rect x="316" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
   <text x="370" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Cloud + AI</text>
-  <text x="370" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">11 providers</text>
+  <text x="370" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">12 providers</text>
 
   <rect x="434" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
   <text x="488" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Code / Pkgs</text>
@@ -71,7 +71,15 @@
   <text x="1040" y="316" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#a371f7">Fleet Mgmt · Trust Score</text>
   <text x="1040" y="336" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a371f7">Replay · Dedup · Integrity</text>
 
-  <text x="1040" y="366" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#484f58">Slack · Jira · ServiceNow · Webhooks</text>
+  <!-- Integration brand pills -->
+  <rect x="960" y="354" width="48" height="20" rx="10" fill="#4A154B"/>
+  <text x="984" y="368" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#fff">Slack</text>
+  <rect x="1014" y="354" width="38" height="20" rx="10" fill="#0052CC"/>
+  <text x="1033" y="368" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#fff">Jira</text>
+  <rect x="1058" y="354" width="72" height="20" rx="10" fill="#81b5a1"/>
+  <text x="1094" y="368" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#fff">ServiceNow</text>
+  <rect x="960" y="380" width="72" height="20" rx="10" fill="#21262d" stroke="#484f58" stroke-width="1"/>
+  <text x="996" y="394" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#8b949e">Webhooks</text>
 
   <!-- Dashed arrow from sidebar into Layer 2 -->
   <path d="M940 340 L910 340" stroke="#a371f7" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-a-p)"/>
@@ -134,9 +142,9 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  LAYER 3: OUTPUT + DELIVERY                             -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="60" y="460" width="1080" height="90" rx="18" fill="#161b22" stroke="#1f5f3a" stroke-width="2"/>
+  <rect x="60" y="460" width="1080" height="120" rx="18" fill="#161b22" stroke="#1f5f3a" stroke-width="2"/>
   <text x="120" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#7ee787">Output + Deployment</text>
-  <text x="326" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#3fb950">13+ formats · 6 delivery channels</text>
+  <text x="326" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#3fb950">13+ formats · 7 delivery channels</text>
 
   <!-- Format pills -->
   <rect x="80" y="510" width="52" height="24" rx="12" fill="#0f3f1f" stroke="#1f7f3a" stroke-width="1"/>
@@ -161,19 +169,30 @@
   <text x="689" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
   <rect x="742" y="510" width="90" height="24" rx="12" fill="#238636"/>
   <text x="787" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
-  <rect x="840" y="510" width="90" height="24" rx="12" fill="#238636"/>
-  <text x="885" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
-  <rect x="938" y="510" width="100" height="24" rx="12" fill="#238636"/>
-  <text x="988" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
+  <rect x="840" y="510" width="78" height="24" rx="12" fill="#238636"/>
+  <text x="879" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
+  <rect x="924" y="510" width="82" height="24" rx="12" fill="#238636"/>
+  <text x="965" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
+  <!-- Analytics delivery channel with brand colors -->
+  <rect x="480" y="540" width="130" height="24" rx="12" fill="none" stroke="#F46800" stroke-width="1.5"/>
+  <circle cx="504" cy="552" r="6" fill="#F46800"/>
+  <text x="506" y="555" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#fff">G</text>
+  <text x="550" y="556" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#F46800">Grafana</text>
+  <text x="596" y="556" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#8b949e">+</text>
+  <rect x="614" y="540" width="140" height="24" rx="12" fill="none" stroke="#FFCC00" stroke-width="1.5"/>
+  <rect x="630" y="546" width="3" height="12" rx="1" fill="#FFCC00"/>
+  <rect x="636" y="549" width="3" height="9" rx="1" fill="#FFCC00"/>
+  <rect x="642" y="543" width="3" height="15" rx="1" fill="#FFCC00"/>
+  <text x="694" y="556" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#FFCC00">ClickHouse</text>
 
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  LAYER 4: INFRASTRUCTURE                                -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="60" y="566" width="1080" height="44" rx="14" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
-  <text x="600" y="594" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#8b949e">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway · Helm</text>
+  <rect x="60" y="596" width="1080" height="44" rx="14" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+  <text x="600" y="624" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#8b949e">SQLite (WAL) · PostgreSQL · ClickHouse · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway · Helm</text>
 
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="650" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 11 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 700" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" fill="none">
   <defs>
     <marker id="eo-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
       <path d="M0 0 L10 5 L0 10 Z" fill="#cbd5e1"/>
@@ -8,7 +8,7 @@
     </marker>
   </defs>
 
-  <rect width="1200" height="700" rx="20" fill="#ffffff"/>
+  <rect width="1200" height="760" rx="20" fill="#ffffff"/>
 
   <!-- Title -->
   <text x="600" y="44" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="700" fill="#0f172a">Enterprise Architecture</text>
@@ -32,7 +32,7 @@
 
   <rect x="316" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
   <text x="370" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Cloud + AI</text>
-  <text x="370" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">11 providers</text>
+  <text x="370" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">12 providers</text>
 
   <rect x="434" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
   <text x="488" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Code / Pkgs</text>
@@ -71,7 +71,15 @@
   <text x="1040" y="316" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7c3aed">Fleet Mgmt · Trust Score</text>
   <text x="1040" y="336" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#a78bfa">Replay · Dedup · Integrity</text>
 
-  <text x="1040" y="366" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#94a3b8">Slack · Jira · ServiceNow · Webhooks</text>
+  <!-- Integration brand pills -->
+  <rect x="960" y="354" width="48" height="20" rx="10" fill="#4A154B"/>
+  <text x="984" y="368" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#fff">Slack</text>
+  <rect x="1014" y="354" width="38" height="20" rx="10" fill="#0052CC"/>
+  <text x="1033" y="368" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#fff">Jira</text>
+  <rect x="1058" y="354" width="72" height="20" rx="10" fill="#81b5a1"/>
+  <text x="1094" y="368" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#fff">ServiceNow</text>
+  <rect x="960" y="380" width="72" height="20" rx="10" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="996" y="394" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" font-weight="600" fill="#64748b">Webhooks</text>
 
   <!-- Dashed arrow from sidebar into Layer 2 -->
   <path d="M940 340 L910 340" stroke="#a78bfa" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#eo-a-p)"/>
@@ -134,9 +142,9 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  LAYER 3: OUTPUT + DELIVERY                             -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="60" y="460" width="1080" height="90" rx="18" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="2"/>
+  <rect x="60" y="460" width="1080" height="120" rx="18" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="2"/>
   <text x="120" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="#14532d">Output + Deployment</text>
-  <text x="326" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#16a34a">13+ formats · 6 delivery channels</text>
+  <text x="326" y="492" text-anchor="start" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#16a34a">13+ formats · 7 delivery channels</text>
 
   <!-- Format pills -->
   <rect x="80" y="510" width="52" height="24" rx="12" fill="#dcfce7" stroke="#86efac" stroke-width="1"/>
@@ -161,19 +169,30 @@
   <text x="689" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP Server</text>
   <rect x="742" y="510" width="90" height="24" rx="12" fill="#16a34a"/>
   <text x="787" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
-  <rect x="840" y="510" width="90" height="24" rx="12" fill="#16a34a"/>
-  <text x="885" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
-  <rect x="938" y="510" width="100" height="24" rx="12" fill="#16a34a"/>
-  <text x="988" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
+  <rect x="840" y="510" width="78" height="24" rx="12" fill="#16a34a"/>
+  <text x="879" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">GH Action</text>
+  <rect x="924" y="510" width="82" height="24" rx="12" fill="#16a34a"/>
+  <text x="965" y="526" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Docker/Helm</text>
+  <!-- Analytics delivery channel with brand colors -->
+  <rect x="480" y="540" width="130" height="24" rx="12" fill="none" stroke="#F46800" stroke-width="1.5"/>
+  <circle cx="504" cy="552" r="6" fill="#F46800"/>
+  <text x="506" y="555" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#fff">G</text>
+  <text x="550" y="556" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#F46800">Grafana</text>
+  <text x="596" y="556" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#64748b">+</text>
+  <rect x="614" y="540" width="140" height="24" rx="12" fill="none" stroke="#FFCC00" stroke-width="1.5"/>
+  <rect x="630" y="546" width="3" height="12" rx="1" fill="#FFCC00"/>
+  <rect x="636" y="549" width="3" height="9" rx="1" fill="#FFCC00"/>
+  <rect x="642" y="543" width="3" height="15" rx="1" fill="#FFCC00"/>
+  <text x="694" y="556" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#FFCC00">ClickHouse</text>
 
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  LAYER 4: INFRASTRUCTURE                                -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <rect x="60" y="566" width="1080" height="44" rx="14" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
-  <text x="600" y="594" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#475569">SQLite (WAL) · PostgreSQL · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway · Helm</text>
+  <rect x="60" y="596" width="1080" height="44" rx="14" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="600" y="624" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#475569">SQLite (WAL) · PostgreSQL · ClickHouse · Snowflake  |  RBAC + scrypt KDF  |  HMAC-SHA256 audit  |  Scheduler · Cache  |  Docker Hub · GHCR · Railway · Helm</text>
 
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="650" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 11 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 2,900+ tests · 0 runtime deps</text>
 </svg>


### PR DESCRIPTION
## Summary
- Replace plain-text integration labels with brand-colored pills (Slack, Jira, ServiceNow) in both light/dark architecture diagrams
- Add Grafana + ClickHouse analytics as a delivery channel in the output layer
- Update provider count 11 → 12 (CoreWeave), add ClickHouse to infrastructure storage bar
- Both SVG variants updated consistently

## Test plan
- [ ] Verify light SVG renders correctly in README (light mode)
- [ ] Verify dark SVG renders correctly in README (dark mode)
- [ ] Brand colors match official guidelines (Slack #4A154B, Jira #0052CC, ServiceNow #81b5a1, Grafana #F46800, ClickHouse #FFCC00)
- [ ] All 2,940 tests pass