### PR TITLE
fix: code tightening — consolidate paths, re-enable F841, centralize timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ target-version = "py311"
 select = ["E", "F", "I", "N", "W"]
 ignore = [
     "E501",  # Line too long (handled by line-length setting)
-    "F841",  # Unused variable (will clean up later)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -70,7 +70,7 @@ from contextlib import asynccontextmanager  # noqa: E402
 async def _lifespan(app_instance: FastAPI):
     """Start background cleanup task on startup, cancel on shutdown."""
     # Priority: Snowflake > SQLite > InMemory (lazy default)
-    if _os.environ.get("SNOWFLAKE_ACCOUNT"):
+    if os.environ.get("SNOWFLAKE_ACCOUNT"):
         from agent_bom.api.snowflake_store import (
             SnowflakeFleetStore,
             SnowflakeJobStore,
@@ -85,7 +85,7 @@ async def _lifespan(app_instance: FastAPI):
             set_fleet_store(SnowflakeFleetStore(sf))
         if _policy_store is None:
             set_policy_store(SnowflakePolicyStore(sf))
-    elif _os.environ.get("AGENT_BOM_POSTGRES_URL"):
+    elif os.environ.get("AGENT_BOM_POSTGRES_URL"):
         from agent_bom.api.postgres_store import (
             PostgresFleetStore,
             PostgresJobStore,
@@ -98,8 +98,8 @@ async def _lifespan(app_instance: FastAPI):
             set_fleet_store(PostgresFleetStore())
         if _policy_store is None:
             set_policy_store(PostgresPolicyStore())
-    elif _os.environ.get("AGENT_BOM_DB"):
-        db_path = _os.environ["AGENT_BOM_DB"]
+    elif os.environ.get("AGENT_BOM_DB"):
+        db_path = os.environ["AGENT_BOM_DB"]
         if _store is None:
             from agent_bom.api.store import SQLiteJobStore
 
@@ -116,25 +116,25 @@ async def _lifespan(app_instance: FastAPI):
     # ── Schedule store ──
     global _schedule_store
     if _schedule_store is None:
-        if _os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        if os.environ.get("AGENT_BOM_POSTGRES_URL"):
             from agent_bom.api.postgres_store import PostgresScheduleStore
 
             _schedule_store = PostgresScheduleStore()
-        elif _os.environ.get("AGENT_BOM_DB"):
+        elif os.environ.get("AGENT_BOM_DB"):
             from agent_bom.api.schedule_store import SQLiteScheduleStore
 
-            _schedule_store = SQLiteScheduleStore(_os.environ["AGENT_BOM_DB"])
+            _schedule_store = SQLiteScheduleStore(os.environ["AGENT_BOM_DB"])
         else:
             from agent_bom.api.schedule_store import InMemoryScheduleStore
 
             _schedule_store = InMemoryScheduleStore()
 
     # ── Analytics store (ClickHouse OLAP — optional) ──
-    if _os.environ.get("AGENT_BOM_CLICKHOUSE_URL") and _analytics_store is None:
+    if os.environ.get("AGENT_BOM_CLICKHOUSE_URL") and _analytics_store is None:
         try:
             from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
 
-            set_analytics_store(ClickHouseAnalyticsStore(url=_os.environ["AGENT_BOM_CLICKHOUSE_URL"]))
+            set_analytics_store(ClickHouseAnalyticsStore(url=os.environ["AGENT_BOM_CLICKHOUSE_URL"]))
             _logger.info("ClickHouse analytics store enabled")
         except Exception:
             _logger.warning("ClickHouse analytics unavailable, using NullAnalyticsStore", exc_info=True)
@@ -172,7 +172,7 @@ async def _lifespan(app_instance: FastAPI):
     _executor.shutdown(wait=True, cancel_futures=True)
     # Close Postgres connection pool if active
     try:
-        if _os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        if os.environ.get("AGENT_BOM_POSTGRES_URL"):
             from agent_bom.api.postgres_store import _pool as _pg_pool
 
             if _pg_pool is not None:
@@ -191,10 +191,10 @@ app = FastAPI(
 )
 
 # ── API hardening config ─────────────────────────────────────────────────
-import os as _os  # noqa: E402
+import os  # noqa: E402
 
 _default_origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
-_cors_env = _os.environ.get("CORS_ORIGINS")
+_cors_env = os.environ.get("CORS_ORIGINS")
 _cors_origins: list[str] = [o.strip() for o in _cors_env.split(",") if o.strip()] if _cors_env else _default_origins
 _api_key: str | None = None
 _rate_limit_rpm: int = 60
@@ -433,7 +433,7 @@ def configure_api(
 
 
 # Thread pool for running blocking scan functions without blocking the event loop
-_executor = ThreadPoolExecutor(max_workers=min(8, (_os.cpu_count() or 4) + 2))
+_executor = ThreadPoolExecutor(max_workers=min(8, (os.cpu_count() or 4) + 2))
 
 # ─── Lazy-init lock (protects _store, _fleet_store, _policy_store) ───────────
 _store_lock = threading.Lock()
@@ -2726,11 +2726,11 @@ async def governance_report(days: int = 30):
     Mines ACCESS_HISTORY, GRANTS_TO_ROLES, TAG_REFERENCES, and
     CORTEX_AGENT_USAGE_HISTORY. Requires SNOWFLAKE_ACCOUNT env var.
     """
-    import os as _os
+    import os
 
     days = max(1, min(days, 365))
 
-    if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
+    if not os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
             detail="SNOWFLAKE_ACCOUNT env var not set. Governance requires Snowflake.",
@@ -2753,11 +2753,11 @@ async def governance_findings(
     category: str | None = None,
 ):
     """Return only governance findings, optionally filtered."""
-    import os as _os
+    import os
 
     days = max(1, min(days, 365))
 
-    if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
+    if not os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
             detail="SNOWFLAKE_ACCOUNT env var not set.",
@@ -2794,11 +2794,11 @@ async def activity_timeline(days: int = 30):
     Reconstructs agent execution history from 365-day query history
     and AI observability traces.
     """
-    import os as _os
+    import os
 
     days = max(1, min(days, 365))
 
-    if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
+    if not os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
             detail="SNOWFLAKE_ACCOUNT env var not set. Activity requires Snowflake.",
@@ -2825,11 +2825,11 @@ async def cortex_telemetry(hours: int = 24):
     into per-agent metrics, error rates, latency percentiles, and
     health status.
     """
-    import os as _os
+    import os
 
     hours = max(1, min(hours, 8760))
 
-    if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
+    if not os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
             detail="SNOWFLAKE_ACCOUNT env var not set.",
@@ -2851,9 +2851,9 @@ async def cortex_telemetry(hours: int = 24):
 @app.get("/v1/cortex/agents/{name}/telemetry", tags=["governance"])
 async def cortex_agent_telemetry(name: str, hours: int = 24):
     """Telemetry for a specific Cortex agent."""
-    import os as _os
+    import os
 
-    if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
+    if not os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
             detail="SNOWFLAKE_ACCOUNT env var not set.",
@@ -2875,9 +2875,9 @@ async def cortex_agent_telemetry(name: str, hours: int = 24):
 @app.get("/v1/cortex/health", tags=["governance"])
 async def cortex_health():
     """Health status for all Cortex agents."""
-    import os as _os
+    import os
 
-    if not _os.environ.get("SNOWFLAKE_ACCOUNT"):
+    if not os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
             status_code=400,
             detail="SNOWFLAKE_ACCOUNT env var not set.",

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -3394,7 +3394,7 @@ def completions_cmd(shell: str):
     try:
         result = _sp.run(["agent-bom"], env=env, capture_output=True, text=True)
         click.echo(result.stdout, nl=False)
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         # Fallback: print activation instructions
         if shell == "bash":
             click.echo('eval "$(_AGENT_BOM_COMPLETE=bash_source agent-bom)"')

--- a/src/agent_bom/cloud/huggingface.py
+++ b/src/agent_bom/cloud/huggingface.py
@@ -209,7 +209,6 @@ def _discover_inference_endpoints(
 
     for ep in endpoints:
         ep_name = getattr(ep, "name", "unknown")
-        model_id = getattr(ep, "model_id", None) or getattr(ep, "repository", None) or ""
         status = getattr(ep, "status", "unknown")
         framework = getattr(ep, "framework", None) or ""
 

--- a/src/agent_bom/cloud/openai_provider.py
+++ b/src/agent_bom/cloud/openai_provider.py
@@ -37,10 +37,7 @@ def discover(
     try:
         import openai  # noqa: F401
     except ImportError:
-        raise CloudDiscoveryError(
-            "openai is required for OpenAI discovery. "
-            "Install with: pip install 'agent-bom[openai]'"
-        )
+        raise CloudDiscoveryError("openai is required for OpenAI discovery. Install with: pip install 'agent-bom[openai]'")
 
     agents: list[Agent] = []
     warnings: list[str] = []
@@ -49,10 +46,7 @@ def discover(
     resolved_org = organization or os.environ.get("OPENAI_ORG_ID", "")
 
     if not resolved_key:
-        warnings.append(
-            "OPENAI_API_KEY not set. Provide --openai-api-key or "
-            "set the OPENAI_API_KEY env var."
-        )
+        warnings.append("OPENAI_API_KEY not set. Provide --openai-api-key or set the OPENAI_API_KEY env var.")
         return agents, warnings
 
     # ── Assistants ────────────────────────────────────────────────────────
@@ -96,7 +90,6 @@ def _discover_assistants(
             asst_id = getattr(asst, "id", "unknown")
             asst_name = getattr(asst, "name", None) or asst_id
             model = getattr(asst, "model", "unknown")
-            instructions = getattr(asst, "instructions", "") or ""
             tools = getattr(asst, "tools", []) or []
 
             # Map assistant tools to MCPTool objects
@@ -107,24 +100,30 @@ def _discover_assistants(
                 tool_type = getattr(tool, "type", "")
 
                 if tool_type == "code_interpreter":
-                    mcp_tools.append(MCPTool(
-                        name="code_interpreter",
-                        description="Executes Python code in a sandbox [HIGH-RISK: code execution]",
-                    ))
+                    mcp_tools.append(
+                        MCPTool(
+                            name="code_interpreter",
+                            description="Executes Python code in a sandbox [HIGH-RISK: code execution]",
+                        )
+                    )
                 elif tool_type == "file_search":
-                    mcp_tools.append(MCPTool(
-                        name="file_search",
-                        description="Searches through uploaded files using vector store",
-                    ))
+                    mcp_tools.append(
+                        MCPTool(
+                            name="file_search",
+                            description="Searches through uploaded files using vector store",
+                        )
+                    )
                 elif tool_type == "function":
                     func = getattr(tool, "function", None)
                     if func:
                         func_name = getattr(func, "name", "unknown")
                         func_desc = getattr(func, "description", "") or ""
-                        mcp_tools.append(MCPTool(
-                            name=func_name,
-                            description=func_desc[:200],
-                        ))
+                        mcp_tools.append(
+                            MCPTool(
+                                name=func_name,
+                                description=func_desc[:200],
+                            )
+                        )
 
             # OpenAI SDK itself is a dependency
             packages.append(Package(name="openai", version="unknown", ecosystem="pypi"))
@@ -193,10 +192,12 @@ def _discover_fine_tunes(
 
             # Add training file info as a tool descriptor
             if training_file:
-                server.tools.append(MCPTool(
-                    name="training_data",
-                    description=f"Trained on file {training_file}, base model {model}",
-                ))
+                server.tools.append(
+                    MCPTool(
+                        name="training_data",
+                        description=f"Trained on file {training_file}, base model {model}",
+                    )
+                )
 
             agent = Agent(
                 name=f"openai-ft:{fine_tuned_model}",

--- a/src/agent_bom/connectors/base.py
+++ b/src/agent_bom/connectors/base.py
@@ -19,6 +19,10 @@ class ConnectorHealthState(str, Enum):
     AUTH_FAILED = "auth_failed"
 
 
+# Shared timeout for health-check probes (intentionally shorter than discovery).
+CONNECTOR_HEALTH_TIMEOUT: float = 10.0
+
+
 @dataclass
 class ConnectorStatus:
     """Health check result for a connector."""

--- a/src/agent_bom/connectors/jira_connector.py
+++ b/src/agent_bom/connectors/jira_connector.py
@@ -13,7 +13,7 @@ import os
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
-from .base import ConnectorError, ConnectorHealthState, ConnectorStatus
+from .base import CONNECTOR_HEALTH_TIMEOUT, ConnectorError, ConnectorHealthState, ConnectorStatus
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ async def _discover_async(
     warnings: list[str] = []
     auth = (email, api_token)
 
-    async with create_client(timeout=30.0) as client:
+    async with create_client() as client:
         # 1. Discover automation rules
         resp = await request_with_retry(
             client,
@@ -144,7 +144,7 @@ def health_check(
         return ConnectorStatus(connector="jira", state=ConnectorHealthState.AUTH_FAILED, message=str(e))
 
     async def _check() -> ConnectorStatus:
-        async with create_client(timeout=10.0) as client:
+        async with create_client(timeout=CONNECTOR_HEALTH_TIMEOUT) as client:
             resp = await request_with_retry(client, "GET", f"{url}/rest/api/3/serverInfo", auth=(user, token))
             if resp is None:
                 return ConnectorStatus(connector="jira", state=ConnectorHealthState.UNREACHABLE, message="No response from Jira API")

--- a/src/agent_bom/connectors/servicenow_connector.py
+++ b/src/agent_bom/connectors/servicenow_connector.py
@@ -13,7 +13,7 @@ import os
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
-from .base import ConnectorError, ConnectorHealthState, ConnectorStatus
+from .base import CONNECTOR_HEALTH_TIMEOUT, ConnectorError, ConnectorHealthState, ConnectorStatus
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ async def _discover_async(
     warnings: list[str] = []
     auth = (username, password)
 
-    async with create_client(timeout=30.0) as client:
+    async with create_client() as client:
         # 1. Discover Flow Designer flows
         resp = await request_with_retry(
             client,
@@ -152,7 +152,7 @@ def health_check(
         return ConnectorStatus(connector="servicenow", state=ConnectorHealthState.AUTH_FAILED, message=str(e))
 
     async def _check() -> ConnectorStatus:
-        async with create_client(timeout=10.0) as client:
+        async with create_client(timeout=CONNECTOR_HEALTH_TIMEOUT) as client:
             resp = await request_with_retry(
                 client,
                 "GET",

--- a/src/agent_bom/connectors/slack_connector.py
+++ b/src/agent_bom/connectors/slack_connector.py
@@ -16,7 +16,7 @@ import os
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
-from .base import ConnectorError, ConnectorHealthState, ConnectorStatus
+from .base import CONNECTOR_HEALTH_TIMEOUT, ConnectorError, ConnectorHealthState, ConnectorStatus
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ async def _discover_async(bot_token: str) -> tuple[list[Agent], list[str]]:
     warnings: list[str] = []
     headers = {"Authorization": f"Bearer {bot_token}"}
 
-    async with create_client(timeout=30.0) as client:
+    async with create_client() as client:
         # 1. Get workspace info
         workspace_name = "unknown-workspace"
         resp = await request_with_retry(client, "GET", f"{_SLACK_API}/team.info", headers=headers)
@@ -133,7 +133,7 @@ def health_check(
 
     async def _check() -> ConnectorStatus:
         headers = {"Authorization": f"Bearer {token}"}
-        async with create_client(timeout=10.0) as client:
+        async with create_client(timeout=CONNECTOR_HEALTH_TIMEOUT) as client:
             resp = await request_with_retry(client, "GET", f"{_SLACK_API}/auth.test", headers=headers)
             if resp is None:
                 return ConnectorStatus(connector="slack", state=ConnectorHealthState.UNREACHABLE, message="No response")

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -369,16 +369,12 @@ def find_lateral_paths(
             current_node = graph.nodes.get(current_id)
             if current_node:
                 is_lateral = False
-                target_agent = ""
-
                 if current_node.kind == NodeKind.AGENT and current_node.label != source_agent:
                     is_lateral = True
-                    target_agent = current_node.label
                 elif current_node.kind in (NodeKind.CREDENTIAL, NodeKind.TOOL):
                     node_agent = current_node.metadata.get("agent", "")
                     if node_agent and node_agent != source_agent:
                         is_lateral = True
-                        target_agent = node_agent
 
                 if is_lateral:
                     path_key = tuple(path_nodes)

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -524,7 +524,6 @@ def parse_snowflake_connections(config_path: str) -> list[MCPServer]:
 
         account = conn_def.get("account", "")
         user = conn_def.get("user", "")
-        authenticator = conn_def.get("authenticator", "SNOWFLAKE")
 
         # Build env dict with redacted credentials
         env: dict[str, str] = {}

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -87,10 +87,12 @@ def _truncate_response(response_str: str) -> str:
 
 def _safe_path(path_str: str) -> Path:
     """Resolve a user-provided path and validate against directory traversal."""
-    p = Path(path_str).expanduser().resolve()
-    if not p.is_relative_to(Path.home()):
-        raise ValueError(f"Path {path_str!r} resolves outside home directory")
-    return p
+    from agent_bom.security import SecurityError, validate_path
+
+    try:
+        return validate_path(path_str, restrict_to_home=True)
+    except SecurityError as exc:
+        raise ValueError(str(exc)) from exc
 
 
 # Cached registry data (loaded once, reused across requests)

--- a/src/agent_bom/parsers/prompt_scanner.py
+++ b/src/agent_bom/parsers/prompt_scanner.py
@@ -27,29 +27,54 @@ logger = logging.getLogger(__name__)
 # ── File discovery patterns ──────────────────────────────────────────────────
 
 PROMPT_FILE_EXTENSIONS = {
-    ".prompt", ".promptfile", ".system-prompt",
-    ".jinja2", ".j2", ".hbs", ".mustache",
+    ".prompt",
+    ".promptfile",
+    ".system-prompt",
+    ".jinja2",
+    ".j2",
+    ".hbs",
+    ".mustache",
 }
 
 PROMPT_FILE_NAMES = {
-    "system_prompt.txt", "system_prompt.md",
-    "system_prompt.yaml", "system_prompt.yml", "system_prompt.json",
-    "prompt.yaml", "prompt.yml", "prompt.json",
-    "user_prompt.txt", "user_prompt.md",
-    "agent_prompt.txt", "agent_prompt.md",
-    "instructions.txt", "instructions.md",
+    "system_prompt.txt",
+    "system_prompt.md",
+    "system_prompt.yaml",
+    "system_prompt.yml",
+    "system_prompt.json",
+    "prompt.yaml",
+    "prompt.yml",
+    "prompt.json",
+    "user_prompt.txt",
+    "user_prompt.md",
+    "agent_prompt.txt",
+    "agent_prompt.md",
+    "instructions.txt",
+    "instructions.md",
 }
 
 PROMPT_DIR_NAMES = {
-    "prompts", "prompt_templates", "prompt-templates",
-    "system_prompts", "system-prompts",
+    "prompts",
+    "prompt_templates",
+    "prompt-templates",
+    "system_prompts",
+    "system-prompts",
 }
 
 # Directories to skip during scanning
 _SKIP_DIRS = {
-    ".git", "node_modules", "__pycache__", ".venv", "venv",
-    ".tox", ".mypy_cache", ".ruff_cache", "dist", "build",
-    ".eggs", "*.egg-info",
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".tox",
+    ".mypy_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    ".eggs",
+    "*.egg-info",
 }
 
 
@@ -285,7 +310,19 @@ def discover_prompt_files(
                 if entry.name.lower() in PROMPT_DIR_NAMES:
                     # Scan all files inside prompt directories
                     for f in sorted(entry.rglob("*")):
-                        if f.is_file() and f.suffix in {".txt", ".md", ".yaml", ".yml", ".json", ".j2", ".jinja2", ".hbs", ".mustache", ".prompt", ".promptfile"}:
+                        if f.is_file() and f.suffix in {
+                            ".txt",
+                            ".md",
+                            ".yaml",
+                            ".yml",
+                            ".json",
+                            ".j2",
+                            ".jinja2",
+                            ".hbs",
+                            ".mustache",
+                            ".prompt",
+                            ".promptfile",
+                        }:
                             found.append(f)
                 else:
                     _walk(entry, depth + 1)
@@ -310,7 +347,6 @@ def _analyze_content(
 ) -> list[PromptFinding]:
     """Analyze prompt content for security risks."""
     findings: list[PromptFinding] = []
-    lines = content.split("\n")
 
     # Build a line-lookup for match positions
     def _find_line(pos: int) -> int:
@@ -320,72 +356,82 @@ def _analyze_content(
     # Critical: Hardcoded secrets
     for pattern, title in _SECRET_PATTERNS:
         for match in pattern.finditer(content):
-            findings.append(PromptFinding(
-                severity="critical",
-                category="hardcoded_secret",
-                title=title,
-                detail=f"Found {title.lower()} in prompt template",
-                source_file=source_file,
-                line_number=_find_line(match.start()),
-                matched_text=_redact(match.group(0)),
-                recommendation="Remove hardcoded secrets. Use environment variables or secret managers.",
-            ))
+            findings.append(
+                PromptFinding(
+                    severity="critical",
+                    category="hardcoded_secret",
+                    title=title,
+                    detail=f"Found {title.lower()} in prompt template",
+                    source_file=source_file,
+                    line_number=_find_line(match.start()),
+                    matched_text=_redact(match.group(0)),
+                    recommendation="Remove hardcoded secrets. Use environment variables or secret managers.",
+                )
+            )
 
     # High: Prompt injection / jailbreak
     for pattern, title in _INJECTION_PATTERNS:
         for match in pattern.finditer(content):
-            findings.append(PromptFinding(
-                severity="high",
-                category="prompt_injection",
-                title=title,
-                detail=f"Detected injection/jailbreak pattern: {match.group(0)[:80]}",
-                source_file=source_file,
-                line_number=_find_line(match.start()),
-                matched_text=match.group(0)[:100],
-                recommendation="Remove prompt injection patterns. These can compromise agent safety controls.",
-            ))
+            findings.append(
+                PromptFinding(
+                    severity="high",
+                    category="prompt_injection",
+                    title=title,
+                    detail=f"Detected injection/jailbreak pattern: {match.group(0)[:80]}",
+                    source_file=source_file,
+                    line_number=_find_line(match.start()),
+                    matched_text=match.group(0)[:100],
+                    recommendation="Remove prompt injection patterns. These can compromise agent safety controls.",
+                )
+            )
 
     # High: Unsafe instructions
     for pattern, title in _UNSAFE_INSTRUCTION_PATTERNS:
         for match in pattern.finditer(content):
-            findings.append(PromptFinding(
-                severity="high",
-                category="unsafe_instruction",
-                title=title,
-                detail=f"Prompt instructs agent to: {match.group(0)[:80]}",
-                source_file=source_file,
-                line_number=_find_line(match.start()),
-                matched_text=match.group(0)[:100],
-                recommendation="Restrict agent capabilities. Avoid granting shell access or data exfiltration paths.",
-            ))
+            findings.append(
+                PromptFinding(
+                    severity="high",
+                    category="unsafe_instruction",
+                    title=title,
+                    detail=f"Prompt instructs agent to: {match.group(0)[:80]}",
+                    source_file=source_file,
+                    line_number=_find_line(match.start()),
+                    matched_text=match.group(0)[:100],
+                    recommendation="Restrict agent capabilities. Avoid granting shell access or data exfiltration paths.",
+                )
+            )
 
     # Medium: Excessive permissions
     for pattern, title in _PERMISSION_PATTERNS:
         for match in pattern.finditer(content):
-            findings.append(PromptFinding(
-                severity="medium",
-                category="excessive_permission",
-                title=title,
-                detail=f"Prompt grants excessive permissions: {match.group(0)[:80]}",
-                source_file=source_file,
-                line_number=_find_line(match.start()),
-                matched_text=match.group(0)[:100],
-                recommendation="Apply least-privilege. Scope agent access to only what's needed.",
-            ))
+            findings.append(
+                PromptFinding(
+                    severity="medium",
+                    category="excessive_permission",
+                    title=title,
+                    detail=f"Prompt grants excessive permissions: {match.group(0)[:80]}",
+                    source_file=source_file,
+                    line_number=_find_line(match.start()),
+                    matched_text=match.group(0)[:100],
+                    recommendation="Apply least-privilege. Scope agent access to only what's needed.",
+                )
+            )
 
     # Medium: Sensitive data in prompt content
     for pattern, title in _SENSITIVE_DATA_PATTERNS:
         for match in pattern.finditer(content):
-            findings.append(PromptFinding(
-                severity="medium",
-                category="sensitive_data",
-                title=title,
-                detail="Possible sensitive data in prompt template",
-                source_file=source_file,
-                line_number=_find_line(match.start()),
-                matched_text=_redact(match.group(0)),
-                recommendation="Remove sensitive data from prompt templates. Use parameterized inputs.",
-            ))
+            findings.append(
+                PromptFinding(
+                    severity="medium",
+                    category="sensitive_data",
+                    title=title,
+                    detail="Possible sensitive data in prompt template",
+                    source_file=source_file,
+                    line_number=_find_line(match.start()),
+                    matched_text=_redact(match.group(0)),
+                    recommendation="Remove sensitive data from prompt templates. Use parameterized inputs.",
+                )
+            )
 
     return findings
 
@@ -419,14 +465,12 @@ def _extract_prompt_from_json(content: str) -> str:
                 _walk_json(item, depth + 1)
         elif isinstance(obj, dict):
             # Prioritize known prompt-related keys
-            for key in ("prompt", "system_prompt", "system", "content",
-                        "instructions", "template", "message", "text"):
+            for key in ("prompt", "system_prompt", "system", "content", "instructions", "template", "message", "text"):
                 if key in obj:
                     _walk_json(obj[key], depth + 1)
             # Also walk other values
             for key, val in obj.items():
-                if key not in ("prompt", "system_prompt", "system", "content",
-                               "instructions", "template", "message", "text"):
+                if key not in ("prompt", "system_prompt", "system", "content", "instructions", "template", "message", "text"):
                     _walk_json(val, depth + 1)
 
     _walk_json(data)
@@ -446,10 +490,19 @@ def _extract_prompt_from_yaml(content: str) -> str:
         lower = stripped.lower()
 
         # Check for prompt-related YAML keys
-        if any(lower.startswith(k) for k in (
-            "prompt:", "system_prompt:", "system:", "content:",
-            "instructions:", "template:", "message:", "text:",
-        )):
+        if any(
+            lower.startswith(k)
+            for k in (
+                "prompt:",
+                "system_prompt:",
+                "system:",
+                "content:",
+                "instructions:",
+                "template:",
+                "message:",
+                "text:",
+            )
+        ):
             # Value on same line after colon
             val = stripped.split(":", 1)[1].strip()
             if val and val not in ("|", ">", "|-", ">-"):
@@ -528,8 +581,6 @@ def scan_prompt_files(
         result.findings.extend(findings)
 
     # Determine pass/fail
-    result.passed = not any(
-        f.severity in ("critical", "high") for f in result.findings
-    )
+    result.passed = not any(f.severity in ("critical", "high") for f in result.findings)
 
     return result

--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -128,9 +128,7 @@ def _fm_value(raw: str, field_name: str) -> str | None:
 
 def _fm_list(raw: str, field_name: str) -> list[str]:
     """Extract list items under a YAML field from raw frontmatter."""
-    section = re.search(
-        rf"^\s*{re.escape(field_name)}\s*:\s*\n((?:\s+-\s+.+\n?)+)", raw, re.MULTILINE
-    )
+    section = re.search(rf"^\s*{re.escape(field_name)}\s*:\s*\n((?:\s+-\s+.+\n?)+)", raw, re.MULTILINE)
     if not section:
         return []
     return re.findall(r"^\s+-\s+(.+)$", section.group(1), re.MULTILINE)
@@ -178,7 +176,7 @@ def _assess_purpose_capability(
             evidence.append(f"{f.category}: {f.title}")
 
     # Check for undocumented network
-    raw = (meta.raw_frontmatter if meta else "")
+    raw = meta.raw_frontmatter if meta else ""
     has_network_docs = _fm_has(raw, "network_endpoints")
 
     if shell_findings:
@@ -215,9 +213,7 @@ def _assess_purpose_capability(
         name="Purpose & Capability",
         key="purpose_capability",
         level=TrustLevel.PASS,
-        summary="Name, description, and required binaries declared" + (
-            "; network endpoints documented" if has_network_docs else ""
-        ),
+        summary="Name, description, and required binaries declared" + ("; network endpoints documented" if has_network_docs else ""),
         details=details,
         evidence=evidence,
     )
@@ -232,7 +228,7 @@ def _assess_instruction_scope(
     details: list[str] = []
     evidence: list[str] = []
 
-    raw = (meta.raw_frontmatter if meta else "")
+    raw = meta.raw_frontmatter if meta else ""
     has_file_reads = _fm_has(raw, "file_reads")
     has_justification = _fm_has(raw, "file_reads_justification")
     has_data_handling = _fm_has(raw, "sensitive_data_handling")
@@ -254,9 +250,7 @@ def _assess_instruction_scope(
             evidence.append(f"file_writes: {writes}")
 
     # Check for credential file access or data exfiltration
-    dangerous_scope = _audit_findings_for(
-        audit, "credential_file_access", "data_exfiltration", "memory_poisoning"
-    )
+    dangerous_scope = _audit_findings_for(audit, "credential_file_access", "data_exfiltration", "memory_poisoning")
     if dangerous_scope:
         for f in dangerous_scope[:3]:
             details.append(f"Behavioral finding: {f.title}")
@@ -306,9 +300,7 @@ def _assess_instruction_scope(
         name="Instruction Scope",
         key="instruction_scope",
         level=TrustLevel.PASS,
-        summary="File reads bounded and justified" + (
-            "; data handling documented" if has_data_handling else ""
-        ),
+        summary="File reads bounded and justified" + ("; data handling documented" if has_data_handling else ""),
         details=details,
         evidence=evidence,
     )
@@ -323,7 +315,7 @@ def _assess_install_mechanism(
     details: list[str] = []
     evidence: list[str] = []
 
-    raw = (meta.raw_frontmatter if meta else "")
+    raw = meta.raw_frontmatter if meta else ""
     has_source = bool(meta and meta.source)
     has_homepage = bool(meta and meta.homepage)
     install_methods = meta.install_methods if meta else []
@@ -337,9 +329,7 @@ def _assess_install_mechanism(
         details.append(f"Homepage: {meta.homepage}")
 
     # Check for verification/signing references
-    has_signing = bool(
-        re.search(r"(?:sigstore|cosign|checksum|sha256|provenance|slsa)", raw, re.IGNORECASE)
-    )
+    has_signing = bool(re.search(r"(?:sigstore|cosign|checksum|sha256|provenance|slsa)", raw, re.IGNORECASE))
     if has_signing:
         details.append("Signing/provenance references found in metadata")
 
@@ -377,9 +367,7 @@ def _assess_install_mechanism(
         name="Install Mechanism",
         key="install_mechanism",
         level=TrustLevel.PASS,
-        summary=f"{len(install_methods)} install method(s), source available" + (
-            ", signed" if has_signing else ""
-        ),
+        summary=f"{len(install_methods)} install method(s), source available" + (", signed" if has_signing else ""),
         details=details,
         evidence=evidence,
     )
@@ -394,15 +382,13 @@ def _assess_credentials(
     details: list[str] = []
     evidence: list[str] = []
 
-    raw = (meta.raw_frontmatter if meta else "")
+    raw = meta.raw_frontmatter if meta else ""
     cred_count = len(scan.credential_env_vars)
     has_optional_env = _fm_has(raw, "optional_env")
-    has_required_env = _fm_has(raw, "env")
     has_sent_only_to = "sent_only_to" in raw if raw else False
 
     # Check what's declared
     required_env_list = _fm_list(raw, "env")
-    env_empty = _fm_value(raw, "env")  # check for "env: []"
 
     if cred_count == 0:
         details.append("No credential env vars referenced")
@@ -454,10 +440,7 @@ def _assess_credentials(
         name="Credentials",
         key="credentials",
         level=TrustLevel.PASS,
-        summary="No required credentials" + (
-            f"; {cred_count} optional, documented" if cred_count > 0 and has_optional_env
-            else ""
-        ),
+        summary="No required credentials" + (f"; {cred_count} optional, documented" if cred_count > 0 and has_optional_env else ""),
         details=details,
         evidence=evidence,
     )
@@ -472,7 +455,7 @@ def _assess_persistence_privilege(
     details: list[str] = []
     evidence: list[str] = []
 
-    raw = (meta.raw_frontmatter if meta else "")
+    raw = meta.raw_frontmatter if meta else ""
 
     # Check frontmatter declarations
     persistence_val = _fm_value(raw, "persistence")
@@ -487,9 +470,7 @@ def _assess_persistence_privilege(
         details.append(f"privilege_escalation: {priv_esc_val}")
 
     # Check audit behavioral findings
-    priv_findings = _audit_findings_for(
-        audit, "persistence_mechanism", "privilege_escalation", "confirmation_bypass"
-    )
+    priv_findings = _audit_findings_for(audit, "persistence_mechanism", "privilege_escalation", "confirmation_bypass")
     if priv_findings:
         for f in priv_findings[:3]:
             details.append(f"Behavioral finding: {f.title}")
@@ -537,9 +518,12 @@ def _assess_persistence_privilege(
 
     # All declared as false → best case
     all_false = (
-        persistence_val and persistence_val.lower() == "false"
-        and telemetry_val and telemetry_val.lower() == "false"
-        and priv_esc_val and priv_esc_val.lower() == "false"
+        persistence_val
+        and persistence_val.lower() == "false"
+        and telemetry_val
+        and telemetry_val.lower() == "false"
+        and priv_esc_val
+        and priv_esc_val.lower() == "false"
     )
 
     if all_false:

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -167,7 +167,7 @@ class ProxyMetricsServer:
 
         async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
             try:
-                request_line = await asyncio.wait_for(reader.readline(), timeout=10)
+                await asyncio.wait_for(reader.readline(), timeout=10)
                 # Read remaining headers
                 while True:
                     header = await asyncio.wait_for(reader.readline(), timeout=5)

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -101,13 +101,18 @@ def validate_environment(env: dict[str, str]) -> None:
     logger.debug(f"Validated {len(env)} environment variable(s)")
 
 
-def validate_path(path: str | Path, must_exist: bool = False) -> Path:
+def validate_path(
+    path: str | Path,
+    must_exist: bool = False,
+    restrict_to_home: bool = False,
+) -> Path:
     """
     Validate and normalize a file path.
 
     Args:
         path: Path to validate
         must_exist: If True, path must exist
+        restrict_to_home: If True, path must resolve inside the user's home directory
 
     Returns:
         Validated and normalized Path object
@@ -115,7 +120,7 @@ def validate_path(path: str | Path, must_exist: bool = False) -> Path:
     Raises:
         SecurityError: If path is invalid or contains path traversal
     """
-    path = Path(path)
+    path = Path(path).expanduser()
 
     # Resolve to absolute path (prevents path traversal)
     try:
@@ -123,7 +128,11 @@ def validate_path(path: str | Path, must_exist: bool = False) -> Path:
     except (OSError, RuntimeError) as e:
         raise SecurityError(f"Invalid path '{path}': {e}")
 
-    # Check for path traversal attempts
+    # Restrict to home directory (used by MCP server for user-provided paths)
+    if restrict_to_home and not resolved.is_relative_to(Path.home()):
+        raise SecurityError(f"Path resolves outside home directory: {path}")
+
+    # Check for path traversal attempts (on unresolved path)
     if ".." in path.parts:
         logger.warning(f"Path traversal attempt detected: {path}")
         raise SecurityError(f"Path traversal not allowed: {path}")

--- a/tests/test_apply_remediation.py
+++ b/tests/test_apply_remediation.py
@@ -45,10 +45,15 @@ def _pip_fix(package="flask", current="2.0.0", fixed="3.0.0"):
 def test_apply_npm_fixes(tmp_path):
     """Modifies package.json with fixed versions."""
     pkg_json = tmp_path / "package.json"
-    pkg_json.write_text(json.dumps({
-        "name": "test-app",
-        "dependencies": {"express": "^4.17.1", "lodash": "^4.17.21"},
-    }, indent=2))
+    pkg_json.write_text(
+        json.dumps(
+            {
+                "name": "test-app",
+                "dependencies": {"express": "^4.17.1", "lodash": "^4.17.21"},
+            },
+            indent=2,
+        )
+    )
 
     plan = RemediationPlan(package_fixes=[_npm_fix()])
     result = apply_fixes(plan, [tmp_path])
@@ -67,9 +72,12 @@ def test_apply_npm_fixes(tmp_path):
 def test_apply_npm_dry_run(tmp_path):
     """Preview without modifying files."""
     pkg_json = tmp_path / "package.json"
-    original = json.dumps({
-        "dependencies": {"express": "^4.17.1"},
-    }, indent=2)
+    original = json.dumps(
+        {
+            "dependencies": {"express": "^4.17.1"},
+        },
+        indent=2,
+    )
     pkg_json.write_text(original)
 
     plan = RemediationPlan(package_fixes=[_npm_fix()])
@@ -84,9 +92,12 @@ def test_apply_npm_dry_run(tmp_path):
 def test_apply_npm_backup(tmp_path):
     """Creates .agent-bom-backup file before modifying."""
     pkg_json = tmp_path / "package.json"
-    original = json.dumps({
-        "dependencies": {"express": "^4.17.1"},
-    }, indent=2)
+    original = json.dumps(
+        {
+            "dependencies": {"express": "^4.17.1"},
+        },
+        indent=2,
+    )
     pkg_json.write_text(original)
 
     plan = RemediationPlan(package_fixes=[_npm_fix()])
@@ -103,9 +114,14 @@ def test_apply_npm_backup(tmp_path):
 def test_apply_npm_no_backup(tmp_path):
     """Skips backup when backup=False."""
     pkg_json = tmp_path / "package.json"
-    pkg_json.write_text(json.dumps({
-        "dependencies": {"express": "^4.17.1"},
-    }, indent=2))
+    pkg_json.write_text(
+        json.dumps(
+            {
+                "dependencies": {"express": "^4.17.1"},
+            },
+            indent=2,
+        )
+    )
 
     plan = RemediationPlan(package_fixes=[_npm_fix()])
     result = apply_fixes(plan, [tmp_path], backup=False)
@@ -117,10 +133,15 @@ def test_apply_npm_no_backup(tmp_path):
 def test_apply_npm_dev_dependencies(tmp_path):
     """Updates packages in devDependencies too."""
     pkg_json = tmp_path / "package.json"
-    pkg_json.write_text(json.dumps({
-        "dependencies": {},
-        "devDependencies": {"express": "^4.17.1"},
-    }, indent=2))
+    pkg_json.write_text(
+        json.dumps(
+            {
+                "dependencies": {},
+                "devDependencies": {"express": "^4.17.1"},
+            },
+            indent=2,
+        )
+    )
 
     plan = RemediationPlan(package_fixes=[_npm_fix()])
     result = apply_fixes(plan, [tmp_path])
@@ -155,7 +176,7 @@ def test_apply_pip_preserves_comments(tmp_path):
     req_txt.write_text("# Production deps\nflask==2.0.0\n\n# Dev deps\npytest==7.0.0\n")
 
     plan = RemediationPlan(package_fixes=[_pip_fix()])
-    result = apply_fixes(plan, [tmp_path])
+    apply_fixes(plan, [tmp_path])
 
     lines = req_txt.read_text().splitlines()
     assert lines[0] == "# Production deps"
@@ -210,25 +231,34 @@ def test_apply_from_json(tmp_path):
     """Standalone apply command reads scan JSON and modifies files."""
     # Create scan output JSON
     scan_json = tmp_path / "scan.json"
-    scan_json.write_text(json.dumps({
-        "remediation_plan": [
+    scan_json.write_text(
+        json.dumps(
             {
-                "package": "express",
-                "ecosystem": "npm",
-                "current_version": "4.17.1",
-                "fixed_version": "4.21.0",
-                "vulnerabilities": ["CVE-2024-0001"],
-                "affected_agents": ["claude-desktop"],
+                "remediation_plan": [
+                    {
+                        "package": "express",
+                        "ecosystem": "npm",
+                        "current_version": "4.17.1",
+                        "fixed_version": "4.21.0",
+                        "vulnerabilities": ["CVE-2024-0001"],
+                        "affected_agents": ["claude-desktop"],
+                    }
+                ],
             }
-        ],
-    }))
+        )
+    )
 
     # Create package.json
     project = tmp_path / "project"
     project.mkdir()
-    (project / "package.json").write_text(json.dumps({
-        "dependencies": {"express": "^4.17.1"},
-    }, indent=2))
+    (project / "package.json").write_text(
+        json.dumps(
+            {
+                "dependencies": {"express": "^4.17.1"},
+            },
+            indent=2,
+        )
+    )
 
     result = apply_fixes_from_json(str(scan_json), str(project))
 
@@ -257,21 +287,25 @@ def test_registry_enrich_fills_missing(tmp_path, monkeypatch):
 
     # Create a minimal registry with incomplete entries
     test_registry = tmp_path / "test_registry.json"
-    test_registry.write_text(json.dumps({
-        "servers": {
-            "mcp-github-server": {
-                "package": "mcp-github-server",
-                "ecosystem": "npm",
-                "latest_version": "1.0.0",
-                "description": "",
-                "name": "GitHub Server",
-                "risk_justification": "",
-                "category": "developer-tools",
-                "verified": False,
-                "tools": ["create_issue"],
-            },
-        },
-    }))
+    test_registry.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "mcp-github-server": {
+                        "package": "mcp-github-server",
+                        "ecosystem": "npm",
+                        "latest_version": "1.0.0",
+                        "description": "",
+                        "name": "GitHub Server",
+                        "risk_justification": "",
+                        "category": "developer-tools",
+                        "verified": False,
+                        "tools": ["create_issue"],
+                    },
+                },
+            }
+        )
+    )
 
     # Monkeypatch the registry path
     monkeypatch.setattr(reg_mod, "_REGISTRY_PATH", test_registry)
@@ -293,23 +327,27 @@ def test_registry_enrich_infers_risk_level(tmp_path, monkeypatch):
     from agent_bom import registry as reg_mod
 
     test_registry = tmp_path / "test_registry.json"
-    test_registry.write_text(json.dumps({
-        "servers": {
-            "mcp-fs-server": {
-                "package": "mcp-fs-server",
-                "ecosystem": "npm",
-                "latest_version": "1.0.0",
-                "description": "Filesystem access",
-                "name": "FS Server",
-                "risk_justification": "Full filesystem access",
-                "category": "filesystem",
-                "verified": False,
-                "tools": ["read_file"],
-                "credential_env_vars": [],
-                # risk_level intentionally missing — should be inferred as "high"
-            },
-        },
-    }))
+    test_registry.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "mcp-fs-server": {
+                        "package": "mcp-fs-server",
+                        "ecosystem": "npm",
+                        "latest_version": "1.0.0",
+                        "description": "Filesystem access",
+                        "name": "FS Server",
+                        "risk_justification": "Full filesystem access",
+                        "category": "filesystem",
+                        "verified": False,
+                        "tools": ["read_file"],
+                        "credential_env_vars": [],
+                        # risk_level intentionally missing — should be inferred as "high"
+                    },
+                },
+            }
+        )
+    )
 
     monkeypatch.setattr(reg_mod, "_REGISTRY_PATH", test_registry)
 
@@ -325,19 +363,23 @@ def test_registry_enrich_infers_credentials(tmp_path, monkeypatch):
     from agent_bom import registry as reg_mod
 
     test_registry = tmp_path / "test_registry.json"
-    test_registry.write_text(json.dumps({
-        "servers": {
-            "mcp-slack-bot": {
-                "package": "mcp-slack-bot",
-                "ecosystem": "npm",
-                "latest_version": "1.0.0",
-                "description": "Slack bot",
-                "name": "Slack Bot",
-                "risk_justification": "",
-                "category": "communication",
-            },
-        },
-    }))
+    test_registry.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "mcp-slack-bot": {
+                        "package": "mcp-slack-bot",
+                        "ecosystem": "npm",
+                        "latest_version": "1.0.0",
+                        "description": "Slack bot",
+                        "name": "Slack Bot",
+                        "risk_justification": "",
+                        "category": "communication",
+                    },
+                },
+            }
+        )
+    )
 
     monkeypatch.setattr(reg_mod, "_REGISTRY_PATH", test_registry)
 
@@ -354,19 +396,21 @@ def test_registry_enrich_dry_run(tmp_path, monkeypatch):
     from agent_bom import registry as reg_mod
 
     test_registry = tmp_path / "test_registry.json"
-    original = json.dumps({
-        "servers": {
-            "mcp-test-server": {
-                "package": "mcp-test-server",
-                "ecosystem": "npm",
-                "latest_version": "1.0.0",
-                "description": "",
-                "name": "Test",
-                "risk_justification": "",
-                "category": "",
+    original = json.dumps(
+        {
+            "servers": {
+                "mcp-test-server": {
+                    "package": "mcp-test-server",
+                    "ecosystem": "npm",
+                    "latest_version": "1.0.0",
+                    "description": "",
+                    "name": "Test",
+                    "risk_justification": "",
+                    "category": "",
+                },
             },
-        },
-    })
+        }
+    )
     test_registry.write_text(original)
 
     monkeypatch.setattr(reg_mod, "_REGISTRY_PATH", test_registry)
@@ -383,23 +427,27 @@ def test_registry_enrich_all_complete(tmp_path, monkeypatch):
     from agent_bom import registry as reg_mod
 
     test_registry = tmp_path / "test_registry.json"
-    test_registry.write_text(json.dumps({
-        "servers": {
-            "mcp-complete-server": {
-                "package": "mcp-complete-server",
-                "ecosystem": "npm",
-                "latest_version": "1.0.0",
-                "description": "A complete server",
-                "name": "Complete",
-                "risk_justification": "Fully documented risk",
-                "category": "utilities",
-                "risk_level": "low",
-                "verified": True,
-                "tools": ["do_thing"],
-                "credential_env_vars": [],
-            },
-        },
-    }))
+    test_registry.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "mcp-complete-server": {
+                        "package": "mcp-complete-server",
+                        "ecosystem": "npm",
+                        "latest_version": "1.0.0",
+                        "description": "A complete server",
+                        "name": "Complete",
+                        "risk_justification": "Fully documented risk",
+                        "category": "utilities",
+                        "risk_level": "low",
+                        "verified": True,
+                        "tools": ["do_thing"],
+                        "credential_env_vars": [],
+                    },
+                },
+            }
+        )
+    )
 
     monkeypatch.setattr(reg_mod, "_REGISTRY_PATH", test_registry)
 

--- a/tests/test_audit_round2.py
+++ b/tests/test_audit_round2.py
@@ -129,7 +129,7 @@ def test_sqlite_job_store_has_indexes():
     from agent_bom.api.store import SQLiteJobStore
 
     with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
-        store = SQLiteJobStore(tmp.name)
+        SQLiteJobStore(tmp.name)
         conn = sqlite3.connect(tmp.name)
         indexes = [r[1] for r in conn.execute("PRAGMA index_list('jobs')").fetchall()]
         assert "idx_jobs_status" in indexes
@@ -145,7 +145,7 @@ def test_sqlite_schedule_store_has_index():
     from agent_bom.api.schedule_store import SQLiteScheduleStore
 
     with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
-        store = SQLiteScheduleStore(tmp.name)
+        SQLiteScheduleStore(tmp.name)
         conn = sqlite3.connect(tmp.name)
         indexes = [r[1] for r in conn.execute("PRAGMA index_list('schedules')").fetchall()]
         assert "idx_sched_due" in indexes
@@ -160,7 +160,7 @@ def test_sqlite_policy_store_has_timestamp_index():
     from agent_bom.api.policy_store import SQLitePolicyStore
 
     with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
-        store = SQLitePolicyStore(tmp.name)
+        SQLitePolicyStore(tmp.name)
         conn = sqlite3.connect(tmp.name)
         indexes = [r[1] for r in conn.execute("PRAGMA index_list('policy_audit_log')").fetchall()]
         assert "idx_pal_ts" in indexes

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -184,7 +184,7 @@ def test_health_endpoint_fields():
     from agent_bom import __version__
     from agent_bom.mcp_server import create_mcp_server
 
-    server = create_mcp_server()
+    create_mcp_server()
     # The routes are registered; verify the build_server_card still works
     from agent_bom.mcp_server import build_server_card
 

--- a/tests/test_expand_registry.py
+++ b/tests/test_expand_registry.py
@@ -87,7 +87,7 @@ class TestSyncAutoClassification:
         }
         mock_request.return_value = _make_response(api_response)
 
-        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+        sync_from_official_registry_sync(max_pages=1, page_size=10)
 
         written = json.loads(mock_path.write_text.call_args[0][0])
         entry = written["servers"]["test/dangerous-server"]
@@ -113,7 +113,7 @@ class TestSyncAutoClassification:
         }
         mock_request.return_value = _make_response(api_response)
 
-        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+        sync_from_official_registry_sync(max_pages=1, page_size=10)
 
         written = json.loads(mock_path.write_text.call_args[0][0])
         assert written["servers"]["github-actions"]["category"] == "developer-tools"
@@ -184,7 +184,7 @@ class TestSyncAutoClassification:
         }
         mock_request.return_value = _make_response(api_response)
 
-        result = sync_from_official_registry_sync(max_pages=1, page_size=10)
+        sync_from_official_registry_sync(max_pages=1, page_size=10)
 
         written = json.loads(mock_path.write_text.call_args[0][0])
         assert written["servers"]["test/reader"]["risk_level"] == "low"

--- a/tests/test_false_positives.py
+++ b/tests/test_false_positives.py
@@ -40,7 +40,7 @@ class TestToolDeduplication:
             _server("srv2", tools=[MCPTool(name="read_file", description="different desc")]),
             _server("srv3", tools=[tool]),
         ]
-        br = BlastRadius(
+        BlastRadius(
             vulnerability=_vuln(),
             package=_pkg(),
             affected_servers=servers,

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -198,8 +198,6 @@ def test_scheduler_backoff_on_failure():
     run_fn = MagicMock()
     sleep_calls = []
 
-    original_sleep = asyncio.sleep
-
     async def mock_sleep(seconds):
         sleep_calls.append(seconds)
         if len(sleep_calls) >= 3:

--- a/tests/test_marketplace_check.py
+++ b/tests/test_marketplace_check.py
@@ -12,7 +12,6 @@ def mcp():
 
 def test_marketplace_tool_registered(mcp):
     """marketplace_check should be registered as a tool."""
-    tools = {name for name in dir(mcp) if not name.startswith("_")}
     # The tool is registered via @mcp.tool — verify import works
     from agent_bom.mcp_server import create_mcp_server as _
 


### PR DESCRIPTION
## Summary
- **Consolidate `_safe_path()`** → thin wrapper over `validate_path(restrict_to_home=True)` in `security.py`
- **Fix `import os as _os`** aliasing in `api/server.py` (7 imports + 17 usage sites)
- **Centralize connector timeouts** → `CONNECTOR_HEALTH_TIMEOUT` constant in `connectors/base.py`
- **Re-enable ruff F841** (unused variables) and fix all 20 violations across 9 source + 11 test files

## Test plan
- [x] All 2,940+ tests pass
- [x] `ruff check src/ tests/` clean
- [x] `ruff format` clean
- [x] Verify `_safe_path()` still raises `ValueError` (API contract preserved)
- [x] Verify connector health probes use shared constant