### PR TITLE
fix: tighten pyproject.toml description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.52.0"
-description = "AI supply chain security scanner — CVEs, blast radius, credential exposure, 10-framework compliance (OWASP LLM/MCP/Agentic + MITRE ATLAS + NIST AI RMF + EU AI Act + NIST CSF + ISO 27001 + SOC 2 + CIS). 20 MCP clients, 17 tools, GPU/container/K8s scanning."
+description = "Open-source security scanner for AI agents, MCP servers, and GPU infrastructure. CVEs, blast radius, credential exposure, 10-framework compliance. 20 MCP clients, 17 tools."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Shorten PyPI description from framework-heavy soup to value-first one-liner
- Before: "AI supply chain security scanner — CVEs, blast radius, credential exposure, 10-framework compliance (OWASP LLM/MCP/Agentic + MITRE ATLAS + NIST AI RMF + EU AI Act + NIST CSF + ISO 27001 + SOC 2 + CIS). 20 MCP clients, 17 tools, GPU/container/K8s scanning."
- After: "Open-source security scanner for AI agents, MCP servers, and GPU infrastructure. CVEs, blast radius, credential exposure, 10-framework compliance. 20 MCP clients, 17 tools."

## Test plan
- [x] No code changes — metadata only
- [x] Description still contains key search terms (CVEs, blast radius, compliance, MCP, tools)