### PR TITLE
fix: audit accuracy — honest positioning, stale counts, missing traces page

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -712,17 +712,15 @@ def scan_with_audit(user, target):
 
 | Feature | agent-bom | Syft | Grype | Snyk | Wiz |
 |---------|-----------|------|-------|------|-----|
-| AI agent scanning | ✅ | ❌ | ❌ | ❌ | ❌ |
+| AI agent config discovery | ✅ (20 MCP clients) | ❌ | ❌ | ❌ | ❌ |
 | MCP server support | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Transitive deps | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Blast radius (AI-specific) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | EPSS/KEV enrichment | ✅ | ❌ | ❌ | ✅ | ✅ |
-| Container scanning | 🔜 | ✅ | ✅ | ✅ | ✅ |
-| Cloud API scanning | 🔜 | ❌ | ❌ | ✅ | ✅ |
+| Container scanning | ✅ (via Grype/Syft) | ✅ | ✅ | ✅ | ✅ |
+| Cloud API scanning | ✅ (AWS, Azure, GCP, Snowflake, Databricks) | ❌ | ❌ | ✅ | ✅ |
 | Open source | ✅ | ✅ | ✅ | ❌ | ❌ |
 | CycloneDX output | ✅ | ✅ | ❌ | ✅ | ✅ |
-
-**agent-bom is the only tool purpose-built for AI infrastructure security.**
 
 ---
 
@@ -736,8 +734,4 @@ agent-bom scales from local CLI to enterprise infrastructure by:
 4. **Remote Scanning**: SSH, agents, cloud APIs
 5. **Performance**: Caching, batching, parallelization
 
-**Similar to Syft/Grype**, agent-bom can be deployed anywhere—but specialized for **AI agents and MCP servers**, not generic software.
-
-**Ready to implement**: Dockerfile → CI/CD → Snowflake API → Remote scanning
-
-Would you like to start with containerization and CI/CD integration?
+agent-bom can be deployed anywhere — CLI, Docker, CI/CD, Kubernetes, Snowflake, or as an MCP server — specialized for AI agent infrastructure security.

--- a/Dockerfile.snowpark
+++ b/Dockerfile.snowpark
@@ -1,8 +1,11 @@
 FROM python:3.11-slim@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
+ARG VERSION=0.53.0
+
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"
 LABEL org.opencontainers.image.source="https://github.com/msaad00/agent-bom"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center">
-  <b>The open-source security scanner for AI agents, MCP servers, and GPU infrastructure.<br>See what Wiz, Snyk, and Grype miss.</b>
+  <b>Open-source security scanner for AI agent infrastructure.<br>Discover configurations, scan dependencies, map blast radius, enforce compliance.</b>
 </p>
 
 ---
@@ -82,7 +82,7 @@ Auto-discovers Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Cop
 | Blast radius to agents | — | — | CVE → agent → creds → tools |
 | MCP tool reachability | — | — | Yes |
 | Credential exposure | — | Partial | Full per-agent mapping |
-| Policy-as-code | — | Yes (Snyk) | Yes (18 conditions) |
+| Policy-as-code | — | Yes (Snyk) | Yes (16 conditions) |
 | 10-framework compliance | — | Partial | Full (OWASP + ATLAS + NIST + EU AI Act + ...) |
 | Open source | Yes | No | Yes (Apache 2.0) |
 
@@ -138,7 +138,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 | Use case | Deploy | Command |
 |----------|--------|---------|
 | Quick local scan | CLI | `agent-bom scan` |
-| CI/CD gate | GitHub Action | `uses: msaad00/agent-bom@v0.52.0` |
+| CI/CD gate | GitHub Action | `uses: msaad00/agent-bom@v0.53.0` |
 | Security dashboard | API + UI | `agent-bom serve` |
 | MCP tool integration | MCP server | `agent-bom mcp-server` (17 tools) |
 | K8s fleet scanning | Helm | `helm install deploy/helm/agent-bom` |
@@ -651,7 +651,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for full Snowflake architecture and setup ins
 
 ## MCP Server Registry (427+ servers)
 
-Curated registry of 427+ known MCP servers with risk levels, tool inventories, credential env vars, categories, and version pins. Auto-synced weekly from the [Official MCP Registry](https://registry.modelcontextprotocol.io). Unverified servers trigger warnings. Policy rules can block them in CI.
+Registry of 427+ known MCP servers with risk levels, tool inventories, credential env vars, categories, and version pins. Risk levels are derived from server category (filesystem/shell = high, database/cloud = medium, search/monitoring = low). Credential env vars are inferred from package-name heuristics (21 patterns). Auto-synced weekly from the [Official MCP Registry](https://registry.modelcontextprotocol.io). 375 servers manually verified; 52 auto-enriched. Unverified servers trigger warnings. Policy rules can block them in CI.
 
 Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python scripts/expand_registry.py`
 

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: agent-bom
 description: >-
-  AI supply chain security scanner — check packages for CVEs, look up MCP servers
-  in the 427+ server threat registry, assess blast radius, generate SBOMs, enforce
+  AI agent infrastructure security scanner — check packages for CVEs, look up MCP servers
+  in the 427+ server security metadata registry, assess blast radius, generate SBOMs, enforce
   compliance (OWASP, MITRE ATLAS, EU AI Act, NIST AI RMF). Use when the user
   mentions vulnerability scanning, dependency security, SBOM generation, MCP server
   trust, or AI supply chain risk.
@@ -18,7 +18,7 @@ metadata:
   pypi: https://pypi.org/project/agent-bom/
   smithery: https://smithery.ai/server/agent-bom/agent-bom
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 2900
+  tests: 2948
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -131,7 +131,7 @@ docker run -p 8080:8080 agent-bom-sse
 | `scan` | Full discovery + vulnerability scan pipeline |
 | `check` | Check a package for CVEs (OSV, NVD, EPSS, KEV) |
 | `blast_radius` | Map CVE impact chain across agents, servers, credentials |
-| `registry_lookup` | Look up MCP server in 427+ server threat registry |
+| `registry_lookup` | Look up MCP server in 427+ server security metadata registry |
 | `compliance` | OWASP LLM/Agentic Top 10, EU AI Act, MITRE ATLAS, NIST AI RMF |
 | `remediate` | Prioritized remediation plan for vulnerabilities |
 | `verify` | Package integrity + SLSA provenance check |
@@ -150,7 +150,7 @@ docker run -p 8080:8080 agent-bom-sse
 
 | Resource | Description |
 |----------|-------------|
-| `registry://servers` | Browse 427+ MCP server threat intelligence registry |
+| `registry://servers` | Browse 427+ MCP server security metadata registry |
 | `policy://template` | Default security policy template |
 
 ## Example Workflows
@@ -215,6 +215,6 @@ installation or self-host your own instance.
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: [smithery.ai/server/agent-bom](https://smithery.ai/server/agent-bom/agent-bom)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.53.0`
-- **2,950+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
+- **2,948 tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.53.0"
-description = "Open-source security scanner for AI agents, MCP servers, and GPU infrastructure. CVEs, blast radius, credential exposure, 10-framework compliance. 20 MCP clients, 17 tools."
+description = "Security scanner for AI agent infrastructure. Discover MCP configurations across 20 clients, scan dependencies for CVEs, map blast radius to credentials and tools, enforce 10-framework compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"

--- a/src/agent_bom/mcp_registry.json
+++ b/src/agent_bom/mcp_registry.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "agent-bom MCP Server Registry \u2014 threat intelligence database for known MCP servers",
+  "_comment": "agent-bom MCP Server Registry \u2014 security metadata database for known MCP servers",
   "_schema_version": "2.0",
   "_updated": "2026-02-24",
   "_total_servers": 427,
-  "_differentiator": "Threat intelligence database \u2014 not just a catalog. Each entry has risk_level, tools, credential_env_vars for blast radius pre-computation.",
+  "_differentiator": "Security metadata database \u2014 not just a catalog. Each entry has risk_level (category-derived), tools, credential_env_vars (heuristic-inferred) for blast radius pre-computation.",
   "_source": "https://github.com/msaad00/agent-bom/blob/main/data/mcp-registry.yaml",
   "servers": {
     "@modelcontextprotocol/server-filesystem": {

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -4,7 +4,7 @@ Start with:
     agent-bom mcp-server              # stdio (for Claude Desktop, Cursor, etc.)
     agent-bom mcp-server --sse        # SSE transport (for remote clients)
 
-Tools (16):
+Tools (17):
     scan              — Full discovery → scan → output pipeline
     check             — Check a specific package for CVEs before installing
     blast_radius      — Look up blast radius for a specific CVE
@@ -21,9 +21,10 @@ Tools (16):
     marketplace_check — Pre-install trust check with registry cross-reference
     code_scan         — SAST scanning via Semgrep with CWE-based compliance mapping
     context_graph     — Agent context graph with lateral movement analysis
+    analytics_query   — Query vulnerability trends and runtime events from ClickHouse
 
 Resources (2):
-    registry://servers  — Browse 427+ server threat intel registry
+    registry://servers  — Browse 427+ server security metadata registry
     policy://template   — Default security policy template
 
 Security: Read-only. Never executes MCP servers or reads credential values.
@@ -1460,10 +1461,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     @mcp.resource("registry://servers")
     def registry_servers_resource() -> str:
-        """Browse the MCP server threat intelligence registry (427+ servers).
+        """Browse the MCP server security metadata registry (427+ servers).
 
-        Returns the full registry with risk levels, tools, credential
-        requirements, and verification status for every known MCP server.
+        Returns the full registry with risk levels (category-derived), tools,
+        credential env vars (heuristic-inferred), and verification status
+        for every known MCP server.
         """
         try:
             return _get_registry_data_raw()

--- a/src/agent_bom/toxic_combos.py
+++ b/src/agent_bom/toxic_combos.py
@@ -1,4 +1,4 @@
-"""Toxic combination detection — Wiz-style chained risk analysis.
+"""Toxic combination detection — chained risk analysis.
 
 Identifies dangerous combinations of vulnerabilities, credentials, tools,
 and blast radius that individually might be acceptable but together form

--- a/tests/test_toxic_combos.py
+++ b/tests/test_toxic_combos.py
@@ -1,4 +1,4 @@
-"""Tests for toxic combination detection — Wiz-style chained risk analysis."""
+"""Tests for toxic combination detection — chained risk analysis."""
 
 from __future__ import annotations
 

--- a/ui/app/traces/page.tsx
+++ b/ui/app/traces/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { Activity, AlertTriangle, CheckCircle2, Loader2, Send } from "lucide-react";
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+interface FlaggedCall {
+  tool_name: string;
+  server: string;
+  package_name?: string;
+  cve_ids: string[];
+  severity: string;
+}
+
+interface TraceResult {
+  traces: number;
+  flagged: FlaggedCall[];
+  message?: string;
+}
+
+export default function TracesPage() {
+  const [payload, setPayload] = useState(
+    JSON.stringify(
+      {
+        resourceSpans: [
+          {
+            scopeSpans: [
+              {
+                spans: [
+                  {
+                    name: "adk.tool.call",
+                    attributes: [
+                      { key: "tool.name", value: { stringValue: "query_db" } },
+                      { key: "mcp.server", value: { stringValue: "sqlite-mcp" } },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  const [result, setResult] = useState<TraceResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch(`${BASE}/v1/traces`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      setResult(await res.json());
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Traces</h1>
+        <p className="text-zinc-400 text-sm mt-1">
+          OpenTelemetry trace ingestion — flag vulnerable tool calls in real time
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Input */}
+        <div className="space-y-3">
+          <label className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
+            OTLP JSON Payload
+          </label>
+          <textarea
+            value={payload}
+            onChange={(e) => setPayload(e.target.value)}
+            rows={18}
+            className="w-full bg-zinc-950 border border-zinc-800 rounded-xl px-4 py-3 font-mono text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-emerald-500 resize-none"
+            spellCheck={false}
+          />
+          <button
+            onClick={submit}
+            disabled={loading}
+            className="flex items-center gap-1.5 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            {loading ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Send className="w-3.5 h-3.5" />
+            )}
+            Ingest Traces
+          </button>
+        </div>
+
+        {/* Result */}
+        <div className="space-y-3">
+          <label className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
+            Response
+          </label>
+
+          {!result && !error && (
+            <div className="border border-dashed border-zinc-800 rounded-xl py-16 text-center">
+              <Activity className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
+              <p className="text-zinc-500 text-sm">
+                Submit OTLP traces to flag vulnerable tool calls.
+              </p>
+              <p className="text-zinc-600 text-xs mt-1">
+                POST /v1/traces with spans containing adk.tool.* attributes.
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div className="border border-red-900/50 bg-red-950/30 rounded-xl px-4 py-3">
+              <div className="flex items-center gap-2 text-red-400 text-sm">
+                <AlertTriangle className="w-4 h-4" />
+                {error}
+              </div>
+            </div>
+          )}
+
+          {result && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="border border-zinc-800 rounded-xl px-4 py-3">
+                  <div className="text-xs text-zinc-500">Traces parsed</div>
+                  <div className="text-xl font-semibold text-zinc-100 mt-1">
+                    {result.traces}
+                  </div>
+                </div>
+                <div className="border border-zinc-800 rounded-xl px-4 py-3">
+                  <div className="text-xs text-zinc-500">Flagged calls</div>
+                  <div className={`text-xl font-semibold mt-1 ${result.flagged.length > 0 ? "text-red-400" : "text-emerald-400"}`}>
+                    {result.flagged.length}
+                  </div>
+                </div>
+              </div>
+
+              {result.flagged.length > 0 && (
+                <div className="border border-zinc-800 rounded-xl overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead className="bg-zinc-900 border-b border-zinc-800">
+                      <tr>
+                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">Tool</th>
+                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">Server</th>
+                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">CVEs</th>
+                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">Severity</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+                      {result.flagged.map((f, i) => (
+                        <tr key={i} className="hover:bg-zinc-900 transition-colors">
+                          <td className="px-4 py-2.5 font-mono text-xs text-zinc-300">{f.tool_name}</td>
+                          <td className="px-4 py-2.5 text-xs text-zinc-400">{f.server}</td>
+                          <td className="px-4 py-2.5 text-xs text-zinc-400">{f.cve_ids?.join(", ") || "-"}</td>
+                          <td className="px-4 py-2.5">
+                            <span className={`text-xs font-medium ${
+                              f.severity === "critical" ? "text-red-400" :
+                              f.severity === "high" ? "text-orange-400" :
+                              f.severity === "medium" ? "text-yellow-400" :
+                              "text-zinc-400"
+                            }`}>
+                              {f.severity}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {result.flagged.length === 0 && (
+                <div className="border border-emerald-900/30 bg-emerald-950/20 rounded-xl px-4 py-3">
+                  <div className="flex items-center gap-2 text-emerald-400 text-sm">
+                    <CheckCircle2 className="w-4 h-4" />
+                    No vulnerable tool calls detected in traces.
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -18,6 +18,7 @@ import {
   Waypoints,
   Eye,
   Clock,
+  Radio,
   Menu,
   X,
 } from "lucide-react";
@@ -55,6 +56,7 @@ const NAV_GROUPS = [
       { href: "/gateway",    label: "Gateway",     icon: Lock },
       { href: "/compliance", label: "Compliance",  icon: Shield },
       { href: "/governance", label: "Governance",  icon: Eye },
+      { href: "/traces",     label: "Traces",      icon: Radio },
       { href: "/activity",   label: "Activity",    icon: Clock },
     ],
   },


### PR DESCRIPTION
## Summary

Full codebase audit surfaced stale counts, misleading language, and a missing UI page. This PR fixes all of them.

- **Tagline rewrite** — drop competitor names from headline, lead with what we actually do: "Discover configurations, scan dependencies, map blast radius, enforce compliance"
- **pyproject.toml description** — value-led, no framework lists
- **mcp_server.py docstring** — 16→17 tools, add missing `analytics_query`
- **README** — fix stale `@v0.52.0` → `@v0.53.0`, policy conditions 18→16 (matches code)
- **SKILL.md** — test count 2900→2948
- **Dockerfile.snowpark** — add `ARG VERSION` for version bump consistency
- **DEPLOYMENT.md** — update stale comparison table (container + cloud scanning now shipped), remove chatbot-style ending
- **Traces page** — create `ui/app/traces/page.tsx` + add to nav (fills the 15th dashboard section that was documented but missing)
- **Registry language** — "threat intelligence" → "security metadata" (honest about heuristic-based risk levels and credential inference)
- **Competitor refs** — remove gratuitous "Wiz-style" from `toxic_combos.py`; keep factual comparison tables

## Test plan

- [x] 2,941 tests pass, 13 skipped, 0 failures
- [x] ruff + ruff-format pass (pre-commit hooks)
- [x] Meta tests (server card / tool count validation) pass
- [ ] Verify traces page renders in dashboard
- [ ] Verify nav shows 15 items