### PR TITLE
feat: CIS AWS Foundations Benchmark v3.0 — 7 IAM checks

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -446,6 +446,7 @@ def main():
 @click.option("--aws-include-step-functions", is_flag=True, help="Discover Step Functions workflows (used with --aws)")
 @click.option("--aws-include-ec2", is_flag=True, help="Discover EC2 instances by tag (used with --aws)")
 @click.option("--aws-ec2-tag", default=None, metavar="KEY=VALUE", help="EC2 tag filter for --aws-include-ec2 (e.g. 'Environment=ai-prod')")
+@click.option("--aws-cis-benchmark", is_flag=True, help="Run CIS AWS Foundations Benchmark v3.0 checks (used with --aws)")
 @click.option("--huggingface", "hf_flag", is_flag=True, help="Discover models, Spaces, and endpoints from Hugging Face Hub")
 @click.option("--hf-token", default=None, envvar="HF_TOKEN", metavar="TOKEN", help="Hugging Face API token")
 @click.option("--hf-username", default=None, metavar="USER", help="Hugging Face username to scope discovery")
@@ -609,6 +610,7 @@ def scan(
     aws_include_step_functions: bool,
     aws_include_ec2: bool,
     aws_ec2_tag: Optional[str],
+    aws_cis_benchmark: bool,
     hf_flag: bool,
     hf_token: Optional[str],
     hf_username: Optional[str],
@@ -1394,6 +1396,45 @@ def scan(
         except CloudDiscoveryError as exc:
             con.print(f"\n  [red]{provider_name.upper()} discovery error: {exc}[/red]")
 
+    # Step 1x: CIS AWS Foundations Benchmark
+    cis_benchmark_report = None
+    if aws_cis_benchmark:
+        from agent_bom.cloud import CloudDiscoveryError
+
+        con.print("\n[bold blue]Running CIS AWS Foundations Benchmark v3.0...[/bold blue]\n")
+        try:
+            from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_cis
+
+            cis_benchmark_report = run_cis(region=aws_region, profile=aws_profile)
+            passed = cis_benchmark_report.passed
+            failed = cis_benchmark_report.failed
+            total = cis_benchmark_report.total
+            rate = cis_benchmark_report.pass_rate
+            con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            if failed > 0:
+                from rich.table import Table
+
+                tbl = Table(title="CIS AWS Foundations Benchmark v3.0", show_lines=False, padding=(0, 1))
+                tbl.add_column("Check", style="cyan", width=6)
+                tbl.add_column("Title", min_width=30)
+                tbl.add_column("Status", width=6)
+                tbl.add_column("Severity", width=8)
+                tbl.add_column("Evidence", max_width=50)
+                _status_style = {"pass": "[green]PASS[/]", "fail": "[red]FAIL[/]", "error": "[yellow]ERR[/]"}
+                _sev_style = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
+                for c in cis_benchmark_report.checks:
+                    tbl.add_row(
+                        c.check_id,
+                        c.title,
+                        _status_style.get(c.status.value, c.status.value),
+                        _sev_style.get(c.severity, c.severity),
+                        c.evidence,
+                    )
+                con.print()
+                con.print(tbl)
+        except CloudDiscoveryError as exc:
+            con.print(f"  [red]CIS Benchmark error: {exc}[/red]")
+
     # Step 1y: SaaS connector discovery
     saas_connectors: list[tuple[str, dict]] = []
     if not skill_only and jira_discover:
@@ -1764,6 +1805,8 @@ def scan(
         report.enforcement_data = _enforcement_data
     if _sast_data:
         report.sast_data = _sast_data
+    if cis_benchmark_report is not None:
+        report.cis_benchmark_data = cis_benchmark_report.to_dict()
 
     # ── Context graph: lateral movement analysis ────────────────────
     if context_graph_flag and report.blast_radii:

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -1,0 +1,453 @@
+"""CIS AWS Foundations Benchmark v3.0 — live account checks.
+
+Runs read-only AWS API checks against the IAM section of the CIS AWS
+Foundations Benchmark v3.0.  Each check returns pass/fail with evidence.
+
+Required IAM permissions (all read-only, covered by SecurityAudit policy):
+    iam:GetAccountSummary
+    iam:GetAccountPasswordPolicy
+    iam:ListUsers
+    iam:ListMFADevices
+    iam:ListVirtualMFADevices
+    iam:ListUserPolicies
+    iam:ListAttachedUserPolicies
+    iam:GenerateCredentialReport
+    iam:GetCredentialReport
+
+Install: ``pip install 'agent-bom[aws]'``
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable
+
+from .base import CloudDiscoveryError
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class CheckStatus(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    ERROR = "error"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass
+class CISCheckResult:
+    """Result of a single CIS AWS Foundations Benchmark check."""
+
+    check_id: str
+    title: str
+    status: CheckStatus
+    severity: str
+    evidence: str = ""
+    resource_ids: list[str] = field(default_factory=list)
+    recommendation: str = ""
+    cis_section: str = ""
+
+
+@dataclass
+class CISBenchmarkReport:
+    """Aggregated CIS AWS Foundations Benchmark results."""
+
+    benchmark_version: str = "3.0"
+    checks: list[CISCheckResult] = field(default_factory=list)
+    region: str = ""
+    account_id: str = ""
+
+    @property
+    def passed(self) -> int:
+        return sum(1 for c in self.checks if c.status == CheckStatus.PASS)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for c in self.checks if c.status == CheckStatus.FAIL)
+
+    @property
+    def total(self) -> int:
+        return len(self.checks)
+
+    @property
+    def pass_rate(self) -> float:
+        evaluated = sum(1 for c in self.checks if c.status in (CheckStatus.PASS, CheckStatus.FAIL))
+        return (self.passed / evaluated * 100) if evaluated else 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "benchmark": "CIS AWS Foundations",
+            "benchmark_version": self.benchmark_version,
+            "account_id": self.account_id,
+            "region": self.region,
+            "pass_rate": round(self.pass_rate, 1),
+            "passed": self.passed,
+            "failed": self.failed,
+            "total": self.total,
+            "checks": [
+                {
+                    "check_id": c.check_id,
+                    "title": c.title,
+                    "status": c.status.value,
+                    "severity": c.severity,
+                    "evidence": c.evidence,
+                    "resource_ids": c.resource_ids,
+                    "recommendation": c.recommendation,
+                    "cis_section": c.cis_section,
+                }
+                for c in self.checks
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Individual checks — CIS 1.x (Identity and Access Management)
+# ---------------------------------------------------------------------------
+
+_IAM_SECTION = "1 - Identity and Access Management"
+
+
+def _check_1_4(iam_client: Any) -> CISCheckResult:
+    """CIS 1.4 — Ensure no 'root' user account access key exists."""
+    result = CISCheckResult(
+        check_id="1.4",
+        title="Ensure no root user account access key exists",
+        status=CheckStatus.PASS,
+        severity="critical",
+        cis_section=_IAM_SECTION,
+        recommendation="Delete root access keys via IAM console > Security credentials.",
+    )
+    summary = iam_client.get_account_summary()["SummaryMap"]
+    root_keys = summary.get("AccountAccessKeysPresent", 0)
+    if root_keys > 0:
+        result.status = CheckStatus.FAIL
+        result.evidence = f"Root account has {root_keys} active access key(s)."
+        result.resource_ids = ["arn:aws:iam::root"]
+    else:
+        result.evidence = "No root access keys found."
+    return result
+
+
+def _check_1_5(iam_client: Any) -> CISCheckResult:
+    """CIS 1.5 — Ensure MFA is enabled for the root user account."""
+    result = CISCheckResult(
+        check_id="1.5",
+        title="Ensure MFA is enabled for the root user account",
+        status=CheckStatus.PASS,
+        severity="critical",
+        cis_section=_IAM_SECTION,
+        recommendation="Enable MFA for root via IAM console > Security credentials > MFA.",
+    )
+    summary = iam_client.get_account_summary()["SummaryMap"]
+    mfa_enabled = summary.get("AccountMFAEnabled", 0)
+    if mfa_enabled == 0:
+        result.status = CheckStatus.FAIL
+        result.evidence = "Root account does not have MFA enabled."
+        result.resource_ids = ["arn:aws:iam::root"]
+    else:
+        result.evidence = "Root account MFA is enabled."
+    return result
+
+
+def _check_1_6(iam_client: Any) -> CISCheckResult:
+    """CIS 1.6 — Ensure hardware MFA is enabled for the root user account."""
+    result = CISCheckResult(
+        check_id="1.6",
+        title="Ensure hardware MFA is enabled for the root user account",
+        status=CheckStatus.PASS,
+        severity="critical",
+        cis_section=_IAM_SECTION,
+        recommendation="Replace virtual MFA with a hardware MFA device for root.",
+    )
+    summary = iam_client.get_account_summary()["SummaryMap"]
+    if summary.get("AccountMFAEnabled", 0) == 0:
+        result.status = CheckStatus.FAIL
+        result.evidence = "Root account has no MFA at all (hardware or virtual)."
+        result.resource_ids = ["arn:aws:iam::root"]
+        return result
+
+    virtual_devices = iam_client.list_virtual_mfa_devices()["VirtualMFADevices"]
+    root_virtual = [d for d in virtual_devices if d.get("SerialNumber", "").endswith(":mfa/root-account-mfa-device")]
+    if root_virtual:
+        result.status = CheckStatus.FAIL
+        result.evidence = "Root uses virtual MFA, not hardware MFA."
+        result.resource_ids = [root_virtual[0]["SerialNumber"]]
+    else:
+        result.evidence = "Root account uses hardware MFA."
+    return result
+
+
+def _check_1_8(iam_client: Any) -> CISCheckResult:
+    """CIS 1.8 — Ensure IAM password policy requires minimum length >= 14."""
+    result = CISCheckResult(
+        check_id="1.8",
+        title="Ensure IAM password policy requires minimum length >= 14",
+        status=CheckStatus.PASS,
+        severity="medium",
+        cis_section=_IAM_SECTION,
+        recommendation="Set minimum password length to 14 via IAM > Account settings.",
+    )
+    try:
+        policy = iam_client.get_account_password_policy()["PasswordPolicy"]
+        min_len = policy.get("MinimumPasswordLength", 0)
+        if min_len < 14:
+            result.status = CheckStatus.FAIL
+            result.evidence = f"Minimum password length is {min_len} (required: 14)."
+        else:
+            result.evidence = f"Minimum password length is {min_len}."
+    except Exception as exc:
+        error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+        if error_code == "NoSuchEntity":
+            result.status = CheckStatus.FAIL
+            result.evidence = "No password policy is configured."
+        else:
+            raise
+    return result
+
+
+def _check_1_10(iam_client: Any) -> CISCheckResult:
+    """CIS 1.10 — Ensure MFA is enabled for all IAM users with console access."""
+    result = CISCheckResult(
+        check_id="1.10",
+        title="Ensure MFA is enabled for all IAM users with console access",
+        status=CheckStatus.PASS,
+        severity="high",
+        cis_section=_IAM_SECTION,
+        recommendation="Enable MFA for all console users via IAM > Users > Security credentials.",
+    )
+    paginator = iam_client.get_paginator("list_users")
+    users_without_mfa = []
+    for page in paginator.paginate():
+        for user in page["Users"]:
+            username = user["UserName"]
+            try:
+                login_profile = iam_client.get_login_profile(UserName=username)  # noqa: F841
+            except Exception as exc:
+                error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+                if error_code == "NoSuchEntity":
+                    continue  # no console access
+                raise
+            mfa_devices = iam_client.list_mfa_devices(UserName=username)["MFADevices"]
+            if not mfa_devices:
+                users_without_mfa.append(username)
+
+    if users_without_mfa:
+        result.status = CheckStatus.FAIL
+        result.evidence = f"{len(users_without_mfa)} console user(s) without MFA: {', '.join(users_without_mfa[:5])}"
+        if len(users_without_mfa) > 5:
+            result.evidence += f" (+{len(users_without_mfa) - 5} more)"
+        result.resource_ids = [f"arn:aws:iam::user/{u}" for u in users_without_mfa]
+    else:
+        result.evidence = "All console users have MFA enabled."
+    return result
+
+
+def _check_1_12(iam_client: Any) -> CISCheckResult:
+    """CIS 1.12 — Ensure credentials unused for 45 days or greater are disabled."""
+    result = CISCheckResult(
+        check_id="1.12",
+        title="Ensure credentials unused for 45 days or greater are disabled",
+        status=CheckStatus.PASS,
+        severity="medium",
+        cis_section=_IAM_SECTION,
+        recommendation="Disable or remove credentials unused for 45+ days.",
+    )
+    # Generate credential report (may need to wait for it)
+    for _ in range(10):
+        resp = iam_client.generate_credential_report()
+        if resp.get("State") == "COMPLETE":
+            break
+        time.sleep(1)
+
+    try:
+        report_resp = iam_client.get_credential_report()
+    except Exception as exc:
+        error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+        if error_code == "ReportNotPresent":
+            result.status = CheckStatus.ERROR
+            result.evidence = "Credential report not available."
+            return result
+        raise
+
+    content = report_resp["Content"]
+    if isinstance(content, bytes):
+        content = content.decode("utf-8")
+
+    reader = csv.DictReader(io.StringIO(content))
+    now = datetime.now(tz=timezone.utc)
+    stale_users = []
+    threshold_days = 45
+
+    for row in reader:
+        username = row.get("user", "<root_account>")
+        if username == "<root_account>":
+            continue
+
+        last_used = row.get("password_last_used", "N/A")
+        key1_used = row.get("access_key_1_last_used_date", "N/A")
+        key2_used = row.get("access_key_2_last_used_date", "N/A")
+
+        is_stale = False
+        for date_str in [last_used, key1_used, key2_used]:
+            if date_str in ("N/A", "no_information", "not_supported", ""):
+                continue
+            try:
+                used_dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                days_unused = (now - used_dt).days
+                if days_unused >= threshold_days:
+                    is_stale = True
+                    break
+            except (ValueError, TypeError):
+                continue
+
+        if is_stale:
+            stale_users.append(username)
+
+    if stale_users:
+        result.status = CheckStatus.FAIL
+        result.evidence = f"{len(stale_users)} user(s) with credentials unused for 45+ days: {', '.join(stale_users[:5])}"
+        if len(stale_users) > 5:
+            result.evidence += f" (+{len(stale_users) - 5} more)"
+        result.resource_ids = [f"arn:aws:iam::user/{u}" for u in stale_users]
+    else:
+        result.evidence = "No credentials unused for 45+ days."
+    return result
+
+
+def _check_1_15(iam_client: Any) -> CISCheckResult:
+    """CIS 1.15 — Ensure IAM users receive permissions only through groups or roles."""
+    result = CISCheckResult(
+        check_id="1.15",
+        title="Ensure IAM users receive permissions only through groups or roles",
+        status=CheckStatus.PASS,
+        severity="medium",
+        cis_section=_IAM_SECTION,
+        recommendation="Remove inline and directly attached policies from IAM users; use groups instead.",
+    )
+    paginator = iam_client.get_paginator("list_users")
+    users_with_direct = []
+
+    for page in paginator.paginate():
+        for user in page["Users"]:
+            username = user["UserName"]
+            inline = iam_client.list_user_policies(UserName=username)["PolicyNames"]
+            attached = iam_client.list_attached_user_policies(UserName=username)["AttachedPolicies"]
+            if inline or attached:
+                users_with_direct.append(username)
+
+    if users_with_direct:
+        result.status = CheckStatus.FAIL
+        result.evidence = f"{len(users_with_direct)} user(s) with direct policies: {', '.join(users_with_direct[:5])}"
+        if len(users_with_direct) > 5:
+            result.evidence += f" (+{len(users_with_direct) - 5} more)"
+        result.resource_ids = [f"arn:aws:iam::user/{u}" for u in users_with_direct]
+    else:
+        result.evidence = "All users receive permissions via groups/roles only."
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Check registry
+# ---------------------------------------------------------------------------
+
+_CHECKS: list[tuple[str, Callable]] = [
+    ("iam", _check_1_4),
+    ("iam", _check_1_5),
+    ("iam", _check_1_6),
+    ("iam", _check_1_8),
+    ("iam", _check_1_10),
+    ("iam", _check_1_12),
+    ("iam", _check_1_15),
+]
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run_benchmark(
+    region: str | None = None,
+    profile: str | None = None,
+    checks: list[str] | None = None,
+) -> CISBenchmarkReport:
+    """Run CIS AWS Foundations Benchmark v3.0 checks.
+
+    Uses the standard boto3 credential chain.  Only read APIs are called.
+
+    Args:
+        region: AWS region (defaults to AWS_DEFAULT_REGION or us-east-1).
+        profile: AWS credential profile name.
+        checks: Optional list of check IDs to run (e.g. ``["1.4", "1.5"]``).
+            Runs all checks if *None*.
+
+    Returns:
+        CISBenchmarkReport with per-check pass/fail results.
+    """
+    try:
+        import boto3
+        from botocore.exceptions import ClientError
+    except ImportError:
+        raise CloudDiscoveryError("boto3 is required for CIS AWS Benchmark checks. Install with: pip install 'agent-bom[aws]'")
+
+    session_kwargs: dict[str, Any] = {}
+    if region:
+        session_kwargs["region_name"] = region
+    if profile:
+        session_kwargs["profile_name"] = profile
+
+    session = boto3.Session(**session_kwargs)
+    resolved_region = session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+    # Get account ID for the report
+    account_id = ""
+    try:
+        sts = session.client("sts", region_name=resolved_region)
+        account_id = sts.get_caller_identity()["Account"]
+    except Exception:
+        pass  # non-fatal
+
+    report = CISBenchmarkReport(region=resolved_region, account_id=account_id)
+
+    # Lazy client cache (one per service)
+    clients: dict[str, Any] = {}
+
+    for service, check_fn in _CHECKS:
+        check_id = check_fn.__doc__.split("—")[0].strip().replace("CIS ", "") if check_fn.__doc__ else ""
+        if checks and check_id not in checks:
+            continue
+
+        if service not in clients:
+            clients[service] = session.client(service, region_name=resolved_region)
+
+        try:
+            result = check_fn(clients[service])
+            report.checks.append(result)
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            report.checks.append(
+                CISCheckResult(
+                    check_id=check_id,
+                    title=check_fn.__doc__.split("—")[1].strip().rstrip(".") if check_fn.__doc__ else "",
+                    status=CheckStatus.ERROR,
+                    severity="unknown",
+                    evidence=f"AWS API error: {code} — {exc.response['Error'].get('Message', '')}",
+                    cis_section=_IAM_SECTION,
+                )
+            )
+        except Exception as exc:
+            logger.warning("CIS check %s failed: %s", check_id, exc)
+
+    return report

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -398,6 +398,7 @@ class AIBOMReport:
     toxic_combinations: Optional[list] = None  # Serialized ToxicCombination list
     prioritized_findings: Optional[list] = None  # Priority-ordered findings
     sast_data: Optional[dict] = None  # Serialized SAST scan results (Semgrep)
+    cis_benchmark_data: Optional[dict] = None  # Serialized CIS AWS Benchmark results
 
     def __post_init__(self):
         if not self.tool_version:

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1554,6 +1554,9 @@ def to_json(report: AIBOMReport) -> dict:
     if report.sast_data:
         result["sast"] = report.sast_data
 
+    if report.cis_benchmark_data:
+        result["cis_benchmark"] = report.cis_benchmark_data
+
     # Posture scorecard
     from agent_bom.posture import (
         compute_credential_risk_ranking,

--- a/tests/test_aws_cis_benchmark.py
+++ b/tests/test_aws_cis_benchmark.py
@@ -1,0 +1,367 @@
+"""Tests for CIS AWS Foundations Benchmark v3.0 checks."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_bom.cloud.aws_cis_benchmark import (
+    CheckStatus,
+    CISBenchmarkReport,
+    CISCheckResult,
+    _check_1_4,
+    _check_1_5,
+    _check_1_6,
+    _check_1_8,
+    _check_1_10,
+    _check_1_12,
+    _check_1_15,
+    run_benchmark,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iam_client(**overrides) -> MagicMock:
+    """Create a mock IAM client with sensible defaults."""
+    client = MagicMock()
+    client.get_account_summary.return_value = {
+        "SummaryMap": {
+            "AccountAccessKeysPresent": 0,
+            "AccountMFAEnabled": 1,
+        }
+    }
+    client.list_virtual_mfa_devices.return_value = {"VirtualMFADevices": []}
+    client.get_account_password_policy.return_value = {"PasswordPolicy": {"MinimumPasswordLength": 14}}
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Users": []}]
+    client.get_paginator.return_value = paginator
+    for k, v in overrides.items():
+        setattr(client, k, v)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# 1.4 — Root access keys
+# ---------------------------------------------------------------------------
+
+
+class TestCheck14:
+    def test_pass_no_root_keys(self):
+        client = _iam_client()
+        result = _check_1_4(client)
+        assert result.status == CheckStatus.PASS
+        assert result.check_id == "1.4"
+
+    def test_fail_root_keys_present(self):
+        client = _iam_client()
+        client.get_account_summary.return_value = {"SummaryMap": {"AccountAccessKeysPresent": 1}}
+        result = _check_1_4(client)
+        assert result.status == CheckStatus.FAIL
+        assert "1 active access key" in result.evidence
+
+
+# ---------------------------------------------------------------------------
+# 1.5 — Root MFA
+# ---------------------------------------------------------------------------
+
+
+class TestCheck15:
+    def test_pass_mfa_enabled(self):
+        client = _iam_client()
+        result = _check_1_5(client)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_mfa_disabled(self):
+        client = _iam_client()
+        client.get_account_summary.return_value = {"SummaryMap": {"AccountMFAEnabled": 0}}
+        result = _check_1_5(client)
+        assert result.status == CheckStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# 1.6 — Root hardware MFA
+# ---------------------------------------------------------------------------
+
+
+class TestCheck16:
+    def test_pass_hardware_mfa(self):
+        client = _iam_client()
+        result = _check_1_6(client)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_no_mfa_at_all(self):
+        client = _iam_client()
+        client.get_account_summary.return_value = {"SummaryMap": {"AccountMFAEnabled": 0}}
+        result = _check_1_6(client)
+        assert result.status == CheckStatus.FAIL
+        assert "no MFA at all" in result.evidence
+
+    def test_fail_virtual_mfa(self):
+        client = _iam_client()
+        client.list_virtual_mfa_devices.return_value = {
+            "VirtualMFADevices": [{"SerialNumber": "arn:aws:iam::123456789:mfa/root-account-mfa-device"}]
+        }
+        result = _check_1_6(client)
+        assert result.status == CheckStatus.FAIL
+        assert "virtual MFA" in result.evidence
+
+
+# ---------------------------------------------------------------------------
+# 1.8 — Password policy length
+# ---------------------------------------------------------------------------
+
+
+class TestCheck18:
+    def test_pass_length_14(self):
+        client = _iam_client()
+        result = _check_1_8(client)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_length_8(self):
+        client = _iam_client()
+        client.get_account_password_policy.return_value = {"PasswordPolicy": {"MinimumPasswordLength": 8}}
+        result = _check_1_8(client)
+        assert result.status == CheckStatus.FAIL
+        assert "8" in result.evidence
+
+    def test_fail_no_policy(self):
+        """NoSuchEntity means no password policy configured."""
+        client = _iam_client()
+        exc = Exception("NoSuchEntity")
+        exc.response = {"Error": {"Code": "NoSuchEntity", "Message": "..."}}
+        client.get_account_password_policy.side_effect = exc
+        result = _check_1_8(client)
+        assert result.status == CheckStatus.FAIL
+        assert "No password policy" in result.evidence
+
+
+# ---------------------------------------------------------------------------
+# 1.10 — Console users MFA
+# ---------------------------------------------------------------------------
+
+
+class TestCheck110:
+    def test_pass_no_users(self):
+        client = _iam_client()
+        result = _check_1_10(client)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_user_without_mfa(self):
+        client = _iam_client()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Users": [{"UserName": "alice"}]}]
+        client.get_paginator.return_value = paginator
+        client.get_login_profile.return_value = {}  # has console access
+        client.list_mfa_devices.return_value = {"MFADevices": []}
+        result = _check_1_10(client)
+        assert result.status == CheckStatus.FAIL
+        assert "alice" in result.evidence
+
+    def test_pass_user_no_console(self):
+        """User without console access should be skipped."""
+        client = _iam_client()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Users": [{"UserName": "bot-user"}]}]
+        client.get_paginator.return_value = paginator
+        exc = Exception("NoSuchEntity")
+        exc.response = {"Error": {"Code": "NoSuchEntity"}}
+        client.get_login_profile.side_effect = exc
+        result = _check_1_10(client)
+        assert result.status == CheckStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# 1.12 — Stale credentials
+# ---------------------------------------------------------------------------
+
+
+class TestCheck112:
+    def test_pass_no_stale(self):
+        client = _iam_client()
+        client.generate_credential_report.return_value = {"State": "COMPLETE"}
+        client.get_credential_report.return_value = {
+            "Content": (
+                "user,password_last_used,access_key_1_last_used_date,access_key_2_last_used_date\n"
+                "<root_account>,N/A,N/A,N/A\n"
+                "alice,2026-03-01T00:00:00+00:00,N/A,N/A\n"
+            ).encode()
+        }
+        result = _check_1_12(client)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_stale_user(self):
+        client = _iam_client()
+        client.generate_credential_report.return_value = {"State": "COMPLETE"}
+        client.get_credential_report.return_value = {
+            "Content": (
+                "user,password_last_used,access_key_1_last_used_date,access_key_2_last_used_date\n"
+                "<root_account>,N/A,N/A,N/A\n"
+                "stale-bob,2020-01-01T00:00:00+00:00,N/A,N/A\n"
+            ).encode()
+        }
+        result = _check_1_12(client)
+        assert result.status == CheckStatus.FAIL
+        assert "stale-bob" in result.evidence
+
+
+# ---------------------------------------------------------------------------
+# 1.15 — Permissions only through groups
+# ---------------------------------------------------------------------------
+
+
+class TestCheck115:
+    def test_pass_no_direct_policies(self):
+        client = _iam_client()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Users": [{"UserName": "alice"}]}]
+        client.get_paginator.return_value = paginator
+        client.list_user_policies.return_value = {"PolicyNames": []}
+        client.list_attached_user_policies.return_value = {"AttachedPolicies": []}
+        result = _check_1_15(client)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_inline_policy(self):
+        client = _iam_client()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Users": [{"UserName": "admin"}]}]
+        client.get_paginator.return_value = paginator
+        client.list_user_policies.return_value = {"PolicyNames": ["InlineAdmin"]}
+        client.list_attached_user_policies.return_value = {"AttachedPolicies": []}
+        result = _check_1_15(client)
+        assert result.status == CheckStatus.FAIL
+        assert "admin" in result.evidence
+
+
+# ---------------------------------------------------------------------------
+# Report model
+# ---------------------------------------------------------------------------
+
+
+class TestCISBenchmarkReport:
+    def test_empty_report(self):
+        report = CISBenchmarkReport()
+        assert report.passed == 0
+        assert report.failed == 0
+        assert report.total == 0
+        assert report.pass_rate == 0.0
+
+    def test_mixed_results(self):
+        report = CISBenchmarkReport(
+            checks=[
+                CISCheckResult(check_id="1.4", title="test", status=CheckStatus.PASS, severity="critical"),
+                CISCheckResult(check_id="1.5", title="test", status=CheckStatus.FAIL, severity="critical"),
+                CISCheckResult(check_id="1.6", title="test", status=CheckStatus.ERROR, severity="critical"),
+            ]
+        )
+        assert report.passed == 1
+        assert report.failed == 1
+        assert report.total == 3
+        assert report.pass_rate == 50.0
+
+    def test_to_dict(self):
+        report = CISBenchmarkReport(
+            account_id="123456789012",
+            region="us-east-1",
+            checks=[
+                CISCheckResult(check_id="1.4", title="Root keys", status=CheckStatus.PASS, severity="critical"),
+            ],
+        )
+        d = report.to_dict()
+        assert d["benchmark"] == "CIS AWS Foundations"
+        assert d["benchmark_version"] == "3.0"
+        assert d["account_id"] == "123456789012"
+        assert len(d["checks"]) == 1
+        assert d["checks"][0]["status"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def _mock_boto3_modules():
+    """Patch sys.modules so `import boto3` inside run_benchmark resolves to a mock."""
+    mock_boto3 = MagicMock()
+    mock_botocore = MagicMock()
+    mock_botocore_exc = MagicMock()
+    # Create a real-ish ClientError for the except clause
+    mock_botocore_exc.ClientError = type(
+        "ClientError",
+        (Exception,),
+        {
+            "__init__": lambda self, response, operation_name: (
+                setattr(self, "response", response) or super(type(self), self).__init__(str(response))
+            ),
+        },
+    )
+    return patch.dict(
+        "sys.modules",
+        {
+            "boto3": mock_boto3,
+            "botocore": mock_botocore,
+            "botocore.exceptions": mock_botocore_exc,
+        },
+    ), mock_boto3
+
+
+class TestRunBenchmark:
+    def test_missing_boto3(self):
+        with patch.dict("sys.modules", {"boto3": None, "botocore": None, "botocore.exceptions": None}):
+            with pytest.raises(Exception, match="boto3"):
+                run_benchmark()
+
+    def test_runs_all_checks(self):
+        modules_patch, mock_boto3 = _mock_boto3_modules()
+        with modules_patch:
+            mock_session = MagicMock()
+            mock_boto3.Session.return_value = mock_session
+            mock_session.region_name = "us-east-1"
+
+            mock_sts = MagicMock()
+            mock_sts.get_caller_identity.return_value = {"Account": "111222333444"}
+
+            mock_iam = _iam_client()
+            mock_iam.generate_credential_report.return_value = {"State": "COMPLETE"}
+            mock_iam.get_credential_report.return_value = {
+                "Content": b"user,password_last_used,access_key_1_last_used_date,access_key_2_last_used_date\n"
+            }
+            mock_iam.list_user_policies.return_value = {"PolicyNames": []}
+            mock_iam.list_attached_user_policies.return_value = {"AttachedPolicies": []}
+
+            def client_factory(service, **kwargs):
+                if service == "sts":
+                    return mock_sts
+                return mock_iam
+
+            mock_session.client.side_effect = client_factory
+
+            report = run_benchmark()
+            assert report.account_id == "111222333444"
+            assert report.total == 7
+            assert all(c.status in (CheckStatus.PASS, CheckStatus.FAIL) for c in report.checks)
+
+    def test_filter_checks(self):
+        modules_patch, mock_boto3 = _mock_boto3_modules()
+        with modules_patch:
+            mock_session = MagicMock()
+            mock_boto3.Session.return_value = mock_session
+            mock_session.region_name = "us-east-1"
+
+            mock_sts = MagicMock()
+            mock_sts.get_caller_identity.return_value = {"Account": "123"}
+            mock_iam = _iam_client()
+
+            def client_factory(service, **kwargs):
+                if service == "sts":
+                    return mock_sts
+                return mock_iam
+
+            mock_session.client.side_effect = client_factory
+
+            report = run_benchmark(checks=["1.4", "1.5"])
+            assert report.total == 2
+            assert {c.check_id for c in report.checks} == {"1.4", "1.5"}


### PR DESCRIPTION
## Summary

- Add CIS AWS Foundations Benchmark v3.0 with 7 live IAM checks (1.4, 1.5, 1.6, 1.8, 1.10, 1.12, 1.15)
- New `--aws-cis-benchmark` CLI flag runs read-only AWS API checks with Rich table output
- Results included in JSON/CycloneDX output via `cis_benchmark_data` field
- 23 new tests covering all checks, report model, and runner (2,964 total passing)

## Checks implemented

| Check | Description | Severity |
|-------|-------------|----------|
| 1.4 | No root user access keys | Critical |
| 1.5 | Root MFA enabled | Critical |
| 1.6 | Root hardware MFA | Critical |
| 1.8 | Password policy min length ≥ 14 | Medium |
| 1.10 | All console users have MFA | High |
| 1.12 | Credentials unused 45+ days disabled | Medium |
| 1.15 | Permissions only through groups/roles | Medium |

## Test plan

- [x] All 23 new CIS benchmark tests pass
- [x] Full suite: 2,964 passed, 13 skipped
- [x] Lint clean (ruff check + ruff-format)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)