### PR TITLE
feat: add cis_benchmark MCP tool — 18th tool for CIS checks via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 | Quick local scan | CLI | `agent-bom scan` |
 | CI/CD gate | GitHub Action | `uses: msaad00/agent-bom@v0.53.0` |
 | Security dashboard | API + UI | `agent-bom serve` |
-| MCP tool integration | MCP server | `agent-bom mcp-server` (17 tools) |
+| MCP tool integration | MCP server | `agent-bom mcp-server` (18 tools) |
 | K8s fleet scanning | Helm | `helm install deploy/helm/agent-bom` |
 | Analytics + viz | Docker Compose | `cd infra/clickhouse && docker compose up` |
 | Snowflake governance | API | `agent-bom api --snowflake` |
@@ -573,7 +573,7 @@ agent-bom mcp-server                    # stdio
 agent-bom mcp-server --transport sse    # remote
 ```
 
-17 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`, `marketplace_check`, `code_scan`, `context_graph`, `analytics_query`
+18 tools: `scan`, `check`, `blast_radius`, `policy_check`, `registry_lookup`, `generate_sbom`, `compliance`, `remediate`, `verify`, `where`, `inventory`, `diff`, `skill_trust`, `marketplace_check`, `code_scan`, `context_graph`, `analytics_query`, `cis_benchmark`
 
 ### Cloud UI
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -282,6 +282,6 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine |
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (17 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (18 tools) |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -124,7 +124,7 @@ docker run -p 8080:8080 agent-bom-sse
 # Connect: { "type": "sse", "url": "http://localhost:8080/sse" }
 ```
 
-## Available MCP Tools (17 tools)
+## Available MCP Tools (18 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -145,6 +145,7 @@ docker run -p 8080:8080 agent-bom-sse
 | `inventory` | List discovered agents, servers, packages |
 | `context_graph` | Agent context graph with lateral movement analysis |
 | `analytics_query` | Query vulnerability trends, posture history, and runtime events from ClickHouse |
+| `cis_benchmark` | Run CIS benchmark checks against AWS or Snowflake accounts |
 
 ## MCP Resources
 

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -56,7 +56,8 @@
             "marketplace_check",
             "code_scan",
             "context_graph",
-            "analytics_query"
+            "analytics_query",
+            "cis_benchmark"
           ]
         }
       }

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1457,6 +1457,55 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("MCP tool error")
             return json.dumps({"error": sanitize_error(exc)})
 
+    @mcp.tool(annotations=_READ_ONLY)
+    async def cis_benchmark(
+        provider: Annotated[
+            str,
+            Field(description="Cloud provider: 'aws' or 'snowflake'."),
+        ],
+        checks: Annotated[
+            str | None,
+            Field(description="Comma-separated check IDs to run (e.g. '1.1,2.1'). Omit to run all."),
+        ] = None,
+        region: Annotated[
+            str | None,
+            Field(description="AWS region (only for provider=aws). Defaults to us-east-1."),
+        ] = None,
+        profile: Annotated[
+            str | None,
+            Field(description="AWS CLI profile (only for provider=aws)."),
+        ] = None,
+    ) -> str:
+        """Run CIS benchmark checks against a cloud account.
+
+        Evaluates security posture against CIS Foundations Benchmarks:
+        - AWS Foundations v3.0: 18 checks (IAM, Storage, Logging, Networking)
+        - Snowflake v1.0: 12 checks (Auth, Network, Data Protection, Monitoring, Access Control)
+
+        All checks are read-only. Requires appropriate credentials (AWS or Snowflake).
+
+        Returns:
+            JSON with per-check pass/fail results, evidence, severity, and pass rate.
+        """
+        try:
+            check_list = [c.strip() for c in checks.split(",")] if checks else None
+
+            if provider == "aws":
+                from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
+
+                report = run_aws_cis(region=region, profile=profile, checks=check_list)
+            elif provider == "snowflake":
+                from agent_bom.cloud.snowflake_cis_benchmark import run_benchmark as run_sf_cis
+
+                report = run_sf_cis(checks=check_list)
+            else:
+                return json.dumps({"error": f"Unsupported provider: {provider}. Use 'aws' or 'snowflake'."})
+
+            return _truncate_response(json.dumps(report.to_dict(), indent=2, default=str))
+        except Exception as exc:
+            logger.exception("MCP tool error")
+            return json.dumps({"error": sanitize_error(exc)})
+
     # ── Resources ────────────────────────────────────────────────
 
     @mcp.resource("registry://servers")
@@ -1601,6 +1650,11 @@ _SERVER_CARD_TOOLS = [
     {
         "name": "analytics_query",
         "description": "Query vulnerability trends, posture history, and runtime events from ClickHouse",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "cis_benchmark",
+        "description": "Run CIS benchmark checks against AWS or Snowflake accounts",
         "annotations": {"readOnlyHint": True},
     },
 ]

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -117,14 +117,14 @@ def test_smithery_yaml_exists():
 
 
 def test_server_card_has_all_tools():
-    """Server card should list all 17 MCP tools."""
+    """Server card should list all 18 MCP tools."""
     from agent_bom.mcp_server import build_server_card
 
     card = build_server_card()
     assert card["name"] == "agent-bom"
     assert "version" in card
     tool_names = [t["name"] for t in card["tools"]]
-    assert len(tool_names) == 17
+    assert len(tool_names) == 18
     assert "scan" in tool_names
     assert "check" in tool_names
     assert "blast_radius" in tool_names

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -57,13 +57,13 @@ def test_create_mcp_server_returns_object():
     assert server.name == "agent-bom"
 
 
-def test_mcp_server_has_seventeen_tools():
-    """Server should register exactly 17 tools."""
+def test_mcp_server_has_eighteen_tools():
+    """Server should register exactly 18 tools."""
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
     tools = _run(server.list_tools())
-    assert len(tools) == 17
+    assert len(tools) == 18
 
 
 def test_mcp_server_tool_names():
@@ -91,6 +91,7 @@ def test_mcp_server_tool_names():
         "code_scan",
         "context_graph",
         "analytics_query",
+        "cis_benchmark",
     }
 
 

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -609,12 +609,13 @@ def test_mcp_skill_trust_tool_exists():
     assert "skill_trust" in tool_names
 
 
-def test_mcp_server_card_has_17_tools():
-    """Server card lists 17 tools (including code_scan, context_graph, analytics_query)."""
+def test_mcp_server_card_has_18_tools():
+    """Server card lists 18 tools (including code_scan, context_graph, analytics_query, cis_benchmark)."""
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
-    assert len(_SERVER_CARD_TOOLS) == 17
+    assert len(_SERVER_CARD_TOOLS) == 18
     tool_names = {t["name"] for t in _SERVER_CARD_TOOLS}
     assert "code_scan" in tool_names
     assert "context_graph" in tool_names
     assert "analytics_query" in tool_names
+    assert "cis_benchmark" in tool_names


### PR DESCRIPTION
## Summary

- New `cis_benchmark` MCP tool (18th tool) — run CIS benchmark checks against AWS or Snowflake from any MCP client
- Parameters: `provider` (aws/snowflake), `checks` (optional filter), `region`/`profile` (AWS only)
- Returns JSON with per-check pass/fail, evidence, severity, and pass rate
- Updated tool counts 17→18 across all files (README, ARCHITECTURE.md, SKILL.md, toolhive, 3 test files)

## Test plan

- [x] 3,027 tests pass (tool count meta-tests updated in test_mcp_server, test_trust_assessment, test_deployment)
- [x] ruff lint + format clean
- [ ] CI checks pass