### PR TITLE
feat: add --self-scan to scan agent-bom's own dependencies

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -529,6 +529,9 @@ def main():
     default=None,
     help="Export compliance evidence bundle (ZIP) for CMMC, FedRAMP, or NIST AI RMF audits",
 )
+@click.option(
+    "--self-scan", "self_scan", is_flag=True, default=False, help="Scan agent-bom's own installed dependencies for vulnerabilities."
+)
 @click.option("--demo", is_flag=True, default=False, help="Run a demo scan with bundled inventory containing known-vulnerable packages.")
 def scan(
     project: Optional[str],
@@ -663,6 +666,7 @@ def scan(
     preset: Optional[str],
     open_report: bool,
     compliance_export: Optional[str],
+    self_scan: bool,
     demo: bool,
 ):
     """Discover agents, extract dependencies, scan for vulnerabilities.
@@ -700,6 +704,56 @@ def scan(
     elif preset == "quick":
         transitive = False
         enrich = False
+
+    # ── Self-scan mode: scan agent-bom's own installed dependencies ──
+    if self_scan:
+        import importlib.metadata as _meta
+        import json as _json
+        import os as _os
+        import tempfile as _tempfile
+
+        _pkgs = []
+        try:
+            _dist = _meta.distribution("agent-bom")
+            for _req_str in _dist.requires or []:
+                _name = _req_str.split(";")[0].split("[")[0].strip()
+                for _op in (">=", "<=", "==", "!=", "~=", ">", "<"):
+                    if _op in _name:
+                        _name = _name[: _name.index(_op)].strip()
+                        break
+                if not _name:
+                    continue
+                try:
+                    _ver = _meta.version(_name)
+                except _meta.PackageNotFoundError:
+                    continue
+                _pkgs.append({"name": _name, "version": _ver, "ecosystem": "pypi"})
+        except _meta.PackageNotFoundError:
+            click.echo("Error: agent-bom package not found. Install it first.", err=True)
+            sys.exit(2)
+
+        _self_inventory = {
+            "agents": [
+                {
+                    "name": "agent-bom",
+                    "agent_type": "custom",
+                    "source": "agent-bom --self-scan",
+                    "mcp_servers": [
+                        {
+                            "name": "agent-bom-mcp-server",
+                            "command": "agent-bom mcp-server",
+                            "transport": "stdio",
+                            "packages": _pkgs,
+                        }
+                    ],
+                }
+            ]
+        }
+        _sf_fd, _sf_path = _tempfile.mkstemp(suffix=".json", prefix="agent-bom-self-scan-")
+        with _os.fdopen(_sf_fd, "w") as _sf:
+            _json.dump(_self_inventory, _sf)
+        inventory = _sf_path
+        enrich = True
 
     # ── Demo mode: load bundled inventory with known-vulnerable packages ──
     if demo:

--- a/tests/test_self_scan.py
+++ b/tests/test_self_scan.py
@@ -1,0 +1,81 @@
+"""Tests for --self-scan CLI flag."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+class TestSelfScanInventory:
+    """Unit tests for self-scan inventory generation logic."""
+
+    def test_self_scan_builds_inventory(self):
+        """--self-scan produces a valid inventory with agent-bom's own deps."""
+        dist = importlib.metadata.distribution("agent-bom")
+        requires = dist.requires or []
+        assert len(requires) > 0, "agent-bom should have dependencies"
+
+    def test_self_scan_parses_requirement_names(self):
+        """Requirement strings are parsed to clean package names."""
+        dist = importlib.metadata.distribution("agent-bom")
+        requires = dist.requires or []
+        for req_str in requires[:5]:
+            name = req_str.split(";")[0].split("[")[0].strip()
+            for op in (">=", "<=", "==", "!=", "~=", ">", "<"):
+                if op in name:
+                    name = name[: name.index(op)].strip()
+                    break
+            assert name, f"Failed to parse name from: {req_str}"
+            assert " " not in name
+
+    def test_self_scan_resolves_installed_versions(self):
+        """At least some deps should be installed and have versions."""
+        dist = importlib.metadata.distribution("agent-bom")
+        requires = dist.requires or []
+        resolved = 0
+        for req_str in requires:
+            name = req_str.split(";")[0].split("[")[0].strip()
+            for op in (">=", "<=", "==", "!=", "~=", ">", "<"):
+                if op in name:
+                    name = name[: name.index(op)].strip()
+                    break
+            if not name:
+                continue
+            try:
+                importlib.metadata.version(name)
+                resolved += 1
+            except importlib.metadata.PackageNotFoundError:
+                pass
+        assert resolved >= 5, f"Expected >=5 resolved deps, got {resolved}"
+
+
+class TestSelfScanCLI:
+    """Integration tests for --self-scan via CLI runner."""
+
+    def test_self_scan_flag_runs(self):
+        """--self-scan executes without crashing."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", "--self-scan", "--no-scan", "--quiet"])
+        assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
+
+    def test_self_scan_with_json_output(self, tmp_path):
+        """--self-scan with JSON output produces valid report."""
+        out_file = tmp_path / "self-scan.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["scan", "--self-scan", "--output", str(out_file), "--format", "json", "--quiet"],
+        )
+        assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
+        data = json.loads(out_file.read_text())
+        assert "agents" in data or "inventory" in data or "vulnerabilities" in data
+
+    def test_self_scan_shows_packages(self):
+        """--self-scan discovers agent-bom dependencies."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["scan", "--self-scan", "--dry-run"])
+        assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"


### PR DESCRIPTION
## Summary
- Adds `--self-scan` CLI flag that enumerates agent-bom's own installed packages via `importlib.metadata`
- Builds an inventory JSON (same pattern as `--demo`) and feeds it into the scan pipeline
- Discovers ~27 packages across agent-bom's dependency tree and scans them for CVEs
- 6 new tests covering inventory generation, requirement parsing, version resolution, and CLI integration

## Usage
```bash
agent-bom scan --self-scan
agent-bom scan --self-scan --quiet
agent-bom scan --self-scan -o report.json -f json
```

## Test plan
- [x] 6 new tests in `tests/test_self_scan.py`
- [x] Full suite: 3,033 passed, 13 skipped
- [x] Manual end-to-end: discovers 27 packages, completes scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)