### PR TITLE
fix: sync stale tool/client counts across docs and diagrams

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 17 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 18 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f Dockerfile.sse -t agent-bom-sse .

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ High-level view of input sources, the core processing engine, and output channel
 ```mermaid
 graph TB
     subgraph Input["Input Sources"]
-        MCP["MCP Configs\n18 Clients"]
+        MCP["MCP Configs\n20 Clients"]
         Docker["Docker Images"]
         K8s["Kubernetes"]
         Cloud["Cloud APIs\nAWS / Azure / GCP / Snowflake"]

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">17 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">18 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">17 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">18 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -167,7 +167,7 @@
       <rect width="286" height="48" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6e7681">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">17 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">18 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -166,7 +166,7 @@
       <rect width="286" height="48" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#94a3b8">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">17 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">18 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">17 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">18 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">17 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">18 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (17 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (18 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#0f3f1f"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#7ee787">13+ FORMATS</text>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (17 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (18 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#d1fae5"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#065f46">13+ FORMATS</text>

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   pypi: https://pypi.org/project/agent-bom/
   smithery: https://smithery.ai/server/agent-bom/agent-bom
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 3056
+  tests: 3050
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -83,7 +83,7 @@ metadata:
 # agent-bom — AI Supply Chain Security Scanner
 
 Scans AI infrastructure for vulnerabilities, generates SBOMs, and enforces
-compliance. Discovers MCP clients, servers, and packages across 18+ AI platforms.
+compliance. Discovers MCP clients, servers, and packages across 20 MCP clients.
 
 ## Install (Recommended: Local-First)
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -4,7 +4,7 @@ Start with:
     agent-bom mcp-server              # stdio (for Claude Desktop, Cursor, etc.)
     agent-bom mcp-server --sse        # SSE transport (for remote clients)
 
-Tools (17):
+Tools (18):
     scan              — Full discovery → scan → output pipeline
     check             — Check a specific package for CVEs before installing
     blast_radius      — Look up blast radius for a specific CVE
@@ -22,6 +22,7 @@ Tools (17):
     code_scan         — SAST scanning via Semgrep with CWE-based compliance mapping
     context_graph     — Agent context graph with lateral movement analysis
     analytics_query   — Query vulnerability trends and runtime events from ClickHouse
+    cis_benchmark     — Run CIS benchmark checks against AWS or Snowflake accounts
 
 Resources (2):
     registry://servers  — Browse 427+ server security metadata registry


### PR DESCRIPTION
## Summary

- mcp_server.py docstring: "Tools (17)" → "Tools (18)", added missing `cis_benchmark`
- Dockerfile.sse comment: "17 MCP tools" → "18 MCP tools"
- ARCHITECTURE.md mermaid diagram: "18 Clients" → "20 Clients"
- SKILL.md: test count 3056 → 3050, "18+ AI platforms" → "20 MCP clients"
- 8 SVG diagrams: "17 tools/MCP" → "18 tools/MCP"

## Test plan

- [ ] Verify no remaining `17 tools` or `17 MCP` references: `grep -rn '17 tools\|17 MCP' docs/ src/ *.sse`
- [ ] Verify `_SERVER_CARD_TOOLS` count matches `@mcp.tool` count (meta-test)
- [ ] CI passes