### PR TITLE
feat: registry CVE enrichment via OSV + EPSS + CISA KEV

### DIFF
--- a/.github/workflows/mcp-registry-sync.yml
+++ b/.github/workflows/mcp-registry-sync.yml
@@ -125,36 +125,61 @@ jobs:
           asyncio.run(main())
           EOF
 
+      - name: Enrich registry with CVE data (OSV + EPSS + KEV)
+        id: cve
+        run: |
+          python - <<'EOF'
+          import asyncio, json, sys
+          from pathlib import Path
+
+          sys.path.insert(0, "src")
+          REGISTRY_PATH = Path("src/agent_bom/mcp_registry.json")
+
+          async def main():
+              from agent_bom.registry import enrich_registry_with_cves
+              result = await enrich_registry_with_cves(dry_run=False)
+              print(f"Scannable: {result.scannable}, With CVEs: {result.enriched}")
+              print(f"Total CVEs: {result.total_cves}, Critical: {result.total_critical}, KEV: {result.total_kev}")
+              for d in result.details[:10]:
+                  print(f"  {d['server']}: {d['cve_count']} CVEs")
+              Path("/tmp/cve_count").write_text(str(result.enriched))
+
+          asyncio.run(main())
+          EOF
+
       - name: Read counts
         id: count
         run: |
           echo "new_count=$(cat /tmp/new_count)" >> "$GITHUB_OUTPUT"
           echo "version_count=$(cat /tmp/version_count 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
+          echo "cve_count=$(cat /tmp/cve_count 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
 
       - name: Create PR if registry changed
-        if: steps.count.outputs.new_count != '0' || steps.count.outputs.version_count != '0'
+        if: steps.count.outputs.new_count != '0' || steps.count.outputs.version_count != '0' || steps.count.outputs.cve_count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_COUNT: ${{ steps.count.outputs.new_count }}
           VERSION_COUNT: ${{ steps.count.outputs.version_count }}
+          CVE_COUNT: ${{ steps.count.outputs.cve_count }}
         run: |
           BRANCH="chore/mcp-registry-$(date +%Y%m%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add src/agent_bom/mcp_registry.json
-          git commit -m "chore: sync MCP registry — ${NEW_COUNT} new server(s), ${VERSION_COUNT} version update(s)"
+          git commit -m "chore: sync MCP registry — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} with CVEs"
           git push origin "$BRANCH"
           gh pr create \
-            --title "chore: MCP registry sync — ${NEW_COUNT} new, ${VERSION_COUNT} version updates" \
+            --title "chore: MCP registry sync — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} CVE-enriched" \
             --body "Automated weekly sync from the official MCP server registry.
 
           **New servers added:** ${NEW_COUNT}
           **Versions refreshed:** ${VERSION_COUNT}
+          **Servers with CVE data:** ${CVE_COUNT}
 
           Please review the changes in \`src/agent_bom/mcp_registry.json\` before merging." \
             --base main
 
       - name: No changes
-        if: steps.count.outputs.new_count == '0' && steps.count.outputs.version_count == '0'
-        run: echo "MCP registry is up to date — no new servers or version changes found."
+        if: steps.count.outputs.new_count == '0' && steps.count.outputs.version_count == '0' && steps.count.outputs.cve_count == '0'
+        run: echo "MCP registry is up to date — no new servers, version changes, or CVE updates found."

--- a/scripts/enrich_registry_cves.py
+++ b/scripts/enrich_registry_cves.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Enrich the MCP registry with CVE data from OSV, EPSS, and CISA KEV.
+
+Usage:
+    python scripts/enrich_registry_cves.py                # Enrich all scannable packages
+    python scripts/enrich_registry_cves.py --dry-run       # Preview without writing
+
+Queries OSV batch API for each npm/pypi package in the registry, then
+enriches with EPSS exploit prediction scores and CISA KEV status.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Enrich registry with CVE data")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without writing",
+    )
+    args = parser.parse_args()
+
+    nvd_api_key = os.environ.get("NVD_API_KEY")
+
+    print("Enriching MCP registry with CVE data (OSV + EPSS + KEV)...")
+    if args.dry_run:
+        print("(dry run — no files will be modified)")
+
+    from agent_bom.registry import enrich_registry_with_cves_sync
+
+    result = enrich_registry_with_cves_sync(nvd_api_key=nvd_api_key, dry_run=args.dry_run)
+
+    print(f"\nTotal servers: {result.total}")
+    print(f"Scannable (npm/pypi): {result.scannable}")
+    print(f"With CVEs: {result.enriched}")
+    print(f"Total CVEs found: {result.total_cves}")
+    print(f"Critical (EPSS >= 0.7 or KEV): {result.total_critical}")
+    print(f"In CISA KEV: {result.total_kev}")
+
+    if result.details:
+        print("\nVulnerable servers:")
+        for d in result.details:
+            kev_tag = " [KEV]" if d["kev"] else ""
+            print(f"  {d['server']}: {d['cve_count']} CVEs{kev_tag}")
+            if d["cves"]:
+                print(f"    {', '.join(d['cves'][:5])}")
+
+    if not args.dry_run and result.enriched > 0:
+        print("\nRegistry file updated with CVE data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -3846,6 +3846,54 @@ def registry_enrich(dry_run):
         con.print("[green]Registry file updated.[/green]")
 
 
+@registry.command("enrich-cves")
+@click.option("--nvd-api-key", envvar="NVD_API_KEY", default=None, help="NVD API key for higher rate limits.")
+@click.option("--dry-run", is_flag=True, help="Preview CVE enrichment without writing.")
+def registry_enrich_cves(nvd_api_key, dry_run):
+    """Enrich registry with CVE data from OSV, EPSS, and CISA KEV.
+
+    \b
+    Scans all npm/pypi packages in the registry for known vulnerabilities:
+    - Queries OSV batch API for CVEs affecting each package version
+    - Fetches EPSS exploit prediction scores
+    - Checks CISA KEV (Known Exploited Vulnerabilities) catalog
+    - Extracts fix versions from OSV affected ranges
+
+    \b
+    Example:
+      agent-bom registry enrich-cves
+      agent-bom registry enrich-cves --dry-run
+    """
+    from rich.console import Console
+
+    from agent_bom.registry import enrich_registry_with_cves_sync
+
+    con = Console(stderr=True)
+    con.print("[bold]Enriching registry with CVE data (OSV + EPSS + KEV)...[/bold]")
+    if dry_run:
+        con.print("[dim](dry run — no files will be modified)[/dim]")
+
+    result = enrich_registry_with_cves_sync(nvd_api_key=nvd_api_key, dry_run=dry_run)
+
+    if result.enriched:
+        con.print(f"\n[bold red]Found vulnerabilities in {result.enriched} server(s):[/bold red]")
+        for d in result.details:
+            kev_tag = " [KEV]" if d["kev"] else ""
+            con.print(f"  {d['server']}: {d['cve_count']} CVEs, {d['ghsa_count']} GHSAs{kev_tag}")
+            if d["cves"]:
+                con.print(f"    {', '.join(d['cves'][:5])}")
+    else:
+        con.print("\n[green]No known CVEs found in scannable registry packages.[/green]")
+
+    con.print(
+        f"\n[bold]Summary:[/bold] {result.scannable} scannable, {result.enriched} with CVEs, "
+        f"{result.total_cves} total CVEs, {result.total_critical} critical, {result.total_kev} KEV "
+        f"(of {result.total} total servers)"
+    )
+    if not dry_run and result.enriched > 0:
+        con.print("[green]Registry file updated with CVE data.[/green]")
+
+
 @registry.command("smithery-sync")
 @click.option("--token", envvar="SMITHERY_API_KEY", help="Smithery API key (or set SMITHERY_API_KEY).")
 @click.option("--max-pages", type=int, default=10, show_default=True, help="Maximum pages to fetch from Smithery.")

--- a/src/agent_bom/registry.py
+++ b/src/agent_bom/registry.py
@@ -508,3 +508,219 @@ def enrich_registry_entries(dry_run: bool = False) -> EnrichResult:
         _REGISTRY_PATH.write_text(json.dumps(data, indent=2) + "\n")
 
     return result
+
+
+# ─── CVE enrichment via OSV + EPSS + KEV ────────────────────────────────────
+
+
+@dataclass
+class CVEEnrichResult:
+    """Result of registry CVE enrichment."""
+
+    total: int = 0
+    scannable: int = 0
+    enriched: int = 0
+    total_cves: int = 0
+    total_critical: int = 0
+    total_kev: int = 0
+    details: list[dict] = field(default_factory=list)
+
+
+async def enrich_registry_with_cves(
+    nvd_api_key: Optional[str] = None,
+    dry_run: bool = False,
+) -> CVEEnrichResult:
+    """Enrich registry entries with CVE data from OSV, EPSS, and CISA KEV.
+
+    For each npm/pypi package in the registry:
+    1. Query OSV batch API for known vulnerabilities
+    2. Fetch EPSS exploit prediction scores
+    3. Check CISA KEV (Known Exploited Vulnerabilities) catalog
+    4. Store summary in registry entry
+
+    Args:
+        nvd_api_key: Optional NVD API key for higher rate limits.
+        dry_run: If True, preview without writing.
+
+    Returns:
+        CVEEnrichResult with counts and per-entry details.
+    """
+    from agent_bom.enrichment import fetch_cisa_kev_catalog, fetch_epss_scores
+    from agent_bom.http_client import create_client
+    from agent_bom.models import Package
+    from agent_bom.scanners import ECOSYSTEM_MAP, query_osv_batch
+
+    data = _load_registry_full()
+    servers = data.get("servers", {})
+    result = CVEEnrichResult(total=len(servers))
+
+    # Build Package objects for scannable entries (npm/pypi only)
+    pkg_to_servers: dict[str, list[str]] = {}
+    packages: list[Package] = []
+
+    for name, entry in servers.items():
+        ecosystem = entry.get("ecosystem", "")
+        if ecosystem not in ECOSYSTEM_MAP:
+            continue
+        pkg_name = entry.get("package", name)
+        version = entry.get("latest_version", "")
+        if not version or version in ("unknown", "latest"):
+            continue
+
+        result.scannable += 1
+        key = f"{ecosystem}:{pkg_name}@{version}"
+        pkg_to_servers.setdefault(key, []).append(name)
+
+        # Avoid duplicate queries for same package
+        if len(pkg_to_servers[key]) == 1:
+            packages.append(Package(name=pkg_name, version=version, ecosystem=ecosystem))
+
+    if not packages:
+        return result
+
+    # 1. Query OSV for vulnerabilities
+    osv_results = await query_osv_batch(packages)
+
+    # Collect all CVE IDs for EPSS/KEV enrichment
+    all_cve_ids: list[str] = []
+    for vulns in osv_results.values():
+        for v in vulns:
+            for alias in v.get("aliases", []):
+                if alias.startswith("CVE-"):
+                    all_cve_ids.append(alias)
+            vid = v.get("id", "")
+            if vid.startswith("CVE-"):
+                all_cve_ids.append(vid)
+    all_cve_ids = list(set(all_cve_ids))
+
+    # 2. Fetch EPSS scores and KEV catalog
+    epss_scores: dict[str, dict] = {}
+    kev_catalog: dict = {}
+    if all_cve_ids:
+        async with create_client(timeout=30.0) as client:
+            epss_scores = await fetch_epss_scores(all_cve_ids, client)
+            kev_catalog = await fetch_cisa_kev_catalog(client)
+
+    # 3. Update registry entries
+    for name, entry in servers.items():
+        ecosystem = entry.get("ecosystem", "")
+        if ecosystem not in ECOSYSTEM_MAP:
+            continue
+        pkg_name = entry.get("package", name)
+        version = entry.get("latest_version", "")
+        if not version or version in ("unknown", "latest"):
+            continue
+
+        key = f"{ecosystem}:{pkg_name}@{version}"
+        vulns = osv_results.get(key, [])
+
+        if not vulns:
+            if not dry_run and entry.get("known_cves"):
+                entry["known_cves"] = []
+                entry["cve_summary"] = {}
+            continue
+
+        # Extract CVE/GHSA IDs and severity info
+        cve_ids: list[str] = []
+        ghsa_ids: list[str] = []
+        severities: list[str] = []
+
+        for v in vulns:
+            vid = v.get("id", "")
+            if vid.startswith("GHSA-"):
+                ghsa_ids.append(vid)
+            for alias in v.get("aliases", []):
+                if alias.startswith("CVE-") and alias not in cve_ids:
+                    cve_ids.append(alias)
+                elif alias.startswith("GHSA-") and alias not in ghsa_ids:
+                    ghsa_ids.append(alias)
+            if vid.startswith("CVE-") and vid not in cve_ids:
+                cve_ids.append(vid)
+
+            for sev in v.get("severity", []):
+                if "CVSS" in sev.get("type", ""):
+                    try:
+                        base = float(sev.get("score", "0").split("/")[0].split(":")[-1])
+                        if base >= 9.0:
+                            severities.append("critical")
+                        elif base >= 7.0:
+                            severities.append("high")
+                        elif base >= 4.0:
+                            severities.append("medium")
+                        else:
+                            severities.append("low")
+                    except (ValueError, IndexError):
+                        pass
+
+        # Count EPSS high-risk and KEV entries
+        critical_count = 0
+        kev_count = 0
+        for cve_id in cve_ids:
+            epss = epss_scores.get(cve_id, {})
+            is_kev = cve_id in kev_catalog
+            if epss.get("score", 0.0) >= 0.7 or is_kev:
+                critical_count += 1
+            if is_kev:
+                kev_count += 1
+
+        # Extract fix versions from OSV affected ranges
+        fix_versions: list[str] = []
+        for v in vulns:
+            for affected in v.get("affected", []):
+                for rng in affected.get("ranges", []):
+                    for event in rng.get("events", []):
+                        if "fixed" in event and event["fixed"] not in fix_versions:
+                            fix_versions.append(event["fixed"])
+
+        summary = {
+            "total": len(cve_ids),
+            "ghsa_count": len(ghsa_ids),
+            "critical": critical_count,
+            "kev": kev_count,
+            "severity_breakdown": {
+                "critical": severities.count("critical"),
+                "high": severities.count("high"),
+                "medium": severities.count("medium"),
+                "low": severities.count("low"),
+            },
+            "fix_available": len(fix_versions) > 0,
+            "fix_versions": fix_versions[:5],
+        }
+
+        if not dry_run:
+            entry["known_cves"] = cve_ids + [g for g in ghsa_ids if g not in cve_ids]
+            entry["cve_summary"] = summary
+
+        result.enriched += 1
+        result.total_cves += len(cve_ids)
+        result.total_critical += critical_count
+        result.total_kev += kev_count
+        result.details.append(
+            {
+                "server": name,
+                "package": pkg_name,
+                "cve_count": len(cve_ids),
+                "ghsa_count": len(ghsa_ids),
+                "critical": critical_count,
+                "kev": kev_count,
+                "cves": cve_ids[:10],
+            }
+        )
+
+    # Write updated registry
+    if not dry_run and result.enriched > 0:
+        from datetime import datetime, timezone
+
+        data["_cve_enriched"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        _REGISTRY_PATH.write_text(json.dumps(data, indent=2) + "\n")
+
+    return result
+
+
+def enrich_registry_with_cves_sync(
+    nvd_api_key: Optional[str] = None,
+    dry_run: bool = False,
+) -> CVEEnrichResult:
+    """Sync wrapper for enrich_registry_with_cves."""
+    return asyncio.run(enrich_registry_with_cves(nvd_api_key=nvd_api_key, dry_run=dry_run))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -376,8 +376,11 @@ def test_cli_registry_search_no_match():
 
 def test_version_drift_dataclass():
     d = VersionDrift(
-        package="test", ecosystem="npm",
-        installed="1.0.0", latest="2.0.0", status="outdated",
+        package="test",
+        ecosystem="npm",
+        installed="1.0.0",
+        latest="2.0.0",
+        status="outdated",
     )
     assert d.package == "test"
     assert d.status == "outdated"
@@ -455,3 +458,170 @@ def test_new_servers_present():
     ]
     for key in expected_new:
         assert key in ids, f"Missing new server: {key}"
+
+
+# ── CVE enrichment ─────────────────────────────────────────────────────────
+
+
+def test_cve_enrich_result_dataclass():
+    from agent_bom.registry import CVEEnrichResult
+
+    r = CVEEnrichResult(total=10, scannable=5, enriched=2, total_cves=3)
+    assert r.total == 10
+    assert r.scannable == 5
+    assert r.enriched == 2
+    assert r.total_cves == 3
+    assert r.total_critical == 0
+    assert r.total_kev == 0
+    assert r.details == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_registry_with_cves_empty_registry():
+    """Enrichment returns zero results on empty registry."""
+    from agent_bom.registry import enrich_registry_with_cves
+
+    with patch("agent_bom.registry._load_registry_full", return_value={"servers": {}}):
+        result = await enrich_registry_with_cves(dry_run=True)
+    assert result.total == 0
+    assert result.scannable == 0
+    assert result.enriched == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_registry_with_cves_no_scannable():
+    """Entries with unsupported ecosystems are skipped."""
+    from agent_bom.registry import enrich_registry_with_cves
+
+    registry = {
+        "servers": {
+            "test-server": {
+                "package": "test",
+                "ecosystem": "mcp-registry",
+                "latest_version": "1.0.0",
+            }
+        }
+    }
+    with patch("agent_bom.registry._load_registry_full", return_value=registry):
+        result = await enrich_registry_with_cves(dry_run=True)
+    assert result.total == 1
+    assert result.scannable == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_registry_with_cves_with_vulns():
+    """Entries with OSV results get CVE data populated."""
+    from agent_bom.registry import enrich_registry_with_cves
+
+    registry = {
+        "servers": {
+            "vuln-server": {
+                "package": "vuln-pkg",
+                "ecosystem": "npm",
+                "latest_version": "1.0.0",
+            }
+        }
+    }
+    osv_vulns = {
+        "npm:vuln-pkg@1.0.0": [
+            {
+                "id": "GHSA-xxxx-yyyy-zzzz",
+                "aliases": ["CVE-2024-12345"],
+                "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+                "affected": [
+                    {
+                        "ranges": [
+                            {
+                                "type": "SEMVER",
+                                "events": [{"introduced": "0"}, {"fixed": "1.0.1"}],
+                            }
+                        ]
+                    }
+                ],
+            }
+        ],
+    }
+
+    with (
+        patch("agent_bom.registry._load_registry_full", return_value=registry),
+        patch("agent_bom.scanners.query_osv_batch", new_callable=AsyncMock, return_value=osv_vulns),
+        patch(
+            "agent_bom.enrichment.fetch_epss_scores",
+            new_callable=AsyncMock,
+            return_value={
+                "CVE-2024-12345": {"score": 0.85, "percentile": 0.95, "date": "2024-01-01"},
+            },
+        ),
+        patch("agent_bom.enrichment.fetch_cisa_kev_catalog", new_callable=AsyncMock, return_value={}),
+    ):
+        result = await enrich_registry_with_cves(dry_run=True)
+
+    assert result.enriched == 1
+    assert result.total_cves == 1
+    assert result.total_critical == 1  # EPSS >= 0.7
+    assert result.details[0]["cves"] == ["CVE-2024-12345"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_registry_with_cves_kev_detection():
+    """CVEs in CISA KEV catalog are flagged."""
+    from agent_bom.registry import enrich_registry_with_cves
+
+    registry = {
+        "servers": {
+            "kev-server": {
+                "package": "kev-pkg",
+                "ecosystem": "pypi",
+                "latest_version": "2.0.0",
+            }
+        }
+    }
+    osv_vulns = {
+        "pypi:kev-pkg@2.0.0": [
+            {"id": "CVE-2024-99999", "aliases": [], "severity": [], "affected": []},
+        ],
+    }
+
+    with (
+        patch("agent_bom.registry._load_registry_full", return_value=registry),
+        patch("agent_bom.scanners.query_osv_batch", new_callable=AsyncMock, return_value=osv_vulns),
+        patch("agent_bom.enrichment.fetch_epss_scores", new_callable=AsyncMock, return_value={}),
+        patch(
+            "agent_bom.enrichment.fetch_cisa_kev_catalog",
+            new_callable=AsyncMock,
+            return_value={
+                "CVE-2024-99999": {"date_added": "2024-06-01"},
+            },
+        ),
+    ):
+        result = await enrich_registry_with_cves(dry_run=True)
+
+    assert result.enriched == 1
+    assert result.total_kev == 1
+    assert result.total_critical == 1  # KEV = critical
+
+
+@pytest.mark.asyncio
+async def test_enrich_registry_with_cves_no_vulns():
+    """Clean packages result in zero enrichment."""
+    from agent_bom.registry import enrich_registry_with_cves
+
+    registry = {
+        "servers": {
+            "clean-server": {
+                "package": "clean-pkg",
+                "ecosystem": "npm",
+                "latest_version": "3.0.0",
+            }
+        }
+    }
+
+    with (
+        patch("agent_bom.registry._load_registry_full", return_value=registry),
+        patch("agent_bom.scanners.query_osv_batch", new_callable=AsyncMock, return_value={}),
+    ):
+        result = await enrich_registry_with_cves(dry_run=True)
+
+    assert result.scannable == 1
+    assert result.enriched == 0
+    assert result.total_cves == 0


### PR DESCRIPTION
## Summary

- New `enrich_registry_with_cves()` function — queries OSV batch API for all 112 npm/pypi packages in the registry, enriches with EPSS exploit prediction scores and CISA KEV status
- New CLI command: `agent-bom registry enrich-cves` (with `--dry-run` and `--nvd-api-key`)
- New script: `scripts/enrich_registry_cves.py` for CI/CD automation
- Updated weekly `mcp-registry-sync.yml` workflow to include CVE enrichment step
- 6 new tests covering all enrichment paths

### What this enables

Each registry entry now gets:
- `known_cves`: list of CVE/GHSA IDs
- `cve_summary`: total count, severity breakdown (critical/high/medium/low), EPSS high-risk count, CISA KEV count, fix availability, fix versions

### Before → After

| Metric | Before | After |
|--------|--------|-------|
| Servers with CVE data | 1 (OpenClaw only) | All 112 npm/pypi servers |
| Data sources | Manual | OSV + EPSS + CISA KEV (automated) |
| Refresh cadence | Never | Weekly via GitHub Action |

## Test plan

- [x] `pytest tests/test_registry.py -x -q` — 51 passed
- [x] `pytest tests/test_core.py tests/test_mcp_server.py -x -q` — 272 passed
- [x] `ruff check` — all clean
- [ ] CI passes
- [ ] Manual: `agent-bom registry enrich-cves --dry-run`