### PR TITLE
fix: sync test count (6,100+) and add runtime security docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,37 @@ Blocks on critical/high CVEs by default. Use `--allow-risky` to install anyway w
 </details>
 
 <details>
+<summary><b>Runtime security — proxy, protect, watch</b></summary>
+
+Three runtime modes for continuous MCP security. Each must be explicitly configured per-server — agent-bom is not an endpoint agent.
+
+**Proxy** — intercept all MCP JSON-RPC traffic between client and server. Policy enforcement, credential leak detection, replay detection, rate limiting, JSONL audit log, Prometheus metrics.
+
+```bash
+agent-bom proxy -- npx @modelcontextprotocol/server-filesystem /tmp
+agent-bom proxy --policy policy.json --log audit.jsonl -- npx @mcp/server-github
+agent-bom proxy --detect-credentials --block-undeclared -- npx @mcp/server-postgres
+```
+
+**Protect** — 5-detector anomaly engine. Accepts OTel traces or runs as HTTP sidecar. Detects tool drift (rug pulls), shell injection in arguments, credential leaks in responses, rate anomalies, and suspicious call sequences (exfiltration patterns).
+
+```bash
+echo '{"tool_name":"exec","arguments":{"cmd":"rm -rf /"}}' | agent-bom protect
+cat otel-export.jsonl | agent-bom protect --alert-file alerts.jsonl
+agent-bom protect --mode http --port 8423    # HTTP sidecar
+```
+
+**Watch** — filesystem watchers on MCP config files. Re-scans on change, diffs against last scan, sends alerts on new servers/vulns/credentials.
+
+```bash
+agent-bom watch                                           # monitor all discovered configs
+agent-bom watch --webhook https://hooks.slack.com/...     # alert to Slack
+agent-bom watch --log alerts.jsonl                        # alert to file
+```
+
+</details>
+
+<details>
 <summary><b>Registry sync</b></summary>
 
 Keep the local MCP server registry current with live sources:

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 3,100+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 6,100+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 107 modules · 3,100+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 6,100+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  2,950+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  6,100+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  2,950+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  6,100+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#484f58">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,950+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  6,100+ tests  ·  0 runtime deps</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#94a3b8">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  107 modules  ·  2,950+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  6,100+ tests  ·  0 runtime deps</text>
 </svg>

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   pypi: https://pypi.org/project/agent-bom/
   smithery: https://smithery.ai/server/agent-bom/agent-bom
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 3100
+  tests: 6100
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -237,6 +237,6 @@ used when you explicitly set them. They are never auto-discovered or inferred.
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: [smithery.ai/server/agent-bom](https://smithery.ai/server/agent-bom/agent-bom)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.56.0`
-- **3,100+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
+- **6,100+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics


### PR DESCRIPTION
## Summary
- Fix stale test count across 6 SVG diagrams and SKILL.md (3,100→6,100+, actual grep count: 6,194)
- Fix stale module count in SVGs (107→132 non-init Python modules)
- Add Runtime Security section to README documenting proxy, protect, and watch modes with usage examples and honest deployment model (per-server, not endpoint agent)

## Test plan
- [ ] Verify SVG footers show updated counts
- [ ] Verify SKILL.md metadata and verification section updated
- [ ] Verify new README section renders correctly