### PR TITLE
fix: ClawHub trust + fail-loud registry publish

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -53,8 +53,8 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           if [ -z "$SMITHERY_API_TOKEN" ]; then
-            echo "::warning::SMITHERY_API_TOKEN not set — skipping Smithery publish"
-            exit 0
+            echo "::error::SMITHERY_API_TOKEN not set — cannot publish to Smithery"
+            exit 1
           fi
 
           QUALIFIED_NAME="agent-bom%2Fagent-bom"
@@ -87,7 +87,9 @@ jobs:
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
             echo "Smithery publish succeeded"
           else
-            echo "::warning::Smithery publish returned HTTP ${HTTP_STATUS} — check response above"
+            echo "::error::Smithery publish failed with HTTP ${HTTP_STATUS}"
+            cat /tmp/smithery-response.json
+            exit 1
           fi
 
   clawhub:
@@ -130,8 +132,8 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           if [ -z "$CLAWHUB_TOKEN" ]; then
-            echo "::warning::CLAWHUB_TOKEN not set — skipping ClawHub publish"
-            exit 0
+            echo "::error::CLAWHUB_TOKEN not set — cannot publish to ClawHub"
+            exit 1
           fi
 
           echo "Publishing agent-bom v${VERSION} to ClawHub..."
@@ -145,5 +147,6 @@ jobs:
             --changelog "Release v${VERSION}"; then
             echo "ClawHub publish succeeded"
           else
-            echo "::warning::ClawHub publish failed (version may already exist) — continuing"
+            echo "::error::ClawHub publish failed"
+            exit 1
           fi

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -31,6 +31,11 @@ metadata:
       - NVD_API_KEY
       - SNYK_TOKEN
       - AGENT_BOM_CLICKHOUSE_URL
+      - AWS_PROFILE
+      - AWS_DEFAULT_REGION
+      - SNOWFLAKE_ACCOUNT
+      - SNOWFLAKE_USER
+      - SNOWFLAKE_PASSWORD
     optional_bins:
       - syft
       - grype
@@ -46,6 +51,8 @@ metadata:
       - linux
       - windows
     file_reads_note: "Reads server names and command paths only — never credentials, tokens, or env var values"
+    credential_handling: "Config files are parsed for JSON keys (mcpServers.*.command, mcpServers.*.args) only. Env var blocks are skipped entirely. Values of env, API keys, tokens, and passwords are never read, stored, or transmitted. Cloud credentials (AWS, Snowflake) are only used when user explicitly runs cis_benchmark with those providers."
+    data_flow: "All scanning is local-first. Network calls go only to public vuln databases (OSV, NVD, EPSS). The SSE endpoint is never auto-contacted — requires explicit user configuration. No discovery data leaves the machine unless the user configures a remote endpoint."
     file_reads:
       - "~/.cursor/mcp.json"
       - "~/Library/Application Support/Claude/claude_desktop_config.json"
@@ -72,8 +79,10 @@ metadata:
         purpose: "Snyk vulnerability enrichment (requires SNYK_TOKEN)"
         auth: true
       - url: "https://agent-bom-mcp.up.railway.app/sse"
-        purpose: "Optional remote MCP endpoint — local-first scanning recommended"
+        purpose: "Optional remote MCP endpoint — never contacted unless user explicitly configures it. Local-first scanning recommended. Only receives tool call arguments (package names, CVE IDs), never config files or credentials."
         auth: false
+        opt_in: true
+        auto_contacted: false
     telemetry: false
     persistence: false
     privilege_escalation: false
@@ -215,6 +224,15 @@ client config. It is never contacted during normal local operation.
 
 Optional tokens (NVD_API_KEY, SNYK_TOKEN, AGENT_BOM_CLICKHOUSE_URL) are only
 used when you explicitly set them. They are never auto-discovered or inferred.
+
+### Cloud credentials (CIS benchmarks)
+
+The `cis_benchmark` tool for AWS uses standard AWS SDK credential chain
+(AWS_PROFILE, AWS_DEFAULT_REGION) and for Snowflake uses SNOWFLAKE_ACCOUNT,
+SNOWFLAKE_USER, SNOWFLAKE_PASSWORD. These are **only used when you explicitly
+invoke `cis_benchmark`** with those providers — they are never read during
+normal scanning, discovery, or any other tool call. If not set, the tool
+returns an error asking you to configure them.
 
 ## Security Boundaries
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -4,7 +4,7 @@ Start with:
     agent-bom mcp-server              # stdio (for Claude Desktop, Cursor, etc.)
     agent-bom mcp-server --sse        # SSE transport (for remote clients)
 
-Tools (18):
+Tools (19):
     scan              — Full discovery → scan → output pipeline
     check             — Check a specific package for CVEs before installing
     blast_radius      — Look up blast radius for a specific CVE
@@ -23,6 +23,7 @@ Tools (18):
     context_graph     — Agent context graph with lateral movement analysis
     analytics_query   — Query vulnerability trends and runtime events from ClickHouse
     cis_benchmark     — Run CIS benchmark checks against AWS or Snowflake accounts
+    fleet_scan        — Batch registry lookup for fleet inventories
 
 Resources (2):
     registry://servers  — Browse 427+ server security metadata registry


### PR DESCRIPTION
## Summary

- **ClawHub trust**: Address all 5 "Suspicious" findings by declaring cloud credentials, SSE opt-in status, and credential handling explicitly in SKILL.md metadata
- **Registry publish**: Change `publish-registries.yml` from silent warnings to hard failures (`exit 1`) when tokens are missing or API calls fail — this is why Smithery stayed on old versions
- **Docstring**: Update mcp_server.py tool count 18→19

## What was broken

| Platform | Root cause | Fix |
|----------|-----------|-----|
| Smithery | API returned HTTP 500 but workflow only warned, stayed green | `exit 1` on non-2xx |
| ClawHub | `CLAWHUB_TOKEN` missing but workflow silently skipped | `exit 1` on missing token |
| ClawHub trust | Undeclared cloud creds, SSE endpoint flagged | `optional_env`, `credential_handling`, `data_flow`, `opt_in` fields |

## Test plan

- [x] SKILL.md YAML frontmatter parses correctly
- [x] Workflow changes are syntactically valid
- [x] ruff lint clean
- [ ] After merge: add `CLAWHUB_TOKEN` + `SMITHERY_API_TOKEN` to repo secrets, re-run `publish-registries` workflow