### PR TITLE
fix: Glama license detection + cloud security skill feedback loop

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,16 +2,198 @@
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-       http://www.apache.org/licenses/LICENSE-2.0
+   1. Definitions.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-   Copyright 2026 Wagdy Saad
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an information
+      on the current year for the copyright.
+
+      Copyright 2024 Wagdy Saad
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "msaad00"
+  ]
+}

--- a/skills/cloud-security-audit.md
+++ b/skills/cloud-security-audit.md
@@ -36,24 +36,35 @@
  │                 │  Target Accounts       │         │ Lambda Execution    │             │
  │                 │                        │         │ Logs S3             │             │
  │                 │  1. Revoke all creds   │         │ (audit trail)       │             │
- │                 │  2. Strip all perms    │         └─────────────────────┘             │
- │                 │  3. Quarantine & delete│                                             │
- │                 └───────────────────────┘                                              │
+ │                 │  2. Strip all perms    │         └──────────┬──────────┘             │
+ │                 │  3. Quarantine & delete│                    │                        │
+ │                 └───────────────────────┘                     │                        │
+ │                                                               ▼                        │
+ │                                                  ┌─────────────────────┐               │
+ │                                                  │ Analytics / DW      │               │
+ │                                                  │ (Snowflake,         │               │
+ │                                                  │  ClickHouse, DBX,   │               │
+ │                                                  │  or S3 archive)     │               │
+ │                                                  │                     │               │
+ │                                                  │ Remediation history │               │
+ │                                                  │ Posture metrics     │               │
+ │                                                  │ Compliance evidence │               │
+ │                                                  └─────────────────────┘               │
  └──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Data Flow — Step by Step
 
 ```
-  STEP 1                STEP 2              STEP 3              STEP 4              STEP 5
- ┌─────────┐          ┌─────────┐         ┌──────────┐        ┌──────────┐        ┌──────────┐
- │Snowflake│          │   S3    │         │EventBrdge│        │  Parser  │        │  Worker  │
- │  Task   │─────────▶│ Bucket  │────────▶│  Rule    │───────▶│  Lambda  │───────▶│  Lambda  │
- └─────────┘          └─────────┘         └──────────┘        └──────────┘        └──────────┘
-  Scheduled            JSON/Parquet        S3 PutObject         Parse export        Cross-account
-  query joins          departed            triggers rule        Match IAM to        IAM actions on
-  IAM + HR data        employee IAM        in EventBridge       departed list       target accounts
-                       export                                   Identify targets    Revoke + strip
+  STEP 1                STEP 2              STEP 3              STEP 4              STEP 5              STEP 6
+ ┌─────────┐          ┌─────────┐         ┌──────────┐        ┌──────────┐        ┌──────────┐        ┌──────────┐
+ │Snowflake│          │   S3    │         │EventBrdge│        │  Parser  │        │  Worker  │        │ Logs S3  │
+ │  Task   │─────────▶│ Bucket  │────────▶│  Rule    │───────▶│  Lambda  │───────▶│  Lambda  │───────▶│ → DW     │
+ └─────────┘          └─────────┘         └──────────┘        └──────────┘        └──────────┘        └──────────┘
+  Scheduled            JSON/Parquet        S3 PutObject         Parse export        Cross-account       Audit logs
+  query joins          departed            triggers rule        Match IAM to        IAM actions on      feed back to
+  IAM + HR data        employee IAM        in EventBridge       departed list       target accounts     Snowflake/CH/
+                       export                                   Identify targets    Revoke + strip      DBX for analytics
 ```
 
 ### Step 1 — Snowflake Task (Scheduled Query)
@@ -255,7 +266,37 @@ The assumed role in each target account has:
 }
 ```
 
-### Step 6 — Validate with agent-bom
+### Step 6 — Audit Logs → Analytics / Data Warehouse
+
+Lambda execution logs land in S3, then feed back into your data warehouse for historical analytics, compliance evidence, and posture tracking.
+
+```
+  Lambda Execution Logs S3
+         │
+         ├──▶ Snowflake (external stage → COPY INTO remediation_log)
+         ├──▶ ClickHouse (S3 table function → INSERT INTO remediation_log)
+         ├──▶ Databricks (Auto Loader → Delta table)
+         └──▶ S3 archive (Athena queries for ad-hoc analysis)
+```
+
+This closes the loop: the same warehouse that sourced the departed employee data now stores the remediation results. You can track:
+- **Remediation velocity** — time from termination to IAM cleanup
+- **Coverage gaps** — departed employees whose IAM was missed
+- **Posture trend** — orphaned IAM count over time
+- **Compliance evidence** — auditor-ready logs of every action taken
+
+```sql
+-- Snowflake: remediation dashboard query
+SELECT
+    DATE_TRUNC('week', remediation_time) AS week,
+    COUNT(*) AS resources_remediated,
+    AVG(DATEDIFF('hour', termination_date, remediation_time)) AS avg_hours_to_remediate
+FROM remediation_log
+GROUP BY 1
+ORDER BY 1 DESC;
+```
+
+### Step 7 — Validate with agent-bom
 
 After the workflow completes, validate the security posture:
 


### PR DESCRIPTION
## Summary
- **LICENSE**: Replaced truncated notice with full Apache 2.0 text. GitHub API was returning `NOASSERTION` because it couldn't match the short header. This caused Glama to show "F" for license and "Missing LICENSE".
- **glama.json**: Added to repo root with `$schema` and `maintainers` field. Glama Score page was flagging "Missing or invalid glama.json".
- **cloud-security-audit.md**: Added Step 6 — Lambda execution logs S3 feeds back to data warehouse (Snowflake/ClickHouse/DBX/S3) for remediation analytics, posture tracking, and compliance evidence. Updated architecture diagram with feedback loop.

## Test plan
- [ ] After merge, verify GitHub shows "Apache-2.0" in repo sidebar (may take a few minutes)
- [ ] Trigger Glama redeploy/rescan — license score should change from F to A
- [ ] Verify glama.json is detected by Glama Score page