### PR TITLE
fix: redesign modes diagram + correct cloud-security-audit architecture

### DIFF
--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -1,407 +1,241 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1060 780" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 720" fill="none">
   <style>
-    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
-    .mode-title { font: 700 11px system-ui, -apple-system, sans-serif; }
-    .mode-sub { font: 500 9.5px system-ui, -apple-system, sans-serif; fill: #8b949e; }
-    .step { font: 600 9px system-ui, -apple-system, sans-serif; fill: #c9d1d9; }
-    .step-detail { font: 400 8px system-ui, -apple-system, sans-serif; fill: #6e7681; }
+    .title { font: 700 16px system-ui, -apple-system, sans-serif; fill: #e6edf3; }
+    .subtitle { font: 500 10px system-ui, -apple-system, sans-serif; fill: #6e7681; }
+    .mode-title { font: 700 12px system-ui, -apple-system, sans-serif; }
+    .mode-cmd { font: 600 9.5px 'SF Mono', 'Fira Code', monospace; fill: #d2a8ff; }
+    .mode-feat { font: 500 9.5px system-ui, -apple-system, sans-serif; fill: #c9d1d9; }
+    .mode-detail { font: 400 8.5px system-ui, -apple-system, sans-serif; fill: #6e7681; }
     .badge { font: 700 8px system-ui, -apple-system, sans-serif; fill: #0d1117; }
+    .engine-title { font: 700 11px system-ui, -apple-system, sans-serif; letter-spacing: 0.06em; fill: #8b949e; }
+    .engine-mod { font: 600 9.5px system-ui, -apple-system, sans-serif; }
+    .engine-detail { font: 400 8px system-ui, -apple-system, sans-serif; fill: #6e7681; }
     .section-label { font: 700 9px system-ui, -apple-system, sans-serif; letter-spacing: 0.08em; }
     .footer { font: 500 9px system-ui, -apple-system, sans-serif; fill: #6e7681; }
-    .connector { fill: none; stroke-width: 1.5; }
-    .cmd { font: 600 9px 'SF Mono', 'Fira Code', monospace; fill: #d2a8ff; }
+    .deploy-label { font: 600 9px system-ui, -apple-system, sans-serif; }
+    .deploy-detail { font: 400 8px system-ui, -apple-system, sans-serif; fill: #6e7681; }
   </style>
   <defs>
-    <marker id="arr-blue" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#58a6ff" opacity="0.7"/>
-    </marker>
-    <marker id="arr-green" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#3fb950" opacity="0.7"/>
-    </marker>
-    <marker id="arr-purple" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#bc8cff" opacity="0.7"/>
-    </marker>
-    <marker id="arr-orange" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#f0883e" opacity="0.7"/>
-    </marker>
-    <marker id="arr-red" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#f85149" opacity="0.7"/>
-    </marker>
-    <marker id="arr-yellow" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#d29922" opacity="0.7"/>
+    <marker id="arr-down" viewBox="0 0 8 8" refX="4" refY="7" markerWidth="6" markerHeight="6" orient="auto">
+      <polygon points="0 0, 8 0, 4 8" fill="#30363d" opacity="0.6"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="1060" height="780" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
-  <text x="530" y="30" text-anchor="middle" class="title">How agent-bom Works — Mode by Mode</text>
+  <rect width="960" height="720" rx="12" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="480" y="32" text-anchor="middle" class="title">How agent-bom Works</text>
+  <text x="480" y="48" text-anchor="middle" class="subtitle">Six modes, one shared engine — every mode uses the same core scanning pipeline</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 1: CLI Scan (blue) -->
+  <!-- MODE CARDS — 3x2 grid, simplified -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="50" width="500" height="108" rx="8" fill="#161b22" stroke="#58a6ff" stroke-width="1.2"/>
-  <rect x="16" y="50" width="500" height="4" rx="2" fill="#58a6ff"/>
-  <rect x="28" y="62" width="32" height="16" rx="4" fill="#58a6ff"/>
-  <text x="44" y="74" text-anchor="middle" class="badge">CLI</text>
-  <text x="70" y="74" class="mode-title" fill="#58a6ff">Local Scan</text>
-  <text x="28" y="92" class="cmd">agent-bom scan [--image] [--sbom cyclonedx]</text>
 
-  <!-- Flow steps -->
-  <rect x="28" y="102" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="67" y="116" text-anchor="middle" class="step">Discovery</text>
-  <text x="67" y="126" text-anchor="middle" class="step-detail">20 MCP clients</text>
+  <!-- MODE 1: CLI Scan (blue) — top left -->
+  <rect x="20" y="66" width="300" height="120" rx="8" fill="#161b22" stroke="#58a6ff" stroke-width="1.2"/>
+  <rect x="20" y="66" width="300" height="3" rx="1.5" fill="#58a6ff"/>
+  <rect x="32" y="80" width="30" height="15" rx="4" fill="#58a6ff"/>
+  <text x="47" y="91" text-anchor="middle" class="badge">CLI</text>
+  <text x="72" y="91" class="mode-title" fill="#58a6ff">Local Scan</text>
+  <text x="32" y="108" class="mode-cmd">agent-bom scan [--image] [--sbom]</text>
+  <text x="32" y="124" class="mode-feat">Discover 20 MCP clients + cloud infra</text>
+  <text x="32" y="138" class="mode-feat">CVE scan with OSV, NVD, Grype, Syft</text>
+  <text x="32" y="152" class="mode-feat">Blast radius: CVE → server → creds → tools</text>
+  <text x="308" y="178" text-anchor="end" class="mode-detail">JSON / CycloneDX / SPDX / SARIF / HTML</text>
 
-  <line x1="108" y1="115" x2="122" y2="115" class="connector" stroke="#58a6ff" marker-end="url(#arr-blue)"/>
+  <!-- MODE 2: MCP Server (purple) — top center -->
+  <rect x="330" y="66" width="300" height="120" rx="8" fill="#161b22" stroke="#bc8cff" stroke-width="1.2"/>
+  <rect x="330" y="66" width="300" height="3" rx="1.5" fill="#bc8cff"/>
+  <rect x="342" y="80" width="34" height="15" rx="4" fill="#bc8cff"/>
+  <text x="359" y="91" text-anchor="middle" class="badge">MCP</text>
+  <text x="386" y="91" class="mode-title" fill="#bc8cff">MCP Server — 19 Tools</text>
+  <text x="342" y="108" class="mode-cmd">agent-bom mcp-server [--transport sse]</text>
+  <text x="342" y="124" class="mode-feat">AI agents call scan, check, blast_radius</text>
+  <text x="342" y="138" class="mode-feat">Registry lookup for 427+ MCP servers</text>
+  <text x="342" y="152" class="mode-feat">Compliance, remediate, policy_check</text>
+  <text x="618" y="178" text-anchor="end" class="mode-detail">Glama · Smithery · ToolHive · Claude Desktop</text>
 
-  <rect x="124" y="102" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="160" y="116" text-anchor="middle" class="step">Parse</text>
-  <text x="160" y="126" text-anchor="middle" class="step-detail">configs + deps</text>
+  <!-- MODE 3: REST API (orange) — top right -->
+  <rect x="640" y="66" width="300" height="120" rx="8" fill="#161b22" stroke="#f0883e" stroke-width="1.2"/>
+  <rect x="640" y="66" width="300" height="3" rx="1.5" fill="#f0883e"/>
+  <rect x="652" y="80" width="30" height="15" rx="4" fill="#f0883e"/>
+  <text x="667" y="91" text-anchor="middle" class="badge">API</text>
+  <text x="692" y="91" class="mode-title" fill="#f0883e">REST API Server</text>
+  <text x="652" y="108" class="mode-cmd">agent-bom serve [--port 8422]</text>
+  <text x="652" y="124" class="mode-feat">50+ endpoints, token + IP rate limiting</text>
+  <text x="652" y="138" class="mode-feat">Webhook delivery: Jira, Slack, ServiceNow</text>
+  <text x="652" y="152" class="mode-feat">Dashboard backend + Snowflake integration</text>
+  <text x="928" y="178" text-anchor="end" class="mode-detail">OpenAPI spec · CORS · health checks</text>
 
-  <line x1="198" y1="115" x2="212" y2="115" class="connector" stroke="#58a6ff" marker-end="url(#arr-blue)"/>
+  <!-- MODE 4: Runtime Proxy (yellow) — bottom left -->
+  <rect x="20" y="196" width="300" height="120" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1.2"/>
+  <rect x="20" y="196" width="300" height="3" rx="1.5" fill="#d29922"/>
+  <rect x="32" y="210" width="44" height="15" rx="4" fill="#d29922"/>
+  <text x="54" y="221" text-anchor="middle" class="badge">PROXY</text>
+  <text x="86" y="221" class="mode-title" fill="#d29922">Runtime Proxy</text>
+  <text x="32" y="238" class="mode-cmd">agent-bom protect [--mode enforce]</text>
+  <text x="32" y="254" class="mode-feat">5 detectors: drift, injection, cred leak</text>
+  <text x="32" y="268" class="mode-feat">Policy enforcement on live MCP traffic</text>
+  <text x="32" y="282" class="mode-feat">Replay detection + sequence analysis</text>
+  <text x="308" y="308" text-anchor="end" class="mode-detail">Prometheus metrics · JSONL audit log</text>
 
-  <rect x="214" y="102" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="250" y="116" text-anchor="middle" class="step">Scan</text>
-  <text x="250" y="126" text-anchor="middle" class="step-detail">OSV + NVD</text>
+  <!-- MODE 5: GitHub Action (green) — bottom center -->
+  <rect x="330" y="196" width="300" height="120" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1.2"/>
+  <rect x="330" y="196" width="300" height="3" rx="1.5" fill="#3fb950"/>
+  <rect x="342" y="210" width="50" height="15" rx="4" fill="#3fb950"/>
+  <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
+  <text x="402" y="221" class="mode-title" fill="#3fb950">GitHub Action</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.57.0</text>
+  <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
+  <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
+  <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>
+  <text x="618" y="308" text-anchor="end" class="mode-detail">GitHub Marketplace · pass/fail gate</text>
 
-  <line x1="288" y1="115" x2="302" y2="115" class="connector" stroke="#58a6ff" marker-end="url(#arr-blue)"/>
-
-  <rect x="304" y="102" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="340" y="116" text-anchor="middle" class="step">Enrich</text>
-  <text x="340" y="126" text-anchor="middle" class="step-detail">EPSS + KEV</text>
-
-  <line x1="378" y1="115" x2="392" y2="115" class="connector" stroke="#58a6ff" marker-end="url(#arr-blue)"/>
-
-  <rect x="394" y="102" width="108" height="26" rx="4" fill="#0d1117" stroke="#58a6ff" stroke-width="1"/>
-  <text x="448" y="116" text-anchor="middle" class="step">Report</text>
-  <text x="448" y="126" text-anchor="middle" class="step-detail">JSON/CycloneDX/SPDX/SARIF</text>
-
-  <text x="504" y="150" text-anchor="end" class="mode-sub">Blast radius: CVE → server → creds → tools</text>
-
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 2: MCP Server (purple) -->
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="544" y="50" width="500" height="108" rx="8" fill="#161b22" stroke="#bc8cff" stroke-width="1.2"/>
-  <rect x="544" y="50" width="500" height="4" rx="2" fill="#bc8cff"/>
-  <rect x="556" y="62" width="40" height="16" rx="4" fill="#bc8cff"/>
-  <text x="576" y="74" text-anchor="middle" class="badge">MCP</text>
-  <text x="606" y="74" class="mode-title" fill="#bc8cff">MCP Server (19 tools)</text>
-  <text x="556" y="92" class="cmd">agent-bom mcp-server [--transport stdio|sse]</text>
-
-  <!-- Flow steps -->
-  <rect x="556" y="102" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="595" y="116" text-anchor="middle" class="step">AI Agent</text>
-  <text x="595" y="126" text-anchor="middle" class="step-detail">Claude, Cursor...</text>
-
-  <line x1="636" y1="115" x2="650" y2="115" class="connector" stroke="#bc8cff" marker-end="url(#arr-purple)"/>
-
-  <rect x="652" y="102" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="688" y="116" text-anchor="middle" class="step">MCP Call</text>
-  <text x="688" y="126" text-anchor="middle" class="step-detail">tool_name(args)</text>
-
-  <line x1="726" y1="115" x2="740" y2="115" class="connector" stroke="#bc8cff" marker-end="url(#arr-purple)"/>
-
-  <rect x="742" y="102" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="781" y="116" text-anchor="middle" class="step">Engine</text>
-  <text x="781" y="126" text-anchor="middle" class="step-detail">scan/check/blast</text>
-
-  <line x1="822" y1="115" x2="836" y2="115" class="connector" stroke="#bc8cff" marker-end="url(#arr-purple)"/>
-
-  <rect x="838" y="102" width="94" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="885" y="116" text-anchor="middle" class="step">JSON Result</text>
-  <text x="885" y="126" text-anchor="middle" class="step-detail">structured to agent</text>
-
-  <line x1="934" y1="115" x2="948" y2="115" class="connector" stroke="#bc8cff" marker-end="url(#arr-purple)"/>
-
-  <rect x="950" y="102" width="78" height="26" rx="4" fill="#0d1117" stroke="#bc8cff" stroke-width="1"/>
-  <text x="989" y="116" text-anchor="middle" class="step">Agent Acts</text>
-  <text x="989" y="126" text-anchor="middle" class="step-detail">remediate / fix</text>
-
-  <text x="1032" y="150" text-anchor="end" class="mode-sub">Glama, ToolHive, Smithery, Claude Desktop</text>
+  <!-- MODE 6: Dashboard (red) — bottom right -->
+  <rect x="640" y="196" width="300" height="120" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1.2"/>
+  <rect x="640" y="196" width="300" height="3" rx="1.5" fill="#f85149"/>
+  <rect x="652" y="210" width="68" height="15" rx="4" fill="#f85149"/>
+  <text x="686" y="221" text-anchor="middle" class="badge">DASHBOARD</text>
+  <text x="730" y="221" class="mode-title" fill="#f85149">Interactive Dashboard</text>
+  <text x="652" y="238" class="mode-cmd">agent-bom dashboard [--port 8501]</text>
+  <text x="652" y="254" class="mode-feat">15-section Streamlit UI with live scan</text>
+  <text x="652" y="268" class="mode-feat">Interactive blast radius graph</text>
+  <text x="652" y="282" class="mode-feat">Compliance scorecard + SBOM viewer</text>
+  <text x="928" y="308" text-anchor="end" class="mode-detail">Self-scan · export PDF / JSON / SBOM</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 3: REST API (orange) -->
+  <!-- CONNECTOR ARROWS: modes → engine -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="178" width="500" height="108" rx="8" fill="#161b22" stroke="#f0883e" stroke-width="1.2"/>
-  <rect x="16" y="178" width="500" height="4" rx="2" fill="#f0883e"/>
-  <rect x="28" y="190" width="32" height="16" rx="4" fill="#f0883e"/>
-  <text x="44" y="202" text-anchor="middle" class="badge">API</text>
-  <text x="70" y="202" class="mode-title" fill="#f0883e">REST API Server</text>
-  <text x="28" y="220" class="cmd">agent-bom serve [--port 8422] [--cors]</text>
-
-  <rect x="28" y="230" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="67" y="244" text-anchor="middle" class="step">HTTP Client</text>
-  <text x="67" y="254" text-anchor="middle" class="step-detail">curl / SDK / UI</text>
-
-  <line x1="108" y1="243" x2="122" y2="243" class="connector" stroke="#f0883e" marker-end="url(#arr-orange)"/>
-
-  <rect x="124" y="230" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="163" y="244" text-anchor="middle" class="step">FastAPI</text>
-  <text x="163" y="254" text-anchor="middle" class="step-detail">/v1/scan, /v1/blast</text>
-
-  <line x1="204" y1="243" x2="218" y2="243" class="connector" stroke="#f0883e" marker-end="url(#arr-orange)"/>
-
-  <rect x="220" y="230" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="259" y="244" text-anchor="middle" class="step">Rate Limit</text>
-  <text x="259" y="254" text-anchor="middle" class="step-detail">token + IP</text>
-
-  <line x1="300" y1="243" x2="314" y2="243" class="connector" stroke="#f0883e" marker-end="url(#arr-orange)"/>
-
-  <rect x="316" y="230" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="355" y="244" text-anchor="middle" class="step">Engine</text>
-  <text x="355" y="254" text-anchor="middle" class="step-detail">same core scan</text>
-
-  <line x1="396" y1="243" x2="410" y2="243" class="connector" stroke="#f0883e" marker-end="url(#arr-orange)"/>
-
-  <rect x="412" y="230" width="94" height="26" rx="4" fill="#0d1117" stroke="#f0883e" stroke-width="1"/>
-  <text x="459" y="244" text-anchor="middle" class="step">JSON / Webhook</text>
-  <text x="459" y="254" text-anchor="middle" class="step-detail">Jira, Slack, ServiceNow</text>
-
-  <text x="504" y="278" text-anchor="end" class="mode-sub">Dashboard backend, Snowflake integration</text>
+  <line x1="170" y1="316" x2="170" y2="346" stroke="#30363d" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
+  <line x1="480" y1="316" x2="480" y2="346" stroke="#30363d" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
+  <line x1="790" y1="316" x2="790" y2="346" stroke="#30363d" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 4: Runtime Proxy (yellow/gold) -->
+  <!-- SHARED ENGINE — horizontal bar -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="544" y="178" width="500" height="108" rx="8" fill="#161b22" stroke="#d29922" stroke-width="1.2"/>
-  <rect x="544" y="178" width="500" height="4" rx="2" fill="#d29922"/>
-  <rect x="556" y="190" width="50" height="16" rx="4" fill="#d29922"/>
-  <text x="581" y="202" text-anchor="middle" class="badge">PROXY</text>
-  <text x="616" y="202" class="mode-title" fill="#d29922">Runtime Proxy (6-layer)</text>
-  <text x="556" y="220" class="cmd">agent-bom protect [--mode monitor|enforce]</text>
+  <rect x="20" y="354" width="920" height="90" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1.2"/>
+  <rect x="20" y="354" width="920" height="3" rx="1.5" fill="#30363d"/>
+  <text x="480" y="374" text-anchor="middle" class="engine-title">SHARED ENGINE — ALL MODES USE THE SAME CORE</text>
 
-  <rect x="556" y="230" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="592" y="244" text-anchor="middle" class="step">MCP Traffic</text>
-  <text x="592" y="254" text-anchor="middle" class="step-detail">agent ↔ server</text>
+  <!-- Engine modules — 7 evenly spaced -->
+  <rect x="32" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="0.8"/>
+  <text x="90" y="402" text-anchor="middle" class="engine-mod" fill="#58a6ff">Discovery</text>
+  <text x="90" y="416" text-anchor="middle" class="engine-detail">20 MCP clients · 4 clouds</text>
 
-  <line x1="630" y1="243" x2="644" y2="243" class="connector" stroke="#d29922" marker-end="url(#arr-yellow)"/>
+  <rect x="158" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="0.8"/>
+  <text x="216" y="402" text-anchor="middle" class="engine-mod" fill="#58a6ff">Parsers</text>
+  <text x="216" y="416" text-anchor="middle" class="engine-detail">npm · pip · cargo · Docker</text>
 
-  <rect x="646" y="230" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="682" y="244" text-anchor="middle" class="step">Replay Det.</text>
-  <text x="682" y="254" text-anchor="middle" class="step-detail">dedup requests</text>
+  <rect x="284" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="342" y="402" text-anchor="middle" class="engine-mod" fill="#3fb950">Scanners</text>
+  <text x="342" y="416" text-anchor="middle" class="engine-detail">OSV · NVD · Grype · Syft</text>
 
-  <line x1="720" y1="243" x2="734" y2="243" class="connector" stroke="#d29922" marker-end="url(#arr-yellow)"/>
+  <rect x="410" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <text x="468" y="402" text-anchor="middle" class="engine-mod" fill="#d29922">Enrichment</text>
+  <text x="468" y="416" text-anchor="middle" class="engine-detail">EPSS · KEV · CVSS</text>
 
-  <rect x="736" y="230" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="772" y="244" text-anchor="middle" class="step">Tool Drift</text>
-  <text x="772" y="254" text-anchor="middle" class="step-detail">undeclared block</text>
+  <rect x="536" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#f0883e" stroke-width="0.8"/>
+  <text x="594" y="402" text-anchor="middle" class="engine-mod" fill="#f0883e">Compliance</text>
+  <text x="594" y="416" text-anchor="middle" class="engine-detail">10 frameworks</text>
 
-  <line x1="810" y1="243" x2="824" y2="243" class="connector" stroke="#d29922" marker-end="url(#arr-yellow)"/>
+  <rect x="662" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="0.8"/>
+  <text x="720" y="402" text-anchor="middle" class="engine-mod" fill="#f85149">Policy</text>
+  <text x="720" y="416" text-anchor="middle" class="engine-detail">16 conditions · YAML</text>
 
-  <rect x="826" y="230" width="72" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="862" y="244" text-anchor="middle" class="step">Policy + Cred</text>
-  <text x="862" y="254" text-anchor="middle" class="step-detail">args + leak scan</text>
-
-  <line x1="900" y1="243" x2="914" y2="243" class="connector" stroke="#d29922" marker-end="url(#arr-yellow)"/>
-
-  <rect x="916" y="230" width="116" height="26" rx="4" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
-  <text x="974" y="244" text-anchor="middle" class="step">Allow / Block / Alert</text>
-  <text x="974" y="254" text-anchor="middle" class="step-detail">Prometheus :8422</text>
-
-  <text x="1032" y="278" text-anchor="end" class="mode-sub">5 detectors, webhook alerts, audit log</text>
+  <rect x="788" y="386" width="140" height="44" rx="5" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="858" y="402" text-anchor="middle" class="engine-mod" fill="#bc8cff">Registry</text>
+  <text x="858" y="416" text-anchor="middle" class="engine-detail">427+ servers · CVE · EPSS</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 5: GitHub Action (green) -->
+  <!-- CONNECTOR ARROWS: engine → I/O -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="306" width="500" height="108" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1.2"/>
-  <rect x="16" y="306" width="500" height="4" rx="2" fill="#3fb950"/>
-  <rect x="28" y="318" width="56" height="16" rx="4" fill="#3fb950"/>
-  <text x="56" y="330" text-anchor="middle" class="badge">ACTION</text>
-  <text x="94" y="330" class="mode-title" fill="#3fb950">GitHub Action (CI/CD Gate)</text>
-  <text x="28" y="348" class="cmd">uses: msaad00/agent-bom@v0.55.0</text>
-
-  <rect x="28" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="67" y="372" text-anchor="middle" class="step">PR Push</text>
-  <text x="67" y="382" text-anchor="middle" class="step-detail">trigger workflow</text>
-
-  <line x1="108" y1="371" x2="122" y2="371" class="connector" stroke="#3fb950" marker-end="url(#arr-green)"/>
-
-  <rect x="124" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="163" y="372" text-anchor="middle" class="step">Install</text>
-  <text x="163" y="382" text-anchor="middle" class="step-detail">pip install agent-bom</text>
-
-  <line x1="204" y1="371" x2="218" y2="371" class="connector" stroke="#3fb950" marker-end="url(#arr-green)"/>
-
-  <rect x="220" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="259" y="372" text-anchor="middle" class="step">Scan Repo</text>
-  <text x="259" y="382" text-anchor="middle" class="step-detail">MCP + deps + code</text>
-
-  <line x1="300" y1="371" x2="314" y2="371" class="connector" stroke="#3fb950" marker-end="url(#arr-green)"/>
-
-  <rect x="316" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="355" y="372" text-anchor="middle" class="step">Policy Check</text>
-  <text x="355" y="382" text-anchor="middle" class="step-detail">fail-on-severity</text>
-
-  <line x1="396" y1="371" x2="410" y2="371" class="connector" stroke="#3fb950" marker-end="url(#arr-green)"/>
-
-  <rect x="412" y="358" width="94" height="26" rx="4" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
-  <text x="459" y="372" text-anchor="middle" class="step">PR Comment</text>
-  <text x="459" y="382" text-anchor="middle" class="step-detail">SARIF upload</text>
-
-  <text x="504" y="406" text-anchor="end" class="mode-sub">GitHub Marketplace, fail/pass gate</text>
+  <line x1="260" y1="444" x2="260" y2="474" stroke="#30363d" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
+  <line x1="700" y1="444" x2="700" y2="474" stroke="#30363d" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 6: Dashboard (red/coral) -->
+  <!-- INPUT / OUTPUT — side by side -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="544" y="306" width="500" height="108" rx="8" fill="#161b22" stroke="#f85149" stroke-width="1.2"/>
-  <rect x="544" y="306" width="500" height="4" rx="2" fill="#f85149"/>
-  <rect x="556" y="318" width="72" height="16" rx="4" fill="#f85149"/>
-  <text x="592" y="330" text-anchor="middle" class="badge">DASHBOARD</text>
-  <text x="638" y="330" class="mode-title" fill="#f85149">Interactive Dashboard</text>
-  <text x="556" y="348" class="cmd">agent-bom dashboard [--port 8501]</text>
 
-  <rect x="556" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="595" y="372" text-anchor="middle" class="step">Streamlit UI</text>
-  <text x="595" y="382" text-anchor="middle" class="step-detail">15 sections</text>
+  <!-- Input Sources -->
+  <text x="250" y="492" text-anchor="middle" class="section-label" fill="#58a6ff">INPUTS</text>
 
-  <line x1="636" y1="371" x2="650" y2="371" class="connector" stroke="#f85149" marker-end="url(#arr-red)"/>
+  <rect x="20" y="502" width="460" height="38" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
+  <text x="250" y="520" text-anchor="middle" class="mode-feat">MCP configs · package files · Docker images · cloud APIs · source code</text>
+  <text x="250" y="533" text-anchor="middle" class="engine-detail">claude_desktop_config.json · package.json · requirements.txt · OCI layers · AWS/Azure/GCP/Snowflake</text>
 
-  <rect x="652" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="691" y="372" text-anchor="middle" class="step">Live Scan</text>
-  <text x="691" y="382" text-anchor="middle" class="step-detail">real-time results</text>
+  <!-- Output Targets -->
+  <text x="710" y="492" text-anchor="middle" class="section-label" fill="#3fb950">OUTPUTS</text>
 
-  <line x1="732" y1="371" x2="746" y2="371" class="connector" stroke="#f85149" marker-end="url(#arr-red)"/>
-
-  <rect x="748" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="787" y="372" text-anchor="middle" class="step">Visualize</text>
-  <text x="787" y="382" text-anchor="middle" class="step-detail">charts + graphs</text>
-
-  <line x1="828" y1="371" x2="842" y2="371" class="connector" stroke="#f85149" marker-end="url(#arr-red)"/>
-
-  <rect x="844" y="358" width="78" height="26" rx="4" fill="#0d1117" stroke="#30363d"/>
-  <text x="883" y="372" text-anchor="middle" class="step">Blast Map</text>
-  <text x="883" y="382" text-anchor="middle" class="step-detail">interactive graph</text>
-
-  <line x1="924" y1="371" x2="938" y2="371" class="connector" stroke="#f85149" marker-end="url(#arr-red)"/>
-
-  <rect x="940" y="358" width="90" height="26" rx="4" fill="#0d1117" stroke="#f85149" stroke-width="1"/>
-  <text x="985" y="372" text-anchor="middle" class="step">Export</text>
-  <text x="985" y="382" text-anchor="middle" class="step-detail">PDF / SBOM / JSON</text>
-
-  <text x="1032" y="406" text-anchor="end" class="mode-sub">Self-scan, compliance scorecard, SBOM viewer</text>
+  <rect x="500" y="502" width="440" height="38" rx="6" fill="#0d1117" stroke="#30363d" stroke-width="0.8"/>
+  <text x="720" y="520" text-anchor="middle" class="mode-feat">SBOM · SARIF · JSON · HTML · Graph · Webhooks · ClickHouse</text>
+  <text x="720" y="533" text-anchor="middle" class="engine-detail">CycloneDX · SPDX · GitHub Code Scanning · Jira · Slack · ServiceNow · Prometheus</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- SHARED ENGINE SECTION -->
+  <!-- DEPLOYMENT — clean horizontal strip -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="434" width="1028" height="4" rx="2" fill="#30363d" opacity="0.5"/>
-  <text x="530" y="458" text-anchor="middle" class="section-label" fill="#8b949e">SHARED ENGINE — ALL MODES USE THE SAME CORE</text>
+  <rect x="20" y="558" width="920" height="2" rx="1" fill="#30363d" opacity="0.4"/>
+  <text x="480" y="578" text-anchor="middle" class="section-label" fill="#d29922">DEPLOY ANYWHERE</text>
 
-  <!-- Engine modules row -->
-  <rect x="16" y="470" width="140" height="50" rx="6" fill="#161b22" stroke="#58a6ff" stroke-width="1"/>
-  <text x="86" y="490" text-anchor="middle" class="step" fill="#58a6ff">Discovery</text>
-  <text x="86" y="504" text-anchor="middle" class="step-detail">20 MCP clients</text>
-  <text x="86" y="514" text-anchor="middle" class="step-detail">4 cloud providers</text>
+  <!-- Deployment pills -->
+  <rect x="36" y="590" width="102" height="32" rx="6" fill="#0d1117" stroke="#58a6ff" stroke-width="0.8"/>
+  <text x="87" y="606" text-anchor="middle" class="deploy-label" fill="#58a6ff">PyPI</text>
+  <text x="87" y="617" text-anchor="middle" class="deploy-detail">pip install</text>
 
-  <rect x="170" y="470" width="140" height="50" rx="6" fill="#161b22" stroke="#58a6ff" stroke-width="1"/>
-  <text x="240" y="490" text-anchor="middle" class="step" fill="#58a6ff">Parsers</text>
-  <text x="240" y="504" text-anchor="middle" class="step-detail">npm, pip, cargo, go</text>
-  <text x="240" y="514" text-anchor="middle" class="step-detail">Docker, requirements.txt</text>
+  <rect x="150" y="590" width="102" height="32" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="201" y="606" text-anchor="middle" class="deploy-label" fill="#bc8cff">Docker</text>
+  <text x="201" y="617" text-anchor="middle" class="deploy-detail">Hub + GHCR</text>
 
-  <rect x="324" y="470" width="140" height="50" rx="6" fill="#161b22" stroke="#3fb950" stroke-width="1"/>
-  <text x="394" y="490" text-anchor="middle" class="step" fill="#3fb950">Scanners</text>
-  <text x="394" y="504" text-anchor="middle" class="step-detail">OSV, NVD, Grype, Syft</text>
-  <text x="394" y="514" text-anchor="middle" class="step-detail">OpenSSF Scorecard</text>
+  <rect x="264" y="590" width="102" height="32" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="0.8"/>
+  <text x="315" y="606" text-anchor="middle" class="deploy-label" fill="#3fb950">GitHub Action</text>
+  <text x="315" y="617" text-anchor="middle" class="deploy-detail">Marketplace</text>
 
-  <rect x="478" y="470" width="140" height="50" rx="6" fill="#161b22" stroke="#d29922" stroke-width="1"/>
-  <text x="548" y="490" text-anchor="middle" class="step" fill="#d29922">Enrichment</text>
-  <text x="548" y="504" text-anchor="middle" class="step-detail">EPSS, KEV, CVSS</text>
-  <text x="548" y="514" text-anchor="middle" class="step-detail">blast radius mapping</text>
+  <rect x="378" y="590" width="102" height="32" rx="6" fill="#0d1117" stroke="#f0883e" stroke-width="0.8"/>
+  <text x="429" y="606" text-anchor="middle" class="deploy-label" fill="#f0883e">Railway SSE</text>
+  <text x="429" y="617" text-anchor="middle" class="deploy-detail">Remote MCP</text>
 
-  <rect x="632" y="470" width="140" height="50" rx="6" fill="#161b22" stroke="#f0883e" stroke-width="1"/>
-  <text x="702" y="490" text-anchor="middle" class="step" fill="#f0883e">Compliance</text>
-  <text x="702" y="504" text-anchor="middle" class="step-detail">OWASP, ATLAS, NIST</text>
-  <text x="702" y="514" text-anchor="middle" class="step-detail">EU AI Act, ISO 42001</text>
+  <rect x="492" y="590" width="102" height="32" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="0.8"/>
+  <text x="543" y="606" text-anchor="middle" class="deploy-label" fill="#d29922">Helm Chart</text>
+  <text x="543" y="617" text-anchor="middle" class="deploy-detail">K8s fleet</text>
 
-  <rect x="786" y="470" width="140" height="50" rx="6" fill="#161b22" stroke="#f85149" stroke-width="1"/>
-  <text x="856" y="490" text-anchor="middle" class="step" fill="#f85149">Policy Engine</text>
-  <text x="856" y="504" text-anchor="middle" class="step-detail">18 conditions</text>
-  <text x="856" y="514" text-anchor="middle" class="step-detail">YAML rules</text>
+  <rect x="606" y="590" width="102" height="32" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="0.8"/>
+  <text x="657" y="606" text-anchor="middle" class="deploy-label" fill="#f85149">Glama</text>
+  <text x="657" y="617" text-anchor="middle" class="deploy-detail">MCP marketplace</text>
 
-  <rect x="940" y="470" width="104" height="50" rx="6" fill="#161b22" stroke="#bc8cff" stroke-width="1"/>
-  <text x="992" y="490" text-anchor="middle" class="step" fill="#bc8cff">Registry</text>
-  <text x="992" y="504" text-anchor="middle" class="step-detail">427+ MCP servers</text>
-  <text x="992" y="514" text-anchor="middle" class="step-detail">CVE + EPSS + KEV</text>
+  <rect x="720" y="590" width="102" height="32" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="0.8"/>
+  <text x="771" y="606" text-anchor="middle" class="deploy-label" fill="#f85149">Smithery</text>
+  <text x="771" y="617" text-anchor="middle" class="deploy-detail">MCP marketplace</text>
+
+  <rect x="834" y="590" width="106" height="32" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="0.8"/>
+  <text x="887" y="606" text-anchor="middle" class="deploy-label" fill="#bc8cff">Snowflake</text>
+  <text x="887" y="617" text-anchor="middle" class="deploy-detail">Native App</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- DATA SOURCES + OUTPUT TARGETS -->
+  <!-- KEY NUMBERS — bottom bar -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="540" width="1028" height="4" rx="2" fill="#30363d" opacity="0.5"/>
+  <rect x="20" y="640" width="920" height="2" rx="1" fill="#30363d" opacity="0.4"/>
 
-  <!-- Data Sources (left) -->
-  <text x="270" y="564" text-anchor="middle" class="section-label" fill="#58a6ff">INPUT SOURCES</text>
+  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#58a6ff">19</text>
+  <text x="120" y="680" text-anchor="middle" class="engine-detail">MCP tools</text>
 
-  <rect x="16" y="576" width="120" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="76" y="594" text-anchor="middle" class="step">MCP Configs</text>
-  <text x="76" y="607" text-anchor="middle" class="step-detail">claude_desktop_config.json</text>
+  <text x="240" y="666" text-anchor="middle" class="mode-title" fill="#bc8cff">427+</text>
+  <text x="240" y="680" text-anchor="middle" class="engine-detail">servers in registry</text>
 
-  <rect x="146" y="576" width="100" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="196" y="594" text-anchor="middle" class="step">Package Files</text>
-  <text x="196" y="607" text-anchor="middle" class="step-detail">package.json, req.txt</text>
+  <text x="360" y="666" text-anchor="middle" class="mode-title" fill="#3fb950">20</text>
+  <text x="360" y="680" text-anchor="middle" class="engine-detail">client integrations</text>
 
-  <rect x="256" y="576" width="100" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="306" y="594" text-anchor="middle" class="step">Docker Images</text>
-  <text x="306" y="607" text-anchor="middle" class="step-detail">OCI layers + SBOM</text>
+  <text x="480" y="666" text-anchor="middle" class="mode-title" fill="#d29922">5</text>
+  <text x="480" y="680" text-anchor="middle" class="engine-detail">runtime detectors</text>
 
-  <rect x="366" y="576" width="100" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="416" y="594" text-anchor="middle" class="step">Cloud APIs</text>
-  <text x="416" y="607" text-anchor="middle" class="step-detail">AWS, Azure, GCP, SF</text>
+  <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#f0883e">10</text>
+  <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <rect x="476" y="576" width="100" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="526" y="594" text-anchor="middle" class="step">Source Code</text>
-  <text x="526" y="607" text-anchor="middle" class="step-detail">prompt injection scan</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#f85149">6,100+</text>
+  <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
-  <!-- Output Targets (right) -->
-  <text x="800" y="564" text-anchor="middle" class="section-label" fill="#3fb950">OUTPUT TARGETS</text>
-
-  <rect x="620" y="576" width="100" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="670" y="594" text-anchor="middle" class="step">SBOM</text>
-  <text x="670" y="607" text-anchor="middle" class="step-detail">CycloneDX, SPDX</text>
-
-  <rect x="730" y="576" width="100" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="780" y="594" text-anchor="middle" class="step">SARIF</text>
-  <text x="780" y="607" text-anchor="middle" class="step-detail">GitHub Code Scanning</text>
-
-  <rect x="840" y="576" width="100" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="890" y="594" text-anchor="middle" class="step">Connectors</text>
-  <text x="890" y="607" text-anchor="middle" class="step-detail">Jira, Slack, SNOW</text>
-
-  <rect x="950" y="576" width="94" height="38" rx="5" fill="#0d1117" stroke="#30363d"/>
-  <text x="997" y="594" text-anchor="middle" class="step">ClickHouse</text>
-  <text x="997" y="607" text-anchor="middle" class="step-detail">Analytics warehouse</text>
-
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- DEPLOYMENT MAP -->
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="634" width="1028" height="4" rx="2" fill="#30363d" opacity="0.5"/>
-  <text x="530" y="658" text-anchor="middle" class="section-label" fill="#d29922">DEPLOYMENT OPTIONS</text>
-
-  <rect x="16" y="668" width="130" height="44" rx="6" fill="#0d1117" stroke="#58a6ff" stroke-width="1"/>
-  <text x="81" y="686" text-anchor="middle" class="step" fill="#58a6ff">pip install</text>
-  <text x="81" y="700" text-anchor="middle" class="step-detail">PyPI package</text>
-
-  <rect x="160" y="668" width="130" height="44" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="1"/>
-  <text x="225" y="686" text-anchor="middle" class="step" fill="#bc8cff">Docker Hub</text>
-  <text x="225" y="700" text-anchor="middle" class="step-detail">GHCR + Docker Hub</text>
-
-  <rect x="304" y="668" width="130" height="44" rx="6" fill="#0d1117" stroke="#3fb950" stroke-width="1"/>
-  <text x="369" y="686" text-anchor="middle" class="step" fill="#3fb950">GitHub Action</text>
-  <text x="369" y="700" text-anchor="middle" class="step-detail">Marketplace</text>
-
-  <rect x="448" y="668" width="130" height="44" rx="6" fill="#0d1117" stroke="#f0883e" stroke-width="1"/>
-  <text x="513" y="686" text-anchor="middle" class="step" fill="#f0883e">Railway SSE</text>
-  <text x="513" y="700" text-anchor="middle" class="step-detail">Remote MCP server</text>
-
-  <rect x="592" y="668" width="130" height="44" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
-  <text x="657" y="686" text-anchor="middle" class="step" fill="#d29922">Helm Chart</text>
-  <text x="657" y="700" text-anchor="middle" class="step-detail">K8s fleet scanning</text>
-
-  <rect x="736" y="668" width="130" height="44" rx="6" fill="#0d1117" stroke="#f85149" stroke-width="1"/>
-  <text x="801" y="686" text-anchor="middle" class="step" fill="#f85149">Glama / Smithery</text>
-  <text x="801" y="700" text-anchor="middle" class="step-detail">MCP marketplaces</text>
-
-  <rect x="880" y="668" width="164" height="44" rx="6" fill="#0d1117" stroke="#bc8cff" stroke-width="1"/>
-  <text x="962" y="686" text-anchor="middle" class="step" fill="#bc8cff">Snowflake Native App</text>
-  <text x="962" y="700" text-anchor="middle" class="step-detail">Enterprise governance</text>
+  <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#bc8cff">12</text>
+  <text x="840" y="680" text-anchor="middle" class="engine-detail">output formats</text>
 
   <!-- Footer -->
-  <text x="530" y="746" text-anchor="middle" class="footer">All modes share the same engine, registry, and enrichment pipeline</text>
-  <text x="530" y="762" text-anchor="middle" class="footer">github.com/msaad00/agent-bom</text>
+  <text x="480" y="708" text-anchor="middle" class="footer">github.com/msaad00/agent-bom · Apache 2.0</text>
 </svg>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -1,407 +1,241 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1060 780" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 720" fill="none">
   <style>
-    .title { font: 700 14px system-ui, -apple-system, sans-serif; fill: #1f2328; }
-    .mode-title { font: 700 11px system-ui, -apple-system, sans-serif; }
-    .mode-sub { font: 500 9.5px system-ui, -apple-system, sans-serif; fill: #656d76; }
-    .step { font: 600 9px system-ui, -apple-system, sans-serif; fill: #1f2328; }
-    .step-detail { font: 400 8px system-ui, -apple-system, sans-serif; fill: #656d76; }
+    .title { font: 700 16px system-ui, -apple-system, sans-serif; fill: #1f2328; }
+    .subtitle { font: 500 10px system-ui, -apple-system, sans-serif; fill: #656d76; }
+    .mode-title { font: 700 12px system-ui, -apple-system, sans-serif; }
+    .mode-cmd { font: 600 9.5px 'SF Mono', 'Fira Code', monospace; fill: #8250df; }
+    .mode-feat { font: 500 9.5px system-ui, -apple-system, sans-serif; fill: #1f2328; }
+    .mode-detail { font: 400 8.5px system-ui, -apple-system, sans-serif; fill: #656d76; }
     .badge { font: 700 8px system-ui, -apple-system, sans-serif; fill: #ffffff; }
+    .engine-title { font: 700 11px system-ui, -apple-system, sans-serif; letter-spacing: 0.06em; fill: #656d76; }
+    .engine-mod { font: 600 9.5px system-ui, -apple-system, sans-serif; }
+    .engine-detail { font: 400 8px system-ui, -apple-system, sans-serif; fill: #656d76; }
     .section-label { font: 700 9px system-ui, -apple-system, sans-serif; letter-spacing: 0.08em; }
     .footer { font: 500 9px system-ui, -apple-system, sans-serif; fill: #656d76; }
-    .connector { fill: none; stroke-width: 1.5; }
-    .cmd { font: 600 9px 'SF Mono', 'Fira Code', monospace; fill: #8250df; }
+    .deploy-label { font: 600 9px system-ui, -apple-system, sans-serif; }
+    .deploy-detail { font: 400 8px system-ui, -apple-system, sans-serif; fill: #656d76; }
   </style>
   <defs>
-    <marker id="arr-blue" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#0969da" opacity="0.8"/>
-    </marker>
-    <marker id="arr-green" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#1a7f37" opacity="0.8"/>
-    </marker>
-    <marker id="arr-purple" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#8250df" opacity="0.8"/>
-    </marker>
-    <marker id="arr-orange" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#bf8700" opacity="0.8"/>
-    </marker>
-    <marker id="arr-red" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#cf222e" opacity="0.8"/>
-    </marker>
-    <marker id="arr-yellow" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#9a6700" opacity="0.8"/>
+    <marker id="arr-down" viewBox="0 0 8 8" refX="4" refY="7" markerWidth="6" markerHeight="6" orient="auto">
+      <polygon points="0 0, 8 0, 4 8" fill="#d0d7de" opacity="0.6"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="1060" height="780" rx="12" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
-  <text x="530" y="30" text-anchor="middle" class="title">How agent-bom Works — Mode by Mode</text>
+  <rect width="960" height="720" rx="12" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="480" y="32" text-anchor="middle" class="title">How agent-bom Works</text>
+  <text x="480" y="48" text-anchor="middle" class="subtitle">Six modes, one shared engine — every mode uses the same core scanning pipeline</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 1: CLI Scan (blue) -->
+  <!-- MODE CARDS — 3x2 grid, simplified -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="50" width="500" height="108" rx="8" fill="#f6f8fa" stroke="#0969da" stroke-width="1.2"/>
-  <rect x="16" y="50" width="500" height="4" rx="2" fill="#0969da"/>
-  <rect x="28" y="62" width="32" height="16" rx="4" fill="#0969da"/>
-  <text x="44" y="74" text-anchor="middle" class="badge">CLI</text>
-  <text x="70" y="74" class="mode-title" fill="#0969da">Local Scan</text>
-  <text x="28" y="92" class="cmd">agent-bom scan [--image] [--sbom cyclonedx]</text>
 
-  <!-- Flow steps -->
-  <rect x="28" y="102" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="67" y="116" text-anchor="middle" class="step">Discovery</text>
-  <text x="67" y="126" text-anchor="middle" class="step-detail">20 MCP clients</text>
+  <!-- MODE 1: CLI Scan (blue) — top left -->
+  <rect x="20" y="66" width="300" height="120" rx="8" fill="#f6f8fa" stroke="#0969da" stroke-width="1.2"/>
+  <rect x="20" y="66" width="300" height="3" rx="1.5" fill="#0969da"/>
+  <rect x="32" y="80" width="30" height="15" rx="4" fill="#0969da"/>
+  <text x="47" y="91" text-anchor="middle" class="badge">CLI</text>
+  <text x="72" y="91" class="mode-title" fill="#0969da">Local Scan</text>
+  <text x="32" y="108" class="mode-cmd">agent-bom scan [--image] [--sbom]</text>
+  <text x="32" y="124" class="mode-feat">Discover 20 MCP clients + cloud infra</text>
+  <text x="32" y="138" class="mode-feat">CVE scan with OSV, NVD, Grype, Syft</text>
+  <text x="32" y="152" class="mode-feat">Blast radius: CVE → server → creds → tools</text>
+  <text x="308" y="178" text-anchor="end" class="mode-detail">JSON / CycloneDX / SPDX / SARIF / HTML</text>
 
-  <line x1="108" y1="115" x2="122" y2="115" class="connector" stroke="#0969da" marker-end="url(#arr-blue)"/>
+  <!-- MODE 2: MCP Server (purple) — top center -->
+  <rect x="330" y="66" width="300" height="120" rx="8" fill="#f6f8fa" stroke="#8250df" stroke-width="1.2"/>
+  <rect x="330" y="66" width="300" height="3" rx="1.5" fill="#8250df"/>
+  <rect x="342" y="80" width="34" height="15" rx="4" fill="#8250df"/>
+  <text x="359" y="91" text-anchor="middle" class="badge">MCP</text>
+  <text x="386" y="91" class="mode-title" fill="#8250df">MCP Server — 19 Tools</text>
+  <text x="342" y="108" class="mode-cmd">agent-bom mcp-server [--transport sse]</text>
+  <text x="342" y="124" class="mode-feat">AI agents call scan, check, blast_radius</text>
+  <text x="342" y="138" class="mode-feat">Registry lookup for 427+ MCP servers</text>
+  <text x="342" y="152" class="mode-feat">Compliance, remediate, policy_check</text>
+  <text x="618" y="178" text-anchor="end" class="mode-detail">Glama · Smithery · ToolHive · Claude Desktop</text>
 
-  <rect x="124" y="102" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="160" y="116" text-anchor="middle" class="step">Parse</text>
-  <text x="160" y="126" text-anchor="middle" class="step-detail">configs + deps</text>
+  <!-- MODE 3: REST API (orange) — top right -->
+  <rect x="640" y="66" width="300" height="120" rx="8" fill="#f6f8fa" stroke="#bc4c00" stroke-width="1.2"/>
+  <rect x="640" y="66" width="300" height="3" rx="1.5" fill="#bc4c00"/>
+  <rect x="652" y="80" width="30" height="15" rx="4" fill="#bc4c00"/>
+  <text x="667" y="91" text-anchor="middle" class="badge">API</text>
+  <text x="692" y="91" class="mode-title" fill="#bc4c00">REST API Server</text>
+  <text x="652" y="108" class="mode-cmd">agent-bom serve [--port 8422]</text>
+  <text x="652" y="124" class="mode-feat">50+ endpoints, token + IP rate limiting</text>
+  <text x="652" y="138" class="mode-feat">Webhook delivery: Jira, Slack, ServiceNow</text>
+  <text x="652" y="152" class="mode-feat">Dashboard backend + Snowflake integration</text>
+  <text x="928" y="178" text-anchor="end" class="mode-detail">OpenAPI spec · CORS · health checks</text>
 
-  <line x1="198" y1="115" x2="212" y2="115" class="connector" stroke="#0969da" marker-end="url(#arr-blue)"/>
+  <!-- MODE 4: Runtime Proxy (yellow) — bottom left -->
+  <rect x="20" y="196" width="300" height="120" rx="8" fill="#f6f8fa" stroke="#9a6700" stroke-width="1.2"/>
+  <rect x="20" y="196" width="300" height="3" rx="1.5" fill="#9a6700"/>
+  <rect x="32" y="210" width="44" height="15" rx="4" fill="#9a6700"/>
+  <text x="54" y="221" text-anchor="middle" class="badge">PROXY</text>
+  <text x="86" y="221" class="mode-title" fill="#9a6700">Runtime Proxy</text>
+  <text x="32" y="238" class="mode-cmd">agent-bom protect [--mode enforce]</text>
+  <text x="32" y="254" class="mode-feat">5 detectors: drift, injection, cred leak</text>
+  <text x="32" y="268" class="mode-feat">Policy enforcement on live MCP traffic</text>
+  <text x="32" y="282" class="mode-feat">Replay detection + sequence analysis</text>
+  <text x="308" y="308" text-anchor="end" class="mode-detail">Prometheus metrics · JSONL audit log</text>
 
-  <rect x="214" y="102" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="250" y="116" text-anchor="middle" class="step">Scan</text>
-  <text x="250" y="126" text-anchor="middle" class="step-detail">OSV + NVD</text>
+  <!-- MODE 5: GitHub Action (green) — bottom center -->
+  <rect x="330" y="196" width="300" height="120" rx="8" fill="#f6f8fa" stroke="#1a7f37" stroke-width="1.2"/>
+  <rect x="330" y="196" width="300" height="3" rx="1.5" fill="#1a7f37"/>
+  <rect x="342" y="210" width="50" height="15" rx="4" fill="#1a7f37"/>
+  <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
+  <text x="402" y="221" class="mode-title" fill="#1a7f37">GitHub Action</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.57.0</text>
+  <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
+  <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
+  <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>
+  <text x="618" y="308" text-anchor="end" class="mode-detail">GitHub Marketplace · pass/fail gate</text>
 
-  <line x1="288" y1="115" x2="302" y2="115" class="connector" stroke="#0969da" marker-end="url(#arr-blue)"/>
-
-  <rect x="304" y="102" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="340" y="116" text-anchor="middle" class="step">Enrich</text>
-  <text x="340" y="126" text-anchor="middle" class="step-detail">EPSS + KEV</text>
-
-  <line x1="378" y1="115" x2="392" y2="115" class="connector" stroke="#0969da" marker-end="url(#arr-blue)"/>
-
-  <rect x="394" y="102" width="108" height="26" rx="4" fill="#ffffff" stroke="#0969da" stroke-width="1"/>
-  <text x="448" y="116" text-anchor="middle" class="step">Report</text>
-  <text x="448" y="126" text-anchor="middle" class="step-detail">JSON/CycloneDX/SPDX/SARIF</text>
-
-  <text x="504" y="150" text-anchor="end" class="mode-sub">Blast radius: CVE → server → creds → tools</text>
-
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 2: MCP Server (purple) -->
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="544" y="50" width="500" height="108" rx="8" fill="#f6f8fa" stroke="#8250df" stroke-width="1.2"/>
-  <rect x="544" y="50" width="500" height="4" rx="2" fill="#8250df"/>
-  <rect x="556" y="62" width="40" height="16" rx="4" fill="#8250df"/>
-  <text x="576" y="74" text-anchor="middle" class="badge">MCP</text>
-  <text x="606" y="74" class="mode-title" fill="#8250df">MCP Server (19 tools)</text>
-  <text x="556" y="92" class="cmd">agent-bom mcp-server [--transport stdio|sse]</text>
-
-  <!-- Flow steps -->
-  <rect x="556" y="102" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="595" y="116" text-anchor="middle" class="step">AI Agent</text>
-  <text x="595" y="126" text-anchor="middle" class="step-detail">Claude, Cursor...</text>
-
-  <line x1="636" y1="115" x2="650" y2="115" class="connector" stroke="#8250df" marker-end="url(#arr-purple)"/>
-
-  <rect x="652" y="102" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="688" y="116" text-anchor="middle" class="step">MCP Call</text>
-  <text x="688" y="126" text-anchor="middle" class="step-detail">tool_name(args)</text>
-
-  <line x1="726" y1="115" x2="740" y2="115" class="connector" stroke="#8250df" marker-end="url(#arr-purple)"/>
-
-  <rect x="742" y="102" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="781" y="116" text-anchor="middle" class="step">Engine</text>
-  <text x="781" y="126" text-anchor="middle" class="step-detail">scan/check/blast</text>
-
-  <line x1="822" y1="115" x2="836" y2="115" class="connector" stroke="#8250df" marker-end="url(#arr-purple)"/>
-
-  <rect x="838" y="102" width="94" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="885" y="116" text-anchor="middle" class="step">JSON Result</text>
-  <text x="885" y="126" text-anchor="middle" class="step-detail">structured to agent</text>
-
-  <line x1="934" y1="115" x2="948" y2="115" class="connector" stroke="#8250df" marker-end="url(#arr-purple)"/>
-
-  <rect x="950" y="102" width="78" height="26" rx="4" fill="#ffffff" stroke="#8250df" stroke-width="1"/>
-  <text x="989" y="116" text-anchor="middle" class="step">Agent Acts</text>
-  <text x="989" y="126" text-anchor="middle" class="step-detail">remediate / fix</text>
-
-  <text x="1032" y="150" text-anchor="end" class="mode-sub">Glama, ToolHive, Smithery, Claude Desktop</text>
+  <!-- MODE 6: Dashboard (red) — bottom right -->
+  <rect x="640" y="196" width="300" height="120" rx="8" fill="#f6f8fa" stroke="#cf222e" stroke-width="1.2"/>
+  <rect x="640" y="196" width="300" height="3" rx="1.5" fill="#cf222e"/>
+  <rect x="652" y="210" width="68" height="15" rx="4" fill="#cf222e"/>
+  <text x="686" y="221" text-anchor="middle" class="badge">DASHBOARD</text>
+  <text x="730" y="221" class="mode-title" fill="#cf222e">Interactive Dashboard</text>
+  <text x="652" y="238" class="mode-cmd">agent-bom dashboard [--port 8501]</text>
+  <text x="652" y="254" class="mode-feat">15-section Streamlit UI with live scan</text>
+  <text x="652" y="268" class="mode-feat">Interactive blast radius graph</text>
+  <text x="652" y="282" class="mode-feat">Compliance scorecard + SBOM viewer</text>
+  <text x="928" y="308" text-anchor="end" class="mode-detail">Self-scan · export PDF / JSON / SBOM</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 3: REST API (orange) -->
+  <!-- CONNECTOR ARROWS: modes → engine -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="178" width="500" height="108" rx="8" fill="#f6f8fa" stroke="#bf8700" stroke-width="1.2"/>
-  <rect x="16" y="178" width="500" height="4" rx="2" fill="#bf8700"/>
-  <rect x="28" y="190" width="32" height="16" rx="4" fill="#bf8700"/>
-  <text x="44" y="202" text-anchor="middle" class="badge">API</text>
-  <text x="70" y="202" class="mode-title" fill="#bf8700">REST API Server</text>
-  <text x="28" y="220" class="cmd">agent-bom serve [--port 8422] [--cors]</text>
-
-  <rect x="28" y="230" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="67" y="244" text-anchor="middle" class="step">HTTP Client</text>
-  <text x="67" y="254" text-anchor="middle" class="step-detail">curl / SDK / UI</text>
-
-  <line x1="108" y1="243" x2="122" y2="243" class="connector" stroke="#bf8700" marker-end="url(#arr-orange)"/>
-
-  <rect x="124" y="230" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="163" y="244" text-anchor="middle" class="step">FastAPI</text>
-  <text x="163" y="254" text-anchor="middle" class="step-detail">/v1/scan, /v1/blast</text>
-
-  <line x1="204" y1="243" x2="218" y2="243" class="connector" stroke="#bf8700" marker-end="url(#arr-orange)"/>
-
-  <rect x="220" y="230" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="259" y="244" text-anchor="middle" class="step">Rate Limit</text>
-  <text x="259" y="254" text-anchor="middle" class="step-detail">token + IP</text>
-
-  <line x1="300" y1="243" x2="314" y2="243" class="connector" stroke="#bf8700" marker-end="url(#arr-orange)"/>
-
-  <rect x="316" y="230" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="355" y="244" text-anchor="middle" class="step">Engine</text>
-  <text x="355" y="254" text-anchor="middle" class="step-detail">same core scan</text>
-
-  <line x1="396" y1="243" x2="410" y2="243" class="connector" stroke="#bf8700" marker-end="url(#arr-orange)"/>
-
-  <rect x="412" y="230" width="94" height="26" rx="4" fill="#ffffff" stroke="#bf8700" stroke-width="1"/>
-  <text x="459" y="244" text-anchor="middle" class="step">JSON / Webhook</text>
-  <text x="459" y="254" text-anchor="middle" class="step-detail">Jira, Slack, ServiceNow</text>
-
-  <text x="504" y="278" text-anchor="end" class="mode-sub">Dashboard backend, Snowflake integration</text>
+  <line x1="170" y1="316" x2="170" y2="346" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
+  <line x1="480" y1="316" x2="480" y2="346" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
+  <line x1="790" y1="316" x2="790" y2="346" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 4: Runtime Proxy (yellow/gold) -->
+  <!-- SHARED ENGINE — horizontal bar -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="544" y="178" width="500" height="108" rx="8" fill="#f6f8fa" stroke="#9a6700" stroke-width="1.2"/>
-  <rect x="544" y="178" width="500" height="4" rx="2" fill="#9a6700"/>
-  <rect x="556" y="190" width="50" height="16" rx="4" fill="#9a6700"/>
-  <text x="581" y="202" text-anchor="middle" class="badge">PROXY</text>
-  <text x="616" y="202" class="mode-title" fill="#9a6700">Runtime Proxy (6-layer)</text>
-  <text x="556" y="220" class="cmd">agent-bom protect [--mode monitor|enforce]</text>
+  <rect x="20" y="354" width="920" height="90" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.2"/>
+  <rect x="20" y="354" width="920" height="3" rx="1.5" fill="#d0d7de"/>
+  <text x="480" y="374" text-anchor="middle" class="engine-title">SHARED ENGINE — ALL MODES USE THE SAME CORE</text>
 
-  <rect x="556" y="230" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="592" y="244" text-anchor="middle" class="step">MCP Traffic</text>
-  <text x="592" y="254" text-anchor="middle" class="step-detail">agent ↔ server</text>
+  <!-- Engine modules — 7 evenly spaced -->
+  <rect x="32" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="0.8"/>
+  <text x="90" y="402" text-anchor="middle" class="engine-mod" fill="#0969da">Discovery</text>
+  <text x="90" y="416" text-anchor="middle" class="engine-detail">20 MCP clients · 4 clouds</text>
 
-  <line x1="630" y1="243" x2="644" y2="243" class="connector" stroke="#9a6700" marker-end="url(#arr-yellow)"/>
+  <rect x="158" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="0.8"/>
+  <text x="216" y="402" text-anchor="middle" class="engine-mod" fill="#0969da">Parsers</text>
+  <text x="216" y="416" text-anchor="middle" class="engine-detail">npm · pip · cargo · Docker</text>
 
-  <rect x="646" y="230" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="682" y="244" text-anchor="middle" class="step">Replay Det.</text>
-  <text x="682" y="254" text-anchor="middle" class="step-detail">dedup requests</text>
+  <rect x="284" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#1a7f37" stroke-width="0.8"/>
+  <text x="342" y="402" text-anchor="middle" class="engine-mod" fill="#1a7f37">Scanners</text>
+  <text x="342" y="416" text-anchor="middle" class="engine-detail">OSV · NVD · Grype · Syft</text>
 
-  <line x1="720" y1="243" x2="734" y2="243" class="connector" stroke="#9a6700" marker-end="url(#arr-yellow)"/>
+  <rect x="410" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#9a6700" stroke-width="0.8"/>
+  <text x="468" y="402" text-anchor="middle" class="engine-mod" fill="#9a6700">Enrichment</text>
+  <text x="468" y="416" text-anchor="middle" class="engine-detail">EPSS · KEV · CVSS</text>
 
-  <rect x="736" y="230" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="772" y="244" text-anchor="middle" class="step">Tool Drift</text>
-  <text x="772" y="254" text-anchor="middle" class="step-detail">undeclared block</text>
+  <rect x="536" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#bc4c00" stroke-width="0.8"/>
+  <text x="594" y="402" text-anchor="middle" class="engine-mod" fill="#bc4c00">Compliance</text>
+  <text x="594" y="416" text-anchor="middle" class="engine-detail">10 frameworks</text>
 
-  <line x1="810" y1="243" x2="824" y2="243" class="connector" stroke="#9a6700" marker-end="url(#arr-yellow)"/>
+  <rect x="662" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#cf222e" stroke-width="0.8"/>
+  <text x="720" y="402" text-anchor="middle" class="engine-mod" fill="#cf222e">Policy</text>
+  <text x="720" y="416" text-anchor="middle" class="engine-detail">16 conditions · YAML</text>
 
-  <rect x="826" y="230" width="72" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="862" y="244" text-anchor="middle" class="step">Policy + Cred</text>
-  <text x="862" y="254" text-anchor="middle" class="step-detail">args + leak scan</text>
-
-  <line x1="900" y1="243" x2="914" y2="243" class="connector" stroke="#9a6700" marker-end="url(#arr-yellow)"/>
-
-  <rect x="916" y="230" width="116" height="26" rx="4" fill="#ffffff" stroke="#9a6700" stroke-width="1"/>
-  <text x="974" y="244" text-anchor="middle" class="step">Allow / Block / Alert</text>
-  <text x="974" y="254" text-anchor="middle" class="step-detail">Prometheus :8422</text>
-
-  <text x="1032" y="278" text-anchor="end" class="mode-sub">5 detectors, webhook alerts, audit log</text>
+  <rect x="788" y="386" width="140" height="44" rx="5" fill="#ffffff" stroke="#8250df" stroke-width="0.8"/>
+  <text x="858" y="402" text-anchor="middle" class="engine-mod" fill="#8250df">Registry</text>
+  <text x="858" y="416" text-anchor="middle" class="engine-detail">427+ servers · CVE · EPSS</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 5: GitHub Action (green) -->
+  <!-- CONNECTOR ARROWS: engine → I/O -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="306" width="500" height="108" rx="8" fill="#f6f8fa" stroke="#1a7f37" stroke-width="1.2"/>
-  <rect x="16" y="306" width="500" height="4" rx="2" fill="#1a7f37"/>
-  <rect x="28" y="318" width="56" height="16" rx="4" fill="#1a7f37"/>
-  <text x="56" y="330" text-anchor="middle" class="badge">ACTION</text>
-  <text x="94" y="330" class="mode-title" fill="#1a7f37">GitHub Action (CI/CD Gate)</text>
-  <text x="28" y="348" class="cmd">uses: msaad00/agent-bom@v0.55.0</text>
-
-  <rect x="28" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="67" y="372" text-anchor="middle" class="step">PR Push</text>
-  <text x="67" y="382" text-anchor="middle" class="step-detail">trigger workflow</text>
-
-  <line x1="108" y1="371" x2="122" y2="371" class="connector" stroke="#1a7f37" marker-end="url(#arr-green)"/>
-
-  <rect x="124" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="163" y="372" text-anchor="middle" class="step">Install</text>
-  <text x="163" y="382" text-anchor="middle" class="step-detail">pip install agent-bom</text>
-
-  <line x1="204" y1="371" x2="218" y2="371" class="connector" stroke="#1a7f37" marker-end="url(#arr-green)"/>
-
-  <rect x="220" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="259" y="372" text-anchor="middle" class="step">Scan Repo</text>
-  <text x="259" y="382" text-anchor="middle" class="step-detail">MCP + deps + code</text>
-
-  <line x1="300" y1="371" x2="314" y2="371" class="connector" stroke="#1a7f37" marker-end="url(#arr-green)"/>
-
-  <rect x="316" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="355" y="372" text-anchor="middle" class="step">Policy Check</text>
-  <text x="355" y="382" text-anchor="middle" class="step-detail">fail-on-severity</text>
-
-  <line x1="396" y1="371" x2="410" y2="371" class="connector" stroke="#1a7f37" marker-end="url(#arr-green)"/>
-
-  <rect x="412" y="358" width="94" height="26" rx="4" fill="#ffffff" stroke="#1a7f37" stroke-width="1"/>
-  <text x="459" y="372" text-anchor="middle" class="step">PR Comment</text>
-  <text x="459" y="382" text-anchor="middle" class="step-detail">SARIF upload</text>
-
-  <text x="504" y="406" text-anchor="end" class="mode-sub">GitHub Marketplace, fail/pass gate</text>
+  <line x1="260" y1="444" x2="260" y2="474" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
+  <line x1="700" y1="444" x2="700" y2="474" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arr-down)"/>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- MODE 6: Dashboard (red/coral) -->
+  <!-- INPUT / OUTPUT — side by side -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="544" y="306" width="500" height="108" rx="8" fill="#f6f8fa" stroke="#cf222e" stroke-width="1.2"/>
-  <rect x="544" y="306" width="500" height="4" rx="2" fill="#cf222e"/>
-  <rect x="556" y="318" width="72" height="16" rx="4" fill="#cf222e"/>
-  <text x="592" y="330" text-anchor="middle" class="badge">DASHBOARD</text>
-  <text x="638" y="330" class="mode-title" fill="#cf222e">Interactive Dashboard</text>
-  <text x="556" y="348" class="cmd">agent-bom dashboard [--port 8501]</text>
 
-  <rect x="556" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="595" y="372" text-anchor="middle" class="step">Streamlit UI</text>
-  <text x="595" y="382" text-anchor="middle" class="step-detail">15 sections</text>
+  <!-- Input Sources -->
+  <text x="250" y="492" text-anchor="middle" class="section-label" fill="#0969da">INPUTS</text>
 
-  <line x1="636" y1="371" x2="650" y2="371" class="connector" stroke="#cf222e" marker-end="url(#arr-red)"/>
+  <rect x="20" y="502" width="460" height="38" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
+  <text x="250" y="520" text-anchor="middle" class="mode-feat">MCP configs · package files · Docker images · cloud APIs · source code</text>
+  <text x="250" y="533" text-anchor="middle" class="engine-detail">claude_desktop_config.json · package.json · requirements.txt · OCI layers · AWS/Azure/GCP/Snowflake</text>
 
-  <rect x="652" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="691" y="372" text-anchor="middle" class="step">Live Scan</text>
-  <text x="691" y="382" text-anchor="middle" class="step-detail">real-time results</text>
+  <!-- Output Targets -->
+  <text x="710" y="492" text-anchor="middle" class="section-label" fill="#1a7f37">OUTPUTS</text>
 
-  <line x1="732" y1="371" x2="746" y2="371" class="connector" stroke="#cf222e" marker-end="url(#arr-red)"/>
-
-  <rect x="748" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="787" y="372" text-anchor="middle" class="step">Visualize</text>
-  <text x="787" y="382" text-anchor="middle" class="step-detail">charts + graphs</text>
-
-  <line x1="828" y1="371" x2="842" y2="371" class="connector" stroke="#cf222e" marker-end="url(#arr-red)"/>
-
-  <rect x="844" y="358" width="78" height="26" rx="4" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="883" y="372" text-anchor="middle" class="step">Blast Map</text>
-  <text x="883" y="382" text-anchor="middle" class="step-detail">interactive graph</text>
-
-  <line x1="924" y1="371" x2="938" y2="371" class="connector" stroke="#cf222e" marker-end="url(#arr-red)"/>
-
-  <rect x="940" y="358" width="90" height="26" rx="4" fill="#ffffff" stroke="#cf222e" stroke-width="1"/>
-  <text x="985" y="372" text-anchor="middle" class="step">Export</text>
-  <text x="985" y="382" text-anchor="middle" class="step-detail">PDF / SBOM / JSON</text>
-
-  <text x="1032" y="406" text-anchor="end" class="mode-sub">Self-scan, compliance scorecard, SBOM viewer</text>
+  <rect x="500" y="502" width="440" height="38" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="0.8"/>
+  <text x="720" y="520" text-anchor="middle" class="mode-feat">SBOM · SARIF · JSON · HTML · Graph · Webhooks · ClickHouse</text>
+  <text x="720" y="533" text-anchor="middle" class="engine-detail">CycloneDX · SPDX · GitHub Code Scanning · Jira · Slack · ServiceNow · Prometheus</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- SHARED ENGINE SECTION -->
+  <!-- DEPLOYMENT — clean horizontal strip -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="434" width="1028" height="4" rx="2" fill="#d0d7de" opacity="0.5"/>
-  <text x="530" y="458" text-anchor="middle" class="section-label" fill="#8b949e">SHARED ENGINE — ALL MODES USE THE SAME CORE</text>
+  <rect x="20" y="558" width="920" height="2" rx="1" fill="#d0d7de" opacity="0.4"/>
+  <text x="480" y="578" text-anchor="middle" class="section-label" fill="#9a6700">DEPLOY ANYWHERE</text>
 
-  <!-- Engine modules row -->
-  <rect x="16" y="470" width="140" height="50" rx="6" fill="#f6f8fa" stroke="#0969da" stroke-width="1"/>
-  <text x="86" y="490" text-anchor="middle" class="step" fill="#0969da">Discovery</text>
-  <text x="86" y="504" text-anchor="middle" class="step-detail">20 MCP clients</text>
-  <text x="86" y="514" text-anchor="middle" class="step-detail">4 cloud providers</text>
+  <!-- Deployment pills -->
+  <rect x="36" y="590" width="102" height="32" rx="6" fill="#ffffff" stroke="#0969da" stroke-width="0.8"/>
+  <text x="87" y="606" text-anchor="middle" class="deploy-label" fill="#0969da">PyPI</text>
+  <text x="87" y="617" text-anchor="middle" class="deploy-detail">pip install</text>
 
-  <rect x="170" y="470" width="140" height="50" rx="6" fill="#f6f8fa" stroke="#0969da" stroke-width="1"/>
-  <text x="240" y="490" text-anchor="middle" class="step" fill="#0969da">Parsers</text>
-  <text x="240" y="504" text-anchor="middle" class="step-detail">npm, pip, cargo, go</text>
-  <text x="240" y="514" text-anchor="middle" class="step-detail">Docker, requirements.txt</text>
+  <rect x="150" y="590" width="102" height="32" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.8"/>
+  <text x="201" y="606" text-anchor="middle" class="deploy-label" fill="#8250df">Docker</text>
+  <text x="201" y="617" text-anchor="middle" class="deploy-detail">Hub + GHCR</text>
 
-  <rect x="324" y="470" width="140" height="50" rx="6" fill="#f6f8fa" stroke="#1a7f37" stroke-width="1"/>
-  <text x="394" y="490" text-anchor="middle" class="step" fill="#1a7f37">Scanners</text>
-  <text x="394" y="504" text-anchor="middle" class="step-detail">OSV, NVD, Grype, Syft</text>
-  <text x="394" y="514" text-anchor="middle" class="step-detail">OpenSSF Scorecard</text>
+  <rect x="264" y="590" width="102" height="32" rx="6" fill="#ffffff" stroke="#1a7f37" stroke-width="0.8"/>
+  <text x="315" y="606" text-anchor="middle" class="deploy-label" fill="#1a7f37">GitHub Action</text>
+  <text x="315" y="617" text-anchor="middle" class="deploy-detail">Marketplace</text>
 
-  <rect x="478" y="470" width="140" height="50" rx="6" fill="#f6f8fa" stroke="#9a6700" stroke-width="1"/>
-  <text x="548" y="490" text-anchor="middle" class="step" fill="#9a6700">Enrichment</text>
-  <text x="548" y="504" text-anchor="middle" class="step-detail">EPSS, KEV, CVSS</text>
-  <text x="548" y="514" text-anchor="middle" class="step-detail">blast radius mapping</text>
+  <rect x="378" y="590" width="102" height="32" rx="6" fill="#ffffff" stroke="#bc4c00" stroke-width="0.8"/>
+  <text x="429" y="606" text-anchor="middle" class="deploy-label" fill="#bc4c00">Railway SSE</text>
+  <text x="429" y="617" text-anchor="middle" class="deploy-detail">Remote MCP</text>
 
-  <rect x="632" y="470" width="140" height="50" rx="6" fill="#f6f8fa" stroke="#bf8700" stroke-width="1"/>
-  <text x="702" y="490" text-anchor="middle" class="step" fill="#bf8700">Compliance</text>
-  <text x="702" y="504" text-anchor="middle" class="step-detail">OWASP, ATLAS, NIST</text>
-  <text x="702" y="514" text-anchor="middle" class="step-detail">EU AI Act, ISO 42001</text>
+  <rect x="492" y="590" width="102" height="32" rx="6" fill="#ffffff" stroke="#9a6700" stroke-width="0.8"/>
+  <text x="543" y="606" text-anchor="middle" class="deploy-label" fill="#9a6700">Helm Chart</text>
+  <text x="543" y="617" text-anchor="middle" class="deploy-detail">K8s fleet</text>
 
-  <rect x="786" y="470" width="140" height="50" rx="6" fill="#f6f8fa" stroke="#cf222e" stroke-width="1"/>
-  <text x="856" y="490" text-anchor="middle" class="step" fill="#cf222e">Policy Engine</text>
-  <text x="856" y="504" text-anchor="middle" class="step-detail">18 conditions</text>
-  <text x="856" y="514" text-anchor="middle" class="step-detail">YAML rules</text>
+  <rect x="606" y="590" width="102" height="32" rx="6" fill="#ffffff" stroke="#cf222e" stroke-width="0.8"/>
+  <text x="657" y="606" text-anchor="middle" class="deploy-label" fill="#cf222e">Glama</text>
+  <text x="657" y="617" text-anchor="middle" class="deploy-detail">MCP marketplace</text>
 
-  <rect x="940" y="470" width="104" height="50" rx="6" fill="#f6f8fa" stroke="#8250df" stroke-width="1"/>
-  <text x="992" y="490" text-anchor="middle" class="step" fill="#8250df">Registry</text>
-  <text x="992" y="504" text-anchor="middle" class="step-detail">427+ MCP servers</text>
-  <text x="992" y="514" text-anchor="middle" class="step-detail">CVE + EPSS + KEV</text>
+  <rect x="720" y="590" width="102" height="32" rx="6" fill="#ffffff" stroke="#cf222e" stroke-width="0.8"/>
+  <text x="771" y="606" text-anchor="middle" class="deploy-label" fill="#cf222e">Smithery</text>
+  <text x="771" y="617" text-anchor="middle" class="deploy-detail">MCP marketplace</text>
+
+  <rect x="834" y="590" width="106" height="32" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="0.8"/>
+  <text x="887" y="606" text-anchor="middle" class="deploy-label" fill="#8250df">Snowflake</text>
+  <text x="887" y="617" text-anchor="middle" class="deploy-detail">Native App</text>
 
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- DATA SOURCES + OUTPUT TARGETS -->
+  <!-- KEY NUMBERS — bottom bar -->
   <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="540" width="1028" height="4" rx="2" fill="#d0d7de" opacity="0.5"/>
+  <rect x="20" y="640" width="920" height="2" rx="1" fill="#d0d7de" opacity="0.4"/>
 
-  <!-- Data Sources (left) -->
-  <text x="270" y="564" text-anchor="middle" class="section-label" fill="#0969da">INPUT SOURCES</text>
+  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#0969da">19</text>
+  <text x="120" y="680" text-anchor="middle" class="engine-detail">MCP tools</text>
 
-  <rect x="16" y="576" width="120" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="76" y="594" text-anchor="middle" class="step">MCP Configs</text>
-  <text x="76" y="607" text-anchor="middle" class="step-detail">claude_desktop_config.json</text>
+  <text x="240" y="666" text-anchor="middle" class="mode-title" fill="#8250df">427+</text>
+  <text x="240" y="680" text-anchor="middle" class="engine-detail">servers in registry</text>
 
-  <rect x="146" y="576" width="100" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="196" y="594" text-anchor="middle" class="step">Package Files</text>
-  <text x="196" y="607" text-anchor="middle" class="step-detail">package.json, req.txt</text>
+  <text x="360" y="666" text-anchor="middle" class="mode-title" fill="#1a7f37">20</text>
+  <text x="360" y="680" text-anchor="middle" class="engine-detail">client integrations</text>
 
-  <rect x="256" y="576" width="100" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="306" y="594" text-anchor="middle" class="step">Docker Images</text>
-  <text x="306" y="607" text-anchor="middle" class="step-detail">OCI layers + SBOM</text>
+  <text x="480" y="666" text-anchor="middle" class="mode-title" fill="#9a6700">5</text>
+  <text x="480" y="680" text-anchor="middle" class="engine-detail">runtime detectors</text>
 
-  <rect x="366" y="576" width="100" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="416" y="594" text-anchor="middle" class="step">Cloud APIs</text>
-  <text x="416" y="607" text-anchor="middle" class="step-detail">AWS, Azure, GCP, SF</text>
+  <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#bc4c00">10</text>
+  <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <rect x="476" y="576" width="100" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="526" y="594" text-anchor="middle" class="step">Source Code</text>
-  <text x="526" y="607" text-anchor="middle" class="step-detail">prompt injection scan</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#cf222e">6,100+</text>
+  <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
-  <!-- Output Targets (right) -->
-  <text x="800" y="564" text-anchor="middle" class="section-label" fill="#1a7f37">OUTPUT TARGETS</text>
-
-  <rect x="620" y="576" width="100" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="670" y="594" text-anchor="middle" class="step">SBOM</text>
-  <text x="670" y="607" text-anchor="middle" class="step-detail">CycloneDX, SPDX</text>
-
-  <rect x="730" y="576" width="100" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="780" y="594" text-anchor="middle" class="step">SARIF</text>
-  <text x="780" y="607" text-anchor="middle" class="step-detail">GitHub Code Scanning</text>
-
-  <rect x="840" y="576" width="100" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="890" y="594" text-anchor="middle" class="step">Connectors</text>
-  <text x="890" y="607" text-anchor="middle" class="step-detail">Jira, Slack, SNOW</text>
-
-  <rect x="950" y="576" width="94" height="38" rx="5" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="997" y="594" text-anchor="middle" class="step">ClickHouse</text>
-  <text x="997" y="607" text-anchor="middle" class="step-detail">Analytics warehouse</text>
-
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <!-- DEPLOYMENT MAP -->
-  <!-- ═══════════════════════════════════════════════════════════ -->
-  <rect x="16" y="634" width="1028" height="4" rx="2" fill="#d0d7de" opacity="0.5"/>
-  <text x="530" y="658" text-anchor="middle" class="section-label" fill="#9a6700">DEPLOYMENT OPTIONS</text>
-
-  <rect x="16" y="668" width="130" height="44" rx="6" fill="#ffffff" stroke="#0969da" stroke-width="1"/>
-  <text x="81" y="686" text-anchor="middle" class="step" fill="#0969da">pip install</text>
-  <text x="81" y="700" text-anchor="middle" class="step-detail">PyPI package</text>
-
-  <rect x="160" y="668" width="130" height="44" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="1"/>
-  <text x="225" y="686" text-anchor="middle" class="step" fill="#8250df">Docker Hub</text>
-  <text x="225" y="700" text-anchor="middle" class="step-detail">GHCR + Docker Hub</text>
-
-  <rect x="304" y="668" width="130" height="44" rx="6" fill="#ffffff" stroke="#1a7f37" stroke-width="1"/>
-  <text x="369" y="686" text-anchor="middle" class="step" fill="#1a7f37">GitHub Action</text>
-  <text x="369" y="700" text-anchor="middle" class="step-detail">Marketplace</text>
-
-  <rect x="448" y="668" width="130" height="44" rx="6" fill="#ffffff" stroke="#bf8700" stroke-width="1"/>
-  <text x="513" y="686" text-anchor="middle" class="step" fill="#bf8700">Railway SSE</text>
-  <text x="513" y="700" text-anchor="middle" class="step-detail">Remote MCP server</text>
-
-  <rect x="592" y="668" width="130" height="44" rx="6" fill="#ffffff" stroke="#9a6700" stroke-width="1"/>
-  <text x="657" y="686" text-anchor="middle" class="step" fill="#9a6700">Helm Chart</text>
-  <text x="657" y="700" text-anchor="middle" class="step-detail">K8s fleet scanning</text>
-
-  <rect x="736" y="668" width="130" height="44" rx="6" fill="#ffffff" stroke="#cf222e" stroke-width="1"/>
-  <text x="801" y="686" text-anchor="middle" class="step" fill="#cf222e">Glama / Smithery</text>
-  <text x="801" y="700" text-anchor="middle" class="step-detail">MCP marketplaces</text>
-
-  <rect x="880" y="668" width="164" height="44" rx="6" fill="#ffffff" stroke="#8250df" stroke-width="1"/>
-  <text x="962" y="686" text-anchor="middle" class="step" fill="#8250df">Snowflake Native App</text>
-  <text x="962" y="700" text-anchor="middle" class="step-detail">Enterprise governance</text>
+  <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#8250df">12</text>
+  <text x="840" y="680" text-anchor="middle" class="engine-detail">output formats</text>
 
   <!-- Footer -->
-  <text x="530" y="746" text-anchor="middle" class="footer">All modes share the same engine, registry, and enrichment pipeline</text>
-  <text x="530" y="762" text-anchor="middle" class="footer">github.com/msaad00/agent-bom</text>
+  <text x="480" y="708" text-anchor="middle" class="footer">github.com/msaad00/agent-bom · Apache 2.0</text>
 </svg>

--- a/skills/cloud-security-audit.md
+++ b/skills/cloud-security-audit.md
@@ -5,53 +5,79 @@
 ## Architecture
 
 ```
-  AWS Corporate Account
- ┌──────────────────────────────────────────────────────────────────────────────────────┐
- │                                                                                      │
- │  ┌──────────────┐    Snowflake    ┌──────────────┐         ┌──────────────────┐      │
- │  │  Snowflake   │    Task         │ Offboarding  │         │  AWS EventBridge │      │
- │  │  IAM &       │───(scheduled)──▶│ S3 Bucket    │────────▶│  Events + Rule   │      │
- │  │  Departed    │                 │ (JSON/Parquet│         │                  │      │
- │  │  Employees   │                 │  exports)    │         └────────┬─────────┘      │
- │  └──────────────┘                 └──────────────┘                  │                 │
- │                                                                     │                 │
- │                                           ┌─────────────────────────┘                 │
- │                                           │                                           │
- │                              ┌────────────▼─────────────────────────────┐             │
- │                              │              VPC                          │             │
- │                              │                                          │             │
- │                              │  ┌─────────────┐    ┌─────────────────┐  │             │
- │                              │  │ Parser      │    │ Worker          │  │             │
- │                              │  │ Lambda      │───▶│ Lambda          │  │             │
- │                              │  │             │    │                 │  │             │
- │                              │  │ IAM USER ◄──┘    │                 │  │             │
- │                              │  └──────┬──────┘    └────────┬────────┘  │             │
- │                              │  Parser IAM Role    Worker IAM Role      │             │
- │                              │  (read-only)        (write, cross-acct)  │             │
- │                              └──────────────────────────────┬───────────┘             │
- │                                                             │                         │
- │                              ┌──────────────────────────────┘                         │
- │                              │                                                        │
- │                 ┌────────────▼──────────┐         ┌─────────────────────┐             │
- │                 │  Target Accounts       │         │ Lambda Execution    │             │
- │                 │                        │         │ Logs S3             │             │
- │                 │  1. Revoke all creds   │         │ (audit trail)       │             │
- │                 │  2. Strip all perms    │         └──────────┬──────────┘             │
- │                 │  3. Quarantine & delete│                    │                        │
- │                 └───────────────────────┘                     │                        │
- │                                                               ▼                        │
- │                                                  ┌─────────────────────┐               │
- │                                                  │ Analytics / DW      │               │
- │                                                  │ (Snowflake,         │               │
- │                                                  │  ClickHouse, DBX,   │               │
- │                                                  │  or S3 archive)     │               │
- │                                                  │                     │               │
- │                                                  │ Remediation history │               │
- │                                                  │ Posture metrics     │               │
- │                                                  │ Compliance evidence │               │
- │                                                  └─────────────────────┘               │
- └──────────────────────────────────────────────────────────────────────────────────────┘
+                         EXTERNAL DATA SOURCES
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │                                                                      │
+ │  ┌───────────┐  ┌────────────┐  ┌────────────┐  ┌──────────────┐   │
+ │  │  Workday  │  │ Snowflake  │  │ Databricks │  │  ClickHouse  │   │
+ │  │  (API)    │  │ (SQL/S.I.) │  │ (Unity)    │  │  (SQL)       │   │
+ │  └─────┬─────┘  └─────┬──────┘  └─────┬──────┘  └──────┬───────┘   │
+ │        └───────────────┴───────┬───────┴─────────────────┘           │
+ └────────────────────────────────┼─────────────────────────────────────┘
+                                  │  HR termination data
+                                  │  + CloudTrail IAM events
+                                  ▼
+ ┌────────────────────────────────────────────────────────────────────────┐
+ │                  AWS Organization — Security OU Account                │
+ │                                                                        │
+ │  ┌──────────────────────────────────────────┐                          │
+ │  │  Reconciler                              │                          │
+ │  │                                          │                          │
+ │  │  sources.py → DepartureRecord[]          │                          │
+ │  │  change_detect.py → SHA-256 row diff     │                          │
+ │  │  export.py → S3 manifest (KMS encrypted) │                          │
+ │  └─────────────────┬────────────────────────┘                          │
+ │                    │                                                    │
+ │                    ▼                                                    │
+ │  ┌──────────────────────────┐     ┌─────────────────────────────┐     │
+ │  │  S3 Departures Bucket    │────▶│  EventBridge Rule           │     │
+ │  │  (KMS, versioned)        │     │  (S3 PutObject trigger)     │     │
+ │  └──────────────────────────┘     └──────────────┬──────────────┘     │
+ │                                                   │                    │
+ │                                   ┌───────────────▼───────────────┐   │
+ │                                   │        Step Function           │   │
+ │   ┌───── VPC ─────────────────────────────────────────────────┐   │   │
+ │   │                                                           │   │   │
+ │   │  ┌─────────────────────┐    ┌──────────────────────────┐  │   │   │
+ │   │  │ Parser Lambda       │    │ Worker Lambda             │  │   │   │
+ │   │  │                     │───▶│                            │  │   │   │
+ │   │  │ - Validate manifest │    │ - 13-step IAM cleanup     │  │   │   │
+ │   │  │ - Grace period check│    │ - Cross-account STS       │  │   │   │
+ │   │  │ - Rehire filtering  │    │ - Multi-cloud workers     │  │   │   │
+ │   │  │ - IAM existence     │    │ - Audit to DDB + S3       │  │   │   │
+ │   │  │                     │    │                            │  │   │   │
+ │   │  │ Parser IAM Role     │    │ Worker IAM Role            │  │   │   │
+ │   │  │ (read-only)         │    │ (write, cross-account)     │  │   │   │
+ │   │  └─────────────────────┘    └────────────┬─────────────┘  │   │   │
+ │   └──────────────────────────────────────────┼─────────────────┘   │   │
+ │                                              │                      │   │
+ │                 ┌────────────────────────────▼──────────────────┐    │
+ │                 │  Target Accounts (via STS AssumeRole)         │    │
+ │                 │                                                │    │
+ │                 │  1. Revoke all credentials                    │    │
+ │                 │  2. Strip all permissions                     │    │
+ │                 │  3. Delete IAM user                           │    │
+ │                 └──────────────────────────────────────────────┘    │
+ │                                                                      │
+ │   ┌──────────────────────────────────────────────────────────────┐   │
+ │   │  Audit Trail                                                 │   │
+ │   │  DynamoDB (per-user) + S3 (execution logs)                   │   │
+ │   └──────────────────────────────┬───────────────────────────────┘   │
+ └──────────────────────────────────┼───────────────────────────────────┘
+                                    │  Remediation logs feed back
+                                    ▼
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │                    EXTERNAL ANALYTICS / DW                            │
+ │                                                                      │
+ │  ┌───────────┐  ┌────────────┐  ┌────────────┐  ┌──────────────┐   │
+ │  │ Snowflake │  │ ClickHouse │  │ Databricks │  │  S3 Archive  │   │
+ │  └───────────┘  └────────────┘  └────────────┘  └──────────────┘   │
+ │                                                                      │
+ │  Remediation history · Posture metrics · Compliance evidence         │
+ └──────────────────────────────────────────────────────────────────────┘
 ```
+
+> **Deployable code**: See [cloud-security](https://github.com/msaad00/cloud-security/tree/main/skills/iam-departures-remediation) for production Lambda code, CloudFormation templates, and multi-cloud workers.
 
 ## Data Flow — Step by Step
 


### PR DESCRIPTION
## Summary
- **SVG diagram**: Replace 30 tiny step-by-step boxes inside each mode card with clean, scannable cards (badge + title + command + 3 key features). Add key numbers bar (19 tools, 427+ servers, 20 clients, etc). Net -306 lines, smaller viewBox.
- **cloud-security-audit.md**: Fix architecture — data warehouses (Snowflake/ClickHouse/DBX/Workday) are EXTERNAL sources, not inside Security OU. Add Reconciler layer, link to cloud-security repo for deployable Lambda code.

## Test plan
- [ ] Verify dark SVG renders on GitHub (dark mode)
- [ ] Verify light SVG renders on GitHub (light mode)
- [ ] Verify cloud-security-audit.md architecture diagram is correct
- [ ] Confirm no stale numbers in SVG (19 tools, 427+ servers, v0.57.0, 16 conditions)