### PR TITLE
fix: bump Dockerfile.snowpark version 0.54.0 → 0.57.0

### DIFF
--- a/Dockerfile.snowpark
+++ b/Dockerfile.snowpark
@@ -1,6 +1,6 @@
 FROM python:3.11-slim@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
-ARG VERSION=0.54.0
+ARG VERSION=0.57.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"


### PR DESCRIPTION
## Summary
- Bump `Dockerfile.snowpark` ARG VERSION from 0.54.0 to 0.57.0
- Only version-bearing file not aligned with current release

## Test plan
- [ ] Verify Snowpark container builds with updated version