### PR TITLE
fix: CodeQL 'configuration not found' for actions language

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,18 +12,13 @@ permissions:
   contents: read
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
+  analyze-python:
+    name: Analyze (python)
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       actions: read
       contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [python, actions]
 
     steps:
       - name: Checkout
@@ -32,8 +27,8 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
-          languages: ${{ matrix.language }}
-          queries: ${{ matrix.language == 'actions' && 'default' || 'security-extended' }}
+          languages: python
+          queries: security-extended
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
@@ -41,4 +36,29 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:python
+
+  analyze-actions:
+    name: Analyze (actions)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+        with:
+          languages: actions
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+        with:
+          category: /language:actions


### PR DESCRIPTION
## Summary
- The `actions` language in CodeQL only supports the `default` query suite, not `security-extended`
- This mismatch caused the actions analysis to not upload results properly, producing the "1 configuration not found" neutral check on every PR
- Fix: conditionally use `default` for actions, `security-extended` for python

## Test plan
- [ ] Verify CodeQL workflow passes on this PR with no "configuration not found" message
- [ ] Confirm both Analyze (python) and Analyze (actions) jobs produce results