### PR TITLE
release: v0.58.1 — security hardening + CodeQL fix + version alignment

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           agent-bom scan --sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.58.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.58.1"}},"results":[]}]}' > results.sarif
           fi
       - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         if: always()

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,7 +31,7 @@ jobs:
           publish_results: true
           repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
-      - name: Upload to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
-        with:
-          sarif_file: scorecard-results.sarif
+      # Scorecard results are published to securityscorecards.dev via publish_results: true.
+      # We intentionally skip upload-sarif here because Scorecard only runs on main
+      # (not PRs), and uploading SARIF creates a "code scanning configuration" that
+      # GitHub expects on PRs too — causing "1 configuration not found" neutral checks.

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -12,7 +12,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.58.0
+ARG VERSION=0.58.1
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.snowpark
+++ b/Dockerfile.snowpark
@@ -1,6 +1,6 @@
 FROM python:3.11-slim@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
-ARG VERSION=0.58.0
+ARG VERSION=0.58.1
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -13,7 +13,7 @@
 
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.58.0
+ARG VERSION=0.58.1
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="AI supply chain security scanner — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.58.0"
+  --version "0.58.1"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.58.0
-git push origin v0.58.0
+git tag v0.58.1
+git push origin v0.58.1
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 | Use case | Deploy | Command |
 |----------|--------|---------|
 | Quick local scan | CLI | `agent-bom scan` |
-| CI/CD gate | GitHub Action | `uses: msaad00/agent-bom@v0.58.0` |
+| CI/CD gate | GitHub Action | `uses: msaad00/agent-bom@v0.58.1` |
 | Security dashboard | API + UI | `agent-bom serve` |
 | MCP tool integration | MCP server | `agent-bom mcp-server` (20 tools) |
 | K8s fleet scanning | Helm | `helm install deploy/helm/agent-bom` |
@@ -285,7 +285,7 @@ Console, HTML dashboard, SARIF, CycloneDX 1.6, SPDX 3.0, Prometheus, OTLP, JSON,
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.58.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.58.1` |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
 | OpenClaw | [SKILL.md](integrations/openclaw/SKILL.md) |
@@ -592,7 +592,7 @@ Both sources deduplicate by CVE ID against OSV results.
 | CLI | `agent-bom scan` | Local audit |
 | Pre-install check | `agent-bom check express@4.18.2 -e npm` | Before running MCP servers |
 | Pre-install guard | `agent-bom guard pip install flask` | Scan-before-install hook |
-| GitHub Action | `uses: msaad00/agent-bom@v0.58.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.58.1` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | Runtime proxy | `agent-bom proxy` | Opt-in MCP traffic audit (per-server) |
@@ -604,7 +604,7 @@ Both sources deduplicate by CVE ID against OSV results.
 ### GitHub Action
 
 ```yaml
-- uses: msaad00/agent-bom@v0.58.0
+- uses: msaad00/agent-bom@v0.58.1
   with:
     severity-threshold: high
     upload-sarif: true
@@ -746,7 +746,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.58.0` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.58.1` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: AI supply chain security scanner — scan containers, MCP servers, and AI agents for CVEs, credential exposure, and compliance violations
 version: 0.1.0
-appVersion: "0.58.0"
+appVersion: "0.58.1"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: msaad02/agent-bom
-  tag: "0.58.0"
+  tag: "0.58.1"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: msaad02/agent-bom-runtime
-  tag: "0.58.0"
+  tag: "0.58.1"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.58.0
+- uses: msaad00/agent-bom@v0.58.1
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.58.0",
+      "version": "0.58.1",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   compliance (OWASP, MITRE ATLAS, EU AI Act, NIST AI RMF). Use when the user
   mentions vulnerability scanning, dependency security, SBOM generation, MCP server
   trust, or AI supply chain risk.
-version: 0.58.0
+version: 0.58.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Docker for container
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.58.0
+    docker: ghcr.io/msaad00/agent-bom:0.58.1
   openclaw:
     requires:
       bins: []
@@ -143,7 +143,7 @@ agent-bom where             # show all discovery paths
 ### As a Docker Container
 
 ```bash
-docker run --rm ghcr.io/msaad00/agent-bom:0.58.0 scan
+docker run --rm ghcr.io/msaad00/agent-bom:0.58.1 scan
 ```
 
 ### Self-Hosted SSE Server
@@ -277,7 +277,7 @@ returns an error asking you to configure them.
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: [smithery.ai/server/agent-bom](https://smithery.ai/server/agent-bom/agent-bom)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.58.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.58.1`
 - **6,300+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.58.0
+ARG VERSION=0.58.1
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom MCP Server: AI supply chain security scanning via MCP protocol"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI supply chain security scanner — scan packages for CVEs, assess credential exposure, map blast radius from vulnerabilities to tools, generate SBOMs, enforce policies",
   "title": "agent-bom",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.58.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.58.1",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.58.0": {
+        "ghcr.io/msaad00/agent-bom:v0.58.1": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.58.0"
+version = "0.58.1"
 description = "Security scanner for AI agent infrastructure. Discover MCP configs (20 clients), scan for CVEs, map blast radius to credentials and tools, CIS benchmarks (AWS, Snowflake), pre-install guard, 10-framework compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.58.0"
+    __version__ = "0.58.1"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.58.0"
+    assert __version__ == "0.58.1"
 
 
 def test_report_version_matches():
@@ -2933,7 +2933,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.58.0"
+    assert data["version"] == "0.58.1"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
Release v0.58.1 rolls up all post-v0.58.0 fixes. **v0.58.0 was never tagged/released** — this is the first release since v0.57.0 that includes:

### From PR #217 (v0.58.0 code)
- Parametric policy expressions (AND/OR/NOT, comparisons, 25 fields)
- Runtime ↔ scan correlation engine + `runtime_correlate` MCP tool (#20)

### From PRs #218, #219, #220 (fixes)
- **Security**: SQL injection prevention (ClickHouse), ReDoS mitigation (proxy), parser depth limits
- **CodeQL**: Split into separate jobs (actions has no query packs), removed Scorecard SARIF upload that caused "1 configuration not found"
- **Stale refs**: 19→20 tools across 15 files + 8 SVGs, Dockerfile.snowpark version, registry count 112→427
- **ClawHub**: Trust transparency improvements (credential_policy, SSE opt-in flags)

### Version bump
0.58.0 → 0.58.1 across 17 files

## After merge
```bash
git tag v0.58.1
git push origin v0.58.1
```
This triggers the release pipeline → PyPI → Smithery/ClawHub auto-update

## Test plan
- [x] 289 tests pass locally
- [ ] CI passes all checks
- [ ] "1 configuration not found" should NOT appear on this PR