### PR TITLE
fix: remove cve-freshness SARIF upload causing 'config not found' on PRs

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -27,8 +27,6 @@ jobs:
           if [ ! -f results.sarif ]; then
             echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.58.1"}},"results":[]}]}' > results.sarif
           fi
-      - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
-        if: always()
-        with:
-          sarif_file: results.sarif
-          category: agent-bom-scheduled
+      # CVE freshness results are logged in workflow output.
+      # We skip upload-sarif because this workflow only runs on schedule (not PRs),
+      # and a schedule-only SARIF category causes "1 configuration not found" on PRs.


### PR DESCRIPTION
## Summary
The **real** root cause of the persistent "1 configuration not found" check on PRs.

The `cve-freshness.yml` workflow uploads SARIF with category `agent-bom-scheduled` but only runs on schedule/dispatch (never PRs). GitHub expects all code scanning categories present on main to also be present on PRs → "1 configuration not found".

**Fix**: Remove the `upload-sarif` step. Also deleted all stale `agent-bom-scheduled` analyses from the code scanning database.

After this, only 3 categories remain — all of which run on PRs:
- `/language:actions` (CodeQL)
- `/language:python` (CodeQL)  
- `agent-bom` (CI self-scan)

## Test plan
- [ ] This PR should NOT show "1 configuration not found"