### PR TITLE
fix: correct test count and policy conditions claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,7 +771,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 | **Compliance** | 10 frameworks (OWASP Agentic/LLM/MCP, MITRE ATLAS, NIST AI RMF, EU AI Act, NIST CSF 2.0, ISO 27001, SOC 2, CIS Controls v8) |
 | **CIS Benchmarks** | AWS Foundations v3.0 (18 checks), Snowflake v1.0 (12 checks) |
 | **Runtime** | MCP proxy, 5-detector protection engine, config watchers, OTel trace ingestion |
-| **Enterprise** | Posture scorecard (A-F), policy-as-code (16 conditions), SAST via Semgrep, pre-install guard |
+| **Enterprise** | Posture scorecard (A-F), policy-as-code (17 conditions), SAST via Semgrep, pre-install guard |
 | **Output** | JSON, SARIF, CycloneDX, SPDX, HTML, Mermaid, Cytoscape graph, Prometheus, Slack/webhook alerts |
 | **Integrations** | Jira, Slack, Vanta, Drata, GitHub Action, Snowflake Native App, Streamlit dashboard |
 

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   pypi: https://pypi.org/project/agent-bom/
   smithery: https://smithery.ai/server/agent-bom/agent-bom
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6300
+  tests: 3173
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -278,6 +278,6 @@ returns an error asking you to configure them.
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: [smithery.ai/server/agent-bom](https://smithery.ai/server/agent-bom/agent-bom)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.58.1`
-- **6,300+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
+- **3,100+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics


### PR DESCRIPTION
## Summary
- Fix inflated test count: 6,300 → 3,173 (verified via `pytest --collect-only`)
- Fix policy conditions count: 16 → 17 (the `condition` expression engine added in v0.58.0 is the 17th)
- Honesty rule: only claim what's actually there

## Files changed
- `integrations/openclaw/SKILL.md` — test count in metadata and verification section
- `README.md` — policy conditions count in capability table