### PR TITLE
fix: security hardening + stale ref cleanup (#213)

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -79,7 +79,7 @@ git add servers/agent-bom.json
 git commit -m "feat: add agent-bom MCP server"
 git push origin add-agent-bom
 gh pr create --title "feat: add agent-bom security scanner" \
-  --body "Adds agent-bom — AI supply chain security scanner with 14 MCP tools."
+  --body "Adds agent-bom — AI supply chain security scanner with 20 MCP tools."
 ```
 
 ### Verification

--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ Browse: [mcp_registry.json](src/agent_bom/mcp_registry.json) | Expand: `python s
 - **[PERMISSIONS.md](PERMISSIONS.md)** — auditable trust contract with all config paths enumerated
 - **Read-only** — never writes configs, runs servers, provisions resources, or stores secrets
 - **Credential redaction** — only env var **names** in reports; values, tokens, passwords never read
-- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.58.1` (SHA-256 + SLSA provenance)
+- **Sigstore signed** — releases v0.7.0+ signed via cosign OIDC; verify PyPI integrity with `agent-bom verify agent-bom@0.59.0` (SHA-256 + SLSA provenance)
 - **No binary needed (MCP)** — SSE transport requires zero local install; local CLI available for air-gapped use
 - **OpenSSF Scorecard** — [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.58.1
+    docker: ghcr.io/msaad00/agent-bom:0.59.0
   openclaw:
     requires:
       bins: []
@@ -190,7 +190,7 @@ agent-bom where             # show all discovery paths
 ### As a Docker Container
 
 ```bash
-docker run --rm ghcr.io/msaad00/agent-bom:0.58.1 scan
+docker run --rm ghcr.io/msaad00/agent-bom:0.59.0 scan
 ```
 
 ### Self-Hosted SSE Server
@@ -330,7 +330,7 @@ returns an error asking you to configure them.
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **PyPI**: [pypi.org/project/agent-bom](https://pypi.org/project/agent-bom/)
 - **Smithery**: [smithery.ai/server/agent-bom](https://smithery.ai/server/agent-bom/agent-bom)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.58.1`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.59.0`
 - **3,200+ tests** with automated security scanning (CodeQL + OpenSSF Scorecard)
 - **OpenSSF Scorecard**: [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **No telemetry**: Zero tracking, zero analytics

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -212,4 +212,5 @@ class ClickHouseAnalyticsStore:
 
 def _escape(value: str) -> str:
     """Escape a string value for ClickHouse SQL (prevent injection)."""
-    return value.replace("\\", "\\\\").replace("'", "\\'")
+    # Strip null bytes which can truncate queries in some drivers
+    return value.replace("\x00", "").replace("\\", "\\\\").replace("'", "\\'")

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -3517,12 +3517,12 @@ def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_jso
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 14 security tools via MCP protocol:
+    Exposes 20 security tools via MCP protocol:
       scan              Full scan — CVEs, config security, blast radius, compliance
       check             Check a specific package for CVEs before installing
       blast_radius      Look up blast radius for a specific CVE
       policy_check      Evaluate policy rules against scan findings
-      registry_lookup   Query the MCP server threat intelligence registry
+      registry_lookup   Query the MCP server security metadata registry
       generate_sbom     Generate CycloneDX or SPDX SBOM
       compliance        10-framework compliance posture
       remediate         Generate actionable remediation plan
@@ -3532,6 +3532,12 @@ def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_jso
       inventory         List agents/servers without CVE scanning
       diff              Compare scan against baseline for new/resolved vulns
       marketplace_check Pre-install marketplace trust check
+      code_scan         SAST scanning via Semgrep with CWE mapping
+      context_graph     Agent context graph with lateral movement analysis
+      analytics_query   Query vulnerability trends from ClickHouse
+      cis_benchmark     Run CIS benchmark checks (AWS/Snowflake)
+      fleet_scan        Batch registry lookup for fleet inventories
+      runtime_correlate Cross-reference runtime audit logs with CVE findings
 
     \b
     Usage:

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1449,6 +1449,14 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             if query_type not in valid_types:
                 return json.dumps({"error": f"Invalid query_type. Use one of: {', '.join(sorted(valid_types))}"})
 
+            # Validate agent name to prevent SQL injection via ClickHouse
+            import re as _re
+
+            if agent and not _re.fullmatch(r"[a-zA-Z0-9._\-/ ]{1,200}", agent):
+                return json.dumps(
+                    {"error": "Invalid agent name. Use only alphanumeric, dot, dash, underscore, slash, space (max 200 chars)."}
+                )
+
             if query_type == "vuln_trends":
                 data = store.query_vuln_trends(days=days, agent=agent)
             elif query_type == "top_cves":
@@ -1573,7 +1581,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("Registry read failed")
             return json.dumps({"error": f"Failed to read registry: {sanitize_error(exc)}"})
 
-    @mcp.tool()
+    @mcp.tool(annotations=_READ_ONLY)
     async def runtime_correlate(
         config_path: Annotated[
             str,
@@ -1599,7 +1607,9 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             summary stats, and uncalled vulnerable tools.
         """
         try:
-            report = await _run_scan_pipeline(config_path)
+            # Normalize "auto" → None so _run_scan_pipeline uses default discovery
+            effective_config = None if config_path == "auto" else config_path
+            report = await _run_scan_pipeline(effective_config)
             result: dict = {
                 "scan_summary": {
                     "agents": report.total_agents,
@@ -1609,9 +1619,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             }
 
             if audit_log:
+                # Validate audit_log path to prevent directory traversal
+                safe_audit = _safe_path(audit_log)
                 from agent_bom.runtime_correlation import correlate as _correlate
 
-                corr = _correlate(report.blast_radii, audit_log_path=audit_log)
+                corr = _correlate(report.blast_radii, audit_log_path=str(safe_audit))
                 result["correlation"] = corr.to_dict()
             else:
                 result["correlation"] = {

--- a/src/agent_bom/sast.py
+++ b/src/agent_bom/sast.py
@@ -285,6 +285,10 @@ def scan_code(
     if not resolved.exists():
         raise SASTScanError(f"Path does not exist: {path}")
 
+    # Validate config: only allow safe values (no URLs that could exfiltrate code)
+    if config.startswith(("http://", "https://", "ftp://")):
+        raise SASTScanError("Remote semgrep config URLs are not allowed. Use 'auto', 'p/<ruleset>', or a local file path.")
+
     start = time.monotonic()
 
     cmd = [

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -243,8 +243,23 @@ def validate_url(url: str) -> None:
         raise SecurityError(f"Only HTTPS URLs are allowed, got: {parsed.scheme}")
 
     # Validate domain is not localhost or internal IP
-    if parsed.hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1"):  # nosec B104 - checking FOR these values to reject them, not binding to them
-        raise SecurityError(f"Cannot connect to localhost/internal IPs: {parsed.hostname}")
+    hostname = parsed.hostname or ""
+    if hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1"):  # nosec B104 - checking FOR these values to reject them, not binding to them
+        raise SecurityError(f"Cannot connect to localhost/internal IPs: {hostname}")
+
+    # Block private/reserved IP ranges (RFC 1918, link-local, cloud metadata)
+    import ipaddress
+
+    try:
+        addr = ipaddress.ip_address(hostname)
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise SecurityError(f"Cannot connect to private/reserved IP: {hostname}")
+    except ValueError:
+        pass  # hostname is a domain name, not an IP — OK
+
+    # Block cloud metadata endpoints (AWS/GCP/Azure)
+    if hostname in ("169.254.169.254", "metadata.google.internal"):
+        raise SecurityError(f"Cannot connect to cloud metadata endpoint: {hostname}")
 
     logger.debug(f"URL validated: {url}")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2986,7 +2986,7 @@ def test_openclaw_skill_declares_mcp_endpoint():
 
 
 def test_openclaw_skill_lists_tools():
-    """OpenClaw SKILL.md should document all 14 MCP tools."""
+    """OpenClaw SKILL.md should document all 20 MCP tools."""
     from pathlib import Path
 
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -222,7 +222,7 @@ def test_mcp_server_help_shows_14_tools():
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp-server", "--help"])
-    assert "14 security tools" in result.output
+    assert "20 security tools" in result.output
     assert "compliance" in result.output
     assert "remediate" in result.output
 


### PR DESCRIPTION
## Summary

- **HIGH**: Path traversal via `audit_log` in `runtime_correlate` — now validated through `_safe_path()`
- **MEDIUM**: SSRF in `validate_url()` — now blocks RFC 1918, link-local, and cloud metadata IPs (`169.254.169.254`)
- **MEDIUM**: Semgrep `config` parameter — rejects remote URLs to prevent code exfiltration
- **MEDIUM**: ClickHouse injection — null byte stripping in `_escape()`, agent name regex validation
- **LOW**: `runtime_correlate` `config_path="auto"` normalized to `None`
- Stale version refs updated (`0.58.1` → `0.59.0`) in SKILL.md, README, PUBLISHING.md
- MCP tool count corrected (`14` → `20`) in CLI help text and tests

## Test plan

- [x] All 3,182 tests pass (`pytest -m "not network"`)
- [x] Ruff lint + format clean
- [ ] CI passes on PR