### PR TITLE
fix: P1/P2 audit backlog — credential scanning, retry logic, input bounds, health checks (#229)

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -65,17 +65,26 @@ jobs:
 
       - name: Publish to MCP Registry
         run: |
-          HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
-            -o /tmp/publish-response.json -w "%{http_code}" \
-            -X POST "https://registry.modelcontextprotocol.io/v0.1/publish" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ steps.auth.outputs.jwt }}" \
-            -d @integrations/mcp-registry/server.json)
-          echo "Publish status: $HTTP_STATUS"
-          cat /tmp/publish-response.json
-          if [ "$HTTP_STATUS" -ge 400 ]; then
-            echo "::error::MCP Registry publish failed (HTTP $HTTP_STATUS) — check response above"
-            exit 1
-          else
-            echo "Published to MCP Registry successfully"
-          fi
+          # Retry up to 3 times with exponential backoff
+          for ATTEMPT in 1 2 3; do
+            HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
+              -o /tmp/publish-response.json -w "%{http_code}" \
+              -X POST "https://registry.modelcontextprotocol.io/v0.1/publish" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ steps.auth.outputs.jwt }}" \
+              -d @integrations/mcp-registry/server.json)
+            echo "MCP Registry attempt ${ATTEMPT}/3 — HTTP $HTTP_STATUS"
+            cat /tmp/publish-response.json
+
+            if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+              echo "Published to MCP Registry successfully"
+              break
+            elif [ "$HTTP_STATUS" -ge 500 ] && [ "$ATTEMPT" -lt 3 ]; then
+              DELAY=$((ATTEMPT * 10))
+              echo "Server error — retrying in ${DELAY}s..."
+              sleep "$DELAY"
+            else
+              echo "::error::MCP Registry publish failed (HTTP $HTTP_STATUS) — check response above"
+              exit 1
+            fi
+          done

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -62,34 +62,64 @@ jobs:
 
           echo "Publishing agent-bom v${VERSION} to Smithery..."
 
+          # Retry up to 3 times with exponential backoff (handles transient 5xx)
+          for ATTEMPT in 1 2 3; do
+            HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
+              -o /tmp/smithery-response.json -w "%{http_code}" \
+              -X PUT "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases" \
+              -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
+              -F "payload={
+                \"type\": \"external\",
+                \"upstreamUrl\": \"${MCP_URL}\",
+                \"configSchema\": {
+                  \"type\": \"object\",
+                  \"properties\": {
+                    \"NVD_API_KEY\": {
+                      \"type\": \"string\",
+                      \"description\": \"NVD API key for higher rate limits on CVSS enrichment (optional)\"
+                    }
+                  },
+                  \"required\": []
+                }
+              }")
+
+            echo "Smithery attempt ${ATTEMPT}/3 — HTTP ${HTTP_STATUS}"
+
+            if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+              echo "Smithery publish succeeded"
+              break
+            elif [ "$HTTP_STATUS" -ge 500 ] && [ "$ATTEMPT" -lt 3 ]; then
+              DELAY=$((ATTEMPT * 10))
+              echo "Server error — retrying in ${DELAY}s..."
+              sleep "$DELAY"
+            else
+              echo "::error::Smithery publish failed with HTTP ${HTTP_STATUS}"
+              cat /tmp/smithery-response.json
+              exit 1
+            fi
+          done
+
+  glama:
+    name: Trigger Glama Rebuild
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Trigger Glama rebuild
+        env:
+          GLAMA_WEBHOOK_URL: ${{ vars.GLAMA_WEBHOOK_URL }}
+        run: |
+          if [ -z "$GLAMA_WEBHOOK_URL" ]; then
+            echo "::notice::GLAMA_WEBHOOK_URL not configured — Glama will rebuild on next auto-sync from PyPI"
+            echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL in repo variables"
+            exit 0
+          fi
           HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
-            -o /tmp/smithery-response.json -w "%{http_code}" \
-            -X PUT "https://api.smithery.ai/servers/${QUALIFIED_NAME}/releases" \
-            -H "Authorization: Bearer ${SMITHERY_API_TOKEN}" \
-            -F "payload={
-              \"type\": \"external\",
-              \"upstreamUrl\": \"${MCP_URL}\",
-              \"configSchema\": {
-                \"type\": \"object\",
-                \"properties\": {
-                  \"NVD_API_KEY\": {
-                    \"type\": \"string\",
-                    \"description\": \"NVD API key for higher rate limits on CVSS enrichment (optional)\"
-                  }
-                },
-                \"required\": []
-              }
-            }")
-
-          echo "Smithery response (HTTP ${HTTP_STATUS}):"
-          cat /tmp/smithery-response.json
-
-          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
-            echo "Smithery publish succeeded"
+            -o /dev/null -w "%{http_code}" \
+            -X POST "$GLAMA_WEBHOOK_URL")
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+            echo "Glama rebuild triggered successfully"
           else
-            echo "::error::Smithery publish failed with HTTP ${HTTP_STATUS}"
-            cat /tmp/smithery-response.json
-            exit 1
+            echo "::warning::Glama rebuild trigger returned HTTP ${HTTP_STATUS} — may need manual rebuild"
           fi
 
   clawhub:
@@ -140,13 +170,23 @@ jobs:
 
           npm install -g clawhub@0.7.0  # pinned — update periodically
           clawhub login --token "${CLAWHUB_TOKEN}"
-          if clawhub publish integrations/openclaw \
-            --slug agent-bom \
-            --name "agent-bom" \
-            --version "${VERSION}" \
-            --changelog "Release v${VERSION}"; then
-            echo "ClawHub publish succeeded"
-          else
-            echo "::error::ClawHub publish failed"
-            exit 1
-          fi
+
+          # Retry up to 3 times with exponential backoff
+          for ATTEMPT in 1 2 3; do
+            echo "ClawHub attempt ${ATTEMPT}/3..."
+            if clawhub publish integrations/openclaw \
+              --slug agent-bom \
+              --name "agent-bom" \
+              --version "${VERSION}" \
+              --changelog "Release v${VERSION}"; then
+              echo "ClawHub publish succeeded"
+              break
+            elif [ "$ATTEMPT" -lt 3 ]; then
+              DELAY=$((ATTEMPT * 10))
+              echo "ClawHub publish failed — retrying in ${DELAY}s..."
+              sleep "$DELAY"
+            else
+              echo "::error::ClawHub publish failed after 3 attempts"
+              exit 1
+            fi
+          done

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -38,7 +38,7 @@ ENV PYTHONUNBUFFERED=1
 
 EXPOSE 8422
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD agent-bom --version || exit 1
 
 ENTRYPOINT ["agent-bom", "proxy"]

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -41,7 +41,7 @@ ENV PORT=8423
 
 EXPOSE ${PORT}
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD agent-bom --version || exit 1
 
 # Use shell form so $PORT is expanded at runtime (Railway/Render inject PORT)

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -21,7 +21,7 @@ USER abom
 
 ENV PYTHONUNBUFFERED=1
 
-HEALTHCHECK --interval=60s --timeout=5s --retries=3 \
+HEALTHCHECK --interval=60s --timeout=10s --start-period=10s --retries=3 \
     CMD agent-bom --version || exit 1
 
 ENTRYPOINT ["agent-bom", "mcp-server"]

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -97,11 +97,16 @@ async def fetch_nvd_data(cve_id: str, client: httpx.AsyncClient, api_key: Option
     """
     _load_enrichment_cache()
 
-    # Check persistent cache
+    # Check persistent cache — reject entries older than 90 days
+    _nvd_max_age_secs = 90 * 86400
+    _now = time.time()
     if cve_id in _nvd_file_cache:
         cached = _nvd_file_cache[cve_id]
-        data = {k: v for k, v in cached.items() if k != "_cached_at"}
-        return data if data else None
+        cached_at = cached.get("_cached_at", 0)
+        if _now - cached_at < _nvd_max_age_secs:
+            data = {k: v for k, v in cached.items() if k != "_cached_at"}
+            return data if data else None
+        # Stale — fall through to refetch
 
     headers = {}
     if api_key:

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1504,6 +1504,14 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         try:
             check_list = [c.strip() for c in checks.split(",")] if checks else None
 
+            # Validate inputs to prevent injection
+            import re as _re
+
+            if region and not _re.fullmatch(r"[a-z]{2}(-gov)?-[a-z]+-\d{1,2}", region):
+                return json.dumps({"error": f"Invalid AWS region format: {region}"})
+            if profile and not _re.fullmatch(r"[a-zA-Z0-9._-]{1,100}", profile):
+                return json.dumps({"error": "Invalid AWS profile name. Use alphanumeric, dot, dash, underscore (max 100 chars)."})
+
             if provider == "aws":
                 from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
 
@@ -1558,6 +1566,9 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
             if not names:
                 return json.dumps({"error": "No server names provided"})
+
+            if len(names) > 1000:
+                return json.dumps({"error": f"Too many servers ({len(names)}). Maximum is 1,000 per request."})
 
             result = _fleet_scan(names)
             return _truncate_response(result.to_json())

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -145,9 +145,23 @@ def validate_path(
     return resolved
 
 
+_VALUE_CREDENTIAL_PATTERNS = [
+    re.compile(r"(?:sk|pk|rk)[-_](?:live|test|prod)[-_]\w{10,}", re.I),  # Stripe/service keys
+    re.compile(r"(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}"),  # GitHub tokens
+    re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}"),  # AWS access key IDs
+    re.compile(r"-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----"),  # Private keys
+    re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}"),  # JWTs
+    re.compile(r"xox[bpsar]-[A-Za-z0-9-]{10,}"),  # Slack tokens
+]
+
+
 def sanitize_env_vars(env: dict[str, Any]) -> dict[str, str]:
     """
     Sanitize environment variables by redacting sensitive values.
+
+    Checks both key names (via SENSITIVE_PATTERNS) and values (via
+    _VALUE_CREDENTIAL_PATTERNS) to catch hardcoded credentials in
+    custom-named variables.
 
     Args:
         env: Dictionary of environment variables
@@ -163,7 +177,12 @@ def sanitize_env_vars(env: dict[str, Any]) -> dict[str, str]:
         if is_sensitive:
             sanitized[key] = "***REDACTED***"
         else:
-            sanitized[key] = str(value)
+            str_value = str(value)
+            # Also scan values for credential patterns (catches custom-named vars)
+            if any(p.search(str_value) for p in _VALUE_CREDENTIAL_PATTERNS):
+                sanitized[key] = "***REDACTED***"
+            else:
+                sanitized[key] = str_value
 
     return sanitized
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -37,4 +37,7 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD node -e "const http = require('http'); http.get('http://localhost:3000', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));" || exit 1
+
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

Clears remaining P1 and P2 findings from the 5-agent pre-release audit.

### P1 — Security & Resilience
- **`sanitize_env_vars()` value scanning** — now detects credentials in values, not just key names. Catches AWS access keys (`AKIA...`), GitHub tokens (`ghp_...`), JWTs (`eyJ...`), Slack tokens (`xox...`), private keys, and Stripe keys even in custom-named env vars
- **Publish retry logic** — Smithery, ClawHub, and MCP Registry workflows now retry 3x with exponential backoff (10s, 20s) on server errors. No more release failures from transient 502/503
- **Glama rebuild trigger** — new job in `publish-registries.yml` that POSTs to `GLAMA_WEBHOOK_URL` (optional repo var). Falls back gracefully to PyPI auto-sync if unset

### P2 — Input Bounds & Hardening
- **fleet_scan** — capped at 1,000 servers per request to prevent DoS via massive input
- **cis_benchmark** — validates AWS region format (`us-east-1`) and profile name (alphanumeric, max 100 chars)
- **NVD cache TTL** — now 90 days (was indefinite), aligning with EPSS 30-day freshness model
- **Docker health checks** — added `--start-period=10s` and consistent `--timeout=10s` across all 4 container images
- **UI container** — added HTTP health check (was the only container without one)

## Test plan
- [x] All 3,182 tests pass
- [x] Ruff lint + format clean
- [ ] CI passes on PR