### PR TITLE
docs: add uninstall instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ Check your version: `agent-bom --version`
 
 </details>
 
+<details>
+<summary><b>Uninstall</b></summary>
+
+| Method | Command |
+|--------|---------|
+| pip | `pip uninstall agent-bom` |
+| pipx | `pipx uninstall agent-bom` |
+| Docker | `docker rmi agentbom/agent-bom` |
+
+Remove local data: `rm -rf ~/.agent-bom`
+
+</details>
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Adds collapsible **Uninstall** section to README, matching the Install/Upgrade format
- Covers pip, pipx, Docker removal + `~/.agent-bom` local data cleanup

## Test plan
- [ ] CI passes
- [ ] README renders correctly on GitHub