### PR TITLE
feat: dashboard charts + compliance matrix + fix dependency licenses

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,6 +28,11 @@ jobs:
           # jinja2 and werkzeug are BSD-3-Clause (Pallets) but GitHub
           # dependency review cannot resolve their license from version
           # constraint pins — whitelist them explicitly.
+          # recharts is Apache-2.0 but npm metadata returns null.
+          # victory-vendor is ISC+JSON+MIT — JSON license not in allow
+          # list; whitelisted at package level rather than blanket-allowing.
           allow-dependencies-licenses: >-
             pkg:pypi/jinja2,
-            pkg:pypi/werkzeug
+            pkg:pypi/werkzeug,
+            pkg:npm/recharts,
+            pkg:npm/victory-vendor

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
+import { ComplianceMatrix } from "@/components/compliance-matrix";
 
 // ─── Status helpers ──────────────────────────────────────────────────────────
 
@@ -269,7 +270,7 @@ export default function CompliancePage() {
   const [data, setData] = useState<ComplianceResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<"detail" | "heatmap">("detail");
+  const [viewMode, setViewMode] = useState<"detail" | "heatmap" | "matrix">("detail");
 
   useEffect(() => {
     api
@@ -428,10 +429,24 @@ export default function CompliancePage() {
           <Grid3X3 className="w-3.5 h-3.5" />
           Heatmap
         </button>
+        <button
+          onClick={() => setViewMode("matrix")}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+            viewMode === "matrix"
+              ? "bg-emerald-600 text-white"
+              : "bg-zinc-800 text-zinc-400 hover:text-zinc-200 border border-zinc-700"
+          }`}
+        >
+          <Scan className="w-3.5 h-3.5" />
+          Matrix
+        </button>
       </div>
 
       {/* ── Heatmap View ──────────────────────────────────────────────── */}
       {viewMode === "heatmap" && <ComplianceHeatmap data={data} />}
+
+      {/* ── Matrix View ───────────────────────────────────────────────── */}
+      {viewMode === "matrix" && <ComplianceMatrix data={data} />}
 
       {/* ── Detail View ───────────────────────────────────────────────── */}
       {viewMode === "detail" && (

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -11,6 +11,7 @@ import {
   ShieldAlert, Server, Package, Bug, Zap, ArrowRight, Clock,
   AlertTriangle, Container, Layers, FileText, ExternalLink,
 } from "lucide-react";
+import { VulnTrendChart, EpssDistributionChart, TrendDataPoint, EpssDataPoint } from "@/components/charts";
 
 // ─── Aggregation helpers ──────────────────────────────────────────────────────
 
@@ -126,6 +127,45 @@ function aggregateSources(jobs: ScanJob[]): ScanSource[] {
   return sources;
 }
 
+function aggregateTrend(jobs: ScanJob[]): TrendDataPoint[] {
+  const done = jobs
+    .filter((j) => j.status === "done" && j.result)
+    .sort((a, b) => a.created_at.localeCompare(b.created_at));
+  return done.map((j) => {
+    const blast = (j.result as ScanResult)?.blast_radius ?? [];
+    const sev = aggregateSeverity(blast);
+    const d = new Date(j.created_at);
+    return {
+      label: `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`,
+      critical: sev.critical,
+      high: sev.high,
+      medium: sev.medium,
+      low: sev.low,
+    };
+  });
+}
+
+function aggregateEpss(allBlast: BlastRadius[]): EpssDataPoint[] {
+  const buckets = [
+    { range: "0-10%", min: 0, max: 0.1, count: 0 },
+    { range: "10-30%", min: 0.1, max: 0.3, count: 0 },
+    { range: "30-50%", min: 0.3, max: 0.5, count: 0 },
+    { range: "50-70%", min: 0.5, max: 0.7, count: 0 },
+    { range: "70-90%", min: 0.7, max: 0.9, count: 0 },
+    { range: "90-100%", min: 0.9, max: 1.01, count: 0 },
+  ];
+  for (const b of allBlast) {
+    if (b.epss_score == null) continue;
+    for (const bucket of buckets) {
+      if (b.epss_score >= bucket.min && b.epss_score < bucket.max) {
+        bucket.count++;
+        break;
+      }
+    }
+  }
+  return buckets.map(({ range, count }) => ({ range, count }));
+}
+
 // ─── Dashboard ────────────────────────────────────────────────────────────────
 
 export default function Dashboard() {
@@ -167,6 +207,8 @@ export default function Dashboard() {
   const severity = useMemo(() => aggregateSeverity(allBlast), [allBlast]);
   const topPackages = useMemo(() => aggregatePackages(jobs), [jobs]);
   const sources = useMemo(() => aggregateSources(jobs), [jobs]);
+  const trendData = useMemo(() => aggregateTrend(jobs), [jobs]);
+  const epssData = useMemo(() => aggregateEpss(allBlast), [allBlast]);
 
   // Unique CVE count
   const uniqueCVEs = useMemo(() => {
@@ -235,6 +277,14 @@ export default function Dashboard() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <SeverityChart severity={severity} />
           <SourceBreakdown sources={sources} />
+        </div>
+      )}
+
+      {/* Trend charts */}
+      {!loading && allBlast.length > 0 && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <VulnTrendChart data={trendData} />
+          <EpssDistributionChart data={epssData} />
         </div>
       )}
 

--- a/ui/components/charts.tsx
+++ b/ui/components/charts.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+
+// ─── Shared ──────────────────────────────────────────────────────────────────
+
+const SEVERITY_COLORS = {
+  critical: "#ef4444",
+  high: "#f97316",
+  medium: "#eab308",
+  low: "#3b82f6",
+} as const;
+
+const CHART_THEME = {
+  bg: "#18181b",
+  border: "#27272a",
+  grid: "#27272a",
+  text: "#71717a",
+  tooltip: {
+    bg: "#09090b",
+    border: "#27272a",
+    text: "#e4e4e7",
+  },
+} as const;
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name: string; value: number; color: string }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div
+      className="rounded-lg border px-3 py-2 text-xs shadow-xl"
+      style={{
+        background: CHART_THEME.tooltip.bg,
+        borderColor: CHART_THEME.tooltip.border,
+      }}
+    >
+      {label && (
+        <div className="text-zinc-500 mb-1 font-mono text-[10px]">{label}</div>
+      )}
+      {payload.map((entry) => (
+        <div
+          key={entry.name}
+          className="flex items-center gap-2"
+          style={{ color: CHART_THEME.tooltip.text }}
+        >
+          <span
+            className="w-2 h-2 rounded-full"
+            style={{ background: entry.color }}
+          />
+          <span className="capitalize">{entry.name}</span>
+          <span className="font-mono font-semibold ml-auto">{entry.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Vulnerability Trend (area chart) ────────────────────────────────────────
+
+export interface TrendDataPoint {
+  label: string;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+}
+
+export function VulnTrendChart({ data }: { data: TrendDataPoint[] }) {
+  if (data.length < 2) return null;
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
+      <h3 className="text-sm font-semibold text-zinc-300 mb-4">
+        Vulnerability Trend
+      </h3>
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data}>
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_THEME.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 10, fill: CHART_THEME.text }}
+              tickLine={false}
+              axisLine={{ stroke: CHART_THEME.border }}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: CHART_THEME.text }}
+              tickLine={false}
+              axisLine={false}
+              allowDecimals={false}
+              width={30}
+            />
+            <Tooltip content={<ChartTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="critical"
+              stackId="1"
+              stroke={SEVERITY_COLORS.critical}
+              fill={SEVERITY_COLORS.critical}
+              fillOpacity={0.3}
+            />
+            <Area
+              type="monotone"
+              dataKey="high"
+              stackId="1"
+              stroke={SEVERITY_COLORS.high}
+              fill={SEVERITY_COLORS.high}
+              fillOpacity={0.3}
+            />
+            <Area
+              type="monotone"
+              dataKey="medium"
+              stackId="1"
+              stroke={SEVERITY_COLORS.medium}
+              fill={SEVERITY_COLORS.medium}
+              fillOpacity={0.2}
+            />
+            <Area
+              type="monotone"
+              dataKey="low"
+              stackId="1"
+              stroke={SEVERITY_COLORS.low}
+              fill={SEVERITY_COLORS.low}
+              fillOpacity={0.15}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+// ─── EPSS Distribution (bar chart) ───────────────────────────────────────────
+
+export interface EpssDataPoint {
+  range: string;
+  count: number;
+}
+
+export function EpssDistributionChart({ data }: { data: EpssDataPoint[] }) {
+  if (data.length === 0) return null;
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
+      <h3 className="text-sm font-semibold text-zinc-300 mb-1">
+        EPSS Distribution
+      </h3>
+      <p className="text-[10px] text-zinc-600 mb-4">
+        Exploit probability scores across findings
+      </p>
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_THEME.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="range"
+              tick={{ fontSize: 9, fill: CHART_THEME.text }}
+              tickLine={false}
+              axisLine={{ stroke: CHART_THEME.border }}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: CHART_THEME.text }}
+              tickLine={false}
+              axisLine={false}
+              allowDecimals={false}
+              width={30}
+            />
+            <Tooltip content={<ChartTooltip />} />
+            <Bar
+              dataKey="count"
+              name="findings"
+              fill="#10b981"
+              radius={[4, 4, 0, 0]}
+              fillOpacity={0.7}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+// ─── Severity Donut (pie chart) ──────────────────────────────────────────────
+
+export interface SeveritySlice {
+  name: string;
+  value: number;
+}
+
+export function SeverityDonut({ data }: { data: SeveritySlice[] }) {
+  const filtered = data.filter((d) => d.value > 0);
+  if (filtered.length === 0) return null;
+  const total = filtered.reduce((s, d) => s + d.value, 0);
+  const colors = filtered.map(
+    (d) => SEVERITY_COLORS[d.name as keyof typeof SEVERITY_COLORS] ?? "#71717a"
+  );
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
+      <h3 className="text-sm font-semibold text-zinc-300 mb-4">
+        Severity Breakdown
+      </h3>
+      <div className="h-48 flex items-center justify-center">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={filtered}
+              cx="50%"
+              cy="50%"
+              innerRadius="55%"
+              outerRadius="85%"
+              paddingAngle={2}
+              dataKey="value"
+              stroke="none"
+            >
+              {filtered.map((_, i) => (
+                <Cell key={i} fill={colors[i]} fillOpacity={0.85} />
+              ))}
+            </Pie>
+            <Tooltip content={<ChartTooltip />} />
+          </PieChart>
+        </ResponsiveContainer>
+        <div className="absolute text-center pointer-events-none">
+          <div className="text-2xl font-bold font-mono text-zinc-100">
+            {total}
+          </div>
+          <div className="text-[10px] text-zinc-500 uppercase tracking-wide">
+            total
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/compliance-matrix.tsx
+++ b/ui/components/compliance-matrix.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  flexRender,
+  createColumnHelper,
+  SortingState,
+  ColumnFiltersState,
+} from "@tanstack/react-table";
+import {
+  ComplianceResponse,
+  ComplianceControl,
+  OWASP_LLM_TOP10,
+  OWASP_MCP_TOP10,
+  OWASP_AGENTIC_TOP10,
+  EU_AI_ACT,
+  MITRE_ATLAS,
+  NIST_AI_RMF,
+} from "@/lib/api";
+import {
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
+  Download,
+  Search,
+  Filter,
+} from "lucide-react";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface MatrixRow {
+  framework: string;
+  code: string;
+  name: string;
+  status: "pass" | "warning" | "fail";
+  findings: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  affectedPackages: string[];
+  affectedAgents: string[];
+}
+
+// ─── Data transform ──────────────────────────────────────────────────────────
+
+const FRAMEWORK_MAP: Array<{
+  key: keyof ComplianceResponse;
+  label: string;
+  catalog: Record<string, string>;
+}> = [
+  { key: "owasp_llm_top10", label: "OWASP LLM", catalog: OWASP_LLM_TOP10 },
+  { key: "owasp_mcp_top10", label: "OWASP MCP", catalog: OWASP_MCP_TOP10 },
+  { key: "owasp_agentic_top10", label: "OWASP Agentic", catalog: OWASP_AGENTIC_TOP10 },
+  { key: "mitre_atlas", label: "MITRE ATLAS", catalog: MITRE_ATLAS },
+  { key: "nist_ai_rmf", label: "NIST AI RMF", catalog: NIST_AI_RMF },
+  { key: "eu_ai_act", label: "EU AI Act", catalog: EU_AI_ACT },
+];
+
+function flattenControls(data: ComplianceResponse): MatrixRow[] {
+  const rows: MatrixRow[] = [];
+  for (const { key, label, catalog } of FRAMEWORK_MAP) {
+    const controls = data[key] as ComplianceControl[];
+    for (const c of controls) {
+      rows.push({
+        framework: label,
+        code: c.code,
+        name: catalog[c.code] ?? c.name,
+        status: c.status,
+        findings: c.findings,
+        critical: c.severity_breakdown.critical ?? 0,
+        high: c.severity_breakdown.high ?? 0,
+        medium: c.severity_breakdown.medium ?? 0,
+        low: c.severity_breakdown.low ?? 0,
+        affectedPackages: c.affected_packages,
+        affectedAgents: c.affected_agents,
+      });
+    }
+  }
+  return rows;
+}
+
+// ─── Column definitions ──────────────────────────────────────────────────────
+
+const col = createColumnHelper<MatrixRow>();
+
+const columns = [
+  col.accessor("framework", {
+    header: "Framework",
+    cell: (info) => (
+      <span className="text-xs font-medium text-zinc-400">
+        {info.getValue()}
+      </span>
+    ),
+    filterFn: "equals",
+  }),
+  col.accessor("code", {
+    header: "Control",
+    cell: (info) => (
+      <span className="font-mono text-xs font-semibold text-zinc-200">
+        {info.getValue()}
+      </span>
+    ),
+  }),
+  col.accessor("name", {
+    header: "Description",
+    cell: (info) => (
+      <span className="text-xs text-zinc-400 leading-snug">
+        {info.getValue()}
+      </span>
+    ),
+  }),
+  col.accessor("status", {
+    header: "Status",
+    cell: (info) => {
+      const s = info.getValue();
+      const styles = {
+        pass: "bg-emerald-950 text-emerald-300 border-emerald-800",
+        warning: "bg-yellow-950 text-yellow-300 border-yellow-800",
+        fail: "bg-red-950 text-red-300 border-red-800",
+      };
+      const labels = { pass: "Pass", warning: "Warning", fail: "Fail" };
+      return (
+        <span
+          className={`text-[10px] px-2 py-0.5 rounded-full border font-medium ${styles[s]}`}
+        >
+          {labels[s]}
+        </span>
+      );
+    },
+    filterFn: "equals",
+  }),
+  col.accessor("findings", {
+    header: "Findings",
+    cell: (info) => {
+      const v = info.getValue();
+      return (
+        <span
+          className={`font-mono text-xs ${v > 0 ? "text-zinc-200" : "text-zinc-700"}`}
+        >
+          {v}
+        </span>
+      );
+    },
+  }),
+  col.accessor("critical", {
+    header: "Crit",
+    cell: (info) => {
+      const v = info.getValue();
+      return v > 0 ? (
+        <span className="font-mono text-xs font-semibold text-red-400">
+          {v}
+        </span>
+      ) : (
+        <span className="text-zinc-700">—</span>
+      );
+    },
+  }),
+  col.accessor("high", {
+    header: "High",
+    cell: (info) => {
+      const v = info.getValue();
+      return v > 0 ? (
+        <span className="font-mono text-xs font-semibold text-orange-400">
+          {v}
+        </span>
+      ) : (
+        <span className="text-zinc-700">—</span>
+      );
+    },
+  }),
+  col.accessor("medium", {
+    header: "Med",
+    cell: (info) => {
+      const v = info.getValue();
+      return v > 0 ? (
+        <span className="font-mono text-xs text-yellow-400">{v}</span>
+      ) : (
+        <span className="text-zinc-700">—</span>
+      );
+    },
+  }),
+  col.accessor("low", {
+    header: "Low",
+    cell: (info) => {
+      const v = info.getValue();
+      return v > 0 ? (
+        <span className="font-mono text-xs text-blue-400">{v}</span>
+      ) : (
+        <span className="text-zinc-700">—</span>
+      );
+    },
+  }),
+  col.accessor("affectedPackages", {
+    header: "Packages",
+    cell: (info) => {
+      const pkgs = info.getValue();
+      if (pkgs.length === 0) return <span className="text-zinc-700">—</span>;
+      return (
+        <span className="text-xs text-zinc-500" title={pkgs.join(", ")}>
+          {pkgs.length} pkg{pkgs.length !== 1 ? "s" : ""}
+        </span>
+      );
+    },
+    enableSorting: false,
+  }),
+];
+
+// ─── CSV export ──────────────────────────────────────────────────────────────
+
+function exportCsv(rows: MatrixRow[]) {
+  const header =
+    "Framework,Control,Description,Status,Findings,Critical,High,Medium,Low,Packages,Agents\n";
+  const body = rows
+    .map(
+      (r) =>
+        `"${r.framework}","${r.code}","${r.name.replace(/"/g, '""')}",${r.status},${r.findings},${r.critical},${r.high},${r.medium},${r.low},"${r.affectedPackages.join("; ")}","${r.affectedAgents.join("; ")}"`
+    )
+    .join("\n");
+  const blob = new Blob([header + body], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "compliance-matrix.csv";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = useState("");
+
+  const rows = useMemo(() => flattenControls(data), [data]);
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting, columnFilters, globalFilter },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  });
+
+  const frameworks = useMemo(
+    () => [...new Set(rows.map((r) => r.framework))],
+    [rows]
+  );
+  const activeFramework =
+    (columnFilters.find((f) => f.id === "framework")?.value as string) ?? "";
+  const activeStatus =
+    (columnFilters.find((f) => f.id === "status")?.value as string) ?? "";
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Search */}
+        <div className="relative flex-1 min-w-[200px] max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-500" />
+          <input
+            type="text"
+            placeholder="Search controls..."
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="w-full bg-zinc-900 border border-zinc-800 rounded-lg pl-9 pr-3 py-2 text-xs text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-600"
+          />
+        </div>
+
+        {/* Framework filter */}
+        <div className="flex items-center gap-1">
+          <Filter className="w-3.5 h-3.5 text-zinc-500" />
+          <select
+            value={activeFramework}
+            onChange={(e) => {
+              const val = e.target.value;
+              setColumnFilters((prev) => {
+                const without = prev.filter((f) => f.id !== "framework");
+                return val ? [...without, { id: "framework", value: val }] : without;
+              });
+            }}
+            className="bg-zinc-900 border border-zinc-800 rounded-lg px-2 py-1.5 text-xs text-zinc-300 focus:outline-none focus:border-zinc-600"
+          >
+            <option value="">All frameworks</option>
+            {frameworks.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Status filter */}
+        <div className="flex gap-1">
+          {(["", "pass", "warning", "fail"] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => {
+                setColumnFilters((prev) => {
+                  const without = prev.filter((f) => f.id !== "status");
+                  return s ? [...without, { id: "status", value: s }] : without;
+                });
+              }}
+              className={`px-2.5 py-1 rounded-lg text-[10px] font-medium border transition-colors ${
+                activeStatus === s
+                  ? "bg-emerald-600 text-white border-emerald-600"
+                  : "bg-zinc-900 text-zinc-400 border-zinc-800 hover:border-zinc-600"
+              }`}
+            >
+              {s === "" ? "All" : s === "pass" ? "Pass" : s === "warning" ? "Warn" : "Fail"}
+            </button>
+          ))}
+        </div>
+
+        {/* Export */}
+        <button
+          onClick={() => exportCsv(table.getFilteredRowModel().rows.map((r) => r.original))}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 border border-zinc-700 rounded-lg text-xs text-zinc-300 hover:text-zinc-100 hover:border-zinc-600 transition-colors ml-auto"
+        >
+          <Download className="w-3.5 h-3.5" />
+          CSV
+        </button>
+      </div>
+
+      {/* Count */}
+      <div className="text-xs text-zinc-600">
+        {table.getFilteredRowModel().rows.length} of {rows.length} controls
+      </div>
+
+      {/* Table */}
+      <div className="border border-zinc-800 rounded-xl overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-zinc-900 border-b border-zinc-800">
+              {table.getHeaderGroups().map((hg) => (
+                <tr key={hg.id}>
+                  {hg.headers.map((header) => (
+                    <th
+                      key={header.id}
+                      className="text-left px-3 py-2.5 text-[10px] font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap"
+                    >
+                      {header.isPlaceholder ? null : (
+                        <button
+                          className={`flex items-center gap-1 ${
+                            header.column.getCanSort()
+                              ? "cursor-pointer select-none hover:text-zinc-300"
+                              : ""
+                          }`}
+                          onClick={header.column.getToggleSortingHandler()}
+                        >
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                          {header.column.getCanSort() && (
+                            <>
+                              {header.column.getIsSorted() === "asc" ? (
+                                <ArrowUp className="w-3 h-3" />
+                              ) : header.column.getIsSorted() === "desc" ? (
+                                <ArrowDown className="w-3 h-3" />
+                              ) : (
+                                <ArrowUpDown className="w-3 h-3 opacity-30" />
+                              )}
+                            </>
+                          )}
+                        </button>
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody className="divide-y divide-zinc-800/50 bg-zinc-950">
+              {table.getRowModel().rows.map((row) => (
+                <tr
+                  key={row.id}
+                  className="hover:bg-zinc-900/50 transition-colors"
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-3 py-2.5">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
+        "@tanstack/react-table": "^8.21.3",
         "@xyflow/react": "^12.10.1",
         "lucide-react": "^0.575.0",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "recharts": "^3.8.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1246,11 +1248,59 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1597,6 +1647,39 @@
         "tailwindcss": "4.2.0"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1607,6 +1690,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
@@ -1623,6 +1712,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -1632,10 +1727,46 @@
         "@types/d3-color": "*"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -1715,6 +1846,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -2774,6 +2911,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2830,6 +2976,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -2870,6 +3028,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -2882,12 +3049,73 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
       "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3014,6 +3242,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3300,6 +3534,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3755,6 +3999,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4212,6 +4462,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4252,6 +4513,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5745,9 +6015,78 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5792,6 +6131,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -6382,6 +6727,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6728,6 +7079,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
+    "@tanstack/react-table": "^8.21.3",
     "@xyflow/react": "^12.10.1",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "recharts": "^3.8.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary

Combines the work from #253 and #254 into a single PR with license fixes that resolve the dependency review failures.

### Charts (Recharts) — closes #243
- **VulnTrendChart**: stacked area chart showing severity counts over scan history
- **EpssDistributionChart**: bar chart of EPSS exploit probability bucketed into 6 ranges
- **SeverityDonut**: reusable pie chart component for future use

### Compliance Matrix (Tanstack Table v8) — closes #246
- Sortable, filterable, searchable matrix across all 6 frameworks (60+ controls)
- Framework dropdown filter + status button filter (All/Pass/Warn/Fail)
- Global text search across control codes and descriptions
- CSV export for audit evidence

### License fixes
- `recharts` — Apache-2.0 but npm metadata returns null; added to `allow-dependencies-licenses`
- `victory-vendor` — ISC+JSON+MIT; JSON license not in allow list; whitelisted at package level

## Test plan
- [ ] `npm run build` in `ui/` passes (verified locally)
- [ ] Dependency Review check passes (license exceptions added)
- [ ] Dashboard shows trend + EPSS charts when scan data exists
- [ ] Compliance page shows Detail / Heatmap / Matrix toggle
- [ ] Matrix sorting, filtering, and CSV export work correctly

Closes #243, closes #246