### PR TITLE
feat: redesign blast radius diagram as branching attack path graph

### DIFF
--- a/docs/images/blast-radius-dark.svg
+++ b/docs/images/blast-radius-dark.svg
@@ -1,94 +1,232 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 360" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 500" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #f4f4f5; }
+    .subtitle { font-size: 10.5px; font-weight: 400; fill: #52525b; }
+    .node-type { font-size: 8.5px; font-weight: 700; letter-spacing: 0.1em; }
+    .node-label { font-size: 12px; font-weight: 700; fill: #e4e4e7; }
+    .node-detail { font-size: 9.5px; font-weight: 400; fill: #71717a; }
+    .cred-label { font-size: 10px; font-weight: 600; font-family: ui-monospace, monospace; }
+    .tool-label { font-size: 10px; font-weight: 600; font-family: ui-monospace, monospace; }
+    .impact-num { font-size: 20px; font-weight: 800; }
+    .impact-label { font-size: 10px; font-weight: 500; fill: #71717a; }
+    .fix-label { font-size: 10.5px; font-weight: 700; font-family: ui-monospace, monospace; }
+    .section-label { font-size: 8.5px; font-weight: 700; letter-spacing: 0.1em; fill: #3f3f46; }
+  </style>
+  <defs>
+    <marker id="arrow-red" viewBox="0 0 8 6" refX="7" refY="3" markerWidth="8" markerHeight="6" orient="auto">
+      <path d="M0 0 L8 3 L0 6Z" fill="#ef4444" opacity="0.5"/>
+    </marker>
+    <marker id="arrow-amber" viewBox="0 0 8 6" refX="7" refY="3" markerWidth="8" markerHeight="6" orient="auto">
+      <path d="M0 0 L8 3 L0 6Z" fill="#f59e0b" opacity="0.4"/>
+    </marker>
+    <marker id="arrow-muted" viewBox="0 0 8 6" refX="7" refY="3" markerWidth="8" markerHeight="6" orient="auto">
+      <path d="M0 0 L8 3 L0 6Z" fill="#52525b" opacity="0.5"/>
+    </marker>
+  </defs>
+
   <!-- Background -->
-  <rect width="880" height="360" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="1.5"/>
+  <rect width="960" height="500" rx="12" fill="#09090b"/>
 
   <!-- Title -->
-  <text x="440" y="32" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#e6edf3">How a CVE propagates through your AI stack</text>
+  <text x="480" y="30" text-anchor="middle" class="title">How a single CVE propagates through your AI stack</text>
+  <text x="480" y="46" text-anchor="middle" class="subtitle">agent-bom maps the full blast radius: vulnerability → package → server → agent → credentials → tools</text>
 
-  <!-- ─── CHAIN: CVE → Package → Server → Agent ─── -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- EDGES (drawn first so nodes sit on top)                                -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
 
-  <!-- Node 1: CVE -->
-  <rect x="30" y="56" width="160" height="80" rx="14" fill="#2d1215" stroke="#f87171" stroke-width="2.5"/>
-  <text x="110" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#f87171" letter-spacing="0.08em">VULNERABILITY</text>
-  <text x="110" y="112" text-anchor="middle" font-family="monospace" font-size="13" font-weight="700" fill="#fca5a5">CVE-2025-1234</text>
-  <text x="110" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#f87171">CRITICAL 9.8 | KEV</text>
+  <!-- CVE → Package -->
+  <line x1="148" y1="218" x2="186" y2="218" stroke="#ef4444" stroke-width="2" opacity="0.5" marker-end="url(#arrow-red)"/>
 
-  <!-- Arrow -->
-  <path d="M190 96 L220 96" stroke="#f87171" stroke-width="3" stroke-linecap="round"/>
-  <path d="M214 90 L224 96 L214 102" fill="#f87171"/>
+  <!-- Package → Server A (sqlite-mcp) -->
+  <path d="M316 205 C340 205, 350 142, 372 142" stroke="#ef4444" stroke-width="1.5" opacity="0.35" fill="none" marker-end="url(#arrow-red)"/>
 
-  <!-- Node 2: Package -->
-  <rect x="228" y="56" width="160" height="80" rx="14" fill="#0a2118" stroke="#34d399" stroke-width="2"/>
-  <text x="308" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#34d399" letter-spacing="0.08em">PACKAGE</text>
-  <text x="308" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#6ee7b7">better-sqlite3</text>
-  <text x="308" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#34d399">npm v9.0.0</text>
+  <!-- Package → Server B (db-tools) -->
+  <path d="M316 232 C340 232, 350 298, 372 298" stroke="#ef4444" stroke-width="1.5" opacity="0.35" fill="none" marker-end="url(#arrow-red)"/>
 
-  <!-- Arrow -->
-  <path d="M388 96 L418 96" stroke="#f87171" stroke-width="3" stroke-linecap="round"/>
-  <path d="M412 90 L422 96 L412 102" fill="#f87171"/>
+  <!-- Server A → Agent 1 (Cursor) -->
+  <path d="M512 128 C536 128, 546 98, 560 98" stroke="#a78bfa" stroke-width="1.5" opacity="0.3" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Node 3: MCP Server -->
-  <rect x="426" y="56" width="160" height="80" rx="14" fill="#1a1028" stroke="#a78bfa" stroke-width="2"/>
-  <text x="506" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#a78bfa" letter-spacing="0.08em">MCP SERVER</text>
-  <text x="506" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#c4b5fd">sqlite-mcp</text>
-  <text x="506" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#a78bfa">unverified | 3 tools</text>
+  <!-- Server A → Agent 2 (Claude Desktop) — shared path highlight -->
+  <path d="M512 155 C540 155, 546 218, 560 218" stroke="#a78bfa" stroke-width="2" opacity="0.5" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Arrow -->
-  <path d="M586 96 L616 96" stroke="#f87171" stroke-width="3" stroke-linecap="round"/>
-  <path d="M610 90 L620 96 L610 102" fill="#f87171"/>
+  <!-- Server B → Agent 2 (Claude Desktop) — shared path highlight -->
+  <path d="M512 285 C540 285, 546 230, 560 230" stroke="#a78bfa" stroke-width="2" opacity="0.5" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Node 4: Agent -->
-  <rect x="624" y="56" width="160" height="80" rx="14" fill="#0c1a2e" stroke="#60a5fa" stroke-width="2"/>
-  <text x="704" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#60a5fa" letter-spacing="0.08em">AI AGENT</text>
-  <text x="704" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#93c5fd">Cursor IDE</text>
-  <text x="704" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#60a5fa">4 servers | 12 tools</text>
+  <!-- Server B → Agent 3 (Windsurf) -->
+  <path d="M512 310 C536 310, 546 340, 560 340" stroke="#a78bfa" stroke-width="1.5" opacity="0.3" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Red propagation glow line -->
-  <rect x="30" y="142" width="754" height="3" rx="1.5" fill="#f87171" opacity="0.15"/>
+  <!-- Agent 1 → Credentials -->
+  <path d="M690 92 C710 92, 720 78, 732 78" stroke="#52525b" stroke-width="1" opacity="0.3" fill="none"/>
+  <path d="M690 104 C710 104, 720 114, 732 114" stroke="#52525b" stroke-width="1" opacity="0.3" fill="none"/>
 
-  <!-- ─── IMPACT ─── -->
-  <text x="440" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#e6edf3">What an attacker can reach</text>
+  <!-- Agent 2 → Credentials (multiple) -->
+  <path d="M690 214 C710 214, 720 78, 732 78" stroke="#52525b" stroke-width="1" opacity="0.2" fill="none"/>
+  <path d="M690 218 C710 218, 720 114, 732 114" stroke="#52525b" stroke-width="1" opacity="0.3" fill="none"/>
+  <path d="M690 226 C710 226, 720 150, 732 150" stroke="#52525b" stroke-width="1" opacity="0.3" fill="none"/>
 
-  <!-- Credentials -->
-  <text x="48" y="210" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#fbbf24" letter-spacing="0.08em">CREDENTIALS EXPOSED</text>
+  <!-- Agent 3 → Credentials -->
+  <path d="M690 340 C710 340, 720 150, 732 150" stroke="#52525b" stroke-width="1" opacity="0.2" fill="none"/>
 
-  <rect x="48" y="220" width="136" height="40" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="116" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fbbf24">ANTHROPIC_KEY</text>
+  <!-- Agent connections to tools -->
+  <path d="M690 100 C714 100, 720 222, 732 222" stroke="#52525b" stroke-width="1" opacity="0.15" fill="none"/>
+  <path d="M690 232 C714 232, 720 222, 732 222" stroke="#52525b" stroke-width="1" opacity="0.2" fill="none"/>
+  <path d="M690 232 C714 232, 720 258, 732 258" stroke="#52525b" stroke-width="1" opacity="0.2" fill="none"/>
+  <path d="M690 232 C714 232, 720 294, 732 294" stroke="#52525b" stroke-width="1" opacity="0.2" fill="none"/>
+  <path d="M690 345 C714 345, 720 258, 732 258" stroke="#52525b" stroke-width="1" opacity="0.15" fill="none"/>
+  <path d="M690 345 C714 345, 720 330, 732 330" stroke="#52525b" stroke-width="1" opacity="0.2" fill="none"/>
 
-  <rect x="196" y="220" width="136" height="40" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="264" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fbbf24">DB_URL</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- COLUMN LABELS                                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <text x="95" y="72" text-anchor="middle" class="section-label">VULNERABILITY</text>
+  <text x="252" y="72" text-anchor="middle" class="section-label">PACKAGE</text>
+  <text x="442" y="72" text-anchor="middle" class="section-label">MCP SERVERS</text>
+  <text x="625" y="72" text-anchor="middle" class="section-label">AI AGENTS</text>
+  <text x="825" y="72" text-anchor="middle" class="section-label">BLAST RADIUS</text>
 
-  <rect x="344" y="220" width="136" height="40" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="412" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fbbf24">AWS_SECRET</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: CVE                                                               -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="28" y="186" width="120" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="28" y="186" width="4" height="64" rx="2" fill="#ef4444"/>
+  <text x="48" y="204" class="node-type" fill="#ef4444">CVE</text>
+  <text x="48" y="220" class="node-label" fill="#fca5a5">CVE-2025-1234</text>
+  <text x="48" y="236" class="node-detail">Critical 9.8 · CISA KEV</text>
 
-  <!-- Tools -->
-  <text x="48" y="288" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#9ca3af" letter-spacing="0.08em">TOOLS REACHABLE</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Package                                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="186" y="186" width="130" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="186" y="186" width="4" height="64" rx="2" fill="#f59e0b"/>
+  <text x="206" y="204" class="node-type" fill="#f59e0b">PACKAGE</text>
+  <text x="206" y="220" class="node-label">better-sqlite3</text>
+  <text x="206" y="236" class="node-detail">npm · v9.0.0</text>
 
-  <rect x="48" y="298" width="100" height="36" rx="8" fill="#161b22" stroke="#4b5563" stroke-width="1.2"/>
-  <text x="98" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#d1d5db">query_db</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Server A (sqlite-mcp)                                             -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="372" y="110" width="140" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="372" y="110" width="4" height="64" rx="2" fill="#a78bfa"/>
+  <text x="392" y="128" class="node-type" fill="#a78bfa">MCP SERVER</text>
+  <text x="392" y="144" class="node-label">sqlite-mcp</text>
+  <text x="392" y="160" class="node-detail">unverified · 3 tools · root</text>
 
-  <rect x="160" y="298" width="100" height="36" rx="8" fill="#161b22" stroke="#4b5563" stroke-width="1.2"/>
-  <text x="210" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#d1d5db">read_file</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Server B (db-tools)                                               -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="372" y="268" width="140" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="372" y="268" width="4" height="64" rx="2" fill="#a78bfa"/>
+  <text x="392" y="286" class="node-type" fill="#a78bfa">MCP SERVER</text>
+  <text x="392" y="302" class="node-label">db-tools</text>
+  <text x="392" y="318" class="node-detail">verified · 5 tools</text>
 
-  <rect x="272" y="298" width="100" height="36" rx="8" fill="#161b22" stroke="#4b5563" stroke-width="1.2"/>
-  <text x="322" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#d1d5db">write_file</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Agent 1 (Cursor)                                                  -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="560" y="78" width="130" height="56" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="560" y="78" width="4" height="56" rx="2" fill="#3b82f6"/>
+  <text x="580" y="96" class="node-type" fill="#3b82f6">AI AGENT</text>
+  <text x="580" y="112" class="node-label">Cursor IDE</text>
+  <text x="580" y="126" class="node-detail">4 servers · 12 tools</text>
 
-  <rect x="384" y="298" width="100" height="36" rx="8" fill="#2d1215" stroke="#f87171" stroke-width="2"/>
-  <text x="434" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#fca5a5">run_shell</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Agent 2 (Claude Desktop) — affected by BOTH servers               -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="560" y="196" width="130" height="56" rx="10" fill="#18181b" stroke="#ef4444" stroke-width="1.5" stroke-opacity="0.4"/>
+  <rect x="560" y="196" width="4" height="56" rx="2" fill="#3b82f6"/>
+  <text x="580" y="214" class="node-type" fill="#3b82f6">AI AGENT</text>
+  <text x="580" y="230" class="node-label">Claude Desktop</text>
+  <text x="580" y="244" class="node-detail">3 servers · 8 tools</text>
 
-  <!-- Impact summary -->
-  <rect x="560" y="196" width="290" height="146" rx="14" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
-  <text x="705" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#e6edf3">Impact Summary</text>
+  <!-- "2 paths" badge on Agent 2 -->
+  <rect x="658" y="196" width="30" height="16" rx="8" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="0.5" stroke-opacity="0.4"/>
+  <text x="673" y="207" text-anchor="middle" font-size="8" font-weight="700" fill="#fca5a5" font-family="system-ui, sans-serif">2x</text>
 
-  <text x="588" y="250" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#f87171">1</text>
-  <text x="616" y="248" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#8b949e">agent compromised</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Agent 3 (Windsurf)                                                -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="560" y="320" width="130" height="56" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="560" y="320" width="4" height="56" rx="2" fill="#3b82f6"/>
+  <text x="580" y="338" class="node-type" fill="#3b82f6">AI AGENT</text>
+  <text x="580" y="354" class="node-label">Windsurf</text>
+  <text x="580" y="368" class="node-detail">2 servers · 6 tools</text>
 
-  <text x="588" y="280" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#fbbf24">3</text>
-  <text x="616" y="278" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#8b949e">credentials exposed</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- CREDENTIALS (pills)                                                     -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="732" y="86" width="118" height="26" rx="6" fill="#1c1917" stroke="#78350f" stroke-width="1"/>
+  <circle cx="746" cy="99" r="4" fill="#f59e0b" opacity="0.6"/>
+  <text x="758" y="103" class="cred-label" fill="#fbbf24">ANTHROPIC_KEY</text>
 
-  <text x="588" y="310" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#9ca3af">4</text>
-  <text x="616" y="308" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#8b949e">tools reachable (incl. RCE)</text>
+  <rect x="732" y="120" width="118" height="26" rx="6" fill="#1c1917" stroke="#78350f" stroke-width="1"/>
+  <circle cx="746" cy="133" r="4" fill="#f59e0b" opacity="0.6"/>
+  <text x="758" y="137" class="cred-label" fill="#fbbf24">DB_URL</text>
 
-  <rect x="560" y="324" width="290" height="2" rx="1" fill="#34d399" opacity="0.4"/>
-  <text x="705" y="344" text-anchor="middle" font-family="monospace" font-size="11" font-weight="700" fill="#34d399">FIX: upgrade better-sqlite3 to 11.7.0</text>
+  <rect x="732" y="154" width="118" height="26" rx="6" fill="#1c1917" stroke="#78350f" stroke-width="1"/>
+  <circle cx="746" cy="167" r="4" fill="#f59e0b" opacity="0.6"/>
+  <text x="758" y="171" class="cred-label" fill="#fbbf24">AWS_SECRET</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- TOOLS (pills)                                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <text x="732" y="206" class="section-label">TOOLS AT RISK</text>
+
+  <rect x="732" y="214" width="100" height="24" rx="6" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="782" y="230" text-anchor="middle" class="tool-label" fill="#a1a1aa">query_db</text>
+
+  <rect x="840" y="214" width="100" height="24" rx="6" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="890" y="230" text-anchor="middle" class="tool-label" fill="#a1a1aa">read_file</text>
+
+  <rect x="732" y="246" width="100" height="24" rx="6" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="782" y="262" text-anchor="middle" class="tool-label" fill="#a1a1aa">write_file</text>
+
+  <rect x="840" y="246" width="100" height="24" rx="6" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="890" y="262" text-anchor="middle" class="tool-label" fill="#a1a1aa">exec_sql</text>
+
+  <!-- Dangerous tool highlighted -->
+  <rect x="732" y="278" width="100" height="24" rx="6" fill="#2d1215" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="782" y="294" text-anchor="middle" class="tool-label" fill="#fca5a5">run_shell</text>
+  <text x="845" y="294" font-size="8" font-weight="700" fill="#ef4444" font-family="system-ui, sans-serif">RCE RISK</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- SHARED PATH HIGHLIGHT (the "aha" moment)                                -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="540" y="186" width="170" height="76" rx="12" stroke="#ef4444" stroke-width="1" stroke-dasharray="4 3" stroke-opacity="0.25" fill="none"/>
+  <text x="547" y="182" font-size="8" font-weight="600" fill="#ef4444" opacity="0.5" font-family="system-ui, sans-serif">HIGHEST RISK — 2 ATTACK PATHS</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- IMPACT SUMMARY BAR                                                      -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="24" y="410" width="912" height="76" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+
+  <!-- Impact stats -->
+  <text x="80" y="440" text-anchor="middle" class="impact-num" fill="#ef4444">3</text>
+  <text x="80" y="458" text-anchor="middle" class="impact-label">agents</text>
+  <text x="80" y="472" text-anchor="middle" class="impact-label">compromised</text>
+
+  <rect x="140" y="424" width="1" height="48" rx="0.5" fill="#27272a"/>
+
+  <text x="200" y="440" text-anchor="middle" class="impact-num" fill="#fbbf24">3</text>
+  <text x="200" y="458" text-anchor="middle" class="impact-label">credentials</text>
+  <text x="200" y="472" text-anchor="middle" class="impact-label">exposed</text>
+
+  <rect x="260" y="424" width="1" height="48" rx="0.5" fill="#27272a"/>
+
+  <text x="320" y="440" text-anchor="middle" class="impact-num" fill="#a1a1aa">5</text>
+  <text x="320" y="458" text-anchor="middle" class="impact-label">tools</text>
+  <text x="320" y="472" text-anchor="middle" class="impact-label">reachable</text>
+
+  <rect x="380" y="424" width="1" height="48" rx="0.5" fill="#27272a"/>
+
+  <text x="440" y="440" text-anchor="middle" class="impact-num" fill="#ef4444">1</text>
+  <text x="440" y="458" text-anchor="middle" class="impact-label">RCE-capable</text>
+  <text x="440" y="472" text-anchor="middle" class="impact-label">tool exposed</text>
+
+  <!-- Fix recommendation -->
+  <rect x="520" y="422" width="400" height="52" rx="8" fill="#052e16" stroke="#065f46" stroke-width="1"/>
+  <text x="540" y="442" font-size="9" font-weight="600" fill="#34d399" letter-spacing="0.05em" font-family="system-ui, sans-serif">RECOMMENDED FIX</text>
+  <text x="540" y="462" class="fix-label" fill="#6ee7b7">upgrade better-sqlite3 → 11.7.0</text>
+  <text x="540" y="476" class="node-detail" fill="#34d399">Resolves all 3 agent exposures in one upgrade</text>
 </svg>

--- a/docs/images/blast-radius-light.svg
+++ b/docs/images/blast-radius-light.svg
@@ -1,95 +1,224 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 360" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 500" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #18181b; }
+    .subtitle { font-size: 10.5px; font-weight: 400; fill: #a1a1aa; }
+    .node-type { font-size: 8.5px; font-weight: 700; letter-spacing: 0.1em; }
+    .node-label { font-size: 12px; font-weight: 700; fill: #27272a; }
+    .node-detail { font-size: 9.5px; font-weight: 400; fill: #71717a; }
+    .cred-label { font-size: 10px; font-weight: 600; font-family: ui-monospace, monospace; }
+    .tool-label { font-size: 10px; font-weight: 600; font-family: ui-monospace, monospace; }
+    .impact-num { font-size: 20px; font-weight: 800; }
+    .impact-label { font-size: 10px; font-weight: 500; fill: #71717a; }
+    .fix-label { font-size: 10.5px; font-weight: 700; font-family: ui-monospace, monospace; }
+    .section-label { font-size: 8.5px; font-weight: 700; letter-spacing: 0.1em; fill: #a1a1aa; }
+  </style>
+  <defs>
+    <marker id="arrow-red" viewBox="0 0 8 6" refX="7" refY="3" markerWidth="8" markerHeight="6" orient="auto">
+      <path d="M0 0 L8 3 L0 6Z" fill="#ef4444" opacity="0.5"/>
+    </marker>
+    <marker id="arrow-muted" viewBox="0 0 8 6" refX="7" refY="3" markerWidth="8" markerHeight="6" orient="auto">
+      <path d="M0 0 L8 3 L0 6Z" fill="#a1a1aa" opacity="0.5"/>
+    </marker>
+  </defs>
+
   <!-- Background -->
-  <rect width="880" height="360" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect width="960" height="500" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
 
   <!-- Title -->
-  <text x="440" y="32" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="700" fill="#0f172a">How a CVE propagates through your AI stack</text>
+  <text x="480" y="30" text-anchor="middle" class="title">How a single CVE propagates through your AI stack</text>
+  <text x="480" y="46" text-anchor="middle" class="subtitle">agent-bom maps the full blast radius: vulnerability → package → server → agent → credentials → tools</text>
 
-  <!-- ─── CHAIN: CVE → Package → Server → Agent ─── -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- EDGES (drawn first so nodes sit on top)                                -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
 
-  <!-- Node 1: CVE -->
-  <rect x="30" y="56" width="160" height="80" rx="14" fill="#fef2f2" stroke="#ef4444" stroke-width="2.5"/>
-  <text x="110" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#dc2626" letter-spacing="0.08em">VULNERABILITY</text>
-  <text x="110" y="112" text-anchor="middle" font-family="monospace" font-size="13" font-weight="700" fill="#991b1b">CVE-2025-1234</text>
-  <text x="110" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#b91c1c">CRITICAL 9.8 | KEV</text>
+  <!-- CVE → Package -->
+  <line x1="148" y1="218" x2="186" y2="218" stroke="#ef4444" stroke-width="2" opacity="0.4" marker-end="url(#arrow-red)"/>
 
-  <!-- Arrow -->
-  <path d="M190 96 L220 96" stroke="#ef4444" stroke-width="3" stroke-linecap="round"/>
-  <path d="M214 90 L224 96 L214 102" fill="#ef4444"/>
+  <!-- Package → Server A -->
+  <path d="M316 205 C340 205, 350 142, 372 142" stroke="#ef4444" stroke-width="1.5" opacity="0.25" fill="none" marker-end="url(#arrow-red)"/>
 
-  <!-- Node 2: Package -->
-  <rect x="228" y="56" width="160" height="80" rx="14" fill="#f0fdf4" stroke="#22c55e" stroke-width="2"/>
-  <text x="308" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#16a34a" letter-spacing="0.08em">PACKAGE</text>
-  <text x="308" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#15803d">better-sqlite3</text>
-  <text x="308" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#166534">npm v9.0.0</text>
+  <!-- Package → Server B -->
+  <path d="M316 232 C340 232, 350 298, 372 298" stroke="#ef4444" stroke-width="1.5" opacity="0.25" fill="none" marker-end="url(#arrow-red)"/>
 
-  <!-- Arrow -->
-  <path d="M388 96 L418 96" stroke="#ef4444" stroke-width="3" stroke-linecap="round"/>
-  <path d="M412 90 L422 96 L412 102" fill="#ef4444"/>
+  <!-- Server A → Agent 1 -->
+  <path d="M512 128 C536 128, 546 98, 560 98" stroke="#8b5cf6" stroke-width="1.5" opacity="0.25" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Node 3: MCP Server -->
-  <rect x="426" y="56" width="160" height="80" rx="14" fill="#faf5ff" stroke="#8b5cf6" stroke-width="2"/>
-  <text x="506" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#7c3aed" letter-spacing="0.08em">MCP SERVER</text>
-  <text x="506" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#6d28d9">sqlite-mcp</text>
-  <text x="506" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#7c3aed">unverified | 3 tools</text>
+  <!-- Server A → Agent 2 — shared path -->
+  <path d="M512 155 C540 155, 546 218, 560 218" stroke="#8b5cf6" stroke-width="2" opacity="0.4" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Arrow -->
-  <path d="M586 96 L616 96" stroke="#ef4444" stroke-width="3" stroke-linecap="round"/>
-  <path d="M610 90 L620 96 L610 102" fill="#ef4444"/>
+  <!-- Server B → Agent 2 — shared path -->
+  <path d="M512 285 C540 285, 546 230, 560 230" stroke="#8b5cf6" stroke-width="2" opacity="0.4" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Node 4: Agent -->
-  <rect x="624" y="56" width="160" height="80" rx="14" fill="#eff6ff" stroke="#3b82f6" stroke-width="2"/>
-  <text x="704" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="700" fill="#2563eb" letter-spacing="0.08em">AI AGENT</text>
-  <text x="704" y="112" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#1d4ed8">Cursor IDE</text>
-  <text x="704" y="128" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#2563eb">4 servers | 12 tools</text>
+  <!-- Server B → Agent 3 -->
+  <path d="M512 310 C536 310, 546 340, 560 340" stroke="#8b5cf6" stroke-width="1.5" opacity="0.25" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Red propagation glow line -->
-  <rect x="30" y="142" width="754" height="3" rx="1.5" fill="#ef4444" opacity="0.15"/>
+  <!-- Agent → Credential edges -->
+  <path d="M690 92 C710 92, 720 78, 732 78" stroke="#d4d4d8" stroke-width="1" opacity="0.4" fill="none"/>
+  <path d="M690 104 C710 104, 720 114, 732 114" stroke="#d4d4d8" stroke-width="1" opacity="0.4" fill="none"/>
+  <path d="M690 214 C710 214, 720 78, 732 78" stroke="#d4d4d8" stroke-width="1" opacity="0.3" fill="none"/>
+  <path d="M690 218 C710 218, 720 114, 732 114" stroke="#d4d4d8" stroke-width="1" opacity="0.4" fill="none"/>
+  <path d="M690 226 C710 226, 720 150, 732 150" stroke="#d4d4d8" stroke-width="1" opacity="0.4" fill="none"/>
+  <path d="M690 340 C710 340, 720 150, 732 150" stroke="#d4d4d8" stroke-width="1" opacity="0.3" fill="none"/>
 
-  <!-- ─── IMPACT: What attacker reaches ─── -->
-  <text x="440" y="176" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="#0f172a">What an attacker can reach</text>
+  <!-- Agent → Tool edges -->
+  <path d="M690 100 C714 100, 720 222, 732 222" stroke="#d4d4d8" stroke-width="1" opacity="0.2" fill="none"/>
+  <path d="M690 232 C714 232, 720 222, 732 222" stroke="#d4d4d8" stroke-width="1" opacity="0.25" fill="none"/>
+  <path d="M690 232 C714 232, 720 258, 732 258" stroke="#d4d4d8" stroke-width="1" opacity="0.25" fill="none"/>
+  <path d="M690 232 C714 232, 720 294, 732 294" stroke="#d4d4d8" stroke-width="1" opacity="0.25" fill="none"/>
+  <path d="M690 345 C714 345, 720 258, 732 258" stroke="#d4d4d8" stroke-width="1" opacity="0.2" fill="none"/>
+  <path d="M690 345 C714 345, 720 330, 732 330" stroke="#d4d4d8" stroke-width="1" opacity="0.25" fill="none"/>
 
-  <!-- Credentials row -->
-  <text x="48" y="210" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#d97706" letter-spacing="0.08em">CREDENTIALS EXPOSED</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- COLUMN LABELS                                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <text x="95" y="72" text-anchor="middle" class="section-label">VULNERABILITY</text>
+  <text x="252" y="72" text-anchor="middle" class="section-label">PACKAGE</text>
+  <text x="442" y="72" text-anchor="middle" class="section-label">MCP SERVERS</text>
+  <text x="625" y="72" text-anchor="middle" class="section-label">AI AGENTS</text>
+  <text x="825" y="72" text-anchor="middle" class="section-label">BLAST RADIUS</text>
 
-  <rect x="48" y="220" width="136" height="40" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="116" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#92400e">ANTHROPIC_KEY</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: CVE                                                               -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="28" y="186" width="120" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="28" y="186" width="4" height="64" rx="2" fill="#ef4444"/>
+  <text x="48" y="204" class="node-type" fill="#dc2626">CVE</text>
+  <text x="48" y="220" class="node-label" fill="#991b1b">CVE-2025-1234</text>
+  <text x="48" y="236" class="node-detail">Critical 9.8 · CISA KEV</text>
 
-  <rect x="196" y="220" width="136" height="40" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="264" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#92400e">DB_URL</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Package                                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="186" y="186" width="130" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="186" y="186" width="4" height="64" rx="2" fill="#f59e0b"/>
+  <text x="206" y="204" class="node-type" fill="#d97706">PACKAGE</text>
+  <text x="206" y="220" class="node-label">better-sqlite3</text>
+  <text x="206" y="236" class="node-detail">npm · v9.0.0</text>
 
-  <rect x="344" y="220" width="136" height="40" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="412" y="245" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#92400e">AWS_SECRET</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Server A                                                          -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="372" y="110" width="140" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="372" y="110" width="4" height="64" rx="2" fill="#8b5cf6"/>
+  <text x="392" y="128" class="node-type" fill="#7c3aed">MCP SERVER</text>
+  <text x="392" y="144" class="node-label">sqlite-mcp</text>
+  <text x="392" y="160" class="node-detail">unverified · 3 tools · root</text>
 
-  <!-- Tools row -->
-  <text x="48" y="288" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#78716c" letter-spacing="0.08em">TOOLS REACHABLE</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Server B                                                          -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="372" y="268" width="140" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="372" y="268" width="4" height="64" rx="2" fill="#8b5cf6"/>
+  <text x="392" y="286" class="node-type" fill="#7c3aed">MCP SERVER</text>
+  <text x="392" y="302" class="node-label">db-tools</text>
+  <text x="392" y="318" class="node-detail">verified · 5 tools</text>
 
-  <rect x="48" y="298" width="100" height="36" rx="8" fill="#f8fafc" stroke="#d1d5db" stroke-width="1.2"/>
-  <text x="98" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#374151">query_db</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Agent 1                                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="560" y="78" width="130" height="56" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="560" y="78" width="4" height="56" rx="2" fill="#3b82f6"/>
+  <text x="580" y="96" class="node-type" fill="#2563eb">AI AGENT</text>
+  <text x="580" y="112" class="node-label">Cursor IDE</text>
+  <text x="580" y="126" class="node-detail">4 servers · 12 tools</text>
 
-  <rect x="160" y="298" width="100" height="36" rx="8" fill="#f8fafc" stroke="#d1d5db" stroke-width="1.2"/>
-  <text x="210" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#374151">read_file</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Agent 2 — affected by BOTH servers                                -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="560" y="196" width="130" height="56" rx="10" fill="#fafafa" stroke="#ef4444" stroke-width="1.5" stroke-opacity="0.35"/>
+  <rect x="560" y="196" width="4" height="56" rx="2" fill="#3b82f6"/>
+  <text x="580" y="214" class="node-type" fill="#2563eb">AI AGENT</text>
+  <text x="580" y="230" class="node-label">Claude Desktop</text>
+  <text x="580" y="244" class="node-detail">3 servers · 8 tools</text>
 
-  <rect x="272" y="298" width="100" height="36" rx="8" fill="#f8fafc" stroke="#d1d5db" stroke-width="1.2"/>
-  <text x="322" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="600" fill="#374151">write_file</text>
+  <!-- "2 paths" badge -->
+  <rect x="658" y="196" width="30" height="16" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="0.5" stroke-opacity="0.4"/>
+  <text x="673" y="207" text-anchor="middle" font-size="8" font-weight="700" fill="#dc2626" font-family="system-ui, sans-serif">2x</text>
 
-  <rect x="384" y="298" width="100" height="36" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
-  <text x="434" y="321" text-anchor="middle" font-family="monospace" font-size="12" font-weight="700" fill="#dc2626">run_shell</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- NODE: Agent 3                                                           -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="560" y="320" width="130" height="56" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="560" y="320" width="4" height="56" rx="2" fill="#3b82f6"/>
+  <text x="580" y="338" class="node-type" fill="#2563eb">AI AGENT</text>
+  <text x="580" y="354" class="node-label">Windsurf</text>
+  <text x="580" y="368" class="node-detail">2 servers · 6 tools</text>
 
-  <!-- Impact summary box -->
-  <rect x="560" y="196" width="290" height="146" rx="14" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
-  <text x="705" y="222" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="700" fill="#0f172a">Impact Summary</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- CREDENTIALS                                                             -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="732" y="86" width="118" height="26" rx="6" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <circle cx="746" cy="99" r="4" fill="#f59e0b" opacity="0.5"/>
+  <text x="758" y="103" class="cred-label" fill="#92400e">ANTHROPIC_KEY</text>
 
-  <text x="588" y="250" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#ef4444">1</text>
-  <text x="616" y="248" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#64748b">agent compromised</text>
+  <rect x="732" y="120" width="118" height="26" rx="6" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <circle cx="746" cy="133" r="4" fill="#f59e0b" opacity="0.5"/>
+  <text x="758" y="137" class="cred-label" fill="#92400e">DB_URL</text>
 
-  <text x="588" y="280" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#f59e0b">3</text>
-  <text x="616" y="278" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#64748b">credentials exposed</text>
+  <rect x="732" y="154" width="118" height="26" rx="6" fill="#fffbeb" stroke="#fde68a" stroke-width="1"/>
+  <circle cx="746" cy="167" r="4" fill="#f59e0b" opacity="0.5"/>
+  <text x="758" y="171" class="cred-label" fill="#92400e">AWS_SECRET</text>
 
-  <text x="588" y="310" font-family="system-ui, sans-serif" font-size="28" font-weight="800" fill="#78716c">4</text>
-  <text x="616" y="308" font-family="system-ui, sans-serif" font-size="12" font-weight="500" fill="#64748b">tools reachable (incl. RCE)</text>
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- TOOLS                                                                   -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <text x="732" y="206" class="section-label">TOOLS AT RISK</text>
 
-  <!-- Fix footer -->
-  <rect x="560" y="324" width="290" height="2" rx="1" fill="#22c55e" opacity="0.4"/>
-  <text x="705" y="344" text-anchor="middle" font-family="monospace" font-size="11" font-weight="700" fill="#16a34a">FIX: upgrade better-sqlite3 to 11.7.0</text>
+  <rect x="732" y="214" width="100" height="24" rx="6" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="782" y="230" text-anchor="middle" class="tool-label" fill="#52525b">query_db</text>
+
+  <rect x="840" y="214" width="100" height="24" rx="6" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="890" y="230" text-anchor="middle" class="tool-label" fill="#52525b">read_file</text>
+
+  <rect x="732" y="246" width="100" height="24" rx="6" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="782" y="262" text-anchor="middle" class="tool-label" fill="#52525b">write_file</text>
+
+  <rect x="840" y="246" width="100" height="24" rx="6" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="890" y="262" text-anchor="middle" class="tool-label" fill="#52525b">exec_sql</text>
+
+  <!-- Dangerous tool -->
+  <rect x="732" y="278" width="100" height="24" rx="6" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="782" y="294" text-anchor="middle" class="tool-label" fill="#dc2626">run_shell</text>
+  <text x="845" y="294" font-size="8" font-weight="700" fill="#dc2626" font-family="system-ui, sans-serif">RCE RISK</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- SHARED PATH HIGHLIGHT                                                   -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="540" y="186" width="170" height="76" rx="12" stroke="#ef4444" stroke-width="1" stroke-dasharray="4 3" stroke-opacity="0.2" fill="none"/>
+  <text x="547" y="182" font-size="8" font-weight="600" fill="#ef4444" opacity="0.5" font-family="system-ui, sans-serif">HIGHEST RISK — 2 ATTACK PATHS</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <!-- IMPACT SUMMARY BAR                                                      -->
+  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="24" y="410" width="912" height="76" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+
+  <text x="80" y="440" text-anchor="middle" class="impact-num" fill="#ef4444">3</text>
+  <text x="80" y="458" text-anchor="middle" class="impact-label">agents</text>
+  <text x="80" y="472" text-anchor="middle" class="impact-label">compromised</text>
+
+  <rect x="140" y="424" width="1" height="48" rx="0.5" fill="#e4e4e7"/>
+
+  <text x="200" y="440" text-anchor="middle" class="impact-num" fill="#d97706">3</text>
+  <text x="200" y="458" text-anchor="middle" class="impact-label">credentials</text>
+  <text x="200" y="472" text-anchor="middle" class="impact-label">exposed</text>
+
+  <rect x="260" y="424" width="1" height="48" rx="0.5" fill="#e4e4e7"/>
+
+  <text x="320" y="440" text-anchor="middle" class="impact-num" fill="#52525b">5</text>
+  <text x="320" y="458" text-anchor="middle" class="impact-label">tools</text>
+  <text x="320" y="472" text-anchor="middle" class="impact-label">reachable</text>
+
+  <rect x="380" y="424" width="1" height="48" rx="0.5" fill="#e4e4e7"/>
+
+  <text x="440" y="440" text-anchor="middle" class="impact-num" fill="#ef4444">1</text>
+  <text x="440" y="458" text-anchor="middle" class="impact-label">RCE-capable</text>
+  <text x="440" y="472" text-anchor="middle" class="impact-label">tool exposed</text>
+
+  <!-- Fix recommendation -->
+  <rect x="520" y="422" width="400" height="52" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>
+  <text x="540" y="442" font-size="9" font-weight="600" fill="#059669" letter-spacing="0.05em" font-family="system-ui, sans-serif">RECOMMENDED FIX</text>
+  <text x="540" y="462" class="fix-label" fill="#047857">upgrade better-sqlite3 → 11.7.0</text>
+  <text x="540" y="476" class="node-detail" fill="#059669">Resolves all 3 agent exposures in one upgrade</text>
 </svg>


### PR DESCRIPTION
## Summary
- Replaced linear chain diagram with branching graph showing one CVE cascading through 2 MCP servers to 3 AI agents
- Shows shared attack paths — Claude Desktop hit by both servers (marked `2x`)
- Credential exposure and tool reachability columns on the right
- RCE-capable tool (`run_shell`) highlighted with distinct styling
- Impact summary bar with actionable fix recommendation
- Both dark and light themes

## What changed
The old diagram showed a flat chain: CVE → Package → Server → Agent. The new one shows the **branching reality** — one vulnerability reaches multiple servers, which fan out to multiple agents, each exposing different credentials and tools. The "2x" badge on Claude Desktop shows it's hit through two separate paths.

## Test plan
- [ ] Dark SVG renders correctly on GitHub dark mode
- [ ] Light SVG renders correctly on GitHub light mode
- [ ] Text readable at 800px width
- [ ] Branching paths and shared connections are visually clear

Closes #258