### PR TITLE
feat: add scan pipeline, architecture stack, and compliance diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ rm -rf ~/.agent-bom                      # remove local data
 3. **Analyze** -- blast radius mapping, tool poisoning detection, compliance tagging, posture scoring
 4. **Report** -- JSON, SARIF, CycloneDX, SPDX, HTML, Mermaid, or console. Alert dispatch to Slack/webhooks.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-light.svg" alt="Scan pipeline" width="800" />
+  </picture>
+</p>
+
 **Read-only guarantee.** Never writes configs, never runs servers, never stores secrets. `--dry-run` previews everything. Every release is [Sigstore-signed](PERMISSIONS.md).
 
 ---
@@ -126,11 +133,18 @@ rm -rf ~/.agent-bom                      # remove local data
 | **Credential exposure** | -- | Which secrets leak per vulnerability, per agent |
 | **Tool poisoning detection** | -- | Description injection, capability combos, drift detection |
 | **Privilege detection** | -- | root, shell access, privileged containers, per-tool permissions |
-| **10-framework compliance** | -- | OWASP LLM + MCP + Agentic, MITRE ATLAS, NIST AI RMF + CSF, EU AI Act, SOC 2, ISO 27001, CIS |
+| **10-framework compliance** | -- | OWASP LLM + MCP + Agentic, MITRE ATLAS, NIST AI RMF + CSF, EU AI Act, SOC 2, ISO 27001, CIS AI |
 | **Posture scorecard** | -- | Letter grade (A-F), 6 dimensions, incident correlation (P1-P4) |
-| **Policy-as-code** | -- | 16 conditions, CI gate, block unverified servers |
+| **Policy-as-code** | -- | 17 conditions, CI gate, block unverified servers |
 | **Lateral movement analysis** | -- | Agent context graph, shared credentials, BFS attack paths |
 | **427+ server MCP registry** | -- | Risk levels, tool inventories, auto-synced weekly |
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/compliance-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/compliance-light.svg" alt="Compliance coverage" width="800" />
+  </picture>
+</p>
 
 <details>
 <summary><b>What it scans</b></summary>
@@ -255,10 +269,22 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 
 <p align="center">
   <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-stack-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-stack-light.svg" alt="Architecture stack" width="800" />
+  </picture>
+</p>
+
+<details>
+<summary><b>Engine internals</b></summary>
+
+<p align="center">
+  <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/engine-internals-dark.svg">
     <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/engine-internals-light.svg" alt="Engine internals" width="800" />
   </picture>
 </p>
+
+</details>
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pipeline, blast radius propagation, compliance framework mapping, integration architecture, and deployment topology.
 
@@ -277,7 +303,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 
 ## Roadmap
 
-- [ ] CIS AI benchmarks
+- [x] CIS AI benchmarks
 - [ ] License compliance engine
 - [ ] Workflow engine scanning (n8n, Zapier, Make)
 

--- a/docs/images/architecture-stack-dark.svg
+++ b/docs/images/architecture-stack-dark.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 440" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #f4f4f5; }
+    .layer-name { font-size: 11px; font-weight: 700; letter-spacing: 0.06em; }
+    .item { font-size: 9.5px; font-weight: 600; fill: #e4e4e7; }
+    .detail { font-size: 8px; font-weight: 400; fill: #71717a; }
+    .arrow-up { font-size: 12px; fill: #3f3f46; }
+    .side-label { font-size: 8px; font-weight: 700; letter-spacing: 0.08em; fill: #3f3f46; }
+  </style>
+
+  <rect width="800" height="440" rx="12" fill="#09090b"/>
+
+  <text x="400" y="28" text-anchor="middle" class="title">Architecture stack</text>
+
+  <!-- ═══ LAYER 5 (top): INTERFACES ═══ -->
+  <rect x="100" y="48" width="600" height="48" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="100" y="48" width="600" height="4" rx="2" fill="#3b82f6"/>
+  <text x="120" y="78" class="layer-name" fill="#3b82f6">INTERFACES</text>
+
+  <rect x="230" y="60" width="56" height="24" rx="5" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
+  <text x="258" y="76" text-anchor="middle" class="item">CLI</text>
+  <rect x="294" y="60" width="72" height="24" rx="5" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
+  <text x="330" y="76" text-anchor="middle" class="item">MCP Server</text>
+  <rect x="374" y="60" width="64" height="24" rx="5" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
+  <text x="406" y="76" text-anchor="middle" class="item">REST API</text>
+  <rect x="446" y="60" width="56" height="24" rx="5" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
+  <text x="474" y="76" text-anchor="middle" class="item">Action</text>
+  <rect x="510" y="60" width="56" height="24" rx="5" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
+  <text x="538" y="76" text-anchor="middle" class="item">Proxy</text>
+  <rect x="574" y="60" width="76" height="24" rx="5" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
+  <text x="612" y="76" text-anchor="middle" class="item">Dashboard</text>
+
+  <!-- Arrow -->
+  <text x="400" y="110" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 4: OUTPUT ENGINE ═══ -->
+  <rect x="100" y="118" width="600" height="48" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="100" y="118" width="600" height="4" rx="2" fill="#10b981"/>
+  <text x="120" y="148" class="layer-name" fill="#10b981">OUTPUT</text>
+
+  <rect x="220" y="130" width="56" height="24" rx="5" fill="#14261e" stroke="#065f46" stroke-width="0.5"/>
+  <text x="248" y="146" text-anchor="middle" class="item">Console</text>
+  <rect x="284" y="130" width="48" height="24" rx="5" fill="#14261e" stroke="#065f46" stroke-width="0.5"/>
+  <text x="308" y="146" text-anchor="middle" class="item">HTML</text>
+  <rect x="340" y="130" width="50" height="24" rx="5" fill="#14261e" stroke="#065f46" stroke-width="0.5"/>
+  <text x="365" y="146" text-anchor="middle" class="item">SARIF</text>
+  <rect x="398" y="130" width="50" height="24" rx="5" fill="#14261e" stroke="#065f46" stroke-width="0.5"/>
+  <text x="423" y="146" text-anchor="middle" class="item">SBOM</text>
+  <rect x="456" y="130" width="46" height="24" rx="5" fill="#14261e" stroke="#065f46" stroke-width="0.5"/>
+  <text x="479" y="146" text-anchor="middle" class="item">JSON</text>
+  <rect x="510" y="130" width="56" height="24" rx="5" fill="#14261e" stroke="#065f46" stroke-width="0.5"/>
+  <text x="538" y="146" text-anchor="middle" class="item">Graph</text>
+  <rect x="574" y="130" width="76" height="24" rx="5" fill="#14261e" stroke="#065f46" stroke-width="0.5"/>
+  <text x="612" y="146" text-anchor="middle" class="item">Webhooks</text>
+
+  <text x="400" y="180" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 3: ANALYSIS ENGINE ═══ -->
+  <rect x="100" y="188" width="600" height="48" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="100" y="188" width="600" height="4" rx="2" fill="#f43f5e"/>
+  <text x="120" y="218" class="layer-name" fill="#f43f5e">ANALYSIS</text>
+
+  <rect x="220" y="200" width="80" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="260" y="216" text-anchor="middle" class="item">Blast Radius</text>
+  <rect x="308" y="200" width="76" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="346" y="216" text-anchor="middle" class="item">Compliance</text>
+  <rect x="392" y="200" width="56" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="420" y="216" text-anchor="middle" class="item">Policy</text>
+  <rect x="456" y="200" width="76" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="494" y="216" text-anchor="middle" class="item">Enforcement</text>
+  <rect x="540" y="200" width="58" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="569" y="216" text-anchor="middle" class="item">Posture</text>
+  <rect x="606" y="200" width="76" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="644" y="216" text-anchor="middle" class="item">Context Graph</text>
+
+  <text x="400" y="250" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 2: VULNERABILITY DATABASES ═══ -->
+  <rect x="100" y="258" width="600" height="48" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="100" y="258" width="600" height="4" rx="2" fill="#f59e0b"/>
+  <text x="120" y="288" class="layer-name" fill="#f59e0b">VULN DATA</text>
+
+  <rect x="240" y="270" width="52" height="24" rx="5" fill="#292524" stroke="#78350f" stroke-width="0.5"/>
+  <text x="266" y="286" text-anchor="middle" class="item">OSV</text>
+  <rect x="300" y="270" width="48" height="24" rx="5" fill="#292524" stroke="#78350f" stroke-width="0.5"/>
+  <text x="324" y="286" text-anchor="middle" class="item">NVD</text>
+  <rect x="356" y="270" width="48" height="24" rx="5" fill="#292524" stroke="#78350f" stroke-width="0.5"/>
+  <text x="380" y="286" text-anchor="middle" class="item">EPSS</text>
+  <rect x="412" y="270" width="48" height="24" rx="5" fill="#292524" stroke="#78350f" stroke-width="0.5"/>
+  <text x="436" y="286" text-anchor="middle" class="item">KEV</text>
+  <rect x="468" y="270" width="52" height="24" rx="5" fill="#292524" stroke="#78350f" stroke-width="0.5"/>
+  <text x="494" y="286" text-anchor="middle" class="item">GHSA</text>
+  <rect x="528" y="270" width="72" height="24" rx="5" fill="#292524" stroke="#78350f" stroke-width="0.5"/>
+  <text x="564" y="286" text-anchor="middle" class="item">MCP Registry</text>
+
+  <text x="400" y="320" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 1 (bottom): INPUT SOURCES ═══ -->
+  <rect x="100" y="328" width="600" height="48" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="100" y="328" width="600" height="4" rx="2" fill="#a78bfa"/>
+  <text x="120" y="358" class="layer-name" fill="#a78bfa">SOURCES</text>
+
+  <rect x="218" y="340" width="64" height="24" rx="5" fill="#1a1028" stroke="#3a1e5f" stroke-width="0.5"/>
+  <text x="250" y="356" text-anchor="middle" class="item">MCP</text>
+  <rect x="290" y="340" width="56" height="24" rx="5" fill="#1a1028" stroke="#3a1e5f" stroke-width="0.5"/>
+  <text x="318" y="356" text-anchor="middle" class="item">Docker</text>
+  <rect x="354" y="340" width="42" height="24" rx="5" fill="#1a1028" stroke="#3a1e5f" stroke-width="0.5"/>
+  <text x="375" y="356" text-anchor="middle" class="item">K8s</text>
+  <rect x="404" y="340" width="50" height="24" rx="5" fill="#1a1028" stroke="#3a1e5f" stroke-width="0.5"/>
+  <text x="429" y="356" text-anchor="middle" class="item">Cloud</text>
+  <rect x="462" y="340" width="58" height="24" rx="5" fill="#1a1028" stroke="#3a1e5f" stroke-width="0.5"/>
+  <text x="491" y="356" text-anchor="middle" class="item">Models</text>
+  <rect x="528" y="340" width="56" height="24" rx="5" fill="#1a1028" stroke="#3a1e5f" stroke-width="0.5"/>
+  <text x="556" y="356" text-anchor="middle" class="item">SBOMs</text>
+  <rect x="592" y="340" width="66" height="24" rx="5" fill="#1a1028" stroke="#3a1e5f" stroke-width="0.5"/>
+  <text x="625" y="356" text-anchor="middle" class="item">Packages</text>
+
+  <!-- ═══ SECURITY SIDEBAR ═══ -->
+  <rect x="24" y="48" width="56" height="328" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="24" y="48" width="4" height="328" rx="2" fill="#ef4444"/>
+  <text x="52" y="140" text-anchor="middle" class="side-label" fill="#ef4444" transform="rotate(-90, 52, 140)">SECURITY LAYER</text>
+  <text x="52" y="260" text-anchor="middle" class="detail" transform="rotate(-90, 52, 260)">redaction · validation · rate limits · signing</text>
+
+  <!-- ═══ RUNTIME SIDEBAR ═══ -->
+  <rect x="720" y="48" width="56" height="328" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="772" y="48" width="4" height="328" rx="2" fill="#7c3aed"/>
+  <text x="748" y="130" text-anchor="middle" class="side-label" fill="#c4b5fd" transform="rotate(90, 748, 130)">RUNTIME (OPT)</text>
+  <text x="748" y="260" text-anchor="middle" class="detail" transform="rotate(90, 748, 260)">proxy · protect · watch · introspect</text>
+
+  <!-- ═══ BOTTOM LABEL ═══ -->
+  <text x="400" y="406" text-anchor="middle" font-size="9" font-weight="500" fill="#3f3f46" font-family="system-ui, sans-serif">Data flows bottom → top. Security and runtime are cross-cutting.</text>
+</svg>

--- a/docs/images/architecture-stack-light.svg
+++ b/docs/images/architecture-stack-light.svg
@@ -1,0 +1,132 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 440" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #18181b; }
+    .layer-name { font-size: 11px; font-weight: 700; letter-spacing: 0.06em; }
+    .item { font-size: 9.5px; font-weight: 600; fill: #27272a; }
+    .detail { font-size: 8px; font-weight: 400; fill: #71717a; }
+    .arrow-up { font-size: 12px; fill: #d4d4d8; }
+    .side-label { font-size: 8px; font-weight: 700; letter-spacing: 0.08em; }
+  </style>
+
+  <rect width="800" height="440" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
+
+  <text x="400" y="28" text-anchor="middle" class="title">Architecture stack</text>
+
+  <!-- ═══ LAYER 5: INTERFACES ═══ -->
+  <rect x="100" y="48" width="600" height="48" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="100" y="48" width="600" height="4" rx="2" fill="#2563eb"/>
+  <text x="120" y="78" class="layer-name" fill="#2563eb">INTERFACES</text>
+
+  <rect x="230" y="60" width="56" height="24" rx="5" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
+  <text x="258" y="76" text-anchor="middle" class="item">CLI</text>
+  <rect x="294" y="60" width="72" height="24" rx="5" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
+  <text x="330" y="76" text-anchor="middle" class="item">MCP Server</text>
+  <rect x="374" y="60" width="64" height="24" rx="5" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
+  <text x="406" y="76" text-anchor="middle" class="item">REST API</text>
+  <rect x="446" y="60" width="56" height="24" rx="5" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
+  <text x="474" y="76" text-anchor="middle" class="item">Action</text>
+  <rect x="510" y="60" width="56" height="24" rx="5" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
+  <text x="538" y="76" text-anchor="middle" class="item">Proxy</text>
+  <rect x="574" y="60" width="76" height="24" rx="5" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
+  <text x="612" y="76" text-anchor="middle" class="item">Dashboard</text>
+
+  <text x="400" y="110" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 4: OUTPUT ═══ -->
+  <rect x="100" y="118" width="600" height="48" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="100" y="118" width="600" height="4" rx="2" fill="#059669"/>
+  <text x="120" y="148" class="layer-name" fill="#059669">OUTPUT</text>
+
+  <rect x="220" y="130" width="56" height="24" rx="5" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="248" y="146" text-anchor="middle" class="item">Console</text>
+  <rect x="284" y="130" width="48" height="24" rx="5" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="308" y="146" text-anchor="middle" class="item">HTML</text>
+  <rect x="340" y="130" width="50" height="24" rx="5" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="365" y="146" text-anchor="middle" class="item">SARIF</text>
+  <rect x="398" y="130" width="50" height="24" rx="5" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="423" y="146" text-anchor="middle" class="item">SBOM</text>
+  <rect x="456" y="130" width="46" height="24" rx="5" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="479" y="146" text-anchor="middle" class="item">JSON</text>
+  <rect x="510" y="130" width="56" height="24" rx="5" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="538" y="146" text-anchor="middle" class="item">Graph</text>
+  <rect x="574" y="130" width="76" height="24" rx="5" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="0.5"/>
+  <text x="612" y="146" text-anchor="middle" class="item">Webhooks</text>
+
+  <text x="400" y="180" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 3: ANALYSIS ═══ -->
+  <rect x="100" y="188" width="600" height="48" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="100" y="188" width="600" height="4" rx="2" fill="#e11d48"/>
+  <text x="120" y="218" class="layer-name" fill="#e11d48">ANALYSIS</text>
+
+  <rect x="220" y="200" width="80" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="260" y="216" text-anchor="middle" class="item">Blast Radius</text>
+  <rect x="308" y="200" width="76" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="346" y="216" text-anchor="middle" class="item">Compliance</text>
+  <rect x="392" y="200" width="56" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="420" y="216" text-anchor="middle" class="item">Policy</text>
+  <rect x="456" y="200" width="76" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="494" y="216" text-anchor="middle" class="item">Enforcement</text>
+  <rect x="540" y="200" width="58" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="569" y="216" text-anchor="middle" class="item">Posture</text>
+  <rect x="606" y="200" width="76" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="644" y="216" text-anchor="middle" class="item">Context Graph</text>
+
+  <text x="400" y="250" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 2: VULN DATA ═══ -->
+  <rect x="100" y="258" width="600" height="48" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="100" y="258" width="600" height="4" rx="2" fill="#d97706"/>
+  <text x="120" y="288" class="layer-name" fill="#d97706">VULN DATA</text>
+
+  <rect x="240" y="270" width="52" height="24" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
+  <text x="266" y="286" text-anchor="middle" class="item">OSV</text>
+  <rect x="300" y="270" width="48" height="24" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
+  <text x="324" y="286" text-anchor="middle" class="item">NVD</text>
+  <rect x="356" y="270" width="48" height="24" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
+  <text x="380" y="286" text-anchor="middle" class="item">EPSS</text>
+  <rect x="412" y="270" width="48" height="24" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
+  <text x="436" y="286" text-anchor="middle" class="item">KEV</text>
+  <rect x="468" y="270" width="52" height="24" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
+  <text x="494" y="286" text-anchor="middle" class="item">GHSA</text>
+  <rect x="528" y="270" width="72" height="24" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
+  <text x="564" y="286" text-anchor="middle" class="item">MCP Registry</text>
+
+  <text x="400" y="320" text-anchor="middle" class="arrow-up">&#x25B2;</text>
+
+  <!-- ═══ LAYER 1: SOURCES ═══ -->
+  <rect x="100" y="328" width="600" height="48" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="100" y="328" width="600" height="4" rx="2" fill="#7c3aed"/>
+  <text x="120" y="358" class="layer-name" fill="#7c3aed">SOURCES</text>
+
+  <rect x="218" y="340" width="64" height="24" rx="5" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="0.5"/>
+  <text x="250" y="356" text-anchor="middle" class="item">MCP</text>
+  <rect x="290" y="340" width="56" height="24" rx="5" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="0.5"/>
+  <text x="318" y="356" text-anchor="middle" class="item">Docker</text>
+  <rect x="354" y="340" width="42" height="24" rx="5" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="0.5"/>
+  <text x="375" y="356" text-anchor="middle" class="item">K8s</text>
+  <rect x="404" y="340" width="50" height="24" rx="5" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="0.5"/>
+  <text x="429" y="356" text-anchor="middle" class="item">Cloud</text>
+  <rect x="462" y="340" width="58" height="24" rx="5" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="0.5"/>
+  <text x="491" y="356" text-anchor="middle" class="item">Models</text>
+  <rect x="528" y="340" width="56" height="24" rx="5" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="0.5"/>
+  <text x="556" y="356" text-anchor="middle" class="item">SBOMs</text>
+  <rect x="592" y="340" width="66" height="24" rx="5" fill="#f5f3ff" stroke="#ddd6fe" stroke-width="0.5"/>
+  <text x="625" y="356" text-anchor="middle" class="item">Packages</text>
+
+  <!-- ═══ SECURITY SIDEBAR ═══ -->
+  <rect x="24" y="48" width="56" height="328" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="24" y="48" width="4" height="328" rx="2" fill="#ef4444"/>
+  <text x="52" y="140" text-anchor="middle" class="side-label" fill="#dc2626" transform="rotate(-90, 52, 140)">SECURITY LAYER</text>
+  <text x="52" y="260" text-anchor="middle" class="detail" transform="rotate(-90, 52, 260)">redaction · validation · rate limits · signing</text>
+
+  <!-- ═══ RUNTIME SIDEBAR ═══ -->
+  <rect x="720" y="48" width="56" height="328" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="772" y="48" width="4" height="328" rx="2" fill="#7c3aed"/>
+  <text x="748" y="130" text-anchor="middle" class="side-label" fill="#7c3aed" transform="rotate(90, 748, 130)">RUNTIME (OPT)</text>
+  <text x="748" y="260" text-anchor="middle" class="detail" transform="rotate(90, 748, 260)">proxy · protect · watch · introspect</text>
+
+  <!-- ═══ BOTTOM LABEL ═══ -->
+  <text x="400" y="406" text-anchor="middle" font-size="9" font-weight="500" fill="#a1a1aa" font-family="system-ui, sans-serif">Data flows bottom → top. Security and runtime are cross-cutting.</text>
+</svg>

--- a/docs/images/compliance-dark.svg
+++ b/docs/images/compliance-dark.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 280" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #f4f4f5; }
+    .subtitle { font-size: 10.5px; font-weight: 400; fill: #52525b; }
+    .fw-name { font-size: 10px; font-weight: 700; fill: #e4e4e7; }
+    .fw-code { font-size: 8px; font-weight: 600; fill: #71717a; }
+    .fw-count { font-size: 18px; font-weight: 800; }
+    .fw-label { font-size: 8px; font-weight: 500; fill: #71717a; }
+    .bar-bg { fill: #27272a; }
+    .summary-num { font-size: 22px; font-weight: 800; }
+    .summary-label { font-size: 9px; font-weight: 500; fill: #71717a; }
+  </style>
+
+  <rect width="960" height="280" rx="12" fill="#09090b"/>
+
+  <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">10 frameworks, 300+ controls mapped automatically from scan findings</text>
+
+  <!-- ═══ ROW 1: 5 frameworks ═══ -->
+
+  <!-- OWASP LLM Top 10 -->
+  <rect x="20" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="36" y="84" class="fw-name">OWASP LLM Top 10</text>
+  <text x="36" y="96" class="fw-code">Prompt injection, data poisoning, supply chain</text>
+  <rect x="36" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="36" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
+  <text x="36" y="126" class="fw-count" fill="#3b82f6">10</text>
+  <text x="64" y="126" class="fw-label">controls</text>
+
+  <!-- OWASP MCP Top 10 -->
+  <rect x="208" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="224" y="84" class="fw-name">OWASP MCP Top 10</text>
+  <text x="224" y="96" class="fw-code">Tool poisoning, auth bypass, rug pull</text>
+  <rect x="224" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="224" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
+  <text x="224" y="126" class="fw-count" fill="#3b82f6">10</text>
+  <text x="252" y="126" class="fw-label">controls</text>
+
+  <!-- OWASP Agentic Top 10 -->
+  <rect x="396" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="412" y="84" class="fw-name">OWASP Agentic Top 10</text>
+  <text x="412" y="96" class="fw-code">Excessive agency, insecure output</text>
+  <rect x="412" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="412" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
+  <text x="412" y="126" class="fw-count" fill="#3b82f6">10</text>
+  <text x="440" y="126" class="fw-label">controls</text>
+
+  <!-- MITRE ATLAS -->
+  <rect x="584" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="600" y="84" class="fw-name">MITRE ATLAS</text>
+  <text x="600" y="96" class="fw-code">Adversarial ML tactics + techniques</text>
+  <rect x="600" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="600" y="104" width="108" height="4" rx="2" fill="#f59e0b"/>
+  <text x="600" y="126" class="fw-count" fill="#f59e0b">14</text>
+  <text x="628" y="126" class="fw-label">techniques</text>
+
+  <!-- NIST AI RMF -->
+  <rect x="772" y="64" width="168" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="788" y="84" class="fw-name">NIST AI RMF</text>
+  <text x="788" y="96" class="fw-code">Govern, map, measure, manage</text>
+  <rect x="788" y="104" width="136" height="4" rx="2" class="bar-bg"/>
+  <rect x="788" y="104" width="102" height="4" rx="2" fill="#10b981"/>
+  <text x="788" y="126" class="fw-count" fill="#10b981">19</text>
+  <text x="816" y="126" class="fw-label">subcategories</text>
+
+  <!-- ═══ ROW 2: 5 frameworks ═══ -->
+
+  <!-- NIST CSF -->
+  <rect x="20" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="36" y="168" class="fw-name">NIST CSF 2.0</text>
+  <text x="36" y="180" class="fw-code">Identify, protect, detect, respond</text>
+  <rect x="36" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="36" y="188" width="108" height="4" rx="2" fill="#10b981"/>
+  <text x="36" y="210" class="fw-count" fill="#10b981">23</text>
+  <text x="64" y="210" class="fw-label">subcategories</text>
+
+  <!-- EU AI Act -->
+  <rect x="208" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="224" y="168" class="fw-name">EU AI Act</text>
+  <text x="224" y="180" class="fw-code">Risk management, transparency, oversight</text>
+  <rect x="224" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="224" y="188" width="86" height="4" rx="2" fill="#a78bfa"/>
+  <text x="224" y="210" class="fw-count" fill="#a78bfa">12</text>
+  <text x="252" y="210" class="fw-label">articles</text>
+
+  <!-- SOC 2 -->
+  <rect x="396" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="412" y="168" class="fw-name">SOC 2</text>
+  <text x="412" y="180" class="fw-code">Trust service criteria</text>
+  <rect x="412" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="412" y="188" width="72" height="4" rx="2" fill="#f43f5e"/>
+  <text x="412" y="210" class="fw-count" fill="#f43f5e">8</text>
+  <text x="432" y="210" class="fw-label">criteria</text>
+
+  <!-- ISO 27001 -->
+  <rect x="584" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="600" y="168" class="fw-name">ISO 27001</text>
+  <text x="600" y="180" class="fw-code">Information security controls</text>
+  <rect x="600" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="600" y="188" width="86" height="4" rx="2" fill="#f43f5e"/>
+  <text x="600" y="210" class="fw-count" fill="#f43f5e">10</text>
+  <text x="628" y="210" class="fw-label">controls</text>
+
+  <!-- CIS Benchmarks -->
+  <rect x="772" y="148" width="168" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="788" y="168" class="fw-name">CIS Benchmarks</text>
+  <text x="788" y="180" class="fw-code">AWS v3.0, Snowflake v1.0</text>
+  <rect x="788" y="188" width="136" height="4" rx="2" class="bar-bg"/>
+  <rect x="788" y="188" width="136" height="4" rx="2" fill="#34d399"/>
+  <text x="788" y="210" class="fw-count" fill="#34d399">200+</text>
+  <text x="828" y="210" class="fw-label">checks</text>
+
+  <!-- ═══ SUMMARY BAR ═══ -->
+  <rect x="20" y="236" width="920" height="32" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+
+  <text x="80" y="258" text-anchor="middle" class="summary-num" fill="#3b82f6">10</text>
+  <text x="126" y="258" class="summary-label">frameworks</text>
+
+  <rect x="186" y="244" width="1" height="16" fill="#27272a"/>
+
+  <text x="230" y="258" text-anchor="middle" class="summary-num" fill="#10b981">300+</text>
+  <text x="276" y="258" class="summary-label">controls mapped</text>
+
+  <rect x="370" y="244" width="1" height="16" fill="#27272a"/>
+
+  <text x="420" y="258" text-anchor="middle" class="summary-num" fill="#f59e0b">3</text>
+  <text x="442" y="258" class="summary-label">OWASP standards (LLM + MCP + Agentic)</text>
+
+  <rect x="660" y="244" width="1" height="16" fill="#27272a"/>
+
+  <text x="710" y="258" text-anchor="middle" class="summary-num" fill="#a78bfa">auto</text>
+  <text x="756" y="258" class="summary-label">mapped from scan findings — no manual config</text>
+</svg>

--- a/docs/images/compliance-light.svg
+++ b/docs/images/compliance-light.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 280" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #18181b; }
+    .subtitle { font-size: 10.5px; font-weight: 400; fill: #a1a1aa; }
+    .fw-name { font-size: 10px; font-weight: 700; fill: #27272a; }
+    .fw-code { font-size: 8px; font-weight: 600; fill: #a1a1aa; }
+    .fw-count { font-size: 18px; font-weight: 800; }
+    .fw-label { font-size: 8px; font-weight: 500; fill: #a1a1aa; }
+    .bar-bg { fill: #e4e4e7; }
+    .summary-num { font-size: 22px; font-weight: 800; }
+    .summary-label { font-size: 9px; font-weight: 500; fill: #a1a1aa; }
+  </style>
+
+  <rect width="960" height="280" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
+
+  <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">10 frameworks, 300+ controls mapped automatically from scan findings</text>
+
+  <!-- ═══ ROW 1: 5 frameworks ═══ -->
+
+  <!-- OWASP LLM Top 10 -->
+  <rect x="20" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="36" y="84" class="fw-name">OWASP LLM Top 10</text>
+  <text x="36" y="96" class="fw-code">Prompt injection, data poisoning, supply chain</text>
+  <rect x="36" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="36" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
+  <text x="36" y="126" class="fw-count" fill="#3b82f6">10</text>
+  <text x="64" y="126" class="fw-label">controls</text>
+
+  <!-- OWASP MCP Top 10 -->
+  <rect x="208" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="224" y="84" class="fw-name">OWASP MCP Top 10</text>
+  <text x="224" y="96" class="fw-code">Tool poisoning, auth bypass, rug pull</text>
+  <rect x="224" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="224" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
+  <text x="224" y="126" class="fw-count" fill="#3b82f6">10</text>
+  <text x="252" y="126" class="fw-label">controls</text>
+
+  <!-- OWASP Agentic Top 10 -->
+  <rect x="396" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="412" y="84" class="fw-name">OWASP Agentic Top 10</text>
+  <text x="412" y="96" class="fw-code">Excessive agency, insecure output</text>
+  <rect x="412" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="412" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
+  <text x="412" y="126" class="fw-count" fill="#3b82f6">10</text>
+  <text x="440" y="126" class="fw-label">controls</text>
+
+  <!-- MITRE ATLAS -->
+  <rect x="584" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="600" y="84" class="fw-name">MITRE ATLAS</text>
+  <text x="600" y="96" class="fw-code">Adversarial ML tactics + techniques</text>
+  <rect x="600" y="104" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="600" y="104" width="108" height="4" rx="2" fill="#f59e0b"/>
+  <text x="600" y="126" class="fw-count" fill="#f59e0b">14</text>
+  <text x="628" y="126" class="fw-label">techniques</text>
+
+  <!-- NIST AI RMF -->
+  <rect x="772" y="64" width="168" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="788" y="84" class="fw-name">NIST AI RMF</text>
+  <text x="788" y="96" class="fw-code">Govern, map, measure, manage</text>
+  <rect x="788" y="104" width="136" height="4" rx="2" class="bar-bg"/>
+  <rect x="788" y="104" width="102" height="4" rx="2" fill="#10b981"/>
+  <text x="788" y="126" class="fw-count" fill="#10b981">19</text>
+  <text x="816" y="126" class="fw-label">subcategories</text>
+
+  <!-- ═══ ROW 2: 5 frameworks ═══ -->
+
+  <!-- NIST CSF -->
+  <rect x="20" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="36" y="168" class="fw-name">NIST CSF 2.0</text>
+  <text x="36" y="180" class="fw-code">Identify, protect, detect, respond</text>
+  <rect x="36" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="36" y="188" width="108" height="4" rx="2" fill="#10b981"/>
+  <text x="36" y="210" class="fw-count" fill="#10b981">23</text>
+  <text x="64" y="210" class="fw-label">subcategories</text>
+
+  <!-- EU AI Act -->
+  <rect x="208" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="224" y="168" class="fw-name">EU AI Act</text>
+  <text x="224" y="180" class="fw-code">Risk management, transparency, oversight</text>
+  <rect x="224" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="224" y="188" width="86" height="4" rx="2" fill="#a78bfa"/>
+  <text x="224" y="210" class="fw-count" fill="#a78bfa">12</text>
+  <text x="252" y="210" class="fw-label">articles</text>
+
+  <!-- SOC 2 -->
+  <rect x="396" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="412" y="168" class="fw-name">SOC 2</text>
+  <text x="412" y="180" class="fw-code">Trust service criteria</text>
+  <rect x="412" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="412" y="188" width="72" height="4" rx="2" fill="#f43f5e"/>
+  <text x="412" y="210" class="fw-count" fill="#f43f5e">8</text>
+  <text x="432" y="210" class="fw-label">criteria</text>
+
+  <!-- ISO 27001 -->
+  <rect x="584" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="600" y="168" class="fw-name">ISO 27001</text>
+  <text x="600" y="180" class="fw-code">Information security controls</text>
+  <rect x="600" y="188" width="144" height="4" rx="2" class="bar-bg"/>
+  <rect x="600" y="188" width="86" height="4" rx="2" fill="#f43f5e"/>
+  <text x="600" y="210" class="fw-count" fill="#f43f5e">10</text>
+  <text x="628" y="210" class="fw-label">controls</text>
+
+  <!-- CIS Benchmarks -->
+  <rect x="772" y="148" width="168" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="788" y="168" class="fw-name">CIS Benchmarks</text>
+  <text x="788" y="180" class="fw-code">AWS v3.0, Snowflake v1.0</text>
+  <rect x="788" y="188" width="136" height="4" rx="2" class="bar-bg"/>
+  <rect x="788" y="188" width="136" height="4" rx="2" fill="#34d399"/>
+  <text x="788" y="210" class="fw-count" fill="#34d399">200+</text>
+  <text x="828" y="210" class="fw-label">checks</text>
+
+  <!-- ═══ SUMMARY BAR ═══ -->
+  <rect x="20" y="236" width="920" height="32" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+
+  <text x="80" y="258" text-anchor="middle" class="summary-num" fill="#3b82f6">10</text>
+  <text x="126" y="258" class="summary-label">frameworks</text>
+
+  <rect x="186" y="244" width="1" height="16" fill="#e4e4e7"/>
+
+  <text x="230" y="258" text-anchor="middle" class="summary-num" fill="#10b981">300+</text>
+  <text x="276" y="258" class="summary-label">controls mapped</text>
+
+  <rect x="370" y="244" width="1" height="16" fill="#e4e4e7"/>
+
+  <text x="420" y="258" text-anchor="middle" class="summary-num" fill="#f59e0b">3</text>
+  <text x="442" y="258" class="summary-label">OWASP standards (LLM + MCP + Agentic)</text>
+
+  <rect x="660" y="244" width="1" height="16" fill="#e4e4e7"/>
+
+  <text x="710" y="258" text-anchor="middle" class="summary-num" fill="#a78bfa">auto</text>
+  <text x="756" y="258" class="summary-label">mapped from scan findings — no manual config</text>
+</svg>

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -1,0 +1,210 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 420" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #f4f4f5; }
+    .subtitle { font-size: 10.5px; font-weight: 400; fill: #52525b; }
+    .step-num { font-size: 11px; font-weight: 800; }
+    .step-name { font-size: 12px; font-weight: 700; fill: #e4e4e7; }
+    .step-desc { font-size: 9px; font-weight: 400; fill: #71717a; }
+    .item-label { font-size: 9px; font-weight: 600; fill: #a1a1aa; }
+    .arrow-label { font-size: 8.5px; font-weight: 600; fill: #3f3f46; }
+  </style>
+
+  <rect width="960" height="420" rx="12" fill="#09090b"/>
+
+  <text x="480" y="28" text-anchor="middle" class="title">Scan pipeline</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No secrets leave your machine — only package names + versions are sent to public APIs.</text>
+
+  <!-- ═══ STEP 1: DISCOVER ═══ -->
+  <rect x="20" y="64" width="160" height="304" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="20" y="64" width="160" height="32" rx="10" fill="#1e3a5f"/>
+  <rect x="20" y="82" width="160" height="14" fill="#1e3a5f"/>
+  <text x="40" y="84" class="step-num" fill="#60a5fa">1</text>
+  <text x="56" y="84" class="step-name" fill="#93c5fd">DISCOVER</text>
+
+  <text x="36" y="114" class="item-label" fill="#60a5fa">MCP configs</text>
+  <text x="140" y="114" text-anchor="end" class="step-desc">20 clients</text>
+  <rect x="30" y="120" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="138" class="item-label" fill="#60a5fa">Cloud providers</text>
+  <text x="140" y="138" text-anchor="end" class="step-desc">AWS/Azure/GCP/SF</text>
+  <rect x="30" y="144" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="162" class="item-label" fill="#60a5fa">Containers</text>
+  <text x="140" y="162" text-anchor="end" class="step-desc">Grype + Syft</text>
+  <rect x="30" y="168" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="186" class="item-label" fill="#60a5fa">Packages</text>
+  <text x="140" y="186" text-anchor="end" class="step-desc">npm/pip/cargo/go</text>
+  <rect x="30" y="192" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="210" class="item-label" fill="#60a5fa">Kubernetes</text>
+  <text x="140" y="210" text-anchor="end" class="step-desc">all namespaces</text>
+  <rect x="30" y="216" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="234" class="item-label" fill="#60a5fa">AI models</text>
+  <text x="140" y="234" text-anchor="end" class="step-desc">13 formats</text>
+  <rect x="30" y="240" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="258" class="item-label" fill="#60a5fa">SBOMs</text>
+  <text x="140" y="258" text-anchor="end" class="step-desc">CDX + SPDX</text>
+  <rect x="30" y="264" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="282" class="item-label" fill="#60a5fa">Terraform</text>
+  <text x="140" y="282" text-anchor="end" class="step-desc">AI resources</text>
+  <rect x="30" y="288" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="306" class="item-label" fill="#60a5fa">GitHub Actions</text>
+  <text x="140" y="306" text-anchor="end" class="step-desc">env vars</text>
+  <rect x="30" y="312" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="330" class="item-label" fill="#60a5fa">Skill files</text>
+  <text x="140" y="330" text-anchor="end" class="step-desc">CLAUDE.md etc</text>
+  <rect x="30" y="336" width="140" height="1" fill="#27272a"/>
+
+  <text x="36" y="354" class="item-label" fill="#60a5fa">Jupyter</text>
+  <text x="140" y="354" text-anchor="end" class="step-desc">AI lib imports</text>
+
+  <!-- Arrow 1→2 -->
+  <line x1="184" y1="216" x2="204" y2="216" stroke="#3f3f46" stroke-width="1.5"/>
+  <polygon points="202,211 212,216 202,221" fill="#3f3f46"/>
+  <text x="198" y="204" text-anchor="middle" class="arrow-label">agents[]</text>
+
+  <!-- ═══ STEP 2: SCAN ═══ -->
+  <rect x="216" y="64" width="160" height="200" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="216" y="64" width="160" height="32" rx="10" fill="#78350f"/>
+  <rect x="216" y="82" width="160" height="14" fill="#78350f"/>
+  <text x="236" y="84" class="step-num" fill="#fbbf24">2</text>
+  <text x="252" y="84" class="step-name" fill="#fde68a">SCAN</text>
+
+  <text x="232" y="114" class="item-label" fill="#fbbf24">OSV.dev</text>
+  <text x="366" y="114" text-anchor="end" class="step-desc">batch CVE lookup</text>
+  <rect x="226" y="120" width="140" height="1" fill="#27272a"/>
+
+  <text x="232" y="138" class="item-label" fill="#fbbf24">NVD</text>
+  <text x="366" y="138" text-anchor="end" class="step-desc">CVSS v3.1 + v4.0</text>
+  <rect x="226" y="144" width="140" height="1" fill="#27272a"/>
+
+  <text x="232" y="162" class="item-label" fill="#fbbf24">EPSS</text>
+  <text x="366" y="162" text-anchor="end" class="step-desc">exploit probability</text>
+  <rect x="226" y="168" width="140" height="1" fill="#27272a"/>
+
+  <text x="232" y="186" class="item-label" fill="#fbbf24">CISA KEV</text>
+  <text x="366" y="186" text-anchor="end" class="step-desc">known exploited</text>
+  <rect x="226" y="192" width="140" height="1" fill="#27272a"/>
+
+  <text x="232" y="210" class="item-label" fill="#fbbf24">GHSA + CSAF</text>
+  <text x="366" y="210" text-anchor="end" class="step-desc">supplemental</text>
+  <rect x="226" y="216" width="140" height="1" fill="#27272a"/>
+
+  <text x="232" y="234" class="item-label" fill="#fbbf24">MCP Registry</text>
+  <text x="366" y="234" text-anchor="end" class="step-desc">427+ servers</text>
+  <rect x="226" y="240" width="140" height="1" fill="#27272a"/>
+
+  <text x="232" y="254" class="step-desc">Queries run in parallel</text>
+
+  <!-- Arrow 2→3 -->
+  <line x1="380" y1="164" x2="400" y2="164" stroke="#3f3f46" stroke-width="1.5"/>
+  <polygon points="398,159 408,164 398,169" fill="#3f3f46"/>
+  <text x="394" y="152" text-anchor="middle" class="arrow-label">findings[]</text>
+
+  <!-- ═══ STEP 3: ANALYZE ═══ -->
+  <rect x="412" y="64" width="160" height="200" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="412" y="64" width="160" height="32" rx="10" fill="#881337"/>
+  <rect x="412" y="82" width="160" height="14" fill="#881337"/>
+  <text x="432" y="84" class="step-num" fill="#fb7185">3</text>
+  <text x="448" y="84" class="step-name" fill="#fecdd3">ANALYZE</text>
+
+  <text x="428" y="114" class="item-label" fill="#fb7185">Blast radius</text>
+  <text x="562" y="114" text-anchor="end" class="step-desc">CVE chains</text>
+  <rect x="422" y="120" width="140" height="1" fill="#27272a"/>
+
+  <text x="428" y="138" class="item-label" fill="#fb7185">Compliance</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">10 frameworks</text>
+  <rect x="422" y="144" width="140" height="1" fill="#27272a"/>
+
+  <text x="428" y="162" class="item-label" fill="#fb7185">Policy engine</text>
+  <text x="562" y="162" text-anchor="end" class="step-desc">17 conditions</text>
+  <rect x="422" y="168" width="140" height="1" fill="#27272a"/>
+
+  <text x="428" y="186" class="item-label" fill="#fb7185">Enforcement</text>
+  <text x="562" y="186" text-anchor="end" class="step-desc">poisoning/drift</text>
+  <rect x="422" y="192" width="140" height="1" fill="#27272a"/>
+
+  <text x="428" y="210" class="item-label" fill="#fb7185">Context graph</text>
+  <text x="562" y="210" text-anchor="end" class="step-desc">lateral movement</text>
+  <rect x="422" y="216" width="140" height="1" fill="#27272a"/>
+
+  <text x="428" y="234" class="item-label" fill="#fb7185">Posture score</text>
+  <text x="562" y="234" text-anchor="end" class="step-desc">A-F grade</text>
+
+  <!-- Arrow 3→4 -->
+  <line x1="576" y1="164" x2="596" y2="164" stroke="#3f3f46" stroke-width="1.5"/>
+  <polygon points="594,159 604,164 594,169" fill="#3f3f46"/>
+  <text x="590" y="152" text-anchor="middle" class="arrow-label">report</text>
+
+  <!-- ═══ STEP 4: REPORT ═══ -->
+  <rect x="608" y="64" width="160" height="200" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="608" y="64" width="160" height="32" rx="10" fill="#065f46"/>
+  <rect x="608" y="82" width="160" height="14" fill="#065f46"/>
+  <text x="628" y="84" class="step-num" fill="#34d399">4</text>
+  <text x="644" y="84" class="step-name" fill="#a7f3d0">REPORT</text>
+
+  <text x="624" y="114" class="item-label" fill="#34d399">Console</text>
+  <text x="758" y="114" text-anchor="end" class="step-desc">table + summary</text>
+  <rect x="618" y="120" width="140" height="1" fill="#27272a"/>
+
+  <text x="624" y="138" class="item-label" fill="#34d399">HTML</text>
+  <text x="758" y="138" text-anchor="end" class="step-desc">interactive dashboard</text>
+  <rect x="618" y="144" width="140" height="1" fill="#27272a"/>
+
+  <text x="624" y="162" class="item-label" fill="#34d399">SARIF</text>
+  <text x="758" y="162" text-anchor="end" class="step-desc">GitHub Security tab</text>
+  <rect x="618" y="168" width="140" height="1" fill="#27272a"/>
+
+  <text x="624" y="186" class="item-label" fill="#34d399">SBOM</text>
+  <text x="758" y="186" text-anchor="end" class="step-desc">CycloneDX + SPDX</text>
+  <rect x="618" y="192" width="140" height="1" fill="#27272a"/>
+
+  <text x="624" y="210" class="item-label" fill="#34d399">JSON / Graph</text>
+  <text x="758" y="210" text-anchor="end" class="step-desc">Cytoscape + Mermaid</text>
+  <rect x="618" y="216" width="140" height="1" fill="#27272a"/>
+
+  <text x="624" y="234" class="item-label" fill="#34d399">Webhooks</text>
+  <text x="758" y="234" text-anchor="end" class="step-desc">Slack + custom</text>
+
+  <!-- Arrow 4→5 -->
+  <line x1="772" y1="164" x2="792" y2="164" stroke="#3f3f46" stroke-width="1.5"/>
+  <polygon points="790,159 800,164 790,169" fill="#3f3f46"/>
+  <text x="786" y="152" text-anchor="middle" class="arrow-label">alert</text>
+
+  <!-- ═══ STEP 5: ENFORCE ═══ -->
+  <rect x="804" y="64" width="136" height="200" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <rect x="804" y="64" width="136" height="32" rx="10" fill="#4c1d95"/>
+  <rect x="804" y="82" width="136" height="14" fill="#4c1d95"/>
+  <text x="824" y="84" class="step-num" fill="#c4b5fd">5</text>
+  <text x="840" y="84" class="step-name" fill="#ddd6fe">ENFORCE</text>
+
+  <text x="820" y="114" class="item-label" fill="#c4b5fd">CI gate</text>
+  <text x="930" y="114" text-anchor="end" class="step-desc">fail on severity</text>
+  <rect x="814" y="120" width="116" height="1" fill="#27272a"/>
+
+  <text x="820" y="138" class="item-label" fill="#c4b5fd">Policy block</text>
+  <text x="930" y="138" text-anchor="end" class="step-desc">YAML rules</text>
+  <rect x="814" y="144" width="116" height="1" fill="#27272a"/>
+
+  <text x="820" y="162" class="item-label" fill="#c4b5fd">KEV block</text>
+  <text x="930" y="162" text-anchor="end" class="step-desc">--fail-on-kev</text>
+  <rect x="814" y="168" width="116" height="1" fill="#27272a"/>
+
+  <text x="820" y="186" class="item-label" fill="#c4b5fd">Remediation</text>
+  <text x="930" y="186" text-anchor="end" class="step-desc">prioritized fixes</text>
+  <rect x="814" y="192" width="116" height="1" fill="#27272a"/>
+
+  <text x="820" y="210" class="item-label" fill="#c4b5fd">VEX apply</text>
+  <text x="930" y="210" text-anchor="end" class="step-desc">suppress accepted</text>
+
+  <!-- ═══ BOTTOM BAR: Security guarantee ═══ -->
+  <rect x="20" y="380" width="920" height="28" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+  <text x="480" y="399" text-anchor="middle" font-size="9" font-weight="600" fill="#52525b" letter-spacing="0.06em" font-family="system-ui, sans-serif">READ-ONLY GUARANTEE · never writes configs · never runs servers · never stores secrets · --dry-run previews everything · Sigstore signed</text>
+</svg>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -1,0 +1,210 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 420" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #18181b; }
+    .subtitle { font-size: 10.5px; font-weight: 400; fill: #a1a1aa; }
+    .step-num { font-size: 11px; font-weight: 800; }
+    .step-name { font-size: 12px; font-weight: 700; fill: #ffffff; }
+    .step-desc { font-size: 9px; font-weight: 400; fill: #71717a; }
+    .item-label { font-size: 9px; font-weight: 600; }
+    .arrow-label { font-size: 8.5px; font-weight: 600; fill: #a1a1aa; }
+  </style>
+
+  <rect width="960" height="420" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
+
+  <text x="480" y="28" text-anchor="middle" class="title">Scan pipeline</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No secrets leave your machine — only package names + versions are sent to public APIs.</text>
+
+  <!-- ═══ STEP 1: DISCOVER ═══ -->
+  <rect x="20" y="64" width="160" height="304" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="20" y="64" width="160" height="32" rx="10" fill="#2563eb"/>
+  <rect x="20" y="82" width="160" height="14" fill="#2563eb"/>
+  <text x="40" y="84" class="step-num" fill="#bfdbfe">1</text>
+  <text x="56" y="84" class="step-name">DISCOVER</text>
+
+  <text x="36" y="114" class="item-label" fill="#2563eb">MCP configs</text>
+  <text x="140" y="114" text-anchor="end" class="step-desc">20 clients</text>
+  <rect x="30" y="120" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="138" class="item-label" fill="#2563eb">Cloud providers</text>
+  <text x="140" y="138" text-anchor="end" class="step-desc">AWS/Azure/GCP/SF</text>
+  <rect x="30" y="144" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="162" class="item-label" fill="#2563eb">Containers</text>
+  <text x="140" y="162" text-anchor="end" class="step-desc">Grype + Syft</text>
+  <rect x="30" y="168" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="186" class="item-label" fill="#2563eb">Packages</text>
+  <text x="140" y="186" text-anchor="end" class="step-desc">npm/pip/cargo/go</text>
+  <rect x="30" y="192" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="210" class="item-label" fill="#2563eb">Kubernetes</text>
+  <text x="140" y="210" text-anchor="end" class="step-desc">all namespaces</text>
+  <rect x="30" y="216" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="234" class="item-label" fill="#2563eb">AI models</text>
+  <text x="140" y="234" text-anchor="end" class="step-desc">13 formats</text>
+  <rect x="30" y="240" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="258" class="item-label" fill="#2563eb">SBOMs</text>
+  <text x="140" y="258" text-anchor="end" class="step-desc">CDX + SPDX</text>
+  <rect x="30" y="264" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="282" class="item-label" fill="#2563eb">Terraform</text>
+  <text x="140" y="282" text-anchor="end" class="step-desc">AI resources</text>
+  <rect x="30" y="288" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="306" class="item-label" fill="#2563eb">GitHub Actions</text>
+  <text x="140" y="306" text-anchor="end" class="step-desc">env vars</text>
+  <rect x="30" y="312" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="330" class="item-label" fill="#2563eb">Skill files</text>
+  <text x="140" y="330" text-anchor="end" class="step-desc">CLAUDE.md etc</text>
+  <rect x="30" y="336" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="36" y="354" class="item-label" fill="#2563eb">Jupyter</text>
+  <text x="140" y="354" text-anchor="end" class="step-desc">AI lib imports</text>
+
+  <!-- Arrow 1→2 -->
+  <line x1="184" y1="216" x2="204" y2="216" stroke="#d4d4d8" stroke-width="1.5"/>
+  <polygon points="202,211 212,216 202,221" fill="#d4d4d8"/>
+  <text x="198" y="204" text-anchor="middle" class="arrow-label">agents[]</text>
+
+  <!-- ═══ STEP 2: SCAN ═══ -->
+  <rect x="216" y="64" width="160" height="200" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="216" y="64" width="160" height="32" rx="10" fill="#d97706"/>
+  <rect x="216" y="82" width="160" height="14" fill="#d97706"/>
+  <text x="236" y="84" class="step-num" fill="#fef3c7">2</text>
+  <text x="252" y="84" class="step-name">SCAN</text>
+
+  <text x="232" y="114" class="item-label" fill="#d97706">OSV.dev</text>
+  <text x="366" y="114" text-anchor="end" class="step-desc">batch CVE lookup</text>
+  <rect x="226" y="120" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="232" y="138" class="item-label" fill="#d97706">NVD</text>
+  <text x="366" y="138" text-anchor="end" class="step-desc">CVSS v3.1 + v4.0</text>
+  <rect x="226" y="144" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="232" y="162" class="item-label" fill="#d97706">EPSS</text>
+  <text x="366" y="162" text-anchor="end" class="step-desc">exploit probability</text>
+  <rect x="226" y="168" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="232" y="186" class="item-label" fill="#d97706">CISA KEV</text>
+  <text x="366" y="186" text-anchor="end" class="step-desc">known exploited</text>
+  <rect x="226" y="192" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="232" y="210" class="item-label" fill="#d97706">GHSA + CSAF</text>
+  <text x="366" y="210" text-anchor="end" class="step-desc">supplemental</text>
+  <rect x="226" y="216" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="232" y="234" class="item-label" fill="#d97706">MCP Registry</text>
+  <text x="366" y="234" text-anchor="end" class="step-desc">427+ servers</text>
+  <rect x="226" y="240" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="232" y="254" class="step-desc">Queries run in parallel</text>
+
+  <!-- Arrow 2→3 -->
+  <line x1="380" y1="164" x2="400" y2="164" stroke="#d4d4d8" stroke-width="1.5"/>
+  <polygon points="398,159 408,164 398,169" fill="#d4d4d8"/>
+  <text x="394" y="152" text-anchor="middle" class="arrow-label">findings[]</text>
+
+  <!-- ═══ STEP 3: ANALYZE ═══ -->
+  <rect x="412" y="64" width="160" height="200" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="412" y="64" width="160" height="32" rx="10" fill="#e11d48"/>
+  <rect x="412" y="82" width="160" height="14" fill="#e11d48"/>
+  <text x="432" y="84" class="step-num" fill="#ffe4e6">3</text>
+  <text x="448" y="84" class="step-name">ANALYZE</text>
+
+  <text x="428" y="114" class="item-label" fill="#e11d48">Blast radius</text>
+  <text x="562" y="114" text-anchor="end" class="step-desc">CVE chains</text>
+  <rect x="422" y="120" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="428" y="138" class="item-label" fill="#e11d48">Compliance</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">10 frameworks</text>
+  <rect x="422" y="144" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="428" y="162" class="item-label" fill="#e11d48">Policy engine</text>
+  <text x="562" y="162" text-anchor="end" class="step-desc">17 conditions</text>
+  <rect x="422" y="168" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="428" y="186" class="item-label" fill="#e11d48">Enforcement</text>
+  <text x="562" y="186" text-anchor="end" class="step-desc">poisoning/drift</text>
+  <rect x="422" y="192" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="428" y="210" class="item-label" fill="#e11d48">Context graph</text>
+  <text x="562" y="210" text-anchor="end" class="step-desc">lateral movement</text>
+  <rect x="422" y="216" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="428" y="234" class="item-label" fill="#e11d48">Posture score</text>
+  <text x="562" y="234" text-anchor="end" class="step-desc">A-F grade</text>
+
+  <!-- Arrow 3→4 -->
+  <line x1="576" y1="164" x2="596" y2="164" stroke="#d4d4d8" stroke-width="1.5"/>
+  <polygon points="594,159 604,164 594,169" fill="#d4d4d8"/>
+  <text x="590" y="152" text-anchor="middle" class="arrow-label">report</text>
+
+  <!-- ═══ STEP 4: REPORT ═══ -->
+  <rect x="608" y="64" width="160" height="200" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="608" y="64" width="160" height="32" rx="10" fill="#059669"/>
+  <rect x="608" y="82" width="160" height="14" fill="#059669"/>
+  <text x="628" y="84" class="step-num" fill="#d1fae5">4</text>
+  <text x="644" y="84" class="step-name">REPORT</text>
+
+  <text x="624" y="114" class="item-label" fill="#059669">Console</text>
+  <text x="758" y="114" text-anchor="end" class="step-desc">table + summary</text>
+  <rect x="618" y="120" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="624" y="138" class="item-label" fill="#059669">HTML</text>
+  <text x="758" y="138" text-anchor="end" class="step-desc">interactive dashboard</text>
+  <rect x="618" y="144" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="624" y="162" class="item-label" fill="#059669">SARIF</text>
+  <text x="758" y="162" text-anchor="end" class="step-desc">GitHub Security tab</text>
+  <rect x="618" y="168" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="624" y="186" class="item-label" fill="#059669">SBOM</text>
+  <text x="758" y="186" text-anchor="end" class="step-desc">CycloneDX + SPDX</text>
+  <rect x="618" y="192" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="624" y="210" class="item-label" fill="#059669">JSON / Graph</text>
+  <text x="758" y="210" text-anchor="end" class="step-desc">Cytoscape + Mermaid</text>
+  <rect x="618" y="216" width="140" height="1" fill="#e4e4e7"/>
+
+  <text x="624" y="234" class="item-label" fill="#059669">Webhooks</text>
+  <text x="758" y="234" text-anchor="end" class="step-desc">Slack + custom</text>
+
+  <!-- Arrow 4→5 -->
+  <line x1="772" y1="164" x2="792" y2="164" stroke="#d4d4d8" stroke-width="1.5"/>
+  <polygon points="790,159 800,164 790,169" fill="#d4d4d8"/>
+  <text x="786" y="152" text-anchor="middle" class="arrow-label">alert</text>
+
+  <!-- ═══ STEP 5: ENFORCE ═══ -->
+  <rect x="804" y="64" width="136" height="200" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <rect x="804" y="64" width="136" height="32" rx="10" fill="#7c3aed"/>
+  <rect x="804" y="82" width="136" height="14" fill="#7c3aed"/>
+  <text x="824" y="84" class="step-num" fill="#ede9fe">5</text>
+  <text x="840" y="84" class="step-name">ENFORCE</text>
+
+  <text x="820" y="114" class="item-label" fill="#7c3aed">CI gate</text>
+  <text x="930" y="114" text-anchor="end" class="step-desc">fail on severity</text>
+  <rect x="814" y="120" width="116" height="1" fill="#e4e4e7"/>
+
+  <text x="820" y="138" class="item-label" fill="#7c3aed">Policy block</text>
+  <text x="930" y="138" text-anchor="end" class="step-desc">YAML rules</text>
+  <rect x="814" y="144" width="116" height="1" fill="#e4e4e7"/>
+
+  <text x="820" y="162" class="item-label" fill="#7c3aed">KEV block</text>
+  <text x="930" y="162" text-anchor="end" class="step-desc">--fail-on-kev</text>
+  <rect x="814" y="168" width="116" height="1" fill="#e4e4e7"/>
+
+  <text x="820" y="186" class="item-label" fill="#7c3aed">Remediation</text>
+  <text x="930" y="186" text-anchor="end" class="step-desc">prioritized fixes</text>
+  <rect x="814" y="192" width="116" height="1" fill="#e4e4e7"/>
+
+  <text x="820" y="210" class="item-label" fill="#7c3aed">VEX apply</text>
+  <text x="930" y="210" text-anchor="end" class="step-desc">suppress accepted</text>
+
+  <!-- ═══ BOTTOM BAR ═══ -->
+  <rect x="20" y="380" width="920" height="28" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
+  <text x="480" y="399" text-anchor="middle" font-size="9" font-weight="600" fill="#a1a1aa" letter-spacing="0.06em" font-family="system-ui, sans-serif">READ-ONLY GUARANTEE · never writes configs · never runs servers · never stores secrets · --dry-run previews everything · Sigstore signed</text>
+</svg>


### PR DESCRIPTION
## Summary
- **Scan pipeline flow diagram**: 5-stage left-to-right visualization (discover → scan → analyze → report → enforce) showing all input sources, vulnerability databases, analysis modules, output formats, and enforcement actions
- **Architecture stack diagram**: 5-layer bottom-to-top stack (sources → vuln data → analysis → output → interfaces) with security and runtime cross-cutting sidebars
- **Compliance heatmap diagram**: 10 framework cards with control counts, progress bars, and summary stats
- All 6 SVGs in dark + light theme variants with `<picture>` blocks for GitHub auto-switching
- README audit: fix policy conditions count (16 → 17), mark CIS AI benchmarks as shipped, add CIS AI to compliance list

Closes #259, closes #260, closes #262

## Test plan
- [ ] Verify SVGs render correctly on GitHub (dark + light theme toggle)
- [ ] Confirm diagrams show in correct README sections
- [ ] Check roadmap checkbox renders as done

Generated with [Claude Code](https://claude.com/claude-code)