### PR TITLE
feat: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill out the sections below so we can reproduce and fix it.
+
+  - type: input
+    id: version
+    attributes:
+      label: agent-bom version
+      description: "Run `agent-bom --version` or `pip show agent-bom`"
+      placeholder: "e.g. 0.59.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      options:
+        - pip
+        - Docker
+        - GitHub Action
+        - From source
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: "When I run `agent-bom scan --enrich`, it..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the issue.
+      placeholder: |
+        1. Run `agent-bom scan ...`
+        2. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output / logs
+      description: Paste any error messages or stack traces. **Redact any secrets or sensitive paths.**
+      render: shell
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "e.g. macOS 15.3, Ubuntu 24.04, Windows 11"
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.12.4"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/msaad00/agent-bom/blob/main/SECURITY.md
+    about: Report security vulnerabilities via our security policy (not here).
+  - name: Discussions
+    url: https://github.com/msaad00/agent-bom/discussions
+    about: Ask questions or start a discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for agent-bom? We'd love to hear it. Please describe the problem you're solving and your proposed solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? What's the use case?
+      placeholder: "I'm trying to ... but currently ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you've considered.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of agent-bom does this relate to?
+      options:
+        - CLI / scanning
+        - MCP server
+        - REST API
+        - Dashboard / UI
+        - Compliance / policy
+        - Cloud providers
+        - Container / K8s scanning
+        - SBOM / output formats
+        - Runtime (proxy / protect / watch)
+        - Documentation
+        - Other
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+<!-- What does this PR do? Keep it to 1-3 bullet points. -->
+
+## Test plan
+<!-- How was this tested? -->
+
+- [ ] `pytest` passes
+- [ ] `ruff check src/` passes
+- [ ] Manual verification (describe below)


### PR DESCRIPTION
## Summary
- **Bug report template**: structured form with version, install method, repro steps, error logs, OS/Python info
- **Feature request template**: problem statement, proposed solution, area dropdown (CLI, MCP, API, UI, etc.)
- **Config**: blank issues disabled (forces structured templates), security vulnerabilities redirected to SECURITY.md, discussions link added
- **PR template**: summary + test plan checklist

People can now report issues at https://github.com/msaad00/agent-bom/issues/new/choose with guided forms instead of blank issues.

## Test plan
- [ ] Visit /issues/new/choose after merge — verify bug report and feature request forms appear
- [ ] Verify security link redirects to SECURITY.md
- [ ] Open a new PR — verify template pre-fills

Generated with [Claude Code](https://claude.com/claude-code)