### PR TITLE
fix: restrict release workflow to semver tags only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"  # semver only — excludes floating tags like v0
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Change release.yml tag filter from `v*` to `v*.*.*` to exclude floating tags like `v0`
- The `@v0` force-push (done by the release job itself) was re-triggering the entire Release pipeline, causing it to fail on "release already exists", which cascaded into all 4 downstream workflows being skipped

## Test plan
- [x] Verified `v*.*.*` matches `v0.59.2`, `v1.0.0`, `v0.59.2-rc1` but NOT `v0`, `v1` (fnmatch)
- [ ] Next release tag push should show clean workflow runs with no skipped downstream jobs