### PR TITLE
fix: P0 audit findings — Helm image repo, credential redaction

### DIFF
--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,10 +1,10 @@
 image:
-  repository: msaad02/agent-bom
+  repository: agentbom/agent-bom
   tag: "0.59.2"
   pullPolicy: IfNotPresent
 
 runtimeImage:
-  repository: msaad02/agent-bom-runtime
+  repository: agentbom/agent-bom-runtime
   tag: "0.59.2"
   pullPolicy: IfNotPresent
 

--- a/src/agent_bom/runtime/detectors.py
+++ b/src/agent_bom/runtime/detectors.py
@@ -157,7 +157,7 @@ class CredentialLeakDetector:
             matches = pattern.findall(response_text)
             if matches:
                 # Redact the actual credential value
-                redacted = [m[:8] + "..." if len(m) > 8 else "***" for m in matches[:3]]
+                redacted = [m[:4] + "..." if len(m) > 4 else "***" for m in matches[:3]]
                 alerts.append(
                     Alert(
                         detector="credential_leak",


### PR DESCRIPTION
## Summary
Fixes from the comprehensive audit (P0 items):

- **Helm image repository mismatch**: `values.yaml` had `msaad02/agent-bom` but Docker Hub publishes as `agentbom/agent-bom`. Would cause image pull failures on Helm deployments.
- **Credential redaction too generous**: `CredentialLeakDetector` showed 8 chars of detected credentials in alert details (`m[:8]`). Reduced to 4 chars to prevent credential reconstruction from logs.
- **Deleted 3 duplicate UI files**: `charts 2.tsx`, `compliance-matrix 2.tsx`, `compliance-matrix 3.tsx` — untracked copies with spaces in filenames.

## Test plan
- [x] `ruff check` passes
- [x] Verify Helm image repo matches Docker Hub org
- [ ] CI passes