### PR TITLE
chore: fix stale doc claims before release (20→22 tools, 6100→3400 tests)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Discovery ──> Scanning ──> Enrichment ──> Blast Radius ──> Compl
 | Entry point | File | Purpose |
 |---|---|---|
 | CLI | `cli.py` | Click-based CLI with 15+ commands |
-| MCP Server | `mcp_server.py` | FastMCP server with 20 tools |
+| MCP Server | `mcp_server.py` | FastMCP server with 22 tools |
 | Proxy | `proxy.py` | MCP JSON-RPC proxy with runtime enforcement |
 | API | `api/server.py` | FastAPI REST server with job queue |
 
@@ -210,8 +210,8 @@ cli.py / mcp_server.py / api/server.py
 |---|---|
 | Python modules | 148 |
 | Test files | 144 |
-| Test functions | ~1,900 (6,100+ parameterized cases) |
-| MCP tools | 20 |
+| Test functions | 3,419 (3,480 collected by pytest) |
+| MCP tools | 22 |
 | Compliance frameworks | 10 |
 | Runtime detectors | 6 |
 | Cloud providers | 12 |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | GitHub Action | `uses: msaad00/agent-bom@v0` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
-| MCP Server | `agent-bom mcp-server` (20 tools) | Inside any MCP client |
+| MCP Server | `agent-bom mcp-server` (22 tools) | Inside any MCP client |
 | Dashboard | `agent-bom serve` | API + Next.js UI (15 pages) |
 | Runtime proxy | `agent-bom proxy` | MCP traffic audit |
 | Snowflake | [DEPLOYMENT.md](DEPLOYMENT.md) | Snowpark + SiS |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -282,7 +282,7 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine |
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (20 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (22 tools) |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |
 | Logging | `src/agent_bom/logging_config.py` | Structured JSON/console logging, env var config |

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">20 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">22 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">20 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">22 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/engine-internals-dark.svg
+++ b/docs/images/engine-internals-dark.svg
@@ -229,9 +229,9 @@
   <text x="612" y="504" text-anchor="middle" class="stat-num" fill="#10b981">12</text>
   <text x="612" y="518" text-anchor="middle" class="stat-label">output formats</text>
 
-  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#a78bfa">20</text>
+  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#a78bfa">22</text>
   <text x="742" y="518" text-anchor="middle" class="stat-label">MCP server tools</text>
 
-  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#71717a">6,100+</text>
+  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#71717a">3,400+</text>
   <text x="872" y="518" text-anchor="middle" class="stat-label">tests</text>
 </svg>

--- a/docs/images/engine-internals-light.svg
+++ b/docs/images/engine-internals-light.svg
@@ -229,9 +229,9 @@
   <text x="612" y="504" text-anchor="middle" class="stat-num" fill="#059669">12</text>
   <text x="612" y="518" text-anchor="middle" class="stat-label">output formats</text>
 
-  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#7c3aed">20</text>
+  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#7c3aed">22</text>
   <text x="742" y="518" text-anchor="middle" class="stat-label">MCP server tools</text>
 
-  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#a1a1aa">6,100+</text>
+  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#a1a1aa">3,400+</text>
   <text x="872" y="518" text-anchor="middle" class="stat-label">tests</text>
 </svg>

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 6,100+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 3,400+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 6,100+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 3,400+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -230,7 +230,7 @@
   <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#f0883e">10</text>
   <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#f85149">6,100+</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#f85149">3,400+</text>
   <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
   <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#bc8cff">12</text>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -230,7 +230,7 @@
   <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#bc4c00">10</text>
   <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#cf222e">6,100+</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#cf222e">3,400+</text>
   <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
   <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#8250df">12</text>

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">20 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">22 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">20 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">22 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  6,100+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  3,400+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  6,100+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  3,400+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (20 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (22 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#0f3f1f"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#7ee787">13+ FORMATS</text>
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#484f58">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  6,100+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  3,400+ tests  ·  0 runtime deps</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (20 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (22 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#d1fae5"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#065f46">13+ FORMATS</text>
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#94a3b8">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  6,100+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  3,400+ tests  ·  0 runtime deps</text>
 </svg>

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6194
+  tests: 3480
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -305,5 +305,5 @@ configured credentials and call only the cloud provider's own APIs.
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.59.3`
-- **6,100+ tests** with CodeQL + OpenSSF Scorecard
+- **3,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6194
+  tests: 3480
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -127,5 +127,5 @@ No credentials needed.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **6,100+ tests** with CodeQL + OpenSSF Scorecard
+- **3,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6194
+  tests: 3480
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -110,5 +110,5 @@ as a string argument (no file system access needed).
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **6,100+ tests** with CodeQL + OpenSSF Scorecard
+- **3,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6194
+  tests: 3480
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -90,5 +90,5 @@ ClickHouse endpoint for persistent analytics.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **6,100+ tests** with CodeQL + OpenSSF Scorecard
+- **3,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6194
+  tests: 3480
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -188,5 +188,5 @@ CVE IDs are sent to vulnerability databases.
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.59.3`
-- **6,100+ tests** with CodeQL + OpenSSF Scorecard
+- **3,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 20 security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 22 security tools to any MCP client.
 
 ## Local (stdio)
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-agent-bom exposes 20 tools via its MCP server.
+agent-bom exposes 22 tools via its MCP server.
 
 ## Tools
 
@@ -87,6 +87,18 @@ fleet_scan(servers=["brave-search", "filesystem", "postgres"])
 
 ### runtime_correlate
 Cross-reference runtime audit logs with CVE findings for risk amplification.
+
+### vector_db_scan
+Probe Qdrant, Weaviate, Chroma, and Milvus instances for authentication misconfigurations and exposure.
+```
+vector_db_scan()
+```
+
+### aisvs_benchmark
+Run OWASP AISVS v1.0 compliance checks — 9 AI security verification checks across model, data, and inference layers.
+```
+aisvs_benchmark()
+```
 
 ## Resources
 


### PR DESCRIPTION
## Summary

Pre-release accuracy audit — corrects two sets of stale claims found across docs, SKILL.md files, and SVG diagrams:

**MCP tool count: 20 → 22**
- `vector_db_scan` and `aisvs_benchmark` were added in v0.59.2 but docs weren't updated
- Fixes README, ARCHITECTURE.md, docs/ARCHITECTURE.md, site-docs, 6 SVG diagrams
- Adds the two missing tools to the `site-docs/reference/mcp-tools.md` reference page

**Test count: 6,100+/6,194 → 3,400+**
- Actual `pytest --collect-only` count is 3,480; `def test_` function count is 3,419
- The "6,100+" figure was incorrect and overstated by ~2x
- Fixes all 5 SKILL.md files (`tests:` metadata field), ARCHITECTURE.md stats table, and 8 SVG footer/stat elements

**Verified accurate (no changes needed):**
- OTel claims: real — `otel_ingest.py`, `--otel-endpoint` CLI flag, `/v1/traces` API
- OPA claims: not claimed anywhere — no issue
- MITRE ATT&CK: real — `mitre_attack.py` module
- MAESTRO: real — `maestro.py` module
- Token-Permissions: all workflows use least-privilege (no write-all)
- Scorecard cron: already runs on every push to main + weekly fallback

## Test plan
- [ ] CI passes
- [ ] Grep confirms no remaining `6,194`, `6,100+`, or `20 tools` in docs