### PR TITLE
fix: avoid duplicate injection alerts for non-vector tools in proxy

### DIFF
--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -809,8 +809,11 @@ async def run_proxy(
                     cred_alerts = cred_detector.check(tool_for_resp or "unknown", result_text)
                     _handle_alerts(cred_alerts, log_file)
 
-                # Runtime detector: response content inspection (cloaking, SVG, invisible chars)
-                # Also runs VectorDBInjectionDetector for vector tool responses (cache poisoning)
+                # Runtime detector: response content inspection (cloaking, SVG, invisible chars,
+                # prompt injection). For confirmed vector DB / RAG retrieval tools, also run
+                # VectorDBInjectionDetector which upgrades injection alerts to CRITICAL and tags
+                # them cache_poison_*. Non-vector tools only run ResponseInspector to avoid
+                # duplicate injection alerts.
                 if "result" in msg:
                     ri_text = json.dumps(msg.get("result", ""))
                     ri_id = msg.get("id")
@@ -819,9 +822,10 @@ async def run_proxy(
                         ri_tool = pending_calls[ri_id][0]
                     ri_alerts = response_inspector.check(ri_tool or "unknown", ri_text)
                     _handle_alerts(ri_alerts, log_file)
-                    # Vector DB / RAG retrieval: specialized cache-poison detection with CRITICAL severity
-                    vec_alerts = vector_detector.check(ri_tool or "unknown", ri_text)
-                    _handle_alerts(vec_alerts, log_file)
+                    # Vector DB / RAG tools get specialized cache-poison detection on top
+                    if vector_detector.is_vector_tool(ri_tool or ""):
+                        vec_alerts = vector_detector.check(ri_tool or "unknown", ri_text)
+                        _handle_alerts(vec_alerts, log_file)
 
                 # Inline response scanning (PII, secrets, payload vuln)
                 if scan_config.enabled and "result" in msg:


### PR DESCRIPTION
## Summary

Follow-up to #326. `VectorDBInjectionDetector.check()` always runs `RESPONSE_INJECTION_PATTERNS` for every tool, regardless of whether it's a vector tool. Running both `response_inspector.check()` and `vector_detector.check()` for all tools caused duplicate injection alerts for non-vector tools.

## Fix

Only invoke `vector_detector.check()` when `vector_detector.is_vector_tool()` returns `True`.

**Non-vector tools**: `ResponseInspector` handles cloaking + SVG + invisible chars + base64 + injection — no change.

**Vector tools** (similarity_search, retrieve, rag_query, fetch_context, etc.): `ResponseInspector` fires first (HIGH severity), then `VectorDBInjectionDetector` fires additionally (CRITICAL severity, `cache_poison_*` tagged). The dual alert is intentional — it gives operators a CRITICAL-severity signal specifically for RAG/vector retrieval paths.

## Test plan

- [x] 88 runtime + proxy tests pass
- [x] No ruff/format warnings