### PR TITLE
feat: poetry.lock, uv.lock, conda env.yml, pnpm-lock.yaml parsers — full package manager interop

### DIFF
--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -249,8 +249,245 @@ def parse_npm_packages(directory: Path) -> list[Package]:
     return packages
 
 
+def parse_poetry_lock(directory: Path) -> list[Package]:
+    """Parse packages from poetry.lock (TOML format).
+
+    poetry.lock lists every resolved package with exact versions and marks
+    which are direct dependencies via the [extras] table and the package
+    categories.  We mark ``is_direct=True`` for packages in the ``main``
+    group (default) and set it False for dev-only packages.
+    """
+    lock_file = directory / "poetry.lock"
+    if not lock_file.exists():
+        return []
+
+    packages: list[Package] = []
+    try:
+        try:
+            import tomllib  # Python 3.11+
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[no-reattr,import-not-found]
+            except ImportError:
+                import toml as tomllib  # type: ignore[no-reattr,import-not-found]
+
+        data = tomllib.loads(lock_file.read_text())
+        for pkg in data.get("package", []):
+            name = pkg.get("name", "")
+            version = pkg.get("version", "unknown")
+            category = pkg.get("category", "main")  # "main" or "dev"
+            if not name:
+                continue
+            packages.append(
+                Package(
+                    name=name,
+                    version=version,
+                    ecosystem="pypi",
+                    purl=f"pkg:pypi/{name}@{version}",
+                    is_direct=(category == "main"),
+                )
+            )
+    except Exception as exc:
+        logger.debug("Failed to parse poetry.lock at %s: %s", lock_file, exc)
+
+    return packages
+
+
+def parse_uv_lock(directory: Path) -> list[Package]:
+    """Parse packages from uv.lock (TOML format, uv package manager).
+
+    uv.lock uses a [[package]] array similar to poetry.lock.  Direct
+    dependencies have a ``[package.metadata]`` table; all entries have
+    ``name`` and ``version``.  We treat every entry as a resolved dep and
+    mark is_direct=False (uv flattens the graph; direct vs transitive
+    distinction requires reading pyproject.toml alongside the lock file).
+    """
+    lock_file = directory / "uv.lock"
+    if not lock_file.exists():
+        return []
+
+    packages: list[Package] = []
+    try:
+        try:
+            import tomllib
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[no-reattr,import-not-found]
+            except ImportError:
+                import toml as tomllib  # type: ignore[no-reattr,import-not-found]
+
+        data = tomllib.loads(lock_file.read_text())
+        # Collect direct dep names from pyproject.toml if available
+        direct_names: set[str] = set()
+        pyproject = directory / "pyproject.toml"
+        if pyproject.exists():
+            try:
+                proj = tomllib.loads(pyproject.read_text())
+                for dep_str in proj.get("project", {}).get("dependencies", []):
+                    m = re.match(r"^([a-zA-Z0-9_.-]+)", dep_str)
+                    if m:
+                        direct_names.add(m.group(1).lower())
+            except Exception:
+                pass
+
+        for pkg in data.get("package", []):
+            name = pkg.get("name", "")
+            version = pkg.get("version", "unknown")
+            if not name:
+                continue
+            packages.append(
+                Package(
+                    name=name,
+                    version=version,
+                    ecosystem="pypi",
+                    purl=f"pkg:pypi/{name}@{version}",
+                    is_direct=(name.lower() in direct_names) if direct_names else False,
+                )
+            )
+    except Exception as exc:
+        logger.debug("Failed to parse uv.lock at %s: %s", lock_file, exc)
+
+    return packages
+
+
+def parse_conda_environment(directory: Path) -> list[Package]:
+    """Parse packages from conda environment.yml or environment.yaml.
+
+    Supports both pip-installed packages (listed under ``pip:`` key) and
+    conda packages (listed under ``dependencies``).  Conda packages with
+    pinned versions (``name=version``) are extracted; unpinned ones are
+    skipped as they have no version to scan.
+    """
+    for name in ("environment.yml", "environment.yaml"):
+        env_file = directory / name
+        if env_file.exists():
+            break
+    else:
+        return []
+
+    packages: list[Package] = []
+    try:
+        try:
+            import yaml  # PyYAML
+        except ImportError:
+            logger.debug("PyYAML not installed; skipping conda environment.yml parsing")
+            return []
+
+        data = yaml.safe_load(env_file.read_text()) or {}
+        for dep in data.get("dependencies", []):
+            if isinstance(dep, str):
+                # conda package: "name=version=build" or "name=version" or "name"
+                parts = dep.split("=")
+                pkg_name = parts[0].strip()
+                pkg_version = parts[1].strip() if len(parts) >= 2 else "unknown"
+                if pkg_name and pkg_version != "unknown":
+                    packages.append(
+                        Package(
+                            name=pkg_name,
+                            version=pkg_version,
+                            ecosystem="conda",
+                            purl=f"pkg:conda/{pkg_name}@{pkg_version}",
+                            is_direct=True,
+                        )
+                    )
+            elif isinstance(dep, dict) and "pip" in dep:
+                # pip sub-list: ["requests==2.28.0", ...]
+                for pip_dep in dep.get("pip", []):
+                    m = re.match(r"^([a-zA-Z0-9_.-]+)\s*[=<>!~]+\s*([a-zA-Z0-9_.*+-]+)", pip_dep)
+                    if m:
+                        packages.append(
+                            Package(
+                                name=m.group(1),
+                                version=m.group(2),
+                                ecosystem="pypi",
+                                purl=f"pkg:pypi/{m.group(1)}@{m.group(2)}",
+                                is_direct=True,
+                            )
+                        )
+    except Exception as exc:
+        logger.debug("Failed to parse conda environment at %s: %s", env_file, exc)
+
+    return packages
+
+
+def parse_pnpm_lock(directory: Path) -> list[Package]:
+    """Parse packages from pnpm-lock.yaml.
+
+    pnpm-lock.yaml v6+ uses a ``packages`` map with keys like
+    ``/name@version`` or ``name@version``.  Earlier versions use
+    ``/name/version``.  We support both.
+    """
+    lock_file = directory / "pnpm-lock.yaml"
+    if not lock_file.exists():
+        return []
+
+    packages: list[Package] = []
+    try:
+        try:
+            import yaml
+        except ImportError:
+            logger.debug("PyYAML not installed; skipping pnpm-lock.yaml parsing")
+            return []
+
+        data = yaml.safe_load(lock_file.read_text()) or {}
+        pkg_map = data.get("packages", {})
+        for key in pkg_map:
+            # key formats (pnpm v6): "/name@version", "/@scope/name@version"
+            # key formats (pnpm v9): "name@version", "@scope/name@version"
+            key = key.lstrip("/")
+            # Handle scoped packages: @scope/name@version
+            m = re.match(r"^(@[^/]+/[^@]+)@([^()\s]+)", key)
+            if not m:
+                # Unscoped: name@version
+                m = re.match(r"^([^@][^@]*)@([^()\s]+)", key)
+            if not m:
+                # Fallback: name/version (old pnpm)
+                parts = key.rsplit("/", 1)
+                if len(parts) == 2:
+                    name, version = parts[0], parts[1]
+                else:
+                    continue
+            else:
+                name, version = m.group(1), m.group(2)
+            name = name.strip()
+            version = version.strip()
+            if name and version:
+                packages.append(
+                    Package(
+                        name=name,
+                        version=version,
+                        ecosystem="npm",
+                        purl=f"pkg:npm/{name}@{version}",
+                        is_direct=False,  # pnpm lock is flat; all entries are resolved
+                    )
+                )
+    except Exception as exc:
+        logger.debug("Failed to parse pnpm-lock.yaml at %s: %s", lock_file, exc)
+
+    return packages
+
+
 def parse_pip_packages(directory: Path) -> list[Package]:
-    """Parse packages from requirements.txt, Pipfile.lock, or pyproject.toml."""
+    """Parse packages from requirements.txt, Pipfile.lock, pyproject.toml,
+    poetry.lock, or uv.lock.
+
+    Priority order (first match wins for Python projects):
+    1. poetry.lock  — exact resolved versions, most accurate
+    2. uv.lock      — exact resolved versions (uv package manager)
+    3. requirements.txt — pinned or ranged versions
+    4. Pipfile.lock — Pipenv resolved versions
+    5. pyproject.toml — declared deps (no resolved versions)
+    """
+    # Poetry (most accurate — full resolved lock)
+    poetry_pkgs = parse_poetry_lock(directory)
+    if poetry_pkgs:
+        return poetry_pkgs
+
+    # uv lock
+    uv_pkgs = parse_uv_lock(directory)
+    if uv_pkgs:
+        return uv_pkgs
+
     packages = []
 
     # Try requirements.txt
@@ -490,7 +727,9 @@ def extract_packages(
     server_dir = find_server_directory(server)
     if server_dir:
         packages.extend(parse_npm_packages(server_dir))
-        packages.extend(parse_pip_packages(server_dir))
+        packages.extend(parse_pnpm_lock(server_dir))
+        packages.extend(parse_pip_packages(server_dir))  # includes poetry.lock + uv.lock
+        packages.extend(parse_conda_environment(server_dir))
         packages.extend(parse_go_packages(server_dir))
         packages.extend(parse_cargo_packages(server_dir))
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -54,6 +54,8 @@ ECOSYSTEM_MAP = {
     "maven": "Maven",
     "nuget": "NuGet",
     "rubygems": "RubyGems",
+    # conda packages are pip-installable and tracked under PyPI in OSV
+    "conda": "PyPI",
 }
 
 

--- a/tests/test_parser_interop.py
+++ b/tests/test_parser_interop.py
@@ -1,0 +1,302 @@
+"""Tests for poetry.lock, uv.lock, conda environment.yml, and pnpm-lock.yaml parsers."""
+
+from __future__ import annotations
+
+import textwrap
+
+from agent_bom.parsers import (
+    parse_conda_environment,
+    parse_pip_packages,
+    parse_pnpm_lock,
+    parse_poetry_lock,
+    parse_uv_lock,
+)
+
+# ── poetry.lock ──────────────────────────────────────────────────────────────
+
+POETRY_LOCK = textwrap.dedent("""\
+    [[package]]
+    name = "requests"
+    version = "2.31.0"
+    description = "Python HTTP for Humans."
+    category = "main"
+    optional = false
+    python-versions = ">=3.7"
+
+    [[package]]
+    name = "pytest"
+    version = "7.4.0"
+    description = "pytest: simple powerful testing with Python"
+    category = "dev"
+    optional = false
+    python-versions = ">=3.7"
+
+    [[package]]
+    name = "flask"
+    version = "3.0.0"
+    description = "A simple framework for building complex web applications."
+    category = "main"
+    optional = false
+    python-versions = ">=3.8"
+""")
+
+
+class TestPoetryLock:
+    def test_parses_main_packages(self, tmp_path):
+        (tmp_path / "poetry.lock").write_text(POETRY_LOCK)
+        pkgs = parse_poetry_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "requests" in names
+        assert "flask" in names
+        assert "pytest" in names
+
+    def test_direct_flag_main_only(self, tmp_path):
+        (tmp_path / "poetry.lock").write_text(POETRY_LOCK)
+        pkgs = parse_poetry_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["requests"].is_direct is True
+        assert by_name["flask"].is_direct is True
+        assert by_name["pytest"].is_direct is False  # dev category
+
+    def test_versions_correct(self, tmp_path):
+        (tmp_path / "poetry.lock").write_text(POETRY_LOCK)
+        pkgs = parse_poetry_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["requests"].version == "2.31.0"
+        assert by_name["flask"].version == "3.0.0"
+
+    def test_ecosystem_is_pypi(self, tmp_path):
+        (tmp_path / "poetry.lock").write_text(POETRY_LOCK)
+        pkgs = parse_poetry_lock(tmp_path)
+        assert all(p.ecosystem == "pypi" for p in pkgs)
+
+    def test_purl_format(self, tmp_path):
+        (tmp_path / "poetry.lock").write_text(POETRY_LOCK)
+        pkgs = parse_poetry_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["requests"].purl == "pkg:pypi/requests@2.31.0"
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert parse_poetry_lock(tmp_path) == []
+
+    def test_integrated_via_parse_pip_packages(self, tmp_path):
+        """parse_pip_packages() should prefer poetry.lock over requirements.txt."""
+        (tmp_path / "poetry.lock").write_text(POETRY_LOCK)
+        (tmp_path / "requirements.txt").write_text("requests==2.25.0\n")
+        pkgs = parse_pip_packages(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        # poetry.lock wins — version from poetry, not requirements.txt
+        assert by_name["requests"].version == "2.31.0"
+
+
+# ── uv.lock ──────────────────────────────────────────────────────────────────
+
+UV_LOCK = textwrap.dedent("""\
+    version = 1
+    requires-python = ">=3.11"
+
+    [[package]]
+    name = "httpx"
+    version = "0.27.0"
+    source = { registry = "https://pypi.org/simple" }
+
+    [[package]]
+    name = "certifi"
+    version = "2024.2.2"
+    source = { registry = "https://pypi.org/simple" }
+
+    [[package]]
+    name = "anyio"
+    version = "4.3.0"
+    source = { registry = "https://pypi.org/simple" }
+""")
+
+PYPROJECT_WITH_DEPS = textwrap.dedent("""\
+    [project]
+    name = "myapp"
+    version = "0.1.0"
+    dependencies = ["httpx>=0.27"]
+""")
+
+
+class TestUvLock:
+    def test_parses_all_packages(self, tmp_path):
+        (tmp_path / "uv.lock").write_text(UV_LOCK)
+        pkgs = parse_uv_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert {"httpx", "certifi", "anyio"} == names
+
+    def test_versions_correct(self, tmp_path):
+        (tmp_path / "uv.lock").write_text(UV_LOCK)
+        pkgs = parse_uv_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["httpx"].version == "0.27.0"
+        assert by_name["certifi"].version == "2024.2.2"
+
+    def test_direct_flag_from_pyproject(self, tmp_path):
+        (tmp_path / "uv.lock").write_text(UV_LOCK)
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_WITH_DEPS)
+        pkgs = parse_uv_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["httpx"].is_direct is True
+        assert by_name["certifi"].is_direct is False  # transitive
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert parse_uv_lock(tmp_path) == []
+
+    def test_ecosystem_is_pypi(self, tmp_path):
+        (tmp_path / "uv.lock").write_text(UV_LOCK)
+        pkgs = parse_uv_lock(tmp_path)
+        assert all(p.ecosystem == "pypi" for p in pkgs)
+
+    def test_integrated_via_parse_pip_packages(self, tmp_path):
+        """parse_pip_packages() should use uv.lock when no poetry.lock exists."""
+        (tmp_path / "uv.lock").write_text(UV_LOCK)
+        (tmp_path / "requirements.txt").write_text("httpx==0.26.0\n")
+        pkgs = parse_pip_packages(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["httpx"].version == "0.27.0"  # uv.lock wins
+
+
+# ── conda environment.yml ─────────────────────────────────────────────────────
+
+CONDA_ENV = textwrap.dedent("""\
+    name: myenv
+    channels:
+      - conda-forge
+      - defaults
+    dependencies:
+      - python=3.11.0
+      - numpy=1.26.4
+      - pandas=2.2.0
+      - pip:
+        - requests==2.31.0
+        - flask>=3.0.0,<4.0.0
+""")
+
+
+class TestCondaEnvironment:
+    def test_parses_conda_packages(self, tmp_path):
+        (tmp_path / "environment.yml").write_text(CONDA_ENV)
+        pkgs = parse_conda_environment(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "numpy" in names
+        assert "pandas" in names
+        assert "python" in names
+
+    def test_parses_pip_sub_list(self, tmp_path):
+        (tmp_path / "environment.yml").write_text(CONDA_ENV)
+        pkgs = parse_conda_environment(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "requests" in names
+
+    def test_conda_ecosystem_label(self, tmp_path):
+        (tmp_path / "environment.yml").write_text(CONDA_ENV)
+        pkgs = parse_conda_environment(tmp_path)
+        conda_pkgs = [p for p in pkgs if p.ecosystem == "conda"]
+        assert len(conda_pkgs) >= 2  # numpy, pandas, python
+
+    def test_pip_packages_have_pypi_ecosystem(self, tmp_path):
+        (tmp_path / "environment.yml").write_text(CONDA_ENV)
+        pkgs = parse_conda_environment(tmp_path)
+        pip_pkgs = [p for p in pkgs if p.name == "requests"]
+        assert pip_pkgs[0].ecosystem == "pypi"
+
+    def test_versions_correct(self, tmp_path):
+        (tmp_path / "environment.yml").write_text(CONDA_ENV)
+        pkgs = parse_conda_environment(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["numpy"].version == "1.26.4"
+        assert by_name["requests"].version == "2.31.0"
+
+    def test_environment_yaml_also_supported(self, tmp_path):
+        (tmp_path / "environment.yaml").write_text(CONDA_ENV)
+        pkgs = parse_conda_environment(tmp_path)
+        assert len(pkgs) > 0
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert parse_conda_environment(tmp_path) == []
+
+    def test_skips_unpinned_conda_packages(self, tmp_path):
+        (tmp_path / "environment.yml").write_text("name: test\ndependencies:\n  - numpy\n")
+        pkgs = parse_conda_environment(tmp_path)
+        # Unpinned packages (no version) are skipped
+        assert all(p.version != "unknown" or p.name != "numpy" for p in pkgs)
+
+
+# ── pnpm-lock.yaml ────────────────────────────────────────────────────────────
+
+PNPM_LOCK_V6 = textwrap.dedent("""\
+    lockfileVersion: '6.0'
+
+    packages:
+
+      /lodash@4.17.21:
+        resolution: {integrity: sha512-xxx}
+
+      /express@4.18.2:
+        resolution: {integrity: sha512-yyy}
+
+      /@types/node@20.0.0:
+        resolution: {integrity: sha512-zzz}
+        dev: true
+""")
+
+PNPM_LOCK_V9 = textwrap.dedent("""\
+    lockfileVersion: '9.0'
+
+    packages:
+      lodash@4.17.21:
+        resolution: {integrity: sha512-xxx}
+
+      express@4.18.2:
+        resolution: {integrity: sha512-yyy}
+""")
+
+
+class TestPnpmLock:
+    def test_parses_v6_format(self, tmp_path):
+        (tmp_path / "pnpm-lock.yaml").write_text(PNPM_LOCK_V6)
+        pkgs = parse_pnpm_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "lodash" in names
+        assert "express" in names
+
+    def test_parses_v9_format(self, tmp_path):
+        (tmp_path / "pnpm-lock.yaml").write_text(PNPM_LOCK_V9)
+        pkgs = parse_pnpm_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "lodash" in names
+        assert "express" in names
+
+    def test_scoped_package(self, tmp_path):
+        (tmp_path / "pnpm-lock.yaml").write_text(PNPM_LOCK_V6)
+        pkgs = parse_pnpm_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "@types/node" in names
+
+    def test_versions_correct(self, tmp_path):
+        (tmp_path / "pnpm-lock.yaml").write_text(PNPM_LOCK_V6)
+        pkgs = parse_pnpm_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["lodash"].version == "4.17.21"
+        assert by_name["express"].version == "4.18.2"
+
+    def test_ecosystem_is_npm(self, tmp_path):
+        (tmp_path / "pnpm-lock.yaml").write_text(PNPM_LOCK_V6)
+        pkgs = parse_pnpm_lock(tmp_path)
+        assert all(p.ecosystem == "npm" for p in pkgs)
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert parse_pnpm_lock(tmp_path) == []
+
+
+# ── ECOSYSTEM_MAP includes conda ──────────────────────────────────────────────
+
+
+def test_conda_in_ecosystem_map():
+    from agent_bom.scanners import ECOSYSTEM_MAP
+
+    assert "conda" in ECOSYSTEM_MAP
+    # conda maps to PyPI in OSV (conda packages are pip-installable)
+    assert ECOSYSTEM_MAP["conda"] == "PyPI"


### PR DESCRIPTION
## Summary

Eliminates the biggest interoperability gap: enterprise Python and Node shops using Poetry, uv, conda, or pnpm were getting 0 packages detected.

## New parsers

**Python:**
| File | Parser | Notes |
|------|--------|-------|
| `poetry.lock` | `parse_poetry_lock()` | Exact resolved versions, `is_direct` from `category = "main"/"dev"` |
| `uv.lock` | `parse_uv_lock()` | Astral uv, `is_direct` cross-referenced from `pyproject.toml` |
| `environment.yml` / `environment.yaml` | `parse_conda_environment()` | Conda packages + pip sub-list |

**Node:**
| File | Parser | Notes |
|------|--------|-------|
| `pnpm-lock.yaml` | `parse_pnpm_lock()` | v6 and v9 format, scoped `@scope/name` packages |

**Priority order** (`parse_pip_packages`): poetry.lock → uv.lock → requirements.txt → Pipfile.lock → pyproject.toml

**Conda → OSV mapping**: conda packages tracked under PyPI in OSV (they are pip-installable). Added `"conda": "PyPI"` to `ECOSYSTEM_MAP`.

## What enterprise inventory can now provide via `--inventory fleet.json`

Any of the above lock files in MCP server working directories are auto-detected. Users can also pre-populate packages in inventory JSON:

```json
{
  "agents": [{
    "name": "prod-agent",
    "mcp_servers": [{
      "name": "my-server",
      "packages": [
        {"name": "requests", "version": "2.25.0", "ecosystem": "pypi"},
        {"name": "flask", "version": "2.2.0", "ecosystem": "pypi"}
      ]
    }]
  }]
}
```

## Test plan
- `pytest tests/test_parser_interop.py -v` → 28 passed
- `pytest tests/ -q` → 3613 passed, 0 failures