### PR TITLE
feat: yarn.lock parser — Classic v1 and Berry v2/v3, completes Node package manager coverage

### DIFF
--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -410,6 +410,98 @@ def parse_conda_environment(directory: Path) -> list[Package]:
     return packages
 
 
+def parse_yarn_lock(directory: Path) -> list[Package]:
+    """Parse packages from yarn.lock (Classic v1 and Berry v2/v3 formats).
+
+    yarn.lock v1 (Classic) uses a block format::
+
+        "name@version":
+          version "resolved_version"
+
+    yarn.lock v2+ (Berry) uses a YAML-like format with ``__metadata``
+    and entries like::
+
+        "name@npm:version":
+          version: "resolved_version"
+
+    We handle both by scanning for version lines after each package header.
+    """
+    lock_file = directory / "yarn.lock"
+    if not lock_file.exists():
+        return []
+
+    packages: list[Package] = []
+    try:
+        content = lock_file.read_text()
+        # Berry v2+ detection
+        is_berry = "__metadata:" in content
+
+        if is_berry:
+            # Berry format: entries separated by blank lines, "version: x.y.z"
+            current_names: list[str] = []
+            seen: set[tuple[str, str]] = set()
+            for line in content.splitlines():
+                stripped = line.strip()
+                # Package header lines: '"name@npm:version, name@npm:version":'
+                if stripped.startswith('"') and stripped.endswith(":") and "@npm:" in stripped:
+                    current_names = []
+                    header = stripped.rstrip(":")
+                    for part in header.strip('"').split(", "):
+                        m = re.match(r'^"?(@?[^@]+)@', part)
+                        if m:
+                            current_names.append(m.group(1))
+                elif stripped.startswith("version:") and current_names:
+                    version = stripped.split(":", 1)[1].strip().strip('"')
+                    for name in current_names:
+                        key = (name, version)
+                        if key not in seen:
+                            seen.add(key)
+                            packages.append(
+                                Package(
+                                    name=name,
+                                    version=version,
+                                    ecosystem="npm",
+                                    purl=f"pkg:npm/{name}@{version}",
+                                    is_direct=False,
+                                )
+                            )
+                    current_names = []
+        else:
+            # Classic v1: '"name@range, name@range":\n  version "x.y.z"'
+            seen: set[tuple[str, str]] = set()
+            current_names: list[str] = []
+            for line in content.splitlines():
+                stripped = line.strip()
+                # Header: one or more "name@range" entries followed by ":"
+                if stripped.endswith(":") and not stripped.startswith("#"):
+                    current_names = []
+                    header = stripped.rstrip(":")
+                    for part in header.strip('"').split(", "):
+                        m = re.match(r'^"?(@?[^@"]+)@', part.strip('"'))
+                        if m:
+                            current_names.append(m.group(1))
+                elif stripped.startswith("version ") and current_names:
+                    version = stripped.split(" ", 1)[1].strip().strip('"')
+                    for name in current_names:
+                        key = (name, version)
+                        if key not in seen:
+                            seen.add(key)
+                            packages.append(
+                                Package(
+                                    name=name,
+                                    version=version,
+                                    ecosystem="npm",
+                                    purl=f"pkg:npm/{name}@{version}",
+                                    is_direct=False,
+                                )
+                            )
+                    current_names = []
+    except Exception as exc:
+        logger.debug("Failed to parse yarn.lock at %s: %s", lock_file, exc)
+
+    return packages
+
+
 def parse_pnpm_lock(directory: Path) -> list[Package]:
     """Parse packages from pnpm-lock.yaml.
 
@@ -727,6 +819,7 @@ def extract_packages(
     server_dir = find_server_directory(server)
     if server_dir:
         packages.extend(parse_npm_packages(server_dir))
+        packages.extend(parse_yarn_lock(server_dir))
         packages.extend(parse_pnpm_lock(server_dir))
         packages.extend(parse_pip_packages(server_dir))  # includes poetry.lock + uv.lock
         packages.extend(parse_conda_environment(server_dir))

--- a/tests/test_yarn_lock.py
+++ b/tests/test_yarn_lock.py
@@ -1,0 +1,127 @@
+"""Tests for yarn.lock (Classic v1 and Berry v2) parser."""
+
+from __future__ import annotations
+
+import textwrap
+
+from agent_bom.parsers import parse_yarn_lock
+
+YARN_V1 = textwrap.dedent("""\
+    # yarn lockfile v1
+
+    "lodash@^4.17.0":
+      version "4.17.21"
+      resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz"
+      integrity sha512-xxx
+
+    "express@^4.18.0":
+      version "4.18.2"
+      resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz"
+      integrity sha512-yyy
+
+    "@types/node@^20.0.0":
+      version "20.0.0"
+      resolved "https://registry.yarnpkg.com/@types/node/-/node-20.0.0.tgz"
+      integrity sha512-zzz
+""")
+
+YARN_V1_MULTI_RANGE = textwrap.dedent("""\
+    # yarn lockfile v1
+
+    "accepts@~1.3.5, accepts@~1.3.7, accepts@^1.3.8":
+      version "1.3.8"
+      resolved "https://registry.yarnpkg.com/accepts"
+      integrity sha512-aaa
+""")
+
+YARN_BERRY = textwrap.dedent("""\
+    __metadata:
+      version: 6
+      cacheKey: 8
+
+    "express@npm:^4.18.0":
+      version: "4.18.2"
+      resolution: "express@npm:4.18.2"
+      checksum: abc123
+
+    "lodash@npm:^4.17.0":
+      version: "4.17.21"
+      resolution: "lodash@npm:4.17.21"
+      checksum: def456
+
+    "@babel/core@npm:^7.0.0":
+      version: "7.23.0"
+      resolution: "@babel/core@npm:7.23.0"
+      checksum: ghi789
+""")
+
+
+class TestYarnV1:
+    def test_parses_packages(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_V1)
+        pkgs = parse_yarn_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "lodash" in names
+        assert "express" in names
+
+    def test_scoped_package(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_V1)
+        pkgs = parse_yarn_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "@types/node" in names
+
+    def test_versions_correct(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_V1)
+        pkgs = parse_yarn_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["lodash"].version == "4.17.21"
+        assert by_name["express"].version == "4.18.2"
+
+    def test_ecosystem_is_npm(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_V1)
+        pkgs = parse_yarn_lock(tmp_path)
+        assert all(p.ecosystem == "npm" for p in pkgs)
+
+    def test_purl_format(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_V1)
+        pkgs = parse_yarn_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["lodash"].purl == "pkg:npm/lodash@4.17.21"
+
+    def test_multi_range_deduplicates(self, tmp_path):
+        """Multiple version ranges resolving to same version → one entry."""
+        (tmp_path / "yarn.lock").write_text(YARN_V1_MULTI_RANGE)
+        pkgs = parse_yarn_lock(tmp_path)
+        accepts = [p for p in pkgs if p.name == "accepts"]
+        assert len(accepts) == 1
+        assert accepts[0].version == "1.3.8"
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert parse_yarn_lock(tmp_path) == []
+
+
+class TestYarnBerry:
+    def test_parses_packages(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_BERRY)
+        pkgs = parse_yarn_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "express" in names
+        assert "lodash" in names
+
+    def test_scoped_package(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_BERRY)
+        pkgs = parse_yarn_lock(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "@babel/core" in names
+
+    def test_versions_correct(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_BERRY)
+        pkgs = parse_yarn_lock(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["express"].version == "4.18.2"
+        assert by_name["lodash"].version == "4.17.21"
+
+    def test_ecosystem_is_npm(self, tmp_path):
+        (tmp_path / "yarn.lock").write_text(YARN_BERRY)
+        pkgs = parse_yarn_lock(tmp_path)
+        assert all(p.ecosystem == "npm" for p in pkgs)


### PR DESCRIPTION
Completes Node.js interop. All package managers now covered: npm, yarn (v1+v2+v3), pnpm. 11 tests, 3624 total passing.