### PR TITLE
feat: native disk snapshot scan + pip environment parser

### DIFF
--- a/src/agent_bom/filesystem.py
+++ b/src/agent_bom/filesystem.py
@@ -1,13 +1,20 @@
-"""Filesystem and disk snapshot scanning via Syft.
+"""Filesystem and disk snapshot scanning — Syft (primary) + native fallback.
 
 Scans mounted directories and tar archives for packages::
 
-    syft dir:/path/to/mounted/snapshot -o cyclonedx-json
-    syft /path/to/archive.tar -o cyclonedx-json
+    syft dir:/path/to/mounted/snapshot -o cyclonedx-json   # preferred
+    agent-bom scan --filesystem /mnt/vm-snapshot           # auto-selects strategy
 
-This enables agentless VM scanning — mount a disk snapshot,
-point agent-bom at it, and get a full package inventory + CVEs.
-Replaces cloud-native image scanners for on-prem environments.
+When Syft is **not** installed, the native fallback is used instead:
+
+- APT/Debian: ``/var/lib/dpkg/status``
+- RPM/RHEL:   ``rpm -qa --qf ...`` (if ``rpm`` binary is on PATH)
+- Python:     walks all ``site-packages/`` and ``dist-packages/`` dirs for
+              ``.dist-info/METADATA`` files (PEP 566 / importlib.metadata)
+- Lock files: runs the full :func:`scan_project_directory` parser suite
+
+This enables agentless VM scanning without requiring Syft — mount a disk
+snapshot, point agent-bom at it, and get a full package inventory + CVEs.
 
 Usage from cli.py::
 
@@ -19,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -34,32 +42,43 @@ class FilesystemScanError(Exception):
     """Raised when a filesystem path cannot be scanned."""
 
 
+# ── Syft-based scanning ───────────────────────────────────────────────────────
+
+
 def scan_filesystem(path: str, timeout: int = 600) -> tuple[list[Package], str]:
     """Scan a filesystem directory or tar archive for packages.
 
+    Tries Syft first; falls back to native parsers for directories when
+    Syft is not installed.
+
     Args:
         path: Directory path or tar archive path.
-              Directories are scanned as ``syft dir:/path``.
-              Tar files are scanned as ``syft /path/to/archive.tar``.
         timeout: Subprocess timeout in seconds (default 600 = 10 min).
 
     Returns:
-        (packages, strategy) where strategy is ``"syft-dir"`` or ``"syft-tar"``.
+        ``(packages, strategy)`` where *strategy* is one of:
+        ``"syft-dir"``, ``"syft-tar"``, ``"native-dir"``.
 
     Raises:
-        FilesystemScanError: if syft is not found or scan fails.
+        FilesystemScanError: if all strategies fail.
     """
     validated = validate_path(path, must_exist=True)
 
-    if not shutil.which("syft"):
-        raise FilesystemScanError("syft not found on PATH. Install from https://github.com/anchore/syft")
-
     if validated.is_dir():
-        return _scan_directory(validated, timeout), "syft-dir"
-    elif validated.suffix in (".tar", ".gz", ".tgz"):
-        return _scan_archive(validated, timeout), "syft-tar"
-    else:
-        raise FilesystemScanError(f"Unsupported path type: {validated}. Expected a directory or .tar/.tar.gz/.tgz archive.")
+        if shutil.which("syft"):
+            return _scan_directory(validated, timeout), "syft-dir"
+        # Native fallback — no Syft required
+        pkgs = scan_disk_path_native(validated)
+        return pkgs, "native-dir"
+
+    if validated.suffix in (".tar", ".gz", ".tgz"):
+        if shutil.which("syft"):
+            return _scan_archive(validated, timeout), "syft-tar"
+        raise FilesystemScanError(
+            "syft not found on PATH — required for tar/archive scanning. Install from https://github.com/anchore/syft"
+        )
+
+    raise FilesystemScanError(f"Unsupported path type: {validated}. Expected a directory or .tar/.tar.gz/.tgz archive.")
 
 
 def _scan_directory(dir_path: Path, timeout: int = 600) -> list[Package]:
@@ -94,6 +113,232 @@ def _run_syft(source: str, timeout: int) -> list[Package]:
         raise FilesystemScanError(f"syft output is not valid JSON: {e}") from e
 
     return parse_cyclonedx(data)
+
+
+# ── Native disk snapshot parsers (no external tools required) ─────────────────
+
+
+def parse_dpkg_status(status_file: Path) -> list[Package]:
+    """Parse installed packages from a Debian/Ubuntu ``dpkg/status`` file.
+
+    Works on live systems (``/var/lib/dpkg/status``) and mounted VM disk
+    snapshots.  Only packages with ``Status: install ok installed`` are
+    included.
+
+    Args:
+        status_file: Path to the ``dpkg/status`` file.
+
+    Returns:
+        List of :class:`~agent_bom.models.Package` objects with
+        ``ecosystem="deb"``.
+    """
+    if not status_file.exists():
+        return []
+
+    packages: list[Package] = []
+    current: dict[str, str] = {}
+
+    for raw_line in status_file.read_text(errors="replace").splitlines():
+        if raw_line.strip() == "":
+            # End of a stanza — commit if it's a fully-installed package
+            if current.get("Package") and current.get("Version"):
+                status = current.get("Status", "")
+                if "install ok installed" in status:
+                    name = current["Package"]
+                    version = current["Version"]
+                    # Strip epoch prefix (e.g. "1:2.3.4" → "2.3.4")
+                    version = re.sub(r"^\d+:", "", version)
+                    packages.append(
+                        Package(
+                            name=name,
+                            version=version,
+                            ecosystem="deb",
+                            purl=f"pkg:deb/debian/{name}@{version}",
+                            is_direct=True,
+                        )
+                    )
+            current = {}
+        elif ":" in raw_line and not raw_line.startswith(" "):
+            key, _, value = raw_line.partition(":")
+            current[key.strip()] = value.strip()
+
+    return packages
+
+
+def parse_rpm_packages(root: Path) -> list[Package]:
+    """Query installed RPM packages from an RPM database.
+
+    For live systems, runs ``rpm -qa`` if the binary is on PATH.
+    For mounted snapshots, tries ``rpm --dbpath <root>/var/lib/rpm -qa``.
+    Returns empty list if rpm is not available.
+
+    Args:
+        root: Filesystem root (``/`` for live, ``/mnt/snapshot`` for VMs).
+
+    Returns:
+        List of :class:`~agent_bom.models.Package` objects with
+        ``ecosystem="rpm"``.
+    """
+    if not shutil.which("rpm"):
+        return []
+
+    rpm_db = root / "var" / "lib" / "rpm"
+    if not rpm_db.exists() and root == Path("/"):
+        # Live system, default db path
+        rpm_db = None
+
+    cmd = ["rpm"]
+    if rpm_db:
+        cmd += ["--dbpath", str(rpm_db)]
+    cmd += ["-qa", "--qf", "%{NAME}\\t%{VERSION}-%{RELEASE}\\t%{ARCH}\\n"]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    packages: list[Package] = []
+    for line in result.stdout.splitlines():
+        parts = line.strip().split("\t")
+        if len(parts) >= 2:
+            name, version = parts[0], parts[1]
+            if name and version:
+                packages.append(
+                    Package(
+                        name=name,
+                        version=version,
+                        ecosystem="rpm",
+                        purl=f"pkg:rpm/redhat/{name}@{version}",
+                        is_direct=True,
+                    )
+                )
+
+    return packages
+
+
+def parse_site_packages(site_packages_dir: Path) -> list[Package]:
+    """Parse installed Python packages from a ``site-packages`` or
+    ``dist-packages`` directory by reading ``.dist-info/METADATA`` files.
+
+    Works on live systems and mounted disk snapshots.
+
+    Args:
+        site_packages_dir: Path to a ``site-packages`` or ``dist-packages``
+            directory.
+
+    Returns:
+        List of :class:`~agent_bom.models.Package` objects with
+        ``ecosystem="pypi"``.
+    """
+    if not site_packages_dir.exists():
+        return []
+
+    packages: list[Package] = []
+    seen: set[tuple[str, str]] = set()
+
+    for dist_info in site_packages_dir.glob("*.dist-info"):
+        metadata_file = dist_info / "METADATA"
+        if not metadata_file.exists():
+            continue
+
+        name = ""
+        version = ""
+        try:
+            for line in metadata_file.read_text(errors="replace").splitlines():
+                if line.startswith("Name:"):
+                    name = line.split(":", 1)[1].strip()
+                elif line.startswith("Version:"):
+                    version = line.split(":", 1)[1].strip()
+                elif line.startswith("") and name and version:
+                    # Empty line signals end of headers
+                    break
+        except OSError:
+            continue
+
+        if name and version:
+            key = (name.lower(), version)
+            if key not in seen:
+                seen.add(key)
+                packages.append(
+                    Package(
+                        name=name,
+                        version=version,
+                        ecosystem="pypi",
+                        purl=f"pkg:pypi/{name.lower()}@{version}",
+                        is_direct=True,
+                    )
+                )
+
+    return packages
+
+
+def scan_disk_path_native(root: Path) -> list[Package]:
+    """Scan a directory (VM disk snapshot or live root) natively — no Syft.
+
+    Combines all native parsers:
+
+    - APT/Debian packages from ``var/lib/dpkg/status``
+    - RPM packages via ``rpm --dbpath`` (if ``rpm`` binary is on PATH)
+    - Python packages from all ``site-packages`` / ``dist-packages`` dirs
+    - Lock-file packages via :func:`~agent_bom.parsers.scan_project_directory`
+
+    Args:
+        root: Root directory to scan (e.g. ``/mnt/snapshot`` or ``/``).
+
+    Returns:
+        Deduplicated list of :class:`~agent_bom.models.Package` objects.
+    """
+    packages: list[Package] = []
+
+    # APT / Debian
+    dpkg_status = root / "var" / "lib" / "dpkg" / "status"
+    deb_pkgs = parse_dpkg_status(dpkg_status)
+    if deb_pkgs:
+        logger.debug("native-dir: found %d deb packages in %s", len(deb_pkgs), dpkg_status)
+    packages.extend(deb_pkgs)
+
+    # RPM / RHEL / CentOS / Fedora
+    rpm_pkgs = parse_rpm_packages(root)
+    if rpm_pkgs:
+        logger.debug("native-dir: found %d rpm packages via rpm --dbpath", len(rpm_pkgs))
+    packages.extend(rpm_pkgs)
+
+    # Python site-packages / dist-packages
+    for pattern in (
+        "usr/lib/python*/site-packages",
+        "usr/lib/python*/dist-packages",
+        "usr/local/lib/python*/site-packages",
+        "usr/local/lib/python*/dist-packages",
+        "opt/conda/lib/python*/site-packages",
+    ):
+        for sp_dir in root.glob(pattern):
+            sp_pkgs = parse_site_packages(sp_dir)
+            if sp_pkgs:
+                logger.debug("native-dir: found %d Python packages in %s", len(sp_pkgs), sp_dir)
+            packages.extend(sp_pkgs)
+
+    # Lock files (requirements.txt, package.json, go.mod, Cargo.toml, etc.)
+    from agent_bom.parsers import scan_project_directory
+
+    for dir_pkgs in scan_project_directory(root, max_depth=5).values():
+        packages.extend(dir_pkgs)
+
+    # Deduplicate by (name, version, ecosystem)
+    seen: set[tuple[str, str, str]] = set()
+    unique: list[Package] = []
+    for pkg in packages:
+        key = (pkg.name, pkg.version, pkg.ecosystem)
+        if key not in seen:
+            seen.add(key)
+            unique.append(pkg)
+
+    return unique
+
+
+# ── Batch helper ──────────────────────────────────────────────────────────────
 
 
 def scan_filesystem_batch(paths: list[str], timeout: int = 600) -> list[tuple[str, list[Package], str]]:

--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -663,6 +663,62 @@ def parse_pip_packages(directory: Path) -> list[Package]:
     return packages
 
 
+def parse_pip_environment(python_exec: str | None = None) -> list[Package]:
+    """Scan an installed Python environment via ``pip list --format=json``.
+
+    Useful when there is no lock file (e.g. bare virtualenv, conda env,
+    system Python) and you want to audit what's actually installed.
+
+    Args:
+        python_exec: Path to the Python interpreter whose environment to scan.
+            Defaults to ``sys.executable`` (the currently-running Python).
+
+    Returns:
+        List of :class:`~agent_bom.models.Package` objects with
+        ``ecosystem="pypi"``.  Returns an empty list if ``pip`` is not
+        available in the target environment.
+    """
+    import sys as _sys
+
+    exe = python_exec or _sys.executable
+    try:
+        result = subprocess.run(
+            [exe, "-m", "pip", "list", "--format=json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        logger.debug("parse_pip_environment: pip not available (%s)", exc)
+        return []
+
+    if result.returncode != 0:
+        logger.debug("parse_pip_environment: pip list failed: %s", result.stderr[:200])
+        return []
+
+    try:
+        raw = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    packages: list[Package] = []
+    for entry in raw:
+        name = entry.get("name", "")
+        version = entry.get("version", "unknown")
+        if name:
+            packages.append(
+                Package(
+                    name=name,
+                    version=version,
+                    ecosystem="pypi",
+                    purl=f"pkg:pypi/{name.lower()}@{version}",
+                    is_direct=True,
+                )
+            )
+
+    return packages
+
+
 def parse_go_packages(directory: Path) -> list[Package]:
     """Parse packages from go.sum."""
     packages = []

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -116,12 +116,22 @@ def test_scan_tar_gz_archive(monkeypatch, tmp_path):
 # ─── Error cases ──────────────────────────────────────────────────────────────
 
 
-def test_syft_not_found(monkeypatch, tmp_path):
-    """Missing syft binary raises FilesystemScanError."""
+def test_syft_not_found_uses_native_fallback(monkeypatch, tmp_path):
+    """Missing syft binary falls back to native scanning for directories."""
     monkeypatch.setattr("shutil.which", lambda name: None)
+    # Empty directory → native scan returns empty list (no error)
+    pkgs, strategy = scan_filesystem(str(tmp_path))
+    assert strategy == "native-dir"
+    assert isinstance(pkgs, list)
 
+
+def test_syft_not_found_tar_raises(monkeypatch, tmp_path):
+    """Missing syft binary raises FilesystemScanError for tar archives."""
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    tar = tmp_path / "archive.tar"
+    tar.write_bytes(b"fake")
     with pytest.raises(FilesystemScanError, match="syft not found"):
-        scan_filesystem(str(tmp_path))
+        scan_filesystem(str(tar))
 
 
 def test_syft_nonzero_exit(monkeypatch, tmp_path):

--- a/tests/test_native_disk_scan.py
+++ b/tests/test_native_disk_scan.py
@@ -1,0 +1,296 @@
+"""Tests for native disk snapshot parsers and parse_pip_environment."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_bom.filesystem import (
+    FilesystemScanError,
+    parse_dpkg_status,
+    parse_site_packages,
+    scan_disk_path_native,
+    scan_filesystem,
+)
+from agent_bom.parsers import parse_pip_environment
+
+# ── parse_dpkg_status ─────────────────────────────────────────────────────────
+
+DPKG_STATUS = """\
+Package: libssl3
+Status: install ok installed
+Architecture: amd64
+Version: 3.0.11-1~deb12u2
+Description: Secure Sockets Layer toolkit - shared libraries
+
+Package: python3-requests
+Status: install ok installed
+Architecture: all
+Version: 2.28.2-1
+Description: elegant and simple HTTP library for Python3
+
+Package: vim-tiny
+Status: deinstall ok config-files
+Version: 2:9.0.1378-2
+Description: Vi IMproved - enhanced vi editor - compact version
+
+Package: incomplete-package
+Status: install ok installed
+Version:
+Description: missing version field
+
+"""
+
+
+class TestParseDpkgStatus:
+    def test_parses_installed_packages(self, tmp_path):
+        f = tmp_path / "status"
+        f.write_text(DPKG_STATUS)
+        pkgs = parse_dpkg_status(f)
+        names = {p.name for p in pkgs}
+        assert "libssl3" in names
+        assert "python3-requests" in names
+
+    def test_excludes_deinstalled(self, tmp_path):
+        f = tmp_path / "status"
+        f.write_text(DPKG_STATUS)
+        pkgs = parse_dpkg_status(f)
+        names = {p.name for p in pkgs}
+        assert "vim-tiny" not in names
+
+    def test_strips_epoch_prefix(self, tmp_path):
+        f = tmp_path / "status"
+        f.write_text(DPKG_STATUS)
+        pkgs = parse_dpkg_status(f)
+        # libssl3 version 3.0.11-1~deb12u2, no epoch
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["libssl3"].version == "3.0.11-1~deb12u2"
+
+    def test_ecosystem_is_deb(self, tmp_path):
+        f = tmp_path / "status"
+        f.write_text(DPKG_STATUS)
+        pkgs = parse_dpkg_status(f)
+        assert all(p.ecosystem == "deb" for p in pkgs)
+
+    def test_purl_format(self, tmp_path):
+        f = tmp_path / "status"
+        f.write_text(DPKG_STATUS)
+        pkgs = parse_dpkg_status(f)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["libssl3"].purl == "pkg:deb/debian/libssl3@3.0.11-1~deb12u2"
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert parse_dpkg_status(tmp_path / "nonexistent") == []
+
+    def test_skips_incomplete_entries(self, tmp_path):
+        f = tmp_path / "status"
+        f.write_text(DPKG_STATUS)
+        pkgs = parse_dpkg_status(f)
+        names = {p.name for p in pkgs}
+        assert "incomplete-package" not in names
+
+    def test_real_vm_path_layout(self, tmp_path):
+        """Simulate mounted VM snapshot structure."""
+        status_dir = tmp_path / "var" / "lib" / "dpkg"
+        status_dir.mkdir(parents=True)
+        (status_dir / "status").write_text("Package: curl\nStatus: install ok installed\nVersion: 7.88.1-10\n\n")
+        pkgs = parse_dpkg_status(status_dir / "status")
+        assert any(p.name == "curl" for p in pkgs)
+
+
+# ── parse_site_packages ───────────────────────────────────────────────────────
+
+
+class TestParseSitePackages:
+    def _make_dist_info(self, site_dir: Path, name: str, version: str) -> None:
+        dist_info = site_dir / f"{name}-{version}.dist-info"
+        dist_info.mkdir(parents=True)
+        (dist_info / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n\nSome description.\n")
+
+    def test_parses_installed_packages(self, tmp_path):
+        self._make_dist_info(tmp_path, "requests", "2.31.0")
+        self._make_dist_info(tmp_path, "flask", "3.0.0")
+        pkgs = parse_site_packages(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "requests" in names
+        assert "flask" in names
+
+    def test_versions_correct(self, tmp_path):
+        self._make_dist_info(tmp_path, "numpy", "1.26.4")
+        pkgs = parse_site_packages(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["numpy"].version == "1.26.4"
+
+    def test_ecosystem_is_pypi(self, tmp_path):
+        self._make_dist_info(tmp_path, "pandas", "2.2.0")
+        pkgs = parse_site_packages(tmp_path)
+        assert all(p.ecosystem == "pypi" for p in pkgs)
+
+    def test_purl_format(self, tmp_path):
+        self._make_dist_info(tmp_path, "Requests", "2.31.0")
+        pkgs = parse_site_packages(tmp_path)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["Requests"].purl == "pkg:pypi/requests@2.31.0"
+
+    def test_missing_directory_returns_empty(self, tmp_path):
+        assert parse_site_packages(tmp_path / "nonexistent") == []
+
+    def test_deduplicates_same_package(self, tmp_path):
+        # Same name+version twice (shouldn't happen but be safe)
+        self._make_dist_info(tmp_path, "requests", "2.31.0")
+        # Manually create a second dist-info with same content
+        dist2 = tmp_path / "requests-2.31.0.dist-info.bak"
+        dist2.mkdir()
+        (dist2 / "METADATA").write_text("Name: requests\nVersion: 2.31.0\n\n")
+        pkgs = parse_site_packages(tmp_path)
+        req_pkgs = [p for p in pkgs if p.name == "requests"]
+        assert len(req_pkgs) == 1
+
+    def test_skips_dist_info_without_metadata(self, tmp_path):
+        (tmp_path / "broken-1.0.dist-info").mkdir()
+        pkgs = parse_site_packages(tmp_path)
+        assert pkgs == []
+
+
+# ── scan_disk_path_native ─────────────────────────────────────────────────────
+
+
+class TestScanDiskPathNative:
+    def test_finds_dpkg_packages(self, tmp_path):
+        status_dir = tmp_path / "var" / "lib" / "dpkg"
+        status_dir.mkdir(parents=True)
+        (status_dir / "status").write_text("Package: openssl\nStatus: install ok installed\nVersion: 3.1.0\n\n")
+        pkgs = scan_disk_path_native(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "openssl" in names
+
+    def test_finds_python_site_packages(self, tmp_path):
+        sp = tmp_path / "usr" / "lib" / "python3.11" / "site-packages"
+        sp.mkdir(parents=True)
+        dist_info = sp / "flask-3.0.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Name: flask\nVersion: 3.0.0\n\n")
+        pkgs = scan_disk_path_native(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "flask" in names
+
+    def test_finds_lock_files(self, tmp_path):
+        (tmp_path / "requirements.txt").write_text("django==4.2.0\n")
+        pkgs = scan_disk_path_native(tmp_path)
+        names = {p.name for p in pkgs}
+        assert "django" in names
+
+    def test_deduplicates_across_sources(self, tmp_path):
+        # Same package in dpkg/status AND requirements.txt (shouldn't happen but cover it)
+        status_dir = tmp_path / "var" / "lib" / "dpkg"
+        status_dir.mkdir(parents=True)
+        (status_dir / "status").write_text("Package: curl\nStatus: install ok installed\nVersion: 7.88.1\n\n")
+        (tmp_path / "requirements.txt").write_text("requests==2.31.0\n")
+        pkgs = scan_disk_path_native(tmp_path)
+        # Should not crash; packages from both sources present
+        names = {p.name for p in pkgs}
+        assert "requests" in names
+        assert "curl" in names
+
+    def test_empty_directory_returns_empty(self, tmp_path):
+        pkgs = scan_disk_path_native(tmp_path)
+        assert pkgs == []
+
+
+# ── parse_pip_environment ─────────────────────────────────────────────────────
+
+
+class TestParsePipEnvironment:
+    def test_parses_current_environment(self):
+        """Runs pip list on the current env — should find at least pytest."""
+        pkgs = parse_pip_environment()
+        names = {p.name.lower() for p in pkgs}
+        assert "pytest" in names
+
+    def test_ecosystem_is_pypi(self):
+        pkgs = parse_pip_environment()
+        assert all(p.ecosystem == "pypi" for p in pkgs)
+
+    def test_versions_are_strings(self):
+        pkgs = parse_pip_environment()
+        assert all(isinstance(p.version, str) for p in pkgs)
+
+    def test_purl_format(self):
+        pkgs = parse_pip_environment()
+        by_name = {p.name.lower(): p for p in pkgs}
+        pip_pkg = by_name.get("pip")
+        if pip_pkg:
+            assert pip_pkg.purl.startswith("pkg:pypi/pip@")
+
+    def test_invalid_python_exec_returns_empty(self):
+        pkgs = parse_pip_environment(python_exec="/nonexistent/python")
+        assert pkgs == []
+
+    def test_mock_pip_output(self):
+        """Test parsing with controlled pip JSON output."""
+        fake_output = json.dumps(
+            [
+                {"name": "requests", "version": "2.31.0"},
+                {"name": "Flask", "version": "3.0.0"},
+            ]
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=fake_output, stderr="")
+            pkgs = parse_pip_environment()
+        names = {p.name for p in pkgs}
+        assert "requests" in names
+        assert "Flask" in names
+        assert len(pkgs) == 2
+
+    def test_pip_failure_returns_empty(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            pkgs = parse_pip_environment()
+        assert pkgs == []
+
+    def test_pip_timeout_returns_empty(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=[], timeout=30)):
+            pkgs = parse_pip_environment()
+        assert pkgs == []
+
+    def test_invalid_json_returns_empty(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="not json", stderr="")
+            pkgs = parse_pip_environment()
+        assert pkgs == []
+
+
+# ── scan_filesystem native fallback ───────────────────────────────────────────
+
+
+class TestScanFilesystemNativeFallback:
+    def test_uses_native_when_syft_not_found(self, tmp_path):
+        (tmp_path / "requirements.txt").write_text("requests==2.31.0\n")
+        with patch("shutil.which", return_value=None):
+            pkgs, strategy = scan_filesystem(str(tmp_path))
+        assert strategy == "native-dir"
+        assert any(p.name == "requests" for p in pkgs)
+
+    def test_uses_syft_when_available(self, tmp_path):
+        fake_cdx = json.dumps(
+            {
+                "bomFormat": "CycloneDX",
+                "components": [{"name": "lodash", "version": "4.17.21", "purl": "pkg:npm/lodash@4.17.21", "type": "library"}],
+            }
+        )
+        mock_result = MagicMock(returncode=0, stdout=fake_cdx, stderr="")
+        with patch("shutil.which", return_value="/usr/bin/syft"), patch("subprocess.run", return_value=mock_result):
+            pkgs, strategy = scan_filesystem(str(tmp_path))
+        assert strategy == "syft-dir"
+        assert any(p.name == "lodash" for p in pkgs)
+
+    def test_tar_without_syft_raises(self, tmp_path):
+        tar_file = tmp_path / "archive.tar"
+        tar_file.write_bytes(b"fake tar content")
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(FilesystemScanError, match="syft not found"):
+                scan_filesystem(str(tar_file))


### PR DESCRIPTION
## Summary

Closes #311 (remaining items).

- **`parse_dpkg_status()`** — pure-Python APT/Debian parser reads `var/lib/dpkg/status` directly; no external tool needed; works on live systems and mounted VM disk snapshots
- **`parse_rpm_packages()`** — queries RPM packages via `rpm --dbpath <root>/var/lib/rpm` when the `rpm` binary is available; returns empty list if not
- **`parse_site_packages()`** — walks any `site-packages/` or `dist-packages/` directory for `.dist-info/METADATA` files (PEP 566); pure Python, no pip required
- **`scan_disk_path_native()`** — combines all native parsers (dpkg + rpm + site-packages + project lock files via `scan_project_directory`) into a single call; deduplicates across sources
- **`scan_filesystem()` native fallback** — when Syft is not installed, directories now fall back to `scan_disk_path_native` (strategy = `"native-dir"`) instead of raising; tar archives still require Syft
- **`parse_pip_environment()`** — runs `python -m pip list --format=json` on any Python interpreter (defaults to `sys.executable`); safe timeout, returns empty on failure

## What this closes in #311
- ✅ VM disk snapshot scanning (APT + site-packages — pure Python, no Syft needed)
- ✅ Python environment SBOM via `pip list` (no lock file required)
- ✅ RPM/RHEL support (when `rpm` binary available)

## No breaking changes
- `scan_filesystem()` signature unchanged — callers get a new possible strategy value `"native-dir"`, old `"syft-dir"` / `"syft-tar"` unchanged
- `parse_pip_environment()` is additive — new function, no existing callers changed

## Test plan
- [ ] 32 new tests in `tests/test_native_disk_scan.py` — all parsers, fallback, mocks
- [ ] `tests/test_filesystem.py` updated — `test_syft_not_found` split into native-fallback test + tar-raises test
- [ ] 3,683 total tests pass