### PR TITLE
feat: process and container MCP server discovery (#304 #305)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ ai-enrich = ["litellm>=1.30"]
 graph = ["networkx>=3.0"]
 postgres = ["psycopg[binary]>=3.1", "psycopg-pool>=3.1"]
 watch = ["watchdog>=4.0"]
+runtime = ["psutil>=5.9"]  # Process + container discovery (--include-processes)
 mcp-server = [
     "mcp>=1.26",
     "smithery>=0.4",

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -453,6 +453,16 @@ def main():
     help="Max directory depth for dynamic discovery filesystem scanning",
 )
 @click.option(
+    "--include-processes",
+    is_flag=True,
+    help="Scan running host processes for MCP servers (requires psutil: pip install psutil)",
+)
+@click.option(
+    "--include-containers",
+    is_flag=True,
+    help="Scan running Docker containers for MCP servers (requires docker CLI on PATH)",
+)
+@click.option(
     "--ai-enrich",
     is_flag=True,
     help="Enrich findings with LLM-generated risk narratives, executive summary, and threat chains. Auto-detects Ollama (free, local) or uses litellm (pip install 'agent-bom[ai-enrich]')",
@@ -708,6 +718,8 @@ def scan(
     graph_backend: str,
     dynamic_discovery: bool,
     dynamic_max_depth: int,
+    include_processes: bool,
+    include_containers: bool,
     ai_enrich: bool,
     ai_model: str,
     aws: bool,
@@ -1047,9 +1059,21 @@ def scan(
         con.print(f"  [green]✓[/green] Loaded {len(agents)} agent(s) from inventory")
     elif not skill_only and config_dir:
         con.print(f"\n[bold blue]Scanning config directory: {config_dir}...[/bold blue]\n")
-        agents = discover_all(project_dir=config_dir, dynamic=dynamic_discovery, dynamic_max_depth=dynamic_max_depth)
+        agents = discover_all(
+            project_dir=config_dir,
+            dynamic=dynamic_discovery,
+            dynamic_max_depth=dynamic_max_depth,
+            include_processes=include_processes,
+            include_containers=include_containers,
+        )
     elif not skill_only:
-        agents = discover_all(project_dir=project, dynamic=dynamic_discovery, dynamic_max_depth=dynamic_max_depth)
+        agents = discover_all(
+            project_dir=project,
+            dynamic=dynamic_discovery,
+            dynamic_max_depth=dynamic_max_depth,
+            include_processes=include_processes,
+            include_containers=include_containers,
+        )
 
     any_cloud = (
         aws

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -1051,10 +1051,258 @@ def discover_compose_mcp_servers(project_dir: Optional[str] = None) -> Optional[
     )
 
 
+# ─── MCP process command patterns ─────────────────────────────────────────────
+#
+# Substrings that, when found in a process's command line, indicate it may be
+# an MCP server.  All comparisons are case-insensitive.
+_MCP_PROCESS_PATTERNS: tuple[str, ...] = (
+    "mcp-server",
+    "@modelcontextprotocol/",
+    "mcp_server",
+    "mcpserver",
+    "uvx mcp",
+    "npx mcp",
+    "python -m mcp",
+)
+
+# Env vars that signal an MCP server process (prefix match, uppercase)
+_MCP_ENV_SIGNALS: tuple[str, ...] = ("MCP_SERVER", "MCP_PORT", "MCP_TRANSPORT", "MCP_HOST")
+
+
+def discover_running_processes() -> Optional[Agent]:
+    """Discover locally running MCP server processes via psutil.
+
+    Iterates all processes on the host and matches command lines against
+    known MCP server patterns (npm/npx @modelcontextprotocol/*, uvx mcp-server-*,
+    python -m mcp*, etc.).  Each matching process becomes an MCPServer entry.
+
+    Requires ``psutil`` (``pip install psutil`` or ``agent-bom[runtime]``).
+    Returns None if psutil is not installed or no MCP processes are found.
+    """
+    try:
+        import psutil
+    except ImportError:
+        logger.debug("psutil not installed — skipping process discovery (pip install psutil)")
+        return None
+
+    mcp_servers: list[MCPServer] = []
+
+    for proc in psutil.process_iter(["pid", "name", "cmdline", "environ", "cwd"]):
+        try:
+            info = proc.info
+            cmdline: list[str] = info.get("cmdline") or []
+            if not cmdline:
+                continue
+
+            cmd_str = " ".join(cmdline).lower()
+            if not any(pat in cmd_str for pat in _MCP_PROCESS_PATTERNS):
+                continue
+
+            # Try to read environment (may raise AccessDenied on some platforms)
+            try:
+                raw_env: dict[str, str] = info.get("environ") or {}
+            except (psutil.AccessDenied, psutil.ZombieProcess):
+                raw_env = {}
+
+            # Check env signals too — catch MCP servers not matching cmd patterns
+            env_signals = any(k.upper().startswith(_MCP_ENV_SIGNALS) for k in raw_env)
+            if not any(pat in cmd_str for pat in _MCP_PROCESS_PATTERNS) and not env_signals:
+                continue
+
+            env = sanitize_env_vars({k: str(v) for k, v in raw_env.items()})
+
+            # Derive a human-readable name from the command
+            args = cmdline[1:] if len(cmdline) > 1 else []
+            # Use the first arg that looks like a package/module name as the server name
+            name_parts = [p for p in args if p.startswith("@") or "mcp" in p.lower()]
+            server_name = name_parts[0].split("/")[-1] if name_parts else f"process-{info['pid']}"
+
+            # Determine transport from env or args
+            transport = TransportType.STDIO
+            if "--transport" in args:
+                idx = args.index("--transport")
+                if idx + 1 < len(args):
+                    t = args[idx + 1].lower()
+                    if "sse" in t:
+                        transport = TransportType.SSE
+                    elif "http" in t:
+                        transport = TransportType.STREAMABLE_HTTP
+
+            working_dir = info.get("cwd")
+
+            server = MCPServer(
+                name=server_name,
+                command=cmdline[0],
+                args=args,
+                env=env,
+                transport=transport,
+                config_path=f"pid:{info['pid']}",
+                working_dir=working_dir,
+            )
+            mcp_servers.append(server)
+
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+    if not mcp_servers:
+        return None
+
+    return Agent(
+        name="running-processes",
+        agent_type=AgentType.CUSTOM,
+        config_path="psutil://processes",
+        mcp_servers=mcp_servers,
+        source="process",
+    )
+
+
+def discover_container_labels() -> Optional[Agent]:
+    """Discover MCP server containers running locally via Docker.
+
+    Uses ``docker ps`` + ``docker inspect`` (no SDK required) to enumerate
+    running containers and identify those whose images, labels, or environment
+    variables indicate an MCP server.
+
+    Returns None if Docker is not available or no MCP containers are found.
+    """
+    if not shutil.which("docker"):
+        return None
+
+    try:
+        ps_result = subprocess.run(
+            ["docker", "ps", "--format", "{{.ID}}"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    if ps_result.returncode != 0:
+        return None
+
+    container_ids = [cid.strip() for cid in ps_result.stdout.splitlines() if cid.strip()]
+    if not container_ids:
+        return None
+
+    mcp_servers: list[MCPServer] = []
+
+    for cid in container_ids:
+        try:
+            inspect_result = subprocess.run(
+                ["docker", "inspect", "--format", "{{json .}}", cid],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+
+        if inspect_result.returncode != 0:
+            continue
+
+        try:
+            info = json.loads(inspect_result.stdout)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        # Normalise: docker inspect returns a list when called without --format json
+        if isinstance(info, list):
+            if not info:
+                continue
+            info = info[0]
+
+        image_name: str = info.get("Config", {}).get("Image", "") or ""
+        labels: dict[str, str] = info.get("Config", {}).get("Labels") or {}
+        cmd: list[str] = info.get("Config", {}).get("Cmd") or []
+        entrypoint: list[str] = info.get("Config", {}).get("Entrypoint") or []
+
+        # Collect raw env list → dict
+        raw_env_list: list[str] = info.get("Config", {}).get("Env") or []
+        raw_env: dict[str, str] = {}
+        for entry in raw_env_list:
+            if "=" in entry:
+                k, _, v = entry.partition("=")
+                raw_env[k] = v
+
+        image_lower = image_name.lower()
+        label_vals = " ".join(labels.values()).lower()
+        label_keys = " ".join(labels.keys()).lower()
+        cmd_str = " ".join(cmd + entrypoint).lower()
+        env_keys = " ".join(raw_env.keys()).upper()
+
+        is_mcp = (
+            "mcp" in image_lower
+            or any(p in image_lower for p in ("modelcontextprotocol", "mcp-server", "mcp_server"))
+            or "mcp" in label_vals
+            or "mcp" in label_keys
+            or "mcp" in cmd_str
+            or any(k.startswith(_MCP_ENV_SIGNALS) for k in env_keys.split())
+        )
+
+        if not is_mcp:
+            continue
+
+        env = sanitize_env_vars(raw_env)
+
+        # Name: prefer label, fall back to image basename, then short container ID
+        server_name = (
+            labels.get("mcp.name") or labels.get("org.opencontainers.image.title") or image_lower.split("/")[-1].split(":")[0] or cid[:12]
+        )
+
+        # Transport: SSE if any port is exposed, else STDIO
+        ports = info.get("NetworkSettings", {}).get("Ports") or {}
+        transport = TransportType.SSE if ports else TransportType.STDIO
+        url: Optional[str] = None
+        if ports:
+            for port_spec, bindings in ports.items():
+                if bindings:
+                    host_port = bindings[0].get("HostPort")
+                    if host_port:
+                        url = f"http://localhost:{host_port}"
+                        break
+
+        from agent_bom.models import Package
+
+        packages = [
+            Package(
+                name=image_name.split(":")[0],
+                version=image_name.split(":")[-1] if ":" in image_name else "latest",
+                ecosystem="docker",
+                is_direct=True,
+            )
+        ]
+
+        server = MCPServer(
+            name=server_name,
+            command=f"docker run {image_name}",
+            args=[],
+            env=env,
+            transport=transport,
+            url=url,
+            packages=packages,
+            config_path=f"docker://{cid[:12]}",
+        )
+        mcp_servers.append(server)
+
+    if not mcp_servers:
+        return None
+
+    return Agent(
+        name="docker-containers",
+        agent_type=AgentType.CUSTOM,
+        config_path="docker://localhost",
+        mcp_servers=mcp_servers,
+        source="container",
+    )
+
+
 def discover_all(
     project_dir: Optional[str] = None,
     dynamic: bool = False,
     dynamic_max_depth: int = 4,
+    include_processes: bool = False,
+    include_containers: bool = False,
 ) -> list[Agent]:
     """Run full discovery: global configs + project configs + CLI agents.
 
@@ -1062,6 +1310,8 @@ def discover_all(
         project_dir: Optional project directory to scan.
         dynamic: Enable dynamic content-based discovery layer.
         dynamic_max_depth: Maximum depth for dynamic filesystem scanning.
+        include_processes: Also scan running host processes for MCP servers (psutil).
+        include_containers: Also scan running Docker containers for MCP servers.
     """
     console.print("\n[bold blue]🔍 Discovering MCP configurations...[/bold blue]\n")
 
@@ -1102,6 +1352,24 @@ def discover_all(
         else:
             console.print("  [dim]  docker-mcp: installed but not configured[/dim]")
         agents.append(docker_agent)
+
+    # Running process discovery (opt-in, requires psutil)
+    if include_processes:
+        proc_agent = discover_running_processes()
+        if proc_agent:
+            console.print(f"  [green]✓[/green] Found {len(proc_agent.mcp_servers)} MCP server process(es) via psutil")
+            agents.append(proc_agent)
+        else:
+            console.print("  [dim]  process scan: no MCP server processes found[/dim]")
+
+    # Docker container discovery (opt-in)
+    if include_containers:
+        container_agent = discover_container_labels()
+        if container_agent:
+            console.print(f"  [green]✓[/green] Found {len(container_agent.mcp_servers)} MCP container(s) via docker inspect")
+            agents.append(container_agent)
+        else:
+            console.print("  [dim]  container scan: no MCP containers found (or docker not running)[/dim]")
 
     # Detect installed-but-not-configured agents
     discovered_types = {a.agent_type for a in agents}

--- a/tests/test_discovery_process_container.py
+++ b/tests/test_discovery_process_container.py
@@ -1,0 +1,549 @@
+"""Tests for process and container MCP server discovery.
+
+Both discovery functions are purely opt-in and degrade gracefully when
+their dependencies (psutil / docker CLI) are absent.  All tests mock
+external dependencies so the suite runs in CI without psutil installed
+or Docker running.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from agent_bom.discovery import discover_container_labels, discover_running_processes
+from agent_bom.models import AgentType, TransportType
+
+# ─── discover_running_processes ───────────────────────────────────────────────
+
+
+def _make_proc(pid: int, cmdline: list[str], environ: dict | None = None, cwd: str = "/tmp") -> MagicMock:
+    """Build a mock psutil.Process with the given attributes."""
+    proc = MagicMock()
+    proc.info = {
+        "pid": pid,
+        "name": cmdline[0].rsplit("/", 1)[-1] if cmdline else "",
+        "cmdline": cmdline,
+        "environ": environ or {},
+        "cwd": cwd,
+    }
+    return proc
+
+
+def test_returns_none_when_psutil_not_installed():
+    """Graceful fallback when psutil is not installed."""
+    with patch.dict("sys.modules", {"psutil": None}):
+        # Re-import to trigger the ImportError path
+        import importlib
+
+        import agent_bom.discovery as disc
+
+        importlib.reload(disc)
+        result = disc.discover_running_processes()
+
+    assert result is None
+
+
+def test_returns_none_when_no_mcp_processes():
+    """No MCP processes → None (not an empty Agent)."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(1001, ["python", "my_script.py"]),
+        _make_proc(1002, ["node", "app.js"]),
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        result = discover_running_processes()
+
+    assert result is None
+
+
+def test_detects_npx_modelcontextprotocol_process():
+    """npx @modelcontextprotocol/server-filesystem detected as MCP server."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(
+            2001,
+            ["node", "/usr/local/lib/node_modules/npx", "@modelcontextprotocol/server-filesystem", "/home/user/docs"],
+        ),
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    assert agent is not None
+    assert len(agent.mcp_servers) == 1
+    assert agent.source == "process"
+    assert agent.agent_type == AgentType.CUSTOM
+    assert "modelcontextprotocol" in agent.mcp_servers[0].name.lower() or "server-filesystem" in agent.mcp_servers[0].name.lower()
+
+
+def test_detects_uvx_mcp_server_process():
+    """uvx mcp-server-fetch detected."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(3001, ["uvx", "mcp-server-fetch"]),
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    assert agent is not None
+    assert len(agent.mcp_servers) >= 1
+    assert agent.mcp_servers[0].command == "uvx"
+
+
+def test_detects_mcp_server_in_name():
+    """Process with mcp-server in its executable name is detected."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(4001, ["/usr/local/bin/mcp-server", "--transport", "sse", "--port", "8080"]),
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    assert agent is not None
+    srv = agent.mcp_servers[0]
+    assert srv.transport == TransportType.SSE
+
+
+def test_skips_inaccessible_processes():
+    """Processes raising AccessDenied are silently skipped."""
+    mock_psutil = MagicMock()
+    bad_proc = MagicMock()
+    bad_proc.info = {"pid": 9999, "name": "denied", "cmdline": None, "environ": {}, "cwd": None}
+
+    good_proc = _make_proc(5001, ["node", "@modelcontextprotocol/server-filesystem"])
+    mock_psutil.process_iter.return_value = [bad_proc, good_proc]
+    mock_psutil.NoSuchProcess = ProcessLookupError
+    mock_psutil.AccessDenied = PermissionError
+    mock_psutil.ZombieProcess = ChildProcessError
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    # Should still find the good process
+    assert agent is not None
+
+
+def test_sse_transport_detected_from_args():
+    """--transport sse in process args sets transport to SSE."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(6001, ["uvx", "mcp-server-fetch", "--transport", "sse"]),
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    assert agent is not None
+    assert agent.mcp_servers[0].transport == TransportType.SSE
+
+
+def test_env_vars_are_sanitized():
+    """Credential env vars in process environment are sanitized (value redacted)."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(7001, ["uvx", "mcp-server-fetch"], environ={"API_KEY": "super-secret", "HOME": "/home/user"}),
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    assert agent is not None
+    env = agent.mcp_servers[0].env
+    assert env.get("API_KEY") != "super-secret"  # must be redacted
+
+
+def test_process_config_path_contains_pid():
+    """config_path for process-discovered servers contains the PID."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(8001, ["node", "@modelcontextprotocol/server-filesystem"]),
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    assert agent is not None
+    assert "8001" in agent.mcp_servers[0].config_path
+
+
+def test_multiple_mcp_processes_all_captured():
+    """Multiple MCP processes result in multiple MCPServer entries."""
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [
+        _make_proc(9001, ["node", "@modelcontextprotocol/server-filesystem"]),
+        _make_proc(9002, ["uvx", "mcp-server-fetch"]),
+        _make_proc(9003, ["python", "my_script.py"]),  # not MCP
+    ]
+    mock_psutil.NoSuchProcess = Exception
+    mock_psutil.AccessDenied = Exception
+    mock_psutil.ZombieProcess = Exception
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        agent = discover_running_processes()
+
+    assert agent is not None
+    assert len(agent.mcp_servers) == 2
+
+
+# ─── discover_container_labels ────────────────────────────────────────────────
+
+
+def _docker_inspect_json(
+    cid: str,
+    image: str,
+    labels: dict | None = None,
+    env: list[str] | None = None,
+    cmd: list[str] | None = None,
+    ports: dict | None = None,
+) -> str:
+    """Build a minimal docker inspect JSON payload."""
+    return json.dumps(
+        {
+            "Id": cid,
+            "Config": {
+                "Image": image,
+                "Labels": labels or {},
+                "Env": env or [],
+                "Cmd": cmd or [],
+                "Entrypoint": [],
+            },
+            "NetworkSettings": {"Ports": ports or {}},
+        }
+    )
+
+
+def _run_side_effects(ps_stdout: str, inspect_outputs: list[str]):
+    """Build side_effect list for subprocess.run mocks."""
+
+    def _side_effect(cmd, **kwargs):
+        mock_result = MagicMock()
+        if cmd[0] == "docker" and cmd[1] == "ps":
+            mock_result.returncode = 0
+            mock_result.stdout = ps_stdout
+        elif cmd[0] == "docker" and cmd[1] == "inspect":
+            if inspect_outputs:
+                mock_result.returncode = 0
+                mock_result.stdout = inspect_outputs.pop(0)
+            else:
+                mock_result.returncode = 1
+                mock_result.stdout = ""
+        return mock_result
+
+    return _side_effect
+
+
+def test_container_returns_none_when_docker_not_installed():
+    """Returns None when docker is not on PATH."""
+    with patch("shutil.which", return_value=None):
+        result = discover_container_labels()
+    assert result is None
+
+
+def test_container_returns_none_when_no_containers_running():
+    """Returns None when docker ps returns an empty list."""
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        result = discover_container_labels()
+    assert result is None
+
+
+def test_container_returns_none_when_docker_ps_fails():
+    """Returns None when docker ps exits non-zero."""
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        result = discover_container_labels()
+    assert result is None
+
+
+def test_container_detects_mcp_image_name():
+    """Container with 'mcp-server' in image name is detected."""
+    cid = "abc123def456"
+    inspect_json = _docker_inspect_json(cid, "ghcr.io/modelcontextprotocol/mcp-server-fetch:latest")
+
+    def _side_effect(cmd, **kwargs):
+        m = MagicMock()
+        if cmd[1] == "ps":
+            m.returncode = 0
+            m.stdout = cid + "\n"
+        else:
+            m.returncode = 0
+            m.stdout = inspect_json
+        return m
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("agent_bom.discovery.subprocess.run", side_effect=_side_effect),
+    ):
+        agent = discover_container_labels()
+
+    assert agent is not None
+    assert len(agent.mcp_servers) == 1
+    assert agent.source == "container"
+    assert agent.agent_type == AgentType.CUSTOM
+
+
+def test_container_detects_mcp_label():
+    """Container with mcp label is detected even without mcp in image name."""
+    cid = "bcd234eff567"
+    inspect_json = _docker_inspect_json(
+        cid,
+        "my-custom-server:1.0",
+        labels={"mcp.name": "my-custom-server", "version": "1.0"},
+    )
+
+    def _side_effect(cmd, **kwargs):
+        m = MagicMock()
+        if cmd[1] == "ps":
+            m.returncode = 0
+            m.stdout = cid + "\n"
+        else:
+            m.returncode = 0
+            m.stdout = inspect_json
+        return m
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("agent_bom.discovery.subprocess.run", side_effect=_side_effect),
+    ):
+        agent = discover_container_labels()
+
+    assert agent is not None
+    assert agent.mcp_servers[0].name == "my-custom-server"
+
+
+def test_container_detects_mcp_env_var():
+    """Container with MCP_SERVER env var is detected."""
+    cid = "cde345f00678"
+    inspect_json = _docker_inspect_json(
+        cid,
+        "custom-server:2.0",
+        env=["MCP_SERVER_PORT=3000", "HOME=/root"],
+    )
+
+    def _side_effect(cmd, **kwargs):
+        m = MagicMock()
+        if cmd[1] == "ps":
+            m.returncode = 0
+            m.stdout = cid + "\n"
+        else:
+            m.returncode = 0
+            m.stdout = inspect_json
+        return m
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("agent_bom.discovery.subprocess.run", side_effect=_side_effect),
+    ):
+        agent = discover_container_labels()
+
+    assert agent is not None
+    assert len(agent.mcp_servers) == 1
+
+
+def test_container_skips_non_mcp_containers():
+    """Containers with no MCP signals are excluded."""
+    cid = "def456a00789"
+    inspect_json = _docker_inspect_json(cid, "nginx:latest", env=["NGINX_PORT=80"])
+
+    def _side_effect(cmd, **kwargs):
+        m = MagicMock()
+        if cmd[1] == "ps":
+            m.returncode = 0
+            m.stdout = cid + "\n"
+        else:
+            m.returncode = 0
+            m.stdout = inspect_json
+        return m
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("agent_bom.discovery.subprocess.run", side_effect=_side_effect),
+    ):
+        result = discover_container_labels()
+
+    assert result is None
+
+
+def test_container_sse_transport_when_ports_exposed():
+    """Container with exposed ports gets SSE transport."""
+    cid = "f00123abc456"
+    inspect_json = _docker_inspect_json(
+        cid,
+        "mcp-server-custom:1.0",
+        ports={"3000/tcp": [{"HostIp": "0.0.0.0", "HostPort": "3000"}]},
+    )
+
+    def _side_effect(cmd, **kwargs):
+        m = MagicMock()
+        if cmd[1] == "ps":
+            m.returncode = 0
+            m.stdout = cid + "\n"
+        else:
+            m.returncode = 0
+            m.stdout = inspect_json
+        return m
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("agent_bom.discovery.subprocess.run", side_effect=_side_effect),
+    ):
+        agent = discover_container_labels()
+
+    assert agent is not None
+    srv = agent.mcp_servers[0]
+    assert srv.transport == TransportType.SSE
+    assert srv.url == "http://localhost:3000"
+
+
+def test_container_env_vars_are_sanitized():
+    """Sensitive env vars in containers are sanitized."""
+    cid = "a1b2c3d4e5f6"
+    inspect_json = _docker_inspect_json(
+        cid,
+        "mcp-server-fetch:latest",
+        env=["OPENAI_API_KEY=sk-secret123", "MCP_PORT=8080"],
+    )
+
+    def _side_effect(cmd, **kwargs):
+        m = MagicMock()
+        if cmd[1] == "ps":
+            m.returncode = 0
+            m.stdout = cid + "\n"
+        else:
+            m.returncode = 0
+            m.stdout = inspect_json
+        return m
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("agent_bom.discovery.subprocess.run", side_effect=_side_effect),
+    ):
+        agent = discover_container_labels()
+
+    assert agent is not None
+    env = agent.mcp_servers[0].env
+    assert env.get("OPENAI_API_KEY") != "sk-secret123"
+
+
+def test_container_multiple_mcp_containers():
+    """Multiple MCP containers each become separate MCPServer entries."""
+    ids = ["aaa111", "bbb222"]
+    inspect_outputs = [
+        _docker_inspect_json("aaa111", "mcp-server-fetch:latest"),
+        _docker_inspect_json("bbb222", "mcp-server-filesystem:latest"),
+    ]
+
+    call_count = {"inspect": 0}
+
+    def _side_effect(cmd, **kwargs):
+        m = MagicMock()
+        if cmd[1] == "ps":
+            m.returncode = 0
+            m.stdout = "\n".join(ids) + "\n"
+        else:
+            m.returncode = 0
+            idx = call_count["inspect"]
+            m.stdout = inspect_outputs[idx] if idx < len(inspect_outputs) else "{}"
+            call_count["inspect"] += 1
+        return m
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("agent_bom.discovery.subprocess.run", side_effect=_side_effect),
+    ):
+        agent = discover_container_labels()
+
+    assert agent is not None
+    assert len(agent.mcp_servers) == 2
+
+
+# ─── discover_all integration ─────────────────────────────────────────────────
+
+
+def test_discover_all_skips_processes_by_default():
+    """discover_all does NOT call process discovery unless include_processes=True."""
+    with (
+        patch("agent_bom.discovery.discover_global_configs", return_value=[]),
+        patch("agent_bom.discovery.discover_project_configs", return_value=[]),
+        patch("agent_bom.discovery.discover_compose_mcp_servers", return_value=None),
+        patch("agent_bom.discovery.discover_toolhive", return_value=None),
+        patch("agent_bom.discovery.discover_docker_mcp", return_value=None),
+        patch("agent_bom.discovery.detect_installed_agents", return_value=[]),
+        patch("agent_bom.discovery.discover_running_processes") as mock_proc,
+        patch("agent_bom.discovery.discover_container_labels") as mock_cont,
+    ):
+        from agent_bom.discovery import discover_all
+
+        discover_all()
+
+    mock_proc.assert_not_called()
+    mock_cont.assert_not_called()
+
+
+def test_discover_all_calls_process_discovery_when_flagged():
+    """discover_all calls discover_running_processes when include_processes=True."""
+    with (
+        patch("agent_bom.discovery.discover_global_configs", return_value=[]),
+        patch("agent_bom.discovery.discover_project_configs", return_value=[]),
+        patch("agent_bom.discovery.discover_compose_mcp_servers", return_value=None),
+        patch("agent_bom.discovery.discover_toolhive", return_value=None),
+        patch("agent_bom.discovery.discover_docker_mcp", return_value=None),
+        patch("agent_bom.discovery.detect_installed_agents", return_value=[]),
+        patch("agent_bom.discovery.discover_running_processes", return_value=None) as mock_proc,
+        patch("agent_bom.discovery.discover_container_labels", return_value=None),
+    ):
+        from agent_bom.discovery import discover_all
+
+        discover_all(include_processes=True)
+
+    mock_proc.assert_called_once()
+
+
+def test_discover_all_calls_container_discovery_when_flagged():
+    """discover_all calls discover_container_labels when include_containers=True."""
+    with (
+        patch("agent_bom.discovery.discover_global_configs", return_value=[]),
+        patch("agent_bom.discovery.discover_project_configs", return_value=[]),
+        patch("agent_bom.discovery.discover_compose_mcp_servers", return_value=None),
+        patch("agent_bom.discovery.discover_toolhive", return_value=None),
+        patch("agent_bom.discovery.discover_docker_mcp", return_value=None),
+        patch("agent_bom.discovery.detect_installed_agents", return_value=[]),
+        patch("agent_bom.discovery.discover_running_processes", return_value=None),
+        patch("agent_bom.discovery.discover_container_labels", return_value=None) as mock_cont,
+    ):
+        from agent_bom.discovery import discover_all
+
+        discover_all(include_containers=True)
+
+    mock_cont.assert_called_once()


### PR DESCRIPTION
## Summary

- **`discover_running_processes()`**: uses psutil to scan host processes for MCP servers matching patterns like `npx @modelcontextprotocol/*`, `uvx mcp-server-*`, `python -m mcp*`. Exposed via `--include-processes` flag.
- **`discover_container_labels()`**: uses `docker inspect` (no SDK) to find running containers with MCP signals (image name, labels, env vars, entrypoint). Exposed via `--include-containers` flag.
- Both wire into `discover_all()` as opt-in — gracefully return `None` when psutil/docker unavailable, so scans never block.
- Added `psutil>=5.9` as `agent-bom[runtime]` optional dependency.

## Test plan

- [ ] 23 new tests in `tests/test_discovery_process_container.py` — all pass offline (no psutil or Docker required in CI)
- [ ] `--include-processes` with psutil installed detects running MCP servers
- [ ] `--include-containers` with docker running detects MCP containers
- [ ] Both flags omitted → neither function called (existing behavior unchanged)
- [ ] `ruff` + `ruff-format` clean