### PR TITLE
feat: post-discovery MCP server health checks (#306)

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -463,6 +463,19 @@ def main():
     help="Scan running Docker containers for MCP servers (requires docker CLI on PATH)",
 )
 @click.option(
+    "--health-check",
+    "health_check",
+    is_flag=True,
+    help="Probe discovered MCP servers for liveness (reachability + tool count, requires mcp SDK)",
+)
+@click.option(
+    "--hc-timeout",
+    type=float,
+    default=5.0,
+    show_default=True,
+    help="Timeout per server for --health-check (seconds)",
+)
+@click.option(
     "--ai-enrich",
     is_flag=True,
     help="Enrich findings with LLM-generated risk narratives, executive summary, and threat chains. Auto-detects Ollama (free, local) or uses litellm (pip install 'agent-bom[ai-enrich]')",
@@ -748,6 +761,8 @@ def scan(
     dynamic_max_depth: int,
     include_processes: bool,
     include_containers: bool,
+    health_check: bool,
+    hc_timeout: float,
     ai_enrich: bool,
     ai_model: str,
     aws: bool,
@@ -2153,6 +2168,27 @@ def scan(
                     con.print(f"\n  [bold]{enriched} server(s) enriched with runtime data.[/bold]")
                 _intro_report = intro_report
             except IntrospectionError as exc:
+                con.print(f"  [yellow]⚠[/yellow] {exc}")
+
+        # Step 2b-hc: Post-discovery health checks (--health-check)
+        if health_check:
+            from agent_bom.mcp_introspect import IntrospectionError as _HCError
+            from agent_bom.mcp_introspect import health_check_servers_sync
+
+            hc_servers = [s for a in agents for s in a.mcp_servers]
+            con.print(f"\n[bold blue]Health-checking {len(hc_servers)} MCP server(s)...[/bold blue]\n")
+            try:
+                hc_results = health_check_servers_sync(hc_servers, timeout=hc_timeout)
+                reachable = sum(1 for h in hc_results if h.reachable)
+                for h in hc_results:
+                    if h.reachable:
+                        latency_str = f" {h.latency_ms:.0f}ms" if h.latency_ms is not None else ""
+                        proto_str = f" [{h.protocol_version}]" if h.protocol_version else ""
+                        con.print(f"  [green]✓[/green] {h.server_name}: {h.tool_count} tool(s){latency_str}{proto_str}")
+                    else:
+                        con.print(f"  [red]✗[/red] {h.server_name}: {h.error or 'unreachable'}")
+                con.print(f"\n  [bold]{reachable}/{len(hc_results)} server(s) reachable.[/bold]")
+            except _HCError as exc:
                 con.print(f"  [yellow]⚠[/yellow] {exc}")
 
         # Step 2c: Tool poisoning detection + enforcement (--enforce)

--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -312,6 +312,83 @@ def introspect_servers_sync(
     return asyncio.run(introspect_servers(servers, timeout))
 
 
+# ── Health Checks ────────────────────────────────────────────────────────────
+
+HEALTH_CHECK_TIMEOUT = 5.0
+
+
+@dataclass
+class HealthStatus:
+    """Lightweight health status for a single MCP server."""
+
+    server_name: str
+    reachable: bool
+    tool_count: int = 0
+    protocol_version: Optional[str] = None
+    latency_ms: Optional[float] = None
+    error: Optional[str] = None
+
+
+async def health_check_servers(
+    servers: list[MCPServer],
+    timeout: float = HEALTH_CHECK_TIMEOUT,
+    max_concurrent: int = 10,
+) -> list[HealthStatus]:
+    """Lightweight health check for MCP servers.
+
+    Faster than full introspection — uses a shorter default timeout and
+    returns simple reachability + tool count without drift analysis.
+
+    Args:
+        servers: List of MCP servers to probe.
+        timeout: Per-server connection timeout in seconds.
+        max_concurrent: Maximum concurrent probes.
+
+    Returns:
+        List of HealthStatus, one per eligible server.
+    """
+    import time
+
+    _check_mcp_sdk()
+
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def _probe(server: MCPServer) -> HealthStatus:
+        async with semaphore:
+            t0 = time.perf_counter()
+            result = await introspect_server(server, timeout)
+            elapsed_ms = round((time.perf_counter() - t0) * 1000.0, 1)
+            return HealthStatus(
+                server_name=result.server_name,
+                reachable=result.success,
+                tool_count=result.tool_count,
+                protocol_version=result.protocol_version,
+                latency_ms=elapsed_ms if result.success else None,
+                error=result.error,
+            )
+
+    eligible = [
+        s
+        for s in servers
+        if (s.transport == TransportType.STDIO and s.command)
+        or (s.transport in (TransportType.SSE, TransportType.STREAMABLE_HTTP) and s.url)
+    ]
+
+    if not eligible:
+        return []
+
+    tasks = [_probe(s) for s in eligible]
+    return list(await asyncio.gather(*tasks))
+
+
+def health_check_servers_sync(
+    servers: list[MCPServer],
+    timeout: float = HEALTH_CHECK_TIMEOUT,
+) -> list[HealthStatus]:
+    """Synchronous wrapper for health_check_servers."""
+    return asyncio.run(health_check_servers(servers, timeout))
+
+
 def enrich_servers(
     servers: list[MCPServer],
     report: IntrospectionReport,

--- a/tests/test_health_checks.py
+++ b/tests/test_health_checks.py
@@ -1,0 +1,256 @@
+"""Tests for MCP server health checks (#306).
+
+Tests cover:
+- HealthStatus dataclass fields and defaults
+- health_check_servers() with all-reachable, all-unreachable, mixed results
+- Ineligible servers (no command/URL) are skipped
+- Latency is measured and populated on success
+- health_check_servers_sync() wrapper
+- CLI --health-check flag wiring (smoke test)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_bom.mcp_introspect import (
+    HEALTH_CHECK_TIMEOUT,
+    HealthStatus,
+    health_check_servers,
+    health_check_servers_sync,
+)
+from agent_bom.models import MCPServer, TransportType
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _stdio_server(name: str = "srv", command: str = "mcp-server") -> MCPServer:
+    return MCPServer(name=name, command=command, transport=TransportType.STDIO)
+
+
+def _sse_server(name: str = "srv-sse", url: str = "http://localhost:9000") -> MCPServer:
+    return MCPServer(name=name, url=url, transport=TransportType.SSE)
+
+
+def _no_cmd_server(name: str = "srv-no-cmd") -> MCPServer:
+    return MCPServer(name=name, command="", transport=TransportType.STDIO)
+
+
+def _mock_reachable(server_name: str, tool_count: int = 3) -> MagicMock:
+    """Return a mock ServerIntrospection for a reachable server."""
+    m = MagicMock()
+    m.server_name = server_name
+    m.success = True
+    m.tool_count = tool_count
+    m.protocol_version = "2024-11-05"
+    m.error = None
+    return m
+
+
+def _mock_unreachable(server_name: str, error: str = "Connection refused") -> MagicMock:
+    m = MagicMock()
+    m.server_name = server_name
+    m.success = False
+    m.tool_count = 0
+    m.protocol_version = None
+    m.error = error
+    return m
+
+
+# ─── HealthStatus dataclass ────────────────────────────────────────────────────
+
+
+def test_health_status_fields():
+    h = HealthStatus(server_name="s", reachable=True, tool_count=5, protocol_version="2024-11-05", latency_ms=42.0)
+    assert h.server_name == "s"
+    assert h.reachable is True
+    assert h.tool_count == 5
+    assert h.protocol_version == "2024-11-05"
+    assert h.latency_ms == 42.0
+    assert h.error is None
+
+
+def test_health_status_defaults():
+    h = HealthStatus(server_name="x", reachable=False)
+    assert h.tool_count == 0
+    assert h.protocol_version is None
+    assert h.latency_ms is None
+    assert h.error is None
+
+
+def test_health_check_timeout_default():
+    assert HEALTH_CHECK_TIMEOUT == 5.0
+
+
+# ─── health_check_servers() ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_check_all_reachable():
+    servers = [_stdio_server("a"), _stdio_server("b")]
+    results_map = {
+        "a": _mock_reachable("a", tool_count=2),
+        "b": _mock_reachable("b", tool_count=7),
+    }
+
+    async def _fake_introspect(server, timeout):
+        return results_map[server.name]
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            statuses = await health_check_servers(servers, timeout=5.0)
+
+    assert len(statuses) == 2
+    a = next(s for s in statuses if s.server_name == "a")
+    assert a.reachable is True
+    assert a.tool_count == 2
+    assert a.protocol_version == "2024-11-05"
+    assert a.latency_ms is not None
+    assert a.latency_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_health_check_all_unreachable():
+    servers = [_stdio_server("x"), _sse_server("y")]
+    results_map = {
+        "x": _mock_unreachable("x", "timeout"),
+        "y": _mock_unreachable("y", "refused"),
+    }
+
+    async def _fake_introspect(server, timeout):
+        return results_map[server.name]
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            statuses = await health_check_servers(servers, timeout=5.0)
+
+    assert all(not s.reachable for s in statuses)
+    assert all(s.latency_ms is None for s in statuses)
+
+
+@pytest.mark.asyncio
+async def test_health_check_mixed_results():
+    servers = [_stdio_server("ok"), _stdio_server("fail")]
+    results_map = {
+        "ok": _mock_reachable("ok", tool_count=4),
+        "fail": _mock_unreachable("fail"),
+    }
+
+    async def _fake_introspect(server, timeout):
+        return results_map[server.name]
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            statuses = await health_check_servers(servers, timeout=5.0)
+
+    reachable = [s for s in statuses if s.reachable]
+    unreachable = [s for s in statuses if not s.reachable]
+    assert len(reachable) == 1
+    assert len(unreachable) == 1
+
+
+@pytest.mark.asyncio
+async def test_health_check_skips_ineligible_servers():
+    """Servers with no command/URL are silently skipped."""
+    eligible = _stdio_server("eligible")
+    ineligible = _no_cmd_server("ineligible")
+
+    async def _fake_introspect(server, timeout):
+        return _mock_reachable(server.name)
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            statuses = await health_check_servers([eligible, ineligible], timeout=5.0)
+
+    assert len(statuses) == 1
+    assert statuses[0].server_name == "eligible"
+
+
+@pytest.mark.asyncio
+async def test_health_check_empty_list():
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        statuses = await health_check_servers([], timeout=5.0)
+    assert statuses == []
+
+
+@pytest.mark.asyncio
+async def test_health_check_latency_none_on_failure():
+    servers = [_stdio_server("bad")]
+
+    async def _fake_introspect(server, timeout):
+        return _mock_unreachable(server.name, "timed out")
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            statuses = await health_check_servers(servers)
+
+    assert statuses[0].latency_ms is None
+    assert statuses[0].error == "timed out"
+
+
+@pytest.mark.asyncio
+async def test_health_check_tool_count_zero_on_failure():
+    servers = [_stdio_server("bad")]
+
+    async def _fake_introspect(server, timeout):
+        return _mock_unreachable(server.name)
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            statuses = await health_check_servers(servers)
+
+    assert statuses[0].tool_count == 0
+
+
+@pytest.mark.asyncio
+async def test_health_check_sse_server_included():
+    """SSE servers with URL are included in health check."""
+    servers = [_sse_server("remote")]
+
+    async def _fake_introspect(server, timeout):
+        return _mock_reachable(server.name, tool_count=10)
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            statuses = await health_check_servers(servers)
+
+    assert len(statuses) == 1
+    assert statuses[0].server_name == "remote"
+    assert statuses[0].reachable is True
+
+
+# ─── health_check_servers_sync() ──────────────────────────────────────────────
+
+
+def test_health_check_servers_sync_returns_list():
+    servers = [_stdio_server("s1")]
+
+    async def _fake_introspect(server, timeout):
+        return _mock_reachable(server.name, tool_count=1)
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        with patch("agent_bom.mcp_introspect.introspect_server", side_effect=_fake_introspect):
+            result = health_check_servers_sync(servers, timeout=5.0)
+
+    assert isinstance(result, list)
+    assert result[0].reachable is True
+
+
+def test_health_check_servers_sync_empty():
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk"):
+        result = health_check_servers_sync([], timeout=5.0)
+    assert result == []
+
+
+# ─── mcp SDK missing ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_check_raises_when_mcp_sdk_missing():
+    from agent_bom.mcp_introspect import IntrospectionError
+
+    with patch("agent_bom.mcp_introspect._check_mcp_sdk", side_effect=IntrospectionError("mcp SDK required")):
+        with pytest.raises(IntrospectionError, match="mcp SDK"):
+            await health_check_servers([_stdio_server("s")])


### PR DESCRIPTION
## Summary
- Adds `health_check_servers()` / `health_check_servers_sync()` to `mcp_introspect.py` — lightweight 5s-timeout probe returning reachability, tool count, protocol version, and latency per server (no drift analysis overhead)
- Adds `--health-check` / `--hc-timeout` CLI flags to the `scan` command, printing a per-server reachability table after discovery
- 14 unit tests covering success, failure, mixed results, ineligible server skipping, and SDK-missing error propagation

## Test plan
- [ ] `pytest tests/test_health_checks.py` — all 14 pass
- [ ] `agent-bom scan --health-check` runs without error; prints table with ✓/✗ per server
- [ ] `agent-bom scan --health-check --hc-timeout 2.0` respects custom timeout
- [ ] Servers with no command/URL are silently skipped (not counted in reachable)
- [ ] `--introspect` and `--health-check` can be combined without conflict