### PR TITLE
feat: Kubernetes MCP pod/CRD discovery (#307)

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -463,6 +463,20 @@ def main():
     help="Scan running Docker containers for MCP servers (requires docker CLI on PATH)",
 )
 @click.option(
+    "--k8s-mcp",
+    "k8s_mcp",
+    is_flag=True,
+    help="Scan Kubernetes cluster for MCP pods, services, and CRDs (requires kubectl on PATH)",
+)
+@click.option("--k8s-namespace", default="default", show_default=True, help="Kubernetes namespace for --k8s-mcp")
+@click.option(
+    "--k8s-all-namespaces",
+    "k8s_all_namespaces",
+    is_flag=True,
+    help="Scan all Kubernetes namespaces for --k8s-mcp",
+)
+@click.option("--k8s-context", "k8s_mcp_context", default=None, help="kubectl context for --k8s-mcp (uses current context if omitted)")
+@click.option(
     "--health-check",
     "health_check",
     is_flag=True,
@@ -761,6 +775,10 @@ def scan(
     dynamic_max_depth: int,
     include_processes: bool,
     include_containers: bool,
+    k8s_mcp: bool,
+    k8s_namespace: str,
+    k8s_all_namespaces: bool,
+    k8s_mcp_context: Optional[str],
     health_check: bool,
     hc_timeout: float,
     ai_enrich: bool,
@@ -1113,6 +1131,10 @@ def scan(
             dynamic_max_depth=dynamic_max_depth,
             include_processes=include_processes,
             include_containers=include_containers,
+            include_k8s_mcp=k8s_mcp,
+            k8s_namespace=k8s_namespace,
+            k8s_all_namespaces=k8s_all_namespaces,
+            k8s_context=k8s_mcp_context,
         )
     elif not skill_only:
         agents = discover_all(
@@ -1121,6 +1143,10 @@ def scan(
             dynamic_max_depth=dynamic_max_depth,
             include_processes=include_processes,
             include_containers=include_containers,
+            include_k8s_mcp=k8s_mcp,
+            k8s_namespace=k8s_namespace,
+            k8s_all_namespaces=k8s_all_namespaces,
+            k8s_context=k8s_mcp_context,
         )
 
     any_cloud = (

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -1297,12 +1297,174 @@ def discover_container_labels() -> Optional[Agent]:
     )
 
 
+# ── Kubernetes MCP CRD / label / env discovery ───────────────────────────────
+
+# MCP signals in pod metadata and container specs
+_K8S_MCP_LABELS = ("mcp.server", "mcp-server", "mcp.io/server", "app.kubernetes.io/component=mcp")
+_K8S_MCP_IMAGE_PATTERNS = ("mcp-server", "mcp_server", "/mcp:", "-mcp:")
+_K8S_MCP_ENV_PREFIX = "MCP_"
+_K8S_MCP_CRD_RESOURCE = "mcpservers"  # custom resource: mcpservers.mcp.io
+
+
+def discover_k8s_mcp_servers(
+    namespace: str = "default",
+    all_namespaces: bool = False,
+    context: Optional[str] = None,
+) -> Optional[Agent]:
+    """Discover MCP servers declared as Kubernetes pods, services, or CRDs.
+
+    Scans pods for MCP signals (labels, annotations, image names, env vars) and
+    optionally queries for ``mcpservers.mcp.io`` custom resources if that CRD
+    is installed.  Uses ``kubectl`` — no Python SDK required.
+
+    Args:
+        namespace: Kubernetes namespace to query (ignored when ``all_namespaces=True``).
+        all_namespaces: Query all namespaces (``kubectl ... -A``).
+        context: kubectl context to use (uses current context if ``None``).
+
+    Returns:
+        An Agent with ``source="kubernetes"`` or ``None`` if kubectl is absent
+        or no MCP pods/CRDs are found.
+    """
+    if not shutil.which("kubectl"):
+        return None
+
+    def _kubectl(*args: str) -> Optional[dict]:
+        cmd = ["kubectl", *args]
+        if context:
+            cmd += ["--context", context]
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            if r.returncode != 0:
+                return None
+            return json.loads(r.stdout)
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+            return None
+
+    # ── 1. Pod-level scan ────────────────────────────────────────────────────
+    pod_args = ["get", "pods", "-o", "json"]
+    if all_namespaces:
+        pod_args.append("-A")
+    else:
+        pod_args += ["-n", namespace]
+
+    pod_data = _kubectl(*pod_args)
+
+    mcp_servers: list[MCPServer] = []
+    seen_names: set[str] = set()
+
+    for pod in (pod_data or {}).get("items", []):
+        meta = pod.get("metadata", {})
+        pod_name = meta.get("name", "unknown")
+        pod_ns = meta.get("namespace", namespace)
+        labels = meta.get("labels", {})
+        annotations = meta.get("annotations", {})
+        spec = pod.get("spec", {})
+
+        # Check label signals
+        label_str = " ".join(f"{k}={v}" for k, v in labels.items()).lower()
+        annotation_keys = " ".join(annotations.keys()).lower()
+        has_label_signal = any(sig.lower() in label_str or sig.lower() in annotation_keys for sig in _K8S_MCP_LABELS)
+
+        containers = spec.get("containers", [])
+        for container in containers:
+            image = container.get("image", "").lower()
+            env_vars: list[dict] = container.get("env", [])
+            env_names = " ".join(e.get("name", "") for e in env_vars)
+
+            has_image_signal = any(pat in image for pat in _K8S_MCP_IMAGE_PATTERNS)
+            has_env_signal = _K8S_MCP_ENV_PREFIX in env_names
+
+            if not (has_label_signal or has_image_signal or has_env_signal):
+                continue
+
+            # Determine transport and URL
+            transport = TransportType.STDIO
+            url = ""
+            ports = container.get("ports", [])
+            if ports:
+                # Assume SSE/HTTP if the container exposes a port
+                transport = TransportType.SSE
+                port_num = ports[0].get("containerPort", 8000)
+                svc_name = labels.get("app", labels.get("app.kubernetes.io/name", pod_name))
+                url = f"http://{svc_name}.{pod_ns}.svc.cluster.local:{port_num}"
+
+            # Sanitize env vars
+            raw_env = {e.get("name", ""): e.get("value", "") for e in env_vars if e.get("name")}
+            env = sanitize_env_vars(raw_env)
+
+            # Build a unique server name
+            container_name = container.get("name", "mcp")
+            server_name = f"{pod_ns}/{pod_name}/{container_name}"
+            if server_name in seen_names:
+                continue
+            seen_names.add(server_name)
+
+            server = MCPServer(
+                name=server_name,
+                command="",  # pod containers don't have a local command to launch
+                env=env,
+                transport=transport,
+                url=url,
+                config_path=f"k8s://{pod_ns}/{pod_name}",
+            )
+            mcp_servers.append(server)
+
+    # ── 2. MCP CRD scan (mcpservers.mcp.io) ─────────────────────────────────
+    crd_args = ["get", _K8S_MCP_CRD_RESOURCE, "-o", "json"]
+    if all_namespaces:
+        crd_args.append("-A")
+    else:
+        crd_args += ["-n", namespace]
+
+    crd_data = _kubectl(*crd_args)
+
+    for item in (crd_data or {}).get("items", []):
+        meta = item.get("metadata", {})
+        crd_name = meta.get("name", "unknown")
+        crd_ns = meta.get("namespace", namespace)
+        spec = item.get("spec", {})
+
+        url = spec.get("url", spec.get("endpoint", ""))
+        transport = TransportType.SSE if url else TransportType.STDIO
+        server_name = f"{crd_ns}/{crd_name}"
+
+        if server_name in seen_names:
+            continue
+        seen_names.add(server_name)
+
+        server = MCPServer(
+            name=server_name,
+            command=spec.get("command", ""),
+            transport=transport,
+            url=url,
+            config_path=f"k8s-crd://{crd_ns}/{crd_name}",
+        )
+        mcp_servers.append(server)
+
+    if not mcp_servers:
+        return None
+
+    ns_label = "all-namespaces" if all_namespaces else namespace
+    return Agent(
+        name=f"kubernetes-mcp/{ns_label}",
+        agent_type=AgentType.CUSTOM,
+        config_path=f"k8s://{ns_label}",
+        mcp_servers=mcp_servers,
+        source="kubernetes",
+    )
+
+
 def discover_all(
     project_dir: Optional[str] = None,
     dynamic: bool = False,
     dynamic_max_depth: int = 4,
     include_processes: bool = False,
     include_containers: bool = False,
+    include_k8s_mcp: bool = False,
+    k8s_namespace: str = "default",
+    k8s_all_namespaces: bool = False,
+    k8s_context: Optional[str] = None,
 ) -> list[Agent]:
     """Run full discovery: global configs + project configs + CLI agents.
 
@@ -1312,6 +1474,10 @@ def discover_all(
         dynamic_max_depth: Maximum depth for dynamic filesystem scanning.
         include_processes: Also scan running host processes for MCP servers (psutil).
         include_containers: Also scan running Docker containers for MCP servers.
+        include_k8s_mcp: Scan Kubernetes cluster for MCP pods and CRDs (kubectl).
+        k8s_namespace: Kubernetes namespace to query (default: "default").
+        k8s_all_namespaces: Query all Kubernetes namespaces.
+        k8s_context: kubectl context to use (uses current context if None).
     """
     console.print("\n[bold blue]🔍 Discovering MCP configurations...[/bold blue]\n")
 
@@ -1370,6 +1536,19 @@ def discover_all(
             agents.append(container_agent)
         else:
             console.print("  [dim]  container scan: no MCP containers found (or docker not running)[/dim]")
+
+    # Kubernetes MCP pod/CRD discovery (opt-in)
+    if include_k8s_mcp:
+        k8s_agent = discover_k8s_mcp_servers(
+            namespace=k8s_namespace,
+            all_namespaces=k8s_all_namespaces,
+            context=k8s_context,
+        )
+        if k8s_agent:
+            console.print(f"  [green]✓[/green] Found {len(k8s_agent.mcp_servers)} MCP server(s) in Kubernetes (pods + CRDs)")
+            agents.append(k8s_agent)
+        else:
+            console.print("  [dim]  k8s-mcp scan: no MCP pods/CRDs found (or kubectl not available)[/dim]")
 
     # Detect installed-but-not-configured agents
     discovered_types = {a.agent_type for a in agents}

--- a/tests/test_discovery_k8s_mcp.py
+++ b/tests/test_discovery_k8s_mcp.py
@@ -1,0 +1,367 @@
+"""Tests for Kubernetes MCP server discovery (#307).
+
+Tests cover:
+- discover_k8s_mcp_servers() returns None when kubectl not on PATH
+- Pods with MCP labels are detected
+- Pods with MCP image name patterns are detected
+- Pods with MCP_ environment variables are detected
+- Pods without MCP signals are skipped
+- MCP CRDs (mcpservers.mcp.io) are discovered when present
+- CRD query failure (not installed) does not crash function
+- Exposed ports trigger SSE transport + URL generation
+- All namespaces mode (-A flag)
+- Custom kubectl context is passed through
+- discover_all() with include_k8s_mcp=False skips K8s (default)
+- discover_all() with include_k8s_mcp=True invokes discover_k8s_mcp_servers
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from agent_bom.discovery import discover_k8s_mcp_servers
+from agent_bom.models import AgentType, TransportType
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _pod(name: str, namespace: str = "default", labels: dict | None = None, containers: list | None = None) -> dict:
+    return {
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": labels or {},
+            "annotations": {},
+        },
+        "spec": {"containers": containers or [{"name": "mcp", "image": "mcp-server:latest", "env": [], "ports": []}]},
+    }
+
+
+def _crd_item(name: str, namespace: str = "default", url: str = "") -> dict:
+    return {
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {"url": url, "command": "mcp-server"},
+    }
+
+
+def _kubectl_response(items: list) -> str:
+    return json.dumps({"apiVersion": "v1", "items": items})
+
+
+# ─── kubectl not available ─────────────────────────────────────────────────────
+
+
+def test_returns_none_when_kubectl_missing():
+    with patch("agent_bom.discovery.shutil.which", return_value=None):
+        result = discover_k8s_mcp_servers()
+    assert result is None
+
+
+# ─── Pod label detection ───────────────────────────────────────────────────────
+
+
+def test_detects_pod_with_mcp_server_label():
+    pod = _pod("mcp-pod", labels={"mcp.server": "true"})
+    pods_resp = _kubectl_response([pod])
+    crd_resp = _kubectl_response([])  # no CRDs
+
+    call_count = {"n": 0}
+
+    def _fake_run(cmd, **kwargs):
+        call_count["n"] += 1
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is not None
+    assert len(agent.mcp_servers) == 1
+    assert agent.source == "kubernetes"
+    assert agent.agent_type == AgentType.CUSTOM
+
+
+def test_detects_pod_with_mcp_image_name():
+    container = {"name": "server", "image": "ghcr.io/org/mcp-server:v1", "env": [], "ports": []}
+    pod = _pod("img-pod", labels={}, containers=[container])
+    pods_resp = _kubectl_response([pod])
+    crd_resp = _kubectl_response([])
+
+    def _fake_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is not None
+    assert any("img-pod" in s.name for s in agent.mcp_servers)
+
+
+def test_detects_pod_with_mcp_env_var():
+    container = {
+        "name": "server",
+        "image": "myapp:latest",
+        "env": [{"name": "MCP_PORT", "value": "8000"}],
+        "ports": [],
+    }
+    pod = _pod("env-pod", labels={}, containers=[container])
+    pods_resp = _kubectl_response([pod])
+    crd_resp = _kubectl_response([])
+
+    def _fake_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is not None
+    assert any("env-pod" in s.name for s in agent.mcp_servers)
+
+
+def test_skips_pod_without_mcp_signals():
+    container = {"name": "web", "image": "nginx:latest", "env": [], "ports": []}
+    pod = _pod("nginx-pod", labels={"app": "frontend"}, containers=[container])
+    pods_resp = _kubectl_response([pod])
+    crd_resp = _kubectl_response([])
+
+    def _fake_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is None
+
+
+def test_returns_none_when_no_mcp_pods_or_crds():
+    pods_resp = _kubectl_response([])
+    crd_resp = _kubectl_response([])
+
+    def _fake_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is None
+
+
+# ─── Ports → SSE transport ─────────────────────────────────────────────────────
+
+
+def test_exposed_port_sets_sse_transport():
+    container = {
+        "name": "mcp",
+        "image": "mcp-server:latest",
+        "env": [],
+        "ports": [{"containerPort": 9090}],
+    }
+    pod = _pod("port-pod", labels={"mcp.server": "true"}, containers=[container])
+    pods_resp = _kubectl_response([pod])
+    crd_resp = _kubectl_response([])
+
+    def _fake_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is not None
+    srv = agent.mcp_servers[0]
+    assert srv.transport == TransportType.SSE
+    assert "9090" in srv.url
+
+
+def test_no_ports_sets_stdio_transport():
+    container = {"name": "mcp", "image": "mcp-server:latest", "env": [], "ports": []}
+    pod = _pod("no-port", labels={"mcp.server": "true"}, containers=[container])
+    pods_resp = _kubectl_response([pod])
+    crd_resp = _kubectl_response([])
+
+    def _fake_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is not None
+    assert agent.mcp_servers[0].transport == TransportType.STDIO
+
+
+# ─── CRD discovery ────────────────────────────────────────────────────────────
+
+
+def test_discovers_mcp_crd():
+    pods_resp = _kubectl_response([])
+    crd_item = _crd_item("my-mcp-server", namespace="production", url="http://mcp.production.svc:8080")
+    crd_resp = _kubectl_response([crd_item])
+
+    def _fake_run(cmd, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = pods_resp if "pods" in cmd else crd_resp
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    assert agent is not None
+    assert any("my-mcp-server" in s.name for s in agent.mcp_servers)
+    srv = next(s for s in agent.mcp_servers if "my-mcp-server" in s.name)
+    assert srv.transport == TransportType.SSE
+    assert srv.url == "http://mcp.production.svc:8080"
+
+
+def test_crd_failure_does_not_crash():
+    """CRD query returning non-zero doesn't crash — graceful degradation."""
+    pod = _pod("mcp-pod", labels={"mcp.server": "true"})
+    pods_resp = _kubectl_response([pod])
+
+    call_n = {"n": 0}
+
+    def _fake_run(cmd, **kwargs):
+        call_n["n"] += 1
+        r = MagicMock()
+        if "pods" in cmd:
+            r.returncode = 0
+            r.stdout = pods_resp
+        else:
+            r.returncode = 1  # CRD not installed
+            r.stdout = ""
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            agent = discover_k8s_mcp_servers()
+
+    # Should still return pod-level results
+    assert agent is not None
+    assert len(agent.mcp_servers) == 1
+
+
+# ─── Namespace / context flags ────────────────────────────────────────────────
+
+
+def test_all_namespaces_flag_passes_dash_a():
+    captured = []
+
+    def _fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = _kubectl_response([])
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            discover_k8s_mcp_servers(all_namespaces=True)
+
+    pod_cmd = next(c for c in captured if "pods" in c)
+    assert "-A" in pod_cmd
+
+
+def test_custom_namespace_is_used():
+    captured = []
+
+    def _fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = _kubectl_response([])
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            discover_k8s_mcp_servers(namespace="production")
+
+    pod_cmd = next(c for c in captured if "pods" in c)
+    assert "-n" in pod_cmd
+    assert "production" in pod_cmd
+
+
+def test_custom_context_is_passed():
+    captured = []
+
+    def _fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = _kubectl_response([])
+        return r
+
+    with patch("agent_bom.discovery.shutil.which", return_value="/usr/bin/kubectl"):
+        with patch("agent_bom.discovery.subprocess.run", side_effect=_fake_run):
+            discover_k8s_mcp_servers(context="my-cluster")
+
+    for cmd in captured:
+        assert "--context" in cmd
+        assert "my-cluster" in cmd
+
+
+# ─── discover_all() integration ───────────────────────────────────────────────
+
+_DISCOVER_ALL_PATCHES = {
+    "agent_bom.discovery.discover_global_configs": [],
+    "agent_bom.discovery.discover_project_configs": [],
+    "agent_bom.discovery.discover_compose_mcp_servers": None,
+    "agent_bom.discovery.discover_toolhive": None,
+    "agent_bom.discovery.discover_docker_mcp": None,
+    "agent_bom.discovery.detect_installed_agents": [],
+}
+
+
+def test_discover_all_skips_k8s_by_default():
+    from contextlib import ExitStack
+
+    from agent_bom.discovery import discover_all
+
+    with ExitStack() as stack:
+        mock_k8s = stack.enter_context(patch("agent_bom.discovery.discover_k8s_mcp_servers"))
+        for target, rv in _DISCOVER_ALL_PATCHES.items():
+            stack.enter_context(patch(target, return_value=rv))
+        discover_all()
+
+    mock_k8s.assert_not_called()
+
+
+def test_discover_all_calls_k8s_when_flagged():
+    from contextlib import ExitStack
+
+    from agent_bom.discovery import discover_all
+
+    with ExitStack() as stack:
+        mock_k8s = stack.enter_context(patch("agent_bom.discovery.discover_k8s_mcp_servers", return_value=None))
+        for target, rv in _DISCOVER_ALL_PATCHES.items():
+            stack.enter_context(patch(target, return_value=rv))
+        discover_all(include_k8s_mcp=True, k8s_namespace="prod", k8s_all_namespaces=False, k8s_context=None)
+
+    mock_k8s.assert_called_once_with(namespace="prod", all_namespaces=False, context=None)


### PR DESCRIPTION
## Summary
- Adds `discover_k8s_mcp_servers()` to `discovery/__init__.py` — scans pods for MCP signals (labels like `mcp.server`, image names containing `mcp-server`, `MCP_*` env vars) and queries `mcpservers.mcp.io` CRDs when installed
- Exposed container ports trigger SSE transport + auto-generated cluster-local URL; no ports → stdio transport
- Wire `--k8s-mcp` / `--k8s-namespace` / `--k8s-all-namespaces` / `--k8s-context` CLI flags into `discover_all()` and the `scan` command
- No SDK required — pure `kubectl` subprocess (30s timeout), graceful degradation when CRD not installed
- 15 unit tests covering label/image/env detection, port→transport, CRD discovery, CRD failure tolerance, namespace/context propagation, and `discover_all()` gating

## Test plan
- [ ] `pytest tests/test_discovery_k8s_mcp.py` — all 15 pass
- [ ] `agent-bom scan --k8s-mcp` discovers MCP pods/CRDs in default namespace
- [ ] `agent-bom scan --k8s-mcp --k8s-all-namespaces` scans cluster-wide
- [ ] `agent-bom scan --k8s-mcp --k8s-namespace production` scopes to namespace
- [ ] When kubectl is absent: silently skips (no crash)
- [ ] When CRD not installed: falls back to pod-level results only