### PR TITLE
fix: update test SBOM fixture to non-vulnerable package versions

### DIFF
--- a/tests/fixtures/test-sbom.cdx.json
+++ b/tests/fixtures/test-sbom.cdx.json
@@ -13,26 +13,26 @@
     {
       "type": "library",
       "name": "flask",
-      "version": "2.2.0",
-      "purl": "pkg:pypi/flask@2.2.0"
+      "version": "3.1.3",
+      "purl": "pkg:pypi/flask@3.1.3"
     },
     {
       "type": "library",
       "name": "werkzeug",
-      "version": "2.2.0",
-      "purl": "pkg:pypi/werkzeug@2.2.0"
+      "version": "3.1.6",
+      "purl": "pkg:pypi/werkzeug@3.1.6"
     },
     {
       "type": "library",
       "name": "jinja2",
-      "version": "3.1.2",
-      "purl": "pkg:pypi/jinja2@3.1.2"
+      "version": "3.1.6",
+      "purl": "pkg:pypi/jinja2@3.1.6"
     },
     {
       "type": "library",
       "name": "requests",
-      "version": "2.28.0",
-      "purl": "pkg:pypi/requests@2.28.0"
+      "version": "2.32.4",
+      "purl": "pkg:pypi/requests@2.32.4"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Updates `tests/fixtures/test-sbom.cdx.json` to use patched package versions
- flask 2.2.0 → 3.1.3 (fixes GHSA-68rp-wp8r-4726, GHSA-m2qf-hxjv-5gpq)
- werkzeug 2.2.0 → 3.1.6 (fixes 8 werkzeug CVEs)
- jinja2 3.1.2 → 3.1.6 (fixes GHSA-cpwx-vrp4-4pq7 and others)
- requests 2.28.0 → 2.32.4 (fixes GHSA-9hjg-9r4m-mvj7 and others)

## Why

The OpenSSF Scorecard scans the entire repo including test fixtures. The old vulnerable versions in this fixture were causing 19 CVE hits, suppressing the Vulnerabilities check score to 0. The fixture is used for dogfood CI scanning (`|| true`) — no tests assert specific versions, so updating is safe.

## Test plan

- [ ] CI passes (no Python tests reference these versions)
- [ ] Dogfood scan in CI still runs without error
- [ ] OpenSSF Scorecard Vulnerabilities score improves after merge + re-scan