### PR TITLE
feat: AI infra/GPU coverage, author name, Wiz-style nav risk badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center">
-  <b>Security scanner for AI infrastructure. Find CVEs, map blast radius, detect credential exposure across MCP agents, containers, Kubernetes, and cloud.</b>
+  <b>Security scanner for AI infrastructure. Find CVEs, map blast radius, detect credential exposure across MCP agents, ML frameworks, GPU packages, containers, Kubernetes, and cloud.</b>
 </p>
 
 <p align="center">
@@ -139,6 +139,9 @@ rm -rf ~/.agent-bom                      # remove local data
 | Package CVE detection | Yes | Yes (OSV + NVD + EPSS + CISA KEV + GHSA + NVIDIA CSAF) |
 | SBOM generation | Yes | Yes (CycloneDX 1.6, SPDX 3.0, SARIF) |
 | **AI agent discovery** | -- | 20 MCP clients + Docker Compose + running processes + containers + K8s pods/CRDs |
+| **GPU/ML package scanning** | -- | NVIDIA CSAF advisories for CUDA, cuDNN, PyTorch, TensorFlow, JAX, vLLM + AMD ROCm via OSV |
+| **AI supply chain** | -- | Model provenance (pickle risk, digest, gating), HuggingFace Hub, Ollama, MLflow, W&B |
+| **AI cloud inventory** | -- | Coreweave, Nebius, Snowflake, Databricks, OpenAI, HuggingFace Hub — config discovery + CVE tagging |
 | **Blast radius mapping** | -- | CVE -> package -> server -> agent -> credentials -> tools |
 | **Credential exposure** | -- | Which secrets leak per vulnerability, per agent |
 | **Tool poisoning detection** | -- | Description injection, capability combos, drift detection |
@@ -171,9 +174,10 @@ rm -rf ~/.agent-bom                      # remove local data
 | MCP configs | Auto-discover (20 clients + Docker Compose) |
 | Docker images | Grype / Syft / Docker CLI fallback |
 | Kubernetes | kubectl across namespaces |
-| Cloud providers | AWS, Azure, GCP, Databricks, Snowflake, Nebius |
+| Cloud providers | AWS, Azure, GCP, Databricks, Snowflake, Coreweave, Nebius |
+| AI cloud services | OpenAI, HuggingFace Hub, W&B, MLflow, Ollama |
+| GPU/ML packages | PyTorch, TF, JAX, vLLM, CUDA toolkit, cuDNN, TensorRT, ROCm |
 | Terraform / GitHub Actions | AI resources + env vars |
-| AI platforms | HuggingFace, W&B, MLflow, OpenAI |
 | Jupyter notebooks | AI library imports + model refs |
 | Model files | 13 formats (.gguf, .safetensors, .pkl, ...) |
 | Skill files | CLAUDE.md, .cursorrules, AGENTS.md |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 authors = [
-    {name = "W S", email = "34316639+msaad00@users.noreply.github.com"}
+    {name = "Wagdy Saad", email = "andwgdysaad@gmail.com"}
 ]
-keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "grype", "syft", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment", "credential-exposure", "config-security", "ai-supply-chain", "ai-infrastructure", "openssf-scorecard", "malicious-package-detection", "runtime-monitoring"]
+keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "grype", "syft", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment", "credential-exposure", "config-security", "ai-supply-chain", "ai-infrastructure", "gpu-security", "cuda", "pytorch", "openssf-scorecard", "malicious-package-detection", "runtime-monitoring", "model-provenance"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -2051,6 +2051,51 @@ async def get_posture_scorecard() -> dict:
     }
 
 
+@app.get("/v1/posture/counts", tags=["compliance"])
+async def get_posture_counts() -> dict:
+    """Aggregate vulnerability counts across all completed scans.
+
+    Lightweight endpoint used by the dashboard nav to show Critical/High
+    badges without loading full scan payloads.
+
+    Returns:
+        {critical, high, medium, low, total, kev, compound_issues}
+    """
+    counts: dict[str, int] = {
+        "critical": 0,
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "total": 0,
+        "kev": 0,
+        "compound_issues": 0,
+    }
+    seen_ids: set[str] = set()
+
+    for job in _get_store().list_all():
+        if job.status != JobStatus.DONE or not job.result:
+            continue
+        blast_list = job.result.get("blast_radius", [])
+        for b in blast_list:
+            vid = b.get("vulnerability_id", "")
+            if vid in seen_ids:
+                continue
+            seen_ids.add(vid)
+            sev = (b.get("severity") or "").lower()
+            if sev in counts:
+                counts[sev] += 1
+            counts["total"] += 1
+            if b.get("cisa_kev") or b.get("is_kev"):
+                counts["kev"] += 1
+            # Compound issue: KEV + reachable tool, or KEV + exposed cred
+            if (b.get("cisa_kev") or b.get("is_kev")) and (b.get("reachable_tools") or b.get("exposed_credentials")):
+                counts["compound_issues"] += 1
+            elif (b.get("epss_score") or 0) >= 0.3 and (b.get("cvss_score") or 0) >= 7:
+                counts["compound_issues"] += 1
+
+    return counts
+
+
 @app.get("/v1/posture/credentials", tags=["compliance"])
 async def get_credential_risk_ranking() -> dict:
     """Rank credentials by blast radius exposure from the latest scan.

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -543,11 +543,13 @@ async def scan_packages(packages: list[Package]) -> int:
             # Flag packages with MAL- prefixed vulnerability IDs as malicious
             flag_malicious_from_vulns(pkg)
 
-    # Supplemental: check NVIDIA advisories for AI framework packages
+    # Supplemental: check NVIDIA advisories for all AI framework packages.
+    # nvidia_advisory.py maps NVIDIA CSAF products to bundling frameworks (torch,
+    # jax, vllm, etc.) so we pass ALL AI packages — not just nvidia-prefixed ones.
     nvidia_packages = [
         p
         for p in scannable
-        if p.name.lower().replace("-", "_") in _AI_FRAMEWORK_PACKAGES and p.name.lower().startswith(("nvidia", "cuda", "tensorrt", "nccl"))
+        if p.name.lower().replace("-", "_") in _AI_FRAMEWORK_PACKAGES or p.name.lower().replace("-", "") in _AI_FRAMEWORK_PACKAGES
     ]
     if nvidia_packages:
         try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3548,3 +3548,68 @@ def test_json_output_includes_license():
     data = to_json(report)
     pkgs = data["agents"][0]["mcp_servers"][0]["packages"]
     assert pkgs[0]["license"] == "MIT"
+
+
+def test_api_posture_counts_empty():
+    """GET /v1/posture/counts returns zero counts with no scans."""
+    pytest.importorskip("fastapi", reason="fastapi not installed")
+    from fastapi.testclient import TestClient
+
+    from agent_bom.api.server import app
+
+    client = TestClient(app)
+    resp = client.get("/v1/posture/counts")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "critical" in body
+    assert "high" in body
+    assert "kev" in body
+    assert "compound_issues" in body
+    assert isinstance(body["total"], int)
+
+
+def test_api_posture_counts_with_data():
+    """GET /v1/posture/counts aggregates critical/high/kev from completed scans."""
+    pytest.importorskip("fastapi", reason="fastapi not installed")
+    from fastapi.testclient import TestClient
+
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest, _get_store, app
+
+    client = TestClient(app)
+    job = ScanJob(
+        job_id="counts-test-001",
+        status=JobStatus.DONE,
+        created_at="2026-01-01T00:00:00Z",
+        request=ScanRequest(),
+        result={
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-2024-0001",
+                    "severity": "critical",
+                    "blast_score": 9.5,
+                    "cisa_kev": True,
+                    "reachable_tools": ["bash"],
+                    "exposed_credentials": [],
+                },
+                {
+                    "vulnerability_id": "CVE-2024-0002",
+                    "severity": "high",
+                    "blast_score": 7.0,
+                    "epss_score": 0.4,
+                    "cvss_score": 8.0,
+                    "cisa_kev": False,
+                    "reachable_tools": [],
+                    "exposed_credentials": [],
+                },
+            ]
+        },
+    )
+    _get_store().put(job)
+    resp = client.get("/v1/posture/counts")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["critical"] >= 1
+    assert body["high"] >= 1
+    assert body["kev"] >= 1
+    assert body["compound_issues"] >= 1  # KEV + reachable_tools
+    assert body["total"] >= 2

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -64,14 +64,47 @@ const NAV_GROUPS = [
 
 const allLinks = NAV_GROUPS.flatMap((g) => g.links);
 
+interface RiskCounts {
+  critical: number;
+  high: number;
+  kev: number;
+  compound_issues: number;
+}
+
 export function Nav() {
   const path = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [counts, setCounts] = useState<RiskCounts | null>(null);
 
   // Close mobile menu on route change
   useEffect(() => {
     setMobileOpen(false);
   }, [path]);
+
+  // Fetch aggregate counts for badges (refresh every 60s)
+  useEffect(() => {
+    let mounted = true;
+    const load = () => {
+      api
+        .getPostureCounts()
+        .then((c) => {
+          if (mounted)
+            setCounts({
+              critical: c.critical,
+              high: c.high,
+              kev: c.kev,
+              compound_issues: c.compound_issues,
+            });
+        })
+        .catch(() => {}); // silent — nav badges are non-critical
+    };
+    load();
+    const interval = setInterval(load, 60_000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, []);
 
   return (
     <nav className="border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-sm sticky top-0 z-50">
@@ -91,6 +124,7 @@ export function Nav() {
                 {gi > 0 && <div className="w-px h-4 bg-zinc-800 mx-1.5" />}
                 {group.links.map(({ href, label, icon: Icon }) => {
                   const active = href === "/" ? path === "/" : path.startsWith(href);
+                  const isVulns = href === "/vulns";
                   return (
                     <Link
                       key={href}
@@ -103,6 +137,18 @@ export function Nav() {
                     >
                       <Icon className="w-3.5 h-3.5" />
                       {label}
+                      {isVulns && counts && counts.critical > 0 && (
+                        <span className="flex items-center gap-1 ml-0.5">
+                          <span className="text-[9px] font-mono font-bold text-red-400 bg-red-950/60 rounded px-1 py-0 leading-4">
+                            {counts.critical}C
+                          </span>
+                          {counts.high > 0 && (
+                            <span className="text-[9px] font-mono font-bold text-orange-400 bg-orange-950/60 rounded px-1 py-0 leading-4">
+                              {counts.high}H
+                            </span>
+                          )}
+                        </span>
+                      )}
                     </Link>
                   );
                 })}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -628,6 +628,18 @@ export const api = {
     return () => es.close(); // cleanup fn
   },
 
+  /** Lightweight aggregate counts for nav badges (Critical/High/KEV/Compound) */
+  getPostureCounts: () =>
+    get<{
+      critical: number;
+      high: number;
+      medium: number;
+      low: number;
+      total: number;
+      kev: number;
+      compound_issues: number;
+    }>("/v1/posture/counts"),
+
   /** Compliance posture across all completed scans */
   getCompliance: () => get<ComplianceResponse>("/v1/compliance"),
 


### PR DESCRIPTION
## Summary

- **AI infrastructure coverage restored accurately** — tagline and capability table now reflect real implemented features: PyTorch/TF/JAX/vLLM/CUDA/ROCm scanning, model provenance (pickle risk, digest, gating), HuggingFace Hub, Coreweave, Nebius — all verified against codebase
- **Author name**: `W S` → `Wagdy Saad <andwgdysaad@gmail.com>` in pyproject.toml
- **PyPI keywords**: Restored `gpu-security`, `cuda`, `pytorch`, added `model-provenance`
- **Bug fix — NVIDIA advisory filter**: Removed the narrow `.startswith("nvidia/cuda/tensorrt/nccl")` guard that was preventing torch/jax/vllm/tensorflow from being checked against NVIDIA CSAF advisories. The `nvidia_advisory.py` module already has `_NVIDIA_PRODUCT_MAP` that bridges CUDA Toolkit CVEs to bundling frameworks — the filter just blocked it
- **New API endpoint** `GET /v1/posture/counts`: lightweight aggregate `{critical, high, medium, low, total, kev, compound_issues}` across all scans, deduped by CVE ID — used by nav
- **Wiz-style nav badges**: Vulns nav link now shows `26C 143H` style count badges (Critical red, High orange) when findings exist. Refreshes every 60s. Zero-state: no badge shown

## Inspired by Wiz
The "Your Issues" panel (Critical: 26, High: 143) from the Wiz UI screenshots was the reference for the nav badge design.

## Test plan
- [ ] CI passes
- [ ] `npm run build` in `ui/` passes (verified locally — clean 18-page Turbopack build)
- [ ] New tests: `test_api_posture_counts_empty` + `test_api_posture_counts_with_data` pass
- [ ] Nav with no scans: no badge shown on Vulns link
- [ ] Nav with scans: red `NC` and orange `NH` badges appear