### PR TITLE
feat: GPU/AI compute infra scanner — Docker, K8s, DCGM (closes #309)

### DIFF
--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -234,6 +234,7 @@ agent-bom where             # show all discovery paths
 | `context_graph` | Agent context graph with lateral movement analysis |
 | `analytics_query` | Query vulnerability trends, posture history, and runtime events |
 | `vector_db_scan` | Probe Qdrant/Weaviate/Chroma/Milvus for auth and exposure |
+| `gpu_infra_scan` | GPU container and K8s node inventory + unauthenticated DCGM probe (MAESTRO KC6) |
 
 ### Resources
 | Resource | Description |
@@ -260,6 +261,9 @@ aisvs_benchmark()
 
 # Scan vector databases for auth misconfigurations
 vector_db_scan()
+
+# Discover GPU containers, K8s GPU nodes, and unauthenticated DCGM endpoints
+gpu_infra_scan()
 
 # Assess trust of a skill file
 skill_trust(skill_content="<paste SKILL.md content>")

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -584,6 +584,14 @@ def main():
     is_flag=True,
     help="Scan for running vector databases (Qdrant, Weaviate, Chroma, Milvus) and assess security",
 )
+@click.option(
+    "--gpu-scan",
+    "gpu_scan_flag",
+    is_flag=True,
+    help="Discover GPU-enabled containers and K8s nodes (NVIDIA base images, CUDA versions, DCGM endpoints). Requires docker/kubectl on PATH.",
+)
+@click.option("--gpu-k8s-context", "gpu_k8s_context", default=None, metavar="CTX", help="kubectl context for --gpu-scan K8s node discovery")
+@click.option("--no-dcgm-probe", "no_dcgm_probe", is_flag=True, help="Skip DCGM exporter endpoint probing during --gpu-scan")
 @click.option("--huggingface", "hf_flag", is_flag=True, help="Discover models, Spaces, and endpoints from Hugging Face Hub")
 @click.option("--hf-token", default=None, envvar="HF_TOKEN", metavar="TOKEN", help="Hugging Face API token")
 @click.option("--hf-username", default=None, metavar="USER", help="Hugging Face username to scope discovery")
@@ -811,6 +819,9 @@ def scan(
     databricks_security: bool,
     aisvs_flag: bool,
     vector_db_scan: bool,
+    gpu_scan_flag: bool,
+    gpu_k8s_context: Optional[str],
+    no_dcgm_probe: bool,
     hf_flag: bool,
     hf_token: Optional[str],
     hf_username: Optional[str],
@@ -2006,6 +2017,55 @@ def scan(
         except Exception as exc:
             con.print(f"  [red]Vector DB scan error: {exc}[/red]")
 
+    # Step 1x-b2: GPU infra scan
+    gpu_infra_report = None
+    if gpu_scan_flag:
+        import asyncio as _asyncio
+
+        from rich.table import Table as _RTable
+
+        con.print("\n[bold blue]Scanning GPU/AI compute infrastructure...[/bold blue]\n")
+        try:
+            from agent_bom.cloud.gpu_infra import gpu_infra_to_agents, scan_gpu_infra
+
+            gpu_infra_report = _asyncio.get_event_loop().run_until_complete(
+                scan_gpu_infra(k8s_context=gpu_k8s_context, probe_dcgm=not no_dcgm_probe)
+            )
+            for w in gpu_infra_report.warnings:
+                con.print(f"  [yellow]⚠[/yellow] {w}")
+            gpu_agents = gpu_infra_to_agents(gpu_infra_report)
+            if gpu_agents:
+                agents.extend(gpu_agents)
+                con.print(
+                    f"  [green]✓[/green] {gpu_infra_report.total_gpu_containers} GPU container(s), "
+                    f"{len(gpu_infra_report.gpu_nodes)} K8s GPU node(s)"
+                )
+                if gpu_infra_report.unique_cuda_versions:
+                    con.print(f"  CUDA versions: {', '.join(gpu_infra_report.unique_cuda_versions)}")
+                if gpu_infra_report.unauthenticated_dcgm_count:
+                    con.print(
+                        f"  [red]⚠ {gpu_infra_report.unauthenticated_dcgm_count} unauthenticated DCGM exporter(s) — metrics leak[/red]"
+                    )
+                if gpu_infra_report.dcgm_endpoints:
+                    tbl = _RTable(title="DCGM Endpoints", show_lines=False)
+                    tbl.add_column("Host", width=20)
+                    tbl.add_column("Port", width=8)
+                    tbl.add_column("Auth", width=8)
+                    tbl.add_column("GPUs", width=6)
+                    for ep in gpu_infra_report.dcgm_endpoints:
+                        tbl.add_row(
+                            ep.host,
+                            str(ep.port),
+                            "[green]yes[/]" if ep.authenticated else "[red]NO[/]",
+                            str(ep.gpu_count) if ep.gpu_count is not None else "?",
+                        )
+                    con.print()
+                    con.print(tbl)
+            else:
+                con.print("  [dim]No GPU containers or K8s GPU nodes found[/dim]")
+        except Exception as exc:
+            con.print(f"  [red]GPU scan error: {exc}[/red]")
+
     # Step 1x-c: AISVS compliance benchmark
     aisvs_report = None
     if aisvs_flag:
@@ -2457,6 +2517,8 @@ def scan(
         report.aisvs_benchmark_data = aisvs_report.to_dict()
     if vector_db_results:
         report.vector_db_scan_data = [r.to_dict() for r in vector_db_results]
+    if gpu_infra_report is not None:
+        report.gpu_infra_data = gpu_infra_report.risk_summary
 
     # ── Context graph: lateral movement analysis ────────────────────
     if context_graph_flag and report.blast_radii:
@@ -4388,7 +4450,7 @@ def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_jso
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 22 security tools via MCP protocol:
+    Exposes 23 security tools via MCP protocol:
       scan              Full scan — CVEs, config security, blast radius, compliance
       check             Check a specific package for CVEs before installing
       blast_radius      Look up blast radius for a specific CVE
@@ -4409,6 +4471,9 @@ def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_jso
       cis_benchmark     Run CIS benchmark checks (AWS/Snowflake)
       fleet_scan        Batch registry lookup for fleet inventories
       runtime_correlate Cross-reference runtime audit logs with CVE findings
+      vector_db_scan    Discover vector databases and assess auth exposure
+      aisvs_benchmark   OWASP AISVS v1.0 compliance checks
+      gpu_infra_scan    GPU container and K8s node inventory + DCGM probe
 
     \b
     Usage:

--- a/src/agent_bom/cloud/gpu_infra.py
+++ b/src/agent_bom/cloud/gpu_infra.py
@@ -1,0 +1,542 @@
+"""GPU/AI compute infrastructure scanner — container and Kubernetes discovery.
+
+Discovers GPU-enabled workloads from running Docker containers and Kubernetes
+clusters. No additional pip packages required — uses ``docker`` and ``kubectl``
+CLI tools with subprocess (same pattern as coreweave.py and discovery/__init__.py).
+
+Discovery targets:
+- NVIDIA base images (nvcr.io/nvidia/, nvidia/cuda)
+- CUDA/cuDNN version labels on running containers
+- GPU-assigned containers (Docker ``--gpus``, K8s ``nvidia.com/gpu`` requests)
+- Unauthenticated DCGM exporter endpoints (port 9400)
+
+Closes: #309 (GPU/AI compute infra inventory — KC6)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_bom.http_client import create_client, request_with_retry
+from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+
+logger = logging.getLogger(__name__)
+
+# NVIDIA image prefixes — treated as GPU workloads
+_NVIDIA_IMAGE_PREFIXES = (
+    "nvcr.io/nvidia/",
+    "nvcr.io/nim/",
+    "nvidia/cuda",
+    "nvidia/cudnn",
+    "nvidia/tensorrt",
+    "nvidia/tritonserver",
+    "nvidia/pytorch",
+    "nvidia/tensorflow",
+)
+
+# Docker label keys that indicate CUDA/cuDNN version
+_CUDA_LABEL_KEYS = (
+    "com.nvidia.cuda.version",
+    "com.nvidia.cudnn.version",
+    "com.nvidia.cuda_version",
+    "cuda_version",
+    "nvidia_cuda_version",
+)
+
+# K8s resource key for GPU requests
+_K8S_GPU_RESOURCE = "nvidia.com/gpu"
+
+# DCGM exporter default port
+_DCGM_PORT = 9400
+_DCGM_METRICS_PATH = "/metrics"
+_DCGM_PROBE_TIMEOUT = 3.0
+
+
+# ─── Data models ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class GpuContainer:
+    """A running container that has GPU access or is an NVIDIA-based image."""
+
+    container_id: str
+    name: str
+    image: str
+    status: str  # "running", "exited", etc.
+    is_nvidia_base: bool
+    cuda_version: str | None
+    cudnn_version: str | None
+    gpu_requested: bool  # explicit GPU device assignment
+    labels: dict[str, str] = field(default_factory=dict)
+    env_vars: list[str] = field(default_factory=list)  # names only, no values
+    ports: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DcgmEndpoint:
+    """A discovered DCGM exporter endpoint."""
+
+    host: str
+    port: int
+    url: str
+    authenticated: bool  # False = unauthenticated metrics leak
+    gpu_count: int | None
+    sample_metric_keys: list[str] = field(default_factory=list)
+
+
+@dataclass
+class GpuNode:
+    """A Kubernetes node with GPU resource capacity."""
+
+    name: str
+    gpu_capacity: int
+    gpu_allocatable: int
+    gpu_allocated: int
+    cuda_driver_version: str | None
+    labels: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class GpuInfraReport:
+    """Aggregated GPU infrastructure inventory from a scan."""
+
+    gpu_containers: list[GpuContainer]
+    dcgm_endpoints: list[DcgmEndpoint]
+    gpu_nodes: list[GpuNode]
+    warnings: list[str]
+
+    @property
+    def total_gpu_containers(self) -> int:
+        return len(self.gpu_containers)
+
+    @property
+    def unauthenticated_dcgm_count(self) -> int:
+        return sum(1 for e in self.dcgm_endpoints if not e.authenticated)
+
+    @property
+    def nvidia_base_image_count(self) -> int:
+        return sum(1 for c in self.gpu_containers if c.is_nvidia_base)
+
+    @property
+    def unique_cuda_versions(self) -> list[str]:
+        versions = {c.cuda_version for c in self.gpu_containers if c.cuda_version}
+        return sorted(versions)
+
+    @property
+    def risk_summary(self) -> dict[str, Any]:
+        return {
+            "total_gpu_containers": self.total_gpu_containers,
+            "nvidia_base_images": self.nvidia_base_image_count,
+            "unique_cuda_versions": self.unique_cuda_versions,
+            "dcgm_endpoints": len(self.dcgm_endpoints),
+            "unauthenticated_dcgm": self.unauthenticated_dcgm_count,
+            "gpu_k8s_nodes": len(self.gpu_nodes),
+        }
+
+
+# ─── Docker discovery ─────────────────────────────────────────────────────────
+
+
+def _run_docker(args: list[str], timeout: int = 30) -> Any:
+    """Run a docker command and return parsed JSON output.
+
+    Returns None on failure (docker not installed, permission denied, etc.)
+    rather than raising — GPU discovery is always best-effort.
+    """
+    if not shutil.which("docker"):
+        return None
+    try:
+        result = subprocess.run(
+            ["docker"] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return None
+
+
+def _is_nvidia_image(image: str) -> bool:
+    """Return True if the image is an NVIDIA-published GPU base image."""
+    img_lower = image.lower()
+    return any(img_lower.startswith(p) for p in _NVIDIA_IMAGE_PREFIXES)
+
+
+def _extract_cuda_versions(labels: dict[str, str]) -> tuple[str | None, str | None]:
+    """Extract CUDA and cuDNN versions from container/image labels."""
+    cuda_version: str | None = None
+    cudnn_version: str | None = None
+
+    for key, value in labels.items():
+        key_lower = key.lower()
+        if "cuda" in key_lower and "cudnn" not in key_lower and not cuda_version:
+            cuda_version = value.strip()
+        elif "cudnn" in key_lower and not cudnn_version:
+            cudnn_version = value.strip()
+
+    return cuda_version, cudnn_version
+
+
+def discover_docker_gpu_containers() -> tuple[list[GpuContainer], list[str]]:
+    """Discover GPU-enabled containers from the local Docker daemon.
+
+    Uses ``docker ps`` + ``docker inspect`` — no Docker SDK required.
+
+    Returns:
+        (containers, warnings)
+    """
+    containers: list[GpuContainer] = []
+    warnings: list[str] = []
+
+    if not shutil.which("docker"):
+        return containers, ["docker not available — GPU container discovery skipped"]
+
+    # List all running containers (plain text output, not JSON)
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.ID}}", "--no-trunc"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return containers, ["docker ps failed — Docker not running or no permission"]
+        container_ids = [cid.strip() for cid in result.stdout.splitlines() if cid.strip()]
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return containers, [f"Docker discovery skipped: {exc}"]
+
+    if not container_ids:
+        return containers, []
+
+    # Inspect each container
+    inspect_result = _run_docker(["inspect"] + container_ids, timeout=60)
+    if not inspect_result or not isinstance(inspect_result, list):
+        warnings.append("docker inspect failed — skipping container GPU analysis")
+        return containers, warnings
+
+    for info in inspect_result:
+        try:
+            cid = info.get("Id", "")[:12]
+            name = (info.get("Name") or "").lstrip("/")
+            image = (info.get("Config", {}) or {}).get("Image", "")
+            status = (info.get("State", {}) or {}).get("Status", "unknown")
+
+            labels: dict[str, str] = (info.get("Config", {}) or {}).get("Labels") or {}
+            env_list: list[str] = (info.get("Config", {}) or {}).get("Env") or []
+
+            # Extract env var names (never values — security)
+            env_names = [e.split("=", 1)[0] for e in env_list if "=" in e]
+
+            cuda_version, cudnn_version = _extract_cuda_versions(labels)
+
+            # Also check env vars for CUDA hints
+            if not cuda_version:
+                for env in env_list:
+                    if env.startswith("CUDA_VERSION="):
+                        cuda_version = env.split("=", 1)[1].strip()
+                    elif env.startswith("CUDNN_VERSION="):
+                        cudnn_version = env.split("=", 1)[1].strip()
+
+            # Check if GPU is explicitly assigned
+            host_config = info.get("HostConfig", {}) or {}
+            device_requests = host_config.get("DeviceRequests") or []
+            gpu_requested = any(
+                dr.get("Driver") in ("nvidia", "gpu")
+                or dr.get("Capabilities")
+                and any("gpu" in cap_list for cap_list in (dr.get("Capabilities") or []))
+                for dr in device_requests
+            )
+
+            # Also check runtime
+            runtime = host_config.get("Runtime", "")
+            if runtime in ("nvidia", "nvidia-container-runtime"):
+                gpu_requested = True
+
+            # Check if NVIDIA image
+            is_nvidia = _is_nvidia_image(image)
+
+            # Port bindings
+            port_bindings = info.get("HostConfig", {}).get("PortBindings") or {}
+            ports = list(port_bindings.keys())
+
+            if is_nvidia or gpu_requested or cuda_version:
+                containers.append(
+                    GpuContainer(
+                        container_id=cid,
+                        name=name,
+                        image=image,
+                        status=status,
+                        is_nvidia_base=is_nvidia,
+                        cuda_version=cuda_version,
+                        cudnn_version=cudnn_version,
+                        gpu_requested=gpu_requested,
+                        labels=labels,
+                        env_vars=env_names,
+                        ports=ports,
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Error parsing container info: %s", exc)
+            continue
+
+    return containers, warnings
+
+
+# ─── Kubernetes discovery ─────────────────────────────────────────────────────
+
+
+def _run_kubectl(args: list[str], context: str | None = None, timeout: int = 60) -> Any:
+    """Run a kubectl command and return parsed JSON output. Returns None on failure."""
+    if not shutil.which("kubectl"):
+        return None
+    cmd = ["kubectl"]
+    if context:
+        cmd.extend(["--context", context])
+    cmd.extend(args + ["-o", "json"])
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return None
+
+
+def discover_k8s_gpu_nodes(
+    context: str | None = None,
+) -> tuple[list[GpuNode], list[str]]:
+    """Discover Kubernetes nodes with GPU resources.
+
+    Returns:
+        (gpu_nodes, warnings)
+    """
+    nodes: list[GpuNode] = []
+    warnings: list[str] = []
+
+    node_list = _run_kubectl(["get", "nodes"], context=context)
+    if node_list is None:
+        return nodes, ["kubectl not available — K8s GPU node discovery skipped"]
+
+    items = node_list.get("items") or []
+    for node in items:
+        try:
+            name = (node.get("metadata") or {}).get("name", "")
+            labels: dict[str, str] = (node.get("metadata") or {}).get("labels") or {}
+            capacity: dict = (node.get("status") or {}).get("capacity") or {}
+            allocatable: dict = (node.get("status") or {}).get("allocatable") or {}
+
+            gpu_cap_str = capacity.get(_K8S_GPU_RESOURCE, "0")
+            gpu_alloc_str = allocatable.get(_K8S_GPU_RESOURCE, "0")
+
+            try:
+                gpu_cap = int(gpu_cap_str)
+                gpu_alloc = int(gpu_alloc_str)
+            except ValueError:
+                continue
+
+            if gpu_cap == 0:
+                continue  # not a GPU node
+
+            # CUDA driver version from labels
+            cuda_driver = labels.get("nvidia.com/cuda.driver.major")
+            cuda_minor = labels.get("nvidia.com/cuda.driver.minor")
+            if cuda_driver and cuda_minor:
+                cuda_driver = f"{cuda_driver}.{cuda_minor}"
+            else:
+                cuda_driver = labels.get("nvidia.com/cuda.driver-version")
+
+            nodes.append(
+                GpuNode(
+                    name=name,
+                    gpu_capacity=gpu_cap,
+                    gpu_allocatable=gpu_alloc,
+                    gpu_allocated=gpu_cap - gpu_alloc,  # rough estimate
+                    cuda_driver_version=cuda_driver,
+                    labels={k: v for k, v in labels.items() if "nvidia" in k.lower()},
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Error parsing K8s node: %s", exc)
+            continue
+
+    return nodes, warnings
+
+
+# ─── DCGM endpoint probing ────────────────────────────────────────────────────
+
+
+async def probe_dcgm_endpoint(host: str, port: int = _DCGM_PORT) -> DcgmEndpoint | None:
+    """Probe a potential DCGM exporter metrics endpoint.
+
+    Returns DcgmEndpoint if metrics are accessible, None otherwise.
+    Flags unauthenticated = True when metrics are returned without auth.
+    """
+    url = f"http://{host}:{port}{_DCGM_METRICS_PATH}"
+    try:
+        async with create_client(timeout=_DCGM_PROBE_TIMEOUT) as client:
+            resp = await request_with_retry(client, "GET", url, max_attempts=1)
+    except Exception:  # noqa: BLE001
+        return None
+
+    if resp.status_code not in (200, 206):
+        return None
+
+    content = resp.text[:4096]  # first 4KB of metrics
+
+    # DCGM metrics start with HELP/TYPE lines for DCGM_FI_ prefixed metrics
+    is_dcgm = "DCGM_FI_" in content or "dcgm_" in content.lower()
+    if not is_dcgm:
+        return None
+
+    # Count GPUs from DCGM_FI_DEV_COUNT if present
+    gpu_count: int | None = None
+    for line in content.splitlines():
+        if line.startswith("DCGM_FI_DEV_COUNT{") and not line.startswith("#"):
+            try:
+                gpu_count = int(line.split()[-1])
+                break
+            except (ValueError, IndexError):
+                pass
+
+    # Extract some metric key names for inventory
+    metric_keys = [line.split("{")[0].strip() for line in content.splitlines() if line.startswith("DCGM_FI_") and not line.startswith("#")][
+        :10
+    ]
+
+    # Unauthenticated if we got 200 without any auth header being required
+    return DcgmEndpoint(
+        host=host,
+        port=port,
+        url=url,
+        authenticated=resp.status_code == 401,
+        gpu_count=gpu_count,
+        sample_metric_keys=list(dict.fromkeys(metric_keys)),  # dedupe, preserve order
+    )
+
+
+async def probe_dcgm_from_containers(
+    containers: list[GpuContainer],
+) -> list[DcgmEndpoint]:
+    """Probe DCGM on localhost and any containers that expose port 9400."""
+    endpoints: list[DcgmEndpoint] = []
+
+    hosts_to_probe: set[str] = {"localhost", "127.0.0.1"}
+
+    for c in containers:
+        for port_str in c.ports:
+            if str(_DCGM_PORT) in port_str:
+                hosts_to_probe.add("localhost")
+
+    for host in hosts_to_probe:
+        ep = await probe_dcgm_endpoint(host, _DCGM_PORT)
+        if ep:
+            endpoints.append(ep)
+
+    return endpoints
+
+
+# ─── Main entry point ─────────────────────────────────────────────────────────
+
+
+async def scan_gpu_infra(
+    k8s_context: str | None = None,
+    probe_dcgm: bool = True,
+) -> GpuInfraReport:
+    """Discover GPU/AI compute infrastructure from Docker and Kubernetes.
+
+    Args:
+        k8s_context: kubectl context to use (default: current context).
+        probe_dcgm: whether to probe DCGM exporter endpoints.
+
+    Returns:
+        GpuInfraReport with containers, K8s nodes, and DCGM endpoints.
+    """
+    all_warnings: list[str] = []
+
+    # Docker container discovery
+    docker_containers, docker_warnings = discover_docker_gpu_containers()
+    all_warnings.extend(docker_warnings)
+
+    # K8s node discovery
+    k8s_nodes, k8s_warnings = discover_k8s_gpu_nodes(context=k8s_context)
+    all_warnings.extend(k8s_warnings)
+
+    # DCGM endpoint probing
+    dcgm_endpoints: list[DcgmEndpoint] = []
+    if probe_dcgm:
+        try:
+            dcgm_endpoints = await probe_dcgm_from_containers(docker_containers)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("DCGM probe error: %s", exc)
+            all_warnings.append(f"DCGM probe skipped: {exc}")
+
+    return GpuInfraReport(
+        gpu_containers=docker_containers,
+        dcgm_endpoints=dcgm_endpoints,
+        gpu_nodes=k8s_nodes,
+        warnings=all_warnings,
+    )
+
+
+# ─── Agent conversion (for scan output) ──────────────────────────────────────
+
+
+def gpu_infra_to_agents(report: GpuInfraReport) -> list[Agent]:
+    """Convert GpuInfraReport to Agent objects for inclusion in AIBOMReport.
+
+    Each GPU container becomes an Agent with its image name as the MCP server.
+    K8s GPU nodes appear as a synthetic "k8s-gpu-cluster" agent.
+    """
+    agents: list[Agent] = []
+
+    for c in report.gpu_containers:
+        # Build package list from CUDA/cuDNN versions
+        packages: list[Package] = []
+        if c.cuda_version:
+            packages.append(Package(name="cuda-toolkit", version=c.cuda_version, ecosystem="container"))
+        if c.cudnn_version:
+            packages.append(Package(name="cudnn", version=c.cudnn_version, ecosystem="container"))
+
+        server = MCPServer(
+            name=c.image,
+            command="",
+            transport=TransportType.STDIO,
+            packages=packages,
+        )
+        agent = Agent(
+            name=c.name or c.container_id,
+            agent_type=AgentType.CUSTOM,
+            config_path=f"docker://{c.container_id}",
+            source="gpu_infra",
+            mcp_servers=[server],
+        )
+        agents.append(agent)
+
+    # Aggregate K8s GPU nodes as a single agent
+    if report.gpu_nodes:
+        total_gpus = sum(n.gpu_capacity for n in report.gpu_nodes)
+        node_server = MCPServer(
+            name=f"k8s-gpu-cluster ({len(report.gpu_nodes)} nodes, {total_gpus} GPUs)",
+            command="",
+            transport=TransportType.STDIO,
+            packages=[],
+        )
+        agents.append(
+            Agent(
+                name="k8s-gpu-cluster",
+                agent_type=AgentType.CUSTOM,
+                config_path="k8s://gpu-nodes",
+                source="gpu_infra",
+                mcp_servers=[node_server],
+            )
+        )
+
+    return agents

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1792,6 +1792,85 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("MCP tool error")
             return json.dumps({"error": sanitize_error(exc)})
 
+    # ── Tool 23: gpu_infra_scan ────────────────────────────────────
+    @mcp.tool(annotations=_READ_ONLY)
+    async def gpu_infra_scan(
+        k8s_context: Annotated[
+            str | None,
+            Field(description="kubectl context to use for K8s GPU node discovery. Omit for current context."),
+        ] = None,
+        probe_dcgm: Annotated[
+            bool,
+            Field(description="Whether to probe DCGM exporter endpoints on port 9400 (unauthenticated metrics leak detection)."),
+        ] = True,
+    ) -> str:
+        """Discover GPU/AI compute infrastructure: containers, K8s nodes, and DCGM endpoints.
+
+        Scans for GPU-enabled workloads from the local Docker daemon and Kubernetes
+        clusters. Identifies NVIDIA base images, CUDA/cuDNN versions, explicit GPU
+        device assignments, and unauthenticated DCGM exporter endpoints.
+
+        Discovery targets (MAESTRO KC6):
+        - NVIDIA base images (nvcr.io/nvidia/, nvidia/cuda, etc.)
+        - CUDA/cuDNN versions from container labels and env vars
+        - GPU-assigned containers (Docker --gpus, K8s nvidia.com/gpu requests)
+        - Unauthenticated DCGM exporter endpoints (port 9400 — GPU metrics leak)
+        - Kubernetes GPU node inventory with capacity and allocatable counts
+
+        Requires docker and/or kubectl on PATH. All discovery is best-effort
+        (returns empty results rather than failing if tools are unavailable).
+
+        Returns:
+            JSON with GPU containers, K8s nodes, DCGM endpoints, CUDA version
+            inventory, and a risk summary with unauthenticated DCGM count.
+        """
+        try:
+            from agent_bom.cloud.gpu_infra import scan_gpu_infra
+
+            report = await scan_gpu_infra(k8s_context=k8s_context, probe_dcgm=probe_dcgm)
+            result = {
+                "risk_summary": report.risk_summary,
+                "gpu_containers": [
+                    {
+                        "container_id": c.container_id,
+                        "name": c.name,
+                        "image": c.image,
+                        "status": c.status,
+                        "is_nvidia_base": c.is_nvidia_base,
+                        "cuda_version": c.cuda_version,
+                        "cudnn_version": c.cudnn_version,
+                        "gpu_requested": c.gpu_requested,
+                    }
+                    for c in report.gpu_containers
+                ],
+                "k8s_gpu_nodes": [
+                    {
+                        "name": n.name,
+                        "gpu_capacity": n.gpu_capacity,
+                        "gpu_allocatable": n.gpu_allocatable,
+                        "gpu_allocated": n.gpu_allocated,
+                        "cuda_driver_version": n.cuda_driver_version,
+                    }
+                    for n in report.gpu_nodes
+                ],
+                "dcgm_endpoints": [
+                    {
+                        "host": ep.host,
+                        "port": ep.port,
+                        "url": ep.url,
+                        "authenticated": ep.authenticated,
+                        "gpu_count": ep.gpu_count,
+                        "risk": "unauthenticated GPU metrics exposure" if not ep.authenticated else "ok",
+                    }
+                    for ep in report.dcgm_endpoints
+                ],
+                "warnings": report.warnings,
+            }
+            return _truncate_response(json.dumps(result, indent=2, default=str))
+        except Exception as exc:
+            logger.exception("MCP tool error")
+            return json.dumps({"error": sanitize_error(exc)})
+
     # ── Custom routes: metadata + health ─────────────────────────────
 
     @mcp.custom_route("/.well-known/mcp/server-card.json", methods=["GET"])
@@ -1900,6 +1979,11 @@ _SERVER_CARD_TOOLS = [
     {
         "name": "aisvs_benchmark",
         "description": "OWASP AISVS v1.0 compliance checks — model safety, vector store auth, inference exposure, supply chain",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "gpu_infra_scan",
+        "description": "Discover GPU containers, K8s GPU nodes, CUDA versions, and unauthenticated DCGM endpoints (MAESTRO KC6)",
         "annotations": {"readOnlyHint": True},
     },
 ]

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -406,6 +406,7 @@ class AIBOMReport:
     databricks_cis_benchmark_data: Optional[dict] = None  # Serialized Databricks Security Best Practices results
     aisvs_benchmark_data: Optional[dict] = None  # Serialized AISVS compliance results
     vector_db_scan_data: Optional[list] = None  # Serialized vector DB security assessments
+    gpu_infra_data: Optional[dict] = None  # Serialized GPU/AI compute infra scan results
     runtime_correlation: Optional[dict] = None  # Runtime ↔ scan correlation (proxy audit vs CVE findings)
 
     def __post_init__(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3024,7 +3024,7 @@ def test_openclaw_registry_skill_minimal_surface():
 
 
 def test_openclaw_skills_all_tools_covered():
-    """All 22 MCP tools should be covered in the consolidated skill."""
+    """All 23 MCP tools should be covered in the consolidated skill."""
     from pathlib import Path
 
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"
@@ -3052,6 +3052,7 @@ def test_openclaw_skills_all_tools_covered():
         "fleet_scan",
         "vector_db_scan",
         "aisvs_benchmark",
+        "gpu_infra_scan",
     ]:
         assert tool in content, f"Tool '{tool}' missing from SKILL.md"
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -117,14 +117,14 @@ def test_smithery_yaml_exists():
 
 
 def test_server_card_has_all_tools():
-    """Server card should list all 22 MCP tools."""
+    """Server card should list all 23 MCP tools."""
     from agent_bom.mcp_server import build_server_card
 
     card = build_server_card()
     assert card["name"] == "agent-bom"
     assert "version" in card
     tool_names = [t["name"] for t in card["tools"]]
-    assert len(tool_names) == 22
+    assert len(tool_names) == 23
     assert "scan" in tool_names
     assert "check" in tool_names
     assert "blast_radius" in tool_names
@@ -224,7 +224,7 @@ def test_mcp_server_help_shows_14_tools():
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp-server", "--help"])
-    assert "22 security tools" in result.output
+    assert "23 security tools" in result.output
     assert "compliance" in result.output
     assert "remediate" in result.output
 

--- a/tests/test_gpu_infra.py
+++ b/tests/test_gpu_infra.py
@@ -1,0 +1,545 @@
+"""Tests for GPU/AI compute infrastructure scanner (cloud/gpu_infra.py).
+
+Covers:
+- NVIDIA image prefix detection
+- CUDA/cuDNN label extraction
+- Docker container discovery (mocked subprocess)
+- Kubernetes GPU node discovery (mocked kubectl)
+- DCGM endpoint probing (mocked HTTP)
+- GpuInfraReport aggregation properties
+- gpu_infra_to_agents() conversion
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_bom.cloud.gpu_infra import (
+    DcgmEndpoint,
+    GpuContainer,
+    GpuInfraReport,
+    GpuNode,
+    _extract_cuda_versions,
+    _is_nvidia_image,
+    discover_docker_gpu_containers,
+    discover_k8s_gpu_nodes,
+    gpu_infra_to_agents,
+    probe_dcgm_endpoint,
+    scan_gpu_infra,
+)
+
+# ─── Unit: helpers ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "image,expected",
+    [
+        ("nvcr.io/nvidia/cuda:12.3-base", True),
+        ("nvcr.io/nim/llama-3.1-8b-instruct:latest", True),
+        ("nvidia/cuda:11.8-cudnn8-runtime-ubuntu20.04", True),
+        ("nvidia/tritonserver:24.01-py3", True),
+        ("python:3.11-slim", False),
+        ("ubuntu:22.04", False),
+        ("pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime", False),  # not nvcr.io prefix
+    ],
+)
+def test_is_nvidia_image(image, expected):
+    assert _is_nvidia_image(image) == expected
+
+
+@pytest.mark.parametrize(
+    "labels,exp_cuda,exp_cudnn",
+    [
+        (
+            {"com.nvidia.cuda.version": "12.3.0", "com.nvidia.cudnn.version": "8.9.0"},
+            "12.3.0",
+            "8.9.0",
+        ),
+        ({"cuda_version": "11.8"}, "11.8", None),
+        ({"some.other.label": "value"}, None, None),
+        ({}, None, None),
+        (
+            {
+                "com.nvidia.cuda.version": "12.2",
+                "unrelated": "x",
+            },
+            "12.2",
+            None,
+        ),
+    ],
+)
+def test_extract_cuda_versions(labels, exp_cuda, exp_cudnn):
+    cuda, cudnn = _extract_cuda_versions(labels)
+    assert cuda == exp_cuda
+    assert cudnn == exp_cudnn
+
+
+# ─── Unit: GpuInfraReport properties ─────────────────────────────────────────
+
+
+def test_gpu_infra_report_properties():
+    containers = [
+        GpuContainer(
+            container_id="abc123",
+            name="cuda-app",
+            image="nvcr.io/nvidia/cuda:12.3",
+            status="running",
+            is_nvidia_base=True,
+            cuda_version="12.3.0",
+            cudnn_version=None,
+            gpu_requested=True,
+        ),
+        GpuContainer(
+            container_id="def456",
+            name="vllm-server",
+            image="vllm/vllm-openai:v0.4.0",
+            status="running",
+            is_nvidia_base=False,
+            cuda_version="12.1.0",
+            cudnn_version="8.9.0",
+            gpu_requested=True,
+        ),
+    ]
+    endpoints = [
+        DcgmEndpoint(host="localhost", port=9400, url="http://localhost:9400/metrics", authenticated=False, gpu_count=4),
+        DcgmEndpoint(host="10.0.0.5", port=9400, url="http://10.0.0.5:9400/metrics", authenticated=True, gpu_count=8),
+    ]
+    nodes = [GpuNode(name="gpu-node-1", gpu_capacity=8, gpu_allocatable=6, gpu_allocated=2, cuda_driver_version="525.85")]
+
+    report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=endpoints, gpu_nodes=nodes, warnings=[])
+
+    assert report.total_gpu_containers == 2
+    assert report.nvidia_base_image_count == 1
+    assert report.unauthenticated_dcgm_count == 1
+    assert set(report.unique_cuda_versions) == {"12.1.0", "12.3.0"}
+    summary = report.risk_summary
+    assert summary["total_gpu_containers"] == 2
+    assert summary["unauthenticated_dcgm"] == 1
+    assert summary["gpu_k8s_nodes"] == 1
+
+
+def test_gpu_infra_report_empty():
+    report = GpuInfraReport(gpu_containers=[], dcgm_endpoints=[], gpu_nodes=[], warnings=[])
+    assert report.total_gpu_containers == 0
+    assert report.unauthenticated_dcgm_count == 0
+    assert report.unique_cuda_versions == []
+
+
+# ─── Unit: gpu_infra_to_agents ────────────────────────────────────────────────
+
+
+def test_gpu_infra_to_agents_containers():
+    containers = [
+        GpuContainer(
+            container_id="abc123",
+            name="cuda-workload",
+            image="nvcr.io/nvidia/cuda:12.3",
+            status="running",
+            is_nvidia_base=True,
+            cuda_version="12.3.0",
+            cudnn_version="8.9.0",
+            gpu_requested=True,
+        ),
+    ]
+    report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=[], gpu_nodes=[], warnings=[])
+    agents = gpu_infra_to_agents(report)
+    assert len(agents) == 1
+    assert agents[0].name == "cuda-workload"
+    assert agents[0].source == "gpu_infra"
+    pkgs = agents[0].mcp_servers[0].packages
+    pkg_names = [p.name for p in pkgs]
+    assert "cuda-toolkit" in pkg_names
+    assert "cudnn" in pkg_names
+
+
+def test_gpu_infra_to_agents_k8s_nodes():
+    nodes = [
+        GpuNode(name="node-1", gpu_capacity=4, gpu_allocatable=4, gpu_allocated=0, cuda_driver_version="525"),
+        GpuNode(name="node-2", gpu_capacity=8, gpu_allocatable=6, gpu_allocated=2, cuda_driver_version="525"),
+    ]
+    report = GpuInfraReport(gpu_containers=[], dcgm_endpoints=[], gpu_nodes=nodes, warnings=[])
+    agents = gpu_infra_to_agents(report)
+    # One synthetic k8s-gpu-cluster agent
+    assert len(agents) == 1
+    assert agents[0].name == "k8s-gpu-cluster"
+    assert "12 GPUs" in agents[0].mcp_servers[0].name
+
+
+def test_gpu_infra_to_agents_no_cuda_version():
+    """Container without CUDA version produces agent with no packages."""
+    containers = [
+        GpuContainer(
+            container_id="xyz",
+            name="gpu-app",
+            image="myapp:latest",
+            status="running",
+            is_nvidia_base=False,
+            cuda_version=None,
+            cudnn_version=None,
+            gpu_requested=True,
+        ),
+    ]
+    report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=[], gpu_nodes=[], warnings=[])
+    agents = gpu_infra_to_agents(report)
+    assert len(agents) == 1
+    assert agents[0].mcp_servers[0].packages == []
+
+
+# ─── Integration: discover_docker_gpu_containers (mocked) ─────────────────────
+
+
+def _make_inspect(container_id, name, image, labels=None, env=None, runtime="runc", device_requests=None, port_bindings=None):
+    return {
+        "Id": container_id + "0" * 52,
+        "Name": f"/{name}",
+        "Config": {
+            "Image": image,
+            "Labels": labels or {},
+            "Env": env or [],
+        },
+        "HostConfig": {
+            "Runtime": runtime,
+            "DeviceRequests": device_requests or [],
+            "PortBindings": port_bindings or {},
+        },
+        "State": {"Status": "running"},
+    }
+
+
+def test_discover_docker_nvidia_runtime():
+    """Containers with nvidia runtime are flagged as GPU containers."""
+    container_data = [
+        _make_inspect(
+            "abc123",
+            "vllm",
+            "vllm/vllm-openai:v0.4",
+            labels={"com.nvidia.cuda.version": "12.1.0"},
+            runtime="nvidia",
+        )
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        # First call: docker ps
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "abc123" + "0" * 52 + "\n"
+
+        # Second call: docker inspect
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, warnings = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].cuda_version == "12.1.0"
+    assert containers[0].gpu_requested is True
+    assert containers[0].is_nvidia_base is False
+    assert not warnings
+
+
+def test_discover_docker_nvidia_base_image():
+    """NVIDIA base image containers are discovered even without runtime flag."""
+    container_data = [_make_inspect("ccc123", "cuda-app", "nvcr.io/nvidia/cuda:12.3-base")]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "ccc123" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, warnings = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].is_nvidia_base is True
+
+
+def test_discover_docker_non_gpu_container_excluded():
+    """Regular Python containers without GPU are not included."""
+    container_data = [_make_inspect("ddd123", "webapp", "python:3.11-slim")]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "ddd123" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, _ = discover_docker_gpu_containers()
+
+    assert containers == []
+
+
+def test_discover_docker_not_installed():
+    """Returns empty list with warning when docker is not on PATH."""
+    with patch("shutil.which", return_value=None):
+        containers, warnings = discover_docker_gpu_containers()
+
+    assert containers == []
+    assert any("docker" in w.lower() for w in warnings)
+
+
+def test_discover_docker_ps_fails():
+    """Returns empty list with warning when docker ps fails."""
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 1
+        ps_result.stdout = ""
+        mock_run.return_value = ps_result
+
+        containers, warnings = discover_docker_gpu_containers()
+
+    assert containers == []
+    assert len(warnings) >= 1
+
+
+def test_discover_docker_env_var_cuda():
+    """CUDA version from CUDA_VERSION env var is captured."""
+    container_data = [
+        _make_inspect(
+            "eee123",
+            "torch-app",
+            "pytorch/pytorch:latest",
+            env=["CUDA_VERSION=11.8.0", "PATH=/usr/bin"],
+            device_requests=[{"Driver": "nvidia", "Capabilities": [["gpu"]]}],
+        )
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "eee123" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, _ = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].cuda_version == "11.8.0"
+
+
+# ─── Integration: discover_k8s_gpu_nodes (mocked) ────────────────────────────
+
+
+def _make_node(name, gpu_capacity, gpu_allocatable, cuda_driver=None):
+    labels = {
+        "kubernetes.io/hostname": name,
+    }
+    if cuda_driver:
+        major, minor = (cuda_driver.split(".") + ["0"])[:2]
+        labels["nvidia.com/cuda.driver.major"] = major
+        labels["nvidia.com/cuda.driver.minor"] = minor
+
+    return {
+        "metadata": {"name": name, "labels": labels},
+        "status": {
+            "capacity": {"nvidia.com/gpu": str(gpu_capacity), "cpu": "32"},
+            "allocatable": {"nvidia.com/gpu": str(gpu_allocatable), "cpu": "32"},
+        },
+    }
+
+
+def test_discover_k8s_gpu_nodes():
+    node_list = {
+        "items": [
+            _make_node("gpu-node-1", 8, 6, cuda_driver="525.85"),
+            _make_node("cpu-node-1", 0, 0),  # not a GPU node
+        ]
+    }
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(node_list)
+        mock_run.return_value = result
+
+        nodes, warnings = discover_k8s_gpu_nodes()
+
+    assert len(nodes) == 1
+    assert nodes[0].name == "gpu-node-1"
+    assert nodes[0].gpu_capacity == 8
+    assert nodes[0].gpu_allocatable == 6
+    assert nodes[0].gpu_allocated == 2
+    assert "525" in (nodes[0].cuda_driver_version or "")
+
+
+def test_discover_k8s_no_gpu_nodes():
+    """Cluster with no GPU nodes returns empty list."""
+    node_list = {
+        "items": [
+            _make_node("cpu-node-1", 0, 0),
+            _make_node("cpu-node-2", 0, 0),
+        ]
+    }
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(node_list)
+        mock_run.return_value = result
+
+        nodes, _ = discover_k8s_gpu_nodes()
+
+    assert nodes == []
+
+
+def test_discover_k8s_kubectl_missing():
+    with patch("shutil.which", return_value=None):
+        nodes, warnings = discover_k8s_gpu_nodes()
+
+    assert nodes == []
+    assert any("kubectl" in w.lower() for w in warnings)
+
+
+# ─── Integration: probe_dcgm_endpoint (mocked HTTP) ──────────────────────────
+
+_DCGM_SAMPLE_METRICS = """\
+# HELP DCGM_FI_DEV_GPU_TEMP GPU temperature (in C).
+# TYPE DCGM_FI_DEV_GPU_TEMP gauge
+DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="GPU-abc"} 45
+DCGM_FI_DEV_COUNT{} 4
+DCGM_FI_DEV_GPU_UTIL{gpu="0"} 87
+"""
+
+
+@pytest.mark.asyncio
+async def test_probe_dcgm_unauthenticated():
+    """DCGM endpoint returning metrics without auth is flagged unauthenticated."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = _DCGM_SAMPLE_METRICS
+
+    with patch("agent_bom.cloud.gpu_infra.create_client") as mock_client:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=None)
+        mock_client.return_value = mock_http
+
+        with patch("agent_bom.cloud.gpu_infra.request_with_retry", return_value=mock_resp):
+            ep = await probe_dcgm_endpoint("localhost", 9400)
+
+    assert ep is not None
+    assert ep.authenticated is False
+    assert ep.gpu_count == 4
+    assert "DCGM_FI_DEV_GPU_TEMP" in ep.sample_metric_keys
+
+
+@pytest.mark.asyncio
+async def test_probe_dcgm_not_found():
+    """Non-DCGM endpoint returns None."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = "# HELP some_other_metric\n"
+
+    with patch("agent_bom.cloud.gpu_infra.create_client") as mock_client:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=None)
+        mock_client.return_value = mock_http
+
+        with patch("agent_bom.cloud.gpu_infra.request_with_retry", return_value=mock_resp):
+            ep = await probe_dcgm_endpoint("localhost", 9400)
+
+    assert ep is None
+
+
+@pytest.mark.asyncio
+async def test_probe_dcgm_connection_refused():
+    """Connection failure returns None without raising."""
+    with patch("agent_bom.cloud.gpu_infra.create_client") as mock_client:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=None)
+        mock_client.return_value = mock_http
+
+        with patch("agent_bom.cloud.gpu_infra.request_with_retry", side_effect=Exception("Connection refused")):
+            ep = await probe_dcgm_endpoint("localhost", 9400)
+
+    assert ep is None
+
+
+# ─── Integration: scan_gpu_infra (mocked end-to-end) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scan_gpu_infra_empty():
+    """scan_gpu_infra with no Docker/K8s returns empty report."""
+    with (
+        patch("agent_bom.cloud.gpu_infra.discover_docker_gpu_containers", return_value=([], ["Docker not running"])),
+        patch("agent_bom.cloud.gpu_infra.discover_k8s_gpu_nodes", return_value=([], ["kubectl missing"])),
+        patch("agent_bom.cloud.gpu_infra.probe_dcgm_from_containers", return_value=[]),
+    ):
+        report = await scan_gpu_infra()
+
+    assert report.total_gpu_containers == 0
+    assert report.gpu_nodes == []
+    assert report.dcgm_endpoints == []
+    assert len(report.warnings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_scan_gpu_infra_with_containers():
+    """scan_gpu_infra aggregates containers and nodes into report."""
+    containers = [
+        GpuContainer(
+            container_id="abc",
+            name="cuda-app",
+            image="nvcr.io/nvidia/cuda:12.3",
+            status="running",
+            is_nvidia_base=True,
+            cuda_version="12.3.0",
+            cudnn_version=None,
+            gpu_requested=True,
+        )
+    ]
+    nodes = [GpuNode(name="node-1", gpu_capacity=4, gpu_allocatable=4, gpu_allocated=0, cuda_driver_version="525")]
+
+    with (
+        patch("agent_bom.cloud.gpu_infra.discover_docker_gpu_containers", return_value=(containers, [])),
+        patch("agent_bom.cloud.gpu_infra.discover_k8s_gpu_nodes", return_value=(nodes, [])),
+        patch("agent_bom.cloud.gpu_infra.probe_dcgm_from_containers", return_value=[]),
+    ):
+        report = await scan_gpu_infra()
+
+    assert report.total_gpu_containers == 1
+    assert len(report.gpu_nodes) == 1
+    assert report.unique_cuda_versions == ["12.3.0"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -58,12 +58,12 @@ def test_create_mcp_server_returns_object():
 
 
 def test_mcp_server_has_eighteen_tools():
-    """Server should register exactly 22 tools."""
+    """Server should register exactly 23 tools."""
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
     tools = _run(server.list_tools())
-    assert len(tools) == 22
+    assert len(tools) == 23
 
 
 def test_mcp_server_tool_names():
@@ -96,6 +96,7 @@ def test_mcp_server_tool_names():
         "runtime_correlate",
         "vector_db_scan",
         "aisvs_benchmark",
+        "gpu_infra_scan",
     }
 
 

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -610,10 +610,10 @@ def test_mcp_skill_trust_tool_exists():
 
 
 def test_mcp_server_card_has_18_tools():
-    """Server card lists 22 tools (including vector_db_scan, aisvs_benchmark, cis_benchmark, fleet_scan)."""
+    """Server card lists 23 tools (including vector_db_scan, aisvs_benchmark, cis_benchmark, fleet_scan, gpu_infra_scan)."""
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
-    assert len(_SERVER_CARD_TOOLS) == 22
+    assert len(_SERVER_CARD_TOOLS) == 23
     tool_names = {t["name"] for t in _SERVER_CARD_TOOLS}
     assert "code_scan" in tool_names
     assert "context_graph" in tool_names


### PR DESCRIPTION
## Summary

- Adds `src/agent_bom/cloud/gpu_infra.py` — GPU/AI compute infrastructure scanner
- Discovers GPU-enabled Docker containers (NVIDIA base images, CUDA labels, `--gpus` runtime, `CUDA_VERSION` env)
- Discovers Kubernetes GPU nodes via `kubectl` (nvidia.com/gpu capacity/allocatable, CUDA driver labels)
- Probes DCGM exporter endpoints (port 9400) — flags unauthenticated metrics exposure
- 31 new tests, all passing
- Wired into CLI (`--gpu-scan`, `--gpu-k8s-context`, `--no-dcgm-probe`), MCP (`gpu_infra_scan`, tool #23), and `AIBOMReport.gpu_infra_data`

## Test plan

- [ ] `pytest tests/test_gpu_infra.py` — 31 tests pass
- [ ] `pytest tests/test_mcp_server.py tests/test_trust_assessment.py tests/test_deployment.py` — tool count assertions updated to 23
- [ ] `pytest tests/test_core.py::test_openclaw_skills_all_tools_covered` — SKILL.md includes gpu_infra_scan