### PR TITLE
docs: update SVG diagrams to 23 tools + honest roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | GitHub Action | `uses: msaad00/agent-bom@v0.63.0 | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
-| MCP Server | `agent-bom mcp-server` (22 tools) | Inside any MCP client |
+| MCP Server | `agent-bom mcp-server` (23 tools) | Inside any MCP client |
 | Dashboard | `agent-bom serve` | API + Next.js UI (15 pages) |
 | Runtime proxy | `agent-bom proxy` | MCP traffic audit |
 | Pre-install guard | `agent-bom guard pip install <pkg>` | Block vulnerable installs |
@@ -347,10 +347,42 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 
 ## Roadmap
 
-- [x] CIS Foundations benchmarks (AWS v3.0, Azure v3.0, GCP v3.0, Snowflake v1.0)
+**GPU / AI compute**
+- [x] GPU container discovery (Docker — NVIDIA images, CUDA labels, `--gpus` runtime)
+- [x] Kubernetes GPU node inventory (nvidia.com/gpu capacity/allocatable, CUDA driver labels)
+- [x] Unauthenticated DCGM exporter detection (port 9400 metrics leak)
+- [ ] Remote Docker host scanning (currently local daemon only)
+- [ ] NVIDIA GPU CVE feed — CUDA/cuDNN specific advisories beyond OSV
+- [ ] GPU utilization and memory anomaly detection
+
+**AI supply chain**
+- [x] OSV + GHSA + NVD + EPSS + CISA KEV vulnerability enrichment
+- [x] ML model file scanning (.gguf, .safetensors, .onnx) + SHA-256 + Sigstore
+- [x] HuggingFace model provenance and dataset card scanning
+- [ ] Dataset poisoning detection
+- [ ] Training pipeline scanning (MLflow DAGs, Kubeflow pipelines)
+- [ ] Model card authenticity verification (beyond hash/sigstore)
+
+**Agents / MCP**
+- [x] 20 MCP client config discovery paths, live introspection, tool drift detection
+- [x] Runtime proxy with 6 behavioral detectors (rug pull, injection, credential leak, etc.)
+- [ ] Semantic prompt injection analysis (currently pattern-based)
+- [ ] Agent memory / vector store content scanning for injected instructions
+- [ ] LLM API call tracing (which model was called, with what context)
+
+**Identity / access**
+- [ ] IdP / OIDC integration (weakest current layer — no token validation or identity graph)
+- [ ] Agent-to-agent permission boundary enforcement
+
+**Compliance / standards**
+- [x] 10 frameworks: OWASP LLM, OWASP MCP, OWASP Agentic, ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls
 - [ ] CIS AI benchmarks (pending CIS publication)
-- [ ] License compliance engine
+- [ ] License compliance engine (OSS license risk flagging)
 - [ ] Workflow engine scanning (n8n, Zapier, Make)
+
+**Ecosystem coverage**
+- [ ] Maven / Go ecosystem — test coverage thin (PyPI, npm, cargo, pip best covered)
+- [ ] Windows container support (currently Linux-focused for Docker GPU discovery)
 
 See the full list of [shipped features](https://github.com/msaad00/agent-bom/releases).
 

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">22 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">23 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">22 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">23 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">22 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">23 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">22 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">23 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (22 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (23 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#0f3f1f"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#7ee787">13+ FORMATS</text>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (22 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (23 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#d1fae5"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#065f46">13+ FORMATS</text>


### PR DESCRIPTION
## Summary

- 6 SVG diagrams updated: 22 tools → 23 tools (architecture, scanner-architecture, offerings-map — dark + light variants)
- README MCP Server table: 22 → 23 tools
- Roadmap expanded with honest gap tracking across 5 areas: GPU/AI compute, AI supply chain, Agents/MCP, Identity/access, Compliance/ecosystem coverage
- Checked and confirmed items vs unimplemented — no false claims

## What's documented as limitations

- Docker GPU scanner is local daemon only (remote hosts not yet supported)
- No NVIDIA GPU-specific CVE feed (uses OSV which has limited CUDA CVEs)
- Prompt injection detection is pattern-based, not semantic
- No agent memory / vector store content scanning
- Maven/Go ecosystem test coverage is thin
- No IdP/OIDC integration