### PR TITLE
ci: scope fuzz workflow to fuzz/** only

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/**'
       - 'fuzz/**'
       - '.clusterfuzzlite/**'
   pull_request:
     branches: [main]
     paths:
-      - 'src/**'
       - 'fuzz/**'
       - '.clusterfuzzlite/**'
   schedule:


### PR DESCRIPTION
PR-Fuzzing was firing on every PR touching `src/**` (almost all of them), running for 60s+ then getting abandoned. Not a required check — pure wasted CI minutes.

**Fix**: paths filter now only includes `fuzz/**` and `.clusterfuzzlite/**`. Weekly batch schedule (Monday 04:00 UTC) unchanged — deep fuzzing still happens regularly.