### PR TITLE
security: harden proxy message size + expand Trust section

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -247,7 +247,7 @@ agent-bom scan --snowflake --snowflake-authenticator oauth
 | Principle | How agent-bom upholds it |
 |-----------|--------------------------|
 | **Confidentiality** | Credentials pass env → SDK, never logged. `sanitize_error()` strips secrets from all error messages. Audit logs stored at `0600` permissions. |
-| **Integrity** | SHA-256 payload hashing on every proxied MCP call. Model weight hash verification (`--verify-model-hashes`). SBOM + VEX support for supply chain integrity. |
+| **Integrity** | SHA-256 payload hashing on every proxied MCP call. Audit logs HMAC-signed (SHA-256) for tamper detection. Set `AGENT_BOM_AUDIT_HMAC_KEY` in production to persist verifiability across restarts. Model weight hash verification (`--verify-model-hashes`). SBOM + VEX support for supply chain integrity. |
 | **Availability** | Graceful degradation on auth failure (warning, not crash). Offline mode (`--no-scan`). Rate limiting respected — we never exhaust API quotas. |
 
 ### What we never do

--- a/README.md
+++ b/README.md
@@ -367,12 +367,19 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 ## Trust & permissions
 
 - **Read-only** -- never writes configs, runs servers, provisions resources, or stores secrets
-- **Credential redaction** -- only env var **names** in reports; values never read
+- **Credential redaction** -- only env var **names** in reports; values never read or logged
+- **No shell injection** -- subprocess uses `asyncio.create_subprocess_exec`; command + args validated before every spawn
+- **No SSRF** -- all outbound URLs hardcoded or validated; DNS rebinding defense blocks private/loopback/cloud-metadata ranges
+- **No path traversal** -- `validate_path(restrict_to_home=True)` on all user-supplied paths; MCP tool inputs sanitized
+- **No SQL injection** -- all database queries use parameterized statements
+- **Proxy size guard** -- messages >10 MB dropped before parsing; protects against DoS
+- **Audit integrity** -- JSONL audit logs stored at `0600`, HMAC-signed (SHA-256). Set `AGENT_BOM_AUDIT_HMAC_KEY` in production for cross-restart verifiability.
+- **API security** -- scrypt KDF for API keys, RBAC (admin/analyst/viewer), OIDC/JWT (RS256/ES256, `none` algorithm rejected), constant-time comparison
 - **`--dry-run`** -- preview every file and API URL before access
 - **Sigstore signed** -- releases v0.7.0+ signed via cosign OIDC
 - **OpenSSF Scorecard** -- [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **OpenSSF Best Practices** -- [passing badge (100%)](https://www.bestpractices.dev/projects/12114) — 67/67 criteria
-- **Continuous fuzzing** -- [ClusterFuzzLite](https://github.com/msaad00/agent-bom/blob/main/.github/workflows/cifuzz.yml) fuzzes SBOM parsers, policy evaluator, and skill parser on every PR
+- **Continuous fuzzing** -- [ClusterFuzzLite](https://github.com/msaad00/agent-bom/blob/main/.github/workflows/cifuzz.yml) fuzzes SBOM parsers, policy evaluator, and skill parser
 - **[PERMISSIONS.md](PERMISSIONS.md)** -- full auditable trust contract
 
 ---

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -31,6 +31,10 @@ from agent_bom.security import validate_arguments, validate_command
 
 logger = logging.getLogger(__name__)
 
+# Maximum JSON-RPC message size accepted from client or server (10 MB).
+# Guards against DoS via oversized payloads in the stdio relay loop.
+_MAX_MESSAGE_BYTES = 10 * 1024 * 1024  # 10 MB
+
 
 # ─── Proxy metrics ──────────────────────────────────────────────────────────
 
@@ -609,6 +613,10 @@ async def run_proxy(
             if not line:
                 break
 
+            if len(line) > _MAX_MESSAGE_BYTES:
+                logger.warning("Oversized message from client (%d bytes) — dropped", len(line))
+                continue
+
             line_str = line.decode("utf-8", errors="replace")
             msg = parse_jsonrpc(line_str)
 
@@ -812,6 +820,10 @@ async def run_proxy(
             line = await process.stdout.readline()
             if not line:
                 break
+
+            if len(line) > _MAX_MESSAGE_BYTES:
+                logger.warning("Oversized message from server (%d bytes) — dropped", len(line))
+                continue
 
             line_str = line.decode("utf-8", errors="replace")
             msg = parse_jsonrpc(line_str)


### PR DESCRIPTION
## Summary

Addresses two findings from an internal OWASP Top 10 security audit.

- **proxy.py**: `_MAX_MESSAGE_BYTES = 10 MB` — drop oversized messages in both relay loops before JSON parsing, closes DoS vector from a malicious MCP server sending unbounded payloads
- **PERMISSIONS.md**: document `AGENT_BOM_AUDIT_HMAC_KEY` in CIA Triad Integrity row for production operators
- **README Trust section**: expand from 7 bullets to 15 specific verified controls — no shell injection, no SSRF (DNS rebinding defense), no path traversal, no SQL injection, proxy size guard, audit HMAC, scrypt/RBAC/OIDC details

## Audit verdict

Full OWASP Top 10 audit: **zero critical or high findings.** Both medium/low gaps fixed here.

## Test plan
- [ ] Proxy drops messages > 10 MB with warning log, does not crash
- [ ] Normal MCP traffic passes through unaffected
- [ ] README and PERMISSIONS.md render correctly