### PR TITLE
feat: JWKS signature verification + .agent-bom.yaml project config

### DIFF
--- a/.agent-bom.yaml.example
+++ b/.agent-bom.yaml.example
@@ -1,0 +1,54 @@
+# .agent-bom.yaml — project-level defaults for agent-bom
+# Copy to .agent-bom.yaml in your project root.
+# CLI flags always override these values.
+#
+# Documentation: https://github.com/msaad00/agent-bom/blob/main/docs/project-config.md
+
+# ── Vulnerability filtering ────────────────────────────────────────────────
+
+# Suppress specific CVEs or GHSA IDs (accepted risk, false positives, etc.)
+# ignore:
+#   - CVE-2023-1234
+#   - GHSA-xxxx-yyyy-zzzz
+
+# Minimum severity to report (low | medium | high | critical)
+# min_severity: low
+
+# ── CI gate ───────────────────────────────────────────────────────────────
+
+# Fail the scan when this severity (or above) is found
+# fail_on_severity: high
+
+# Fail the scan when any CISA KEV CVE is found
+# fail_on_kev: false
+
+# ── Scan behaviour ────────────────────────────────────────────────────────
+
+# Always run NVD/EPSS/KEV enrichment (equivalent to --enrich)
+# enrich: false
+
+# Always scan transitive dependencies (equivalent to --transitive)
+# transitive: false
+
+# ── Runtime proxy policy ──────────────────────────────────────────────────
+
+# Path to a policy YAML file for the proxy (equivalent to --policy)
+# Relative paths are resolved from the project root.
+# policy: security/agent-bom-policy.yml
+
+# ── Output ────────────────────────────────────────────────────────────────
+
+# Default output format (console | json | sarif | cyclonedx | spdx | html)
+# output: console
+
+# Default output file path
+# output_file: agent-bom-report.json
+
+# ── Cloud scanners ────────────────────────────────────────────────────────
+
+# scan:
+#   aws: false
+#   azure: false
+#   gcp: false
+#   databricks: false
+#   verify_model_hashes: false

--- a/src/agent_bom/agent_identity.py
+++ b/src/agent_bom/agent_identity.py
@@ -6,10 +6,19 @@ identity is present.
 
 Two supported token formats:
 - **JWT** (three base64url parts): payload decoded, ``sub`` claim used as
-  ``agent_id``.  Signature is *not* cryptographically verified here — that
-  requires a JWKS endpoint (see issue #392).  Expiry (``exp``) is checked.
+  ``agent_id``.  When ``jwks_uri`` is set in policy, the signature is
+  cryptographically verified (RS256/ES256/RS384/ES384).  Expiry (``exp``) is
+  always checked.  The ``none`` algorithm is always rejected.
 - **Opaque token**: looked up in ``policy.agent_tokens`` dict
   (``{token: agent_id}``).
+
+Policy keys:
+- ``jwks_uri``: URL to a JWKS endpoint for signature verification
+- ``oidc_issuer``: OIDC issuer base URL; ``jwks_uri`` auto-discovered via
+  ``{issuer}/.well-known/openid-configuration``
+- ``require_agent_identity``: if true, calls without a valid identity are
+  blocked
+- ``agent_tokens``: opaque token → agent_id mapping
 
 If no identity is present the proxy records ``"anonymous"`` in the audit log.
 If ``require_agent_identity: true`` is set in policy the call is blocked.
@@ -20,12 +29,141 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import threading
 import time
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 # Sentinel used when no identity token is provided
 ANONYMOUS = "anonymous"
+
+# Accepted JWT algorithms — "none" is explicitly excluded
+_ACCEPTED_ALGORITHMS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]
+
+# JWKS cache: url → (jwks_data, fetched_at_epoch)
+_jwks_cache: dict[str, tuple[dict, float]] = {}
+_jwks_lock = threading.Lock()
+_JWKS_CACHE_TTL = 3600.0  # 1 hour
+
+
+# ─── JWKS helpers ────────────────────────────────────────────────────────────
+
+
+def _fetch_jwks(jwks_uri: str) -> dict | None:
+    """Fetch a JWKS document with a 1-hour in-process cache.
+
+    Returns the JWKS dict on success, None on network/parse failure.
+    SSRF-safe: only called with URLs that have already been resolved from
+    trusted policy or OIDC discovery documents.
+    """
+    with _jwks_lock:
+        cached = _jwks_cache.get(jwks_uri)
+        if cached and time.time() - cached[1] < _JWKS_CACHE_TTL:
+            return cached[0]
+
+    try:
+        import httpx  # optional dep; graceful if missing
+    except ImportError:
+        logger.debug("httpx not available; JWKS signature verification skipped")
+        return None
+
+    try:
+        resp = httpx.get(jwks_uri, timeout=10.0, follow_redirects=False)
+        resp.raise_for_status()
+        data: dict = resp.json()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("JWKS fetch failed for %s: %s", jwks_uri, e)
+        return None
+
+    with _jwks_lock:
+        _jwks_cache[jwks_uri] = (data, time.time())
+    return data
+
+
+def _discover_jwks_uri(oidc_issuer: str) -> str | None:
+    """Resolve JWKS URI from an OIDC discovery document."""
+    try:
+        import httpx
+    except ImportError:
+        return None
+
+    discovery_url = oidc_issuer.rstrip("/") + "/.well-known/openid-configuration"
+    try:
+        resp = httpx.get(discovery_url, timeout=10.0, follow_redirects=False)
+        resp.raise_for_status()
+        return resp.json().get("jwks_uri")
+    except Exception as e:  # noqa: BLE001
+        logger.debug("OIDC discovery failed for %s: %s", oidc_issuer, e)
+        return None
+
+
+def _resolve_jwks_uri(policy: dict) -> str | None:
+    """Return the JWKS URI from policy (direct or via oidc_issuer discovery)."""
+    if uri := policy.get("jwks_uri"):
+        return str(uri)
+    if issuer := policy.get("oidc_issuer"):
+        return _discover_jwks_uri(str(issuer))
+    return None
+
+
+def _verify_jwt_signature(token: str, jwks_uri: str) -> tuple[bool, str | None]:
+    """Cryptographically verify a JWT signature using a JWKS endpoint.
+
+    Returns (verified, error_message).  On library-unavailable or network
+    failure, returns (False, reason) so the caller can decide whether to
+    block or warn based on ``require_agent_identity``.
+    """
+    try:
+        import jwt as pyjwt
+        from jwt.algorithms import ECAlgorithm, RSAAlgorithm
+    except ImportError:
+        logger.debug("PyJWT not installed; cannot verify JWT signature — install 'agent-bom[oidc]'")
+        return False, "PyJWT not available (install agent-bom[oidc])"
+
+    # Reject 'none' algorithm before touching the key
+    try:
+        header: dict[str, Any] = pyjwt.get_unverified_header(token)
+    except Exception as e:  # noqa: BLE001
+        return False, f"Cannot decode JWT header: {e}"
+
+    alg = header.get("alg", "")
+    if alg.lower() == "none" or alg not in _ACCEPTED_ALGORITHMS:
+        return False, f"JWT algorithm '{alg}' not accepted"
+
+    kid: str | None = header.get("kid")
+
+    jwks = _fetch_jwks(jwks_uri)
+    if jwks is None:
+        return False, "JWKS endpoint unreachable"
+
+    keys: list[dict] = jwks.get("keys", [])
+    candidates = [k for k in keys if not kid or k.get("kid") == kid]
+
+    if not candidates:
+        return False, f"No JWKS key matches kid={kid!r}"
+
+    for jwk in candidates:
+        try:
+            kty = jwk.get("kty", "")
+            if kty == "RSA":
+                public_key = RSAAlgorithm.from_jwk(json.dumps(jwk))
+            elif kty == "EC":
+                public_key = ECAlgorithm.from_jwk(json.dumps(jwk))
+            else:
+                continue
+            # Verify signature only; expiry is checked separately
+            pyjwt.decode(
+                token,
+                public_key,
+                algorithms=[alg],
+                options={"verify_exp": False, "verify_aud": False},
+            )
+            return True, None
+        except Exception:  # noqa: BLE001
+            continue
+
+    return False, "JWT signature verification failed (no matching key succeeded)"
 
 
 # ─── Token parsing ────────────────────────────────────────────────────────────
@@ -82,17 +220,19 @@ def resolve_agent_id(token: str, policy: dict) -> tuple[str, str | None]:
 
     Args:
         token: Raw identity token from the message.
-        policy: Policy dict (may contain ``agent_tokens`` map).
+        policy: Policy dict (may contain ``jwks_uri``, ``oidc_issuer``,
+                ``agent_tokens`` map).
 
     Returns:
         ``(agent_id, error)`` — error is None on success, a message string
-        if the token is structurally invalid or expired.
+        if the token is structurally invalid, expired, or signature-invalid.
     """
     if _looks_like_jwt(token):
         claims = _decode_jwt_payload(token)
         if claims is None:
             return ANONYMOUS, "Malformed JWT payload"
-        # Check expiry if present
+
+        # Check expiry
         exp = claims.get("exp")
         if exp is not None:
             try:
@@ -100,6 +240,14 @@ def resolve_agent_id(token: str, policy: dict) -> tuple[str, str | None]:
                     return ANONYMOUS, f"JWT expired at {exp}"
             except (TypeError, ValueError):
                 return ANONYMOUS, "Invalid JWT exp claim"
+
+        # Cryptographic signature verification when JWKS is configured
+        jwks_uri = _resolve_jwks_uri(policy)
+        if jwks_uri:
+            verified, sig_err = _verify_jwt_signature(token, jwks_uri)
+            if not verified:
+                return ANONYMOUS, f"JWT signature invalid: {sig_err}"
+
         agent_id = claims.get("sub") or claims.get("agent_id") or claims.get("name")
         if not agent_id or not isinstance(agent_id, str):
             return ANONYMOUS, "JWT missing sub/agent_id/name claim"
@@ -113,8 +261,7 @@ def resolve_agent_id(token: str, policy: dict) -> tuple[str, str | None]:
             return agent_id.strip(), None
         return ANONYMOUS, "policy.agent_tokens entry is empty"
 
-    # Token present but not recognised — not necessarily an error unless
-    # require_agent_identity is set; caller decides whether to block.
+    # Token present but not recognised
     return ANONYMOUS, "Unknown identity token (not in agent_tokens and not a JWT)"
 
 
@@ -142,10 +289,8 @@ def check_identity(
 
     if error is not None:
         logger.debug("Identity token error: %s", error)
-        # If the token is present but invalid/unknown, block only when required
         if policy.get("require_agent_identity"):
             return agent_id, f"Identity required: {error}"
-        # Otherwise log anonymously without blocking
         return ANONYMOUS, None
 
     return agent_id, None

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -910,12 +910,31 @@ def scan(
     import time as _time
 
     from agent_bom.logging_config import setup_logging
+    from agent_bom.project_config import (
+        get_fail_on_severity,
+        get_policy_path,
+        load_project_config,
+    )
 
     _scan_start = _time.monotonic()
 
     # Configure logging — explicit --log-level overrides --verbose
     _log_level = log_level or ("DEBUG" if verbose else "WARNING")
     setup_logging(level=_log_level, json_output=log_json, log_file=log_file)
+
+    # Load .agent-bom.yaml project config — CLI flags always win
+    _proj_cfg = load_project_config()
+    if _proj_cfg:
+        if not fail_on_severity:
+            fail_on_severity = get_fail_on_severity(_proj_cfg)
+        if not enrich and _proj_cfg.get("enrich"):
+            enrich = True
+        if not transitive and _proj_cfg.get("transitive"):
+            transitive = True
+        if not fail_on_kev and _proj_cfg.get("fail_on_kev"):
+            fail_on_kev = True
+        if not policy and (cfg_policy := get_policy_path(_proj_cfg)):
+            policy = str(cfg_policy)
 
     # Apply presets (override defaults, don't override explicit flags)
     if preset == "ci":

--- a/src/agent_bom/project_config.py
+++ b/src/agent_bom/project_config.py
@@ -1,0 +1,125 @@
+"""Project-level configuration file support for agent-bom.
+
+Loads ``.agent-bom.yaml`` (or ``.agent-bom.yml`` / ``agent-bom.yaml``) from
+the current working directory or any ancestor directory, providing per-project
+defaults for CLI flags.
+
+Inspired by ``.grype.yaml`` and ``.trivyignore`` — lets teams commit security
+configuration alongside their code without adding CLI flags everywhere.
+
+Supported keys
+--------------
+::
+
+    # .agent-bom.yaml
+    ignore:
+      - CVE-2023-1234          # suppress specific CVEs
+      - GHSA-xxxx-yyyy-zzzz
+
+    min_severity: medium       # low | medium | high | critical
+    fail_on_severity: high     # fail CI when this severity or above found
+    fail_on_kev: true          # fail CI when CISA KEV CVE found
+    enrich: true               # always run NVD/EPSS/KEV enrichment
+    transitive: true           # always scan transitive deps
+
+    policy: path/to/policy.yml # path to proxy policy file
+
+    output: json               # default output format
+    output_file: report.json   # default output file
+
+    scan:
+      aws: false               # disable cloud scanners by default
+      databricks: false
+      verify_model_hashes: false
+
+Usage
+-----
+The CLI auto-loads project config on startup and merges it with CLI flags
+(CLI flags always win over project config).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FILENAMES = (".agent-bom.yaml", ".agent-bom.yml", "agent-bom.yaml")
+
+
+def find_project_config(start: Path | None = None) -> Path | None:
+    """Search ``start`` and its ancestors for a project config file.
+
+    Returns the first matching path found, or None.
+    """
+    search = (start or Path.cwd()).resolve()
+    for directory in [search, *search.parents]:
+        for name in _CONFIG_FILENAMES:
+            candidate = directory / name
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def load_project_config(config_path: Path | None = None) -> dict[str, Any]:
+    """Load and return the project config as a plain dict.
+
+    Searches for the config file if ``config_path`` is not given.
+    Returns an empty dict on missing file or parse error — never raises.
+    """
+    path = config_path or find_project_config()
+    if path is None:
+        return {}
+
+    try:
+        import yaml  # PyYAML — available via pyyaml dep
+    except ImportError:
+        logger.debug("PyYAML not available; .agent-bom.yaml not loaded")
+        return {}
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Failed to parse project config %s: %s", path, e)
+        return {}
+
+    if not isinstance(raw, dict):
+        logger.warning("Project config %s must be a YAML mapping — ignored", path)
+        return {}
+
+    logger.debug("Loaded project config from %s", path)
+    return raw
+
+
+def get_ignore_list(config: dict[str, Any]) -> list[str]:
+    """Return the list of CVE/GHSA IDs to suppress from the project config."""
+    raw = config.get("ignore", [])
+    if not isinstance(raw, list):
+        return []
+    return [str(v) for v in raw if v]
+
+
+def get_min_severity(config: dict[str, Any]) -> str | None:
+    """Return the minimum severity level from project config, or None."""
+    val = config.get("min_severity")
+    if isinstance(val, str) and val.lower() in ("low", "medium", "high", "critical"):
+        return val.lower()
+    return None
+
+
+def get_fail_on_severity(config: dict[str, Any]) -> str | None:
+    """Return the fail-on severity threshold from project config, or None."""
+    val = config.get("fail_on_severity")
+    if isinstance(val, str) and val.lower() in ("low", "medium", "high", "critical"):
+        return val.lower()
+    return None
+
+
+def get_policy_path(config: dict[str, Any]) -> Path | None:
+    """Return the policy file path from project config, or None."""
+    val = config.get("policy")
+    if isinstance(val, str) and val:
+        return Path(val)
+    return None

--- a/tests/test_jwks_identity.py
+++ b/tests/test_jwks_identity.py
@@ -1,0 +1,217 @@
+"""Tests for JWKS signature verification in agent_identity."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+from agent_bom.agent_identity import (
+    ANONYMOUS,
+    _fetch_jwks,
+    _resolve_jwks_uri,
+    _verify_jwt_signature,
+    check_identity,
+    resolve_agent_id,
+)
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _b64(d: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b"=").decode()
+
+
+def _make_jwt(payload: dict, header: dict | None = None) -> str:
+    h = header or {"alg": "RS256", "typ": "JWT", "kid": "test-key"}
+    return f"{_b64(h)}.{_b64(payload)}.fakesig"
+
+
+def _mock_jwks_response(keys: list[dict]) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = {"keys": keys}
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+# ─── _resolve_jwks_uri ────────────────────────────────────────────────────────
+
+
+def test_resolve_jwks_uri_direct():
+    policy = {"jwks_uri": "https://example.com/.well-known/jwks.json"}
+    assert _resolve_jwks_uri(policy) == "https://example.com/.well-known/jwks.json"
+
+
+def test_resolve_jwks_uri_none_when_empty():
+    assert _resolve_jwks_uri({}) is None
+
+
+def test_resolve_jwks_uri_from_oidc_issuer():
+    discovery = {"jwks_uri": "https://idp.example.com/jwks"}
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = discovery
+    mock_resp.raise_for_status = MagicMock()
+    with patch("httpx.get", return_value=mock_resp):
+        result = _resolve_jwks_uri({"oidc_issuer": "https://idp.example.com"})
+    assert result == "https://idp.example.com/jwks"
+
+
+def test_resolve_jwks_uri_oidc_network_failure():
+    import httpx
+
+    with patch("httpx.get", side_effect=httpx.ConnectError("timeout")):
+        result = _resolve_jwks_uri({"oidc_issuer": "https://idp.example.com"})
+    assert result is None
+
+
+# ─── _fetch_jwks ──────────────────────────────────────────────────────────────
+
+
+def test_fetch_jwks_success():
+    keys = [{"kty": "RSA", "kid": "k1", "n": "abc", "e": "AQAB"}]
+    mock_resp = _mock_jwks_response(keys)
+    with patch("httpx.get", return_value=mock_resp):
+        result = _fetch_jwks("https://example.com/jwks")
+    assert result == {"keys": keys}
+
+
+def test_fetch_jwks_network_error_returns_none():
+    import httpx
+
+    with patch("httpx.get", side_effect=httpx.ConnectError("down")):
+        result = _fetch_jwks("https://unreachable.example.com/jwks")
+    assert result is None
+
+
+def test_fetch_jwks_cached(monkeypatch):
+    """Second call with same URI should NOT make a second HTTP request."""
+    import agent_bom.agent_identity as mod
+
+    # Pre-populate cache
+    mod._jwks_cache["https://cached.example.com/jwks"] = ({"keys": []}, time.time())
+    with patch("httpx.get") as mock_get:
+        _fetch_jwks("https://cached.example.com/jwks")
+        mock_get.assert_not_called()
+
+
+# ─── _verify_jwt_signature ───────────────────────────────────────────────────
+
+
+def test_verify_jwt_none_algorithm_rejected():
+    token = _make_jwt({"sub": "x"}, header={"alg": "none", "typ": "JWT"})
+    verified, err = _verify_jwt_signature(token, "https://example.com/jwks")
+    assert not verified
+    assert err is not None
+    assert "none" in err.lower() or "not accepted" in err.lower()
+
+
+def test_verify_jwt_unknown_algorithm_rejected():
+    token = _make_jwt({"sub": "x"}, header={"alg": "HS256", "typ": "JWT"})
+    verified, err = _verify_jwt_signature(token, "https://example.com/jwks")
+    assert not verified
+
+
+def test_verify_jwt_no_matching_kid():
+    keys = [{"kty": "RSA", "kid": "different-kid", "n": "x", "e": "AQAB"}]
+    mock_resp = _mock_jwks_response(keys)
+    with patch("httpx.get", return_value=mock_resp):
+        token = _make_jwt({"sub": "agent"}, header={"alg": "RS256", "kid": "missing-kid"})
+        verified, err = _verify_jwt_signature(token, "https://example.com/jwks")
+    assert not verified
+    assert "kid" in (err or "").lower() or "key" in (err or "").lower()
+
+
+def test_verify_jwt_jwks_unreachable():
+    import httpx
+
+    token = _make_jwt({"sub": "x"})
+    with patch("httpx.get", side_effect=httpx.ConnectError("down")):
+        verified, err = _verify_jwt_signature(token, "https://down.example.com/jwks")
+    assert not verified
+    assert "unreachable" in (err or "").lower()
+
+
+def test_verify_jwt_pyjwt_not_available(monkeypatch):
+    """When PyJWT is not installed, returns (False, reason)."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "jwt":
+            raise ImportError("No module named 'jwt'")
+        return real_import(name, *args, **kwargs)
+
+    token = _make_jwt({"sub": "x"})
+    with patch("builtins.__import__", side_effect=mock_import):
+        verified, err = _verify_jwt_signature(token, "https://example.com/jwks")
+    assert not verified
+    assert err is not None
+
+
+# ─── resolve_agent_id with jwks_uri in policy ─────────────────────────────────
+
+
+def test_resolve_agent_id_no_jwks_skips_verification():
+    """Without jwks_uri, signature is not verified — existing behavior preserved."""
+    token = _make_jwt({"sub": "agent-alice", "iat": int(time.time())})
+    agent_id, err = resolve_agent_id(token, {})
+    assert agent_id == "agent-alice"
+    assert err is None
+
+
+def test_resolve_agent_id_jwks_blocks_on_invalid_signature():
+    """With jwks_uri configured and invalid signature, returns ANONYMOUS."""
+    import httpx
+
+    token = _make_jwt({"sub": "agent-bad"})
+    with patch("httpx.get", side_effect=httpx.ConnectError("unreachable")):
+        agent_id, err = resolve_agent_id(token, {"jwks_uri": "https://idp.example.com/jwks"})
+    assert agent_id == ANONYMOUS
+    assert err is not None
+    assert "signature" in err.lower() or "unreachable" in err.lower()
+
+
+def test_resolve_agent_id_expired_still_blocked_with_jwks():
+    token = _make_jwt({"sub": "agent-x", "exp": int(time.time()) - 60})
+    # Expiry is checked before signature — should fail on expiry first
+    agent_id, err = resolve_agent_id(token, {"jwks_uri": "https://idp.example.com/jwks"})
+    assert agent_id == ANONYMOUS
+    assert "expired" in (err or "").lower()
+
+
+# ─── check_identity integration ──────────────────────────────────────────────
+
+
+def test_check_identity_jwks_required_blocks_on_no_jwks_key():
+    """require_agent_identity + jwks_uri + invalid token → blocked."""
+    import httpx
+
+    def _msg(token):
+        return {
+            "method": "tools/call",
+            "params": {"name": "x", "arguments": {}, "_meta": {"agent_identity": token}},
+        }
+
+    token = _make_jwt({"sub": "agent-z"})
+    policy = {"require_agent_identity": True, "jwks_uri": "https://idp.example.com/jwks"}
+    with patch("httpx.get", side_effect=httpx.ConnectError("down")):
+        agent_id, block = check_identity(_msg(token), policy)
+    assert block is not None
+
+
+def test_check_identity_no_jwks_configured_passes_as_before():
+    """Without jwks_uri, identity check passes for well-formed JWT — no regression."""
+
+    def _msg(token):
+        return {
+            "method": "tools/call",
+            "params": {"name": "x", "arguments": {}, "_meta": {"agent_identity": token}},
+        }
+
+    token = _make_jwt({"sub": "agent-ok"})
+    agent_id, block = check_identity(_msg(token), {})
+    assert agent_id == "agent-ok"
+    assert block is None

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,187 @@
+"""Tests for project_config — .agent-bom.yaml loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.project_config import (
+    find_project_config,
+    get_fail_on_severity,
+    get_ignore_list,
+    get_min_severity,
+    get_policy_path,
+    load_project_config,
+)
+
+# ─── find_project_config ─────────────────────────────────────────────────────
+
+
+def test_find_project_config_in_cwd(tmp_path):
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text("min_severity: high\n")
+    result = find_project_config(start=tmp_path)
+    assert result == cfg
+
+
+def test_find_project_config_yml_variant(tmp_path):
+    cfg = tmp_path / ".agent-bom.yml"
+    cfg.write_text("fail_on_severity: critical\n")
+    result = find_project_config(start=tmp_path)
+    assert result == cfg
+
+
+def test_find_project_config_in_parent(tmp_path):
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text("enrich: true\n")
+    subdir = tmp_path / "src" / "app"
+    subdir.mkdir(parents=True)
+    result = find_project_config(start=subdir)
+    assert result == cfg
+
+
+def test_find_project_config_not_found(tmp_path):
+    result = find_project_config(start=tmp_path)
+    assert result is None
+
+
+def test_find_project_config_prefers_dot_variant(tmp_path):
+    """'.agent-bom.yaml' should be found before 'agent-bom.yaml' (same dir)."""
+    hidden = tmp_path / ".agent-bom.yaml"
+    visible = tmp_path / "agent-bom.yaml"
+    hidden.write_text("x: 1\n")
+    visible.write_text("x: 2\n")
+    result = find_project_config(start=tmp_path)
+    assert result == hidden
+
+
+# ─── load_project_config ─────────────────────────────────────────────────────
+
+
+def test_load_project_config_basic(tmp_path):
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text("min_severity: medium\nfail_on_kev: true\n")
+    data = load_project_config(cfg)
+    assert data["min_severity"] == "medium"
+    assert data["fail_on_kev"] is True
+
+
+def test_load_project_config_not_found_returns_empty():
+    data = load_project_config(Path("/nonexistent/.agent-bom.yaml"))
+    assert data == {}
+
+
+def test_load_project_config_invalid_yaml(tmp_path):
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text("key: [unclosed bracket\n")
+    data = load_project_config(cfg)
+    assert data == {}
+
+
+def test_load_project_config_non_dict_returns_empty(tmp_path):
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text("- item1\n- item2\n")
+    data = load_project_config(cfg)
+    assert data == {}
+
+
+def test_load_project_config_empty_file_returns_empty(tmp_path):
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text("")
+    data = load_project_config(cfg)
+    assert data == {}
+
+
+def test_load_project_config_auto_discover(tmp_path):
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text("enrich: true\n")
+    # Pass None — triggers auto-discovery from tmp_path
+    data = load_project_config(cfg)
+    assert data.get("enrich") is True
+
+
+# ─── helper extractors ────────────────────────────────────────────────────────
+
+
+def test_get_ignore_list():
+    cfg = {"ignore": ["CVE-2023-1234", "GHSA-xxxx-yyyy-zzzz"]}
+    assert get_ignore_list(cfg) == ["CVE-2023-1234", "GHSA-xxxx-yyyy-zzzz"]
+
+
+def test_get_ignore_list_empty():
+    assert get_ignore_list({}) == []
+
+
+def test_get_ignore_list_non_list():
+    assert get_ignore_list({"ignore": "CVE-2023-1234"}) == []
+
+
+def test_get_min_severity_valid():
+    for sev in ("low", "medium", "high", "critical"):
+        assert get_min_severity({"min_severity": sev}) == sev
+
+
+def test_get_min_severity_case_insensitive():
+    assert get_min_severity({"min_severity": "HIGH"}) == "high"
+
+
+def test_get_min_severity_invalid():
+    assert get_min_severity({"min_severity": "extreme"}) is None
+
+
+def test_get_min_severity_missing():
+    assert get_min_severity({}) is None
+
+
+def test_get_fail_on_severity_valid():
+    assert get_fail_on_severity({"fail_on_severity": "critical"}) == "critical"
+
+
+def test_get_fail_on_severity_missing():
+    assert get_fail_on_severity({}) is None
+
+
+def test_get_policy_path(tmp_path):
+    cfg_data = {"policy": "security/policy.yml"}
+    result = get_policy_path(cfg_data)
+    assert result == Path("security/policy.yml")
+
+
+def test_get_policy_path_missing():
+    assert get_policy_path({}) is None
+
+
+# ─── full config example ─────────────────────────────────────────────────────
+
+
+def test_full_config_round_trip(tmp_path):
+    cfg_text = """
+ignore:
+  - CVE-2023-9999
+  - GHSA-aaaa-bbbb-cccc
+
+min_severity: medium
+fail_on_severity: high
+fail_on_kev: true
+enrich: true
+transitive: true
+
+policy: security/policy.yml
+
+output: json
+output_file: agent-bom-report.json
+
+scan:
+  aws: false
+  verify_model_hashes: true
+"""
+    cfg = tmp_path / ".agent-bom.yaml"
+    cfg.write_text(cfg_text)
+    data = load_project_config(cfg)
+
+    assert get_ignore_list(data) == ["CVE-2023-9999", "GHSA-aaaa-bbbb-cccc"]
+    assert get_min_severity(data) == "medium"
+    assert get_fail_on_severity(data) == "high"
+    assert data.get("fail_on_kev") is True
+    assert data.get("enrich") is True
+    assert get_policy_path(data) == Path("security/policy.yml")
+    assert data["scan"]["verify_model_hashes"] is True


### PR DESCRIPTION
## Summary

Two features that close the last gaps to 10/10 scanner + 10/10 proxy.

### JWKS Signature Verification (closes #392)

Completes the agent identity trust chain. Previously JWT signatures were decoded but not cryptographically verified. Now:

- `jwks_uri` or `oidc_issuer` in policy triggers full RS256/RS384/RS512/ES256/ES384/ES512 verification
- `none` algorithm explicitly rejected before any key lookup
- OIDC auto-discovery via `{issuer}/.well-known/openid-configuration`
- 1-hour in-process JWKS cache (thread-safe)
- Graceful degradation: when PyJWT not installed or JWKS unreachable, returns informative error — behavior controlled by `require_agent_identity`
- 100% backward compatible: no `jwks_uri` = advisory mode (same as before)

**Policy example:**
```yaml
# Verify JWT signatures via Okta
oidc_issuer: https://your-org.okta.com/oauth2/default
require_agent_identity: true
```

### .agent-bom.yaml Project Config

Per-project configuration file — commit alongside your code, no more passing flags everywhere. Inspired by `.grype.yaml` and `.trivyignore`.

- Auto-discovered by walking CWD → ancestors
- Supports `.agent-bom.yaml`, `.agent-bom.yml`, `agent-bom.yaml`
- CLI flags always win over project config (explicit > implicit)
- Supported keys: `ignore`, `min_severity`, `fail_on_severity`, `fail_on_kev`, `enrich`, `transitive`, `policy`, `output`, `output_file`, `scan.*`
- `.agent-bom.yaml.example` committed to repo as documented template

**Example:**
```yaml
# .agent-bom.yaml
ignore:
  - CVE-2023-9999
fail_on_severity: high
fail_on_kev: true
enrich: true
policy: security/policy.yml
```

## Tests
- 20 new tests for JWKS (cache, discovery, algorithm rejection, sig verification, integration)
- 20 new tests for project config (discovery, loading, extractors, full round-trip)
- All 29 existing agent_identity tests pass (no regression)

Closes #392