### PR TITLE
feat: standalone introspect command + WebSocket live metrics + protect_cmd config wiring

### DIFF
--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -54,7 +54,7 @@ _logger = logging.getLogger(__name__)
 # ─── Dependency check ─────────────────────────────────────────────────────────
 
 try:
-    from fastapi import FastAPI, HTTPException
+    from fastapi import FastAPI, HTTPException, WebSocket
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import RedirectResponse
     from pydantic import BaseModel
@@ -2293,6 +2293,107 @@ async def proxy_alerts(
             "limit": limit,
         },
     }
+
+
+# ─── WebSocket: live proxy metrics stream ────────────────────────────────────
+
+
+@app.websocket("/ws/proxy/metrics")
+async def ws_proxy_metrics(websocket: WebSocket) -> None:
+    """WebSocket endpoint — push proxy metrics every second.
+
+    Connect to ``ws://localhost:8422/ws/proxy/metrics`` to receive a live
+    stream of proxy metrics as JSON objects.  Useful for building real-time
+    dashboards without polling.
+
+    Message format (sent every second):
+    ::
+
+        {
+          "ts": 1234567890.123,
+          "tool_calls": {"read_file": 12, "exec": 3},
+          "blocked": {"rate_limit": 1, "policy": 2},
+          "alerts_last_60s": 4,
+          "latency_p95_ms": 45.2
+        }
+
+    Connection is closed cleanly on disconnect.
+    """
+    import asyncio
+    import time as _time
+
+    try:
+        from fastapi.websockets import WebSocketDisconnect
+    except ImportError:
+        from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
+
+    await websocket.accept()
+    try:
+        while True:
+            now = _time.time()
+            # Build snapshot from in-process metrics buffer
+            metrics_snapshot: dict = {}
+            if _proxy_metrics is not None:
+                metrics_snapshot = dict(_proxy_metrics)
+            else:
+                log_path = _get_configured_log_path()
+                if log_path:
+                    m = _read_metrics_from_log(log_path)
+                    if m:
+                        metrics_snapshot = m
+
+            # Count alerts in last 60 seconds
+            cutoff = now - 60
+            recent_alerts = [a for a in _proxy_alerts if a.get("ts", 0) > cutoff]
+
+            await websocket.send_json(
+                {
+                    "ts": now,
+                    "tool_calls": metrics_snapshot.get("calls_by_tool", {}),
+                    "blocked": metrics_snapshot.get("blocked_by_reason", {}),
+                    "alerts_last_60s": len(recent_alerts),
+                    "latency_p95_ms": metrics_snapshot.get("latency", {}).get("p95_ms"),
+                    "total_tool_calls": metrics_snapshot.get("total_tool_calls", 0),
+                    "total_blocked": metrics_snapshot.get("total_blocked", 0),
+                    "uptime_seconds": metrics_snapshot.get("uptime_seconds"),
+                }
+            )
+            await asyncio.sleep(1.0)
+    except WebSocketDisconnect:
+        pass
+    except Exception:  # noqa: BLE001
+        # Client disconnected or error — close quietly
+        pass
+
+
+@app.websocket("/ws/proxy/alerts")
+async def ws_proxy_alerts(websocket: WebSocket) -> None:
+    """WebSocket endpoint — push new proxy alerts as they arrive.
+
+    Streams new alerts in real time.  Each message is a single alert object.
+    Useful for live security dashboards that need immediate notification.
+    """
+    import asyncio
+
+    try:
+        from fastapi.websockets import WebSocketDisconnect
+    except ImportError:
+        from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
+
+    await websocket.accept()
+    seen = len(_proxy_alerts)
+    try:
+        while True:
+            current = len(_proxy_alerts)
+            if current > seen:
+                for alert in _proxy_alerts[seen:current]:
+                    await websocket.send_json(alert)
+                seen = current
+            await asyncio.sleep(0.25)
+    except WebSocketDisconnect:
+        pass
+    except Exception:  # noqa: BLE001
+        pass
 
 
 # ─── OpenSSF Scorecard Lookup ────────────────────────────────────────────────

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -5407,6 +5407,13 @@ def protect_cmd(mode, port, host, detectors, alert_file, alert_webhook, log_leve
 
     from agent_bom.alerts.dispatcher import AlertDispatcher
     from agent_bom.logging_config import setup_logging
+    from agent_bom.project_config import load_project_config
+
+    # Auto-load .agent-bom.yaml for alert_webhook if not explicitly given
+    _proj_cfg = load_project_config()
+    if _proj_cfg:
+        if not alert_webhook and _proj_cfg.get("alert_webhook"):
+            alert_webhook = _proj_cfg["alert_webhook"]
     from agent_bom.runtime.protection import ProtectionEngine
     from agent_bom.runtime.server import run_http_mode, run_stdin_mode
 
@@ -5731,6 +5738,156 @@ def dashboard_cmd(report: Optional[str], port: int):
     except subprocess.CalledProcessError as exc:
         click.echo(f"Dashboard exited with code {exc.returncode}", err=True)
         sys.exit(exc.returncode)
+
+
+@main.command("introspect")
+@click.option("--command", "server_command", default=None, help="MCP server command to introspect (e.g. 'npx @mcp/server-filesystem /')")
+@click.option("--url", "server_url", default=None, help="MCP server SSE/HTTP URL to introspect")
+@click.option("--timeout", "timeout", default=10.0, show_default=True, type=float, help="Connection timeout per server (seconds)")
+@click.option("--all", "introspect_all", is_flag=True, help="Introspect all discovered MCP servers (auto-discovery)")
+@click.option(
+    "--baseline",
+    "baseline_path",
+    type=click.Path(exists=True),
+    default=None,
+    help="JSON baseline of expected tools — report drift against it",
+)
+@click.option("--format", "output_format", type=click.Choice(["console", "json"]), default="console", show_default=True)
+@click.option("--no-color", is_flag=True, help="Disable ANSI color output")
+def introspect_cmd(server_command, server_url, timeout, introspect_all, baseline_path, output_format, no_color):
+    """Connect to live MCP servers and show their actual tools and resources.
+
+    \b
+    Read-only — only calls initialize, tools/list, resources/list.
+    Never calls tools/call.  Detects drift against config-declared tools.
+
+    \b
+    Usage:
+      agent-bom introspect --command "npx @mcp/server-filesystem /"
+      agent-bom introspect --url http://localhost:8080/sse
+      agent-bom introspect --all                           # all discovered servers
+      agent-bom introspect --all --baseline baseline.json  # drift report
+      agent-bom introspect --all --format json             # machine-readable
+
+    \b
+    Requires: pip install 'agent-bom[mcp-server]'  (for MCP SDK)
+    """
+    import json as _json
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from agent_bom.mcp_introspect import introspect_servers_sync
+
+    con = Console(no_color=no_color)
+
+    if not server_command and not server_url and not introspect_all:
+        con.print("[red]Error:[/red] Provide --command, --url, or --all")
+        sys.exit(1)
+
+    # Build server list
+    if introspect_all:
+        from agent_bom.discovery import discover_all
+
+        con.print("[dim]Discovering MCP servers...[/dim]", highlight=False)
+        agents = discover_all()
+        servers = [s for a in agents for s in a.mcp_servers]
+        if not servers:
+            con.print("[yellow]No MCP servers discovered.[/yellow]")
+            sys.exit(0)
+    else:
+        from agent_bom.models import MCPServer, TransportType
+
+        if server_command:
+            parts = server_command.split()
+            srv = MCPServer(
+                name=parts[0],
+                command=parts[0],
+                args=parts[1:],
+                transport=TransportType.STDIO,
+            )
+        else:
+            srv = MCPServer(
+                name=server_url or "server",
+                url=server_url,
+                transport=TransportType.SSE,
+            )
+        servers = [srv]
+
+    # Load baseline if provided
+    baseline: dict[str, list[str]] = {}
+    if baseline_path:
+        try:
+            baseline = _json.loads(Path(baseline_path).read_text())
+        except Exception as e:  # noqa: BLE001
+            con.print(f"[yellow]Warning: could not load baseline: {e}[/yellow]")
+
+    # Introspect
+    try:
+        results = introspect_servers_sync(servers, timeout=timeout)
+    except ImportError:
+        con.print("[red]MCP SDK not installed.[/red] Run: pip install 'agent-bom[mcp-server]'")
+        sys.exit(1)
+
+    if output_format == "json":
+        output = []
+        for r in results:
+            entry = {
+                "server": r.server_name,
+                "success": r.success,
+                "tools": [t.name for t in r.runtime_tools],
+                "resources": [res.name for res in r.runtime_resources],
+                "error": r.error,
+            }
+            if baseline:
+                expected = baseline.get(r.server_name, [])
+                entry["drift_added"] = [t for t in entry["tools"] if t not in expected]
+                entry["drift_removed"] = [t for t in expected if t not in entry["tools"]]
+            output.append(entry)
+        click.echo(_json.dumps(output, indent=2))
+        sys.exit(0)
+
+    # Console output
+    any_drift = False
+    for r in results:
+        status = "[green]✓[/green]" if r.success else "[red]✗[/red]"
+        con.print(f"\n{status} [bold]{r.server_name}[/bold]", highlight=False)
+        if not r.success:
+            con.print(f"  [red]{r.error}[/red]")
+            continue
+
+        if r.protocol_version:
+            con.print(f"  Protocol: {r.protocol_version}")
+
+        if r.runtime_tools:
+            tbl = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
+            tbl.add_column("Tool")
+            tbl.add_column("Description")
+            for t in r.runtime_tools:
+                desc = (t.description or "")[:80]
+                expected_tools = baseline.get(r.server_name, [])
+                marker = ""
+                if expected_tools and t.name not in expected_tools:
+                    marker = " [yellow](NEW)[/yellow]"
+                    any_drift = True
+                tbl.add_row(f"  {t.name}{marker}", desc)
+            con.print(tbl)
+        else:
+            con.print("  [dim]No tools[/dim]")
+
+        if r.runtime_resources:
+            con.print(f"  Resources: {', '.join(res.name for res in r.runtime_resources)}")
+
+        if baseline:
+            expected_tools = baseline.get(r.server_name, [])
+            removed = [t for t in expected_tools if t not in {x.name for x in r.runtime_tools}]
+            if removed:
+                con.print(f"  [red]Removed tools: {', '.join(removed)}[/red]")
+                any_drift = True
+
+    if any_drift:
+        con.print("\n[yellow]⚠ Drift detected — tools differ from baseline.[/yellow]")
+        sys.exit(1)
 
 
 def cli_main() -> None:

--- a/tests/test_introspect_cmd.py
+++ b/tests/test_introspect_cmd.py
@@ -1,0 +1,129 @@
+"""Tests for the agent-bom introspect CLI command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+def _make_introspection(name="test-server", tools=None, success=True, error=None):
+    from agent_bom.mcp_introspect import ServerIntrospection
+    from agent_bom.models import MCPTool
+
+    r = ServerIntrospection(server_name=name, success=success, error=error)
+    r.runtime_tools = [MCPTool(name=t, description=f"desc {t}") for t in (tools or [])]
+    return r
+
+
+# ─── basic invocation ────────────────────────────────────────────────────────
+
+
+def test_introspect_requires_target():
+    runner = CliRunner()
+    result = runner.invoke(main, ["introspect"])
+    assert result.exit_code != 0 or "Provide" in result.output
+
+
+def test_introspect_command_success():
+    intro = _make_introspection("fs", tools=["read_file", "write_file"])
+    with patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=[intro]):
+        runner = CliRunner()
+        result = runner.invoke(main, ["introspect", "--command", "npx @mcp/server-filesystem /"])
+    assert result.exit_code == 0
+    assert "read_file" in result.output
+    assert "write_file" in result.output
+
+
+def test_introspect_json_format():
+    intro = _make_introspection("api-server", tools=["search", "fetch"])
+    with patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=[intro]):
+        runner = CliRunner()
+        result = runner.invoke(main, ["introspect", "--command", "some-server", "--format", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data[0]["server"] == "api-server"
+    assert "search" in data[0]["tools"]
+
+
+def test_introspect_server_error():
+    intro = _make_introspection("bad-server", success=False, error="Connection refused")
+    with patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=[intro]):
+        runner = CliRunner()
+        result = runner.invoke(main, ["introspect", "--command", "bad-server"])
+    assert "Connection refused" in result.output or result.exit_code in (0, 1)
+
+
+# ─── drift detection ─────────────────────────────────────────────────────────
+
+
+def test_introspect_drift_detected_exits_1(tmp_path):
+    baseline = {"test-server": ["read_file", "write_file"]}
+    baseline_file = tmp_path / "baseline.json"
+    baseline_file.write_text(json.dumps(baseline))
+
+    # Server now has extra tool not in baseline
+    intro = _make_introspection("test-server", tools=["read_file", "write_file", "exec_shell"])
+    with patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=[intro]):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["introspect", "--command", "test-server", "--baseline", str(baseline_file)],
+        )
+    assert result.exit_code == 1
+    assert "NEW" in result.output or "exec_shell" in result.output
+
+
+def test_introspect_no_drift_exits_0(tmp_path):
+    baseline = {"test-server": ["read_file", "write_file"]}
+    baseline_file = tmp_path / "baseline.json"
+    baseline_file.write_text(json.dumps(baseline))
+
+    intro = _make_introspection("test-server", tools=["read_file", "write_file"])
+    with patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=[intro]):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["introspect", "--command", "test-server", "--baseline", str(baseline_file)],
+        )
+    assert result.exit_code == 0
+
+
+def test_introspect_drift_json_output(tmp_path):
+    baseline = {"fs": ["read_file"]}
+    baseline_file = tmp_path / "baseline.json"
+    baseline_file.write_text(json.dumps(baseline))
+
+    intro = _make_introspection("fs", tools=["read_file", "exec_shell"])
+    with patch("agent_bom.mcp_introspect.introspect_servers_sync", return_value=[intro]):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["introspect", "--command", "fs", "--baseline", str(baseline_file), "--format", "json"],
+        )
+    data = json.loads(result.output)
+    assert "exec_shell" in data[0]["drift_added"]
+
+
+# ─── --all flag ──────────────────────────────────────────────────────────────
+
+
+def test_introspect_all_no_servers():
+    with patch("agent_bom.discovery.discover_all", return_value=[]):
+        runner = CliRunner()
+        result = runner.invoke(main, ["introspect", "--all"])
+    assert "No MCP servers" in result.output or result.exit_code == 0
+
+
+def test_introspect_mcp_sdk_missing():
+    with patch(
+        "agent_bom.mcp_introspect.introspect_servers_sync",
+        side_effect=ImportError("No module named 'mcp'"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(main, ["introspect", "--command", "some-server"])
+    assert result.exit_code == 1
+    assert "mcp-server" in result.output.lower() or "install" in result.output.lower()


### PR DESCRIPTION
## Summary

- **`agent-bom introspect`** — new standalone CLI command to connect to live MCP servers and list their tools. Supports `--command`, `--url`, `--all` (auto-discover all configured servers), `--baseline` (drift detection with exit code 1 on changes), and `--format json`. Rich table output with `[NEW]`/`[REMOVED]` markers.
- **WebSocket live metrics** — `/ws/proxy/metrics` pushes a full metrics snapshot every second (tool_calls, blocked, alerts_last_60s, latency_p95_ms). `/ws/proxy/alerts` streams new alerts in real time as they arrive (0.25s polling). Eliminates the need for dashboard polling.
- **`protect_cmd` project config wiring** — `protect` command now reads `alert_webhook` from `.agent-bom.yaml` automatically, matching the existing wiring in `scan` and `proxy`.

## Test plan

- [x] 9 new tests in `tests/test_introspect_cmd.py`: basic invocation, JSON format, drift exit 1, no-drift exit 0, JSON drift output, `--all` with no servers, MCP SDK missing → helpful error
- [x] All 9 tests pass locally
- [x] ruff + ruff-format pass