### PR TITLE
fix: WebSocket auth + O(1) deque ring buffer + AI enrichment call cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ agent-bom protect --mode http
 # Watch MCP configs for drift — alert on changes
 agent-bom watch --webhook https://hooks.slack.com/...
 
+# Introspect a live MCP server — list tools, detect drift
+agent-bom introspect --command "uvx mcp-server-filesystem /"
+agent-bom introspect --all                                         # auto-discover all configured servers
+agent-bom introspect --all --baseline baseline.json               # exit 1 on new/removed tools
+
 # Policy file — 17 conditions, zero code required
 # policy.yml:
 #   blocked_tools: [run_shell, exec_command]
@@ -283,6 +288,8 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 | `GET /v1/proxy/status` | Live proxy metrics (tool calls, blocked, latency p95) |
 | `GET /v1/proxy/alerts` | Runtime behavioral alerts from audit log |
 | `GET /v1/audit` | Query JSONL audit trail (HMAC integrity verified) |
+| `WS /ws/proxy/metrics` | Live metrics push every second (tool_calls, blocked, latency_p95) |
+| `WS /ws/proxy/alerts` | Real-time alert stream — new alerts arrive as they happen |
 
 </details>
 

--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -539,14 +539,22 @@ def _build_remediation_prompt(items: list[dict]) -> str:
 # ─── Enrichment functions ────────────────────────────────────────────────────
 
 
+_DEFAULT_AI_MAX_CALLS = 50  # Hard cap: prevent runaway spend on large monorepos
+
+
 async def enrich_blast_radii(
     blast_radii: list[BlastRadius],
     model: str = DEFAULT_MODEL,
+    max_calls: int = _DEFAULT_AI_MAX_CALLS,
 ) -> int:
     """Add AI-generated risk narratives to blast radius findings.
 
-    Groups findings by package to minimize API calls.
-    Returns count of enriched findings.
+    Groups findings by package to minimize API calls (one call per unique
+    package, regardless of how many CVEs affect it).
+
+    ``max_calls`` caps total LLM requests per scan run to prevent runaway
+    API spend on large monorepos.  Defaults to 50; pass ``max_calls=0`` to
+    disable the cap.  Returns count of enriched findings.
     """
     if not blast_radii:
         return 0
@@ -554,6 +562,7 @@ async def enrich_blast_radii(
         return 0
 
     enriched = 0
+    calls_made = 0
     seen_packages: dict[str, Optional[str]] = {}  # pkg_key -> ai_summary
 
     for br in blast_radii:
@@ -566,9 +575,17 @@ async def enrich_blast_radii(
                 enriched += 1
             continue
 
+        if max_calls and calls_made >= max_calls:
+            logger.warning(
+                "AI enrichment cap reached (%d unique-package calls). Pass max_calls= to enrich_blast_radii() to increase the limit.",
+                max_calls,
+            )
+            break
+
         prompt = _build_blast_radius_prompt(br)
         result = await _call_llm(prompt, model)
         seen_packages[pkg_key] = result
+        calls_made += 1
         if result:
             br.ai_summary = result
             enriched += 1

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -37,7 +37,7 @@ import secrets
 import threading
 import time
 import uuid
-from collections import defaultdict
+from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from enum import Enum
@@ -2143,16 +2143,22 @@ async def get_incident_correlation() -> dict:
 # In-process ring buffer for proxy alerts/metrics.  The proxy (when running
 # in the same process, e.g. via the API) pushes records here.  External proxy
 # processes write to the JSONL audit log, and these endpoints read it.
+#
+# _proxy_alerts is a bounded deque (O(1) append/pop from both ends).
+# _proxy_alerts_total is a monotonic counter that never decrements — WebSocket
+# clients track their position by this counter, not by deque index, so they
+# correctly detect new alerts even when old ones are evicted from the ring.
 
-_proxy_alerts: list[dict] = []
+_proxy_alerts: deque[dict] = deque(maxlen=1000)
+_proxy_alerts_total: int = 0
 _proxy_metrics: dict | None = None
 
 
 def push_proxy_alert(alert: dict) -> None:
     """Called by the proxy to record a runtime alert (in-process path)."""
+    global _proxy_alerts_total
     _proxy_alerts.append(alert)
-    if len(_proxy_alerts) > 1000:
-        _proxy_alerts.pop(0)
+    _proxy_alerts_total += 1
 
 
 def push_proxy_metrics(metrics: dict) -> None:
@@ -2298,6 +2304,22 @@ async def proxy_alerts(
 # ─── WebSocket: live proxy metrics stream ────────────────────────────────────
 
 
+def _ws_check_auth(websocket: WebSocket) -> bool:
+    """Return True if the WebSocket connection is authorized.
+
+    When ``AGENT_BOM_API_KEY`` is set, callers must pass ``?token=<key>`` in
+    the WebSocket URL.  When the env var is unset the endpoint is open (local
+    dev / single-user mode).
+    """
+    import os as _os
+
+    api_key = _os.environ.get("AGENT_BOM_API_KEY")
+    if not api_key:
+        return True  # no auth configured — open
+    token = websocket.query_params.get("token", "")
+    return bool(token and token == api_key)
+
+
 @app.websocket("/ws/proxy/metrics")
 async def ws_proxy_metrics(websocket: WebSocket) -> None:
     """WebSocket endpoint — push proxy metrics every second.
@@ -2305,6 +2327,8 @@ async def ws_proxy_metrics(websocket: WebSocket) -> None:
     Connect to ``ws://localhost:8422/ws/proxy/metrics`` to receive a live
     stream of proxy metrics as JSON objects.  Useful for building real-time
     dashboards without polling.
+
+    Authentication: pass ``?token=<AGENT_BOM_API_KEY>`` when the env var is set.
 
     Message format (sent every second):
     ::
@@ -2326,6 +2350,10 @@ async def ws_proxy_metrics(websocket: WebSocket) -> None:
         from fastapi.websockets import WebSocketDisconnect
     except ImportError:
         from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
+
+    if not _ws_check_auth(websocket):
+        await websocket.close(code=4001)
+        return
 
     await websocket.accept()
     try:
@@ -2372,6 +2400,11 @@ async def ws_proxy_alerts(websocket: WebSocket) -> None:
 
     Streams new alerts in real time.  Each message is a single alert object.
     Useful for live security dashboards that need immediate notification.
+
+    Authentication: pass ``?token=<AGENT_BOM_API_KEY>`` when the env var is set.
+
+    Uses a monotonic total counter (not deque length) to detect new alerts
+    correctly even when old entries are evicted from the 1000-entry ring buffer.
     """
     import asyncio
 
@@ -2380,13 +2413,18 @@ async def ws_proxy_alerts(websocket: WebSocket) -> None:
     except ImportError:
         from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
 
+    if not _ws_check_auth(websocket):
+        await websocket.close(code=4001)
+        return
+
     await websocket.accept()
-    seen = len(_proxy_alerts)
+    seen = _proxy_alerts_total  # monotonic — tracks absolute count, not deque position
     try:
         while True:
-            current = len(_proxy_alerts)
+            current = _proxy_alerts_total
             if current > seen:
-                for alert in _proxy_alerts[seen:current]:
+                new_count = min(current - seen, len(_proxy_alerts))
+                for alert in list(_proxy_alerts)[-new_count:]:
                     await websocket.send_json(alert)
                 seen = current
             await asyncio.sleep(0.25)


### PR DESCRIPTION
## Summary

- **WebSocket auth (P0 security fix)** — `/ws/proxy/metrics` and `/ws/proxy/alerts` now require `?token=<AGENT_BOM_API_KEY>` when the env var is set. When unset, endpoints are open (local dev / single-user mode). Unauthenticated connections receive close code `4001`.
- **O(1) deque ring buffer** — replaced `list[dict]` with `deque(maxlen=1000)`. Removes the O(n) `pop(0)` on every eviction. Added `_proxy_alerts_total` monotonic counter so `ws_proxy_alerts` tracks position by absolute count, not deque length — correct even when old entries are evicted.
- **AI enrichment call cap** — `enrich_blast_radii()` now accepts `max_calls=50` (default). Prevents runaway LLM API spend on large monorepos. Logs a warning when the cap is hit. Pass `max_calls=0` to disable.
- **README** — added `agent-bom introspect` examples to Get Started; added WebSocket endpoints to REST API table.

## Test plan

- [x] All 4033 tests pass (1 pre-existing version sync failure unrelated to this PR)
- [x] ruff + ruff-format pass
- [x] Deque + counter logic verified manually: `list(deque)[-new_count:]` correctly retrieves new alerts after eviction