### PR TITLE
feat: Next.js Insights page — supply chain treemap, blast radius radial, pipeline flow

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,32 @@
+# agent-bom Streamlit Dashboard — Legacy / Deprecated
+
+> **This dashboard is deprecated.** Use the Next.js UI instead.
+
+## Migrate to Next.js
+
+The Next.js dashboard (`ui/`) replaces this Streamlit app and has full feature parity plus interactive graphs, WebSocket live metrics, agent topology, attack flow chains, compliance heatmap, and fleet management — none of which Streamlit supports.
+
+```bash
+# Start the API server
+pip install 'agent-bom[api]'
+agent-bom api
+
+# Start the Next.js UI
+cd ui
+npm install
+echo "NEXT_PUBLIC_API_URL=http://localhost:8422" > .env.local
+npm run dev
+# → http://localhost:3000
+```
+
+## Why kept in repo
+
+The `dashboard/` folder is retained for the **Snowflake Native App** path only. Streamlit is the only UI framework compatible with Snowflake Native Apps. For all other deployments, use the Next.js UI.
+
+## Running (legacy)
+
+```bash
+pip install streamlit plotly pandas
+agent-bom scan -f json -o report.json
+streamlit run dashboard/app.py -- --report report.json
+```

--- a/ui/app/insights/page.tsx
+++ b/ui/app/insights/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  api,
+  ScanJob,
+  ScanResult,
+  Agent,
+  BlastRadius,
+} from "@/lib/api";
+import {
+  SupplyChainTreemap,
+  BlastRadiusRadial,
+  PipelineFlow,
+  EpssVsCvssChart,
+  VulnTrendChart,
+  type PipelineStats,
+  type EpssVsCvssPoint,
+  type TrendDataPoint,
+} from "@/components/charts";
+import { BarChart3, RefreshCw, AlertTriangle } from "lucide-react";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function buildPipelineStats(result: ScanResult): PipelineStats {
+  let servers = 0;
+  let packages = 0;
+  for (const agent of result.agents) {
+    servers += agent.mcp_servers.length;
+    for (const srv of agent.mcp_servers) {
+      packages += srv.packages.length;
+    }
+  }
+
+  const blasts = result.blast_radius ?? [];
+  let critical = 0;
+  let high = 0;
+  let vulnerabilities = 0;
+  let kev = 0;
+
+  // Deduplicate vuln IDs across all packages
+  const seen = new Set<string>();
+  for (const br of blasts) {
+    if (!seen.has(br.vulnerability_id)) {
+      seen.add(br.vulnerability_id);
+      vulnerabilities++;
+      if (br.severity === "critical") critical++;
+      if (br.severity === "high") high++;
+      if (br.is_kev || br.cisa_kev) kev++;
+    }
+  }
+
+  return {
+    agents: result.agents.length,
+    servers,
+    packages,
+    vulnerabilities,
+    critical,
+    high,
+    kev,
+  };
+}
+
+function buildEpssVsCvss(blasts: BlastRadius[]): EpssVsCvssPoint[] {
+  const seen = new Set<string>();
+  const out: EpssVsCvssPoint[] = [];
+  for (const br of blasts) {
+    if (seen.has(br.vulnerability_id)) continue;
+    seen.add(br.vulnerability_id);
+    if (!br.cvss_score && !br.epss_score) continue;
+    out.push({
+      cve: br.vulnerability_id,
+      cvss: br.cvss_score ?? 0,
+      epss: br.epss_score ?? 0,
+      blast: br.blast_score,
+      severity: br.severity ?? "low",
+      kev: !!(br.is_kev || br.cisa_kev),
+      package: br.package,
+    });
+  }
+  return out;
+}
+
+function buildTrendData(jobs: ScanJob[]): TrendDataPoint[] {
+  return jobs
+    .filter((j) => j.status === "done" && j.result)
+    .slice(-10)
+    .map((j) => {
+      const blasts = j.result!.blast_radius ?? [];
+      let critical = 0, high = 0, medium = 0, low = 0;
+      const seen = new Set<string>();
+      for (const br of blasts) {
+        if (seen.has(br.vulnerability_id)) continue;
+        seen.add(br.vulnerability_id);
+        if (br.severity === "critical") critical++;
+        else if (br.severity === "high") high++;
+        else if (br.severity === "medium") medium++;
+        else low++;
+      }
+      const date = new Date(j.completed_at ?? j.created_at);
+      const label = `${date.getMonth() + 1}/${date.getDate()} ${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}`;
+      return { label, critical, high, medium, low };
+    });
+}
+
+// ─── Page ───────────────────────────────────────────────────────────────────
+
+export default function InsightsPage() {
+  const [jobs, setJobs] = useState<ScanJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = () => {
+    setLoading(true);
+    setError(null);
+    api
+      .listJobs()
+      .then(async (res) => {
+        const doneIds = res.jobs
+          .filter((j) => j.status === "done")
+          .slice(0, 10)
+          .map((j) => j.job_id);
+
+        const fullJobs = await Promise.all(
+          doneIds.map((id) => api.getScan(id).catch(() => null))
+        );
+        setJobs(fullJobs.filter(Boolean) as ScanJob[]);
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  // Use the most recent completed scan for single-scan charts
+  const latest = useMemo(
+    () => jobs.find((j) => j.status === "done" && j.result) ?? null,
+    [jobs]
+  );
+  const result = latest?.result ?? null;
+  const agents: Agent[] = result?.agents ?? [];
+  const blasts: BlastRadius[] = result?.blast_radius ?? [];
+
+  const pipelineStats = useMemo(
+    () => (result ? buildPipelineStats(result) : null),
+    [result]
+  );
+
+  const epssVsCvss = useMemo(() => buildEpssVsCvss(blasts), [blasts]);
+  const trendData = useMemo(() => buildTrendData(jobs), [jobs]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh] text-zinc-500 text-sm font-mono">
+        <div className="flex items-center gap-2">
+          <RefreshCw className="w-4 h-4 animate-spin" />
+          Loading insights...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="flex items-center gap-3 p-4 bg-red-950/30 border border-red-800/40 rounded-xl text-red-400 text-sm">
+          <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!result) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
+        <BarChart3 className="w-10 h-10 text-zinc-700 mx-auto mb-3" />
+        <p className="text-zinc-500 text-sm">No completed scans yet.</p>
+        <p className="text-zinc-600 text-xs mt-1">
+          Run a scan to populate this page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-zinc-100 flex items-center gap-2">
+            <BarChart3 className="w-5 h-5 text-emerald-400" />
+            Insights
+          </h1>
+          <p className="text-xs text-zinc-500 mt-0.5">
+            Supply chain visualizations · latest scan:{" "}
+            <span className="font-mono text-zinc-400">{latest?.job_id?.slice(0, 8)}</span>
+          </p>
+        </div>
+        <button
+          onClick={fetchData}
+          className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-200 px-3 py-1.5 rounded-lg border border-zinc-800 hover:border-zinc-700 transition-colors"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Pipeline flow — full width */}
+      {pipelineStats && <PipelineFlow stats={pipelineStats} />}
+
+      {/* Supply chain treemap — full width */}
+      {agents.length > 0 && <SupplyChainTreemap agents={agents} />}
+
+      {/* 2-col: blast radius radial + EPSS×CVSS scatter */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        {blasts.length > 0 && <BlastRadiusRadial data={blasts} />}
+        {epssVsCvss.length > 0 && <EpssVsCvssChart data={epssVsCvss} />}
+      </div>
+
+      {/* Trend (multi-scan history) — full width */}
+      {trendData.length >= 2 && (
+        <div>
+          <VulnTrendChart data={trendData} />
+        </div>
+      )}
+
+      {trendData.length < 2 && (
+        <div className="text-center py-6 text-zinc-600 text-xs border border-zinc-800 border-dashed rounded-xl">
+          Run 2+ scans to see vulnerability trend over time
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/components/charts.tsx
+++ b/ui/components/charts.tsx
@@ -17,7 +17,11 @@ import {
   Tooltip,
   CartesianGrid,
   ReferenceLine,
+  Treemap,
+  RadialBarChart,
+  RadialBar,
 } from "recharts";
+import type { Agent, BlastRadius, ScanResult } from "@/lib/api";
 
 // ─── Shared ──────────────────────────────────────────────────────────────────
 
@@ -260,6 +264,273 @@ export function SeverityDonut({ data }: { data: SeveritySlice[] }) {
             total
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Supply Chain Treemap ─────────────────────────────────────────────────────
+
+interface TreemapItem {
+  name: string;
+  size?: number;
+  color?: string;
+  children?: TreemapItem[];
+  [key: string]: unknown;
+}
+
+function TreemapCell({
+  x, y, width, height, name, color,
+}: {
+  x?: number; y?: number; width?: number; height?: number;
+  name?: string; color?: string;
+}) {
+  if (!width || !height || width < 4 || height < 4) return null;
+  const bg = color ?? "#27272a";
+  return (
+    <g>
+      <rect
+        x={x} y={y} width={width} height={height}
+        fill={bg}
+        fillOpacity={0.85}
+        stroke="#18181b"
+        strokeWidth={1.5}
+        rx={3}
+      />
+      {width > 40 && height > 20 && (
+        <text
+          x={(x ?? 0) + (width) / 2}
+          y={(y ?? 0) + (height) / 2}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fill="#e4e4e7"
+          fontSize={Math.min(11, Math.max(8, width / 10))}
+          fontFamily="monospace"
+        >
+          {name && name.length > 16 ? name.slice(0, 14) + "…" : name}
+        </text>
+      )}
+    </g>
+  );
+}
+
+export function SupplyChainTreemap({ agents }: { agents: Agent[] }) {
+  const treeData: TreemapItem[] = agents.map((agent) => ({
+    name: agent.name,
+    children: agent.mcp_servers.map((srv) => ({
+      name: srv.name,
+      children: srv.packages.map((pkg) => {
+        const vulns = pkg.vulnerabilities ?? [];
+        const hasVuln = vulns.length > 0;
+        const worst = vulns.reduce(
+          (w, v) => {
+            const order: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+            return (order[v.severity] ?? 0) > (order[w] ?? 0) ? v.severity : w;
+          },
+          "none" as string
+        );
+        const color = hasVuln
+          ? worst === "critical" ? "#ef4444"
+          : worst === "high" ? "#f97316"
+          : worst === "medium" ? "#eab308"
+          : "#3b82f6"
+          : "#22c55e";
+        return { name: `${pkg.name}@${pkg.version}`, size: Math.max(1, vulns.length || 1), color };
+      }),
+    })),
+  }));
+
+  if (treeData.length === 0) return null;
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
+      <h3 className="text-sm font-semibold text-zinc-300 mb-1">Supply Chain Map</h3>
+      <p className="text-[10px] text-zinc-600 mb-4">
+        Agent → Server → Package · green = clean · red/orange/yellow = vulnerable
+      </p>
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <Treemap
+            data={treeData}
+            dataKey="size"
+            content={<TreemapCell />}
+          />
+        </ResponsiveContainer>
+      </div>
+      <div className="flex gap-4 mt-3">
+        {[
+          { label: "Clean", color: "#22c55e" },
+          { label: "Low", color: "#3b82f6" },
+          { label: "Medium", color: "#eab308" },
+          { label: "High", color: "#f97316" },
+          { label: "Critical", color: "#ef4444" },
+        ].map(({ label, color }) => (
+          <div key={label} className="flex items-center gap-1.5">
+            <span className="w-2 h-2 rounded-sm" style={{ background: color }} />
+            <span className="text-[10px] text-zinc-500">{label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Blast Radius Radial Bar ──────────────────────────────────────────────────
+
+interface RadialPoint {
+  name: string;
+  value: number;
+  fill: string;
+}
+
+export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
+  const top = [...data]
+    .sort((a, b) => b.blast_score - a.blast_score)
+    .slice(0, 8);
+
+  if (top.length === 0) return null;
+
+  const maxScore = top[0].blast_score;
+
+  const radialData: RadialPoint[] = top.map((br) => {
+    const sev = br.severity?.toLowerCase() ?? "low";
+    const fill =
+      sev === "critical" ? "#ef4444"
+      : sev === "high" ? "#f97316"
+      : sev === "medium" ? "#eab308"
+      : "#3b82f6";
+    return {
+      name: br.package ?? br.vulnerability_id,
+      value: Math.round((br.blast_score / Math.max(maxScore, 1)) * 100),
+      fill,
+    };
+  });
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
+      <h3 className="text-sm font-semibold text-zinc-300 mb-1">Blast Radius</h3>
+      <p className="text-[10px] text-zinc-600 mb-2">
+        Top packages by blast score (relative %)
+      </p>
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <RadialBarChart
+            cx="50%"
+            cy="50%"
+            innerRadius="15%"
+            outerRadius="90%"
+            barSize={10}
+            data={radialData}
+            startAngle={180}
+            endAngle={0}
+          >
+            <RadialBar
+              dataKey="value"
+              cornerRadius={4}
+              background={{ fill: "#27272a" }}
+              label={false}
+            />
+            <Tooltip
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const d = payload[0].payload as RadialPoint;
+                return (
+                  <div
+                    className="rounded-lg border px-3 py-2 text-xs shadow-xl"
+                    style={{ background: "#09090b", borderColor: "#27272a" }}
+                  >
+                    <div className="font-mono text-zinc-300 mb-1 truncate max-w-[160px]">{d.name}</div>
+                    <div className="flex justify-between gap-4">
+                      <span className="text-zinc-500">Blast %</span>
+                      <span className="font-mono" style={{ color: d.fill }}>{d.value}%</span>
+                    </div>
+                  </div>
+                );
+              }}
+            />
+          </RadialBarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="space-y-1 mt-2">
+        {radialData.slice(0, 5).map((d) => (
+          <div key={d.name} className="flex items-center gap-2 text-[10px]">
+            <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: d.fill }} />
+            <span className="text-zinc-400 font-mono truncate flex-1">{d.name}</span>
+            <span className="text-zinc-600 font-mono">{d.value}%</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Pipeline Flow ────────────────────────────────────────────────────────────
+
+export interface PipelineStats {
+  agents: number;
+  servers: number;
+  packages: number;
+  vulnerabilities: number;
+  critical: number;
+  high: number;
+  kev: number;
+}
+
+const PIPELINE_STAGES = [
+  { id: "discovery",  label: "Discovery",  stat: (s: PipelineStats) => `${s.agents} agents` },
+  { id: "extraction", label: "Extraction", stat: (s: PipelineStats) => `${s.servers} servers` },
+  { id: "scanning",   label: "Scanning",   stat: (s: PipelineStats) => `${s.packages} pkgs` },
+  { id: "enrichment", label: "Enrichment", stat: (s: PipelineStats) => `${s.vulnerabilities} CVEs` },
+  { id: "analysis",   label: "Analysis",   stat: (s: PipelineStats) => `${s.critical}C ${s.high}H` },
+  { id: "output",     label: "Report",     stat: (s: PipelineStats) => s.kev > 0 ? `${s.kev} KEV` : "Clean" },
+] as const;
+
+export function PipelineFlow({ stats }: { stats: PipelineStats }) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
+      <h3 className="text-sm font-semibold text-zinc-300 mb-1">Scan Pipeline</h3>
+      <p className="text-[10px] text-zinc-600 mb-5">
+        End-to-end flow with live stats from the latest scan
+      </p>
+      <div className="flex items-stretch gap-0 overflow-x-auto pb-2">
+        {PIPELINE_STAGES.map((stage, i) => {
+          const isLast = i === PIPELINE_STAGES.length - 1;
+          const isAlert = stage.id === "output" && stats.kev > 0;
+          return (
+            <div key={stage.id} className="flex items-center flex-1 min-w-0">
+              <div
+                className={`flex-1 min-w-[72px] flex flex-col items-center gap-1.5 px-3 py-3 rounded-lg border transition-colors ${
+                  isAlert
+                    ? "bg-red-950/30 border-red-800/50"
+                    : "bg-zinc-800/50 border-zinc-700/40"
+                }`}
+              >
+                <div
+                  className={`w-1.5 h-1.5 rounded-full ${
+                    isAlert ? "bg-red-500" : "bg-emerald-500"
+                  }`}
+                />
+                <span className="text-[10px] font-semibold text-zinc-300 uppercase tracking-wide whitespace-nowrap">
+                  {stage.label}
+                </span>
+                <span
+                  className={`text-[11px] font-mono font-bold ${
+                    isAlert ? "text-red-400" : "text-emerald-400"
+                  }`}
+                >
+                  {stage.stat(stats)}
+                </span>
+              </div>
+              {!isLast && (
+                <div className="w-4 flex-shrink-0 flex items-center justify-center">
+                  <svg width="12" height="10" viewBox="0 0 12 10" fill="none">
+                    <path d="M0 5H10M7 1L11 5L7 9" stroke="#52525b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -21,6 +21,7 @@ import {
   Radio,
   Menu,
   X,
+  BarChart3,
 } from "lucide-react";
 import { api } from "@/lib/api";
 
@@ -48,6 +49,7 @@ const NAV_GROUPS = [
       { href: "/graph",      label: "Lineage",     icon: GitBranch },
       { href: "/mesh",       label: "Mesh",        icon: Network },
       { href: "/context",    label: "Context",     icon: Waypoints },
+      { href: "/insights",   label: "Insights",    icon: BarChart3 },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- **SupplyChainTreemap** — Recharts `Treemap` showing Agent → MCP Server → Package hierarchy; cells colored green (clean) through red (critical)
- **BlastRadiusRadial** — `RadialBarChart` ranking top-8 packages by blast score, severity-colored with percentage bars
- **PipelineFlow** — 6-stage scan pipeline visualization (Discovery → Extraction → Scanning → Enrichment → Analysis → Report) with live stats from the latest scan; KEV alert state turns red
- **`/insights` page** — fetches latest 10 completed scan jobs, renders all 4 charts (+ reuses existing `EpssVsCvssChart` and `VulnTrendChart`)
- **Nav** — Insights link added to Graphs group
- **`dashboard/README.md`** — Streamlit deprecated notice; Snowflake Native App exception documented

Closes #408

## Test plan

- [ ] Start FastAPI backend: `agent-bom api`
- [ ] `cd ui && npm run dev` → navigate to `/insights`
- [ ] Verify pipeline flow shows 6 stages with correct stat counts
- [ ] Verify supply chain treemap renders agent→server→package cells, color-coded
- [ ] Verify blast radius radial shows top packages with severity colors
- [ ] Verify EPSS×CVSS scatter and trend charts appear
- [ ] Check "Insights" nav link appears in Graphs group
- [ ] Confirm TypeScript: `npx tsc --noEmit` no new errors