### PR TITLE
fix: validate + sanitize JSON report upload

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
 import { api, ScanJob, ScanResult, BlastRadius, Agent, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS } from "@/lib/api";
+import { checkFileSize, validateScanReport } from "@/lib/validators";
 import { AgentTopology } from "@/components/agent-topology";
 import { TrustStack } from "@/components/trust-stack";
 import { SeverityBadge } from "@/components/severity-badge";
@@ -323,7 +324,7 @@ export default function Dashboard() {
     return [{
       job_id: "imported",
       status: "done",
-      created_at: importedReport.generated_at ?? new Date().toISOString(),
+      created_at: importedReport.scan_timestamp ?? new Date().toISOString(),
       request: {} as ScanJob["request"],
       progress: [],
       result: importedReport as unknown as Record<string, unknown>,
@@ -896,17 +897,35 @@ function CompoundIssueCard({ issue }: { issue: CompoundIssue }) {
 }
 
 function ApiDown({ onImport }: { onImport: (data: ScanResult) => void }) {
+  const [importError, setImportError] = useState<string | null>(null);
+
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    setImportError(null);
+
+    // Reject oversized files before loading into memory
+    const sizeCheck = checkFileSize(file);
+    if (!sizeCheck.ok) {
+      setImportError(sizeCheck.error);
+      e.target.value = "";
+      return;
+    }
+
     const reader = new FileReader();
+    reader.onerror = () => setImportError("Failed to read file.");
     reader.onload = (ev) => {
-      try {
-        const data = JSON.parse(ev.target?.result as string) as ScanResult;
-        onImport(data);
-      } catch {
-        alert("Invalid JSON — make sure this is an agent-bom scan report.");
+      const text = ev.target?.result;
+      if (typeof text !== "string") {
+        setImportError("Could not read file contents.");
+        return;
       }
+      const result = validateScanReport(text);
+      if (!result.ok) {
+        setImportError(result.error);
+        return;
+      }
+      onImport(result.data as ScanResult);
     };
     reader.readAsText(file);
   };
@@ -931,7 +950,13 @@ function ApiDown({ onImport }: { onImport: (data: ScanResult) => void }) {
         <p className="text-xs text-zinc-600 mb-4">
           Generated with{" "}
           <code className="font-mono">agent-bom scan -f json -o report.json</code>
+          <span className="block mt-1 text-zinc-700">Max 10 MB · schema-validated</span>
         </p>
+        {importError && (
+          <div className="mb-4 px-3 py-2 bg-red-950/40 border border-red-800/50 rounded-lg text-left">
+            <p className="text-xs text-red-400 font-mono break-words">{importError}</p>
+          </div>
+        )}
         <label className="cursor-pointer inline-flex items-center gap-2 px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-sm text-zinc-300 transition-colors">
           <FileText className="w-4 h-4" />
           Choose report.json

--- a/ui/lib/validators.ts
+++ b/ui/lib/validators.ts
@@ -1,0 +1,185 @@
+/**
+ * Runtime validation for user-supplied JSON (report import).
+ *
+ * TypeScript type assertions are compile-time only — they do NOT validate at
+ * runtime. Any JSON file a user uploads must be structurally validated before
+ * being passed into aggregation functions that assume specific shapes.
+ *
+ * Threats addressed:
+ *  - DoS via oversized file (size check before FileReader)
+ *  - App crash from missing/wrong-type fields
+ *  - Prototype pollution (__proto__, constructor, prototype keys)
+ *  - NaN / Infinity in numeric fields causing math failures
+ */
+
+const MAX_IMPORT_BYTES = 10 * 1024 * 1024; // 10 MB
+
+type ValidationResult =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string };
+
+/** Call BEFORE FileReader.readAsText() to reject oversized files. */
+export function checkFileSize(file: File): ValidationResult {
+  if (file.size > MAX_IMPORT_BYTES) {
+    return {
+      ok: false,
+      error: `File is ${(file.size / 1024 / 1024).toFixed(1)} MB — maximum is 10 MB.`,
+    };
+  }
+  return { ok: true, data: null };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function isArray(v: unknown): v is unknown[] {
+  return Array.isArray(v);
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+function isFiniteNum(v: unknown): v is number {
+  return typeof v === "number" && isFinite(v);
+}
+
+/** Detect prototype-pollution keys anywhere in the JSON text. */
+function hasPollutionKeys(jsonText: string): boolean {
+  return (
+    jsonText.includes('"__proto__"') ||
+    jsonText.includes('"constructor"') ||
+    // Allow the word "prototype" in values like package names, but
+    // explicitly exclude it as a JSON key (preceded by `"prototype"`).
+    /"\bprototype\b"\s*:/.test(jsonText)
+  );
+}
+
+/** Validate a single vulnerability object. Returns an error string or null. */
+function validateVuln(v: unknown, path: string): string | null {
+  if (!isPlainObject(v)) return `${path}: must be an object`;
+  if (!isString(v.id) || !v.id) return `${path}.id: must be a non-empty string`;
+  const SEVERITIES = ["critical", "high", "medium", "low", "none"];
+  if (!SEVERITIES.includes(v.severity as string))
+    return `${path}.severity: must be one of ${SEVERITIES.join(", ")}`;
+  if (v.cvss_score !== undefined && !isFiniteNum(v.cvss_score))
+    return `${path}.cvss_score: must be a finite number`;
+  if (v.epss_score !== undefined && !isFiniteNum(v.epss_score))
+    return `${path}.epss_score: must be a finite number`;
+  return null;
+}
+
+/** Validate a package object. */
+function validatePackage(p: unknown, path: string): string | null {
+  if (!isPlainObject(p)) return `${path}: must be an object`;
+  if (!isString(p.name) || !p.name) return `${path}.name: must be a non-empty string`;
+  if (!isString(p.version)) return `${path}.version: must be a string`;
+  if (!isString(p.ecosystem)) return `${path}.ecosystem: must be a string`;
+  if (p.vulnerabilities !== undefined) {
+    if (!isArray(p.vulnerabilities)) return `${path}.vulnerabilities: must be an array`;
+    for (let i = 0; i < p.vulnerabilities.length; i++) {
+      const err = validateVuln(p.vulnerabilities[i], `${path}.vulnerabilities[${i}]`);
+      if (err) return err;
+    }
+  }
+  return null;
+}
+
+/** Validate an MCP server object. */
+function validateServer(s: unknown, path: string): string | null {
+  if (!isPlainObject(s)) return `${path}: must be an object`;
+  if (!isString(s.name) || !s.name) return `${path}.name: must be a non-empty string`;
+  if (!isArray(s.packages)) return `${path}.packages: must be an array`;
+  for (let i = 0; i < s.packages.length; i++) {
+    const err = validatePackage(s.packages[i], `${path}.packages[${i}]`);
+    if (err) return err;
+  }
+  return null;
+}
+
+/** Validate an agent object. */
+function validateAgent(a: unknown, path: string): string | null {
+  if (!isPlainObject(a)) return `${path}: must be an object`;
+  if (!isString(a.name) || !a.name) return `${path}.name: must be a non-empty string`;
+  if (!isString(a.agent_type)) return `${path}.agent_type: must be a string`;
+  if (!isArray(a.mcp_servers)) return `${path}.mcp_servers: must be an array`;
+  for (let i = 0; i < a.mcp_servers.length; i++) {
+    const err = validateServer(a.mcp_servers[i], `${path}.mcp_servers[${i}]`);
+    if (err) return err;
+  }
+  return null;
+}
+
+/** Validate a blast_radius entry. */
+function validateBlast(b: unknown, path: string): string | null {
+  if (!isPlainObject(b)) return `${path}: must be an object`;
+  if (!isString(b.vulnerability_id) || !b.vulnerability_id)
+    return `${path}.vulnerability_id: must be a non-empty string`;
+  if (!isString(b.severity)) return `${path}.severity: must be a string`;
+  if (!isArray(b.affected_agents)) return `${path}.affected_agents: must be an array`;
+  if (!isArray(b.exposed_credentials)) return `${path}.exposed_credentials: must be an array`;
+  if (!isArray(b.reachable_tools)) return `${path}.reachable_tools: must be an array`;
+  if (b.blast_score !== undefined && !isFiniteNum(b.blast_score))
+    return `${path}.blast_score: must be a finite number`;
+  if (b.cvss_score !== undefined && !isFiniteNum(b.cvss_score))
+    return `${path}.cvss_score: must be a finite number`;
+  if (b.epss_score !== undefined && !isFiniteNum(b.epss_score))
+    return `${path}.epss_score: must be a finite number`;
+  return null;
+}
+
+/**
+ * Parse and validate a JSON string from an untrusted file upload.
+ *
+ * On success returns the parsed data (safe to cast to ScanResult).
+ * On failure returns an error string suitable for display to the user.
+ */
+export function validateScanReport(jsonText: string): ValidationResult {
+  // 1. Pollution check on raw text (before parsing)
+  if (hasPollutionKeys(jsonText)) {
+    return { ok: false, error: "Invalid report: unexpected structural keys." };
+  }
+
+  // 2. Parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (e) {
+    return { ok: false, error: `Invalid JSON: ${(e as Error).message}` };
+  }
+
+  // 3. Top-level shape
+  if (!isPlainObject(parsed)) {
+    return { ok: false, error: "Report must be a JSON object." };
+  }
+
+  // 4. Required: agents array
+  if (!isArray(parsed.agents)) {
+    return { ok: false, error: "Missing or invalid \"agents\" field — is this an agent-bom JSON report?" };
+  }
+
+  // 5. Required: blast_radius array
+  if (!isArray(parsed.blast_radius)) {
+    return {
+      ok: false,
+      error: "Missing or invalid \"blast_radius\" field — is this an agent-bom JSON report?",
+    };
+  }
+
+  // 6. Validate agents (cap validation at first 200 for perf)
+  const agentLimit = Math.min(parsed.agents.length, 200);
+  for (let i = 0; i < agentLimit; i++) {
+    const err = validateAgent(parsed.agents[i], `agents[${i}]`);
+    if (err) return { ok: false, error: err };
+  }
+
+  // 7. Validate blast_radius (cap at first 500)
+  const blastLimit = Math.min(parsed.blast_radius.length, 500);
+  for (let i = 0; i < blastLimit; i++) {
+    const err = validateBlast(parsed.blast_radius[i], `blast_radius[${i}]`);
+    if (err) return { ok: false, error: err };
+  }
+
+  return { ok: true, data: parsed };
+}


### PR DESCRIPTION
## Summary

- **File size limit** — reject files >10 MB before `FileReader.readAsText()` (prevents memory DoS)
- **Schema validation** — new `ui/lib/validators.ts` checks required fields (`agents[]`, `blast_radius[]`), types, and finite numeric values without adding any npm dependency
- **Prototype pollution guard** — scan raw JSON text for `__proto__`, `constructor`, `prototype` keys before parsing
- **Inline error display** — replaces `alert()` with a styled error box inside the upload widget so the user knows what went wrong
- **`generated_at` TS error fixed** — `ScanResult` doesn't have that field; use `scan_timestamp` instead

## Test plan

- [ ] Upload a valid `report.json` → loads normally
- [ ] Upload a >10 MB file → error: "X.X MB — maximum is 10 MB"
- [ ] Upload malformed JSON (`{invalid`) → error: "Invalid JSON: ..."
- [ ] Upload `{}` (wrong shape) → error: 'Missing or invalid "agents" field'
- [ ] Upload `{"agents": "string", "blast_radius": []}` → error: `agents: must be an array`
- [ ] `npx tsc --noEmit` → zero errors