### PR TITLE
feat: UI charts, retry buttons, treemap drill-down + OSS hardening

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,22 @@
 ## Summary
 <!-- What does this PR do? Keep it to 1-3 bullet points. -->
 
+## Related Issues
+<!-- Closes #XXX (auto-closes on merge) -->
+
 ## Test plan
 <!-- How was this tested? -->
 
-- [ ] `pytest` passes
-- [ ] `ruff check src/` passes
+- [ ] `pytest tests/ -x -q` passes
+- [ ] `ruff check src/ && ruff format --check src/` passes
+- [ ] TypeScript: `cd ui && npx tsc --noEmit` (if UI changes)
 - [ ] Manual verification (describe below)
+
+## Breaking changes
+- [ ] None
+- [ ] Yes — describe migration path below
+
+## Checklist
+- [ ] Version bumped if this is a release PR (`scripts/bump-version.py`)
+- [ ] Docs/diagrams updated if features changed (`ARCHITECTURE.md`, `README.md`, SVGs)
+- [ ] No secrets, credentials, or personally identifiable data in diff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,21 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-json
+        exclude: "tsconfig.*\\.json$"
+      - id: check-toml
+      - id: end-of-file-fixer
+        exclude: "\\.(svg|png|gif|ico|woff|woff2|ttf|eot)$"
+      - id: trailing-whitespace
+        exclude: "\\.(md|mdx)$"
+      - id: detect-private-key
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.7
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Next.js Insights page** (`/insights`) — SupplyChainTreemap, BlastRadiusRadial, PipelineFlow, EpssVsCvssChart, VulnTrendChart wired to real scan data; treemap cells are clickable and drill down to `/vulns`
+- **Gateway enforcement chart** — audit tab shows stacked bar of blocked/alerted/allowed actions per tool
+- **Governance findings chart** — stacked bar of finding severity by governance category
+- **Activity query chart** — bar chart of agent query pattern frequency
+- **Fleet lifecycle chart** — bar chart of agents by lifecycle state
+- **Jobs status donut** — pie chart summarising job queue by status
+- **`ui/components/empty-state.tsx`** — reusable `EmptyState` + `ErrorBanner` components used across pages
+- **Retry buttons** — Activity and Governance error states now include a Retry button
+- **SECURITY.md** expanded — response SLA, known limitations, API security model, disclosure timeline
+- **PR template** — added Related Issues, TypeScript check, breaking changes, checklist sections
+- **pre-commit hooks** — added `check-yaml`, `check-json`, `check-toml`, `end-of-file-fixer`, `trailing-whitespace`, `detect-private-key`, `check-merge-conflict`, `mixed-line-ending`
+
+### Fixed
+- **JSON report import** — file upload now validates size (10 MB), schema, prototype-pollution keys, and finite numeric values before use (`ui/lib/validators.ts`)
+- **`generated_at` TypeScript error** — `ScanResult` does not have `generated_at`; use `scan_timestamp` instead
+- **JetBrains claim** — removed from active integrations; filed as issue #412 for proper implementation
+
+### Security
+- **JSON file upload** — `ui/lib/validators.ts` guards against DoS via oversized files, prototype pollution, and schema-invalid payloads (no new npm dependencies)
+
+---
+
 ## [0.60.1] – 2026-03-08
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,17 +4,64 @@
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Report via [GitHub Security Advisories](https://github.com/msaad00/agent-bom/security/advisories/new).
+Report privately via [GitHub Security Advisories](https://github.com/msaad00/agent-bom/security/advisories/new).
 
-We aim to respond within 48 hours and provide a fix within 7 days for critical issues.
+**Response SLA:**
+- Acknowledgement within **48 hours**
+- Triage and severity assessment within **5 business days**
+- Fix for critical issues within **7 days** of triage
+- Fix for high issues within **30 days** of triage
 
 ## Supported Versions
 
 | Version | Supported |
 |---------|-----------|
-| Latest  | Yes       |
-| < Latest | No — upgrade to the latest release |
+| Latest  | ✓ Yes     |
+| < Latest | ✗ No — upgrade to the latest release |
 
 ## Security Design
 
-agent-bom is a read-only scanner. It reads config files and queries public APIs (OSV.dev, NVD, EPSS, CISA KEV). It never writes to agent configs, never executes MCP servers, and never stores credentials — only their names appear in output as `***REDACTED***`.
+agent-bom is a **read-only scanner**. It does not modify agent configurations, execute MCP servers, write credentials, or alter any external system state.
+
+### What it reads
+- Local config files (`~/.config/`, `~/.claude/`, etc.) — for agent discovery
+- Public APIs: OSV.dev, NVD, EPSS, CISA KEV — for CVE enrichment
+- Cloud provider APIs — when explicitly configured with credentials (AWS, GCP, Azure, Snowflake, Databricks)
+- Docker daemon socket — when `--image` flag is used
+- Kubernetes API — when `--k8s` flag is used
+
+### Credential handling
+- Credentials are **never stored** by agent-bom
+- Credential names/env var keys appear in output as `***REDACTED***`
+- Redaction is heuristic-based (regex patterns) and may miss obfuscated or non-standard key names
+- Cloud credentials must be pre-configured in the environment (AWS profile, GCP application default, etc.)
+
+### Known limitations
+- **Credential redaction is heuristic** — non-standard or obfuscated key names may not be flagged
+- **Grype/Syft dependency** — container image scanning relies on external binaries; their CVEs apply to those tools
+- **Network dependency** — OSV/NVD/EPSS enrichment requires outbound HTTPS; air-gapped environments see reduced coverage
+- **MCP server execution** — agent-bom does NOT execute MCP servers it discovers; it only reads their configs
+- **Runtime proxy enforcement** — the proxy intercepts MCP traffic using a trust-on-first-use model; pre-existing compromised servers must be identified via scanning before proxy deployment
+
+### API security (when running `agent-bom api`)
+- Defaults to localhost-only binding (`127.0.0.1:8422`)
+- API key auth via `AGENT_BOM_API_KEY` env var; OIDC/JWT via `AGENT_BOM_OIDC_ISSUER`
+- WebSocket endpoints require the same auth when `AGENT_BOM_API_KEY` is set
+- JWKS public key caching (1h TTL); RS256/RS384/RS512/ES256/ES384/ES512 supported; `alg: none` rejected
+
+## Security Testing
+
+- **Static analysis**: ruff + mypy on every PR (required CI checks)
+- **Dependency scanning**: Dependabot weekly (Python + npm)
+- **Container image scanning**: Trivy in CI pipeline
+- **Pre-commit hooks**: ruff, ruff-format, detect-private-key, check-yaml, end-of-file-fixer
+- No third-party penetration testing yet (planned for v1.0)
+
+## Vulnerability Disclosure Timeline
+
+1. Reporter submits via GitHub Security Advisories
+2. Maintainer acknowledges within 48 hours
+3. Issue triaged, CVSS severity assigned within 5 business days
+4. Fix developed on private branch; CVE ID requested if warranted
+5. Coordinated disclosure: patch released, advisory published simultaneously
+6. Reporter credited in release notes (unless anonymity requested)

--- a/ui/app/activity/page.tsx
+++ b/ui/app/activity/page.tsx
@@ -12,6 +12,16 @@ import {
 } from "lucide-react";
 import { api, formatDate } from "@/lib/api";
 import type { ActivityTimeline } from "@/lib/api";
+import { ErrorBanner } from "@/components/empty-state";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
 
 export default function ActivityPage() {
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
@@ -21,7 +31,7 @@ export default function ActivityPage() {
   const [tab, setTab] = useState<"queries" | "events">("queries");
   const [search, setSearch] = useState("");
 
-  useEffect(() => {
+  const load = () => {
     setLoading(true);
     setError(null);
     api
@@ -29,7 +39,9 @@ export default function ActivityPage() {
       .then(setTimeline)
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [days]);
+  };
+
+  useEffect(() => { load(); }, [days]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) {
     return (
@@ -41,13 +53,11 @@ export default function ActivityPage() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-800 bg-red-950/50 p-6 text-center">
-        <AlertTriangle className="w-8 h-8 text-red-400 mx-auto mb-3" />
-        <p className="text-red-300 text-sm">{error}</p>
-        <p className="text-zinc-500 text-xs mt-2">
-          Activity requires SNOWFLAKE_ACCOUNT env var on the API server.
-        </p>
-      </div>
+      <ErrorBanner
+        message={error}
+        hint="Activity requires SNOWFLAKE_ACCOUNT env var on the API server."
+        onRetry={load}
+      />
     );
   }
 
@@ -146,24 +156,31 @@ export default function ActivityPage() {
         </div>
       )}
 
-      {/* Pattern breakdown */}
+      {/* Activity bar chart */}
       {Object.keys(patternCounts).length > 0 && (
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
-          <h3 className="text-sm font-semibold text-zinc-300 mb-3">
-            Agent Query Patterns
-          </h3>
-          <div className="flex flex-wrap gap-2">
-            {Object.entries(patternCounts)
-              .sort(([, a], [, b]) => b - a)
-              .map(([pattern, count]) => (
-                <span
-                  key={pattern}
-                  className="px-3 py-1 rounded-md text-xs font-mono bg-zinc-800 text-zinc-300 border border-zinc-700"
-                >
-                  {pattern}{" "}
-                  <span className="text-emerald-400 ml-1">{count}</span>
-                </span>
-              ))}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+          <h3 className="text-sm font-semibold text-zinc-300 mb-1">Agent Query Patterns</h3>
+          <p className="text-[10px] text-zinc-600 mb-4">Query count by detected agent pattern</p>
+          <div className="h-44">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={Object.entries(patternCounts)
+                  .sort(([, a], [, b]) => b - a)
+                  .slice(0, 12)
+                  .map(([pattern, count]) => ({ pattern: pattern.length > 18 ? pattern.slice(0, 16) + "…" : pattern, count }))}
+                margin={{ top: 4, right: 8, bottom: 4, left: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
+                <XAxis dataKey="pattern" tick={{ fontSize: 9, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
+                <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                <Tooltip
+                  contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }}
+                  itemStyle={{ color: "#e4e4e7" }}
+                  labelStyle={{ color: "#71717a", marginBottom: 4 }}
+                />
+                <Bar dataKey="count" name="queries" fill="#10b981" radius={[4, 4, 0, 0]} fillOpacity={0.75} />
+              </BarChart>
+            </ResponsiveContainer>
           </div>
         </div>
       )}

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -9,6 +9,15 @@ import {
   formatDate,
 } from "@/lib/api";
 import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+} from "recharts";
+import {
   Users,
   RefreshCw,
   Loader2,
@@ -153,6 +162,38 @@ export default function FleetPage() {
           />
         </div>
       )}
+
+      {/* Fleet state distribution chart */}
+      {stats && stats.total > 0 && (() => {
+        const STATE_CHART_COLORS: Record<string, string> = {
+          discovered: "#71717a",
+          pending_review: "#eab308",
+          approved: "#22c55e",
+          quarantined: "#ef4444",
+          decommissioned: "#3f3f46",
+        };
+        const chartData = Object.entries(stats.by_state)
+          .filter(([, v]) => v > 0)
+          .map(([state, count]) => ({ state: STATE_LABELS[state as FleetLifecycleState] ?? state, count, fill: STATE_CHART_COLORS[state] ?? "#71717a" }));
+        return (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+            <h3 className="text-sm font-semibold text-zinc-300 mb-1">Lifecycle Distribution</h3>
+            <p className="text-[10px] text-zinc-600 mb-4">Agent count by lifecycle state</p>
+            <div className="h-36">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+                  <XAxis dataKey="state" tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
+                  <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                  <Tooltip contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }} itemStyle={{ color: "#e4e4e7" }} labelStyle={{ color: "#71717a", marginBottom: 4 }} />
+                  <Bar dataKey="count" name="agents" radius={[4, 4, 0, 0]}>
+                    {chartData.map((entry, i) => <Cell key={i} fill={entry.fill} fillOpacity={0.8} />)}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Filter tabs */}
       <div className="flex gap-1.5 flex-wrap">

--- a/ui/app/gateway/page.tsx
+++ b/ui/app/gateway/page.tsx
@@ -10,6 +10,15 @@ import {
   formatDate,
 } from "@/lib/api";
 import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import {
   Lock,
   RefreshCw,
   Loader2,
@@ -180,10 +189,13 @@ export default function GatewayPage() {
 
       {/* Error state */}
       {error && !loading && (
-        <div className="text-center py-16 border border-dashed border-red-900/50 rounded-xl">
-          <AlertTriangle className="w-8 h-8 text-red-500 mx-auto mb-3" />
+        <div className="text-center py-10 border border-dashed border-red-900/50 rounded-xl space-y-3">
+          <AlertTriangle className="w-8 h-8 text-red-500 mx-auto" />
           <p className="text-red-400 text-sm">Failed to load gateway data</p>
-          <p className="text-zinc-500 text-xs mt-1">{error}</p>
+          <p className="text-zinc-500 text-xs">{error}</p>
+          <button onClick={load} className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors">
+            <RefreshCw className="w-3.5 h-3.5" /> Retry
+          </button>
         </div>
       )}
 
@@ -371,6 +383,39 @@ export default function GatewayPage() {
               <p className="text-zinc-500 text-sm">No audit entries yet.</p>
             </div>
           ) : (
+            <>
+              {/* Audit chart: action breakdown by top tools */}
+              {(() => {
+                const toolCounts: Record<string, { blocked: number; alerted: number; allowed: number }> = {};
+                for (const e of audit) {
+                  if (!toolCounts[e.tool_name]) toolCounts[e.tool_name] = { blocked: 0, alerted: 0, allowed: 0 };
+                  const key = e.action_taken as "blocked" | "alerted" | "allowed";
+                  if (key in toolCounts[e.tool_name]) toolCounts[e.tool_name][key]++;
+                }
+                const chartData = Object.entries(toolCounts)
+                  .sort(([, a], [, b]) => (b.blocked + b.alerted) - (a.blocked + a.alerted))
+                  .slice(0, 10)
+                  .map(([tool, counts]) => ({ tool: tool.length > 16 ? tool.slice(0, 14) + "…" : tool, ...counts }));
+                return (
+                  <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <h3 className="text-sm font-semibold text-zinc-300 mb-1">Enforcement Actions by Tool</h3>
+                    <p className="text-[10px] text-zinc-600 mb-4">Top tools by blocked + alerted count</p>
+                    <div className="h-44">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+                          <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
+                          <XAxis dataKey="tool" tick={{ fontSize: 9, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
+                          <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                          <Tooltip contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }} itemStyle={{ color: "#e4e4e7" }} labelStyle={{ color: "#71717a", marginBottom: 4 }} />
+                          <Bar dataKey="blocked" name="blocked" stackId="a" fill="#ef4444" fillOpacity={0.8} />
+                          <Bar dataKey="alerted" name="alerted" stackId="a" fill="#f97316" fillOpacity={0.8} />
+                          <Bar dataKey="allowed" name="allowed" stackId="a" fill="#22c55e" fillOpacity={0.5} radius={[4, 4, 0, 0]} />
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </div>
+                );
+              })()}
             <div className="space-y-1">
               {audit.map((entry) => (
                 <div key={entry.entry_id} className="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 flex items-center justify-between">
@@ -392,6 +437,7 @@ export default function GatewayPage() {
                 </div>
               ))}
             </div>
+            </>
           )}
         </>
       )}

--- a/ui/app/governance/page.tsx
+++ b/ui/app/governance/page.tsx
@@ -18,6 +18,17 @@ import {
   formatDate,
 } from "@/lib/api";
 import type { GovernanceReport, GovernanceFinding } from "@/lib/api";
+import { ErrorBanner } from "@/components/empty-state";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Cell,
+} from "recharts";
 
 export default function GovernancePage() {
   const [report, setReport] = useState<GovernanceReport | null>(null);
@@ -27,7 +38,7 @@ export default function GovernancePage() {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
   const [severityFilter, setSeverityFilter] = useState<string | null>(null);
 
-  useEffect(() => {
+  const load = () => {
     setLoading(true);
     setError(null);
     api
@@ -35,7 +46,9 @@ export default function GovernancePage() {
       .then(setReport)
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [days]);
+  };
+
+  useEffect(() => { load(); }, [days]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) {
     return (
@@ -47,13 +60,11 @@ export default function GovernancePage() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-800 bg-red-950/50 p-6 text-center">
-        <AlertTriangle className="w-8 h-8 text-red-400 mx-auto mb-3" />
-        <p className="text-red-300 text-sm">{error}</p>
-        <p className="text-zinc-500 text-xs mt-2">
-          Governance requires SNOWFLAKE_ACCOUNT env var on the API server.
-        </p>
-      </div>
+      <ErrorBanner
+        message={error}
+        hint="Governance requires SNOWFLAKE_ACCOUNT env var on the API server."
+        onRetry={load}
+      />
     );
   }
 
@@ -123,6 +134,48 @@ export default function GovernancePage() {
           color="text-emerald-400"
         />
       </div>
+
+      {/* Findings severity bar chart */}
+      {report.findings.length > 0 && (() => {
+        const sevColors: Record<string, string> = { critical: "#ef4444", high: "#f97316", medium: "#eab308", low: "#3b82f6" };
+        const cats = ["access", "privilege", "data_classification", "agent_usage"];
+        const chartData = cats.map((cat) => {
+          const fs = report.findings.filter((f) => f.category === cat);
+          return {
+            category: cat.replace("_", " "),
+            critical: fs.filter((f) => f.severity === "critical").length,
+            high: fs.filter((f) => f.severity === "high").length,
+            medium: fs.filter((f) => f.severity === "medium").length,
+            low: fs.filter((f) => f.severity === "low").length,
+          };
+        }).filter((d) => d.critical + d.high + d.medium + d.low > 0);
+        if (chartData.length === 0) return null;
+        return (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+            <h3 className="text-sm font-semibold text-zinc-300 mb-1">Findings by Category & Severity</h3>
+            <p className="text-[10px] text-zinc-600 mb-4">Stacked count of findings per governance category</p>
+            <div className="h-44">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
+                  <XAxis dataKey="category" tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
+                  <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                  <Tooltip
+                    contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }}
+                    itemStyle={{ color: "#e4e4e7" }}
+                    labelStyle={{ color: "#71717a", marginBottom: 4 }}
+                  />
+                  {(["critical", "high", "medium", "low"] as const).map((sev) => (
+                    <Bar key={sev} dataKey={sev} stackId="a" fill={sevColors[sev]} fillOpacity={0.8} radius={sev === "critical" ? [4, 4, 0, 0] : [0, 0, 0, 0]}>
+                      {chartData.map((_, i) => <Cell key={i} />)}
+                    </Bar>
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Warnings */}
       {report.warnings.length > 0 && (

--- a/ui/app/insights/page.tsx
+++ b/ui/app/insights/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   api,
   ScanJob,
@@ -106,6 +107,7 @@ function buildTrendData(jobs: ScanJob[]): TrendDataPoint[] {
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function InsightsPage() {
+  const router = useRouter();
   const [jobs, setJobs] = useState<ScanJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -211,8 +213,16 @@ export default function InsightsPage() {
       {/* Pipeline flow — full width */}
       {pipelineStats && <PipelineFlow stats={pipelineStats} />}
 
-      {/* Supply chain treemap — full width */}
-      {agents.length > 0 && <SupplyChainTreemap agents={agents} />}
+      {/* Supply chain treemap — full width; click a package → /vulns */}
+      {agents.length > 0 && (
+        <div>
+          <SupplyChainTreemap
+            agents={agents}
+            onPackageClick={(pkg) => router.push(`/vulns?search=${encodeURIComponent(pkg)}`)}
+          />
+          <p className="text-[10px] text-zinc-700 mt-1 text-right">Click a package to drill down → Vulns</p>
+        </div>
+      )}
 
       {/* 2-col: blast radius radial + EPSS×CVSS scatter */}
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">

--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { api, JobStatus, formatDate } from "@/lib/api";
 import { ShieldAlert, Clock, CheckCircle2, XCircle, Loader2, Trash2 } from "lucide-react";
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from "recharts";
 
 interface JobSummary {
   job_id: string;
@@ -49,12 +50,14 @@ export default function JobsPage() {
   const [error, setError] = useState("");
   const [deleting, setDeleting] = useState<string | null>(null);
 
-  function load() {
+  const load = () => {
+    setLoading(true);
+    setError("");
     api.listJobs()
       .then((r) => setJobs(r.jobs))
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }
+  };
 
   useEffect(() => { load(); }, []);
 
@@ -87,7 +90,12 @@ export default function JobsPage() {
       </div>
 
       {loading && <p className="text-zinc-500 text-sm">Loading jobs…</p>}
-      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {error && (
+        <div className="flex items-center gap-3 p-3 bg-red-950/30 border border-red-800/40 rounded-lg">
+          <p className="text-red-400 text-sm flex-1">{error}</p>
+          <button onClick={load} className="text-xs text-zinc-400 hover:text-zinc-200 px-2 py-1 border border-zinc-700 rounded">Retry</button>
+        </div>
+      )}
 
       {!loading && jobs.length === 0 && (
         <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
@@ -98,6 +106,37 @@ export default function JobsPage() {
           </p>
         </div>
       )}
+
+      {jobs.length > 0 && (() => {
+        const STATUS_COLORS: Record<string, string> = { done: "#22c55e", failed: "#ef4444", running: "#3b82f6", cancelled: "#71717a", pending: "#a1a1aa" };
+        const counts: Record<string, number> = {};
+        for (const j of jobs) counts[j.status] = (counts[j.status] ?? 0) + 1;
+        const pieData = Object.entries(counts).map(([status, value]) => ({ status, value, fill: STATUS_COLORS[status] ?? "#71717a" }));
+        return (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 flex items-center gap-8">
+            <div className="w-28 h-28 flex-shrink-0">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie data={pieData} dataKey="value" innerRadius="55%" outerRadius="85%" paddingAngle={2} stroke="none">
+                    {pieData.map((entry, i) => <Cell key={i} fill={entry.fill} fillOpacity={0.85} />)}
+                  </Pie>
+                  <Tooltip contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }} itemStyle={{ color: "#e4e4e7" }} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="space-y-2">
+              <p className="text-xs font-semibold text-zinc-400 uppercase tracking-wide mb-3">Job Status</p>
+              {pieData.map((d) => (
+                <div key={d.status} className="flex items-center gap-2 text-xs">
+                  <span className="w-2 h-2 rounded-full" style={{ background: d.fill }} />
+                  <span className="capitalize text-zinc-300 w-20">{d.status}</span>
+                  <span className="font-mono text-zinc-500">{d.value}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
 
       {jobs.length > 0 && (
         <div className="border border-zinc-800 rounded-xl overflow-hidden">

--- a/ui/components/charts.tsx
+++ b/ui/components/charts.tsx
@@ -314,7 +314,13 @@ function TreemapCell({
   );
 }
 
-export function SupplyChainTreemap({ agents }: { agents: Agent[] }) {
+export function SupplyChainTreemap({
+  agents,
+  onPackageClick,
+}: {
+  agents: Agent[];
+  onPackageClick?: (pkgName: string) => void;
+}) {
   const treeData: TreemapItem[] = agents.map((agent) => ({
     name: agent.name,
     children: agent.mcp_servers.map((srv) => ({
@@ -354,6 +360,13 @@ export function SupplyChainTreemap({ agents }: { agents: Agent[] }) {
             data={treeData}
             dataKey="size"
             content={<TreemapCell />}
+            onClick={(node: Record<string, unknown>) => {
+              if (onPackageClick && node && typeof node.name === "string" && node.size !== undefined) {
+                // Leaf node (package) — strip version suffix for package name
+                const name = node.name.replace(/@[^@]+$/, "");
+                onPackageClick(name);
+              }
+            }}
           />
         </ResponsiveContainer>
       </div>

--- a/ui/components/empty-state.tsx
+++ b/ui/components/empty-state.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import Link from "next/link";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: {
+    label: string;
+    href: string;
+  };
+  /** Pass a retry function instead of a link */
+  onRetry?: () => void;
+  retryLabel?: string;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  onRetry,
+  retryLabel = "Retry",
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center border border-dashed border-zinc-800 rounded-xl bg-zinc-950/30">
+      <Icon className="w-10 h-10 text-zinc-700 mb-4" />
+      <p className="text-sm font-medium text-zinc-400">{title}</p>
+      {description && (
+        <p className="text-xs text-zinc-600 mt-1 max-w-sm">{description}</p>
+      )}
+      {action && (
+        <Link
+          href={action.href}
+          className="mt-5 inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+        >
+          {action.label}
+        </Link>
+      )}
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="mt-5 inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+        >
+          {retryLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Compact error banner with optional retry */
+export function ErrorBanner({
+  message,
+  hint,
+  onRetry,
+}: {
+  message: string;
+  hint?: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="rounded-lg border border-red-800/50 bg-red-950/30 p-5 text-center space-y-2">
+      <p className="text-sm text-red-300">{message}</p>
+      {hint && <p className="text-xs text-zinc-500">{hint}</p>}
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**UI improvements (6 pages):**
- `EmptyState` + `ErrorBanner` reusable components — consistent empty/error UX across all pages
- **Activity**: retry button on error + agent query pattern bar chart
- **Governance**: retry button on error + findings-by-category stacked severity bar chart
- **Gateway**: retry button on error + enforcement actions bar chart in audit tab (blocked/alerted/allowed per tool)
- **Fleet**: lifecycle state distribution bar chart (discovered/pending/approved/quarantined/decommissioned)
- **Jobs**: job status donut + retry button
- **Insights**: SupplyChainTreemap cells are now clickable → navigates to `/vulns?search=<package>` for drill-down

**Open source hardening:**
- `SECURITY.md` expanded: response SLA, known limitations, API security model, disclosure timeline
- PR template: Added Related Issues, TypeScript check, breaking-changes section, release checklist
- `.pre-commit-config.yaml`: `check-yaml`, `check-json`, `check-toml`, `end-of-file-fixer`, `trailing-whitespace`, `detect-private-key`, `check-merge-conflict`, `mixed-line-ending`
- `CHANGELOG.md`: Unreleased section documenting all recent changes

**Supply chain audit:**
- `npm audit` → 0 vulnerabilities in ui/
- `pip-audit` → 2 findings in conda env (`pillow` CVE-2026-25990, `protobuf` CVE-2026-0994) — not agent-bom direct deps

## Test plan

- [ ] `cd ui && npx tsc --noEmit` → 0 errors
- [ ] Navigate `/activity` — query pattern bar chart renders; error state shows Retry button
- [ ] Navigate `/governance` — findings chart renders; error state shows Retry button
- [ ] Navigate `/gateway` → Audit tab → enforcement bar chart renders
- [ ] Navigate `/fleet` — lifecycle distribution chart renders
- [ ] Navigate `/jobs` — donut chart renders next to job table
- [ ] Navigate `/insights` — click a treemap cell → redirects to `/vulns?search=<pkg>`
- [ ] `pre-commit run --all-files` passes all new hooks