### PR TITLE
fix: pin transitive CVEs + slowloris hardening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ otel = [
     "opentelemetry-api>=1.20",
     "opentelemetry-sdk>=1.20",
     "opentelemetry-exporter-otlp-proto-http>=1.20",
+    "protobuf>=3.20.2",  # CVE-2022-1941 (fixed in 3.18.3 / 3.20.2) — transitive via otlp-proto-http
 ]
 ui = [
     "agent-bom[api]",
@@ -93,7 +94,7 @@ mcp-server = [
     "mcp>=1.26",
     "smithery>=0.4",
 ]
-dashboard = ["streamlit>=1.37.0", "plotly>=5.18"]  # GHSA-rxff-vr5r-8cj5 (fixed in 1.37.0)
+dashboard = ["streamlit>=1.37.0", "plotly>=5.18", "pillow>=10.4.0"]  # GHSA-rxff-vr5r-8cj5 (fixed in 1.37.0); pillow>=10.4.0 fixes CVE-2023-50447 + CVE-2024-28219 (transitive via streamlit)
 snyk = []  # Uses existing httpx dependency, no additional packages needed
 oidc = [
     "PyJWT>=2.8",

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -414,7 +414,17 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
 
 class MaxBodySizeMiddleware(BaseHTTPMiddleware):
-    """Reject requests with body larger than max_bytes."""
+    """Reject oversized bodies and enforce a per-request read timeout (slowloris mitigation).
+
+    Two-layer protection:
+    1. Content-Length fast-path: reject before reading if header exceeds limit.
+    2. Streaming body drain with asyncio timeout: covers chunked/streaming uploads
+       that omit Content-Length — a common slowloris vector.
+    """
+
+    # 30s to fully receive a request body; covers slow legitimate clients
+    # while cutting off slowloris attacks that trickle bytes indefinitely.
+    _BODY_TIMEOUT_SECONDS = 30
 
     def __init__(self, app: ASGIApp, max_bytes: int = 10 * 1024 * 1024):
         super().__init__(app)
@@ -432,6 +442,31 @@ class MaxBodySizeMiddleware(BaseHTTPMiddleware):
                     status_code=413,
                     content={"detail": f"Request body too large (max {self._max_bytes // (1024 * 1024)}MB)"},
                 )
+        elif request.method in ("POST", "PUT", "PATCH"):
+            # No Content-Length — drain and check streaming body under timeout
+            try:
+                chunks: list[bytes] = []
+                total = 0
+                async with asyncio.timeout(self._BODY_TIMEOUT_SECONDS):
+                    async for chunk in request.stream():
+                        total += len(chunk)
+                        if total > self._max_bytes:
+                            return JSONResponse(
+                                status_code=413,
+                                content={"detail": f"Request body too large (max {self._max_bytes // (1024 * 1024)}MB)"},
+                            )
+                        chunks.append(chunk)
+            except TimeoutError:
+                return JSONResponse(status_code=408, content={"detail": "Request body read timed out"})
+
+            # Re-inject the drained body so downstream handlers can read it
+            body = b"".join(chunks)
+
+            async def _receive():
+                return {"type": "http.request", "body": body, "more_body": False}
+
+            request._receive = _receive  # type: ignore[attr-defined]
+
         return await call_next(request)
 
 

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -4372,6 +4372,8 @@ def serve_cmd(host: str, port: int, persist: Optional[str], cors_allow_all: bool
         host=host,
         port=port,
         reload=reload,
+        timeout_keep_alive=5,
+        limit_concurrency=500,
     )
 
 
@@ -4500,6 +4502,13 @@ def api_cmd(
         reload=reload,
         workers=1 if reload else workers,
         log_level=log_level.lower(),
+        # Slowloris / connection-exhaustion hardening:
+        # Close idle keep-alive connections after 5s (uvicorn default is 5s but
+        # we set it explicitly so it's visible and auditable).
+        timeout_keep_alive=5,
+        # Hard cap on concurrent in-flight requests; prevents thread/FD exhaustion
+        # under a slow-connection flood. 500 ≫ any realistic single-server load.
+        limit_concurrency=500,
     )
 
 


### PR DESCRIPTION
## Summary

- **Transitive CVE pins**: `pillow>=10.4.0` in `[dashboard]` extra (CVE-2023-50447, CVE-2024-28219 — via streamlit); `protobuf>=3.20.2` in `[otel]` extra (CVE-2022-1941 — via opentelemetry-exporter-otlp-proto-http)
- **Slowloris mitigation**: `MaxBodySizeMiddleware` now enforces a 30-second `asyncio.timeout()` on streaming (chunked / no `Content-Length`) request bodies — the classic vector for slow-POST / slowloris attacks that bypass header-only size checks
- **Uvicorn hardening**: `timeout_keep_alive=5` and `limit_concurrency=500` made explicit in both `agent-bom ui` and `agent-bom api` startup paths so these limits are auditable and not left to uvicorn defaults

## Test plan

- [ ] `pip install 'agent-bom[dashboard]'` — verify pillow ≥10.4.0 is resolved
- [ ] `pip install 'agent-bom[otel]'` — verify protobuf ≥3.20.2 is resolved
- [ ] Start `agent-bom api` and send a chunked POST without `Content-Length` that takes >30s — confirm 408 response
- [ ] Start `agent-bom api` and send a body >10MB without `Content-Length` — confirm 413 response
- [ ] Existing test suite: `pytest tests/` — no regressions

Closes #415