### PR TITLE
feat: fullstack deploy guide + MCP tool titles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,16 @@ POSTGRES_APP_USER=agent_bom_app
 
 # For external/managed Postgres (Supabase, Neon, RDS), set this directly:
 # AGENT_BOM_POSTGRES_URL=postgresql://agent_bom_app:<password>@<host>:5432/agent_bom
+
+# ── Full-stack (docker-compose.fullstack.yml) ────────────────────────────────
+# Port bindings
+API_PORT=8422
+UI_PORT=3000
+
+# URL the Next.js UI uses to reach the FastAPI backend.
+# Local dev (docker-compose): http://localhost:8422
+# Production: https://api.yourdomain.com
+NEXT_PUBLIC_API_URL=http://localhost:8422
+
+# Optional: protect the API with a Bearer token
+# AGENT_BOM_API_KEY=change-me-secret-key

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` (23 tools) | Inside any MCP client |
-| Dashboard | `agent-bom serve` | API + Next.js UI (15 pages) |
+| Dashboard | `agent-bom serve` · [Full deploy guide](docs/DEPLOYMENT.md) | API + Next.js UI (15 pages) · Postgres/Supabase |
 | Runtime proxy | `agent-bom proxy` | Intercept + enforce MCP traffic in real time |
 | Protect engine | `agent-bom protect` | 7 behavioral detectors (rug pull, injection, exfil, credential leak) |
 | Config watcher | `agent-bom watch` | Filesystem watch on MCP configs, alert on drift |

--- a/docker-compose.fullstack.yml
+++ b/docker-compose.fullstack.yml
@@ -1,0 +1,121 @@
+# agent-bom full-stack compose — API + Dashboard UI + PostgreSQL
+#
+# Usage (local dev):
+#   cp .env.example .env   # fill in POSTGRES_PASSWORD at minimum
+#   docker compose -f docker-compose.fullstack.yml up
+#
+# Then open:
+#   Dashboard  →  http://localhost:3000
+#   API docs   →  http://localhost:8422/docs
+#
+# For production, swap the postgres service for a managed Postgres/Supabase URL:
+#   AGENT_BOM_POSTGRES_URL=postgresql://user:pass@db.supabase.co:5432/postgres
+#   Then remove the postgres + depends_on sections.
+
+version: '3.8'
+
+services:
+
+  # ── FastAPI backend ────────────────────────────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: agentbom/agent-bom:latest
+    container_name: agent-bom-api
+    restart: unless-stopped
+    command: api --host 0.0.0.0 --port 8422
+    environment:
+      AGENT_BOM_POSTGRES_URL: >-
+        postgresql://${POSTGRES_USER:-agent_bom}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-agent_bom}
+      # Optional enrichment API keys
+      NVD_API_KEY: ${NVD_API_KEY:-}
+      # Optional cloud scanning
+      SNOWFLAKE_ACCOUNT: ${SNOWFLAKE_ACCOUNT:-}
+      SNOWFLAKE_USER: ${SNOWFLAKE_USER:-}
+      SNOWFLAKE_PASSWORD: ${SNOWFLAKE_PASSWORD:-}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      # Optional: protect the API with a key
+      AGENT_BOM_API_KEY: ${AGENT_BOM_API_KEY:-}
+    ports:
+      - "${API_PORT:-8422}:8422"
+    volumes:
+      # Mount host MCP config dirs read-only so the API can discover local agents
+      - ~/.config:/root/.config:ro
+      - ~/.claude:/root/.claude:ro
+    networks:
+      - agent-bom
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8422/health')\""]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ── Next.js dashboard ─────────────────────────────────────────────────────
+  ui:
+    build:
+      context: ui/
+      dockerfile: Dockerfile
+      args:
+        # Baked into the Next.js build — must match the publicly reachable API URL
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
+    image: agentbom/agent-bom-ui:latest
+    container_name: agent-bom-ui
+    restart: unless-stopped
+    ports:
+      - "${UI_PORT:-3000}:3000"
+    networks:
+      - agent-bom
+    depends_on:
+      api:
+        condition: service_healthy
+
+  # ── PostgreSQL (dev / self-hosted) ─────────────────────────────────────────
+  # For production: replace with Supabase, Railway, or any managed Postgres.
+  # Set AGENT_BOM_POSTGRES_URL env var on the api service and remove this block.
+  postgres:
+    image: postgres:16-alpine
+    container_name: agent-bom-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-agent_bom}
+      POSTGRES_USER: ${POSTGRES_USER:-agent_bom}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
+    ports:
+      # Only expose locally — remove in production
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./infra/postgres/init-wrapper.sh:/docker-entrypoint-initdb.d/00-init-wrapper.sh:ro
+      - ./infra/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    command: >
+      postgres
+        -c password_encryption=scram-sha-256
+        -c log_connections=on
+        -c log_disconnections=on
+        -c log_statement=ddl
+        -c max_connections=100
+        -c shared_buffers=128MB
+        -c work_mem=4MB
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-agent_bom} -d ${POSTGRES_DB:-agent_bom}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    networks:
+      - agent-bom
+
+volumes:
+  postgres-data:
+
+networks:
+  agent-bom:
+    name: agent-bom

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,142 @@
+# Deployment Guide
+
+## Architecture
+
+```
+Browser → Next.js UI (port 3000)
+               │ NEXT_PUBLIC_API_URL
+               ▼
+         FastAPI backend (port 8422)
+               │ AGENT_BOM_POSTGRES_URL
+               ▼
+         PostgreSQL  (Supabase · Railway · RDS · self-hosted)
+               │ optional analytics sidecar
+               ▼
+         ClickHouse  (AGENT_BOM_CLICKHOUSE_URL)
+```
+
+The scanner engine, MCP server, and CLI all share the same Python package. The FastAPI backend wraps the scanner as async jobs. The Next.js UI is a static build that talks to the API.
+
+---
+
+## Option 1 — Local dev (all-in-one docker compose)
+
+```bash
+# 1. Clone and copy env template
+git clone https://github.com/msaad00/agent-bom
+cd agent-bom
+cp .env.example .env
+
+# 2. Set required vars in .env
+#    POSTGRES_PASSWORD=<any strong password>
+#    NEXT_PUBLIC_API_URL=http://localhost:8422   (already the default)
+
+# 3. Start everything
+docker compose -f docker-compose.fullstack.yml up --build
+
+# Dashboard →  http://localhost:3000
+# API docs  →  http://localhost:8422/docs
+```
+
+The `docker-compose.fullstack.yml` starts three services:
+| Service | Image | Port |
+|---------|-------|------|
+| `api` | `agentbom/agent-bom` | 8422 |
+| `ui` | `agentbom/agent-bom-ui` | 3000 |
+| `postgres` | `postgres:16-alpine` | 5432 |
+
+---
+
+## Option 2 — Supabase + local API (recommended for production)
+
+Supabase gives you Postgres + auth + realtime for free on the free tier.
+
+```bash
+# 1. Create a Supabase project at https://supabase.com
+#    Copy the "Connection string" (Session mode, port 5432)
+
+# 2. Set env vars
+export AGENT_BOM_POSTGRES_URL="postgresql://postgres.<ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres"
+export NEXT_PUBLIC_API_URL="http://localhost:8422"
+
+# 3. Start API only (no local postgres needed)
+pip install 'agent-bom[api]'
+agent-bom api --host 0.0.0.0 --port 8422
+
+# 4. Start UI
+cd ui
+npm install
+NEXT_PUBLIC_API_URL=http://localhost:8422 npm run dev
+```
+
+### Supabase table setup
+
+Run the schema migrations from `infra/postgres/init.sql` in the Supabase SQL editor:
+
+```
+Supabase dashboard → SQL Editor → paste contents of infra/postgres/init.sql → Run
+```
+
+---
+
+## Option 3 — Docker Compose with Supabase (no local DB)
+
+Remove the `postgres` service and `depends_on` from `docker-compose.fullstack.yml`, then:
+
+```bash
+# .env
+AGENT_BOM_POSTGRES_URL=postgresql://postgres.<ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres
+NEXT_PUBLIC_API_URL=http://localhost:8422
+
+docker compose -f docker-compose.fullstack.yml up api ui --build
+```
+
+---
+
+## Option 4 — Railway one-click deploy
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/agent-bom)
+
+Railway auto-provisions Postgres and wires `DATABASE_URL` → map it to `AGENT_BOM_POSTGRES_URL` in the service settings. Set `NEXT_PUBLIC_API_URL` to the Railway API service URL before deploying the UI service.
+
+---
+
+## Environment Variables Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `POSTGRES_PASSWORD` | ✅ | — | Postgres admin password (docker-compose only) |
+| `AGENT_BOM_POSTGRES_URL` | ✅ prod | — | Full Postgres connection URL (overrides individual vars) |
+| `NEXT_PUBLIC_API_URL` | ✅ | `""` (same origin) | URL the browser uses to reach the FastAPI backend |
+| `AGENT_BOM_API_KEY` | optional | — | Bearer token to protect all API endpoints |
+| `NVD_API_KEY` | optional | — | NVD API key for higher CVE enrichment rate limits |
+| `AGENT_BOM_OIDC_ISSUER` | optional | — | OIDC issuer URL for SSO/JWT auth (`pip install agent-bom[oidc]`) |
+| `AGENT_BOM_CLICKHOUSE_URL` | optional | — | ClickHouse URL for analytics trends |
+| `SNOWFLAKE_ACCOUNT` | optional | — | Snowflake account for governance reports |
+
+Full list: see `.env.example`.
+
+---
+
+## Production checklist
+
+- [ ] `AGENT_BOM_API_KEY` set (or `AGENT_BOM_OIDC_ISSUER` for SSO)
+- [ ] `NEXT_PUBLIC_API_URL` points to your API domain (not localhost)
+- [ ] Postgres behind a firewall / Supabase RLS enabled
+- [ ] TLS termination in front of both services (nginx / Caddy / Cloudflare Tunnel)
+- [ ] `POSTGRES_PORT` not exposed to the public internet
+- [ ] NVD_API_KEY set for production enrichment speed
+
+---
+
+## Running the MCP server alongside the API
+
+```bash
+# stdio (Claude Desktop, Cursor, Windsurf)
+agent-bom mcp-server
+
+# SSE / remote clients
+agent-bom mcp-server --sse --host 0.0.0.0 --port 8765
+```
+
+The MCP server is stateless — it doesn't need Postgres. It calls the scanner engine directly and returns JSON to the AI assistant.

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -281,7 +281,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 1: scan ──────────────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Security Scan")
     async def scan(
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
         image: Annotated[str | None, Field(description="Docker image to scan (e.g. 'nginx:1.25', 'ghcr.io/org/app:v1').")] = None,
@@ -396,7 +396,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 2: check ────────────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Package CVE Check")
     async def check(
         package: Annotated[
             str,
@@ -506,7 +506,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 3: blast_radius ──────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Blast Radius Analysis")
     async def blast_radius(
         cve_id: Annotated[str, Field(description="CVE identifier to look up, e.g. 'CVE-2024-1234' or 'GHSA-xxxx'.")],
     ) -> str:
@@ -569,7 +569,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 4: policy_check ──────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Policy Evaluation")
     async def policy_check(
         policy_json: Annotated[
             str,
@@ -613,7 +613,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 5: registry_lookup ───────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Registry Lookup")
     def registry_lookup(
         server_name: Annotated[
             str | None, Field(description="MCP server name to look up, e.g. 'filesystem', '@modelcontextprotocol/server-github'.")
@@ -686,7 +686,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 6: generate_sbom ─────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Generate SBOM")
     async def generate_sbom(
         format: Annotated[str, Field(description="SBOM format: 'cyclonedx' (CycloneDX 1.6) or 'spdx' (SPDX 3.0).")] = "cyclonedx",
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
@@ -724,7 +724,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 7: compliance ───────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Compliance Posture")
     async def compliance(
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
         image: Annotated[str | None, Field(description="Docker image to scan, e.g. 'nginx:1.25'.")] = None,
@@ -831,7 +831,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 8: remediate ────────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Remediation Plan")
     async def remediate(
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
         image: Annotated[str | None, Field(description="Docker image to scan, e.g. 'nginx:1.25'.")] = None,
@@ -907,7 +907,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 9: skill_trust ──────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Skill Trust Assessment")
     def skill_trust(
         skill_path: Annotated[str, Field(description="Path to a SKILL.md file (or any skill/instruction file) to assess.")],
     ) -> str:
@@ -981,7 +981,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 10: verify ─────────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Package Integrity Verify")
     async def verify(
         package: Annotated[str, Field(description="Package name with optional version, e.g. 'express@4.18.2' or 'requests==2.31.0'.")],
         ecosystem: Annotated[str, Field(description="Package ecosystem: 'npm' or 'pypi'.")] = "npm",
@@ -1042,7 +1042,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 11: where ────────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Discovery Paths")
     def where() -> str:
         """Show all MCP discovery paths and which config files exist.
 
@@ -1088,7 +1088,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 12: inventory ────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Agent Inventory")
     def inventory(
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
     ) -> str:
@@ -1141,7 +1141,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 13: diff ─────────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Vulnerability Diff")
     async def diff(
         baseline: Annotated[
             dict | None, Field(description="Baseline report JSON object. If omitted, uses the latest saved report from history.")
@@ -1193,7 +1193,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 14: marketplace_check ───────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Marketplace Trust Check")
     async def marketplace_check(
         package: Annotated[str, Field(description="Package name, e.g. 'express', 'langchain'.")],
         ecosystem: Annotated[str, Field(description="Package ecosystem: 'npm' or 'pypi'.")] = "npm",
@@ -1318,7 +1318,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 16: code_scan ────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Code SAST Scan")
     async def code_scan(
         path: Annotated[str, Field(description="Path to source code directory to scan.")],
         config: Annotated[
@@ -1352,7 +1352,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 17: context_graph ──────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Context Graph")
     async def context_graph(
         config_path: Annotated[
             str | None,
@@ -1416,7 +1416,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("MCP tool error")
             return json.dumps({"error": sanitize_error(exc)})
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Analytics Query")
     async def analytics_query(
         query_type: Annotated[
             str,
@@ -1474,7 +1474,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("MCP tool error")
             return json.dumps({"error": sanitize_error(exc)})
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="CIS Benchmark")
     async def cis_benchmark(
         provider: Annotated[
             str,
@@ -1552,7 +1552,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 19: fleet_scan ────────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Fleet Scan")
     async def fleet_scan(
         servers: Annotated[
             str,
@@ -1614,7 +1614,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("Registry read failed")
             return json.dumps({"error": f"Failed to read registry: {sanitize_error(exc)}"})
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Runtime Correlation")
     async def runtime_correlate(
         config_path: Annotated[
             str,
@@ -1716,7 +1716,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 21: vector_db_scan ───────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="Vector DB Scan")
     async def vector_db_scan(
         hosts: Annotated[
             str | None,
@@ -1760,7 +1760,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     # ── Tool 22: aisvs_benchmark ──────────────────────────────────────
 
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="AISVS Benchmark")
     async def aisvs_benchmark(
         checks: Annotated[
             str | None,
@@ -1796,7 +1796,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             return json.dumps({"error": sanitize_error(exc)})
 
     # ── Tool 23: gpu_infra_scan ────────────────────────────────────
-    @mcp.tool(annotations=_READ_ONLY)
+    @mcp.tool(annotations=_READ_ONLY, title="GPU Infrastructure Scan")
     async def gpu_infra_scan(
         k8s_context: Annotated[
             str | None,


### PR DESCRIPTION
## Summary

- **`docker-compose.fullstack.yml`**: new compose file that starts `api` (FastAPI on 8422) + `ui` (Next.js on 3000) + `postgres` (16-alpine) wired together. Supabase swap-out documented inline.
- **`docs/DEPLOYMENT.md`**: 4 deployment options — local compose, Supabase cloud DB + local API, compose+Supabase (no local DB), Railway. Includes env var reference table and production security checklist.
- **`.env.example`**: added `NEXT_PUBLIC_API_URL`, `AGENT_BOM_API_KEY`, `UI_PORT`, `API_PORT` for fullstack compose config.
- **`README.md`**: dashboard table row now links to `docs/DEPLOYMENT.md`.
- **`mcp_server.py`**: added `title=` to all 23 `@mcp.tool()` decorators. FastMCP 1.26.0 exposes titles in the tool list — Claude Desktop and Cursor now show human-readable names (e.g. "GPU Infrastructure Scan" instead of "gpu_infra_scan") in the tool picker.

## Test plan

- [ ] `docker compose -f docker-compose.fullstack.yml up --build` — all three services start, UI reachable at :3000, API docs at :8422/docs
- [ ] `pytest tests/test_mcp_server.py` — 54 tests pass (confirmed locally)
- [ ] Tool titles visible: connect to MCP server and call `tools/list` — confirm each entry has a `title` field