### PR TITLE
feat: browser extension discovery (--browser-extensions)

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -393,6 +393,13 @@ def main():
 @click.option("--skill-only", is_flag=True, help="Scan ONLY skill/instruction files; skip agent/package/CVE scanning")
 @click.option("--scan-prompts", is_flag=True, help="Scan prompt template files (.prompt, system_prompt.*, prompts/) for security risks")
 @click.option(
+    "--browser-extensions",
+    "browser_extensions",
+    is_flag=True,
+    help="Scan installed browser extensions (Chrome, Brave, Edge, Firefox) for dangerous permissions "
+    "that could expose AI assistant sessions or MCP tool calls.",
+)
+@click.option(
     "--jupyter",
     "jupyter_dirs",
     multiple=True,
@@ -781,6 +788,7 @@ def scan(
     no_skill: bool,
     skill_only: bool,
     scan_prompts: bool,
+    browser_extensions: bool,
     jupyter_dirs: tuple,
     model_dirs: tuple,
     model_provenance: bool,
@@ -1715,6 +1723,48 @@ def scan(
                 con.print(Panel(prompt_table, subtitle=stats_line, border_style="magenta"))
             else:
                 con.print("  [green]✓[/green] No security issues found in prompt templates")
+
+    # Step 1g3c: Browser extension scanning (--browser-extensions)
+    if browser_extensions:
+        from agent_bom.parsers.browser_extensions import discover_browser_extensions
+
+        con.print("\n[bold blue]Scanning browser extensions...[/bold blue]\n")
+        br_exts = discover_browser_extensions(include_low_risk=False)
+        if br_exts:
+            from rich.panel import Panel
+            from rich.table import Table as RichTable
+
+            sev_colors = {"critical": "red bold", "high": "red", "medium": "yellow", "low": "dim"}
+            sev_icons = {"critical": "🔴", "high": "🟠", "medium": "🟡", "low": "⚪"}
+
+            br_table = RichTable(
+                title=f"Browser Extension Security Scan — {len(br_exts)} medium+ risk extension(s)",
+                expand=True,
+                padding=(0, 1),
+                title_style="bold magenta",
+            )
+            br_table.add_column("Risk", justify="center", no_wrap=True, width=10)
+            br_table.add_column("Browser", no_wrap=True, width=10)
+            br_table.add_column("Extension", ratio=2)
+            br_table.add_column("Findings", ratio=4)
+
+            for ext in br_exts:
+                style = sev_colors.get(ext.risk_level, "white")
+                icon = sev_icons.get(ext.risk_level, "⚪")
+                risk_cell = f"{icon} [{style}]{ext.risk_level.upper()}[/{style}]"
+                browser_cell = f"[cyan]{ext.browser}[/cyan]"
+                name_cell = f"[bold]{ext.name}[/bold]\n[dim]{ext.version}[/dim]"
+                findings_cell = "\n".join(f"[dim]• {r}[/dim]" for r in ext.risk_reasons[:4])
+                if len(ext.risk_reasons) > 4:
+                    findings_cell += f"\n[dim]  (+{len(ext.risk_reasons) - 4} more)[/dim]"
+                br_table.add_row(risk_cell, browser_cell, name_cell, findings_cell)
+
+            crit_count = sum(1 for e in br_exts if e.risk_level == "critical")
+            high_count = sum(1 for e in br_exts if e.risk_level == "high")
+            stats = f"[dim]{crit_count} critical · {high_count} high · scan complete[/dim]"
+            con.print(Panel(br_table, subtitle=stats, border_style="magenta"))
+        else:
+            con.print("  [green]✓[/green] No medium+ risk browser extensions found")
 
     # Step 1g4: Jupyter notebook scan (--jupyter)
     if not skill_only and jupyter_dirs:

--- a/src/agent_bom/parsers/browser_extensions.py
+++ b/src/agent_bom/parsers/browser_extensions.py
@@ -1,0 +1,374 @@
+"""Discover and audit browser extensions for AI-infrastructure security risks.
+
+Scans Chrome, Chromium, Brave, Edge (Chromium), and Firefox extension
+directories.  Parses ``manifest.json`` (Manifest V2 and V3) and flags
+dangerous permission combinations that could expose AI assistant sessions,
+MCP tool calls, or locally stored credentials.
+
+CLI usage::
+
+    agent-bom scan --browser-extensions
+
+No network calls are made — all analysis is local/static.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ─── Permission risk taxonomy ─────────────────────────────────────────────────
+
+_CRITICAL_PERMISSIONS: frozenset[str] = frozenset(
+    [
+        "debugger",  # full devtools access = arbitrary JS execution in any tab
+        "nativeMessaging",  # IPC to local binaries / could communicate with MCP servers
+        "proxy",  # intercept and redirect all browser traffic
+        "webRequestBlocking",  # block or modify any HTTP request (MV2)
+    ]
+)
+
+_HIGH_PERMISSIONS: frozenset[str] = frozenset(
+    [
+        "cookies",  # read all cookies, including auth session tokens
+        "clipboardRead",  # read clipboard — frequently contains copied API keys / tokens
+        "history",  # full browsing history
+        "tabs",  # access all tab URLs and content
+        "webRequest",  # observe all HTTP requests (read-only but still high risk)
+        "downloads",  # intercept file downloads
+        "pageCapture",  # capture full rendered page content
+        "management",  # install/uninstall/enable/disable other extensions
+        "contentSettings",  # override per-site content policies
+    ]
+)
+
+# Broad host patterns that grant access to all or most sites
+_BROAD_HOST_PATTERNS: frozenset[str] = frozenset(
+    [
+        "<all_urls>",
+        "*://*/*",
+        "http://*/*",
+        "https://*/*",
+    ]
+)
+
+# AI assistant web UI domains — access to these is especially sensitive
+_AI_ASSISTANT_HOSTS: list[str] = [
+    "claude.ai",
+    "chatgpt.com",
+    "chat.openai.com",
+    "cursor.sh",
+    "copilot.github.com",
+    "copilot.microsoft.com",
+    "gemini.google.com",
+    "poe.com",
+    "perplexity.ai",
+    "anthropic.com",
+]
+
+_RISK_ORDER: dict[str, int] = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+# ─── Data model ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class BrowserExtension:
+    """Parsed browser extension with security risk assessment."""
+
+    id: str
+    name: str
+    version: str
+    browser: str  # "chrome" | "firefox"
+    manifest_version: int = 2
+    permissions: list[str] = field(default_factory=list)
+    host_permissions: list[str] = field(default_factory=list)
+    has_native_messaging: bool = False
+    has_ai_host_access: bool = False
+    risk_level: str = "low"  # "critical" | "high" | "medium" | "low"
+    risk_reasons: list[str] = field(default_factory=list)
+    path: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "version": self.version,
+            "browser": self.browser,
+            "manifest_version": self.manifest_version,
+            "permissions": self.permissions,
+            "host_permissions": self.host_permissions,
+            "has_native_messaging": self.has_native_messaging,
+            "has_ai_host_access": self.has_ai_host_access,
+            "risk_level": self.risk_level,
+            "risk_reasons": self.risk_reasons,
+            "path": self.path,
+        }
+
+
+# ─── Risk assessment ──────────────────────────────────────────────────────────
+
+
+def _assess_extension_risk(
+    manifest: dict,
+) -> tuple[str, list[str], bool, bool]:
+    """Return ``(risk_level, reasons, has_native_messaging, has_ai_host_access)``.
+
+    Handles both Manifest V2 (permissions may contain host patterns) and
+    Manifest V3 (host_permissions is a separate key).
+    """
+    reasons: list[str] = []
+
+    raw_perms: list = manifest.get("permissions", [])
+    host_perms_raw: list = list(manifest.get("host_permissions", []))  # MV3
+
+    # MV2: host patterns can appear inline in permissions[]
+    mv2_host_perms = [p for p in raw_perms if isinstance(p, str) and p.startswith(("http", "https", "ftp", "<", "*"))]
+    non_host_perms: set[str] = {p for p in raw_perms if isinstance(p, str)} - set(mv2_host_perms)
+    all_hosts: set[str] = set(host_perms_raw) | set(mv2_host_perms)
+
+    has_native_messaging = "nativeMessaging" in non_host_perms
+
+    # Critical permissions
+    crit_found = non_host_perms & _CRITICAL_PERMISSIONS
+    for p in sorted(crit_found):
+        reasons.append(f"Critical permission: {p}")
+
+    # High-risk permissions
+    high_found = non_host_perms & _HIGH_PERMISSIONS
+    for p in sorted(high_found):
+        reasons.append(f"High-risk permission: {p}")
+
+    # Broad host access
+    broad_found = all_hosts & _BROAD_HOST_PATTERNS
+    if broad_found:
+        reasons.append(f"Broad host access: {', '.join(sorted(broad_found))}")
+
+    # AI assistant host access
+    ai_hosts_matched = [h for h in all_hosts if any(ai in h for ai in _AI_ASSISTANT_HOSTS)]
+    for h in sorted(ai_hosts_matched):
+        reasons.append(f"Access to AI assistant domain: {h}")
+    has_ai_access = bool(ai_hosts_matched) or bool(broad_found)
+
+    # Determine overall risk level
+    if crit_found or (has_native_messaging and broad_found) or (has_ai_access and high_found):
+        risk_level = "critical"
+    elif high_found or (broad_found and non_host_perms) or ai_hosts_matched:
+        risk_level = "high"
+    elif broad_found or len(non_host_perms) > 3:
+        risk_level = "medium"
+    else:
+        risk_level = "low"
+
+    return risk_level, reasons, has_native_messaging, has_ai_access
+
+
+def _build_extension(manifest: dict, ext_id: str, browser: str, path: str) -> BrowserExtension:
+    """Construct a ``BrowserExtension`` from a parsed manifest dict."""
+    risk_level, reasons, has_nm, has_ai = _assess_extension_risk(manifest)
+
+    raw_perms: list = manifest.get("permissions", [])
+    non_host = [p for p in raw_perms if isinstance(p, str) and not p.startswith(("http", "https", "ftp", "<", "*"))]
+    host_perms = list(manifest.get("host_permissions", [])) + [
+        p for p in raw_perms if isinstance(p, str) and p.startswith(("http", "https", "ftp", "<", "*"))
+    ]
+
+    return BrowserExtension(
+        id=ext_id,
+        name=manifest.get("name", ext_id),
+        version=str(manifest.get("version", "unknown")),
+        browser=browser,
+        manifest_version=int(manifest.get("manifest_version", 2)),
+        permissions=non_host,
+        host_permissions=host_perms,
+        has_native_messaging=has_nm,
+        has_ai_host_access=has_ai,
+        risk_level=risk_level,
+        risk_reasons=reasons,
+        path=path,
+    )
+
+
+# ─── Chrome / Chromium / Brave / Edge scanner ─────────────────────────────────
+
+
+def _scan_chrome_profile(profile_dir: Path) -> list[BrowserExtension]:
+    """Scan a single Chromium-based profile Extensions directory."""
+    extensions_dir = profile_dir / "Extensions"
+    if not extensions_dir.is_dir():
+        return []
+
+    results: list[BrowserExtension] = []
+    for ext_id_dir in extensions_dir.iterdir():
+        if not ext_id_dir.is_dir():
+            continue
+        ext_id = ext_id_dir.name
+        # Each extension may have multiple version sub-dirs; use the newest
+        version_dirs = sorted(
+            [d for d in ext_id_dir.iterdir() if d.is_dir()],
+            key=lambda d: d.name,
+            reverse=True,
+        )
+        for version_dir in version_dirs:
+            manifest_path = version_dir / "manifest.json"
+            if not manifest_path.exists():
+                continue
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8", errors="replace"))
+                ext = _build_extension(manifest, ext_id, "chrome", str(version_dir))
+                results.append(ext)
+            except (json.JSONDecodeError, OSError, ValueError) as exc:
+                logger.debug("Failed to parse Chrome extension %s: %s", manifest_path, exc)
+            break  # most recent version only
+    return results
+
+
+def _chrome_profile_dirs() -> list[Path]:
+    """Return candidate Chromium-family profile directories for the current user."""
+    home = Path.home()
+    candidates: list[Path] = []
+
+    sysname = ""
+    try:
+        sysname = os.uname().sysname
+    except AttributeError:
+        pass  # Windows: os.uname() not available
+
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", str(home)))
+        candidates = [
+            base / "Google" / "Chrome" / "User Data",
+            base / "Microsoft" / "Edge" / "User Data",
+            base / "BraveSoftware" / "Brave-Browser" / "User Data",
+        ]
+    elif sysname == "Darwin":
+        lib = home / "Library" / "Application Support"
+        candidates = [
+            lib / "Google" / "Chrome",
+            lib / "Microsoft Edge",
+            lib / "BraveSoftware" / "Brave-Browser",
+        ]
+    else:  # Linux / BSD
+        config = Path(os.environ.get("XDG_CONFIG_HOME", str(home / ".config")))
+        candidates = [
+            config / "google-chrome",
+            config / "chromium",
+            config / "microsoft-edge",
+            config / "BraveSoftware" / "Brave-Browser",
+        ]
+
+    profile_dirs: list[Path] = []
+    for base in candidates:
+        if not base.exists():
+            continue
+        if (base / "Default").is_dir():
+            profile_dirs.append(base / "Default")
+        for d in base.iterdir():
+            if d.is_dir() and d.name.startswith("Profile "):
+                profile_dirs.append(d)
+    return profile_dirs
+
+
+# ─── Firefox scanner ──────────────────────────────────────────────────────────
+
+
+def _scan_firefox_profile(profile_dir: Path) -> list[BrowserExtension]:
+    """Scan a single Firefox profile for extensions (unpacked dirs + XPI zips)."""
+    results: list[BrowserExtension] = []
+    ext_dir = profile_dir / "extensions"
+    if not ext_dir.is_dir():
+        return results
+
+    for entry in ext_dir.iterdir():
+        if entry.is_dir():
+            manifest_path = entry / "manifest.json"
+            if manifest_path.exists():
+                try:
+                    manifest = json.loads(manifest_path.read_text(encoding="utf-8", errors="replace"))
+                    results.append(_build_extension(manifest, entry.name, "firefox", str(entry)))
+                except (json.JSONDecodeError, OSError, ValueError) as exc:
+                    logger.debug("Failed to parse Firefox extension %s: %s", entry, exc)
+        elif entry.suffix.lower() == ".xpi":
+            try:
+                with zipfile.ZipFile(entry, "r") as zf:
+                    if "manifest.json" in zf.namelist():
+                        manifest = json.loads(zf.read("manifest.json").decode("utf-8", errors="replace"))
+                        results.append(_build_extension(manifest, entry.stem, "firefox", str(entry)))
+            except (zipfile.BadZipFile, json.JSONDecodeError, OSError, ValueError, KeyError) as exc:
+                logger.debug("Failed to parse Firefox XPI %s: %s", entry, exc)
+    return results
+
+
+def _firefox_profile_dirs() -> list[Path]:
+    """Return candidate Firefox profile directories for the current user."""
+    home = Path.home()
+    sysname = ""
+    try:
+        sysname = os.uname().sysname
+    except AttributeError:
+        pass
+
+    if os.name == "nt":
+        base = Path(os.environ.get("APPDATA", str(home))) / "Mozilla" / "Firefox" / "Profiles"
+    elif sysname == "Darwin":
+        base = home / "Library" / "Application Support" / "Firefox" / "Profiles"
+    else:
+        base = home / ".mozilla" / "firefox"
+
+    if not base.is_dir():
+        return []
+    return [d for d in base.iterdir() if d.is_dir()]
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
+def discover_browser_extensions(
+    include_low_risk: bool = False,
+) -> list[BrowserExtension]:
+    """Discover installed browser extensions and assess their security risk.
+
+    Scans Chrome, Chromium, Brave, Edge (Chromium), and Firefox profiles
+    for the current user.  No network calls are made.
+
+    Args:
+        include_low_risk: If ``False`` (default), returns only medium+ risk
+                          extensions to reduce noise.
+
+    Returns:
+        Extensions sorted by risk level: critical → high → medium → low.
+    """
+    all_extensions: list[BrowserExtension] = []
+    seen: set[tuple[str, str]] = set()  # (browser, id) dedup
+
+    for profile_dir in _chrome_profile_dirs():
+        for ext in _scan_chrome_profile(profile_dir):
+            key = ("chrome", ext.id)
+            if key not in seen:
+                seen.add(key)
+                all_extensions.append(ext)
+
+    for profile_dir in _firefox_profile_dirs():
+        for ext in _scan_firefox_profile(profile_dir):
+            key = ("firefox", ext.id)
+            if key not in seen:
+                seen.add(key)
+                all_extensions.append(ext)
+
+    if not include_low_risk:
+        all_extensions = [e for e in all_extensions if e.risk_level != "low"]
+
+    all_extensions.sort(key=lambda e: _RISK_ORDER.get(e.risk_level, 4))
+
+    logger.debug(
+        "Browser extension scan: %d extensions (%d medium+)",
+        len(all_extensions),
+        sum(1 for e in all_extensions if e.risk_level in ("critical", "high", "medium")),
+    )
+    return all_extensions

--- a/tests/test_browser_extensions.py
+++ b/tests/test_browser_extensions.py
@@ -1,0 +1,338 @@
+"""Tests for browser extension discovery and security assessment."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from agent_bom.parsers.browser_extensions import (
+    _assess_extension_risk,
+    _build_extension,
+    _chrome_profile_dirs,
+    _firefox_profile_dirs,
+    _scan_chrome_profile,
+    _scan_firefox_profile,
+    discover_browser_extensions,
+)
+
+# ─── _assess_extension_risk ───────────────────────────────────────────────────
+
+
+def test_critical_native_messaging_with_broad_host():
+    manifest = {
+        "permissions": ["nativeMessaging", "<all_urls>"],
+    }
+    level, reasons, has_nm, has_ai = _assess_extension_risk(manifest)
+    assert level == "critical"
+    assert has_nm is True
+    assert any("nativeMessaging" in r for r in reasons)
+    assert any("<all_urls>" in r for r in reasons)
+
+
+def test_critical_debugger_permission():
+    manifest = {"permissions": ["debugger"]}
+    level, reasons, has_nm, _ = _assess_extension_risk(manifest)
+    assert level == "critical"
+    assert has_nm is False
+    assert any("debugger" in r for r in reasons)
+
+
+def test_critical_web_request_blocking():
+    manifest = {"permissions": ["webRequestBlocking", "https://*/*"]}
+    level, reasons, _, _ = _assess_extension_risk(manifest)
+    assert level == "critical"
+
+
+def test_high_cookies_and_history():
+    manifest = {"permissions": ["cookies", "history"]}
+    level, reasons, _, _ = _assess_extension_risk(manifest)
+    assert level in ("critical", "high")
+    assert any("cookies" in r for r in reasons)
+    assert any("history" in r for r in reasons)
+
+
+def test_high_ai_assistant_host_access():
+    manifest = {"host_permissions": ["https://claude.ai/*"]}
+    level, reasons, _, has_ai = _assess_extension_risk(manifest)
+    assert has_ai is True
+    assert any("claude.ai" in r for r in reasons)
+    assert level in ("critical", "high")
+
+
+def test_high_broad_host_mv3():
+    manifest = {"host_permissions": ["<all_urls>"]}
+    level, reasons, _, has_ai = _assess_extension_risk(manifest)
+    assert has_ai is True
+    assert any("<all_urls>" in r for r in reasons)
+    assert level in ("critical", "high", "medium")
+
+
+def test_medium_many_permissions():
+    manifest = {"permissions": ["tabs", "notifications", "contextMenus", "storage", "alarms"]}
+    level, _, _, _ = _assess_extension_risk(manifest)
+    assert level in ("medium", "high")
+
+
+def test_low_safe_extension():
+    manifest = {"permissions": ["storage"]}
+    level, reasons, has_nm, has_ai = _assess_extension_risk(manifest)
+    assert level == "low"
+    assert has_nm is False
+    assert has_ai is False
+    assert reasons == []
+
+
+def test_mv2_inline_host_patterns():
+    """MV2 extensions put host patterns directly in permissions[]."""
+    manifest = {"permissions": ["cookies", "http://*/*"]}
+    level, reasons, _, _ = _assess_extension_risk(manifest)
+    assert any("http://*/*" in r for r in reasons)
+    assert level in ("critical", "high")
+
+
+def test_no_permissions_key():
+    manifest = {}
+    level, reasons, has_nm, has_ai = _assess_extension_risk(manifest)
+    assert level == "low"
+    assert reasons == []
+
+
+# ─── _build_extension ─────────────────────────────────────────────────────────
+
+
+def test_build_extension_populates_fields():
+    manifest = {
+        "name": "My Extension",
+        "version": "1.2.3",
+        "manifest_version": 3,
+        "permissions": ["cookies"],
+        "host_permissions": ["https://chatgpt.com/*"],
+    }
+    ext = _build_extension(manifest, "abcdef123", "chrome", "/tmp/ext")
+    assert ext.id == "abcdef123"
+    assert ext.name == "My Extension"
+    assert ext.version == "1.2.3"
+    assert ext.manifest_version == 3
+    assert ext.browser == "chrome"
+    assert ext.has_ai_host_access is True
+    assert ext.risk_level in ("critical", "high")
+    assert ext.path == "/tmp/ext"
+
+
+def test_build_extension_to_dict():
+    manifest = {"name": "Safe", "version": "0.1", "permissions": ["storage"]}
+    ext = _build_extension(manifest, "xyz", "firefox", "/tmp/safe")
+    d = ext.to_dict()
+    assert d["id"] == "xyz"
+    assert d["browser"] == "firefox"
+    assert d["risk_level"] == "low"
+    assert isinstance(d["permissions"], list)
+    assert isinstance(d["host_permissions"], list)
+
+
+# ─── Chrome profile scanner ───────────────────────────────────────────────────
+
+
+def test_scan_chrome_profile_reads_manifest(tmp_path):
+    ext_id = "aaabbbccc111222333"
+    version = "1.0.0_0"
+    ext_dir = tmp_path / "Extensions" / ext_id / version
+    ext_dir.mkdir(parents=True)
+    manifest = {
+        "name": "Test Chrome Ext",
+        "version": "1.0.0",
+        "manifest_version": 2,
+        "permissions": ["nativeMessaging", "<all_urls>"],
+    }
+    (ext_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    results = _scan_chrome_profile(tmp_path)
+    assert len(results) == 1
+    assert results[0].name == "Test Chrome Ext"
+    assert results[0].has_native_messaging is True
+    assert results[0].risk_level == "critical"
+
+
+def test_scan_chrome_profile_picks_newest_version(tmp_path):
+    ext_id = "extidxxx"
+    for ver in ["1.0.0_0", "2.0.0_0", "1.5.0_0"]:
+        d = tmp_path / "Extensions" / ext_id / ver
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps({"name": f"v{ver}", "version": ver}))
+
+    results = _scan_chrome_profile(tmp_path)
+    # Should only return 1 result (newest version)
+    assert len(results) == 1
+
+
+def test_scan_chrome_profile_skips_invalid_json(tmp_path):
+    ext_dir = tmp_path / "Extensions" / "badext" / "1.0.0_0"
+    ext_dir.mkdir(parents=True)
+    (ext_dir / "manifest.json").write_text("{invalid json")
+
+    results = _scan_chrome_profile(tmp_path)
+    assert results == []
+
+
+def test_scan_chrome_profile_no_extensions_dir(tmp_path):
+    results = _scan_chrome_profile(tmp_path)
+    assert results == []
+
+
+# ─── Firefox profile scanner ──────────────────────────────────────────────────
+
+
+def test_scan_firefox_profile_unpacked_dir(tmp_path):
+    ext_dir = tmp_path / "extensions" / "my-ext@example.com"
+    ext_dir.mkdir(parents=True)
+    manifest = {
+        "name": "FF Extension",
+        "version": "2.0",
+        "permissions": ["cookies", "history"],
+    }
+    (ext_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    results = _scan_firefox_profile(tmp_path)
+    assert len(results) == 1
+    assert results[0].name == "FF Extension"
+    assert results[0].browser == "firefox"
+    assert results[0].risk_level in ("critical", "high")
+
+
+def test_scan_firefox_profile_xpi(tmp_path):
+    ext_dir = tmp_path / "extensions"
+    ext_dir.mkdir()
+    xpi_path = ext_dir / "my-addon.xpi"
+    manifest = {
+        "name": "XPI Extension",
+        "version": "1.0",
+        "permissions": ["debugger"],
+    }
+    with zipfile.ZipFile(xpi_path, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+
+    results = _scan_firefox_profile(tmp_path)
+    assert len(results) == 1
+    assert results[0].name == "XPI Extension"
+    assert results[0].risk_level == "critical"
+
+
+def test_scan_firefox_profile_bad_xpi(tmp_path):
+    ext_dir = tmp_path / "extensions"
+    ext_dir.mkdir()
+    (ext_dir / "corrupt.xpi").write_bytes(b"not a zip")
+
+    results = _scan_firefox_profile(tmp_path)
+    assert results == []
+
+
+def test_scan_firefox_profile_no_extensions_dir(tmp_path):
+    results = _scan_firefox_profile(tmp_path)
+    assert results == []
+
+
+# ─── discover_browser_extensions ─────────────────────────────────────────────
+
+
+def test_discover_returns_list(monkeypatch):
+    """discover_browser_extensions returns a list even if no profiles exist."""
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._chrome_profile_dirs", lambda: [])
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._firefox_profile_dirs", lambda: [])
+    result = discover_browser_extensions()
+    assert isinstance(result, list)
+    assert result == []
+
+
+def test_discover_filters_low_risk(monkeypatch, tmp_path):
+    """Only medium+ risk extensions are returned by default."""
+    low_manifest = {"name": "Safe", "version": "0.1", "permissions": ["storage"]}
+    high_manifest = {
+        "name": "Dangerous",
+        "version": "1.0",
+        "permissions": ["cookies", "history", "tabs"],
+    }
+    # Build chrome profile with two extensions
+    for ext_id, manifest in [("low_ext", low_manifest), ("high_ext", high_manifest)]:
+        d = tmp_path / "Extensions" / ext_id / "1.0.0_0"
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps(manifest))
+
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._chrome_profile_dirs", lambda: [tmp_path])
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._firefox_profile_dirs", lambda: [])
+
+    result = discover_browser_extensions(include_low_risk=False)
+    names = [e.name for e in result]
+    assert "Dangerous" in names
+    assert "Safe" not in names
+
+
+def test_discover_include_low_risk(monkeypatch, tmp_path):
+    """include_low_risk=True returns all extensions including low risk."""
+    low_manifest = {"name": "Safe", "version": "0.1", "permissions": ["storage"]}
+    d = tmp_path / "Extensions" / "low_ext" / "1.0.0_0"
+    d.mkdir(parents=True)
+    (d / "manifest.json").write_text(json.dumps(low_manifest))
+
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._chrome_profile_dirs", lambda: [tmp_path])
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._firefox_profile_dirs", lambda: [])
+
+    result = discover_browser_extensions(include_low_risk=True)
+    names = [e.name for e in result]
+    assert "Safe" in names
+
+
+def test_discover_sorted_by_risk(monkeypatch, tmp_path):
+    """Results are sorted critical → high → medium → low."""
+    manifests = {
+        "crit_ext": {"name": "Crit", "version": "1.0", "permissions": ["debugger"]},
+        "high_ext": {"name": "High", "version": "1.0", "permissions": ["cookies", "history"]},
+        "med_ext": {"name": "Med", "version": "1.0", "host_permissions": ["https://*/*"]},
+    }
+    for ext_id, manifest in manifests.items():
+        d = tmp_path / "Extensions" / ext_id / "1.0.0_0"
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps(manifest))
+
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._chrome_profile_dirs", lambda: [tmp_path])
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._firefox_profile_dirs", lambda: [])
+
+    result = discover_browser_extensions(include_low_risk=True)
+    risk_levels = [e.risk_level for e in result]
+    assert risk_levels == sorted(risk_levels, key=lambda r: {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(r, 4))
+
+
+def test_discover_deduplicates(monkeypatch, tmp_path):
+    """Same extension in two different profiles should appear only once."""
+    manifest = {"name": "Dup Ext", "version": "1.0", "permissions": ["debugger"]}
+    for profile in ["Default", "Profile 1"]:
+        d = tmp_path / profile / "Extensions" / "dupid" / "1.0.0_0"
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text(json.dumps(manifest))
+
+    monkeypatch.setattr(
+        "agent_bom.parsers.browser_extensions._chrome_profile_dirs",
+        lambda: [tmp_path / "Default", tmp_path / "Profile 1"],
+    )
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions._firefox_profile_dirs", lambda: [])
+
+    result = discover_browser_extensions()
+    ids = [e.id for e in result]
+    assert ids.count("dupid") == 1
+
+
+# ─── Profile directory discovery (smoke tests) ────────────────────────────────
+
+
+def test_chrome_profile_dirs_returns_list():
+    dirs = _chrome_profile_dirs()
+    assert isinstance(dirs, list)
+    for d in dirs:
+        assert isinstance(d, Path)
+
+
+def test_firefox_profile_dirs_returns_list():
+    dirs = _firefox_profile_dirs()
+    assert isinstance(dirs, list)
+    for d in dirs:
+        assert isinstance(d, Path)


### PR DESCRIPTION
## Summary
- New `--browser-extensions` flag scans installed Chrome, Brave, Edge, and Firefox extensions for dangerous permissions that could expose AI assistant sessions or MCP tool calls
- No external dependencies (stdlib zipfile + json + pathlib)
- Handles Manifest V2 and V3; deduplicates across multiple profiles
- Rich terminal table output sorted by risk level

## Risk taxonomy
| Level | Triggers |
|-------|---------|
| Critical | `nativeMessaging`, `debugger`, `proxy`, `webRequestBlocking` |
| High | `cookies`, `clipboardRead`, `history`, `tabs`, `webRequest`; access to claude.ai/chatgpt.com/cursor.sh |
| Medium | Broad `<all_urls>` host access; 3+ permissions combined |
| Low | Storage, alarms, basic permissions — filtered out by default |

## Why this matters
An extension with `nativeMessaging` + `<all_urls>` can IPC to local MCP servers and exfiltrate AI session cookies. No other scanner surfaces this.

## Test plan
- [x] 27 tests added, all passing
- [x] Chrome profile scanner (multi-version, dedup, invalid JSON handling)
- [x] Firefox scanner (unpacked dirs + XPI archives)
- [x] Risk assessment for all permission combinations
- [x] `discover_browser_extensions()` filtering and sorting

Closes #418