### PR TITLE
docs: sync all surfaces to v0.64.0 — browser extensions, AISVS, 23 tools

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Module dependency map and data flow guide for contributors.
 Discovery ──> Scanning ──> Enrichment ──> Blast Radius ──> Compliance ──> Output
     │              │            │              │                │            │
     ▼              ▼            ▼              ▼                ▼            ▼
- 21 MCP         OSV API      NVD/EPSS      Risk scoring     10 frameworks  JSON/SARIF/
+ 21 MCP         OSV API      NVD/EPSS      Risk scoring     11 frameworks  JSON/SARIF/
  clients        batch        KEV/GHSA      per CVE with     mapped per     CycloneDX/
  parsed         query        enrichment    agent/cred/tool  finding        SPDX/SVG
                                            reachability
@@ -19,7 +19,7 @@ Discovery ──> Scanning ──> Enrichment ──> Blast Radius ──> Compl
 | Entry point | File | Purpose |
 |---|---|---|
 | CLI | `cli.py` | Click-based CLI with 22+ commands and groups |
-| MCP Server | `mcp_server.py` | FastMCP server with 22 tools |
+| MCP Server | `mcp_server.py` | FastMCP server with 23 tools |
 | Proxy | `proxy.py` | MCP JSON-RPC proxy with runtime enforcement |
 | API | `api/server.py` | FastAPI REST server with job queue |
 
@@ -123,9 +123,10 @@ Each module exports `tag_blast_radius(br: BlastRadius)` to annotate findings.
 ├── context_graph.py     # Lateral movement analysis — BFS pathfinding, interaction risk
 ├── risk_analyzer.py     # Capability classification, dangerous combo detection
 └── parsers/
-    ├── skills.py        # SKILL.md YAML frontmatter parser
-    ├── skill_audit.py   # Skill trust assessment (5-category analysis)
-    └── trust_assessment.py # Trust scoring engine
+    ├── skills.py           # SKILL.md YAML frontmatter parser
+    ├── skill_audit.py      # Skill trust assessment (5-category analysis)
+    ├── trust_assessment.py # Trust scoring engine
+    └── browser_extensions.py # Chrome/Edge/Brave/Firefox manifest.json permission auditor
 ```
 
 ### API & Storage Layer
@@ -219,11 +220,11 @@ cli.py / mcp_server.py / api/server.py
 
 | Metric | Count |
 |---|---|
-| Python modules | 160 |
+| Python modules | 161 |
 | Test files | 168 |
-| Test functions | ~3,900 (collected by pytest) |
-| MCP tools | 22 |
-| Compliance frameworks | 10 |
+| Test functions | ~4,086 (collected by pytest) |
+| MCP tools | 23 |
+| Compliance frameworks | 11 |
 | Runtime detectors | 7 |
 | Cloud providers | 12 |
 | SAST CWE mappings | 52 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full module map. Key paths:
 | `src/agent_bom/models.py` | Core data models (Package, Vulnerability, Agent…) |
 | `src/agent_bom/runtime/` | Proxy detectors (7 detectors) |
 | `src/agent_bom/api/server.py` | FastAPI REST server |
-| `src/agent_bom/mcp_server.py` | MCP server (22 tools) |
+| `src/agent_bom/mcp_server.py` | MCP server (23 tools) |
 
 The scan pipeline: **discover** MCP configs → **parse** packages → **scan** via OSV batch API → **enrich** full vuln details → **optional** NVD/EPSS/KEV enrichment → **output** (table, JSON, SARIF, CycloneDX…).
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ agent-bom scan --aws --snowflake --databricks      # Multi-cloud
 agent-bom scan --hf-model meta-llama/Llama-3.1-8B  # model provenance
 agent-bom scan --vector-db-scan                    # Scan self-hosted + Pinecone cloud vector DBs
 agent-bom scan --gpu-scan                          # Discover GPU containers + K8s nodes, detect unauthenticated DCGM exporters
+agent-bom scan --browser-extensions               # Scan Chrome/Edge/Brave/Firefox extensions for dangerous permissions
+agent-bom scan --skill-only                       # Audit AI instruction files (CLAUDE.md, .cursorrules, AGENTS.md)
 agent-bom graph report.json --format dot           # Export dependency graph (DOT/Mermaid/JSON)
 agent-bom proxy-configure --apply                  # Auto-wrap MCP configs with security proxy
 ```
@@ -178,7 +180,7 @@ rm -rf ~/.agent-bom                      # remove local data
 | **Credential exposure** | -- | Which secrets leak per vulnerability, per agent |
 | **Tool poisoning detection** | -- | Description injection, capability combos, drift detection |
 | **Privilege detection** | -- | root, shell access, privileged containers, per-tool permissions |
-| **10-framework compliance** | -- | OWASP LLM + MCP + Agentic, MITRE ATLAS, NIST AI RMF + CSF, EU AI Act, SOC 2, ISO 27001, CIS |
+| **11-framework compliance** | -- | OWASP LLM + MCP + Agentic + AISVS v1.0, MITRE ATLAS, NIST AI RMF + CSF, EU AI Act, SOC 2, ISO 27001, CIS |
 | **MITRE ATT&CK mapping** | -- | Dynamic technique lookup by tactic phase (no hardcoded T-codes) |
 | **Posture scorecard** | -- | Letter grade (A-F), 6 dimensions, incident correlation (P1-P4) |
 | **Policy-as-code + Jira** | -- | 17 conditions, CI gate, auto-create Jira tickets for violations |
@@ -190,6 +192,8 @@ rm -rf ~/.agent-bom                      # remove local data
 | **Cloud vector DB scanning** | -- | Pinecone index inventory, risk flags, replica counts via API key |
 | **Dependency graph export** | -- | DOT, Mermaid, JSON — agent → server → package → CVE graph |
 | **OIDC/SSO authentication** | -- | JWT verification (Okta, Google, Azure AD, Auth0) for REST API |
+| **Instruction file trust** | -- | SKILL.md/CLAUDE.md/.cursorrules — 17 behavioral patterns, typosquat detection, Sigstore provenance verification |
+| **Browser extension scanning** | -- | Chrome/Edge/Firefox manifest.json — nativeMessaging, dangerous permissions, AI assistant domain access |
 
 <p align="center">
   <picture>
@@ -212,7 +216,8 @@ rm -rf ~/.agent-bom                      # remove local data
 | Terraform / GitHub Actions | AI resources + env vars |
 | Jupyter notebooks | AI library imports + model refs |
 | Model files | 13 formats (.gguf, .safetensors, .pkl, ...) |
-| Skill files | CLAUDE.md, .cursorrules, AGENTS.md |
+| Skill files | CLAUDE.md, .cursorrules, AGENTS.md — behavioral audit, typosquat detection, Sigstore trust verification |
+| Browser extensions | Chrome, Brave, Edge, Firefox — dangerous permission detection (nativeMessaging, cookies, AI host access) |
 | Existing SBOMs | CycloneDX / SPDX import |
 
 </details>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -277,12 +277,14 @@ graph TB
 | CLI | `src/agent_bom/cli.py` | Click entry point, flag parsing |
 | Discovery | `src/agent_bom/discovery/__init__.py` | MCP client config discovery (20 clients) |
 | Parsers | `src/agent_bom/parsers/__init__.py` | Package extraction + MCP registry lookup |
+| Skill Parsers | `src/agent_bom/parsers/skills.py` + `skill_audit.py` | SKILL.md/CLAUDE.md behavioral audit, typosquat, Sigstore trust |
+| Browser Extensions | `src/agent_bom/parsers/browser_extensions.py` | Chrome/Edge/Brave/Firefox manifest.json permission auditor |
 | Scanners | `src/agent_bom/scanners/__init__.py` | OSV batch scan + CVSS + AI risk tagging |
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console output |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine |
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (22 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (23 tools) |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |
 | Logging | `src/agent_bom/logging_config.py` | Structured JSON/console logging, env var config |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-agent-bom exposes 22 tools via its MCP server.
+agent-bom exposes 23 tools via its MCP server.
 
 ## Tools
 


### PR DESCRIPTION
## Summary

- Add `--browser-extensions` and `--skill-only` to README CLI examples block
- Add **Browser extensions** row to "What it scans" table (Chrome/Brave/Edge/Firefox)
- Expand **Skill files** row with security analysis detail (behavioral audit, typosquat, Sigstore)
- Add **Instruction file trust** + **Browser extension scanning** rows to "What it covers"
- Bump compliance count 10 → 11 (OWASP AISVS v1.0 was already implemented, not documented)
- ARCHITECTURE.md: add `browser_extensions.py` to parsers tree; sync module/tool/framework counts
- docs/ARCHITECTURE.md: add Skill Parsers + Browser Extensions module rows
- CONTRIBUTING.md + site-docs/reference/mcp-tools.md: MCP tool count 22 → 23

Closes #419

## Test plan

- [ ] README renders correctly on GitHub (tables, code blocks)
- [ ] All counts match codebase: 23 MCP tools, 11 frameworks, 161 modules, ~4,086 tests