### PR TITLE
docs: fix stale counts in integrations, architecture, and README

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -220,7 +220,7 @@ cli.py / mcp_server.py / api/server.py
 
 | Metric | Count |
 |---|---|
-| Python modules | 161 |
+| Python modules | 165 |
 | Test files | 168 |
 | Test functions | ~4,086 (collected by pytest) |
 | MCP tools | 23 |

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 | `GET /v1/scan/{id}` | Results + status |
 | `GET /v1/scan/{id}/attack-flow` | Per-CVE blast radius graph |
 | `GET /v1/registry` | 427+ server registry |
-| `GET /v1/compliance` | Full 10-framework compliance posture |
+| `GET /v1/compliance` | Full 11-framework compliance posture |
 | `GET /v1/posture` | Enterprise posture scorecard (A-F) |
 | `GET /v1/posture/credentials` | Credential risk ranking |
 | `GET /v1/posture/incidents` | Incident correlation (P1-P4) |
@@ -428,7 +428,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 - [ ] Agent-to-agent permission boundary enforcement
 
 **Compliance / standards**
-- [x] 10 frameworks: OWASP LLM, OWASP MCP, OWASP Agentic, ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls
+- [x] 11 frameworks: OWASP LLM, OWASP MCP, OWASP Agentic, OWASP AISVS v1.0, ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls
 - [ ] CIS AI benchmarks (pending CIS publication)
 - [ ] License compliance engine (OSS license risk flagging)
 - [ ] Workflow engine scanning (n8n, Zapier, Make)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ graph TB
         Parser["Package Parser"]
         Scanner["Vulnerability Scanner\nOSV + NVD + EPSS + KEV"]
         Blast["Blast Radius Analyzer"]
-        Compliance["Compliance Tagger\n10 Frameworks"]
+        Compliance["Compliance Tagger\n11 Frameworks"]
         Posture["Posture Scorer"]
     end
 
@@ -92,7 +92,7 @@ sequenceDiagram
     BlastRadius-->>CLI: Blast radius chains
 
     CLI->>ComplianceTagger: Findings
-    ComplianceTagger->>ComplianceTagger: Tag 10 frameworks
+    ComplianceTagger->>ComplianceTagger: Tag 11 frameworks
     ComplianceTagger-->>CLI: Tagged findings
 
     CLI->>Reporter: Full results
@@ -158,7 +158,7 @@ graph LR
 
 ## 4. Compliance Framework Mapping
 
-Every blast radius finding is tagged against 10 compliance frameworks simultaneously.
+Every blast radius finding is tagged against 11 compliance frameworks simultaneously.
 
 ```mermaid
 graph TD

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   and vector database security checks. Use when the user mentions vulnerability
   scanning, MCP server trust, compliance, SBOM generation, CIS benchmarks,
   blast radius, or AI supply chain risk.
-version: 0.59.3
+version: 0.64.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -19,11 +19,11 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 3480
+  tests: 4086
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.59.3
+    docker: ghcr.io/msaad00/agent-bom:0.64.0
   openclaw:
     requires:
       bins: []
@@ -196,7 +196,7 @@ agent-bom where             # show all discovery paths
 }
 ```
 
-## Tools (22)
+## Tools (23)
 
 ### Vulnerability Scanning
 | Tool | Description |
@@ -233,6 +233,7 @@ agent-bom where             # show all discovery paths
 |------|-------------|
 | `context_graph` | Agent context graph with lateral movement analysis |
 | `analytics_query` | Query vulnerability trends, posture history, and runtime events |
+| `runtime_correlate` | Cross-reference proxy audit JSONL with CVE findings, risk amplification |
 | `vector_db_scan` | Probe Qdrant/Weaviate/Chroma/Milvus for auth and exposure |
 | `gpu_infra_scan` | GPU container and K8s node inventory + unauthenticated DCGM probe (MAESTRO KC6) |
 
@@ -308,6 +309,6 @@ configured credentials and call only the cloud provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.60.0`
-- **3,400+ tests** with CodeQL + OpenSSF Scorecard
+- **Sigstore signed**: `agent-bom verify agent-bom@0.64.0`
+- **4,086 tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 3480
+  tests: 4086
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 3480
+  tests: 4086
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 3480
+  tests: 4086
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 3480
+  tests: 4086
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -61,7 +61,8 @@
             "fleet_scan",
             "runtime_correlate",
             "vector_db_scan",
-            "aisvs_benchmark"
+            "aisvs_benchmark",
+            "gpu_infra_scan"
           ]
         }
       }


### PR DESCRIPTION
## Summary

- **toolhive/server.json**: add missing `gpu_infra_scan` tool (22 → 23)
- **openclaw/SKILL.md**: version 0.59.3 → 0.64.0; docker tag updated; tests 3480 → 4086; Tools(22) → Tools(23); add missing `runtime_correlate` row; Sigstore reference → 0.64.0; test count 3,400+ → 4,086
- **4× split SKILL.mds** (scan/compliance/registry/runtime): tests 3480 → 4086
- **README.md**: compliance posture API endpoint → "11-framework"; roadmap checklist 10 → 11 with OWASP AISVS v1.0 added
- **docs/ARCHITECTURE.md**: 3× "10 frameworks" → "11 frameworks" (Mermaid diagram node, sequence diagram, prose)
- **ARCHITECTURE.md**: Python modules 161 → 165

## Test plan

- [ ] toolhive/server.json has 23 tools in tools array
- [ ] openclaw SKILL.md has correct version, test count, and 23 tools with runtime_correlate
- [ ] No remaining "10 framework" or "3480 tests" or "0.59.3" references