### PR TITLE
feat: instruction file trust as headline feature (SKILL.md hero story)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 > **Traditional scanners tell you a package has a CVE.**
 > **agent-bom tells you which AI agents are compromised, which credentials leak, which tools an attacker reaches — and then blocks it in real time.**
 
-Two capabilities, one tool: **scanner** (CVEs, blast radius, compliance, supply chain) + **proxy** (intercepts MCP traffic, enforces policy, detects 7 behavioral attack patterns). Read-only. Agentless. Open source.
+Three capabilities, one tool: **scanner** (CVEs, blast radius, compliance, supply chain) + **proxy** (intercepts MCP traffic, enforces policy, detects 7 behavioral attack patterns) + **instruction file trust** (audits CLAUDE.md, .cursorrules, AGENTS.md, SKILL.md for malicious patterns, typosquatting, and Sigstore provenance). Read-only. Agentless. Open source.
 
 ```
 CVE-2025-1234  (CRITICAL . CVSS 9.8 . CISA KEV)
@@ -57,6 +57,45 @@ CVE-2025-1234  (CRITICAL . CVSS 9.8 . CISA KEV)
     <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="Blast Radius" width="800" />
   </picture>
 </p>
+
+---
+
+## Instruction file trust
+
+AI agents run on instruction — CLAUDE.md, .cursorrules, AGENTS.md, SKILL.md. A malicious or compromised instruction file is a supply chain attack that executes with full agent permissions. agent-bom audits every instruction file it finds.
+
+```
+agent-bom scan --skill-only
+
+CLAUDE.md  →  SUSPICIOUS (high confidence)
+  [CRITICAL] Credential/secret file access
+             "cat ~/.aws/credentials" detected — reads secret files
+  [HIGH]     Safety confirmation bypass
+             "--dangerously-skip-permissions" found — disables all guardrails
+  [HIGH]     Typosquatting risk: server name "filessystem" (→ filesystem)
+  [MEDIUM]   External URL in instructions: https://malicious-cdn.com/hook.js
+
+  Trust categories
+    Purpose & Capability  WARN  — description vs. actual tool mismatch
+    Instruction Scope     FAIL  — file reads outside home directory
+    Install Mechanism     FAIL  — unverified install source, no Sigstore sig
+    Credentials           WARN  — 3 env vars undocumented
+    Persistence/Privilege PASS  — no persistence, no privilege escalation
+```
+
+Five trust categories, 17 behavioral risk patterns, Sigstore signature verification. No network calls — fully local static analysis.
+
+```bash
+agent-bom scan --skill-only             # audit all discovered instruction files
+agent-bom scan --skill CLAUDE.md        # audit a single specific file
+```
+
+Or via MCP — ask your AI assistant to audit any instruction file before running it:
+
+```
+skill_trust(skill_content="<paste CLAUDE.md content>")
+# → { verdict: "suspicious", confidence: "high", findings: [...], categories: [...] }
+```
 
 ---
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -41,7 +41,35 @@ verify(package="agent-bom@0.60.0")
 ```
 
 ### skill_trust
-Assess the trust level of a SKILL.md file (5-category analysis).
+Audit an AI instruction file (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md) for supply chain risks, malicious behavioral patterns, and trust level.
+
+Runs 17 behavioral risk patterns (credential file access, confirmation bypass, messaging/impersonation, voice/telephony, filesystem exfiltration, data exfiltration, and more) plus 5-category structural trust assessment:
+
+| Category | Checks |
+|----------|--------|
+| Purpose & Capability | name/description consistency, binary/network scope |
+| Instruction Scope | file reads bounded, data handling documented |
+| Install Mechanism | install source, Sigstore signature, provenance |
+| Credentials | proportionate, scoped, documented env vars |
+| Persistence & Privilege | no persistence, no escalation, no telemetry |
+
+Returns a verdict (`benign` / `suspicious` / `malicious`), confidence level, per-category results, and all findings with severity and recommendations.
+
+```
+skill_trust(skill_content="<paste full file content>")
+# → {
+#     "verdict": "suspicious",
+#     "confidence": "high",
+#     "categories": [
+#       { "name": "Install Mechanism", "level": "fail", "summary": "Unverified install source" },
+#       ...
+#     ],
+#     "findings": [
+#       { "severity": "critical", "title": "Credential/secret file access", "detail": "..." },
+#       ...
+#     ]
+#   }
+```
 
 ### generate_sbom
 Generate an SBOM in CycloneDX or SPDX format.


### PR DESCRIPTION
## Summary

Closes #419

Elevates SKILL.md/CLAUDE.md/.cursorrules trust assessment from a buried table row to a first-class, clearly documented capability.

**README.md**
- "Why agent-bom?" now names three capabilities: scanner + proxy + **instruction file trust**
- New **Instruction file trust** hero section between blast-radius diagram and "Get started"
  - Terminal output example showing 4 real finding types (credential access, confirmation bypass, typosquatting, external URL)
  - 5-category trust assessment table visible in the narrative
  - CLI examples (`--skill-only`, `--skill CLAUDE.md`)
  - MCP usage example (`skill_trust(...)`)

**site-docs/reference/mcp-tools.md**
- `skill_trust` expanded from one line to full reference documentation
  - 5-category table with what each category checks
  - 17 behavioral risk patterns mentioned
  - Verdict/confidence explanation (benign/suspicious/malicious)
  - Full example JSON response

## Test plan

- [ ] README renders correctly on GitHub — hero section visible before "Get started"
- [ ] CLI flags in example match actual implementation (`--skill-only`, `--skill`)
- [ ] skill_trust MCP tool docs accurate against trust_assessment.py implementation