### PR TITLE
fix: proxy relay hardening — client readline timeout + relay error logging

### DIFF
--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -609,7 +609,11 @@ async def run_proxy(
         await asyncio.get_running_loop().connect_read_pipe(lambda: protocol, sys.stdin.buffer)
 
         while True:
-            line = await reader.readline()
+            try:
+                line = await asyncio.wait_for(reader.readline(), timeout=120.0)
+            except asyncio.TimeoutError:
+                logger.debug("Client readline timed out — closing relay")
+                break
             if not line:
                 break
 
@@ -925,14 +929,15 @@ async def run_proxy(
             sys.stderr.buffer.flush()
 
     try:
-        await asyncio.gather(
+        results = await asyncio.gather(
             relay_client_to_server(),
             relay_server_to_client(),
             forward_stderr(),
             return_exceptions=True,
         )
-    except (BrokenPipeError, ConnectionResetError):
-        pass
+        for result in results:
+            if isinstance(result, Exception) and not isinstance(result, (BrokenPipeError, ConnectionResetError, asyncio.CancelledError)):
+                logger.debug("Relay task exited with error: %s", result)
     finally:
         # Write metrics summary + runtime alerts to audit log before closing
         if log_file:


### PR DESCRIPTION
## Summary

Two security gaps found in relay logic (static analysis audit):

**Gap A — Missing client readline timeout**
`relay_client_to_server()` called `await reader.readline()` with no timeout. A stalled or slow MCP client could block the relay coroutine indefinitely, starving the server side. Fixed with `asyncio.wait_for(..., timeout=120.0)` — 120s matches the outer MCP request lifecycle; idle connections time out cleanly.

**Gap B — Silent relay task exception swallowing**
`asyncio.gather(..., return_exceptions=True)` suppressed all exceptions from relay tasks — a crash in any relay coroutine was invisible. Fixed by iterating the results and logging unexpected exceptions at DEBUG level. Expected pipe/cancel errors (`BrokenPipeError`, `ConnectionResetError`, `CancelledError`) are still silently discarded as they represent normal shutdown paths.

## Test plan

- [x] `pytest tests/test_proxy.py` → 31 passed
- [x] `bandit src/agent_bom/proxy.py --severity-level medium` → 0 medium/high issues