### PR TITLE
feat: HMAC-SHA256 response signing + relay error observability in proxy

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -5239,6 +5239,12 @@ def registry_sync_all(max_pages, smithery_token, dry_run):
 )
 @click.option("--metrics-port", default=8422, show_default=True, help="Prometheus metrics port (0 to disable)")
 @click.option("--metrics-token", default=None, envvar="AGENT_BOM_METRICS_TOKEN", help="Bearer token for Prometheus /metrics endpoint")
+@click.option(
+    "--response-sign-key",
+    default=None,
+    envvar="AGENT_BOM_RESPONSE_SIGN_KEY",
+    help="Secret key for HMAC-SHA256 response signing written to audit log (tamper detection)",
+)
 @click.argument("server_cmd", nargs=-1, required=True)
 def proxy_cmd(
     policy,
@@ -5250,6 +5256,7 @@ def proxy_cmd(
     alert_webhook,
     metrics_port,
     metrics_token,
+    response_sign_key,
     server_cmd,
 ):
     """Run an MCP server through agent-bom's security proxy.
@@ -5261,6 +5268,7 @@ def proxy_cmd(
     - Blocks undeclared tools (not in tools/list response)
     - Detects tool drift (rug pull), dangerous arguments, credential leaks
     - Rate limiting and suspicious sequence detection
+    - HMAC-SHA256 response signing in audit log (--response-sign-key)
 
     \b
     Usage:
@@ -5268,6 +5276,7 @@ def proxy_cmd(
       agent-bom proxy --log audit.jsonl -- npx @mcp/server-github
       agent-bom proxy --policy policy.json --block-undeclared -- npx @mcp/server-postgres
       agent-bom proxy --detect-credentials --log-only -- npx @mcp/server-github
+      agent-bom proxy --log audit.jsonl --response-sign-key $MY_SECRET -- npx @mcp/server-github
 
     \b
     Configure in your MCP client (e.g. Claude Desktop):
@@ -5304,6 +5313,7 @@ def proxy_cmd(
             alert_webhook=alert_webhook,
             metrics_port=metrics_port,
             metrics_token=metrics_token,
+            response_signing_key=response_sign_key,
         )
     )
     sys.exit(exit_code)

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -50,6 +51,7 @@ class ProxyMetrics:
     total_messages_client_to_server: int = 0
     total_messages_server_to_client: int = 0
     replay_rejections: int = 0
+    relay_errors: int = 0
 
     def record_call(self, tool_name: str) -> None:
         """Record an allowed tool call."""
@@ -98,6 +100,7 @@ class ProxyMetrics:
             "messages_client_to_server": self.total_messages_client_to_server,
             "messages_server_to_client": self.total_messages_server_to_client,
             "replay_rejections": self.replay_rejections,
+            "relay_errors": self.relay_errors,
         }
 
 
@@ -353,6 +356,25 @@ def compute_payload_hash(payload: dict) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def compute_response_hmac(payload: dict, key: str) -> str:
+    """HMAC-SHA256 of the canonical JSON response payload.
+
+    Written to the audit log so operators can verify responses were not
+    tampered with between the MCP server and this proxy.  The signature is
+    NOT inserted into the wire protocol (that would break the MCP spec).
+
+    Args:
+        payload: The parsed JSON-RPC response dict.
+        key: A shared secret known to both the proxy operator and the
+             verification tool.  Must be non-empty.
+
+    Returns:
+        Hex-encoded HMAC-SHA256 digest.
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hmac.new(key.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
 @dataclass
 class ReplayDetector:
     """Detect replayed JSON-RPC messages by tracking payload hashes.
@@ -514,6 +536,7 @@ async def run_proxy(
     alert_webhook: Optional[str] = None,
     metrics_port: int = 8422,
     metrics_token: Optional[str] = None,
+    response_signing_key: Optional[str] = None,
 ) -> int:
     """Main proxy loop. Spawns server subprocess, relays JSON-RPC.
 
@@ -913,6 +936,22 @@ async def run_proxy(
                 for k in stale:
                     pending_calls.pop(k, None)
 
+            # Response signing — write HMAC to audit log for tamper detection
+            if msg and response_signing_key and log_file:
+                sig = compute_response_hmac(msg, response_signing_key)
+                sig_entry = (
+                    json.dumps(
+                        {
+                            "ts": datetime.now(timezone.utc).isoformat(),
+                            "type": "response_hmac",
+                            "id": msg.get("id"),
+                            "hmac_sha256": sig,
+                        }
+                    )
+                    + "\n"
+                )
+                log_file.write(sig_entry)
+
             # Forward to client
             sys.stdout.buffer.write(line)
             sys.stdout.buffer.flush()
@@ -937,7 +976,21 @@ async def run_proxy(
         )
         for result in results:
             if isinstance(result, Exception) and not isinstance(result, (BrokenPipeError, ConnectionResetError, asyncio.CancelledError)):
-                logger.debug("Relay task exited with error: %s", result)
+                metrics.relay_errors += 1
+                logger.warning("Relay task exited with unexpected error: %s", result)
+                if log_file:
+                    err_entry = (
+                        json.dumps(
+                            {
+                                "ts": datetime.now(timezone.utc).isoformat(),
+                                "type": "relay_error",
+                                "error": str(result),
+                                "error_type": type(result).__name__,
+                            }
+                        )
+                        + "\n"
+                    )
+                    log_file.write(err_entry)
     finally:
         # Write metrics summary + runtime alerts to audit log before closing
         if log_file:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -10,6 +10,7 @@ from agent_bom.proxy import (
     ReplayDetector,
     check_policy,
     compute_payload_hash,
+    compute_response_hmac,
     extract_tool_name,
     is_tools_call,
     log_tool_call,
@@ -392,3 +393,66 @@ def test_check_policy_allowlist_warn_does_not_enforce():
     }
     allowed, reason = check_policy(policy, "write_file", {})
     assert allowed is True  # warn rules are not enforced at runtime
+
+
+# ── compute_response_hmac ───────────────────────────────────────────────────
+
+
+def test_response_hmac_deterministic():
+    """Same payload + key always produces the same HMAC."""
+    msg = {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "ok"}]}}
+    h1 = compute_response_hmac(msg, "secret-key")
+    h2 = compute_response_hmac(msg, "secret-key")
+    assert h1 == h2
+    assert len(h1) == 64  # HMAC-SHA256 hex digest
+
+
+def test_response_hmac_key_sensitivity():
+    """Different keys produce different HMACs for the same payload."""
+    msg = {"jsonrpc": "2.0", "id": 1, "result": {"data": "hello"}}
+    assert compute_response_hmac(msg, "key-a") != compute_response_hmac(msg, "key-b")
+
+
+def test_response_hmac_payload_sensitivity():
+    """Different payloads produce different HMACs with the same key."""
+    msg_a = {"jsonrpc": "2.0", "id": 1, "result": {"data": "hello"}}
+    msg_b = {"jsonrpc": "2.0", "id": 1, "result": {"data": "tampered"}}
+    assert compute_response_hmac(msg_a, "key") != compute_response_hmac(msg_b, "key")
+
+
+def test_response_hmac_canonical_key_order():
+    """HMAC is the same regardless of dict key insertion order."""
+    msg_a = {"b": 2, "a": 1}
+    msg_b = {"a": 1, "b": 2}
+    assert compute_response_hmac(msg_a, "key") == compute_response_hmac(msg_b, "key")
+
+
+def test_response_hmac_differs_from_payload_hash():
+    """HMAC with a key is not the same as a plain SHA-256 hash."""
+    msg = {"jsonrpc": "2.0", "id": 1, "result": {}}
+    assert compute_response_hmac(msg, "some-key") != compute_payload_hash(msg)
+
+
+# ── ProxyMetrics relay_errors ───────────────────────────────────────────────
+
+
+def test_proxy_metrics_relay_errors_default_zero():
+    """relay_errors starts at zero."""
+    m = ProxyMetrics()
+    assert m.relay_errors == 0
+
+
+def test_proxy_metrics_relay_errors_in_summary():
+    """relay_errors is included in the summary dict."""
+    m = ProxyMetrics()
+    m.relay_errors = 2
+    s = m.summary()
+    assert s["relay_errors"] == 2
+
+
+def test_proxy_metrics_summary_relay_errors_zero():
+    """summary() includes relay_errors=0 when no errors occurred."""
+    m = ProxyMetrics()
+    s = m.summary()
+    assert "relay_errors" in s
+    assert s["relay_errors"] == 0


### PR DESCRIPTION
## Summary

Two proxy hardening improvements closing the remaining gaps from the security audit:

**HMAC-SHA256 response signing (Gap → implemented)**
- New `--response-sign-key` flag (or `AGENT_BOM_RESPONSE_SIGN_KEY` env var)
- For every JSON-RPC response the proxy relays, computes `HMAC-SHA256(canonical_json, key)` and writes a `response_hmac` entry to the audit JSONL log
- Canonical JSON uses sorted keys + compact separators (same as `compute_payload_hash`) — deterministic across Python dict orderings
- Signature is NOT inserted into the wire protocol (would break MCP spec) — it's an audit trail artifact for post-hoc tamper verification
- Usage: `agent-bom proxy --log audit.jsonl --response-sign-key $MY_SECRET -- npx @mcp/server-github`

**Relay error observability (8/10 → 9/10)**
- `relay_errors` counter added to `ProxyMetrics` dataclass
- Unexpected relay task exceptions now: increment `relay_errors`, log at WARNING (was DEBUG), write structured `relay_error` entry to audit JSONL
- Expected shutdown errors (`BrokenPipeError`, `ConnectionResetError`, `CancelledError`) still discarded silently
- `relay_errors` included in the `proxy_summary` JSONL entry written at session end

## Test plan

- [x] `pytest tests/test_proxy.py` → 39 passed (was 31 — 8 new tests)
- [x] `bandit src/agent_bom/proxy.py --severity-level medium` → 0 issues
- [x] New tests: HMAC determinism, key sensitivity, payload sensitivity, canonical ordering, differs-from-hash, relay_errors default/summary