### PR TITLE
feat: Cortex Code integration + v0.65.0 doc alignment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -220,9 +220,9 @@ cli.py / mcp_server.py / api/server.py
 
 | Metric | Count |
 |---|---|
-| Python modules | 165 |
-| Test files | 168 |
-| Test functions | ~4,086 (collected by pytest) |
+| Python modules | 167 |
+| Test files | 179 |
+| Test functions | ~4,314 (collected by pytest) |
 | MCP tools | 23 |
 | Compliance frameworks | 11 |
 | Runtime detectors | 7 |

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ agent-bom introspect --all --baseline baseline.json               # exit 1 on ne
 #   rate_limit: {threshold: 50, window_seconds: 60}
 ```
 
-Auto-discovers 20 MCP clients: Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Copilot, Continue, Zed, Cortex Code, Codex CLI, Gemini CLI, Goose, Snowflake CLI, OpenClaw, Roo Code, Amazon Q, ToolHive, Docker MCP Toolkit, JetBrains AI, and Junie.
+Auto-discovers 21 MCP clients: Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Copilot, Continue, Zed, Cortex Code, Codex CLI, Gemini CLI, Goose, Snowflake CLI, OpenClaw, Roo Code, Amazon Q, ToolHive, Docker MCP Toolkit, JetBrains AI, Junie, and custom paths.
 
 <p align="center">
   <picture>
@@ -211,7 +211,7 @@ rm -rf ~/.agent-bom                      # remove local data
 |---|---|---|
 | Package CVE detection | Yes | Yes (OSV + NVD + EPSS + CISA KEV + GHSA + NVIDIA CSAF) |
 | SBOM generation | Yes | Yes (CycloneDX 1.6, SPDX 3.0, SARIF) |
-| **AI agent discovery** | -- | 20 MCP clients + Docker Compose + running processes + containers + K8s pods/CRDs |
+| **AI agent discovery** | -- | 21 MCP clients + Docker Compose + running processes + containers + K8s pods/CRDs |
 | **GPU/ML package scanning** | -- | NVIDIA CSAF advisories for CUDA, cuDNN, PyTorch, TensorFlow, JAX, vLLM + AMD ROCm via OSV |
 | **AI supply chain** | -- | Model provenance (pickle risk, digest, gating), HuggingFace Hub, Ollama, MLflow, W&B |
 | **AI cloud inventory** | -- | Coreweave, Nebius, Snowflake, Databricks, OpenAI, HuggingFace Hub — config discovery + CVE tagging |

--- a/docs/STRATEGIC_AUDIT_2026_03.md
+++ b/docs/STRATEGIC_AUDIT_2026_03.md
@@ -1,0 +1,469 @@
+# agent-bom Strategic Audit — March 2026
+
+## Table of Contents
+
+1. [Competitive Landscape](#1-competitive-landscape)
+2. [agent-bom Capability Audit](#2-agent-bom-capability-audit)
+3. [Differentiators & Uniqueness](#3-differentiators--uniqueness)
+4. [Snowflake Coco / Cortex Code Integration](#4-snowflake-coco--cortex-code-integration)
+5. [OpenAI Frontier Platform](#5-openai-frontier-platform)
+6. [Gap Analysis & Roadmap](#6-gap-analysis--roadmap)
+7. [Trademark & IP Protection](#7-trademark--ip-protection)
+
+---
+
+## 1. Competitive Landscape
+
+### Direct Competitors (AI Agent Security Scanners)
+
+| Tool | Vendor | GitHub Stars | Focus | Key Capabilities | Gaps vs agent-bom |
+|------|--------|-------------|-------|-------------------|-------------------|
+| **agent-scan** | Snyk | ~1.7k | MCP + Skills | 15+ risk types, auto-discovery (Claude/Cursor/Gemini/Windsurf), prompt injection, tool poisoning, tool shadowing, toxic flows, rug pull, background monitoring, Snyk Evo integration | No CVE scanning, no blast radius, no SBOM, no runtime proxy, no cloud scanning, no compliance mapping, no enrichment pipeline |
+| **skill-scanner** | Cisco AI Defense | ~900 | Skill files | Static analysis of SKILL.md files, comprehensive but CLI-only, requires Python 3.10+ and 3 API keys | No MCP scanning, no runtime, no CVE/vuln scanning, no cloud, heavy setup |
+| **SkillCheck** | Repello AI | N/A (SaaS) | Browser-based | Prompt injection, policy violations, payload delivery, severity score /100, zero setup | Browser-only, no CLI, no MCP scanning, no CVE, no runtime |
+| **mcp-scan** | Invariant Labs | ~3k+ | MCP servers | Tool poisoning, prompt injection, cross-origin escalation, WhitelistGuard | No CVE scanning, no skills, no cloud, no compliance |
+| **MCP Scan** | Enkrypt AI | N/A (SaaS) | MCP assessment | Security assessment of MCP servers | Limited scope |
+| **GuardFive** | GuardFive | N/A (SaaS) | MCP security | Tool poisoning, credential theft detection, enterprise features | SaaS-only, limited public info |
+| **Proximity** | Open source | ~500 | MCP scanning | Open-source MCP security scanner | Narrower scope |
+| **mcp-guard** | SaravanaGuhan | <100 | MCP servers | Comprehensive MCP server scanning | Small project, limited maintenance |
+
+### Indirect Competitors
+
+| Tool | Focus | Overlap with agent-bom |
+|------|-------|------------------------|
+| **Grype/Syft** (Anchore) | Container/package CVE scanning | CVE scanning only — agent-bom uses these as optional engines |
+| **Trivy** (Aqua) | Container/IaC scanning | CVE + IaC, no AI agent awareness |
+| **Snyk CLI** | Dependency/container scanning | CVE scanning, no MCP/agent awareness |
+| **Wiz** | Cloud security posture | Cloud scanning, no MCP/agent focus |
+
+### Key Insight
+
+**No single competitor covers what agent-bom covers.** The market is fragmented:
+- Snyk agent-scan: skill/MCP *behavioral* scanning (prompt injection, poisoning) — no CVEs
+- Grype/Trivy/Snyk CLI: CVE scanning — no AI agent awareness
+- Wiz/Prisma: cloud posture — no MCP, no agent runtime
+
+**agent-bom is the only tool that combines:** CVE scanning + AI agent discovery + MCP tool security + blast radius + runtime proxy + compliance mapping + cloud scanning + enrichment pipeline + SBOM + VEX + policy engine. This is the core differentiator.
+
+---
+
+## 2. agent-bom Capability Audit
+
+### 2.1 Scanner Engine
+
+| Dimension | Details |
+|-----------|---------|
+| **Package ecosystems** | npm, pip/PyPI, Go (go.mod), Maven (pom.xml), Ruby (Gemfile.lock), .NET (*.csproj/*.deps.json), RPM (sqlite), Rust (Cargo.lock) |
+| **Container scanning** | OCI layer parsing (native, no Docker/Grype required), Grype/Syft as optional engines for `--image` |
+| **Native OCI parsers** | Java JARs, Go binaries, Ruby gems, .NET assemblies, RPM sqlite — full ecosystem coverage without external tools |
+| **Filesystem scanning** | `--filesystem` flag, dpkg/rpm/pip native parsers with Syft fallback |
+| **SBOM ingestion** | CycloneDX 1.x, SPDX 2.x/3.0 JSON |
+| **SBOM generation** | CycloneDX output |
+| **VEX** | OpenVEX load/generate/apply/export, CLI flags |
+| **SAST** | 52 CWE rule map, code_scan MCP tool |
+| **Browser extensions** | Chrome/Chromium/Brave/Edge/Firefox, Manifest V2+V3, nativeMessaging/debugger/cookies/clipboardRead/broad-host detection, AI assistant domain access (claude.ai, chatgpt.com, cursor.sh) |
+| **SKILL.md scanning** | 17 behavioral risk patterns, typosquat detection, Sigstore provenance, auto-discovery of CLAUDE.md/.cursorrules/AGENTS.md/.windsurfrules |
+| **Output formats** | JSON, SARIF, HTML, CycloneDX, DOT, Mermaid |
+
+### 2.2 Enrichment Pipeline
+
+| Source | Data | Cache TTL |
+|--------|------|-----------|
+| **OSV** | Primary vuln database | Real-time |
+| **GHSA** | Supplemental GitHub advisories | Real-time |
+| **NVD** | CVSS scores, CWE mapping | 90 days |
+| **EPSS** | Exploit probability scores | 30 days |
+| **CISA KEV** | Known exploited vulns | 24 hours |
+| **NVIDIA advisories** | GPU/CUDA/TensorRT/NCCL vulns | Supplemental |
+| **OpenSSF Scorecard** | Project health → risk boost | On-demand |
+| **MITRE ATT&CK** | CWE→CAPEC→ATT&CK via STIX | 30 days |
+
+### 2.3 MCP Server (23 Tools)
+
+| # | Tool | Purpose |
+|---|------|---------|
+| 1 | `scan` | Full vulnerability scan |
+| 2 | `check` | Quick package check |
+| 3 | `blast_radius` | Dependency blast radius analysis |
+| 4 | `policy_check` | Policy-as-code evaluation |
+| 5 | `registry_lookup` | MCP server registry metadata |
+| 6 | `generate_sbom` | SBOM generation |
+| 7 | `compliance` | Compliance framework mapping |
+| 8 | `remediate` | Remediation suggestions |
+| 9 | `verify` | Verify scan results |
+| 10 | `where` | Locate packages in dependency tree |
+| 11 | `inventory` | Full dependency inventory |
+| 12 | `diff` | Compare scan results |
+| 13 | `skill_trust` | SKILL.md trust assessment |
+| 14 | `marketplace_check` | Check marketplace listings |
+| 15 | `code_scan` | SAST code scanning |
+| 16 | `context_graph` | BFS lateral movement graph |
+| 17 | `analytics_query` | Analytics/metrics query |
+| 18 | `cis_benchmark` | CIS benchmark scanning |
+| 19 | `fleet_scan` | Fleet/batch scanning |
+| 20 | `runtime_correlate` | Cross-reference proxy audit with CVEs |
+| 21 | `vector_db_scan` | Pinecone/vector DB scanning |
+| 22 | `aisvs_benchmark` | AI security verification standard |
+| 23 | `gpu_infra_scan` | GPU/AI compute infrastructure |
+
+### 2.4 CLI UX
+
+- Rich spinners on all network operations
+- Exit codes for CI/CD gating
+- `--help` on all commands
+- Key commands: `scan`, `graph`, `proxy`, `protect`, `watch`, `mcp-server`, `proxy-configure`, `health-check`
+- Key flags: `--image`, `--filesystem`, `--sbom`, `--vex`, `--browser-extensions`, `--skill`, `--gpu-scan`, `--k8s-mcp`, `--siem`, `--health-check`, `--include-processes`, `--include-containers`
+- Output: JSON, SARIF, HTML, CycloneDX
+- "No known vulnerabilities found" vs "N finding(s)" — clear UX
+
+### 2.5 Runtime & Proxy
+
+| Component | Capabilities |
+|-----------|-------------|
+| **proxy.py** | stdio MCP proxy, policy enforcement, credential leak detection, replay detection, per-tool rate limiting (sliding window), Prometheus metrics, JSONL audit, HMAC signing, JWKS signature verification (RS256/RS384/RS512/ES256/ES384/ES512), OIDC discovery, client readline timeout (120s), relay task exception logging |
+| **protect** | 7 detectors: ToolDrift (rug pull), ArgumentAnalyzer (injection), CredentialLeak, RateLimit, SequenceAnalyzer (exfil patterns), ResponseInspector (cloaking/SVG/invisible chars), VectorDBInjectionDetector |
+| **watch** | Filesystem watchers on MCP configs, diff-on-change, webhook alerts (Slack/Teams/PagerDuty) |
+| **introspect** | Live MCP server connection, tools/list + resources/list, drift detection |
+| **enforcement** | Tool poisoning detection, unicode normalization, description drift, inputSchema injection scanning |
+| **OTel ingest** | Parse OTel traces, cross-reference tool calls with CVE data, `gen_ai.*` span detection, flag deprecated models |
+| **runtime_correlation** | Cross-reference proxy audit JSONL with CVE findings, risk amplification (1.5-3.0x) |
+| **audit_replay** | Rich TUI viewer for proxy JSONL logs |
+
+### 2.6 Security Posture
+
+- `validate_path(restrict_to_home=True)` — path traversal protection
+- HMAC proxy signing
+- JWKS signature verification (6 algorithms, 'none' rejected)
+- OIDC/SSO JWT auth for API
+- Credential leak detection in tool arguments/responses
+- Input validation (JSON schema, size limits, pollution guards)
+- Rate limiting (per-tool sliding window)
+- 10 MB proxy DoS limit
+- `.agent-bom.yaml` per-project config (like .grype.yaml)
+
+### 2.7 Cloud Coverage (12 Providers)
+
+| Provider | Scanner | Capabilities |
+|----------|---------|-------------|
+| AWS | Cloud posture | IAM, S3, security groups |
+| Azure | CIS Benchmark | Compliance scanning |
+| GCP | CIS Benchmark | Compliance scanning |
+| CoreWeave | GPU infra | GPU container detection |
+| Databricks | Security audit | Workspace security (custom, no CIS exists for Databricks) |
+| Snowflake | Security audit | Account security posture |
+| Nebius | Cloud posture | GPU cloud scanning |
+| HuggingFace | Model registry | Model provenance |
+| Weights & Biases | ML ops | Experiment tracking security |
+| MLflow | ML ops | Model registry security |
+| OpenAI | API posture | API key/model scanning |
+| Ollama | Local models | Local model security |
+
+### 2.8 Compliance Frameworks (10)
+
+OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Security, MITRE ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls
+
+### 2.9 MCP Client Discovery (21 Types)
+
+Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Copilot, JetBrains AI, and 12+ more — auto-discovers configs from known locations.
+
+### 2.10 UI/Dashboard
+
+- **Next.js**: 15 pages including SupplyChainTreemap, BlastRadiusRadial, PipelineFlow, EpssVsCvssChart, VulnTrendChart, Insights page
+- **Streamlit**: Legacy dashboard, Snowflake Native App compatible
+- **Validators**: Runtime JSON validation for file imports (size limit, schema, pollution guard)
+
+### 2.11 Tests
+
+- **3,841 collected** by pytest (3,760 `def test_` functions)
+- Meta-tests enforce MCP tool count alignment
+- Integration tests for all major features
+- 168 test files across 160 Python modules
+
+### 2.12 Integrations
+
+| Platform | Status |
+|----------|--------|
+| PyPI | Live |
+| Docker Hub | Live (multi-arch: amd64 + arm64) |
+| GHCR | Live |
+| GitHub Action / Marketplace | Live |
+| Smithery | Live |
+| Glama | Live |
+| ClawHub/OpenClaw | 4 split skills |
+| MCP Registry | Live (OIDC auth) |
+| Railway SSE | Live |
+| ToolHive | PR open |
+| awesome-mcp-servers | Listed |
+| Helm chart | Available |
+| Snowflake Native App | Streamlit path |
+
+---
+
+## 3. Differentiators & Uniqueness
+
+### What ONLY agent-bom does (no competitor matches all):
+
+1. **Full-spectrum AI infra scanning**: CVE + MCP tool security + skill trust + blast radius + compliance — in one tool
+2. **Blast radius analysis**: No competitor does dependency blast radius with compliance framework mapping
+3. **Runtime proxy with enforcement**: Not just scanning — real-time interception, rate limiting, credential leak blocking, rug pull detection
+4. **23 MCP tools**: Deepest MCP server integration — usable by any AI assistant
+5. **12 cloud provider coverage**: AWS/Azure/GCP + AI-specific (CoreWeave, Databricks, Snowflake, HuggingFace, W&B, MLflow, OpenAI, Ollama, Nebius)
+6. **10 compliance frameworks**: Every finding mapped to OWASP LLM/MCP/Agentic, ATLAS, NIST, EU AI Act, ISO 27001, SOC 2, CIS
+7. **Enrichment depth**: OSV + GHSA + NVD + EPSS + CISA KEV + NVIDIA + OpenSSF Scorecard + MITRE ATT&CK
+8. **Browser extension scanning**: AI assistant domain access detection — unique capability
+9. **SKILL.md behavioral analysis**: 17 risk patterns + typosquat + Sigstore provenance
+10. **OTel provenance**: Parse agent traces, flag deprecated models, cross-reference with CVEs
+11. **Context graph**: BFS lateral movement analysis from any agent
+12. **Native OCI parsing**: Scan container images without Docker/Grype/Syft installed
+13. **Policy-as-code**: 17 conditions + expression engine with AND/OR/NOT — custom enforcement
+14. **SIEM push**: Splunk/Datadog/Elasticsearch in OCSF format
+15. **VEX**: Full OpenVEX lifecycle (load/generate/apply/export) — no competitor in this space has VEX
+
+### Competitive Matrix
+
+| Capability | agent-bom | Snyk agent-scan | Cisco skill-scanner | mcp-scan | Grype | Trivy |
+|------------|-----------|-----------------|---------------------|----------|-------|-------|
+| CVE scanning | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| MCP tool security | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Skill/AGENTS.md scanning | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Blast radius | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Runtime proxy | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Compliance mapping | ✅ (10) | ❌ | ❌ | ❌ | ❌ | ✅ (partial) |
+| Cloud scanning | ✅ (12) | ❌ | ❌ | ❌ | ❌ | ✅ (IaC) |
+| SBOM/VEX | ✅ | ❌ | ❌ | ❌ | ✅ (SBOM) | ✅ (SBOM) |
+| MCP server (AI tool) | ✅ (23) | ❌ | ❌ | ❌ | ❌ | ❌ |
+| GPU/AI compute | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| SIEM integration | ✅ | Via Snyk | ❌ | ❌ | ❌ | ❌ |
+| Browser extensions | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| OTel trace analysis | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Policy engine | ✅ (17) | ❌ | ❌ | ❌ | ❌ | ✅ (Rego) |
+| Open source | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| GitHub Action | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
+
+---
+
+## 4. Snowflake Coco / Cortex Code Integration
+
+### 4.1 What is Cortex Code (Coco)?
+
+Cortex Code is Snowflake's AI coding agent, unveiled at BUILD London (Feb 3, 2026):
+- **Access**: Snowsight (web) + CLI (local shell) — **desktop app is coming** (per Renxu)
+- **Models**: Claude Opus 4.6, Claude Sonnet 4.5, GPT 5.2
+- **MCP support**: First-class — `mcp.json` at `~/.snowflake/cortex/`, connects to GitHub, Jira, custom MCP servers
+- **Extensibility**: Custom commands, tools, subagents, hooks, AGENTS.md, skills (SKILL.md)
+- **Expanding scope**: Beyond Snowflake-native — now supports dbt, Apache Airflow, any data source
+
+### 4.2 Cortex Code Security Model
+
+Cortex Code has a sophisticated security model that agent-bom should integrate with:
+
+| Feature | Details |
+|---------|---------|
+| **Three-tier approval** | Confirm (prompts), Plan (review), Bypass (trusted only) |
+| **Risk classification** | SAFE → LOW → MEDIUM → HIGH → CRITICAL for commands |
+| **SQL categorization** | READ_ONLY, WRITE, USE_ROLE — different approval levels |
+| **Dangerous pattern detection** | Pipe-to-shell, -rf, --force, system paths, hidden files |
+| **RBAC** | Full Snowflake role-based access control |
+| **OS sandboxing** | OS-level sandboxing for CLI operations |
+| **MCP security** | "Verify source and integrity" guidance — but no automated scanning |
+| **Permission caching** | Session and persistent (permissions.json) |
+| **PAT management** | ≤90-day expiration, rotation, revocation |
+| **Private mode** | `cortex --private` disables session saving |
+
+### 4.3 Integration Opportunities
+
+#### Immediate (High Value)
+
+1. **agent-bom as Cortex Code MCP server**
+   - Cortex Code supports MCP via `mcp.json` — agent-bom can be added as an MCP server
+   - All 23 tools become available to Cortex Code users
+   - Users can scan their Snowflake pipelines for CVEs, check MCP server trust, run compliance audits — all through natural language in Cortex Code
+   - Config: add agent-bom to `~/.snowflake/cortex/mcp.json`
+
+2. **Cortex Code config discovery**
+   - Add `CORTEX_CODE` to `CONFIG_LOCATIONS` in `discovery/__init__.py`
+   - Path: `~/.snowflake/cortex/mcp.json`
+   - Discover and scan all MCP servers configured for Cortex Code
+
+3. **Cortex Code skill for agent-bom**
+   - Create an agent-bom SKILL.md for Cortex Code's skills directory
+   - Cortex Code supports the same SKILL.md format — our existing skills work
+   - Deploy as a Cortex Code skill that wraps `agent-bom scan`
+
+4. **Scan Cortex Code's MCP servers**
+   - Auto-discover `~/.snowflake/cortex/mcp.json`
+   - Scan all configured MCP servers for tool poisoning, credential exposure, drift
+   - Scan their npm/pip dependencies for CVEs
+
+#### Medium-term
+
+5. **Snowflake Native App integration**
+   - Streamlit dashboard already works as Native App
+   - Can receive scan results from Cortex Code skill → visualize in Snowsight
+   - Compliance dashboards for enterprise Snowflake deployments
+
+6. **Cortex Agent MCP server scanning**
+   - Snowflake has `CREATE MCP SERVER` SQL command — managed MCP servers
+   - Scan these for tool configuration, SQL permissions, tool descriptions
+   - Verify `sql_statement_permissions` settings
+
+7. **Cortex Code permissions.json audit**
+   - Scan `~/.snowflake/cortex/permissions.json` for overly permissive cached approvals
+   - Flag "Always allow (persist)" entries for high-risk tools
+   - Detect MCP servers approved without integrity verification
+
+#### Strategic
+
+8. **Pre-built Cortex Code hook**
+   - Cortex Code supports hooks (like Claude Code)
+   - Create a pre-execution hook that runs agent-bom scan before installing new MCP servers
+   - Automatic supply chain check before any new tool is added
+
+9. **Snowflake Marketplace listing**
+   - List agent-bom as a Snowflake Marketplace offering
+   - Enterprise customers can deploy via Snowflake's ecosystem
+
+### 4.4 What Coco Needs That agent-bom Provides
+
+| Coco Security Gap | agent-bom Solution |
+|-------------------|--------------------|
+| "Verify MCP server integrity" — manual guidance only | Automated MCP server scanning (23 tools) |
+| No CVE scanning of MCP server dependencies | Full enrichment pipeline (OSV+GHSA+NVD+EPSS+KEV) |
+| No blast radius analysis | Blast radius with compliance mapping |
+| Permission caching risks (permissions.json) | Audit cached approvals, flag overly permissive |
+| AGENTS.md/SKILL.md trust unknown | 17 behavioral risk patterns + typosquat detection |
+| No runtime MCP traffic inspection | Proxy with 7 detectors, JSONL audit |
+| SQL injection via MCP tool descriptions | InputSchema injection scanning |
+| No supply chain visibility | SBOM generation, dependency graph, context graph |
+
+---
+
+## 5. OpenAI Frontier Platform
+
+### 5.1 What Is It
+
+OpenAI launched **Frontier** on Feb 5, 2026 — an enterprise platform for building, deploying, and managing AI agents:
+- **Customers**: Uber, State Farm, Intuit, Thermo Fisher Scientific
+- **Partners**: Accenture, BCG, Capgemini, McKinsey (multiyear deals)
+- **Architecture**: Intelligence layer stitching together enterprise systems and data
+- **Features**: Shared context, onboarding, learning with feedback, permissions and boundaries
+
+### 5.2 Security Implications for agent-bom
+
+| Frontier Feature | agent-bom Scanning Opportunity |
+|------------------|-------------------------------|
+| Agent permissions & boundaries | Scan permission configurations for overly broad access |
+| Enterprise system integration | Blast radius analysis of agent → system connections |
+| Agent onboarding/learning | Detect prompt injection in training/feedback loops |
+| Multi-agent orchestration | Cross-agent trust boundary analysis (context graph) |
+| MCP tool usage (via Agents SDK) | All existing MCP scanning capabilities apply |
+
+### 5.3 OpenAI Agents SDK (Confirmed)
+
+- Open-sourced March 2025, actively developed
+- **MCP support**: First-party — agents consume MCP tools
+- **Guardrails**: Input/output validation via secondary LLM
+- **Tracing**: OpenTelemetry-compatible (agent-bom's OTel ingest handles this)
+- **Security gaps**: No built-in sandboxing, no credential management, no policy enforcement, no tool signing
+
+### 5.4 Broader Agent Framework Landscape
+
+| Framework | MCP Support | Security Model | agent-bom Coverage |
+|-----------|------------|----------------|-------------------|
+| OpenAI Agents SDK | ✅ | Guardrails only | OTel ingest, MCP scanning |
+| Google ADK | ✅ | Vertex AI guardrails | MCP scanning, OTel ingest |
+| AWS Bedrock Agents | ❌ (action groups) | Managed guardrails, CloudFormation | Cloud scanning (AWS) |
+| LangGraph | Via tools | None built-in | Dependency scanning |
+| CrewAI | Via tools | None built-in | Dependency scanning |
+| AutoGen | Via tools | None built-in | Dependency scanning |
+| Mastra | ✅ | None built-in | MCP scanning |
+
+---
+
+## 6. Gap Analysis & Roadmap
+
+### 6.1 Critical Gaps to Close
+
+| Priority | Gap | Effort | Impact |
+|----------|-----|--------|--------|
+| **P0** | Add Cortex Code to CONFIG_LOCATIONS discovery | Small (1 PR) | Direct Coco integration |
+| **P0** | Create Cortex Code SKILL.md for agent-bom | Small (1 PR) | Coco users can use agent-bom |
+| **P1** | Multi-agent handoff trust analysis | Medium | Frontier/Agents SDK coverage |
+| **P1** | MCP transport security checks (HTTPS, auth) | Medium | 43% of MCP servers vulnerable |
+| **P1** | Guardrail adequacy scanning | Medium | Detect unprotected agents |
+| **P2** | Code execution sandbox verification | Medium | Safety check for code interpreters |
+| **P2** | Model weights provenance (checksums/signatures) | Medium | Model supply chain |
+| **P2** | Cross-framework agent discovery (ADK, Bedrock, CrewAI, LangGraph) | Large | Broader agent coverage |
+| **P3** | RAG poisoning detection in vector stores | Medium | Extend vector DB scanning |
+| **P3** | MCP OAuth 2.1 auth verification | Medium | As MCP auth standardizes |
+
+### 6.2 Competitive Responses Needed
+
+| Competitor Move | Our Response |
+|-----------------|-------------|
+| Snyk agent-scan: background monitoring + Snyk Evo dashboard | agent-bom watch + SIEM push already covers this; consider adding `--daemon` mode |
+| Cisco skill-scanner: deep static analysis | Our SKILL.md scanning already does 17 patterns + typosquat; add Cisco's API-key-gated patterns if publicly documented |
+| Repello SkillCheck: zero-setup browser scanner | Consider a hosted web UI for quick scans (lower priority — our CLI/MCP/Action coverage is stronger) |
+| mcp-scan: WhitelistGuard | Our policy engine can do this — document `allowed_tools` policy condition |
+
+### 6.3 Scalability Assessment
+
+| Dimension | Status | Notes |
+|-----------|--------|-------|
+| Fleet scanning | ✅ | `fleet_scan` MCP tool, batch operations |
+| Async patterns | ✅ | asyncio throughout proxy/runtime |
+| K8s discovery | ✅ | Pod labels, images, envs, CRDs |
+| Caching | ✅ | NVD 90d, EPSS 30d, KEV 24h, MITRE 30d |
+| Docker multi-arch | ✅ | amd64 + arm64 |
+| Helm chart | ✅ | K8s deployment ready |
+| CI/CD integration | ✅ | GitHub Action + SARIF upload |
+| Horizontal scaling | ⚠️ | No distributed scanning mode yet — single-process |
+| Database backend | ⚠️ | File-based caching, no shared state for multi-instance |
+
+---
+
+## 7. Trademark & IP Protection
+
+### 7.1 Trademark (Recommended — File Now)
+
+| Item | Details |
+|------|---------|
+| **What to file** | Word mark "AGENT-BOM" (covers the name in any stylization) |
+| **Classes** | Class 9 (downloadable software) + Class 42 (SaaS security services) |
+| **Filing method** | USPTO TEAS Standard ($350/class) or TEAS Plus ($250/class if using pre-approved descriptions) |
+| **Total cost (self-filing)** | $500-700 for two classes |
+| **With attorney** | $1,500-3,000 total |
+| **Timeline** | 8-12 months to registration |
+| **US system** | First-to-use (you already have priority from first commercial use) |
+| **Evidence needed** | Screenshots of PyPI listing, GitHub, Docker Hub showing the mark in commerce |
+| **International** | Madrid Protocol filing ($1,000-2,000 additional) for multi-country protection after US filing |
+
+**Action items:**
+1. Do a USPTO TESS search for "AGENT-BOM" and similar marks
+2. File TEAS Plus application (~$500 for 2 classes)
+3. Prepare specimens: screenshot of CLI output, PyPI page, Docker Hub page showing "agent-bom" branding
+4. Consider also filing for the logo if you have one
+
+### 7.2 Patent (Consider Later)
+
+Potentially patentable novel methods:
+- Blast radius analysis combined with compliance framework mapping
+- MCP tool poisoning detection via description drift + unicode normalization
+- Context graph BFS lateral movement analysis for AI agents
+- Cross-reference of OTel traces with CVE databases for runtime risk amplification
+
+**Recommendation**: File a provisional patent ($320 self, $1,600 with attorney) to establish priority date, then decide within 12 months whether to pursue full utility patent ($5-15K).
+
+---
+
+## Summary
+
+**agent-bom is uniquely positioned** — no competitor combines CVE scanning + AI agent security + runtime enforcement + compliance. The Coco opportunity is immediate and high-value:
+
+1. **File trademark NOW** — protect the name before the space gets crowded
+2. **Add Cortex Code discovery** — `~/.snowflake/cortex/mcp.json` to CONFIG_LOCATIONS (tiny PR, huge signal)
+3. **Create Cortex Code skill** — SKILL.md that wraps `agent-bom scan` for Coco users
+4. **Engage Renxu** — he can champion internal adoption at Snowflake
+5. **Position clearly**: "agent-bom is the only security scanner that covers the full AI agent stack — from CVEs to MCP tools to runtime enforcement to compliance"
+
+The competitive landscape is fragmented. Snyk has brand recognition but narrow scope. Cisco has static analysis but no runtime. Nobody else has the depth we have. The window to establish agent-bom as the definitive AI infrastructure security scanner is now.

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.63.0 demo — run with: vhs docs/demo.tape
+# agent-bom v0.65.0 demo — run with: vhs docs/demo.tape
 # Install vhs: brew install vhs  (or https://github.com/charmbracelet/vhs)
 # Prereqs:
 #   pip install agent-bom
@@ -7,7 +7,7 @@
 #     --label com.nvidia.cuda.version=12.3.0 \
 #     node:18-slim sleep 3600
 
-Output docs/images/demo-v0.63.0.gif
+Output docs/images/demo-v0.65.0.gif
 
 Set Shell "bash"
 Set FontSize 14

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 3,400+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 167 modules · 4,300+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">20 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 132 modules · 3,400+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 167 modules · 4,300+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  3,400+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  4,300+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  3,400+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  4,300+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#484f58">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  3,400+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  167 modules  ·  4,300+ tests  ·  0 runtime deps</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#94a3b8">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  132 modules  ·  3,400+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  167 modules  ·  4,300+ tests  ·  0 runtime deps</text>
 </svg>

--- a/integrations/cortex-code/README.md
+++ b/integrations/cortex-code/README.md
@@ -1,0 +1,96 @@
+# agent-bom + Cortex Code CLI Integration
+
+## Add agent-bom as an MCP Server
+
+Add to `~/.snowflake/cortex/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "uvx",
+      "args": ["agent-bom", "mcp-server"]
+    }
+  }
+}
+```
+
+Or if installed via pip/pipx:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "agent-bom",
+      "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+This gives Cortex Code access to 23 security scanning tools via natural language.
+
+## Install as a Cortex Code Skill
+
+Copy the skill to your Cortex Code skills directory:
+
+```bash
+cp integrations/cortex-code/SKILL.md ~/.snowflake/cortex/skills/agent-bom/SKILL.md
+```
+
+Or for project-level:
+
+```bash
+mkdir -p .cortex/skills/agent-bom
+cp integrations/cortex-code/SKILL.md .cortex/skills/agent-bom/SKILL.md
+```
+
+## What You Get
+
+### As MCP Server (23 tools)
+
+All agent-bom MCP tools become available in Cortex Code:
+
+| Tool | What it does |
+|------|-------------|
+| `scan` | Full discovery + vulnerability scan |
+| `check` | Pre-install CVE check for a package |
+| `blast_radius` | Map CVE impact across agents and credentials |
+| `policy_check` | Evaluate security policy against findings |
+| `registry_lookup` | Query 427+ MCP server security metadata |
+| `generate_sbom` | Generate CycloneDX or SPDX SBOM |
+| `compliance` | Map findings to 10 compliance frameworks |
+| `remediate` | Prioritized remediation plan |
+| `skill_trust` | Trust assessment for SKILL.md files |
+| `code_scan` | SAST scanning with CWE mapping |
+| `context_graph` | Lateral movement analysis |
+| `cis_benchmark` | CIS benchmark for AWS/Azure/GCP/Snowflake |
+| `gpu_infra_scan` | GPU/AI compute infrastructure scanning |
+| ... and 10 more | See `agent-bom mcp-server --help` |
+
+### As Skill
+
+Cortex Code can use agent-bom CLI commands directly:
+- "Scan my MCP setup for vulnerabilities"
+- "Check if langchain has any CVEs"
+- "Generate an SBOM for compliance"
+- "What's the blast radius of CVE-2024-21538?"
+
+## Cortex Code Security Coverage
+
+agent-bom fills these security gaps in Cortex Code:
+
+| Cortex Code guidance | agent-bom automation |
+|---------------------|---------------------|
+| "Verify MCP server integrity" | Automated scanning of all configured MCP servers |
+| "Only install from trusted sources" | Trust assessment with 17 behavioral risk patterns |
+| Manual permission review | Blast radius analysis showing credential exposure |
+| No CVE scanning | Full enrichment: OSV + NVD + EPSS + CISA KEV |
+| No compliance mapping | 10 frameworks: OWASP, NIST, EU AI Act, ISO 27001 |
+| No runtime enforcement | Proxy with 7 real-time detectors |
+
+## Auto-Discovery
+
+agent-bom already discovers Cortex Code's MCP configuration at
+`~/.snowflake/cortex/mcp.json`. Running `agent-bom scan` will
+automatically find and scan your Cortex Code MCP servers.

--- a/integrations/cortex-code/SKILL.md
+++ b/integrations/cortex-code/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: agent-bom
+description: >-
+  Security scanner for AI infrastructure — scan MCP servers and packages for CVEs,
+  map blast radius from packages to credentials and tools, detect credential exposure,
+  and enforce runtime policy. Works with Cortex Code's MCP servers, skills, and agents.
+tools:
+  - bash
+---
+
+# agent-bom — Security Scanner for AI Infrastructure
+
+Scan your MCP servers, packages, and AI agent configurations for CVEs,
+credential exposure, and supply chain risks. Maps blast radius from
+vulnerable packages to the credentials and tools they can reach.
+
+## When to Use
+
+- Before installing a new MCP server or skill
+- To audit your Cortex Code MCP configuration for vulnerabilities
+- To check if a specific package has known CVEs
+- To map the blast radius of a vulnerability across your agent setup
+- To generate an SBOM for compliance (CycloneDX, SPDX)
+- To verify package integrity via Sigstore provenance
+
+## What This Skill Provides
+
+- **CVE scanning** with enrichment from OSV, NVD, EPSS, CISA KEV
+- **MCP server discovery** across 21 AI tools (including Cortex Code)
+- **Blast radius mapping** — which agents, credentials, and tools are exposed
+- **10 compliance frameworks** per finding (OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST, EU AI Act)
+- **Runtime proxy** for MCP traffic interception and policy enforcement
+- **SKILL.md trust assessment** with 17 behavioral risk patterns
+
+## Install
+
+```bash
+# Install via pip or pipx
+pipx install agent-bom
+
+# Or run directly with uvx (no install needed)
+uvx agent-bom scan
+```
+
+## Instructions
+
+### Scan the current MCP setup
+
+```bash
+agent-bom scan
+```
+
+Auto-discovers all configured MCP clients (Cortex Code, Claude Desktop, Cursor, etc.),
+resolves their server packages, and scans for CVEs.
+
+### Check a package before installing
+
+```bash
+agent-bom check <package>@<version> --ecosystem <npm|pypi|go|maven|cargo|nuget|gem>
+```
+
+### Map blast radius of a CVE
+
+```bash
+agent-bom scan --enrich
+# Then review the blast radius section in the output
+```
+
+### Generate SBOM
+
+```bash
+agent-bom scan -f cyclonedx -o sbom.json
+agent-bom scan -f spdx -o sbom.spdx.json
+```
+
+### Scan with GPU infrastructure detection
+
+```bash
+agent-bom scan --gpu-scan
+```
+
+### Run as MCP server (for other AI tools)
+
+```bash
+agent-bom mcp-server
+```
+
+### Proxy MCP traffic with policy enforcement
+
+```bash
+agent-bom proxy --command "npx @modelcontextprotocol/server-filesystem /tmp" --policy policy.yml
+```
+
+## Common Patterns
+
+### Pre-install security check
+When a user asks to install a new MCP server or package:
+1. Run `agent-bom check <package> --ecosystem <ecosystem>`
+2. If vulnerabilities found, show severity and suggest fixed versions
+3. If clean, confirm safe to proceed
+
+### Full security audit
+When a user asks for a security review:
+1. Run `agent-bom scan --enrich`
+2. Summarize findings by severity
+3. Highlight any credential exposure
+4. Show blast radius for critical/high findings
+
+### Compliance report
+When compliance documentation is needed:
+1. Run `agent-bom scan -f cyclonedx -o sbom.json`
+2. Run `agent-bom scan --enrich` for compliance framework mapping
+3. Report maps to OWASP, NIST, EU AI Act, ISO 27001, SOC 2
+
+## Best Practices
+
+- Always run `agent-bom check` before adding new MCP servers to your `mcp.json`
+- Use `--enrich` for full NVD/EPSS/KEV enrichment (slower but more complete)
+- Review blast radius for any CRITICAL or HIGH findings
+- Use `agent-bom scan -f sarif` for CI/CD integration with GitHub Security tab
+- No API keys required for basic scanning (NVD_API_KEY optional for higher rate limits)
+
+## Privacy
+
+- Only public package names and versions are sent to vulnerability databases
+- Credentials in MCP configs are redacted by `sanitize_env_vars()`
+- No telemetry, no tracking, no analytics
+- Apache 2.0 licensed, fully open source

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4086
+  tests: 4314
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -310,5 +310,5 @@ configured credentials and call only the cloud provider's own APIs.
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.64.0`
-- **4,086 tests** with CodeQL + OpenSSF Scorecard
+- **4,300+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4086
+  tests: 4314
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -127,5 +127,5 @@ No credentials needed.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **3,400+ tests** with CodeQL + OpenSSF Scorecard
+- **4,300+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4086
+  tests: 4314
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -110,5 +110,5 @@ as a string argument (no file system access needed).
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **3,400+ tests** with CodeQL + OpenSSF Scorecard
+- **4,300+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4086
+  tests: 4314
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -90,5 +90,5 @@ ClickHouse endpoint for persistent analytics.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **3,400+ tests** with CodeQL + OpenSSF Scorecard
+- **4,300+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4086
+  tests: 4314
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -110,7 +110,7 @@ metadata:
 
 # agent-bom-scan — AI Supply Chain Vulnerability Scanner
 
-Discovers MCP clients and servers across 20 AI tools, checks packages for CVEs,
+Discovers MCP clients and servers across 21 AI tools, checks packages for CVEs,
 maps blast radius, and generates remediation plans.
 
 ## Install
@@ -188,5 +188,5 @@ CVE IDs are sent to vulnerability databases.
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.65.0
-- **3,400+ tests** with CodeQL + OpenSSF Scorecard
+- **4,300+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics


### PR DESCRIPTION
## Summary
- Add Cortex Code CLI integration — SKILL.md for Coco's skills directory + README with MCP server setup guide (`~/.snowflake/cortex/mcp.json`)
- Align all stale counts across 14 files: tests (3,400+ → 4,300+), modules (132 → 167), MCP clients (20 → 21)
- Update `docs/demo.tape` version references from v0.63.0 to v0.65.0
- Add strategic audit doc covering competitive landscape, Coco/Cortex integration strategy, OpenAI Frontier, and gap analysis

## Test plan
- [ ] Verify SVG diagrams render correctly with updated counts
- [ ] Verify Cortex Code SKILL.md works when copied to `~/.snowflake/cortex/skills/agent-bom/`
- [ ] Verify agent-bom MCP server starts via Cortex Code's `mcp.json` config
- [ ] CI passes (no Python changes, docs/integration only)