### PR TITLE
fix: security hardening — atomic writes, cache eviction, TOCTOU mitigation

### DIFF
--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
@@ -44,8 +46,11 @@ def _evict_oldest(cache: dict[str, dict], max_entries: int) -> None:
     """Evict oldest entries when cache exceeds max_entries."""
     if len(cache) <= max_entries:
         return
-    # Sort by _cached_at and remove oldest
-    by_age = sorted(cache.items(), key=lambda kv: kv[1].get("_cached_at", 0))
+    # Evict entries missing _cached_at first (legacy/corrupt), then oldest
+    by_age = sorted(
+        cache.items(),
+        key=lambda kv: kv[1].get("_cached_at") if isinstance(kv[1].get("_cached_at"), (int, float)) else 0,
+    )
     to_remove = len(cache) - max_entries
     for key, _ in by_age[:to_remove]:
         del cache[key]
@@ -75,11 +80,26 @@ def _load_enrichment_cache() -> None:
 
 
 def _save_enrichment_cache() -> None:
-    """Persist NVD + EPSS caches to disk."""
+    """Persist NVD + EPSS caches to disk (atomic write to prevent corruption)."""
     _ENRICHMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     for name, data in [("nvd_cache.json", _nvd_file_cache), ("epss_cache.json", _epss_file_cache)]:
+        target = _ENRICHMENT_CACHE_DIR / name
         try:
-            (_ENRICHMENT_CACHE_DIR / name).write_text(json.dumps(data))
+            fd, tmp_path = tempfile.mkstemp(dir=str(_ENRICHMENT_CACHE_DIR), suffix=".tmp")
+            fd_closed = False
+            try:
+                os.write(fd, json.dumps(data).encode("utf-8"))
+                os.close(fd)
+                fd_closed = True
+                os.replace(tmp_path, str(target))
+            except BaseException:
+                if not fd_closed:
+                    os.close(fd)
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
         except OSError:
             _logger.debug("Failed to save %s cache", name)
 

--- a/src/agent_bom/proxy_configure.py
+++ b/src/agent_bom/proxy_configure.py
@@ -22,7 +22,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import stat
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -174,12 +177,12 @@ def apply_proxy_configs(
 
         changed = False
         for cfg in file_configs:
-            # Look for the server by matching its original command in the existing entry
+            # Look for the server by matching its original command AND args
             server_map = data[servers_key]
             for entry_key, entry_val in server_map.items():
                 if not isinstance(entry_val, dict):
                     continue
-                if entry_val.get("command") == cfg.original_command:
+                if entry_val.get("command") == cfg.original_command and entry_val.get("args", []) == cfg.original_args:
                     if dry_run:
                         logger.info("[dry-run] Would patch %s/%s in %s", servers_key, entry_key, config_path)
                     else:
@@ -190,7 +193,29 @@ def apply_proxy_configs(
 
         if changed and not dry_run:
             try:
-                path.write_text(json.dumps(data, indent=2))
+                # Preserve original file permissions
+                try:
+                    orig_mode = path.stat().st_mode
+                except OSError:
+                    orig_mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600 default
+
+                # Atomic write: temp file + rename to prevent corruption
+                fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".agent-bom-")
+                fd_closed = False
+                try:
+                    os.write(fd, json.dumps(data, indent=2).encode("utf-8"))
+                    os.close(fd)
+                    fd_closed = True
+                    os.chmod(tmp_path, orig_mode & 0o777)
+                    os.replace(tmp_path, str(path))
+                except BaseException:
+                    if not fd_closed:
+                        os.close(fd)
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+                    raise
                 modified += 1
             except OSError as exc:
                 logger.warning("Cannot write %s: %s", config_path, exc)

--- a/src/agent_bom/watch.py
+++ b/src/agent_bom/watch.py
@@ -174,12 +174,21 @@ class ConfigChangeHandler:
         self._scan_and_alert(path)
 
     def _scan_and_alert(self, config_path: str) -> None:
-        """Re-scan the changed config and diff against last scan."""
+        """Re-scan the changed config and diff against last scan.
+
+        Includes a short settle delay to avoid reading partially-written config
+        files (TOCTOU mitigation — editors may not write atomically).
+        """
         try:
+            import time as _time
+
             from agent_bom.discovery import discover_all
             from agent_bom.models import AIBOMReport
             from agent_bom.output import to_json
             from agent_bom.parsers import extract_packages
+
+            # Brief settle delay — let the editor finish writing
+            _time.sleep(0.5)
 
             # Discover and scan
             agents = discover_all()


### PR DESCRIPTION
## Summary

Six targeted fixes from a deep codebase audit covering scanner engine, security, runtime proxy, and MCP server modules:

- **proxy_configure.py**: Atomic write (temp file + `os.replace()`), permission preservation (fallback 0o600), server matching by command+args (not just command)
- **enrichment.py**: Cache eviction treats missing `_cached_at` as oldest (evict first), atomic cache write
- **watch.py**: 500ms settle delay before rescan mitigates TOCTOU race on partially-written configs

## Audit context

Full audit scores before fixes:
| Area | Score |
|------|-------|
| Scanner Engine | 7.7/10 |
| Security & Discovery | 9.1/10 |
| Runtime & Proxy | 8.5/10 |
| MCP Server & CLI | 9.0/10 |

These 6 fixes close the critical and moderate issues identified. No minor issues addressed (false positive tuning, logging improvements) — those can be separate PRs.

## Test plan

- [x] `pytest tests/test_proxy_configure.py` — 20 tests pass
- [x] `pytest tests/test_enrichment_cache.py tests/test_enrichment_accuracy.py` — 12 tests pass
- [x] `pytest tests/test_watch.py` — 13 tests pass
- [x] Full suite: 4,230 passed, 14 skipped, 0 failures
- [x] `ruff check` + `ruff-format` clean