### PR TITLE
fix: proxy/runtime depth — 4 correctness and security fixes

### DIFF
--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -559,8 +559,13 @@ async def run_proxy(
         policy = json.loads(Path(policy_path).read_text())
 
     # Open audit log with restricted permissions (0o600)
+    # Reject symlinks to prevent log injection attacks (attacker creates
+    # symlink to overwrite another file via the proxy's audit writes).
     log_file = None
     if log_path:
+        log_p = Path(log_path)
+        if log_p.is_symlink():
+            raise ValueError(f"Audit log path must not be a symlink: {log_path}")
         fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
         log_file = os.fdopen(fd, "a")
 
@@ -750,7 +755,7 @@ async def run_proxy(
 
                     # Gateway policy evaluation
                     if _gateway_evaluator is not None:
-                        gw_allowed, gw_reason = _gateway_evaluator(tool_name, arguments)
+                        gw_allowed, gw_reason = _gateway_evaluator(agent_id, tool_name, arguments)
                         if not gw_allowed:
                             metrics.record_blocked("gateway_policy")
                             if log_file:
@@ -896,6 +901,24 @@ async def run_proxy(
                         vec_alerts = vector_detector.check(ri_tool or "unknown", ri_text)
                         _handle_alerts(vec_alerts, log_file)
 
+                # Response signing — compute HMAC on ORIGINAL response before
+                # inline scanning may modify msg (tamper detection must sign
+                # the server's actual response, not a scanner-modified version).
+                if response_signing_key and log_file:
+                    sig = compute_response_hmac(msg, response_signing_key)
+                    sig_entry = (
+                        json.dumps(
+                            {
+                                "ts": datetime.now(timezone.utc).isoformat(),
+                                "type": "response_hmac",
+                                "id": msg.get("id"),
+                                "hmac_sha256": sig,
+                            }
+                        )
+                        + "\n"
+                    )
+                    log_file.write(sig_entry)
+
                 # Inline response scanning (PII, secrets, payload vuln)
                 if scan_config.enabled and "result" in msg:
                     resp_text = json.dumps(msg.get("result", ""))
@@ -935,22 +958,6 @@ async def run_proxy(
                 stale = [k for k, (_, t) in pending_calls.items() if now_mono - t > pending_call_ttl]
                 for k in stale:
                     pending_calls.pop(k, None)
-
-            # Response signing — write HMAC to audit log for tamper detection
-            if msg and response_signing_key and log_file:
-                sig = compute_response_hmac(msg, response_signing_key)
-                sig_entry = (
-                    json.dumps(
-                        {
-                            "ts": datetime.now(timezone.utc).isoformat(),
-                            "type": "response_hmac",
-                            "id": msg.get("id"),
-                            "hmac_sha256": sig,
-                        }
-                    )
-                    + "\n"
-                )
-                log_file.write(sig_entry)
 
             # Forward to client
             sys.stdout.buffer.write(line)

--- a/src/agent_bom/runtime/detectors.py
+++ b/src/agent_bom/runtime/detectors.py
@@ -284,7 +284,12 @@ class SequenceAnalyzer:
 
         pattern_idx = 0
         for call in calls:
-            if re.search(patterns[pattern_idx], call, re.IGNORECASE):
+            # Normalize separators to spaces so word boundaries work on
+            # tool names like "read_file" or "http-request" — prevents
+            # false positives like "spreadsheet" matching "read"
+            normalized = re.sub(r"[_\-.]", " ", call)
+            bounded = rf"\b(?:{patterns[pattern_idx]})\b"
+            if re.search(bounded, normalized, re.IGNORECASE):
                 pattern_idx += 1
                 if pattern_idx == len(patterns):
                     return True


### PR DESCRIPTION
## Summary
- **Gateway evaluator signature**: was called with 2 args (`tool_name, arguments`) but documented signature expects 3 (`agent_id, tool_name, arguments`) — would crash with TypeError when gateway is enabled
- **HMAC signing order**: was signing the response AFTER inline scanner could modify it, defeating tamper detection. Now signs the original server response before any modification
- **SequenceAnalyzer false positives**: `re.search("read", "spreadsheet")` was True — now normalizes tool names (`_`→space) and uses `\b` word boundaries so only actual `read`/`run`/`exec` tool names match
- **Audit log symlink guard**: rejects symlink paths to prevent log injection via symlink dereference (defense-in-depth)

## Test plan
- [x] All 4,230 tests pass locally
- [ ] CI green on Python 3.11/3.12/3.13