### PR TITLE
fix: proxy/runtime depth round 2 — detection accuracy and drift reliability

### DIFF
--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -202,6 +202,7 @@ async def _query_capabilities(
     """Query tools/list and resources/list from an active MCP session."""
 
     # ── Tools ──────────────────────────────────────────────────────────
+    tools_ok = False
     try:
         tools_result = await session.list_tools()
         for tool in tools_result.tools:
@@ -212,10 +213,12 @@ async def _query_capabilities(
                     input_schema=getattr(tool, "inputSchema", None),
                 )
             )
+        tools_ok = True
     except Exception as exc:
-        logger.debug("tools/list failed for %s: %s", server.name, exc)
+        logger.warning("tools/list failed for %s: %s — drift detection skipped", server.name, exc)
 
     # ── Resources ──────────────────────────────────────────────────────
+    resources_ok = False
     try:
         resources_result = await session.list_resources()
         for resource in resources_result.resources:
@@ -227,23 +230,28 @@ async def _query_capabilities(
                     mime_type=getattr(resource, "mimeType", None),
                 )
             )
+        resources_ok = True
     except Exception as exc:
-        logger.debug("resources/list failed for %s: %s", server.name, exc)
+        logger.warning("resources/list failed for %s: %s", server.name, exc)
 
     result.success = True
 
     # ── Drift detection ────────────────────────────────────────────────
+    # Only compare tools if tools/list succeeded — otherwise empty runtime_tools
+    # would falsely report all config tools as "removed".
     config_tool_names = {t.name for t in server.tools}
     runtime_tool_names = {t.name for t in result.runtime_tools}
 
-    result.tools_added = sorted(runtime_tool_names - config_tool_names)
-    result.tools_removed = sorted(config_tool_names - runtime_tool_names)
+    if tools_ok:
+        result.tools_added = sorted(runtime_tool_names - config_tool_names)
+        result.tools_removed = sorted(config_tool_names - runtime_tool_names)
 
-    config_resource_uris = {r.uri for r in server.resources}
-    runtime_resource_uris = {r.uri for r in result.runtime_resources}
+    if resources_ok:
+        config_resource_uris = {r.uri for r in server.resources}
+        runtime_resource_uris = {r.uri for r in result.runtime_resources}
 
-    result.resources_added = sorted(runtime_resource_uris - config_resource_uris)
-    result.resources_removed = sorted(config_resource_uris - runtime_resource_uris)
+        result.resources_added = sorted(runtime_resource_uris - config_resource_uris)
+        result.resources_removed = sorted(config_resource_uris - runtime_resource_uris)
 
     return result
 

--- a/src/agent_bom/runtime/patterns.py
+++ b/src/agent_bom/runtime/patterns.py
@@ -34,7 +34,10 @@ DANGEROUS_ARG_PATTERNS: list[tuple[str, re.Pattern]] = [
     ("Shell metacharacter", re.compile(r"[;&|`$]|\$\(|>\s*/|<\s*/")),
     ("Path traversal", re.compile(r"\.\./|\.\.\\|%2e%2e")),
     ("Command injection", re.compile(r"\b(?:curl|wget|nc|ncat|bash|sh|python|perl|ruby)\s", re.IGNORECASE)),
-    ("Environment variable access", re.compile(r"\$(?:HOME|PATH|USER|AWS_|ANTHROPIC_|OPENAI_|GITHUB_)", re.IGNORECASE)),
+    (
+        "Environment variable access",
+        re.compile(r"\$\{?(?:HOME|PATH|USER|AWS_[A-Z_]+|ANTHROPIC_[A-Z_]+|OPENAI_[A-Z_]+|GITHUB_[A-Z_]+)\b", re.IGNORECASE),
+    ),
     ("Credential-like value", re.compile(r"(?:password|secret|token|key)\s*[=:]\s*\S{8,}", re.IGNORECASE)),
     ("Base64 encoded payload", re.compile(r"(?:^|[^A-Za-z0-9])(?:[A-Za-z0-9+/]{40,}={0,2})(?:$|[^A-Za-z0-9])")),
     ("Hex encoded payload", re.compile(r"\\x[0-9a-fA-F]{2}(?:\\x[0-9a-fA-F]{2}){9,}")),
@@ -75,7 +78,7 @@ RESPONSE_INVISIBLE_CHARS: list[tuple[str, re.Pattern]] = [
 ]
 
 # Base64 encoded content in responses (potential exfiltration staging)
-RESPONSE_BASE64_PATTERN = re.compile(r"(?:^|[^A-Za-z0-9+/])([A-Za-z0-9+/]{60,}={0,2})(?:$|[^A-Za-z0-9+/])")
+RESPONSE_BASE64_PATTERN = re.compile(r"(?:(?:^|[^A-Za-z0-9+/]))([A-Za-z0-9+/]{60,}={0,2})(?:$|[^A-Za-z0-9+/])", re.MULTILINE)
 
 
 # ─── Prompt injection patterns in tool responses ──────────────────────────────

--- a/src/agent_bom/runtime_correlation.py
+++ b/src/agent_bom/runtime_correlation.py
@@ -209,9 +209,11 @@ def _compute_amplifier(
     if call_info["count"] >= 10:
         amp += RISK_AMPLIFIER_FREQUENT - RISK_AMPLIFIER_CALLED  # +0.5 bonus for frequent
 
-    # Check recency
+    # Check recency — ensure timezone-aware comparison
     try:
         last = datetime.fromisoformat(call_info["last_called"].replace("Z", "+00:00"))
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
         now = datetime.now(timezone.utc)
         hours_since = (now - last).total_seconds() / 3600
         if hours_since <= recency_hours:


### PR DESCRIPTION
## Summary
- **Base64 detection**: pattern now catches blobs at message boundaries (start of line/string) using `re.MULTILINE` — previously missed base64 at response start
- **Env var false positives**: pattern requires full variable name (`AWS_SECRET_KEY`) instead of just prefix (`AWS_`) — stops flagging documentation strings that mention env vars
- **Drift detection reliability**: skip tool/resource drift comparison when `tools/list` or `resources/list` fails — prevents false "all tools removed" alerts when server introspection partially errors
- **Timezone safety**: ensure timezone-aware datetime comparison in runtime correlation recency bonus — naive timestamps no longer silently skip the recency multiplier

## Test plan
- [x] All 4,230 tests pass locally
- [ ] CI green on Python 3.11/3.12/3.13