### PR TITLE
fix: toxic_combos word boundary — normalize separators before matching

### DIFF
--- a/src/agent_bom/toxic_combos.py
+++ b/src/agent_bom/toxic_combos.py
@@ -33,10 +33,11 @@ class ToxicPattern(str, Enum):
 def _word_boundary_match(keyword: str, text: str) -> bool:
     """Check if keyword appears as a whole word (not substring) in text.
 
-    Uses word boundaries so "run" matches "run_command" and "run command"
-    but not "runner" or "list_runner_status".
+    Normalizes separators (underscores, hyphens, dots) to spaces first so
+    "run" matches "run_command" and "run-task" but not "runner".
     """
-    return bool(re.search(rf"\b{re.escape(keyword)}\b", text))
+    normalized = re.sub(r"[_\-.]", " ", text)
+    return bool(re.search(rf"\b{re.escape(keyword)}\b", normalized))
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- `_word_boundary_match()` used raw `\b` on tool names but underscores are word characters in regex, so `"run"` failed to match `"run_command"` — a false negative in dangerous tool detection
- Now normalizes `_`/`-`/`.` to spaces before matching, consistent with SequenceAnalyzer (detectors.py) and enforcement.py which already do this

## Test plan
- [x] All 4,230 tests pass locally
- [x] Verified: `run_command` ✓, `shell_execute` ✓, `write_file` ✓ — all now detected
- [x] Verified: `runner` ✗, `list_runner_status` ✗, `spreadsheet` ✗ — no false positives
- [ ] CI green on Python 3.11/3.12/3.13