### PR TITLE
feat: security hardening + context-aware compliance tags

### DIFF
--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -2653,7 +2653,31 @@ def scan(
                 con.print(f"  [yellow]⚠[/yellow] Cortex observability failed: {exc}")
 
     # Build report
-    report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+    # Determine scan sources for context-aware output and framework applicability
+    _scan_sources: list[str] = []
+    if inventory or dynamic_discovery:
+        _scan_sources.append("agent_discovery")
+    if images or image_tars:
+        _scan_sources.append("image")
+    if sbom_file:
+        _scan_sources.append("sbom")
+    if k8s or k8s_mcp:
+        _scan_sources.append("k8s")
+    if filesystem_paths:
+        _scan_sources.append("filesystem")
+    if tf_dirs:
+        _scan_sources.append("terraform")
+    if gha_path:
+        _scan_sources.append("github_actions")
+    if browser_extensions:
+        _scan_sources.append("browser_extensions")
+    if jupyter_dirs:
+        _scan_sources.append("jupyter")
+    if gpu_scan_flag:
+        _scan_sources.append("gpu_infra")
+    if not _scan_sources:
+        _scan_sources.append("agent_discovery")  # Default scan type
+    report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=_scan_sources)
     if _skill_audit_data:
         report.skill_audit_data = _skill_audit_data
     if _trust_assessment_data:

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -8,7 +8,7 @@ import logging
 import os
 import tempfile
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -240,7 +240,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
 
     # Use cache if less than 24 hours old
     if _kev_cache and _kev_cache_time:
-        age = datetime.now() - _kev_cache_time
+        age = datetime.now(timezone.utc) - _kev_cache_time
         if age.total_seconds() < 86400:  # 24 hours
             return _kev_cache
 
@@ -264,7 +264,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
                     }
 
             _kev_cache = kev_dict
-            _kev_cache_time = datetime.now()
+            _kev_cache_time = datetime.now(timezone.utc)
             return kev_dict
         except (ValueError, KeyError) as e:
             console.print(f"  [dim yellow]CISA KEV parse error: {e}[/dim yellow]")

--- a/src/agent_bom/http_client.py
+++ b/src/agent_bom/http_client.py
@@ -77,6 +77,7 @@ def create_client(timeout: float | None = None, max_redirects: int = 5) -> httpx
         transport=transport,
         follow_redirects=True,
         max_redirects=max_redirects,
+        verify=True,  # Explicit: always verify TLS certificates (defense-in-depth)
     )
 
 

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -410,6 +410,21 @@ class AIBOMReport:
     gpu_infra_data: Optional[dict] = None  # Serialized GPU/AI compute infra scan results
     runtime_correlation: Optional[dict] = None  # Runtime ↔ scan correlation (proxy audit vs CVE findings)
 
+    # Scan context metadata — what input sources were actually processed.
+    # Populated by the CLI/API after scan completes. Consumers use this to
+    # determine which UI panels, compliance frameworks, and graphs apply.
+    scan_sources: list[str] = field(default_factory=list)  # e.g. ["agent_discovery", "image", "sbom"]
+
+    @property
+    def has_mcp_context(self) -> bool:
+        """True if scan discovered MCP servers (enables MCP/Agentic framework tags)."""
+        return any(len(a.mcp_servers) > 0 for a in self.agents)
+
+    @property
+    def has_agent_context(self) -> bool:
+        """True if scan discovered AI agents (enables agent-specific graphs)."""
+        return len(self.agents) > 0 and any(a.mcp_servers for a in self.agents)
+
     def __post_init__(self):
         if not self.tool_version:
             from agent_bom import __version__

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1417,6 +1417,9 @@ def to_json(report: AIBOMReport) -> dict:
         "spec_version": "1.0",
         "ai_bom_version": report.tool_version,
         "generated_at": report.generated_at.isoformat(),
+        "scan_sources": report.scan_sources,
+        "has_mcp_context": report.has_mcp_context,
+        "has_agent_context": report.has_agent_context,
         "summary": {
             "total_agents": report.total_agents,
             "total_mcp_servers": report.total_servers,

--- a/src/agent_bom/owasp_agentic.py
+++ b/src/agent_bom/owasp_agentic.py
@@ -56,10 +56,15 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     - ASI09: Always — any vuln in agent stack = trust exploitation risk.
     - ASI10: Credentials + EXECUTE capability + HIGH+ (persistent rogue).
     """
+    # Agentic tags only apply when there are actual agents in the blast radius.
+    # A container image scan with no agent context should NOT get Agentic tags.
+    if not br.affected_agents:
+        return []
+
     tags: set[str] = {
-        "ASI01",  # always — autonomy risk
-        "ASI04",  # always — supply chain
-        "ASI09",  # always — trust exploitation
+        "ASI01",  # autonomy risk (within agentic context)
+        "ASI04",  # supply chain (within agentic context)
+        "ASI09",  # trust exploitation (within agentic context)
     }
 
     has_exec = False

--- a/src/agent_bom/owasp_mcp.py
+++ b/src/agent_bom/owasp_mcp.py
@@ -53,7 +53,12 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     - MCP09: Server found via discovery but not in the curated registry.
     - MCP10: A reachable tool has READ capability AND credentials are exposed.
     """
-    tags: set[str] = {"MCP04"}  # always — supply chain attack surface
+    # MCP tags only apply when there are actual MCP servers in the blast radius.
+    # A plain container image scan with no MCP context should NOT get MCP tags.
+    if not br.affected_servers:
+        return []
+
+    tags: set[str] = {"MCP04"}  # supply chain attack surface (within MCP context)
 
     # MCP01 — token/secret exposure via credential env vars
     if br.exposed_credentials:

--- a/src/agent_bom/remediate.py
+++ b/src/agent_bom/remediate.py
@@ -66,6 +66,14 @@ class RemediationPlan:
 
 # ─── Package fix generation ──────────────────────────────────────────────────
 
+_SHELL_METACHAR_RE = re.compile(r"[;&|`$\n\r<>\"'\\]")
+
+
+def _has_shell_metachar(value: str) -> bool:
+    """Check if a string contains shell metacharacters that could enable injection."""
+    return bool(_SHELL_METACHAR_RE.search(value))
+
+
 _ECOSYSTEM_COMMANDS: dict[str, str] = {
     "npm": "npm install {package}@{version}",
     "pypi": "pip install '{package}>={version}'",
@@ -100,8 +108,25 @@ def generate_package_fixes(plan_items: list[dict]) -> tuple[list[PackageFix], li
             )
             continue
 
+        # Validate package name and version before templating to prevent
+        # command injection via malicious OSV/NVD response data.
+        pkg_name = item["package"]
+        fix_ver = item["fix"]
+        if _has_shell_metachar(pkg_name) or _has_shell_metachar(fix_ver):
+            logger.warning("Skipping remediation for %s — unsafe characters in name/version", pkg_name)
+            unfixable.append(
+                {
+                    "package": pkg_name,
+                    "ecosystem": item["ecosystem"],
+                    "reason": "unsafe characters in package name or version",
+                    "current_version": item["current"],
+                    "vulns": item["vulns"],
+                    "agents": item["agents"],
+                }
+            )
+            continue
         template = _ECOSYSTEM_COMMANDS.get(item["ecosystem"], "# Upgrade {package} to {version}")
-        command = template.format(package=item["package"], version=item["fix"])
+        command = template.format(package=pkg_name, version=fix_ver)
 
         fixable.append(
             PackageFix(
@@ -656,8 +681,12 @@ def apply_fixes_from_json(
         if not fixed:
             continue
         eco = item.get("ecosystem", "")
+        pkg_name = item["package"]
+        if _has_shell_metachar(pkg_name) or _has_shell_metachar(fixed):
+            logger.warning("Skipping auto-apply for %s — unsafe characters", pkg_name)
+            continue
         template = _ECOSYSTEM_COMMANDS.get(eco, "# Upgrade {package} to {version}")
-        command = template.format(package=item["package"], version=fixed)
+        command = template.format(package=pkg_name, version=fixed)
         fixable.append(
             PackageFix(
                 package=item["package"],


### PR DESCRIPTION
## Summary

**Security hardening:**
- KEV cache uses UTC-aware datetime (was naive — could break on DST/clock changes)
- Remediation commands validate package names and versions for shell metacharacters before templating (prevents injection via malicious OSV/NVD data)
- HTTP client uses explicit `verify=True` for TLS certificate validation (defense-in-depth)

**Context-aware compliance:**
- `AIBOMReport.scan_sources` tracks what was actually scanned (e.g. `["agent_discovery", "image"]`)
- `has_mcp_context` / `has_agent_context` properties for UI and API consumers to know what panels apply
- JSON output includes scan context metadata
- **OWASP MCP tags now require MCP servers in blast radius** — a plain `--image nginx:latest` scan no longer gets MCP04/MCP07/MCP09
- **OWASP Agentic tags now require agents in blast radius** — no more ASI01/ASI04/ASI09 on non-agent scans

This makes compliance output factual and context-appropriate rather than always-on.

## Test plan
- [x] All 4,230 tests pass locally
- [ ] CI green on Python 3.11/3.12/3.13