### PR TITLE
chore: bump version to v0.66.0

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           uv run agent-bom scan --sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.65.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.65.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.66.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.66.0"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.65.0  # pinned — bump on each release
+        run: uv tool install agent-bom==0.66.0  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -13,14 +13,14 @@
 ## ── Builder stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49 AS builder
 
-ARG VERSION=0.65.0
+ARG VERSION=0.66.0
 
 RUN pip install --no-cache-dir --prefix=/install agent-bom==${VERSION}
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.65.0
+ARG VERSION=0.66.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.snowpark
+++ b/Dockerfile.snowpark
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11-slim@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
-ARG VERSION=0.65.0
+ARG VERSION=0.66.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.65.0
+ARG VERSION=0.66.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="Security scanner for AI infrastructure — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.65.0"
+  --version "0.66.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.65.0
-git push origin v0.65.0
+git tag v0.66.0
+git push origin v0.66.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
-| GitHub Action | `uses: msaad00/agent-bom@v0.65.0 | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.66.0 | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` (23 tools) | Inside any MCP client |
@@ -300,7 +300,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 <summary><b>GitHub Action</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.65.0
+- uses: msaad00/agent-bom@v0.66.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -382,7 +382,7 @@ Options:
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.65.0 |
+| GitHub Action | `uses: msaad00/agent-bom@v0.66.0 |
 | Glama | [glama.ai/mcp/servers/@msaad00/agent-bom](https://glama.ai/mcp/servers/@msaad00/agent-bom) |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: AI supply chain security scanner — scan containers, MCP servers, and AI agents for CVEs, credential exposure, and compliance violations
 version: 0.1.0
-appVersion: "0.65.0"
+appVersion: "0.66.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.65.0"
+  tag: "0.66.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.65.0"
+  tag: "0.66.0"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.65.0
+- uses: msaad00/agent-bom@v0.66.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -49,7 +49,7 @@
   <rect x="330" y="66" width="300" height="3" rx="1.5" fill="#bc8cff"/>
   <rect x="342" y="80" width="34" height="15" rx="4" fill="#bc8cff"/>
   <text x="359" y="91" text-anchor="middle" class="badge">MCP</text>
-  <text x="386" y="91" class="mode-title" fill="#bc8cff">MCP Server — 19 Tools</text>
+  <text x="386" y="91" class="mode-title" fill="#bc8cff">MCP Server — 23 Tools</text>
   <text x="342" y="108" class="mode-cmd">agent-bom mcp-server [--transport sse]</text>
   <text x="342" y="124" class="mode-feat">AI agents call scan, check, blast_radius</text>
   <text x="342" y="138" class="mode-feat">Registry lookup for 427+ MCP servers</text>
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#3fb950"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#3fb950">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.57.0</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.66.0</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>
@@ -137,7 +137,7 @@
 
   <rect x="536" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#f0883e" stroke-width="0.8"/>
   <text x="594" y="402" text-anchor="middle" class="engine-mod" fill="#f0883e">Compliance</text>
-  <text x="594" y="416" text-anchor="middle" class="engine-detail">10 frameworks</text>
+  <text x="594" y="416" text-anchor="middle" class="engine-detail">11 frameworks</text>
 
   <rect x="662" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#f85149" stroke-width="0.8"/>
   <text x="720" y="402" text-anchor="middle" class="engine-mod" fill="#f85149">Policy</text>
@@ -215,7 +215,7 @@
   <!-- ═══════════════════════════════════════════════════════════ -->
   <rect x="20" y="640" width="920" height="2" rx="1" fill="#30363d" opacity="0.4"/>
 
-  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#58a6ff">19</text>
+  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#58a6ff">23</text>
   <text x="120" y="680" text-anchor="middle" class="engine-detail">MCP tools</text>
 
   <text x="240" y="666" text-anchor="middle" class="mode-title" fill="#bc8cff">427+</text>
@@ -224,13 +224,13 @@
   <text x="360" y="666" text-anchor="middle" class="mode-title" fill="#3fb950">20</text>
   <text x="360" y="680" text-anchor="middle" class="engine-detail">client integrations</text>
 
-  <text x="480" y="666" text-anchor="middle" class="mode-title" fill="#d29922">5</text>
+  <text x="480" y="666" text-anchor="middle" class="mode-title" fill="#d29922">7</text>
   <text x="480" y="680" text-anchor="middle" class="engine-detail">runtime detectors</text>
 
-  <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#f0883e">10</text>
+  <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#f0883e">11</text>
   <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#f85149">3,400+</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#f85149">4,230+</text>
   <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
   <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#bc8cff">12</text>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -49,7 +49,7 @@
   <rect x="330" y="66" width="300" height="3" rx="1.5" fill="#8250df"/>
   <rect x="342" y="80" width="34" height="15" rx="4" fill="#8250df"/>
   <text x="359" y="91" text-anchor="middle" class="badge">MCP</text>
-  <text x="386" y="91" class="mode-title" fill="#8250df">MCP Server — 19 Tools</text>
+  <text x="386" y="91" class="mode-title" fill="#8250df">MCP Server — 23 Tools</text>
   <text x="342" y="108" class="mode-cmd">agent-bom mcp-server [--transport sse]</text>
   <text x="342" y="124" class="mode-feat">AI agents call scan, check, blast_radius</text>
   <text x="342" y="138" class="mode-feat">Registry lookup for 427+ MCP servers</text>
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#1a7f37"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#1a7f37">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.57.0</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.66.0</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>
@@ -137,7 +137,7 @@
 
   <rect x="536" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#bc4c00" stroke-width="0.8"/>
   <text x="594" y="402" text-anchor="middle" class="engine-mod" fill="#bc4c00">Compliance</text>
-  <text x="594" y="416" text-anchor="middle" class="engine-detail">10 frameworks</text>
+  <text x="594" y="416" text-anchor="middle" class="engine-detail">11 frameworks</text>
 
   <rect x="662" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#cf222e" stroke-width="0.8"/>
   <text x="720" y="402" text-anchor="middle" class="engine-mod" fill="#cf222e">Policy</text>
@@ -215,7 +215,7 @@
   <!-- ═══════════════════════════════════════════════════════════ -->
   <rect x="20" y="640" width="920" height="2" rx="1" fill="#d0d7de" opacity="0.4"/>
 
-  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#0969da">19</text>
+  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#0969da">23</text>
   <text x="120" y="680" text-anchor="middle" class="engine-detail">MCP tools</text>
 
   <text x="240" y="666" text-anchor="middle" class="mode-title" fill="#8250df">427+</text>
@@ -224,13 +224,13 @@
   <text x="360" y="666" text-anchor="middle" class="mode-title" fill="#1a7f37">20</text>
   <text x="360" y="680" text-anchor="middle" class="engine-detail">client integrations</text>
 
-  <text x="480" y="666" text-anchor="middle" class="mode-title" fill="#9a6700">5</text>
+  <text x="480" y="666" text-anchor="middle" class="mode-title" fill="#9a6700">7</text>
   <text x="480" y="680" text-anchor="middle" class="engine-detail">runtime detectors</text>
 
-  <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#bc4c00">10</text>
+  <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#bc4c00">11</text>
   <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#cf222e">3,400+</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#cf222e">4,230+</text>
   <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
   <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#8250df">12</text>

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.65.0",
+      "version": "0.66.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   MITRE ATLAS, EU AI Act, NIST AI RMF, and custom policy-as-code rules. Generate
   SBOMs in CycloneDX or SPDX format. Use when the user mentions compliance checking,
   security policy enforcement, SBOM generation, or regulatory frameworks.
-version: 0.65.0
+version: 0.66.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.65.0
+version: 0.66.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.65.0
+version: 0.66.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checks packages for CVEs (OSV, NVD, EPSS, KEV), maps blast radius, and generates
   remediation plans. Use when the user mentions vulnerability scanning, dependency
   security, CVE lookup, blast radius analysis, or AI supply chain risk.
-version: 0.65.0
+version: 0.66.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Grype/Syft for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.65.0
+    docker: ghcr.io/msaad00/agent-bom:0.66.0
   openclaw:
     requires:
       bins: []
@@ -187,6 +187,6 @@ CVE IDs are sent to vulnerability databases.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.65.0
+- **Sigstore signed**: `agent-bom verify agent-bom@0.66.0
 - **4,300+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.65.0
+ARG VERSION=0.66.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — MCP server mode"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, credential exposure, runtime enforcement across MCP servers, containers, cloud, and GPU",
   "title": "agent-bom",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.65.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.66.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.65.0": {
+        "ghcr.io/msaad00/agent-bom:v0.66.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.65.0"
+version = "0.66.0"
 description = "Security scanner for AI infrastructure. Discover MCP configs (20 clients), scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to reachable credentials and tools, runtime proxy with 7 detectors, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, and 10-framework compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.65.0"
+    __version__ = "0.66.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.65.0"
+    assert __version__ == "0.66.0"
 
 
 def test_report_version_matches():
@@ -2954,7 +2954,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.65.0"
+    assert data["version"] == "0.66.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.63.3"
+version = "0.66.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Version bump to v0.66.0 across all 20+ files (pyproject.toml, __init__.py, Dockerfiles, Helm chart, integrations, workflows, tests)
- SVG diagram updates (light + dark): 23 MCP tools, 7 runtime detectors, 11 compliance frameworks, 4,230+ tests, v0.66.0 action ref

## What's in v0.66.0
- Scanner depth fixes: AI risk boost 2/3 threshold, posture dedup, word boundary normalization, additive runtime amplification (#444, #445)
- Proxy/runtime depth fixes: gateway evaluator signature, HMAC signing order, sequence boundaries, drift detection gating (#446, #447)
- Security hardening: context-aware compliance tags, shell metachar validation, TLS verify, UTC-aware caching, symlink guard (#448, #449)
- Full ecosystem OCI layer parsers — Java JARs, Go binaries, Ruby gems, .NET, RPM sqlite (#436)
- Native OCI layer parser — scan image tarballs without Grype/Syft/Docker (#435)
- ML API OTel provenance — detect deprecated models via gen_ai.* spans (#434)
- Audit-replay CLI — Rich TUI viewer for proxy JSONL logs (#433)
- HMAC proxy signing (#432), proxy/registry hardening (#429-431)
- Maven pom.xml + Go go.mod parsers (#427)

## Test plan
- [x] 4,208 tests pass (15 skipped, 12 deselected), 0 failures
- [x] Version alignment CI check will pass (all files bumped)
- [x] Pre-commit hooks pass (ruff, ruff-format, YAML/JSON/TOML)

Closes #437