### PR TITLE
feat: end-to-end alignment — detector parity, scan context, UI gating, Scorecard fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
   lint:
     name: Lint and Type Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -73,6 +75,8 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +99,8 @@ jobs:
   base-branch-check:
     name: PR Base Branch Guard
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
     steps:
       - name: Verify PR targets main
@@ -114,6 +120,8 @@ jobs:
   version-check:
     name: Version Alignment
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -233,6 +241,8 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [security, lint, test]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -257,6 +267,8 @@ jobs:
   docker:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [security, lint, test]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -309,6 +321,8 @@ jobs:
   action-dogfood:
     name: Dogfood GitHub Action
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [test]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
@@ -42,6 +44,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -20,6 +20,8 @@ jobs:
   smithery:
     name: Publish to Smithery
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -102,6 +104,8 @@ jobs:
   glama:
     name: Trigger Glama Rebuild
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Trigger Glama rebuild
@@ -125,6 +129,8 @@ jobs:
   clawhub:
     name: Publish to ClawHub
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
     name: Generate CycloneDX SBOM
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -1712,6 +1712,9 @@ async def get_compliance() -> dict:
     all_blast: list[dict] = []
     latest_scan: str | None = None
     scan_count = 0
+    has_mcp_context = False
+    has_agent_context = False
+    all_scan_sources: set[str] = set()
 
     for job in _get_store().list_all():
         if job.status != JobStatus.DONE or not job.result:
@@ -1721,6 +1724,13 @@ async def get_compliance() -> dict:
         all_blast.extend(br_list)
         if latest_scan is None or (job.completed_at and job.completed_at > latest_scan):
             latest_scan = job.completed_at
+        # Detect scan context from result metadata
+        if job.result.get("has_mcp_context"):
+            has_mcp_context = True
+        if job.result.get("has_agent_context"):
+            has_agent_context = True
+        for src in job.result.get("scan_sources", []):
+            all_scan_sources.add(src)
 
     def _build_controls(
         catalog: dict[str, str],
@@ -1823,6 +1833,9 @@ async def get_compliance() -> dict:
         "overall_status": overall_status,
         "scan_count": scan_count,
         "latest_scan": latest_scan,
+        "has_mcp_context": has_mcp_context,
+        "has_agent_context": has_agent_context,
+        "scan_sources": sorted(all_scan_sources),
         "owasp_llm_top10": owasp,
         "owasp_mcp_top10": owasp_mcp,
         "mitre_atlas": atlas,

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -161,6 +161,7 @@ async def _run_scan_pipeline(
     from agent_bom.scanners import scan_agents, scan_agents_with_enrichment
 
     warnings: list[str] = []
+    scan_sources: list[str] = []
 
     # Validate user-provided paths against directory traversal
     if config_path:
@@ -184,14 +185,33 @@ async def _run_scan_pipeline(
             return json.dumps({"error": sanitize_error(exc)})
 
     agents = discover_all(project_dir=config_path)
+    if agents:
+        scan_sources.append("agent_discovery")
 
     # Docker image scanning
     if image:
         try:
-            from agent_bom.image import scan_image
+            from agent_bom.image import scan_image as _scan_image
 
-            img_agents, _warnings = scan_image(image)
-            agents.extend(img_agents)
+            img_packages, _strategy = _scan_image(image)
+            if img_packages:
+                img_server = MCPServer(
+                    name=f"image:{image}",
+                    command="",
+                    args=[],
+                    env={},
+                    transport=TransportType.UNKNOWN,
+                    packages=img_packages,
+                )
+                agents.append(
+                    Agent(
+                        name=f"image:{image}",
+                        agent_type=AgentType.CUSTOM,
+                        config_path="",
+                        mcp_servers=[img_server],
+                    )
+                )
+                scan_sources.append("image")
         except Exception as exc:
             msg = f"Image scan failed for {image}: {sanitize_error(exc)}"
             logger.warning(msg)
@@ -226,13 +246,14 @@ async def _run_scan_pipeline(
                             mcp_servers=[sbom_server],
                         )
                     )
+                    scan_sources.append("sbom")
         except Exception as exc:
             msg = f"SBOM load failed for {sbom_path}: {exc}"
             logger.warning(msg)
             warnings.append(msg)
 
     if not agents:
-        return [], [], warnings
+        return [], [], warnings, scan_sources
 
     for agent in agents:
         for server in agent.mcp_servers:
@@ -243,7 +264,7 @@ async def _run_scan_pipeline(
         blast_radii = await scan_agents_with_enrichment(agents)
     else:
         blast_radii = await scan_agents(agents)
-    return agents, blast_radii, warnings
+    return agents, blast_radii, warnings, scan_sources
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +342,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             from agent_bom.models import AIBOMReport
             from agent_bom.output import to_json
 
-            agents, blast_radii, scan_warnings = await _run_scan_pipeline(
+            agents, blast_radii, scan_warnings, scan_sources = await _run_scan_pipeline(
                 config_path,
                 image,
                 sbom_path,
@@ -361,7 +382,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                 except Exception as exc:
                     logger.debug("Scorecard enrichment failed: %s", exc)
 
-            report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+            report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=scan_sources)
             result = to_json(report)
 
             # Policy evaluation
@@ -534,7 +555,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             return json.dumps({"error": sanitize_error(exc)})
 
         try:
-            _agents, blast_radii, _warnings = await _run_scan_pipeline()
+            _agents, blast_radii, _warnings, _srcs = await _run_scan_pipeline()
 
             matches = [br for br in blast_radii if br.vulnerability.id.upper() == validated_cve.upper()]
             if not matches:
@@ -602,7 +623,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             policy = json.loads(policy_json)
             _validate_policy(policy)
 
-            _agents, blast_radii, _warnings = await _run_scan_pipeline()
+            _agents, blast_radii, _warnings, _srcs = await _run_scan_pipeline()
             result = evaluate_policy(policy, blast_radii)
             return json.dumps(result, indent=2, default=str)
         except json.JSONDecodeError as exc:
@@ -711,11 +732,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             from agent_bom.models import AIBOMReport
             from agent_bom.output import to_cyclonedx, to_spdx
 
-            agents, blast_radii, _warnings = await _run_scan_pipeline(config_path=config_path)
+            agents, blast_radii, _warnings, scan_sources = await _run_scan_pipeline(config_path=config_path)
             if not agents:
                 return json.dumps({"error": "No agents found to generate SBOM from"})
 
-            report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+            report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=scan_sources)
 
             if format.lower() == "spdx":
                 return _truncate_response(json.dumps(to_spdx(report), indent=2, default=str))
@@ -755,7 +776,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             from agent_bom.owasp import OWASP_LLM_TOP10
             from agent_bom.owasp_mcp import OWASP_MCP_TOP10
 
-            agents, blast_radii, _warnings = await _run_scan_pipeline(config_path, image)
+            agents, blast_radii, _warnings, _srcs = await _run_scan_pipeline(config_path, image)
 
             # Convert BlastRadius objects to dicts for aggregation
             br_dicts = []
@@ -858,7 +879,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             from agent_bom.models import AIBOMReport
             from agent_bom.remediate import generate_remediation
 
-            agents, blast_radii, _warnings = await _run_scan_pipeline(config_path, image)
+            agents, blast_radii, _warnings, scan_sources = await _run_scan_pipeline(config_path, image)
             if not agents:
                 return json.dumps(
                     {
@@ -869,7 +890,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                     }
                 )
 
-            report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+            report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=scan_sources)
             plan = generate_remediation(report, blast_radii)
 
             return _truncate_response(
@@ -1165,11 +1186,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             from agent_bom.models import AIBOMReport
             from agent_bom.output import to_json
 
-            agents, blast_radii, _warnings = await _run_scan_pipeline()
+            agents, blast_radii, _warnings, scan_sources = await _run_scan_pipeline()
             if not agents:
                 return json.dumps({"error": "No agents found — nothing to diff"})
 
-            report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+            report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=scan_sources)
             current = to_json(report)
 
             if baseline is None:
@@ -1390,11 +1411,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             from agent_bom.models import AIBOMReport
             from agent_bom.output import to_json
 
-            agents, blast_radii, _warnings = await _run_scan_pipeline(config_path)
+            agents, blast_radii, _warnings, scan_sources = await _run_scan_pipeline(config_path)
             if not agents:
                 return json.dumps({"error": "No agents found"})
 
-            report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+            report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=scan_sources)
             report_json = to_json(report)
             graph = build_context_graph(
                 report_json["agents"],
@@ -1652,12 +1673,12 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         try:
             # Normalize "auto" → None so _run_scan_pipeline uses default discovery
             effective_config = None if config_path == "auto" else config_path
-            report = await _run_scan_pipeline(effective_config)
+            agents, blast_radii, _warnings, _srcs = await _run_scan_pipeline(effective_config)
             result: dict = {
                 "scan_summary": {
-                    "agents": report.total_agents,
-                    "servers": report.total_servers,
-                    "vulnerabilities": len(report.blast_radii),
+                    "agents": len(agents) if agents else 0,
+                    "servers": sum(len(a.mcp_servers) for a in agents) if agents else 0,
+                    "vulnerabilities": len(blast_radii),
                 },
             }
 
@@ -1666,12 +1687,12 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                 safe_audit = _safe_path(audit_log)
                 from agent_bom.runtime_correlation import correlate as _correlate
 
-                corr = _correlate(report.blast_radii, audit_log_path=str(safe_audit))
+                corr = _correlate(blast_radii, audit_log_path=str(safe_audit))
                 result["correlation"] = corr.to_dict()
             else:
                 result["correlation"] = {
                     "note": "No audit log provided. Run 'agent-bom proxy --log audit.jsonl' to capture tool calls, then pass the log path.",
-                    "vulnerable_tools": len({t.name for br in report.blast_radii for t in br.exposed_tools}) if report.blast_radii else 0,
+                    "vulnerable_tools": len({t.name for br in blast_radii for t in br.exposed_tools}) if blast_radii else 0,
                 }
 
             # ML API provenance via OTel trace

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -417,13 +417,21 @@ class AIBOMReport:
 
     @property
     def has_mcp_context(self) -> bool:
-        """True if scan discovered MCP servers (enables MCP/Agentic framework tags)."""
-        return any(len(a.mcp_servers) > 0 for a in self.agents)
+        """True if scan discovered real MCP servers (not synthetic SBOM/image wrappers).
+
+        A synthetic wrapper has ``command=""`` — real MCP servers always have a command.
+        """
+        return any(s.command for a in self.agents for s in a.mcp_servers)
 
     @property
     def has_agent_context(self) -> bool:
-        """True if scan discovered AI agents (enables agent-specific graphs)."""
-        return len(self.agents) > 0 and any(a.mcp_servers for a in self.agents)
+        """True if scan discovered real AI agents (not synthetic SBOM/image wrappers).
+
+        Synthetic agents (SBOM ingest, image scan) use ``AgentType.CUSTOM`` with
+        names prefixed by ``sbom:`` or ``image:``.  Real discovered agents have
+        specific agent types (CLAUDE_DESKTOP, CURSOR, etc.).
+        """
+        return any(a.agent_type != AgentType.CUSTOM for a in self.agents)
 
     def __post_init__(self):
         if not self.tool_version:

--- a/src/agent_bom/runtime/protection.py
+++ b/src/agent_bom/runtime/protection.py
@@ -1,6 +1,6 @@
 """Runtime protection engine — unified detector orchestration.
 
-Connects the five runtime detectors, OTel trace ingestion, and the alert
+Connects all seven runtime detectors, OTel trace ingestion, and the alert
 dispatcher into a single protection pipeline. Activated via the API
 (``POST /v1/protect/start``) or CLI (``agent-bom protect``).
 """
@@ -17,8 +17,10 @@ from agent_bom.runtime.detectors import (
     ArgumentAnalyzer,
     CredentialLeakDetector,
     RateLimitTracker,
+    ResponseInspector,
     SequenceAnalyzer,
     ToolDriftDetector,
+    VectorDBInjectionDetector,
 )
 
 logger = logging.getLogger(__name__)
@@ -32,7 +34,7 @@ class ProtectionStats:
     traces_processed: int = 0
     tool_calls_analyzed: int = 0
     alerts_generated: int = 0
-    detectors_active: int = 5
+    detectors_active: int = 7
 
 
 class ProtectionEngine:
@@ -54,6 +56,8 @@ class ProtectionEngine:
         self.cred_detector = CredentialLeakDetector()
         self.rate_tracker = RateLimitTracker()
         self.seq_analyzer = SequenceAnalyzer()
+        self.response_inspector = ResponseInspector()
+        self.vector_db_detector = VectorDBInjectionDetector()
         self.dispatcher = dispatcher or AlertDispatcher()
         self._active = False
         self._stats = ProtectionStats()
@@ -87,6 +91,8 @@ class ProtectionEngine:
                 "CredentialLeakDetector",
                 "RateLimitTracker",
                 "SequenceAnalyzer",
+                "ResponseInspector",
+                "VectorDBInjectionDetector",
             ],
             "detectors_active": self._stats.detectors_active,
         }
@@ -143,17 +149,31 @@ class ProtectionEngine:
         return all_alerts
 
     async def process_tool_response(self, tool_name: str, response_text: str) -> list[dict]:
-        """Check a tool response for credential leaks.
+        """Check a tool response for credential leaks, injection, and cloaking.
+
+        Runs all response-path detectors: CredentialLeakDetector,
+        ResponseInspector, and VectorDBInjectionDetector.
 
         Args:
             tool_name: MCP tool that produced the response.
             response_text: Response text to analyze.
 
         Returns:
-            List of alert dicts for any credential leaks detected.
+            List of alert dicts for any findings detected.
         """
+        all_alerts: list[dict] = []
+
+        # Credential leak detection
         cred_alerts = self.cred_detector.check(tool_name, response_text)
-        all_alerts = [a.to_dict() for a in cred_alerts]
+        all_alerts.extend(a.to_dict() for a in cred_alerts)
+
+        # Response inspection — cloaking, SVG, invisible unicode, injection
+        resp_alerts = self.response_inspector.check(tool_name, response_text)
+        all_alerts.extend(a.to_dict() for a in resp_alerts)
+
+        # Vector DB injection — elevated severity for RAG/retrieval tools
+        vec_alerts = self.vector_db_detector.check(tool_name, response_text)
+        all_alerts.extend(a.to_dict() for a in vec_alerts)
 
         for alert_dict in all_alerts:
             await self.dispatcher.dispatch(alert_dict)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -244,7 +244,7 @@ def test_scan_returns_json(mock_pipeline):
         config_path="/tmp/test",
         mcp_servers=[MCPServer(name="test-server", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
     )
-    mock_pipeline.return_value = ([mock_agent], [], [])
+    mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
 
     from agent_bom.mcp_server import create_mcp_server
 
@@ -257,7 +257,7 @@ def test_scan_returns_json(mock_pipeline):
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_scan_no_agents(mock_pipeline):
     """Scan with no agents should return no_agents_found status."""
-    mock_pipeline.return_value = ([], [], [])
+    mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -273,7 +273,7 @@ def test_scan_no_agents(mock_pipeline):
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_blast_radius_not_found(mock_pipeline):
     """Unknown CVE should return found=False."""
-    mock_pipeline.return_value = ([], [], [])
+    mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -289,7 +289,7 @@ def test_blast_radius_not_found(mock_pipeline):
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_policy_check_valid(mock_pipeline):
     """Valid policy with no findings should pass."""
-    mock_pipeline.return_value = ([], [], [])
+    mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -324,7 +324,7 @@ def test_generate_sbom_cyclonedx(mock_pipeline):
         config_path="/tmp/test",
         mcp_servers=[MCPServer(name="test-server", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
     )
-    mock_pipeline.return_value = ([mock_agent], [], [])
+    mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -336,7 +336,7 @@ def test_generate_sbom_cyclonedx(mock_pipeline):
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_generate_sbom_no_agents(mock_pipeline):
     """generate_sbom with no agents should return error."""
-    mock_pipeline.return_value = ([], [], [])
+    mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -374,7 +374,7 @@ def test_cli_mcp_server_transport_options():
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_compliance_no_agents(mock_pipeline):
     """Compliance with no agents should return 100% score."""
-    mock_pipeline.return_value = ([], [], [])
+    mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -422,7 +422,7 @@ def test_compliance_with_findings(mock_pipeline):
     br.atlas_tags = ["AML.T0010"]
     br.nist_ai_rmf_tags = ["MAP-3.5"]
 
-    mock_pipeline.return_value = ([mock_agent], [br], [])
+    mock_pipeline.return_value = ([mock_agent], [br], [], ["agent_discovery"])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -444,7 +444,7 @@ def test_compliance_with_findings(mock_pipeline):
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_remediate_no_agents(mock_pipeline):
     """Remediate with no agents should return empty plan."""
-    mock_pipeline.return_value = ([], [], [])
+    mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -469,7 +469,7 @@ def test_remediate_returns_plan(mock_pipeline):
         config_path="/tmp/test",
         mcp_servers=[MCPServer(name="test-server", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
     )
-    mock_pipeline.return_value = ([mock_agent], [], [])
+    mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -539,7 +539,7 @@ def test_scan_with_transitive(mock_pipeline):
         config_path="/tmp/test",
         mcp_servers=[MCPServer(name="s", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
     )
-    mock_pipeline.return_value = ([mock_agent], [], [])
+    mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -559,7 +559,7 @@ def test_scan_with_fail_severity_pass(mock_pipeline):
         config_path="/tmp/test",
         mcp_servers=[MCPServer(name="s", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
     )
-    mock_pipeline.return_value = ([mock_agent], [], [])
+    mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -596,7 +596,7 @@ def test_scan_with_fail_severity_fail(mock_pipeline):
         exposed_credentials=[],
         exposed_tools=[],
     )
-    mock_pipeline.return_value = ([mock_agent], [br], [])
+    mock_pipeline.return_value = ([mock_agent], [br], [], ["agent_discovery"])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -615,7 +615,7 @@ def test_scan_with_policy(mock_pipeline):
         config_path="/tmp/test",
         mcp_servers=[MCPServer(name="s", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
     )
-    mock_pipeline.return_value = ([mock_agent], [], [])
+    mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -700,7 +700,7 @@ def test_diff_no_baseline(mock_pipeline):
         config_path="/tmp/test",
         mcp_servers=[MCPServer(name="s", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
     )
-    mock_pipeline.return_value = ([mock_agent], [], [])
+    mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
 
     with patch("agent_bom.history.latest_report", return_value=None), patch("agent_bom.history.save_report"):
         from agent_bom.mcp_server import create_mcp_server
@@ -714,7 +714,7 @@ def test_diff_no_baseline(mock_pipeline):
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_diff_no_agents(mock_pipeline):
     """diff with no agents should return error."""
-    mock_pipeline.return_value = ([], [], [])
+    mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
@@ -806,7 +806,7 @@ def test_scan_with_invalid_severity_gate():
             config_path="/tmp/test",
             mcp_servers=[MCPServer(name="test-server", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
         )
-        mock_pipeline.return_value = ([mock_agent], [], [])
+        mock_pipeline.return_value = ([mock_agent], [], [], ["agent_discovery"])
 
         result = _call_tool(server, "scan", {"fail_severity": "invalid_sev"})
         assert "error" in result
@@ -826,7 +826,7 @@ def test_scan_surfaces_warnings():
             config_path="/tmp/test",
             mcp_servers=[MCPServer(name="test-server", command="npx", args=[], env={}, transport=TransportType.STDIO, packages=[])],
         )
-        mock_pipeline.return_value = ([mock_agent], [], ["Image scan failed for bad:image: not found"])
+        mock_pipeline.return_value = ([mock_agent], [], ["Image scan failed for bad:image: not found"], ["agent_discovery"])
 
         result = _call_tool(server, "scan", {})
         assert "warnings" in result
@@ -840,7 +840,7 @@ def test_scan_no_agents_with_warnings():
 
     server = create_mcp_server()
     with patch("agent_bom.mcp_server._run_scan_pipeline") as mock_pipeline:
-        mock_pipeline.return_value = ([], [], ["SBOM file too large"])
+        mock_pipeline.return_value = ([], [], ["SBOM file too large"], [])
 
         result = _call_tool(server, "scan", {})
         assert result["status"] == "no_agents_found"

--- a/tests/test_protection_engine.py
+++ b/tests/test_protection_engine.py
@@ -54,9 +54,11 @@ def test_engine_status():
     engine = ProtectionEngine()
     status = engine.status()
     assert status["active"] is False
-    assert status["detectors_active"] == 5
-    assert len(status["detectors"]) == 5
+    assert status["detectors_active"] == 7
+    assert len(status["detectors"]) == 7
     assert "ArgumentAnalyzer" in status["detectors"]
+    assert "ResponseInspector" in status["detectors"]
+    assert "VectorDBInjectionDetector" in status["detectors"]
 
 
 # ─── Tool Call Processing ─────────────────────────────────────────────────────

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -304,6 +304,7 @@ export default function CompliancePage() {
   if (!data) return null;
 
   const { summary: s } = data;
+  const hasMcp = data.has_mcp_context ?? false;
 
   return (
     <div className="space-y-8">
@@ -347,16 +348,22 @@ export default function CompliancePage() {
               {s.owasp_warn > 0 && <span className="text-yellow-400">{s.owasp_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className={`bg-zinc-950 rounded-xl p-4 border border-zinc-800 ${!hasMcp ? "opacity-40" : ""}`}>
             <div className="text-xs text-amber-500/80 mb-1">OWASP MCP Top 10</div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.owasp_mcp_pass}</span>
-              <span className="text-sm text-zinc-500">/ 10 pass</span>
-            </div>
-            <div className="flex gap-2 mt-2 text-xs">
-              {s.owasp_mcp_fail > 0 && <span className="text-red-400">{s.owasp_mcp_fail} fail</span>}
-              {s.owasp_mcp_warn > 0 && <span className="text-yellow-400">{s.owasp_mcp_warn} warn</span>}
-            </div>
+            {hasMcp ? (
+              <>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-2xl font-bold text-zinc-100">{s.owasp_mcp_pass}</span>
+                  <span className="text-sm text-zinc-500">/ 10 pass</span>
+                </div>
+                <div className="flex gap-2 mt-2 text-xs">
+                  {s.owasp_mcp_fail > 0 && <span className="text-red-400">{s.owasp_mcp_fail} fail</span>}
+                  {s.owasp_mcp_warn > 0 && <span className="text-yellow-400">{s.owasp_mcp_warn} warn</span>}
+                </div>
+              </>
+            ) : (
+              <div className="text-xs text-zinc-600 mt-1">No MCP servers detected</div>
+            )}
           </div>
           <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
             <div className="text-xs text-zinc-500 mb-1">MITRE ATLAS</div>
@@ -380,16 +387,22 @@ export default function CompliancePage() {
               {s.nist_warn > 0 && <span className="text-yellow-400">{s.nist_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className={`bg-zinc-950 rounded-xl p-4 border border-zinc-800 ${!hasMcp ? "opacity-40" : ""}`}>
             <div className="text-xs text-fuchsia-500/80 mb-1">OWASP Agentic Top 10</div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.owasp_agentic_pass}</span>
-              <span className="text-sm text-zinc-500">/ 10 pass</span>
-            </div>
-            <div className="flex gap-2 mt-2 text-xs">
-              {s.owasp_agentic_fail > 0 && <span className="text-red-400">{s.owasp_agentic_fail} fail</span>}
-              {s.owasp_agentic_warn > 0 && <span className="text-yellow-400">{s.owasp_agentic_warn} warn</span>}
-            </div>
+            {hasMcp ? (
+              <>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-2xl font-bold text-zinc-100">{s.owasp_agentic_pass}</span>
+                  <span className="text-sm text-zinc-500">/ 10 pass</span>
+                </div>
+                <div className="flex gap-2 mt-2 text-xs">
+                  {s.owasp_agentic_fail > 0 && <span className="text-red-400">{s.owasp_agentic_fail} fail</span>}
+                  {s.owasp_agentic_warn > 0 && <span className="text-yellow-400">{s.owasp_agentic_warn} warn</span>}
+                </div>
+              </>
+            ) : (
+              <div className="text-xs text-zinc-600 mt-1">No agents detected</div>
+            )}
           </div>
           <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
             <div className="text-xs text-blue-500/80 mb-1">EU AI Act</div>
@@ -457,9 +470,9 @@ export default function CompliancePage() {
         <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wider">Framework Coverage</h2>
         <FrameworkBar label="OWASP LLM Top 10" pass={s.owasp_pass} warn={s.owasp_warn} fail={s.owasp_fail} total={10} />
         <FrameworkBar label="MITRE ATLAS" pass={s.atlas_pass} warn={s.atlas_warn} fail={s.atlas_fail} total={data.mitre_atlas.length} />
-        <FrameworkBar label="OWASP MCP Top 10" pass={s.owasp_mcp_pass} warn={s.owasp_mcp_warn} fail={s.owasp_mcp_fail} total={10} />
+        {hasMcp && <FrameworkBar label="OWASP MCP Top 10" pass={s.owasp_mcp_pass} warn={s.owasp_mcp_warn} fail={s.owasp_mcp_fail} total={10} />}
         <FrameworkBar label="NIST AI RMF" pass={s.nist_pass} warn={s.nist_warn} fail={s.nist_fail} total={data.nist_ai_rmf.length} />
-        <FrameworkBar label="OWASP Agentic Top 10" pass={s.owasp_agentic_pass} warn={s.owasp_agentic_warn} fail={s.owasp_agentic_fail} total={10} />
+        {hasMcp && <FrameworkBar label="OWASP Agentic Top 10" pass={s.owasp_agentic_pass} warn={s.owasp_agentic_warn} fail={s.owasp_agentic_fail} total={10} />}
         <FrameworkBar label="EU AI Act" pass={s.eu_ai_act_pass} warn={s.eu_ai_act_warn} fail={s.eu_ai_act_fail} total={data.eu_ai_act.length} />
       </div>
 
@@ -478,6 +491,7 @@ export default function CompliancePage() {
       </section>
 
       {/* ── OWASP MCP Top 10 ─────────────────────────────────────────── */}
+      {hasMcp ? (
       <section>
         <div className="flex items-center gap-2 mb-4">
           <Shield className="w-5 h-5 text-amber-400" />
@@ -490,6 +504,18 @@ export default function CompliancePage() {
           ))}
         </div>
       </section>
+      ) : (
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <Shield className="w-5 h-5 text-amber-400 opacity-40" />
+          <h2 className="text-lg font-semibold text-zinc-500">OWASP MCP Top 10</h2>
+        </div>
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center">
+          <p className="text-sm text-zinc-500">MCP framework analysis not applicable — no MCP servers detected</p>
+          <p className="text-xs text-zinc-600 mt-2">Run an agent discovery scan to include MCP server data</p>
+        </div>
+      </section>
+      )}
 
       {/* ── MITRE ATLAS ───────────────────────────────────────────────── */}
       <section>
@@ -520,6 +546,7 @@ export default function CompliancePage() {
       </section>
 
       {/* ── OWASP Agentic Top 10 ─────────────────────────────────────── */}
+      {hasMcp ? (
       <section>
         <div className="flex items-center gap-2 mb-4">
           <Shield className="w-5 h-5 text-fuchsia-400" />
@@ -532,6 +559,18 @@ export default function CompliancePage() {
           ))}
         </div>
       </section>
+      ) : (
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <Shield className="w-5 h-5 text-fuchsia-400 opacity-40" />
+          <h2 className="text-lg font-semibold text-zinc-500">OWASP Agentic Top 10</h2>
+        </div>
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center">
+          <p className="text-sm text-zinc-500">Agentic framework analysis not applicable — no AI agents detected</p>
+          <p className="text-xs text-zinc-600 mt-2">Run an agent discovery scan to include agent data</p>
+        </div>
+      </section>
+      )}
 
       {/* ── EU AI Act ────────────────────────────────────────────────── */}
       <section>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -358,6 +358,9 @@ export interface ComplianceResponse {
   overall_status: "pass" | "warning" | "fail";
   scan_count: number;
   latest_scan: string | null;
+  has_mcp_context?: boolean;
+  has_agent_context?: boolean;
+  scan_sources?: string[];
   owasp_llm_top10: ComplianceControl[];
   owasp_mcp_top10: ComplianceControl[];
   mitre_atlas: ComplianceControl[];


### PR DESCRIPTION
## Summary
- **ProtectionEngine 7/7 parity**: wire ResponseInspector + VectorDBInjectionDetector into `agent-bom protect` (was only 5/7 vs proxy's 7/7)
- **MCP server image scan bug fix**: `scan_image()` returns `(packages, strategy)` — was incorrectly unpacked as `(agents, warnings)`, now properly wraps in synthetic Agent/MCPServer
- **scan_sources populated everywhere**: all MCP server tools now pass scan_sources to AIBOMReport (was always empty via MCP path)
- **runtime_correlate tool fix**: was treating `_run_scan_pipeline` tuple as AIBOMReport object (would crash)
- **has_mcp_context accuracy**: now checks `server.command` — synthetic SBOM/image wrappers (command="") correctly return False
- **has_agent_context accuracy**: now excludes `AgentType.CUSTOM` synthetic wrappers — SBOM/image scans don't falsely report agent context
- **UI compliance context-awareness**: OWASP MCP and Agentic panels gated on `hasMcp` — shows placeholder message when no MCP servers detected instead of confusing 0/0 panels
- **API compliance endpoint**: emits `has_mcp_context`, `has_agent_context`, `scan_sources` for frontend consumption
- **OpenSSF Scorecard Token-Permissions**: added explicit job-level `permissions:` blocks to 10 jobs across ci.yml, docs.yml, release.yml, publish-registries.yml
- **Pinned-Dependencies**: fixed docs.yml checkout SHA from v4 to v6

## Test plan
- [x] 4,208 tests pass (0 failures)
- [x] MCP server tests updated for 4-element tuple return
- [x] ProtectionEngine tests updated for 7 detectors
- [x] Pre-commit hooks pass