### PR TITLE
chore: bump version to v0.67.0

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           uv run agent-bom scan --sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.66.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.66.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.67.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.67.0"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.66.0  # pinned — bump on each release
+        run: uv tool install agent-bom==0.67.0  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,12 +41,13 @@ src/agent_bom/
 ├── transitive.py        # Transitive dep resolution via deps.dev API
 ├── models.py            # Agent, MCPServer, Package, Vulnerability, BlastRadius, AIBOMReport
 │                        #   BlastRadius.calculate_risk_score() — 8-factor risk computation
+├── asset_tracker.py     # Persistent SQLite vuln tracker — first_seen, resolved, MTTR
 ├── security.py          # validate_path(), sanitize_env_vars(), credential redaction
 └── output/
     └── __init__.py      # JSON, SARIF, CycloneDX, SPDX, SVG, text formatters
 ```
 
-### Compliance Frameworks (10)
+### Compliance Frameworks (11)
 
 Each module exports `tag_blast_radius(br: BlastRadius)` to annotate findings.
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -13,14 +13,14 @@
 ## ── Builder stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49 AS builder
 
-ARG VERSION=0.66.0
+ARG VERSION=0.67.0
 
 RUN pip install --no-cache-dir --prefix=/install agent-bom==${VERSION}
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.66.0
+ARG VERSION=0.67.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.snowpark
+++ b/Dockerfile.snowpark
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11-slim@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
-ARG VERSION=0.66.0
+ARG VERSION=0.67.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.66.0
+ARG VERSION=0.67.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="Security scanner for AI infrastructure — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.66.0"
+  --version "0.67.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.66.0
-git push origin v0.66.0
+git tag v0.67.0
+git push origin v0.67.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ agent-bom scan --vector-db-scan                    # Scan self-hosted + Pinecone
 agent-bom scan --gpu-scan                          # Discover GPU containers + K8s nodes, detect unauthenticated DCGM exporters
 agent-bom scan --browser-extensions               # Scan Chrome/Edge/Brave/Firefox extensions for dangerous permissions
 agent-bom scan --skill-only                       # Audit AI instruction files (CLAUDE.md, .cursorrules, AGENTS.md)
+agent-bom scan --save report.json                  # Save + track assets (first_seen, resolved, MTTR)
 agent-bom graph report.json --format dot           # Export dependency graph (DOT/Mermaid/JSON)
 agent-bom proxy-configure --apply                  # Auto-wrap MCP configs with security proxy
 ```
@@ -194,7 +195,8 @@ rm -rf ~/.agent-bom                      # remove local data
 1. **Discover** -- auto-detect MCP configs, Docker images, K8s pods, cloud resources, model files
 2. **Scan** -- send package names + versions to public APIs (OSV.dev, NVD, EPSS, CISA KEV). No secrets leave your machine.
 3. **Analyze** -- blast radius mapping, tool poisoning detection, compliance tagging, posture scoring
-4. **Report** -- JSON, SARIF, CycloneDX, SPDX, HTML, Mermaid, or console. Alert dispatch to Slack/webhooks.
+4. **Track** -- persistent asset database records first_seen, last_seen, resolved status, and MTTR per vulnerability across scans
+5. **Report** -- JSON, SARIF, CycloneDX, SPDX, HTML, Mermaid, or console. Alert dispatch to Slack/webhooks.
 
 <p align="center">
   <picture>
@@ -235,6 +237,7 @@ rm -rf ~/.agent-bom                      # remove local data
 | **OIDC/SSO authentication** | -- | JWT verification (Okta, Google, Azure AD, Auth0) for REST API |
 | **Instruction file trust** | -- | SKILL.md/CLAUDE.md/.cursorrules — 17 behavioral patterns, typosquat detection, Sigstore provenance verification |
 | **Browser extension scanning** | -- | Chrome/Edge/Firefox manifest.json — nativeMessaging, dangerous permissions, AI assistant domain access |
+| **Persistent asset tracking** | -- | SQLite DB — first_seen/last_seen/resolved/reopened per vulnerability, MTTR calculation, scan-over-scan diff |
 
 <p align="center">
   <picture>
@@ -285,7 +288,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
-| GitHub Action | `uses: msaad00/agent-bom@v0.66.0 | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.67.0 | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` (23 tools) | Inside any MCP client |
@@ -300,7 +303,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 <summary><b>GitHub Action</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.66.0
+- uses: msaad00/agent-bom@v0.67.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -335,6 +338,8 @@ agent-bom api --api-key $SECRET --rate-limit 30   # http://127.0.0.1:8422/docs
 | `GET /v1/proxy/alerts` | Runtime behavioral alerts from audit log |
 | `GET /v1/audit` | Query JSONL audit trail (HMAC integrity verified) |
 | `WS /ws/proxy/metrics` | Live metrics push every second (tool_calls, blocked, latency_p95) |
+| `GET /v1/assets` | Persistent vulnerability asset inventory (first_seen, resolved, MTTR) |
+| `GET /v1/assets/stats` | Aggregate asset statistics — open/resolved/critical counts |
 | `WS /ws/proxy/alerts` | Real-time alert stream — new alerts arrive as they happen |
 
 </details>
@@ -382,7 +387,7 @@ Options:
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.66.0 |
+| GitHub Action | `uses: msaad00/agent-bom@v0.67.0 |
 | Glama | [glama.ai/mcp/servers/@msaad00/agent-bom](https://glama.ai/mcp/servers/@msaad00/agent-bom) |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |
@@ -432,7 +437,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 - **Sigstore signed** -- releases v0.7.0+ signed via cosign OIDC
 - **OpenSSF Scorecard** -- [automated supply chain scoring](https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom)
 - **OpenSSF Best Practices** -- [passing badge (100%)](https://www.bestpractices.dev/projects/12114) — 67/67 criteria
-- **Continuous fuzzing** -- [ClusterFuzzLite](https://github.com/msaad00/agent-bom/blob/main/.github/workflows/cifuzz.yml) fuzzes SBOM parsers, policy evaluator, and skill parser
+- **Continuous fuzzing** -- [ClusterFuzzLite](https://github.com/msaad00/agent-bom/blob/main/.github/workflows/cflite-pr.yml) fuzzes SBOM parsers, policy evaluator, and skill parser
 - **[PERMISSIONS.md](PERMISSIONS.md)** -- full auditable trust contract
 
 ---
@@ -454,6 +459,14 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 - [ ] Dataset poisoning detection
 - [ ] Training pipeline scanning (MLflow DAGs, Kubeflow pipelines)
 - [ ] Model card authenticity verification (beyond hash/sigstore)
+
+**Asset tracking / posture**
+- [x] Persistent SQLite asset database — first_seen, last_seen, resolved, reopened per vulnerability
+- [x] MTTR (Mean Time To Remediate) calculation across scans
+- [x] Scan-over-scan diff — new, resolved, reopened, unchanged counts
+- [x] REST API: `/v1/assets` + `/v1/assets/stats` for dashboard integration
+- [ ] SLA enforcement — time-to-fix deadlines per severity (critical < 7d, high < 30d)
+- [ ] Trend analytics — vulnerability count over time, resolution velocity
 
 **Agents / MCP**
 - [x] 21 MCP client config discovery paths, live introspection, tool drift detection

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: AI supply chain security scanner — scan containers, MCP servers, and AI agents for CVEs, credential exposure, and compliance violations
 version: 0.1.0
-appVersion: "0.66.0"
+appVersion: "0.67.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.66.0"
+  tag: "0.67.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.66.0"
+  tag: "0.67.0"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.66.0
+- uses: msaad00/agent-bom@v0.67.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ High-level view of input sources, the core processing engine, and output channel
 ```mermaid
 graph TB
     subgraph Input["Input Sources"]
-        MCP["MCP Configs\n20 Clients"]
+        MCP["MCP Configs\n21 Clients"]
         Docker["Docker Images"]
         K8s["Kubernetes"]
         Cloud["Cloud APIs\nAWS / Azure / GCP / Snowflake"]
@@ -25,6 +25,7 @@ graph TB
         Scanner["Vulnerability Scanner\nOSV + NVD + EPSS + KEV"]
         Blast["Blast Radius Analyzer"]
         Compliance["Compliance Tagger\n11 Frameworks"]
+        Assets["Asset Tracker\nfirst_seen / resolved / MTTR"]
         Posture["Posture Scorer"]
     end
 
@@ -46,7 +47,8 @@ graph TB
     Parser --> Scanner
     Scanner --> Blast
     Blast --> Compliance
-    Compliance --> Posture
+    Compliance --> Assets
+    Assets --> Posture
 
     Posture --> Console
     Posture --> SBOM_Out
@@ -94,6 +96,8 @@ sequenceDiagram
     CLI->>ComplianceTagger: Findings
     ComplianceTagger->>ComplianceTagger: Tag 11 frameworks
     ComplianceTagger-->>CLI: Tagged findings
+
+    CLI->>CLI: Asset tracking (first_seen / resolved / MTTR)
 
     CLI->>Reporter: Full results
     Reporter-->>User: Console / JSON / HTML / SBOM / SARIF
@@ -275,7 +279,7 @@ graph TB
 | Module | Path | Responsibility |
 |--------|------|----------------|
 | CLI | `src/agent_bom/cli.py` | Click entry point, flag parsing |
-| Discovery | `src/agent_bom/discovery/__init__.py` | MCP client config discovery (20 clients) |
+| Discovery | `src/agent_bom/discovery/__init__.py` | MCP client config discovery (21 clients) |
 | Parsers | `src/agent_bom/parsers/__init__.py` | Package extraction + MCP registry lookup |
 | Skill Parsers | `src/agent_bom/parsers/skills.py` + `skill_audit.py` | SKILL.md/CLAUDE.md behavioral audit, typosquat, Sigstore trust |
 | Browser Extensions | `src/agent_bom/parsers/browser_extensions.py` | Chrome/Edge/Brave/Firefox manifest.json permission auditor |
@@ -285,6 +289,7 @@ graph TB
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
 | MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (23 tools) |
+| Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |
 | Logging | `src/agent_bom/logging_config.py` | Structured JSON/console logging, env var config |

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -38,7 +38,7 @@
 
   <rect x="28" y="68" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="84" text-anchor="middle" class="box-label">MCP Configs</text>
-  <text x="101" y="96" text-anchor="middle" class="box-sub">20 clients · auto-detect</text>
+  <text x="101" y="96" text-anchor="middle" class="box-sub">21 clients · auto-detect</text>
 
   <rect x="28" y="106" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="122" text-anchor="middle" class="box-label">Cloud Providers</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -38,7 +38,7 @@
 
   <rect x="28" y="68" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="84" text-anchor="middle" class="box-label">MCP Configs</text>
-  <text x="101" y="96" text-anchor="middle" class="box-sub">20 clients · auto-detect</text>
+  <text x="101" y="96" text-anchor="middle" class="box-sub">21 clients · auto-detect</text>
 
   <rect x="28" y="106" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="122" text-anchor="middle" class="box-label">Cloud Providers</text>

--- a/docs/images/architecture-stack-dark.svg
+++ b/docs/images/architecture-stack-dark.svg
@@ -61,18 +61,20 @@
   <rect x="100" y="188" width="600" height="4" rx="2" fill="#f43f5e"/>
   <text x="120" y="218" class="layer-name" fill="#f43f5e">ANALYSIS</text>
 
-  <rect x="220" y="200" width="80" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
-  <text x="260" y="216" text-anchor="middle" class="item">Blast Radius</text>
-  <rect x="308" y="200" width="76" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
-  <text x="346" y="216" text-anchor="middle" class="item">Compliance</text>
-  <rect x="392" y="200" width="56" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
-  <text x="420" y="216" text-anchor="middle" class="item">Policy</text>
-  <rect x="456" y="200" width="76" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
-  <text x="494" y="216" text-anchor="middle" class="item">Enforcement</text>
-  <rect x="540" y="200" width="58" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
-  <text x="569" y="216" text-anchor="middle" class="item">Posture</text>
-  <rect x="606" y="200" width="76" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
-  <text x="644" y="216" text-anchor="middle" class="item">Context Graph</text>
+  <rect x="210" y="200" width="72" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="246" y="216" text-anchor="middle" class="item">Blast Radius</text>
+  <rect x="288" y="200" width="68" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="322" y="216" text-anchor="middle" class="item">Compliance</text>
+  <rect x="362" y="200" width="48" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="386" y="216" text-anchor="middle" class="item">Policy</text>
+  <rect x="416" y="200" width="70" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="451" y="216" text-anchor="middle" class="item">Enforcement</text>
+  <rect x="492" y="200" width="50" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="517" y="216" text-anchor="middle" class="item">Posture</text>
+  <rect x="548" y="200" width="48" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="572" y="216" text-anchor="middle" class="item">Assets</text>
+  <rect x="602" y="200" width="86" height="24" rx="5" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
+  <text x="645" y="216" text-anchor="middle" class="item">Context Graph</text>
 
   <text x="400" y="250" text-anchor="middle" class="arrow-up">&#x25B2;</text>
 

--- a/docs/images/architecture-stack-light.svg
+++ b/docs/images/architecture-stack-light.svg
@@ -60,18 +60,20 @@
   <rect x="100" y="188" width="600" height="4" rx="2" fill="#e11d48"/>
   <text x="120" y="218" class="layer-name" fill="#e11d48">ANALYSIS</text>
 
-  <rect x="220" y="200" width="80" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
-  <text x="260" y="216" text-anchor="middle" class="item">Blast Radius</text>
-  <rect x="308" y="200" width="76" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
-  <text x="346" y="216" text-anchor="middle" class="item">Compliance</text>
-  <rect x="392" y="200" width="56" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
-  <text x="420" y="216" text-anchor="middle" class="item">Policy</text>
-  <rect x="456" y="200" width="76" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
-  <text x="494" y="216" text-anchor="middle" class="item">Enforcement</text>
-  <rect x="540" y="200" width="58" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
-  <text x="569" y="216" text-anchor="middle" class="item">Posture</text>
-  <rect x="606" y="200" width="76" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
-  <text x="644" y="216" text-anchor="middle" class="item">Context Graph</text>
+  <rect x="210" y="200" width="72" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="246" y="216" text-anchor="middle" class="item">Blast Radius</text>
+  <rect x="288" y="200" width="68" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="322" y="216" text-anchor="middle" class="item">Compliance</text>
+  <rect x="362" y="200" width="48" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="386" y="216" text-anchor="middle" class="item">Policy</text>
+  <rect x="416" y="200" width="70" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="451" y="216" text-anchor="middle" class="item">Enforcement</text>
+  <rect x="492" y="200" width="50" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="517" y="216" text-anchor="middle" class="item">Posture</text>
+  <rect x="548" y="200" width="48" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="572" y="216" text-anchor="middle" class="item">Assets</text>
+  <rect x="602" y="200" width="86" height="24" rx="5" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
+  <text x="645" y="216" text-anchor="middle" class="item">Context Graph</text>
 
   <text x="400" y="250" text-anchor="middle" class="arrow-up">&#x25B2;</text>
 

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -47,7 +47,7 @@
     <rect width="200" height="36" rx="6" fill="#161b22" stroke="#1f6feb" stroke-width="1" opacity="0.8"/>
     <circle cx="16" cy="18" r="5" fill="#58a6ff" opacity="0.5"/>
     <text x="28" y="15" class="node-label">MCP Agent Configs</text>
-    <text x="28" y="28" class="node-sub">20 clients: Claude, Cursor, Codex, Gemini...</text>
+    <text x="28" y="28" class="node-sub">21 clients: Claude, Cursor, Codex, Gemini...</text>
   </g>
 
   <!-- Source 3: Container Images  (y=186, h=36, midY=204) -->
@@ -167,7 +167,7 @@
       <rect width="286" height="48" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6e7681">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">20 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">23 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -47,7 +47,7 @@
     <rect width="200" height="36" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
     <circle cx="16" cy="18" r="5" fill="#3b82f6" opacity="0.6"/>
     <text x="28" y="15" class="node-label">MCP Agent Configs</text>
-    <text x="28" y="28" class="node-sub">20 clients: Claude, Cursor, Codex, Gemini...</text>
+    <text x="28" y="28" class="node-sub">21 clients: Claude, Cursor, Codex, Gemini...</text>
   </g>
 
   <!-- Source 3: Container Images  (y=186, h=36, midY=204) -->
@@ -166,7 +166,7 @@
       <rect width="286" height="48" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#94a3b8">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">20 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">23 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/engine-internals-dark.svg
+++ b/docs/images/engine-internals-dark.svg
@@ -37,7 +37,7 @@
   <!-- Modules -->
   <rect x="38" y="130" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="148" class="mod-name">MCP Config Parser</text>
-  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#60a5fa">20 clients</text>
+  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#60a5fa">21 clients</text>
 
   <rect x="38" y="164" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="182" class="mod-name">Cloud Connectors</text>

--- a/docs/images/engine-internals-light.svg
+++ b/docs/images/engine-internals-light.svg
@@ -37,7 +37,7 @@
   <!-- Modules -->
   <rect x="38" y="130" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="148" class="mod-name">MCP Config Parser</text>
-  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#2563eb">20 clients</text>
+  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#2563eb">21 clients</text>
 
   <rect x="38" y="164" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="182" class="mod-name">Cloud Connectors</text>

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -24,7 +24,7 @@
   <!-- Source blocks — clean rounded pills -->
   <rect x="80" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
   <text x="134" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">MCP Agents</text>
-  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">20 clients</text>
+  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">21 clients</text>
 
   <rect x="198" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
   <text x="252" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Containers</text>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -24,7 +24,7 @@
   <!-- Source blocks — clean rounded pills -->
   <rect x="80" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
   <text x="134" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Agents</text>
-  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">20 clients</text>
+  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">21 clients</text>
 
   <rect x="198" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
   <text x="252" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Containers</text>

--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -39,7 +39,7 @@
   <text x="47" y="91" text-anchor="middle" class="badge">CLI</text>
   <text x="72" y="91" class="mode-title" fill="#58a6ff">Local Scan</text>
   <text x="32" y="108" class="mode-cmd">agent-bom scan [--image] [--sbom]</text>
-  <text x="32" y="124" class="mode-feat">Discover 20 MCP clients + cloud infra</text>
+  <text x="32" y="124" class="mode-feat">Discover 21 MCP clients + cloud infra</text>
   <text x="32" y="138" class="mode-feat">CVE scan with OSV, NVD, Grype, Syft</text>
   <text x="32" y="152" class="mode-feat">Blast radius: CVE → server → creds → tools</text>
   <text x="308" y="178" text-anchor="end" class="mode-detail">JSON / CycloneDX / SPDX / SARIF / HTML</text>
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#3fb950"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#3fb950">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.66.0</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.67.0</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>
@@ -121,7 +121,7 @@
   <!-- Engine modules — 7 evenly spaced -->
   <rect x="32" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="0.8"/>
   <text x="90" y="402" text-anchor="middle" class="engine-mod" fill="#58a6ff">Discovery</text>
-  <text x="90" y="416" text-anchor="middle" class="engine-detail">20 MCP clients · 4 clouds</text>
+  <text x="90" y="416" text-anchor="middle" class="engine-detail">21 MCP clients · 4 clouds</text>
 
   <rect x="158" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="0.8"/>
   <text x="216" y="402" text-anchor="middle" class="engine-mod" fill="#58a6ff">Parsers</text>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -39,7 +39,7 @@
   <text x="47" y="91" text-anchor="middle" class="badge">CLI</text>
   <text x="72" y="91" class="mode-title" fill="#0969da">Local Scan</text>
   <text x="32" y="108" class="mode-cmd">agent-bom scan [--image] [--sbom]</text>
-  <text x="32" y="124" class="mode-feat">Discover 20 MCP clients + cloud infra</text>
+  <text x="32" y="124" class="mode-feat">Discover 21 MCP clients + cloud infra</text>
   <text x="32" y="138" class="mode-feat">CVE scan with OSV, NVD, Grype, Syft</text>
   <text x="32" y="152" class="mode-feat">Blast radius: CVE → server → creds → tools</text>
   <text x="308" y="178" text-anchor="end" class="mode-detail">JSON / CycloneDX / SPDX / SARIF / HTML</text>
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#1a7f37"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#1a7f37">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.66.0</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.67.0</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>
@@ -121,7 +121,7 @@
   <!-- Engine modules — 7 evenly spaced -->
   <rect x="32" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="0.8"/>
   <text x="90" y="402" text-anchor="middle" class="engine-mod" fill="#0969da">Discovery</text>
-  <text x="90" y="416" text-anchor="middle" class="engine-detail">20 MCP clients · 4 clouds</text>
+  <text x="90" y="416" text-anchor="middle" class="engine-detail">21 MCP clients · 4 clouds</text>
 
   <rect x="158" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="0.8"/>
   <text x="216" y="402" text-anchor="middle" class="engine-mod" fill="#0969da">Parsers</text>

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -23,7 +23,7 @@
   <text x="56" y="84" class="step-name" fill="#93c5fd">DISCOVER</text>
 
   <text x="36" y="114" class="item-label" fill="#60a5fa">MCP configs</text>
-  <text x="140" y="114" text-anchor="end" class="step-desc">20 clients</text>
+  <text x="140" y="114" text-anchor="end" class="step-desc">21 clients</text>
   <rect x="30" y="120" width="140" height="1" fill="#27272a"/>
 
   <text x="36" y="138" class="item-label" fill="#60a5fa">Cloud</text>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -23,7 +23,7 @@
   <text x="56" y="84" class="step-name">DISCOVER</text>
 
   <text x="36" y="114" class="item-label" fill="#2563eb">MCP configs</text>
-  <text x="140" y="114" text-anchor="end" class="step-desc">20 clients</text>
+  <text x="140" y="114" text-anchor="end" class="step-desc">21 clients</text>
   <rect x="30" y="120" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="36" y="138" class="item-label" fill="#2563eb">Cloud</text>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -61,7 +61,7 @@
   <text x="210" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#58a6ff">Auto-detect every component</text>
 
   <!-- Discover details — clean list, not boxes -->
-  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">20 MCP clients  ·  11 cloud providers</text>
+  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">21 MCP clients  ·  11 cloud providers</text>
   <text x="210" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Docker + K8s  ·  7 code ecosystems</text>
   <text x="210" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">12 AI/ML formats  ·  SBOM ingest</text>
   <text x="210" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Integrity verification  ·  Filesystem</text>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -61,7 +61,7 @@
   <text x="210" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#3b82f6">Auto-detect every component</text>
 
   <!-- Discover details — clean list, not boxes -->
-  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">20 MCP clients  ·  11 cloud providers</text>
+  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">21 MCP clients  ·  11 cloud providers</text>
   <text x="210" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Docker + K8s  ·  7 code ecosystems</text>
   <text x="210" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">12 AI/ML formats  ·  SBOM ingest</text>
   <text x="210" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Integrity verification  ·  Filesystem</text>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -77,7 +77,7 @@
 
   <!-- Card 1: Discover -->
   <rect x="30" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#1f3a5f" stroke-width="1.5"/>
-  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">MCP (20 clients)</text>
+  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">MCP (21 clients)</text>
   <text x="100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Docker / K8s</text>
   <text x="100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Cloud (11)</text>
   <text x="100" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">AI/ML (12 fmts)</text>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -77,7 +77,7 @@
 
   <!-- Card 1: Discover -->
   <rect x="30" y="190" width="140" height="160" rx="14" fill="#eff6ff" stroke="#dbeafe" stroke-width="1.5"/>
-  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">MCP (20 clients)</text>
+  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">MCP (21 clients)</text>
   <text x="100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Docker / K8s</text>
   <text x="100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Cloud (11)</text>
   <text x="100" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">AI/ML (12 fmts)</text>

--- a/docs/images/workflow-dark.svg
+++ b/docs/images/workflow-dark.svg
@@ -25,7 +25,7 @@
   <text x="96" y="74" text-anchor="middle" class="step-num" fill="#1f6feb">1</text>
   <text x="96" y="90" text-anchor="middle" class="step-label">Discover</text>
   <line x1="44" y1="98" x2="148" y2="98" stroke="#30363d" stroke-width="0.5"/>
-  <text x="96" y="116" text-anchor="middle" class="step-detail">20 MCP clients</text>
+  <text x="96" y="116" text-anchor="middle" class="step-detail">21 MCP clients</text>
   <text x="96" y="130" text-anchor="middle" class="step-detail">Docker images</text>
   <text x="96" y="144" text-anchor="middle" class="step-detail">Kubernetes pods</text>
   <text x="96" y="158" text-anchor="middle" class="step-detail">Cloud providers</text>

--- a/docs/images/workflow-light.svg
+++ b/docs/images/workflow-light.svg
@@ -25,7 +25,7 @@
   <text x="96" y="74" text-anchor="middle" class="step-num" fill="#0969da">1</text>
   <text x="96" y="90" text-anchor="middle" class="step-label">Discover</text>
   <line x1="44" y1="98" x2="148" y2="98" stroke="#d0d7de" stroke-width="0.5"/>
-  <text x="96" y="116" text-anchor="middle" class="step-detail">20 MCP clients</text>
+  <text x="96" y="116" text-anchor="middle" class="step-detail">21 MCP clients</text>
   <text x="96" y="130" text-anchor="middle" class="step-detail">Docker images</text>
   <text x="96" y="144" text-anchor="middle" class="step-detail">Kubernetes pods</text>
   <text x="96" y="158" text-anchor="middle" class="step-detail">Cloud providers</text>

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   MITRE ATLAS, EU AI Act, NIST AI RMF, and custom policy-as-code rules. Generate
   SBOMs in CycloneDX or SPDX format. Use when the user mentions compliance checking,
   security policy enforcement, SBOM generation, or regulatory frameworks.
-version: 0.66.0
+version: 0.67.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.66.0
+version: 0.67.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.66.0
+version: 0.67.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checks packages for CVEs (OSV, NVD, EPSS, KEV), maps blast radius, and generates
   remediation plans. Use when the user mentions vulnerability scanning, dependency
   security, CVE lookup, blast radius analysis, or AI supply chain risk.
-version: 0.66.0
+version: 0.67.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Grype/Syft for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.66.0
+    docker: ghcr.io/msaad00/agent-bom:0.67.0
   openclaw:
     requires:
       bins: []
@@ -187,6 +187,6 @@ CVE IDs are sent to vulnerability databases.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.66.0
+- **Sigstore signed**: `agent-bom verify agent-bom@0.67.0
 - **4,300+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.66.0
+ARG VERSION=0.67.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — MCP server mode"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, credential exposure, runtime enforcement across MCP servers, containers, cloud, and GPU",
   "title": "agent-bom",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.66.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.67.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.66.0": {
+        "ghcr.io/msaad00/agent-bom:v0.67.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.66.0"
+version = "0.67.0"
 description = "Security scanner for AI infrastructure. Discover MCP configs (20 clients), scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to reachable credentials and tools, runtime proxy with 7 detectors, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, and 10-framework compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -6,7 +6,7 @@ For the comprehensive guide, see [AI_INFRASTRUCTURE_SCANNING.md](https://github.
 
 | Layer | What we scan |
 |-------|-------------|
-| **MCP Clients** | 20 clients — Claude, Cursor, VS Code, Windsurf, Cline, Codex, Gemini, Goose, etc. |
+| **MCP Clients** | 21 clients — Claude, Cursor, VS Code, Windsurf, Cline, Codex, Gemini, Goose, etc. |
 | **MCP Servers** | Package deps, tool definitions, credential exposure, description drift |
 | **Container Images** | OS + language packages via Grype/Syft |
 | **Kubernetes** | Namespace enumeration, pod MCP detection |

--- a/site-docs/architecture/overview.md
+++ b/site-docs/architecture/overview.md
@@ -14,7 +14,7 @@ graph LR
     F --> G[Output]
 
     D --> |OSV, NVD, EPSS| H[(Vuln DBs)]
-    B --> |20 clients| I[Config Files]
+    B --> |21 clients| I[Config Files]
 ```
 
 ## Key modules
@@ -26,7 +26,8 @@ graph LR
 | Blast Radius | `src/agent_bom/blast_radius.py` | Impact chain mapping |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Registry | `src/agent_bom/registry.py` | 427+ server security metadata |
-| Compliance | `src/agent_bom/compliance/` | 10 framework mappings |
+| Compliance | `src/agent_bom/compliance/` | 11 framework mappings |
+| Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP interception |
 | Protection | `src/agent_bom/runtime/` | 5-detector anomaly engine |
 | Enforcement | `src/agent_bom/enforcement.py` | Tool poisoning detection |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -23,7 +23,7 @@ Traditional scanners tell you a package has a CVE. agent-bom tells you which AI 
 
 ```bash
 pip install agent-bom
-agent-bom scan       # auto-discover 20 MCP clients + scan
+agent-bom scan       # auto-discover 21 MCP clients + scan
 agent-bom check langchain   # check a specific package
 ```
 
@@ -34,7 +34,7 @@ agent-bom check langchain   # check a specific package
 
 | Capability | Description |
 |---|---|
-| **Discovery** | Auto-detect 20 MCP clients (Claude, Cursor, Windsurf, VS Code, etc.) |
+| **Discovery** | Auto-detect 21 MCP clients (Claude, Cursor, Windsurf, VS Code, etc.) |
 | **CVE scanning** | OSV + NVD CVSS v4 + EPSS + CISA KEV + GHSA |
 | **Blast radius** | Map CVE impact: package → server → agent → credentials → tools |
 | **Registry** | 427+ MCP server security metadata entries |

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.66.0"
+    __version__ = "0.67.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.66.0"
+    assert __version__ == "0.67.0"
 
 
 def test_report_version_matches():
@@ -2954,7 +2954,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.66.0"
+    assert data["version"] == "0.67.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
- Version bump to v0.67.0 across 20 files (bump-version.py)
- README: asset tracking in "How it works", "What it covers", quick start, REST API, roadmap
- Architecture SVGs: "Assets" chip added to ANALYSIS layer (dark + light)
- All SVG diagrams: 20→21 clients, 20→23 MCP tools, v0.66.0→v0.67.0
- ARCHITECTURE.md: asset_tracker.py module, compliance 10→11, Mermaid diagram updates
- site-docs: 21 clients, asset tracker module

## What's new in v0.67.0 (since v0.66.0)
- **Persistent asset tracker** — SQLite DB tracking first_seen/last_seen/resolved/reopened per vulnerability, MTTR calculation
- **Asset API endpoints** — `GET /v1/assets` + `GET /v1/assets/stats`
- **Context-aware UI nav** — dims irrelevant pages based on scan sources
- **OpenSSF Scorecard fixes** — fuzzing detection (cflite rename), token-permissions on 6 workflows
- **sanitize_error()** — smarter default strips paths/URLs, preserves safe messages
- **Detector parity + scan context alignment** (#451)

## Test plan
- [ ] Version Alignment CI check passes (all 20 files in sync)
- [ ] All tests pass (Python 3.11/3.12/3.13)
- [ ] SVG diagrams render correctly with updated counts
- [ ] README features table includes asset tracking row