### PR TITLE
fix: harden URL/domain validation across codebase (CodeQL)

### DIFF
--- a/src/agent_bom/cloud/gcp_cis_benchmark.py
+++ b/src/agent_bom/cloud/gcp_cis_benchmark.py
@@ -170,7 +170,7 @@ def _check_1_5(project_id: str) -> CISCheckResult:
             if role in primitive_roles:
                 members = binding.get("members", [])
                 # Exclude service agents and GCP-managed accounts
-                user_members = [m for m in members if not m.startswith("serviceAccount:") or "gserviceaccount.com" not in m]
+                user_members = [m for m in members if not (m.startswith("serviceAccount:") and m.endswith(".iam.gserviceaccount.com"))]
                 for m in user_members:
                     failing_members.append(f"{role}: {m}")
 

--- a/src/agent_bom/enforcement.py
+++ b/src/agent_bom/enforcement.py
@@ -449,7 +449,14 @@ def check_claude_config(config_path: str) -> list[EnforcementFinding]:
     # 3. ANTHROPIC_BASE_URL redirect
     env = data.get("env", {})
     base_url = env.get("ANTHROPIC_BASE_URL", "")
-    if base_url and "api.anthropic.com" not in base_url:
+    if base_url:
+        from urllib.parse import urlparse
+
+        _parsed_host = urlparse(base_url).hostname or ""
+        _is_anthropic = _parsed_host == "api.anthropic.com" or _parsed_host.endswith(".anthropic.com")
+    else:
+        _is_anthropic = True  # no override = safe
+    if base_url and not _is_anthropic:
         findings.append(
             EnforcementFinding(
                 severity="high",

--- a/src/agent_bom/parsers/browser_extensions.py
+++ b/src/agent_bom/parsers/browser_extensions.py
@@ -150,8 +150,14 @@ def _assess_extension_risk(
     if broad_found:
         reasons.append(f"Broad host access: {', '.join(sorted(broad_found))}")
 
-    # AI assistant host access
-    ai_hosts_matched = [h for h in all_hosts if any(ai in h for ai in _AI_ASSISTANT_HOSTS)]
+    # AI assistant host access (proper domain suffix matching)
+    def _host_matches_domain(host_pattern: str, domain: str) -> bool:
+        """Check if a host permission pattern matches a domain or its subdomains."""
+        # Strip protocol and wildcard prefixes: *://*.claude.ai/* → claude.ai
+        h = host_pattern.split("://")[-1].lstrip("*.").rstrip("/*").lower()
+        return h == domain or h.endswith(f".{domain}")
+
+    ai_hosts_matched = [h for h in all_hosts if any(_host_matches_domain(h, ai) for ai in _AI_ASSISTANT_HOSTS)]
     for h in sorted(ai_hosts_matched):
         reasons.append(f"Access to AI assistant domain: {h}")
     has_ai_access = bool(ai_hosts_matched) or bool(broad_found)


### PR DESCRIPTION
## Summary
- **enforcement.py**: `ANTHROPIC_BASE_URL` now validated with `urlparse()` hostname extraction instead of `"api.anthropic.com" not in base_url` substring check
- **gcp_cis_benchmark.py**: GCP service account exclusion uses `endswith(".iam.gserviceaccount.com")` instead of loose `"gserviceaccount.com" not in m`
- **browser_extensions.py**: AI assistant domain matching uses proper domain suffix matching (strips protocol/wildcards, checks exact domain or `.subdomain`) instead of `any(ai in h for ai ...)`

All three were the only instances of "Incomplete URL substring sanitization" patterns in the codebase. This should prevent future CodeQL findings of this type.

## Test plan
- [x] 70 related tests pass (enforcement, GCP CIS, browser extensions)
- [x] Ruff lint + format clean
- [ ] CI + CodeQL passes