### PR TITLE
fix: prod hardening round 2 — policy validation, log rotation, KEV resilience

### DIFF
--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -28,9 +28,11 @@ NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 EPSS_API_URL = "https://api.first.org/data/v1/epss"
 CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 
-# Cache for CISA KEV catalog (refresh daily)
+# Cache for CISA KEV catalog (refresh daily, persisted to disk)
 _kev_cache: Optional[dict] = None
 _kev_cache_time: Optional[datetime] = None
+_KEV_CACHE_FILE = Path.home() / ".agent-bom" / "kev_cache.json"
+_KEV_CACHE_TTL_SECONDS = 86400  # 24 hours
 
 # ─── Persistent enrichment cache (NVD + EPSS) ──────────────────────────────
 
@@ -238,11 +240,23 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
     """
     global _kev_cache, _kev_cache_time
 
-    # Use cache if less than 24 hours old
+    # Use in-memory cache if less than 24 hours old
     if _kev_cache and _kev_cache_time:
         age = datetime.now(timezone.utc) - _kev_cache_time
-        if age.total_seconds() < 86400:  # 24 hours
+        if age.total_seconds() < _KEV_CACHE_TTL_SECONDS:
             return _kev_cache
+
+    # Try loading from disk cache if in-memory cache is stale
+    if not _kev_cache and _KEV_CACHE_FILE.exists():
+        try:
+            disk_data = json.loads(_KEV_CACHE_FILE.read_text())
+            cached_at = disk_data.get("_cached_at", 0)
+            if (time.time() - cached_at) < _KEV_CACHE_TTL_SECONDS:
+                _kev_cache = disk_data.get("data", {})
+                _kev_cache_time = datetime.fromtimestamp(cached_at, tz=timezone.utc)
+                return _kev_cache
+        except (OSError, json.JSONDecodeError, ValueError):
+            _logger.debug("Failed to load KEV disk cache")
 
     response = await request_with_retry(client, "GET", CISA_KEV_URL)
 
@@ -265,9 +279,29 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
 
             _kev_cache = kev_dict
             _kev_cache_time = datetime.now(timezone.utc)
+
+            # Persist to disk for cross-session resilience
+            try:
+                _KEV_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+                _KEV_CACHE_FILE.write_text(json.dumps({"_cached_at": time.time(), "data": kev_dict}))
+            except OSError:
+                _logger.debug("Failed to persist KEV cache to disk")
+
             return kev_dict
         except (ValueError, KeyError) as e:
             console.print(f"  [dim yellow]CISA KEV parse error: {e}[/dim yellow]")
+
+    # Fallback: serve stale disk cache if API is down
+    if _KEV_CACHE_FILE.exists():
+        try:
+            disk_data = json.loads(_KEV_CACHE_FILE.read_text())
+            stale_data = disk_data.get("data", {})
+            if stale_data:
+                console.print("  [dim yellow]⚠ Using stale CISA KEV cache (API unreachable)[/dim yellow]")
+                _kev_cache = stale_data
+                return stale_data
+        except (OSError, json.JSONDecodeError):
+            pass
 
     return {}
 
@@ -341,6 +375,8 @@ async def enrich_vulnerabilities(
             epss_data = await fetch_epss_scores(cve_ids, client)
             if epss_data:
                 console.print(f"  [green]✓[/green] Retrieved EPSS data for {len(epss_data)} CVE(s)")
+            else:
+                console.print("  [yellow]⚠[/yellow] EPSS data unavailable (API unreachable or no matches)")
 
         # Fetch CISA KEV catalog (cached)
         kev_data = {}
@@ -373,6 +409,8 @@ async def enrich_vulnerabilities(
 
             if nvd_data:
                 console.print(f"  [green]✓[/green] Retrieved NVD data for {len(nvd_data)}/{len(cve_ids)} CVE(s)")
+            else:
+                console.print("  [yellow]⚠[/yellow] NVD data unavailable (API unreachable or rate-limited)")
 
         # Enrich each vulnerability — match by primary ID or CVE aliases
         for vuln in vulnerabilities:

--- a/src/agent_bom/policy.py
+++ b/src/agent_bom/policy.py
@@ -385,7 +385,11 @@ def load_policy(path: str) -> dict:
 
 
 def _validate_policy(policy: dict) -> None:
-    """Light validation of policy structure."""
+    """Validate policy structure and condition syntax at load time.
+
+    Catches invalid conditions immediately rather than at evaluation time,
+    giving operators clear feedback on misconfigured policies.
+    """
     if not isinstance(policy, dict):
         raise ValueError("Policy must be a JSON object")
     if "rules" not in policy:
@@ -397,6 +401,13 @@ def _validate_policy(policy: dict) -> None:
             raise ValueError(f"Rule at index {i} missing 'id'")
         if rule.get("action") not in ("fail", "warn", "jira", None):
             raise ValueError(f"Rule '{rule['id']}' action must be 'fail', 'warn', or 'jira'")
+        # Validate condition expression syntax at load time (fail-fast)
+        condition = rule.get("condition")
+        if condition and isinstance(condition, str):
+            try:
+                _tokenize(condition)
+            except ValueError as e:
+                raise ValueError(f"Rule '{rule['id']}' has invalid condition syntax: {e}") from e
 
 
 def _rule_matches(rule: dict, br) -> bool:

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -69,6 +69,62 @@ def _safe_regex_search(pattern: str, text: str) -> bool:
     return compiled.search(text) is not None
 
 
+# ─── Rotating audit log ─────────────────────────────────────────────────────
+
+# Maximum audit log size before rotation (100 MB). Prevents disk exhaustion
+# on long-running proxy instances.
+_AUDIT_LOG_MAX_BYTES = 100 * 1024 * 1024
+
+
+class RotatingAuditLog:
+    """File-like wrapper that rotates the JSONL audit log at a size threshold.
+
+    Checks file size every 1000 writes (not every line) to minimize stat() overhead.
+    Keeps one rotated backup (.1). Rejects symlinks on open.
+    """
+
+    def __init__(self, path: str, max_bytes: int = _AUDIT_LOG_MAX_BYTES) -> None:
+        self._path = path
+        self._max_bytes = max_bytes
+        self._writes = 0
+        self._file = self._open(path)
+
+    @staticmethod
+    def _open(path: str) -> object:
+        p = Path(path)
+        if p.is_symlink():
+            raise ValueError(f"Audit log path must not be a symlink: {path}")
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        return os.fdopen(fd, "a")
+
+    def write(self, data: str) -> int:
+        result = self._file.write(data)  # type: ignore[union-attr]
+        self._writes += 1
+        if self._writes % 1000 == 0:
+            self._maybe_rotate()
+        return result
+
+    def flush(self) -> None:
+        self._file.flush()  # type: ignore[union-attr]
+
+    def close(self) -> None:
+        self._file.close()  # type: ignore[union-attr]
+
+    def _maybe_rotate(self) -> None:
+        try:
+            size = Path(self._path).stat().st_size
+            if size >= self._max_bytes:
+                self._file.close()  # type: ignore[union-attr]
+                rotated = self._path + ".1"
+                if Path(rotated).exists():
+                    Path(rotated).unlink()
+                Path(self._path).rename(rotated)
+                self._file = self._open(self._path)
+                logger.info("Rotated audit log at %d bytes", size)
+        except OSError:
+            pass
+
+
 # ─── Proxy metrics ──────────────────────────────────────────────────────────
 
 
@@ -602,13 +658,10 @@ async def run_proxy(
     # Open audit log with restricted permissions (0o600)
     # Reject symlinks to prevent log injection attacks (attacker creates
     # symlink to overwrite another file via the proxy's audit writes).
+    # RotatingAuditLog handles automatic rotation at 100 MB.
     log_file = None
     if log_path:
-        log_p = Path(log_path)
-        if log_p.is_symlink():
-            raise ValueError(f"Audit log path must not be a symlink: {log_path}")
-        fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
-        log_file = os.fdopen(fd, "a")
+        log_file = RotatingAuditLog(log_path)
 
     # Metrics
     metrics = ProxyMetrics()


### PR DESCRIPTION
## Summary
Continues the credibility hardening from PR #488 with policy engine, audit log, and enrichment resilience fixes.

### Policy engine (fail-fast)
- **Condition syntax validation at load time** — `_validate_policy()` now pre-tokenizes all `condition` expressions. Operators get immediate `ValueError` with rule ID + position instead of silent runtime failures
- Previously: bad condition like `"epss_score @@ 0.7"` loaded silently, failed only at first evaluation

### Audit log rotation
- **`RotatingAuditLog` class** — wraps the JSONL audit file with automatic rotation at 100 MB
- Checks size every 1000 writes (minimizes `stat()` overhead)
- Keeps one rotated backup (`.jsonl.1`), rejects symlinks on open
- Prevents disk exhaustion on long-running proxy instances

### Enrichment resilience
- **CISA KEV disk persistence** — was in-memory only (lost on restart). Now persists to `~/.agent-bom/kev_cache.json` with 24h TTL
- **Stale KEV fallback** — if CISA API is unreachable, serves last known good cache with yellow warning
- **EPSS/NVD failure feedback** — now shows `⚠ EPSS data unavailable` or `⚠ NVD data unavailable` when APIs fail (was completely silent)
- **No single point of failure**: every enrichment source degrades gracefully — scan always completes

### Resilience posture (all verified)
| Service | Cache | Fallback | Breaks on Outage |
|---------|-------|----------|-----------------|
| OSV | 24h SQLite | GHSA supplement | No |
| NVD | 90d disk | Skip enrichment | No |
| EPSS | 30d disk | Skip enrichment | No |
| CISA KEV | 24h disk (**new**) | Stale cache (**new**) | No |
| GHSA | None (supplement) | OSV primary | No |
| MITRE ATT&CK | 30d disk | Stale cache | No |

## Test plan
- [x] Full test suite: 4,342 passed, 0 failed
- [x] Policy engine tests: 33 passed
- [x] ruff check + ruff format: all clean
- [x] Pre-commit hooks: all passed