### PR TITLE
feat: surface security-blocked servers in reports

### DIFF
--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -1044,6 +1044,8 @@ def _run_scan_sync(job: ScanJob) -> None:
         total_pkgs = 0
         for agent in agents:
             for server in agent.mcp_servers:
+                if server.security_blocked:
+                    continue  # Don't extract packages from security-blocked servers
                 if not server.packages:
                     server.packages = extract_packages(server)
                 total_pkgs += len(server.packages)

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -2347,6 +2347,10 @@ def scan(
             con.print(f"  [cyan]Transitive resolution enabled (max depth: {max_depth})[/cyan]\n")
         for agent in agents:
             for server in agent.mcp_servers:
+                if server.security_blocked:
+                    if not quiet:
+                        con.print(f"    [yellow]⚠ {server.name}: blocked — {', '.join(server.security_warnings)}[/yellow]")
+                    continue  # Don't extract from security-blocked servers
                 # Keep pre-populated packages from inventory, merge with discovered ones
                 pre_populated = list(server.packages)
                 _smithery_tok = smithery_token if smithery_flag else None
@@ -3680,6 +3684,8 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
 
     for agent in agents:
         for server in agent.mcp_servers:
+            if server.security_blocked:
+                continue  # Don't extract from security-blocked servers
             server.packages = extract_packages(server, resolve_transitive=transitive, max_depth=max_depth)
 
     report = AIBOMReport(agents=agents)

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -281,8 +281,18 @@ def parse_mcp_config(config_data: dict, config_path: str) -> list[MCPServer]:
         try:
             validate_mcp_server_config(server_def)
         except SecurityError as e:
-            logger.warning(f"Skipping insecure MCP server '{name}': {e}")
-            console.print(f"[yellow]⚠️  Skipped insecure server '{name}': {e}[/yellow]")
+            warning_msg = f"Blocked insecure server '{name}': {e}"
+            logger.warning(warning_msg)
+            console.print(f"[yellow]⚠️  {warning_msg}[/yellow]")
+            # Include blocked server in report for visibility — no silent skips
+            blocked_server = MCPServer(
+                name=name,
+                command=server_def.get("command", ""),
+                config_path=config_path,
+                security_blocked=True,
+                security_warnings=[str(e)],
+            )
+            servers.append(blocked_server)
             continue
 
         # Determine transport type

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -238,6 +238,8 @@ class MCPServer:
     registry_verified: bool = False  # True if found in agent-bom MCP registry
     registry_id: Optional[str] = None  # Registry entry ID, e.g. "modelcontextprotocol/filesystem"
     permission_profile: Optional[PermissionProfile] = None
+    security_blocked: bool = False  # True if server was rejected for security reasons
+    security_warnings: list[str] = field(default_factory=list)  # Security issues found during discovery
 
     @property
     def vulnerable_packages(self) -> list[Package]:

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1453,6 +1453,8 @@ def to_json(report: AIBOMReport) -> dict:
                         "mcp_version": server.mcp_version,
                         "has_credentials": server.has_credentials,
                         "credential_env_vars": server.credential_names,
+                        "security_blocked": server.security_blocked,
+                        "security_warnings": server.security_warnings,
                         "tools": [{"name": t.name, "description": t.description} for t in server.tools],
                         "packages": [
                             {


### PR DESCRIPTION
## Summary
- Insecure MCP servers (e.g. HTTP instead of HTTPS) now appear in reports with `security_blocked: true` and `security_warnings: [...]` instead of being silently skipped
- Added `security_blocked` and `security_warnings` fields to MCPServer model
- JSON/SARIF output includes blocked servers for full audit visibility
- CLI prints warning for each blocked server during extraction
- Package extraction skipped for blocked servers (no point scanning insecure endpoints)

Closes the "no silent skips" gap from the architecture audit.

## Test plan
- [x] 4,377 tests pass, 0 failures
- [x] All pre-commit hooks pass
- [x] Blocked servers included in to_json() serialization
- [x] CLI extraction skips blocked servers with visible warning