### PR TITLE
feat: multi-vendor GPU detection — AMD ROCm, Intel, Windows WDDM

### DIFF
--- a/src/agent_bom/cloud/gpu_infra.py
+++ b/src/agent_bom/cloud/gpu_infra.py
@@ -1,16 +1,23 @@
-"""GPU/AI compute infrastructure scanner — container and Kubernetes discovery.
+"""GPU/AI compute infrastructure scanner — multi-vendor container and K8s discovery.
 
 Discovers GPU-enabled workloads from running Docker containers and Kubernetes
 clusters. No additional pip packages required — uses ``docker`` and ``kubectl``
 CLI tools with subprocess (same pattern as coreweave.py and discovery/__init__.py).
 
-Discovery targets:
-- NVIDIA base images (nvcr.io/nvidia/, nvidia/cuda)
-- CUDA/cuDNN version labels on running containers
-- GPU-assigned containers (Docker ``--gpus``, K8s ``nvidia.com/gpu`` requests)
-- Unauthenticated DCGM exporter endpoints (port 9400)
+Supported GPU vendors:
+- **NVIDIA** (Linux): runtime, DeviceRequests, base images, CUDA/cuDNN labels/env
+- **AMD ROCm** (Linux): /dev/kfd device mount, ROCR_VISIBLE_DEVICES env
+- **Intel** (Linux): /dev/dri (without /dev/kfd), ONEAPI_DEVICE_SELECTOR env
+- **Windows WDDM**: device class GUID 5B45201D-..., process isolation
+- **K8s**: nvidia.com/gpu, amd.com/gpu, gpu.intel.com/i915, gpu.intel.com/xe
 
-Closes: #309 (GPU/AI compute infra inventory — KC6)
+Detection sources:
+- https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
+- https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
+- https://intel.github.io/intel-device-plugins-for-kubernetes/cmd/gpu_plugin/README.html
+- https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/gpu-acceleration
+
+Closes: #309, #471
 """
 
 from __future__ import annotations
@@ -27,6 +34,8 @@ from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 logger = logging.getLogger(__name__)
 
+# ─── Vendor detection constants ──────────────────────────────────────────────
+
 # NVIDIA image prefixes — treated as GPU workloads
 _NVIDIA_IMAGE_PREFIXES = (
     "nvcr.io/nvidia/",
@@ -39,6 +48,15 @@ _NVIDIA_IMAGE_PREFIXES = (
     "nvidia/tensorflow",
 )
 
+# AMD ROCm image prefixes
+_AMD_IMAGE_PREFIXES = (
+    "rocm/",
+    "amd/",
+    "rocm/pytorch",
+    "rocm/tensorflow",
+    "rocm/rocm-terminal",
+)
+
 # Docker label keys that indicate CUDA/cuDNN version
 _CUDA_LABEL_KEYS = (
     "com.nvidia.cuda.version",
@@ -48,7 +66,28 @@ _CUDA_LABEL_KEYS = (
     "nvidia_cuda_version",
 )
 
-# K8s resource key for GPU requests
+# AMD ROCm env vars that indicate GPU usage
+_AMD_ENV_VARS = ("ROCR_VISIBLE_DEVICES", "AMD_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "HSA_OVERRIDE_GFX_VERSION")
+
+# Intel GPU env vars
+_INTEL_ENV_VARS = ("ONEAPI_DEVICE_SELECTOR", "ZE_AFFINITY_MASK")
+
+# NVIDIA env vars
+_NVIDIA_ENV_VARS = ("NVIDIA_VISIBLE_DEVICES", "NVIDIA_DRIVER_CAPABILITIES")
+
+# Windows GPU device class GUID (DirectX/WDDM passthrough)
+# https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/gpu-acceleration
+_WINDOWS_GPU_DEVICE_CLASS = "5B45201D-F2F2-4F3B-85BB-30FF1F953599"
+
+# K8s resource keys for GPU requests (multi-vendor)
+_K8S_GPU_RESOURCES = {
+    "nvidia.com/gpu": "nvidia",
+    "amd.com/gpu": "amd",
+    "gpu.intel.com/i915": "intel",
+    "gpu.intel.com/xe": "intel",
+}
+
+# Legacy single-vendor constant kept for backward compatibility
 _K8S_GPU_RESOURCE = "nvidia.com/gpu"
 
 # DCGM exporter default port
@@ -62,12 +101,13 @@ _DCGM_PROBE_TIMEOUT = 3.0
 
 @dataclass
 class GpuContainer:
-    """A running container that has GPU access or is an NVIDIA-based image."""
+    """A running container that has GPU access or is a vendor GPU base image."""
 
     container_id: str
     name: str
     image: str
     status: str  # "running", "exited", etc.
+    gpu_vendor: str  # "nvidia", "amd", "intel", "windows", "unknown"
     is_nvidia_base: bool
     cuda_version: str | None
     cudnn_version: str | None
@@ -94,6 +134,7 @@ class GpuNode:
     """A Kubernetes node with GPU resource capacity."""
 
     name: str
+    gpu_vendor: str  # "nvidia", "amd", "intel", "unknown"
     gpu_capacity: int
     gpu_allocatable: int
     gpu_allocated: int
@@ -128,11 +169,20 @@ class GpuInfraReport:
         return sorted(versions)
 
     @property
+    def vendor_breakdown(self) -> dict[str, int]:
+        """Count GPU containers by vendor."""
+        breakdown: dict[str, int] = {}
+        for c in self.gpu_containers:
+            breakdown[c.gpu_vendor] = breakdown.get(c.gpu_vendor, 0) + 1
+        return breakdown
+
+    @property
     def risk_summary(self) -> dict[str, Any]:
         return {
             "total_gpu_containers": self.total_gpu_containers,
             "nvidia_base_images": self.nvidia_base_image_count,
             "unique_cuda_versions": self.unique_cuda_versions,
+            "vendor_breakdown": self.vendor_breakdown,
             "dcgm_endpoints": len(self.dcgm_endpoints),
             "unauthenticated_dcgm": self.unauthenticated_dcgm_count,
             "gpu_k8s_nodes": len(self.gpu_nodes),
@@ -168,6 +218,12 @@ def _is_nvidia_image(image: str) -> bool:
     """Return True if the image is an NVIDIA-published GPU base image."""
     img_lower = image.lower()
     return any(img_lower.startswith(p) for p in _NVIDIA_IMAGE_PREFIXES)
+
+
+def _is_amd_image(image: str) -> bool:
+    """Return True if the image is an AMD ROCm GPU base image."""
+    img_lower = image.lower()
+    return any(img_lower.startswith(p) for p in _AMD_IMAGE_PREFIXES)
 
 
 def _extract_cuda_versions(labels: dict[str, str]) -> tuple[str | None, str | None]:
@@ -237,6 +293,7 @@ def discover_docker_gpu_containers() -> tuple[list[GpuContainer], list[str]]:
 
             # Extract env var names (never values — security)
             env_names = [e.split("=", 1)[0] for e in env_list if "=" in e]
+            env_name_set = set(env_names)
 
             cuda_version, cudnn_version = _extract_cuda_versions(labels)
 
@@ -263,20 +320,59 @@ def discover_docker_gpu_containers() -> tuple[list[GpuContainer], list[str]]:
             if runtime in ("nvidia", "nvidia-container-runtime"):
                 gpu_requested = True
 
-            # Check if NVIDIA image
+            # ─── Vendor detection ────────────────────────────────────────
             is_nvidia = _is_nvidia_image(image)
+            is_amd = _is_amd_image(image)
+
+            # Device mounts (AMD ROCm = /dev/kfd, Intel/AMD = /dev/dri)
+            devices = host_config.get("Devices") or []
+            device_paths = [d.get("PathOnHost", "") for d in devices if isinstance(d, dict)]
+
+            has_kfd = any("/dev/kfd" in p for p in device_paths)
+            has_dri = any("/dev/dri" in p for p in device_paths)
+            has_amd_env = bool(env_name_set & set(_AMD_ENV_VARS))
+            has_intel_env = bool(env_name_set & set(_INTEL_ENV_VARS))
+            has_nvidia_env = bool(env_name_set & set(_NVIDIA_ENV_VARS))
+
+            # Windows GPU: device class GUID + process isolation
+            # https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/gpu-acceleration
+            is_windows_gpu = any(_WINDOWS_GPU_DEVICE_CLASS.lower() in p.lower() for p in device_paths)
+
+            # Determine vendor
+            gpu_vendor = "unknown"
+            if is_nvidia or gpu_requested or has_nvidia_env or cuda_version:
+                gpu_vendor = "nvidia"
+            elif has_kfd or is_amd or has_amd_env:
+                gpu_vendor = "amd"
+            elif is_windows_gpu:
+                gpu_vendor = "windows"
+            elif has_intel_env or (has_dri and not has_kfd and not is_nvidia):
+                gpu_vendor = "intel"
+
+            is_gpu = (
+                is_nvidia
+                or is_amd
+                or gpu_requested
+                or cuda_version
+                or has_kfd
+                or has_amd_env
+                or has_intel_env
+                or has_nvidia_env
+                or is_windows_gpu
+            )
 
             # Port bindings
             port_bindings = info.get("HostConfig", {}).get("PortBindings") or {}
             ports = list(port_bindings.keys())
 
-            if is_nvidia or gpu_requested or cuda_version:
+            if is_gpu:
                 containers.append(
                     GpuContainer(
                         container_id=cid,
                         name=name,
                         image=image,
                         status=status,
+                        gpu_vendor=gpu_vendor,
                         is_nvidia_base=is_nvidia,
                         cuda_version=cuda_version,
                         cudnn_version=cudnn_version,
@@ -336,19 +432,27 @@ def discover_k8s_gpu_nodes(
             capacity: dict = (node.get("status") or {}).get("capacity") or {}
             allocatable: dict = (node.get("status") or {}).get("allocatable") or {}
 
-            gpu_cap_str = capacity.get(_K8S_GPU_RESOURCE, "0")
-            gpu_alloc_str = allocatable.get(_K8S_GPU_RESOURCE, "0")
-
-            try:
-                gpu_cap = int(gpu_cap_str)
-                gpu_alloc = int(gpu_alloc_str)
-            except ValueError:
-                continue
+            # Check all vendor GPU resources
+            gpu_cap = 0
+            gpu_alloc = 0
+            gpu_vendor = "unknown"
+            for resource_key, vendor in _K8S_GPU_RESOURCES.items():
+                cap_str = capacity.get(resource_key, "0")
+                alloc_str = allocatable.get(resource_key, "0")
+                try:
+                    cap_val = int(cap_str)
+                    alloc_val = int(alloc_str)
+                except ValueError:
+                    continue
+                if cap_val > 0:
+                    gpu_cap += cap_val
+                    gpu_alloc += alloc_val
+                    gpu_vendor = vendor
 
             if gpu_cap == 0:
                 continue  # not a GPU node
 
-            # CUDA driver version from labels
+            # CUDA driver version from labels (NVIDIA-specific)
             cuda_driver = labels.get("nvidia.com/cuda.driver.major")
             cuda_minor = labels.get("nvidia.com/cuda.driver.minor")
             if cuda_driver and cuda_minor:
@@ -356,14 +460,19 @@ def discover_k8s_gpu_nodes(
             else:
                 cuda_driver = labels.get("nvidia.com/cuda.driver-version")
 
+            # Collect vendor-relevant labels
+            gpu_label_keywords = ("nvidia", "amd", "gpu", "intel", "rocm")
+            gpu_labels = {k: v for k, v in labels.items() if any(kw in k.lower() for kw in gpu_label_keywords)}
+
             nodes.append(
                 GpuNode(
                     name=name,
+                    gpu_vendor=gpu_vendor,
                     gpu_capacity=gpu_cap,
                     gpu_allocatable=gpu_alloc,
                     gpu_allocated=gpu_cap - gpu_alloc,  # rough estimate
                     cuda_driver_version=cuda_driver,
-                    labels={k: v for k, v in labels.items() if "nvidia" in k.lower()},
+                    labels=gpu_labels,
                 )
             )
         except Exception as exc:  # noqa: BLE001

--- a/tests/test_gpu_infra.py
+++ b/tests/test_gpu_infra.py
@@ -23,6 +23,7 @@ from agent_bom.cloud.gpu_infra import (
     GpuInfraReport,
     GpuNode,
     _extract_cuda_versions,
+    _is_amd_image,
     _is_nvidia_image,
     discover_docker_gpu_containers,
     discover_k8s_gpu_nodes,
@@ -87,6 +88,7 @@ def test_gpu_infra_report_properties():
             name="cuda-app",
             image="nvcr.io/nvidia/cuda:12.3",
             status="running",
+            gpu_vendor="nvidia",
             is_nvidia_base=True,
             cuda_version="12.3.0",
             cudnn_version=None,
@@ -97,6 +99,7 @@ def test_gpu_infra_report_properties():
             name="vllm-server",
             image="vllm/vllm-openai:v0.4.0",
             status="running",
+            gpu_vendor="nvidia",
             is_nvidia_base=False,
             cuda_version="12.1.0",
             cudnn_version="8.9.0",
@@ -107,7 +110,9 @@ def test_gpu_infra_report_properties():
         DcgmEndpoint(host="localhost", port=9400, url="http://localhost:9400/metrics", authenticated=False, gpu_count=4),
         DcgmEndpoint(host="10.0.0.5", port=9400, url="http://10.0.0.5:9400/metrics", authenticated=True, gpu_count=8),
     ]
-    nodes = [GpuNode(name="gpu-node-1", gpu_capacity=8, gpu_allocatable=6, gpu_allocated=2, cuda_driver_version="525.85")]
+    nodes = [
+        GpuNode(name="gpu-node-1", gpu_vendor="nvidia", gpu_capacity=8, gpu_allocatable=6, gpu_allocated=2, cuda_driver_version="525.85")
+    ]
 
     report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=endpoints, gpu_nodes=nodes, warnings=[])
 
@@ -142,6 +147,7 @@ def test_gpu_infra_to_agents_containers():
             cuda_version="12.3.0",
             cudnn_version="8.9.0",
             gpu_requested=True,
+            gpu_vendor="nvidia",
         ),
     ]
     report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=[], gpu_nodes=[], warnings=[])
@@ -157,8 +163,8 @@ def test_gpu_infra_to_agents_containers():
 
 def test_gpu_infra_to_agents_k8s_nodes():
     nodes = [
-        GpuNode(name="node-1", gpu_capacity=4, gpu_allocatable=4, gpu_allocated=0, cuda_driver_version="525"),
-        GpuNode(name="node-2", gpu_capacity=8, gpu_allocatable=6, gpu_allocated=2, cuda_driver_version="525"),
+        GpuNode(name="node-1", gpu_vendor="nvidia", gpu_capacity=4, gpu_allocatable=4, gpu_allocated=0, cuda_driver_version="525"),
+        GpuNode(name="node-2", gpu_vendor="nvidia", gpu_capacity=8, gpu_allocatable=6, gpu_allocated=2, cuda_driver_version="525"),
     ]
     report = GpuInfraReport(gpu_containers=[], dcgm_endpoints=[], gpu_nodes=nodes, warnings=[])
     agents = gpu_infra_to_agents(report)
@@ -180,6 +186,7 @@ def test_gpu_infra_to_agents_no_cuda_version():
             cuda_version=None,
             cudnn_version=None,
             gpu_requested=True,
+            gpu_vendor="nvidia",
         ),
     ]
     report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=[], gpu_nodes=[], warnings=[])
@@ -191,7 +198,9 @@ def test_gpu_infra_to_agents_no_cuda_version():
 # ─── Integration: discover_docker_gpu_containers (mocked) ─────────────────────
 
 
-def _make_inspect(container_id, name, image, labels=None, env=None, runtime="runc", device_requests=None, port_bindings=None):
+def _make_inspect(
+    container_id, name, image, labels=None, env=None, runtime="runc", device_requests=None, port_bindings=None, devices=None, isolation=""
+):
     return {
         "Id": container_id + "0" * 52,
         "Name": f"/{name}",
@@ -204,6 +213,8 @@ def _make_inspect(container_id, name, image, labels=None, env=None, runtime="run
             "Runtime": runtime,
             "DeviceRequests": device_requests or [],
             "PortBindings": port_bindings or {},
+            "Devices": devices or [],
+            "Isolation": isolation,
         },
         "State": {"Status": "running"},
     }
@@ -529,9 +540,10 @@ async def test_scan_gpu_infra_with_containers():
             cuda_version="12.3.0",
             cudnn_version=None,
             gpu_requested=True,
+            gpu_vendor="nvidia",
         )
     ]
-    nodes = [GpuNode(name="node-1", gpu_capacity=4, gpu_allocatable=4, gpu_allocated=0, cuda_driver_version="525")]
+    nodes = [GpuNode(name="node-1", gpu_vendor="nvidia", gpu_capacity=4, gpu_allocatable=4, gpu_allocated=0, cuda_driver_version="525")]
 
     with (
         patch("agent_bom.cloud.gpu_infra.discover_docker_gpu_containers", return_value=(containers, [])),
@@ -543,3 +555,412 @@ async def test_scan_gpu_infra_with_containers():
     assert report.total_gpu_containers == 1
     assert len(report.gpu_nodes) == 1
     assert report.unique_cuda_versions == ["12.3.0"]
+
+
+# ─── Multi-vendor: AMD ROCm detection ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "image,expected",
+    [
+        ("rocm/pytorch:latest", True),
+        ("rocm/tensorflow:latest", True),
+        ("rocm/rocm-terminal:latest", True),
+        ("amd/amdgpu:latest", True),
+        ("nvcr.io/nvidia/cuda:12.3", False),
+        ("python:3.11", False),
+    ],
+)
+def test_is_amd_image(image, expected):
+    assert _is_amd_image(image) == expected
+
+
+def test_discover_docker_amd_rocm_device_mount():
+    """Container with /dev/kfd device mount is detected as AMD GPU."""
+    container_data = [
+        _make_inspect(
+            "aaa111",
+            "rocm-app",
+            "rocm/pytorch:latest",
+            devices=[{"PathOnHost": "/dev/kfd", "PathInContainer": "/dev/kfd", "CgroupPermissions": "rwm"}],
+        )
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "aaa111" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, warnings = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].gpu_vendor == "amd"
+    assert containers[0].is_nvidia_base is False
+
+
+def test_discover_docker_amd_env_vars():
+    """Container with ROCR_VISIBLE_DEVICES env var is detected as AMD GPU."""
+    container_data = [
+        _make_inspect(
+            "aaa222",
+            "hip-app",
+            "myapp:latest",
+            env=["ROCR_VISIBLE_DEVICES=0,1", "PATH=/usr/bin"],
+        )
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "aaa222" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, _ = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].gpu_vendor == "amd"
+
+
+def test_discover_docker_amd_image_prefix():
+    """AMD ROCm base image is detected by image prefix."""
+    container_data = [_make_inspect("aaa333", "rocm-train", "rocm/tensorflow:latest")]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "aaa333" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, _ = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].gpu_vendor == "amd"
+
+
+# ─── Multi-vendor: Intel GPU detection ────────────────────────────────────────
+
+
+def test_discover_docker_intel_env_var():
+    """Container with ONEAPI_DEVICE_SELECTOR env var is detected as Intel GPU."""
+    container_data = [
+        _make_inspect(
+            "bbb111",
+            "oneapi-app",
+            "intel/oneapi-basekit:latest",
+            env=["ONEAPI_DEVICE_SELECTOR=level_zero:0", "PATH=/usr/bin"],
+        )
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "bbb111" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, _ = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].gpu_vendor == "intel"
+
+
+def test_discover_docker_intel_dri_without_kfd():
+    """Container with /dev/dri but NOT /dev/kfd is Intel (not AMD)."""
+    container_data = [
+        _make_inspect(
+            "bbb222",
+            "sycl-app",
+            "myapp:latest",
+            env=["ZE_AFFINITY_MASK=0", "PATH=/usr/bin"],
+            devices=[{"PathOnHost": "/dev/dri", "PathInContainer": "/dev/dri", "CgroupPermissions": "rwm"}],
+        )
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "bbb222" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, _ = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].gpu_vendor == "intel"
+
+
+# ─── Multi-vendor: Windows WDDM GPU detection ────────────────────────────────
+
+
+def test_discover_docker_windows_gpu():
+    """Container with Windows GPU device class GUID is detected."""
+    container_data = [
+        _make_inspect(
+            "ccc111",
+            "directx-app",
+            "mcr.microsoft.com/windows/servercore:ltsc2022",
+            devices=[
+                {
+                    "PathOnHost": "class/5B45201D-F2F2-4F3B-85BB-30FF1F953599",
+                    "PathInContainer": "",
+                    "CgroupPermissions": "",
+                }
+            ],
+            isolation="process",
+        )
+    ]
+
+    with (
+        patch("shutil.which", return_value="C:\\docker\\docker.exe"),
+        patch("subprocess.run") as mock_run,
+    ):
+        ps_result = MagicMock()
+        ps_result.returncode = 0
+        ps_result.stdout = "ccc111" + "0" * 52 + "\n"
+
+        inspect_result = MagicMock()
+        inspect_result.returncode = 0
+        inspect_result.stdout = json.dumps(container_data)
+
+        mock_run.side_effect = [ps_result, inspect_result]
+
+        containers, _ = discover_docker_gpu_containers()
+
+    assert len(containers) == 1
+    assert containers[0].gpu_vendor == "windows"
+
+
+# ─── Multi-vendor: K8s GPU resources ──────────────────────────────────────────
+
+
+def _make_k8s_node(name, resources=None, labels=None):
+    """Build a K8s node dict with arbitrary GPU resources."""
+    return {
+        "metadata": {"name": name, "labels": labels or {}},
+        "status": {
+            "capacity": {**(resources or {}), "cpu": "32"},
+            "allocatable": {**(resources or {}), "cpu": "32"},
+        },
+    }
+
+
+def test_discover_k8s_amd_gpu_node():
+    """K8s node with amd.com/gpu resource is detected as AMD."""
+    node_list = {"items": [_make_k8s_node("amd-node-1", resources={"amd.com/gpu": "4"})]}
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(node_list)
+        mock_run.return_value = result
+
+        nodes, _ = discover_k8s_gpu_nodes()
+
+    assert len(nodes) == 1
+    assert nodes[0].gpu_vendor == "amd"
+    assert nodes[0].gpu_capacity == 4
+
+
+def test_discover_k8s_intel_gpu_node():
+    """K8s node with gpu.intel.com/i915 resource is detected as Intel."""
+    node_list = {"items": [_make_k8s_node("intel-node-1", resources={"gpu.intel.com/i915": "2"})]}
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(node_list)
+        mock_run.return_value = result
+
+        nodes, _ = discover_k8s_gpu_nodes()
+
+    assert len(nodes) == 1
+    assert nodes[0].gpu_vendor == "intel"
+    assert nodes[0].gpu_capacity == 2
+
+
+def test_discover_k8s_intel_xe_gpu_node():
+    """K8s node with gpu.intel.com/xe resource is detected as Intel."""
+    node_list = {"items": [_make_k8s_node("xe-node-1", resources={"gpu.intel.com/xe": "1"})]}
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(node_list)
+        mock_run.return_value = result
+
+        nodes, _ = discover_k8s_gpu_nodes()
+
+    assert len(nodes) == 1
+    assert nodes[0].gpu_vendor == "intel"
+
+
+def test_discover_k8s_mixed_vendor_nodes():
+    """Cluster with NVIDIA + AMD nodes detects both vendors."""
+    node_list = {
+        "items": [
+            _make_k8s_node("nvidia-node", resources={"nvidia.com/gpu": "8"}),
+            _make_k8s_node("amd-node", resources={"amd.com/gpu": "4"}),
+            _make_k8s_node("cpu-node", resources={}),
+        ]
+    }
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(node_list)
+        mock_run.return_value = result
+
+        nodes, _ = discover_k8s_gpu_nodes()
+
+    assert len(nodes) == 2
+    vendors = {n.gpu_vendor for n in nodes}
+    assert vendors == {"nvidia", "amd"}
+
+
+# ─── Multi-vendor: vendor_breakdown property ──────────────────────────────────
+
+
+def test_vendor_breakdown_property():
+    """GpuInfraReport.vendor_breakdown counts containers per vendor."""
+    containers = [
+        GpuContainer(
+            container_id="a",
+            name="nv1",
+            image="nvcr.io/nvidia/cuda:12",
+            status="running",
+            gpu_vendor="nvidia",
+            is_nvidia_base=True,
+            cuda_version=None,
+            cudnn_version=None,
+            gpu_requested=True,
+        ),
+        GpuContainer(
+            container_id="b",
+            name="nv2",
+            image="nvcr.io/nvidia/cuda:11",
+            status="running",
+            gpu_vendor="nvidia",
+            is_nvidia_base=True,
+            cuda_version=None,
+            cudnn_version=None,
+            gpu_requested=True,
+        ),
+        GpuContainer(
+            container_id="c",
+            name="amd1",
+            image="rocm/pytorch:latest",
+            status="running",
+            gpu_vendor="amd",
+            is_nvidia_base=False,
+            cuda_version=None,
+            cudnn_version=None,
+            gpu_requested=False,
+        ),
+        GpuContainer(
+            container_id="d",
+            name="intel1",
+            image="myapp:latest",
+            status="running",
+            gpu_vendor="intel",
+            is_nvidia_base=False,
+            cuda_version=None,
+            cudnn_version=None,
+            gpu_requested=False,
+        ),
+    ]
+    report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=[], gpu_nodes=[], warnings=[])
+    assert report.vendor_breakdown == {"nvidia": 2, "amd": 1, "intel": 1}
+
+
+def test_vendor_breakdown_in_risk_summary():
+    """vendor_breakdown appears in risk_summary output."""
+    report = GpuInfraReport(gpu_containers=[], dcgm_endpoints=[], gpu_nodes=[], warnings=[])
+    assert report.risk_summary["vendor_breakdown"] == {}
+
+
+def test_k8s_gpu_labels_collected():
+    """K8s GPU nodes collect vendor-relevant labels (nvidia, amd, gpu, intel, rocm)."""
+    node_list = {
+        "items": [
+            {
+                "metadata": {
+                    "name": "labeled-node",
+                    "labels": {
+                        "nvidia.com/gpu.product": "A100",
+                        "kubernetes.io/hostname": "labeled-node",
+                        "unrelated-label": "ignored",
+                    },
+                },
+                "status": {
+                    "capacity": {"nvidia.com/gpu": "8", "cpu": "64"},
+                    "allocatable": {"nvidia.com/gpu": "8", "cpu": "64"},
+                },
+            }
+        ]
+    }
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = json.dumps(node_list)
+        mock_run.return_value = result
+
+        nodes, _ = discover_k8s_gpu_nodes()
+
+    assert len(nodes) == 1
+    assert "nvidia.com/gpu.product" in nodes[0].labels
+    assert "unrelated-label" not in nodes[0].labels


### PR DESCRIPTION
## Summary
- Expand `gpu_infra.py` from NVIDIA-only to detect **AMD ROCm** (`/dev/kfd`, `ROCR_VISIBLE_DEVICES`), **Intel GPU** (`/dev/dri`, `ONEAPI_DEVICE_SELECTOR`), **Windows WDDM** (device class GUID), and multi-vendor **K8s resources** (`amd.com/gpu`, `gpu.intel.com/i915`, `gpu.intel.com/xe`)
- Add `gpu_vendor` field to `GpuContainer` and `GpuNode` dataclasses, `vendor_breakdown` property to `GpuInfraReport`
- 19 new tests covering all vendor detection paths (50 total, all passing)

Detection sources:
- [NVIDIA Container Toolkit docs](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html)
- [AMD ROCm Docker docs](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html)
- [Intel GPU Device Plugin for K8s](https://intel.github.io/intel-device-plugins-for-kubernetes/cmd/gpu_plugin/README.html)
- [Windows GPU Acceleration docs](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/gpu-acceleration)

Closes #471

## Test plan
- [x] All 50 GPU infra tests pass
- [x] 913+ other tests unaffected
- [x] Ruff lint + format clean
- [ ] CI passes (9 jobs)