### PR TITLE
feat: upgrade license engine — full SPDX catalog, network-copyleft, MCP tool

### DIFF
--- a/src/agent_bom/license_policy.py
+++ b/src/agent_bom/license_policy.py
@@ -1,69 +1,163 @@
 """License policy engine — categorize, evaluate, and report license compliance.
 
+Uses the ``license-expression`` library (transitive dep via cyclonedx-python-lib)
+for proper SPDX expression parsing, deprecated ID normalization, and access to the
+full ScanCode license index (2,500+ licenses with category metadata).
+
 Provides SPDX license categorization, policy evaluation against configurable
 block/warn lists, and Rich console output for license findings.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 
 from agent_bom.models import Agent
 
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
-# SPDX license categories
+# SPDX license index — built from license-expression's vendored ScanCode data
 # ---------------------------------------------------------------------------
 
-PERMISSIVE: set[str] = {
-    "MIT",
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "0BSD",
-    "Unlicense",
-    "CC0-1.0",
-    "CC-BY-4.0",
-    "Zlib",
-    "BSL-1.0",  # Boost, not Business Source License
-    "PSF-2.0",
-    "Python-2.0",
-    "BlueOak-1.0.0",
+# Map library categories → our risk tiers
+_CATEGORY_TO_TIER: dict[str, tuple[str, str]] = {
+    "Permissive": ("permissive", "low"),
+    "Public Domain": ("permissive", "low"),
+    "Copyleft Limited": ("weak_copyleft", "medium"),
+    "Copyleft": ("strong_copyleft", "high"),
+    "Source-available": ("source_available", "high"),
+    "Free Restricted": ("restricted", "medium"),
+    "Proprietary Free": ("proprietary", "medium"),
+    "Commercial": ("commercial_risk", "critical"),
+    "CLA": ("permissive", "low"),
+    "Patent License": ("permissive", "low"),
+    "Unstated License": ("unknown", "medium"),
 }
 
-WEAK_COPYLEFT: set[str] = {
-    "LGPL-2.1-only",
-    "LGPL-2.1-or-later",
-    "LGPL-3.0-only",
-    "LGPL-3.0-or-later",
-    "MPL-2.0",
-    "EPL-2.0",
-    "EPL-1.0",
-    "CDDL-1.0",
-    "CDDL-1.1",
-    "CPL-1.0",
-}
-
-STRONG_COPYLEFT: set[str] = {
-    "GPL-2.0-only",
-    "GPL-2.0-or-later",
-    "GPL-3.0-only",
-    "GPL-3.0-or-later",
+# Network-copyleft overrides — AGPL/EUPL/OSL are stricter than regular copyleft.
+# These get "network_copyleft" category with "critical" risk because they trigger
+# on network use (not just distribution), which catches SaaS/API deployments.
+_NETWORK_COPYLEFT: set[str] = {
+    "AGPL-1.0-only",
+    "AGPL-1.0-or-later",
     "AGPL-3.0-only",
     "AGPL-3.0-or-later",
+    "EUPL-1.1",
+    "EUPL-1.2",
+    "OSL-3.0",
+    "OSL-2.1",
+    "OSL-2.0",
+    "OSL-1.0",
+    "RPL-1.1",
+    "RPL-1.5",
+    "Watcom-1.0",
 }
 
-COMMERCIAL_RISK: set[str] = {
+# Commercial/source-available overrides — these are NOT open source despite
+# sometimes appearing in open ecosystems (MariaDB BSL→BUSL, MongoDB SSPL, etc.)
+_COMMERCIAL_RISK: set[str] = {
     "SSPL-1.0",
-    "BSL-1.1",  # Business Source License (MariaDB/HashiCorp)
+    "BUSL-1.1",  # Business Source License — SPDX key is BUSL, not BSL
     "Elastic-2.0",
-    "Commons-Clause",
 }
 
-# Default policy: block strong copyleft + commercial risk, warn weak copyleft
+# Backward compat aliases — users may pass non-SPDX IDs in policy files
+_ALIASES: dict[str, str] = {
+    "BSL-1.1": "BUSL-1.1",
+    "Commons-Clause": "Commons-Clause",  # Not in SPDX index, flagged as unknown
+}
+
+
+def _build_spdx_index() -> dict[str, tuple[str, str]]:
+    """Build SPDX key → (category, risk_level) lookup from license-expression index.
+
+    Falls back to hardcoded sets if the library is unavailable.
+    """
+    index: dict[str, tuple[str, str]] = {}
+
+    try:
+        from license_expression import get_license_index
+
+        for entry in get_license_index():
+            spdx_key = entry.get("spdx_license_key", "")
+            if not spdx_key or entry.get("is_exception"):
+                continue
+
+            # Network-copyleft overrides
+            if spdx_key in _NETWORK_COPYLEFT:
+                index[spdx_key] = ("network_copyleft", "critical")
+                continue
+
+            # Commercial-risk overrides
+            if spdx_key in _COMMERCIAL_RISK:
+                index[spdx_key] = ("commercial_risk", "critical")
+                continue
+
+            category = entry.get("category", "")
+            tier = _CATEGORY_TO_TIER.get(category, ("unknown", "medium"))
+            index[spdx_key] = tier
+
+    except ImportError:
+        logger.debug("license-expression not available, using hardcoded license sets")
+        # Fallback: hardcoded sets from original implementation
+        for lic in (
+            "MIT",
+            "Apache-2.0",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "ISC",
+            "0BSD",
+            "Unlicense",
+            "CC0-1.0",
+            "CC-BY-4.0",
+            "Zlib",
+            "BSL-1.0",
+            "PSF-2.0",
+            "Python-2.0",
+            "BlueOak-1.0.0",
+        ):
+            index[lic] = ("permissive", "low")
+        for lic in (
+            "LGPL-2.1-only",
+            "LGPL-2.1-or-later",
+            "LGPL-3.0-only",
+            "LGPL-3.0-or-later",
+            "MPL-2.0",
+            "EPL-2.0",
+            "EPL-1.0",
+            "CDDL-1.0",
+            "CDDL-1.1",
+            "CPL-1.0",
+        ):
+            index[lic] = ("weak_copyleft", "medium")
+        for lic in ("GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-only", "GPL-3.0-or-later"):
+            index[lic] = ("strong_copyleft", "high")
+        for lic in _NETWORK_COPYLEFT:
+            index[lic] = ("network_copyleft", "critical")
+        for lic in _COMMERCIAL_RISK:
+            index[lic] = ("commercial_risk", "critical")
+        index["SSPL-1.0"] = ("commercial_risk", "critical")
+        index["Elastic-2.0"] = ("commercial_risk", "critical")
+
+    return index
+
+
+# Module-level singleton — built once at import time
+_SPDX_INDEX: dict[str, tuple[str, str]] = _build_spdx_index()
+
+# Expose legacy sets for backward compatibility (tests reference these)
+PERMISSIVE: set[str] = {k for k, v in _SPDX_INDEX.items() if v[0] == "permissive"}
+WEAK_COPYLEFT: set[str] = {k for k, v in _SPDX_INDEX.items() if v[0] == "weak_copyleft"}
+STRONG_COPYLEFT: set[str] = {k for k, v in _SPDX_INDEX.items() if v[0] == "strong_copyleft"}
+COMMERCIAL_RISK: set[str] = {k for k, v in _SPDX_INDEX.items() if v[0] == "commercial_risk"}
+NETWORK_COPYLEFT: set[str] = {k for k, v in _SPDX_INDEX.items() if v[0] == "network_copyleft"}
+
+# Default policy: block strong/network copyleft + commercial risk, warn weak copyleft
 DEFAULT_LICENSE_POLICY: dict = {
-    "license_block": ["GPL-*", "AGPL-*", "SSPL-*", "BSL-1.1", "Elastic-*"],
+    "license_block": ["GPL-*", "AGPL-*", "SSPL-*", "BUSL-*", "BSL-1.1", "Elastic-*", "EUPL-*", "OSL-*"],
     "license_warn": ["LGPL-*", "MPL-*", "EPL-*", "CDDL-*"],
 }
 
@@ -82,7 +176,7 @@ class LicenseFinding:
     ecosystem: str
     license_id: str  # SPDX identifier
     license_expression: str  # Full SPDX expression if available
-    category: str  # permissive, weak_copyleft, strong_copyleft, commercial_risk, unknown
+    category: str  # permissive, weak_copyleft, strong_copyleft, network_copyleft, commercial_risk, unknown
     risk_level: str  # low, medium, high, critical
     reason: str  # Human-readable explanation
     agents: list[str] = field(default_factory=list)
@@ -100,55 +194,119 @@ class LicenseReport:
 
 
 # ---------------------------------------------------------------------------
-# License categorization
+# SPDX expression parsing
 # ---------------------------------------------------------------------------
+
+_RISK_ORDER = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+
+def _parse_expression_keys(expression: str) -> list[str]:
+    """Parse an SPDX expression into individual license keys.
+
+    Uses license-expression for proper parsing (handles WITH exceptions,
+    nested parens, deprecated ID normalization like GPL-2.0 → GPL-2.0-only).
+    Falls back to naive split on OR/AND if library unavailable.
+    """
+    try:
+        from license_expression import get_spdx_licensing
+
+        spdx = get_spdx_licensing()
+        parsed = spdx.parse(expression)
+        if parsed is not None:
+            return spdx.license_keys(parsed)
+    except (ImportError, Exception):  # noqa: BLE001
+        pass
+
+    # Fallback: naive split (original behavior)
+    cleaned = expression.replace("(", "").replace(")", "")
+    parts = []
+    for chunk in cleaned.split(" OR "):
+        for sub in chunk.split(" AND "):
+            key = sub.strip()
+            # Strip WITH exceptions (e.g., "GPL-2.0-only WITH Classpath-exception-2.0")
+            if " WITH " in key:
+                key = key.split(" WITH ")[0].strip()
+            if key:
+                parts.append(key)
+    return parts
+
+
+def _categorize_single(spdx_key: str) -> tuple[str, str]:
+    """Categorize a single SPDX license key (not an expression)."""
+    if not spdx_key:
+        return "unknown", "medium"
+
+    # Check alias map
+    resolved = _ALIASES.get(spdx_key, spdx_key)
+
+    # Look up in index
+    if resolved in _SPDX_INDEX:
+        return _SPDX_INDEX[resolved]
+
+    return "unknown", "medium"
 
 
 def categorize_license(spdx_id: str) -> tuple[str, str]:
-    """Categorize an SPDX license identifier.
+    """Categorize an SPDX license identifier or expression.
 
     Returns (category, risk_level) where:
-    - category: permissive, weak_copyleft, strong_copyleft, commercial_risk, unknown
+    - category: permissive, weak_copyleft, strong_copyleft, network_copyleft,
+                commercial_risk, source_available, restricted, proprietary, unknown
     - risk_level: low, medium, high, critical
+
+    Handles compound expressions:
+    - OR: licensee chooses → picks the most permissive (lowest risk)
+    - AND: all apply → picks the most restrictive (highest risk)
+    - WITH: exception modifies base license → categorize base only
     """
     if not spdx_id:
         return "unknown", "medium"
 
     normalized = spdx_id.strip()
+    if not normalized:
+        return "unknown", "medium"
 
-    if normalized in PERMISSIVE:
-        return "permissive", "low"
-    if normalized in WEAK_COPYLEFT:
-        return "weak_copyleft", "medium"
-    if normalized in STRONG_COPYLEFT:
-        return "strong_copyleft", "high"
-    if normalized in COMMERCIAL_RISK:
-        return "commercial_risk", "critical"
+    # Try direct lookup first (fast path for simple IDs)
+    direct = _categorize_single(normalized)
+    if direct[0] != "unknown":
+        return direct
 
-    # Handle SPDX expressions (e.g., "Apache-2.0 OR MIT" → permissive)
-    if " OR " in normalized:
-        parts = [p.strip() for p in normalized.split(" OR ")]
-        categories = [categorize_license(p) for p in parts]
-        # OR means user can choose — pick the most permissive
-        risk_order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
-        best = min(categories, key=lambda c: risk_order.get(c[1], 99))
-        return best
+    # Check if it's a compound expression
+    is_compound = any(op in normalized for op in (" OR ", " AND ", " WITH "))
+    if not is_compound:
+        # Try parsing as deprecated ID (e.g., GPL-2.0 → GPL-2.0-only)
+        keys = _parse_expression_keys(normalized)
+        if len(keys) == 1 and keys[0] != normalized:
+            return _categorize_single(keys[0])
+        return "unknown", "medium"
 
-    if " AND " in normalized:
-        parts = [p.strip() for p in normalized.split(" AND ")]
-        categories = [categorize_license(p) for p in parts]
-        # AND means all apply — pick the most restrictive
-        risk_order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
-        worst = max(categories, key=lambda c: risk_order.get(c[1], 99))
-        return worst
+    # Parse compound expression
+    keys = _parse_expression_keys(normalized)
+    if not keys:
+        return "unknown", "medium"
 
-    return "unknown", "medium"
+    categories = [_categorize_single(k) for k in keys]
+
+    # Determine if OR or AND dominates
+    if " OR " in normalized and " AND " not in normalized:
+        # Pure OR: pick most permissive
+        return min(categories, key=lambda c: _RISK_ORDER.get(c[1], 99))
+    elif " AND " in normalized and " OR " not in normalized:
+        # Pure AND: pick most restrictive
+        return max(categories, key=lambda c: _RISK_ORDER.get(c[1], 99))
+    else:
+        # Mixed: let the parser handle it, take most restrictive (conservative)
+        return max(categories, key=lambda c: _RISK_ORDER.get(c[1], 99))
 
 
 def _matches_pattern(license_id: str, patterns: list[str]) -> bool:
     """Check if a license ID matches any of the glob patterns."""
     for pattern in patterns:
         if fnmatch(license_id, pattern):
+            return True
+        # Also match BSL-1.1 alias for BUSL-1.1
+        resolved = _ALIASES.get(license_id, "")
+        if resolved and fnmatch(resolved, pattern):
             return True
     return False
 
@@ -249,7 +407,8 @@ def evaluate_license_policy(
                             agents=[agent.name],
                         )
                     )
-                elif category in ("strong_copyleft", "commercial_risk"):
+                elif category in ("strong_copyleft", "network_copyleft", "commercial_risk", "source_available"):
+                    report.compliant = False if category in ("network_copyleft", "commercial_risk") else report.compliant
                     report.findings.append(
                         LicenseFinding(
                             package_name=pkg.name,
@@ -331,7 +490,7 @@ def print_license_report(report: LicenseReport, console: object) -> None:
     from rich.table import Table
 
     if not report.findings:
-        console.print("\n  [green]✓[/green] License compliance: no findings\n")
+        console.print("\n  [green]\u2713[/green] License compliance: no findings\n")
         return
 
     status = "[green]COMPLIANT[/green]" if report.compliant else "[red]NON-COMPLIANT[/red]"
@@ -351,7 +510,11 @@ def print_license_report(report: LicenseReport, console: object) -> None:
         "permissive": "green",
         "weak_copyleft": "yellow",
         "strong_copyleft": "red",
+        "network_copyleft": "red",
         "commercial_risk": "red",
+        "source_available": "yellow",
+        "restricted": "yellow",
+        "proprietary": "cyan",
         "unknown": "dim",
     }
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -4,7 +4,7 @@ Start with:
     agent-bom mcp-server              # stdio (for Claude Desktop, Cursor, etc.)
     agent-bom mcp-server --sse        # SSE transport (for remote clients)
 
-Tools (29):
+Tools (30):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE
@@ -34,6 +34,7 @@ Tools (29):
     model_provenance_scan  — Check ML model provenance from HuggingFace/Ollama
     prompt_scan         — Scan prompt templates for injection risks
     model_file_scan     — Scan model files for serialization risks
+    license_compliance_scan — Evaluate package licenses against SPDX compliance policy
 
 Resources (2):
     registry://servers  — Browse 427+ server security metadata registry
@@ -2201,6 +2202,95 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             logger.exception("MCP tool error")
             return json.dumps({"error": sanitize_error(exc)})
 
+    # ── Tool 30: license_compliance_scan ────────────────────────────
+
+    @mcp.tool(annotations=_READ_ONLY, title="License Compliance Scan")
+    async def license_compliance_scan(
+        scan_json: Annotated[
+            str,
+            Field(
+                description=(
+                    "JSON string of a previous scan result (from the 'scan' tool) "
+                    "containing agents with packages. Or a JSON array of "
+                    '{"name": "pkg", "version": "1.0", "ecosystem": "npm", "license": "MIT"} objects.'
+                ),
+            ),
+        ],
+        policy_json: Annotated[
+            str,
+            Field(
+                default="",
+                description=(
+                    'Optional JSON policy: {"license_block": ["GPL-*"], "license_warn": ["LGPL-*"]}. '
+                    "Uses default policy (block GPL/AGPL/SSPL/BUSL/EUPL/OSL, warn LGPL/MPL/EPL/CDDL) if empty."
+                ),
+            ),
+        ] = "",
+    ) -> str:
+        """Evaluate package licenses against compliance policy.
+
+        Categorizes each package license using the full SPDX catalog (2,500+ licenses)
+        with proper expression parsing (OR/AND/WITH), deprecated ID normalization,
+        and network-copyleft detection (AGPL, EUPL, OSL).
+
+        Risk tiers: permissive (low), weak-copyleft (medium), strong-copyleft (high),
+        network-copyleft (critical), commercial-risk (critical), source-available (high).
+
+        Returns structured report with compliance status, findings, and risk summary.
+        """
+        try:
+            from agent_bom.license_policy import evaluate_license_policy, to_serializable
+            from agent_bom.models import Agent, MCPServer, Package
+
+            data = json.loads(scan_json)
+            policy = json.loads(policy_json) if policy_json else None
+
+            # Accept either a full scan result (with agents) or a flat package list
+            agents: list[Agent] = []
+            if isinstance(data, dict) and "agents" in data:
+                # Full scan result — reconstruct agents
+                for agent_data in data["agents"]:
+                    servers = []
+                    for srv in agent_data.get("mcp_servers", []):
+                        pkgs = [
+                            Package(
+                                name=p.get("name", ""),
+                                version=p.get("version", ""),
+                                ecosystem=p.get("ecosystem", ""),
+                                license=p.get("license"),
+                                license_expression=p.get("license_expression"),
+                            )
+                            for p in srv.get("packages", [])
+                        ]
+                        servers.append(MCPServer(name=srv.get("name", ""), command="", packages=pkgs))
+                    agents.append(Agent(name=agent_data.get("name", ""), agent_type="custom", config_path="", mcp_servers=servers))
+            elif isinstance(data, list):
+                # Flat package list
+                pkgs = [
+                    Package(
+                        name=p.get("name", ""),
+                        version=p.get("version", ""),
+                        ecosystem=p.get("ecosystem", ""),
+                        license=p.get("license"),
+                        license_expression=p.get("license_expression"),
+                    )
+                    for p in data
+                ]
+                agents = [
+                    Agent(
+                        name="input",
+                        agent_type="custom",
+                        config_path="",
+                        mcp_servers=[MCPServer(name="packages", command="", packages=pkgs)],
+                    )
+                ]
+
+            report = evaluate_license_policy(agents, policy=policy)
+            return _truncate_response(json.dumps(to_serializable(report), indent=2))
+        except Exception as exc:
+            logger.exception("MCP tool error")
+            return json.dumps({"error": sanitize_error(exc)})
+
     # ── Custom routes: metadata + health ─────────────────────────────
 
     @mcp.custom_route("/.well-known/mcp/server-card.json", methods=["GET"])
@@ -2360,6 +2450,11 @@ _SERVER_CARD_TOOLS = [
     {
         "name": "model_file_scan",
         "description": "Scan model files (.gguf, .safetensors, .pkl, .pt) for serialization risks and format metadata",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "license_compliance_scan",
+        "description": "Evaluate package licenses against SPDX compliance policy — 2,500+ licenses, network-copyleft detection, deprecated ID normalization",
         "annotations": {"readOnlyHint": True},
     },
 ]

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -124,7 +124,7 @@ def test_server_card_has_all_tools():
     assert card["name"] == "agent-bom"
     assert "version" in card
     tool_names = [t["name"] for t in card["tools"]]
-    assert len(tool_names) == 29
+    assert len(tool_names) == 30
     assert "scan" in tool_names
     assert "check" in tool_names
     assert "blast_radius" in tool_names

--- a/tests/test_license_policy.py
+++ b/tests/test_license_policy.py
@@ -53,16 +53,28 @@ class TestCategorizeLicense:
             assert risk == "medium"
 
     def test_strong_copyleft_licenses(self):
-        for lic in ["GPL-2.0-only", "GPL-3.0-only", "AGPL-3.0-only", "GPL-3.0-or-later"]:
+        for lic in ["GPL-2.0-only", "GPL-3.0-only", "GPL-3.0-or-later"]:
             cat, risk = categorize_license(lic)
             assert cat == "strong_copyleft", f"{lic} should be strong copyleft"
             assert risk == "high"
 
+    def test_network_copyleft_licenses(self):
+        for lic in ["AGPL-3.0-only", "AGPL-3.0-or-later", "EUPL-1.2", "OSL-3.0"]:
+            cat, risk = categorize_license(lic)
+            assert cat == "network_copyleft", f"{lic} should be network copyleft"
+            assert risk == "critical"
+
     def test_commercial_risk_licenses(self):
-        for lic in ["SSPL-1.0", "BSL-1.1", "Elastic-2.0"]:
+        for lic in ["SSPL-1.0", "Elastic-2.0"]:
             cat, risk = categorize_license(lic)
             assert cat == "commercial_risk", f"{lic} should be commercial risk"
             assert risk == "critical"
+
+    def test_bsl_alias(self):
+        """BSL-1.1 (user alias) maps to BUSL-1.1 commercial risk."""
+        cat, risk = categorize_license("BSL-1.1")
+        assert cat == "commercial_risk"
+        assert risk == "critical"
 
     def test_unknown_license(self):
         cat, risk = categorize_license("CustomLicense-1.0")
@@ -294,3 +306,103 @@ class TestDefaultPolicy:
 
         assert not _matches_pattern("MIT", DEFAULT_LICENSE_POLICY["license_block"])
         assert not _matches_pattern("MIT", DEFAULT_LICENSE_POLICY["license_warn"])
+
+    def test_default_blocks_eupl(self):
+        from agent_bom.license_policy import _matches_pattern
+
+        assert _matches_pattern("EUPL-1.2", DEFAULT_LICENSE_POLICY["license_block"])
+
+    def test_default_blocks_osl(self):
+        from agent_bom.license_policy import _matches_pattern
+
+        assert _matches_pattern("OSL-3.0", DEFAULT_LICENSE_POLICY["license_block"])
+
+    def test_default_blocks_busl(self):
+        from agent_bom.license_policy import _matches_pattern
+
+        assert _matches_pattern("BUSL-1.1", DEFAULT_LICENSE_POLICY["license_block"])
+
+
+# ---------------------------------------------------------------------------
+# TestSPDXIndex — expanded license catalog via license-expression
+# ---------------------------------------------------------------------------
+
+
+class TestSPDXIndex:
+    """Tests for the expanded SPDX catalog from license-expression library."""
+
+    def test_artistic_is_recognized(self):
+        """Artistic-2.0 was 'unknown' with 33 hardcoded licenses, now categorized."""
+        cat, risk = categorize_license("Artistic-2.0")
+        assert cat != "unknown", "Artistic-2.0 should be recognized from SPDX index"
+
+    def test_wtfpl_is_permissive(self):
+        """WTFPL is Public Domain → permissive."""
+        cat, risk = categorize_license("WTFPL")
+        assert cat == "permissive"
+        assert risk == "low"
+
+    def test_cc_by_sa_is_copyleft_limited(self):
+        """CC-BY-SA-4.0 is Copyleft Limited → weak_copyleft."""
+        cat, risk = categorize_license("CC-BY-SA-4.0")
+        assert cat == "weak_copyleft"
+        assert risk == "medium"
+
+    def test_deprecated_gpl_normalizes(self):
+        """GPL-2.0 (deprecated) normalizes to GPL-2.0-only via license-expression."""
+        cat, risk = categorize_license("GPL-2.0")
+        assert cat == "strong_copyleft"
+        assert risk == "high"
+
+    def test_deprecated_lgpl_normalizes(self):
+        """LGPL-2.1 (deprecated) normalizes to LGPL-2.1-only."""
+        cat, risk = categorize_license("LGPL-2.1")
+        assert cat == "weak_copyleft"
+        assert risk == "medium"
+
+    def test_with_exception_handled(self):
+        """GPL-2.0-only WITH Classpath-exception-2.0 parses without error."""
+        cat, risk = categorize_license("GPL-2.0-only WITH Classpath-exception-2.0")
+        # WITH exceptions don't change the base license category
+        assert cat == "strong_copyleft"
+        assert risk == "high"
+
+    def test_nested_parens(self):
+        """(MIT OR Apache-2.0) AND GPL-3.0-only parses correctly."""
+        cat, risk = categorize_license("(MIT OR Apache-2.0) AND GPL-3.0-only")
+        # AND: most restrictive wins → strong_copyleft
+        assert cat == "strong_copyleft"
+        assert risk == "high"
+
+    def test_index_has_many_licenses(self):
+        """The SPDX index should have 100+ entries (vs 33 hardcoded)."""
+        from agent_bom.license_policy import _SPDX_INDEX
+
+        assert len(_SPDX_INDEX) > 100
+
+    def test_agpl_is_network_not_strong(self):
+        """AGPL should be network_copyleft, distinct from GPL strong_copyleft."""
+        agpl_cat, _ = categorize_license("AGPL-3.0-only")
+        gpl_cat, _ = categorize_license("GPL-3.0-only")
+        assert agpl_cat == "network_copyleft"
+        assert gpl_cat == "strong_copyleft"
+        assert agpl_cat != gpl_cat
+
+    def test_network_copyleft_set_exported(self):
+        """NETWORK_COPYLEFT set should be available for downstream code."""
+        from agent_bom.license_policy import NETWORK_COPYLEFT
+
+        assert "AGPL-3.0-only" in NETWORK_COPYLEFT
+        assert "EUPL-1.2" in NETWORK_COPYLEFT
+
+    def test_sspl_blocked_breaks_compliance(self):
+        """SSPL-1.0 is blocked by default policy and breaks compliance."""
+        agents = [_agent(servers=[_server(packages=[_pkg(license="SSPL-1.0")])])]
+        report = evaluate_license_policy(agents)
+        assert report.compliant is False
+
+    def test_eupl_blocked_breaks_compliance(self):
+        """EUPL-1.2 is blocked by default and breaks compliance."""
+        agents = [_agent(servers=[_server(packages=[_pkg(license="EUPL-1.2")])])]
+        report = evaluate_license_policy(agents)
+        assert report.compliant is False

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -63,7 +63,7 @@ def test_mcp_server_has_eighteen_tools():
 
     server = create_mcp_server()
     tools = _run(server.list_tools())
-    assert len(tools) == 29
+    assert len(tools) == 30
 
 
 def test_mcp_server_tool_names():
@@ -103,6 +103,7 @@ def test_mcp_server_tool_names():
         "model_provenance_scan",
         "prompt_scan",
         "model_file_scan",
+        "license_compliance_scan",
     }
 
 

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -613,7 +613,7 @@ def test_mcp_server_card_has_18_tools():
     """Server card lists 29 tools (23 original + 6 scan type tools)."""
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
-    assert len(_SERVER_CARD_TOOLS) == 29
+    assert len(_SERVER_CARD_TOOLS) == 30
     tool_names = {t["name"] for t in _SERVER_CARD_TOOLS}
     assert "code_scan" in tool_names
     assert "context_graph" in tool_names


### PR DESCRIPTION
## Summary
- Upgrade license categorization from 33 hardcoded licenses to **2,500+ SPDX entries** via `license-expression` library (already transitive dep, zero new deps)
- Proper SPDX expression parsing: `OR`/`AND`/`WITH`/nested parens, deprecated ID normalization (`GPL-2.0` → `GPL-2.0-only`)
- New **network-copyleft** tier (critical risk): AGPL, EUPL, OSL — triggers on network use, not just distribution
- `BUSL-1.1` alias for `BSL-1.1`, commercial-risk detection for source-available licenses
- Default policy expanded: blocks `EUPL-*`, `OSL-*`, `BUSL-*`
- **MCP tool 30**: `license_compliance_scan` — accepts scan JSON or flat package list
- 17 new tests (50 total license tests), 4,213 total tests pass

Sources:
- [SPDX License List](https://spdx.org/licenses/)
- [ScanCode LicenseDB](https://scancode-licensedb.aboutcode.org/)
- [license-expression API](https://github.com/aboutcode-org/license-expression)

Closes #470

## Test plan
- [x] 50 license policy tests pass (17 new)
- [x] 4,213 total tests pass, 0 failures
- [x] MCP tool count updated to 30 (meta-tests pass)
- [x] Ruff lint + format clean
- [ ] CI passes (9 jobs)