### PR TITLE
docs: ADR structure with 5 initial architecture decision records

### DIFF
--- a/docs/adr/001-osv-primary-vuln-source.md
+++ b/docs/adr/001-osv-primary-vuln-source.md
@@ -1,0 +1,43 @@
+# ADR-001: OSV as primary vulnerability source
+
+## Status
+
+Accepted
+
+## Context
+
+agent-bom needs a vulnerability database to check packages against known CVEs.
+Options considered:
+
+1. **NVD (National Vulnerability Database)** — comprehensive but rate-limited API,
+   requires API key for reasonable throughput, CPE matching is complex
+2. **OSV.dev** — open, no API key required, ecosystem-native identifiers (GHSA, PYSEC),
+   supports batch queries, maintained by Google
+3. **Snyk** — commercial API, requires token, good data quality but vendor lock-in
+4. **GitHub Advisory Database (GHSA)** — good for npm/PyPI but limited ecosystem coverage
+
+## Decision
+
+Use **OSV.dev** as the primary vulnerability source with NVD and GHSA as
+supplemental enrichment sources.
+
+- OSV provides the initial vulnerability match (package name + version → advisories)
+- NVD enriches with CVSS scores, CWE IDs, and reference links (90-day cache)
+- EPSS enriches with exploit probability scores (30-day cache)
+- CISA KEV flags known-exploited vulnerabilities (24-hour cache)
+- Snyk is available as an optional source via `--snyk-token`
+
+## Consequences
+
+### Positive
+
+- No API key required for basic scanning — zero-config experience
+- Batch query support keeps scan times fast (one HTTP call per ecosystem)
+- Ecosystem-native IDs reduce false positives vs CPE matching
+- Multi-source enrichment gives comprehensive risk context
+
+### Negative
+
+- OSV coverage for some ecosystems (C/C++, system packages) is thinner than NVD
+- NVD enrichment adds latency (mitigated by 90-day disk cache)
+- No single source has complete coverage — users may see different results vs Grype/Snyk

--- a/docs/adr/002-custom-policy-engine.md
+++ b/docs/adr/002-custom-policy-engine.md
@@ -1,0 +1,44 @@
+# ADR-002: Custom JSON policy engine over OPA
+
+## Status
+
+Accepted
+
+## Context
+
+agent-bom needs a policy engine to evaluate security rules against scan findings
+(e.g., "fail if any CRITICAL CVE exists", "warn if EPSS > 0.7 and has credentials").
+Options considered:
+
+1. **Open Policy Agent (OPA/Rego)** — industry standard, powerful, but requires learning
+   Rego language, adds a Go binary dependency, and is heavyweight for our use case
+2. **Custom JSON policy engine** — declarative JSON rules with a built-in expression
+   evaluator, no external dependencies
+3. **Python-native rules (code)** — flexible but not user-configurable without code changes
+
+## Decision
+
+Build a **custom JSON policy engine** (`policy.py`) with:
+
+- 17 declarative conditions (`severity_gte`, `is_kev`, `has_credentials`, `min_agents`,
+  `ecosystem`, `owasp_tag`, etc.)
+- A `condition` expression engine supporting AND/OR/NOT, comparisons, and field access
+  (e.g., `"epss_score > 0.7 and has_credentials and severity >= CRITICAL"`)
+- Actions: `fail` (exit code 1), `warn` (log + continue), `jira` (create ticket)
+- Policy files are plain JSON — no new language to learn
+
+## Consequences
+
+### Positive
+
+- Zero external dependencies — no OPA binary, no Rego learning curve
+- JSON policy files are readable by security teams without programming knowledge
+- Expression engine covers 95%+ of real policy needs
+- `--policy` CLI flag and `.agent-bom.yaml` project config make it easy to adopt
+- Jira action enables automated ticket creation on policy violations
+
+### Negative
+
+- Less expressive than Rego for complex logic (nested quantifiers, aggregation)
+- No ecosystem of pre-built policy bundles like OPA has
+- Custom implementation means we maintain the parser ourselves

--- a/docs/adr/003-cyclonedx-sbom-format.md
+++ b/docs/adr/003-cyclonedx-sbom-format.md
@@ -1,0 +1,44 @@
+# ADR-003: CycloneDX as primary SBOM format
+
+## Status
+
+Accepted
+
+## Context
+
+agent-bom generates SBOMs (Software Bill of Materials) from scan results.
+Two dominant standards exist:
+
+1. **CycloneDX** — OWASP project, JSON/XML, strong security focus (VEX, VDR),
+   versioned schema (1.4–1.6), Python library (`cyclonedx-python-lib`)
+2. **SPDX** — Linux Foundation / ISO standard, broader scope (licensing focus),
+   JSON/RDF/tag-value, more complex data model
+
+Both are required by various compliance frameworks (EU CRA, US EO 14028).
+
+## Decision
+
+Use **CycloneDX 1.6** as the primary SBOM output format, with SPDX 3.0 as a
+secondary export option.
+
+- `generate_sbom` MCP tool and `--sbom-format` CLI flag default to CycloneDX
+- SPDX export is available via `--sbom-format spdx`
+- SBOM ingest (`--sbom` flag) accepts both CycloneDX 1.x and SPDX 2.x/3.0
+
+We also support VEX (Vulnerability Exploitability eXchange) via `--vex` / `--generate-vex`
+using the OpenVEX format, which pairs naturally with CycloneDX.
+
+## Consequences
+
+### Positive
+
+- CycloneDX's security-first design aligns with agent-bom's mission
+- `cyclonedx-python-lib` provides validated serialization (already a dependency)
+- VEX integration enables "not affected" / "false positive" annotations
+- Both major standards supported for compliance flexibility
+
+### Negative
+
+- Some government contracts prefer SPDX — secondary support mitigates this
+- CycloneDX 1.6 is newer, some tools may not fully support it yet
+- Maintaining two SBOM serializers adds code surface

--- a/docs/adr/004-subprocess-over-sdk.md
+++ b/docs/adr/004-subprocess-over-sdk.md
@@ -1,0 +1,44 @@
+# ADR-004: Subprocess CLI over vendor SDKs for infrastructure discovery
+
+## Status
+
+Accepted
+
+## Context
+
+agent-bom discovers GPU containers (Docker), Kubernetes GPU nodes, cloud resources,
+and other infrastructure. Two approaches for interacting with these systems:
+
+1. **Vendor SDKs** — `docker` Python SDK, `kubernetes` client library, `boto3`, etc.
+   Type-safe, well-documented, but each adds a dependency (often heavy)
+2. **Subprocess CLI** — shell out to `docker`, `kubectl`, `aws`, `gcloud` CLI tools
+   that are already installed in target environments
+
+## Decision
+
+Use **subprocess + JSON output** (`docker inspect --format json`, `kubectl get -o json`)
+for all infrastructure discovery. No vendor SDK dependencies.
+
+This follows the same pattern used by Grype/Syft (subprocess to container runtimes)
+and is consistent across all discovery modules:
+
+- `gpu_infra.py` — `docker ps`, `docker inspect`, `kubectl get nodes`
+- `discovery/__init__.py` — reads config files directly (no SDK)
+- `cloud/coreweave.py`, `cloud/aws.py`, etc. — CLI tools or REST APIs
+
+## Consequences
+
+### Positive
+
+- Zero additional dependencies — keeps `pip install agent-bom` lightweight
+- Works in any environment where the CLI tools are already installed
+- JSON output is stable across CLI versions (more stable than SDK APIs)
+- No authentication/credential management in our code — CLIs handle their own auth
+- Consistent pattern across all discovery modules
+
+### Negative
+
+- Subprocess calls are harder to mock in tests (requires MagicMock on `subprocess.run`)
+- No type safety on CLI output — we parse raw JSON
+- Error messages from CLI tools are less structured than SDK exceptions
+- Container ID hex validation needed as defense-in-depth against injection

--- a/docs/adr/005-no-rbac-custom-auth.md
+++ b/docs/adr/005-no-rbac-custom-auth.md
@@ -1,0 +1,49 @@
+# ADR-005: API auth without RBAC framework
+
+## Status
+
+Accepted
+
+## Context
+
+The agent-bom REST API (`/v1/*`) needs authentication and authorization.
+Options considered:
+
+1. **Full RBAC framework** — role-based access control with user/group/permission
+   models, database-backed, like Django's auth or Casbin
+2. **OIDC/JWT Bearer tokens** — leverage existing identity providers (Okta, Auth0,
+   Azure AD) via standard OIDC token verification
+3. **API key middleware** — simple `X-API-Key` header check, no external dependencies
+4. **No auth** — rely on network-level security (VPN, private subnet)
+
+## Decision
+
+Implement a **layered auth approach** without an RBAC framework:
+
+1. **API key middleware** (`api/server.py`) — `AGENT_BOM_API_KEY` env var, checked
+   on every request via `APIKeyMiddleware`. Simple, stateless, no database.
+2. **OIDC/JWT Bearer** (`api/oidc.py`) — optional upgrade path via
+   `AGENT_BOM_OIDC_ISSUER` env var. Verifies RS256/ES256 JWTs against JWKS endpoint,
+   maps claims to roles (`admin`, `viewer`). Requires `pip install agent-bom[oidc]`.
+3. **JWKS proxy signature** (`proxy.py`) — runtime proxy verifies HMAC/RS256/ES256
+   signatures on tool calls. JWKS endpoint with 1-hour cache, `none` algorithm rejected.
+
+No user database. No permission tables. No RBAC models. Identity comes from the
+token issuer, authorization comes from claims-to-role mapping.
+
+## Consequences
+
+### Positive
+
+- No database dependency for auth — fully stateless, works in containers/serverless
+- OIDC integration leverages enterprise identity providers users already have
+- API key path is trivial to set up for single-user/CI scenarios
+- JWKS verification is industry-standard (RFC 7517) with no custom crypto
+- Claims-to-role mapping is configurable without code changes
+
+### Negative
+
+- No fine-grained permissions (can't restrict user A to read-only on specific scan types)
+- No audit trail of who did what (beyond proxy JSONL logs)
+- OIDC setup requires understanding JWT/JWKS concepts
+- Two auth paths (API key vs OIDC) add complexity to middleware

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for agent-bom.
+
+ADRs document significant technical decisions — the context, options considered,
+and rationale for the chosen approach. They help current and future contributors
+understand *why* the codebase is shaped the way it is.
+
+## Format
+
+We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records).
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [001](001-osv-primary-vuln-source.md) | OSV as primary vulnerability source | Accepted | 2025-06 |
+| [002](002-custom-policy-engine.md) | Custom JSON policy engine over OPA | Accepted | 2025-08 |
+| [003](003-cyclonedx-sbom-format.md) | CycloneDX as primary SBOM format | Accepted | 2025-07 |
+| [004](004-subprocess-over-sdk.md) | Subprocess CLI over vendor SDKs | Accepted | 2025-06 |
+| [005](005-no-rbac-custom-auth.md) | API auth without RBAC framework | Accepted | 2025-11 |
+
+## Adding a new ADR
+
+1. Copy `template.md` to `NNN-short-title.md`
+2. Fill in all sections
+3. Add entry to the index table above
+4. Submit as part of your PR

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,29 @@
+# ADR-NNN: Title
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by [ADR-NNN](NNN-link.md)
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Neutral
+
+- ...


### PR DESCRIPTION
## Summary
- Create `docs/adr/` with MADR template and index
- 5 initial ADRs documenting architectural decisions already in the codebase:
  - **ADR-001**: OSV as primary vuln source (+ NVD/EPSS/KEV enrichment)
  - **ADR-002**: Custom JSON policy engine over OPA
  - **ADR-003**: CycloneDX as primary SBOM format
  - **ADR-004**: Subprocess CLI over vendor SDKs
  - **ADR-005**: API auth without RBAC framework (API key + OIDC/JWT)

Closes #472

## Test plan
- [x] Docs only — no code changes
- [ ] Links render correctly on GitHub