### PR TITLE
chore: bump version to v0.68.0 + sync docs, diagrams, and stats

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           uv run agent-bom scan --sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.67.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.67.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.68.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.68.0"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.67.0  # pinned — bump on each release
+        run: uv tool install agent-bom==0.68.0  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Discovery ──> Scanning ──> Enrichment ──> Blast Radius ──> Compl
 | Entry point | File | Purpose |
 |---|---|---|
 | CLI | `cli.py` | Click-based CLI with 22+ commands and groups |
-| MCP Server | `mcp_server.py` | FastMCP server with 23 tools |
+| MCP Server | `mcp_server.py` | FastMCP server with 30 tools |
 | Proxy | `proxy.py` | MCP JSON-RPC proxy with runtime enforcement |
 | API | `api/server.py` | FastAPI REST server with job queue |
 
@@ -221,10 +221,10 @@ cli.py / mcp_server.py / api/server.py
 
 | Metric | Count |
 |---|---|
-| Python modules | 167 |
-| Test files | 179 |
-| Test functions | ~4,314 (collected by pytest) |
-| MCP tools | 23 |
+| Python modules | 171 |
+| Test files | 185 |
+| Test functions | ~4,449 (collected by pytest) |
+| MCP tools | 30 |
 | Compliance frameworks | 11 |
 | Runtime detectors | 7 |
 | Cloud providers | 12 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full module map. Key paths:
 | `src/agent_bom/models.py` | Core data models (Package, Vulnerability, Agent…) |
 | `src/agent_bom/runtime/` | Proxy detectors (7 detectors) |
 | `src/agent_bom/api/server.py` | FastAPI REST server |
-| `src/agent_bom/mcp_server.py` | MCP server (23 tools) |
+| `src/agent_bom/mcp_server.py` | MCP server (30 tools) |
 
 The scan pipeline: **discover** MCP configs → **parse** packages → **scan** via OSV batch API → **enrich** full vuln details → **optional** NVD/EPSS/KEV enrichment → **output** (table, JSON, SARIF, CycloneDX…).
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -16,14 +16,14 @@ FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf7
 WORKDIR /app
 COPY LICENSE ./
 
-ARG VERSION=0.67.0
+ARG VERSION=0.68.0
 
 RUN pip install --no-cache-dir --prefix=/install agent-bom==${VERSION}
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.67.0
+ARG VERSION=0.68.0
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.snowpark
+++ b/Dockerfile.snowpark
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11-slim@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
-ARG VERSION=0.67.0
+ARG VERSION=0.68.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.67.0
+ARG VERSION=0.68.0
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="Security scanner for AI infrastructure — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.67.0"
+  --version "0.68.0"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.67.0
-git push origin v0.67.0
+git tag v0.68.0
+git push origin v0.68.0
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -288,10 +288,10 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
-| GitHub Action | `uses: msaad00/agent-bom@v0.67.0 | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.68.0 | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans |
 | REST API | `agent-bom api` | Dashboards, SIEM |
-| MCP Server | `agent-bom mcp-server` (23 tools) | Inside any MCP client |
+| MCP Server | `agent-bom mcp-server` (30 tools) | Inside any MCP client |
 | Dashboard | `agent-bom serve` · [Full deploy guide](docs/DEPLOYMENT.md) | API + Next.js UI (15 pages) · Postgres/Supabase |
 | Runtime proxy | `agent-bom proxy` | Intercept + enforce MCP traffic in real time |
 | Protect engine | `agent-bom protect` | 7 behavioral detectors (rug pull, injection, exfil, credential leak) |
@@ -303,7 +303,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 <summary><b>GitHub Action</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.67.0
+- uses: msaad00/agent-bom@v0.68.0
   with:
     severity-threshold: high
     upload-sarif: true
@@ -387,7 +387,7 @@ Options:
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.67.0 |
+| GitHub Action | `uses: msaad00/agent-bom@v0.68.0 |
 | Glama | [glama.ai/mcp/servers/@msaad00/agent-bom](https://glama.ai/mcp/servers/@msaad00/agent-bom) |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: AI supply chain security scanner — scan containers, MCP servers, and AI agents for CVEs, credential exposure, and compliance violations
 version: 0.1.0
-appVersion: "0.67.0"
+appVersion: "0.68.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.67.0"
+  tag: "0.68.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.67.0"
+  tag: "0.68.0"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.67.0
+- uses: msaad00/agent-bom@v0.68.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -288,7 +288,7 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine |
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (23 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (30 tools) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |

--- a/docs/STRATEGIC_AUDIT_2026_03.md
+++ b/docs/STRATEGIC_AUDIT_2026_03.md
@@ -206,7 +206,7 @@ Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Cop
 1. **Full-spectrum AI infra scanning**: CVE + MCP tool security + skill trust + blast radius + compliance — in one tool
 2. **Blast radius analysis**: No competitor does dependency blast radius with compliance framework mapping
 3. **Runtime proxy with enforcement**: Not just scanning — real-time interception, rate limiting, credential leak blocking, rug pull detection
-4. **23 MCP tools**: Deepest MCP server integration — usable by any AI assistant
+4. **30 MCP tools**: Deepest MCP server integration — usable by any AI assistant
 5. **12 cloud provider coverage**: AWS/Azure/GCP + AI-specific (CoreWeave, Databricks, Snowflake, HuggingFace, W&B, MLflow, OpenAI, Ollama, Nebius)
 6. **10 compliance frameworks**: Every finding mapped to OWASP LLM/MCP/Agentic, ATLAS, NIST, EU AI Act, ISO 27001, SOC 2, CIS
 7. **Enrichment depth**: OSV + GHSA + NVD + EPSS + CISA KEV + NVIDIA + OpenSSF Scorecard + MITRE ATT&CK
@@ -276,7 +276,7 @@ Cortex Code has a sophisticated security model that agent-bom should integrate w
 
 1. **agent-bom as Cortex Code MCP server**
    - Cortex Code supports MCP via `mcp.json` — agent-bom can be added as an MCP server
-   - All 23 tools become available to Cortex Code users
+   - All 30 tools become available to Cortex Code users
    - Users can scan their Snowflake pipelines for CVEs, check MCP server trust, run compliance audits — all through natural language in Cortex Code
    - Config: add agent-bom to `~/.snowflake/cortex/mcp.json`
 
@@ -327,7 +327,7 @@ Cortex Code has a sophisticated security model that agent-bom should integrate w
 
 | Coco Security Gap | agent-bom Solution |
 |-------------------|--------------------|
-| "Verify MCP server integrity" — manual guidance only | Automated MCP server scanning (23 tools) |
+| "Verify MCP server integrity" — manual guidance only | Automated MCP server scanning (30 tools) |
 | No CVE scanning of MCP server dependencies | Full enrichment pipeline (OSV+GHSA+NVD+EPSS+KEV) |
 | No blast radius analysis | Blast radius with compliance mapping |
 | Permission caching risks (permissions.json) | Audit cached approvals, flag overly permissive |

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">23 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">30 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">23 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">30 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/data-flow-dark.svg
+++ b/docs/images/data-flow-dark.svg
@@ -158,7 +158,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#0d1117" stroke="#d29922" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d29922">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,800+ automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 4,400+ automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d29922">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/data-flow-light.svg
+++ b/docs/images/data-flow-light.svg
@@ -151,7 +151,7 @@
   <rect x="330" y="346" width="536" height="64" rx="6" fill="#fffbeb" stroke="#d97706" stroke-width="1"/>
   <text x="598" y="362" text-anchor="middle" class="badge" fill="#d97706">SUPPLY CHAIN VERIFICATION</text>
   <text x="598" y="378" text-anchor="middle" class="sub">Sigstore OIDC signing on every release · SLSA provenance via GitHub Actions</text>
-  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 2,800+ automated tests · Apache 2.0 source</text>
+  <text x="598" y="392" text-anchor="middle" class="sub">cosign verify-blob · OpenSSF Scorecard · 4,400+ automated tests · Apache 2.0 source</text>
   <text x="598" y="404" text-anchor="middle" class="data" fill="#d97706">agent-bom verify agent-bom  →  check integrity yourself</text>
 
   <!-- Arrow: engine → output -->

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -167,7 +167,7 @@
       <rect width="286" height="48" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6e7681">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">23 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">30 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -166,7 +166,7 @@
       <rect width="286" height="48" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#94a3b8">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">23 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">30 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 167 modules · 4,300+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 171 modules · 4,400+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 167 modules · 4,300+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 171 modules · 4,400+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -49,7 +49,7 @@
   <rect x="330" y="66" width="300" height="3" rx="1.5" fill="#bc8cff"/>
   <rect x="342" y="80" width="34" height="15" rx="4" fill="#bc8cff"/>
   <text x="359" y="91" text-anchor="middle" class="badge">MCP</text>
-  <text x="386" y="91" class="mode-title" fill="#bc8cff">MCP Server — 23 Tools</text>
+  <text x="386" y="91" class="mode-title" fill="#bc8cff">MCP Server — 30 Tools</text>
   <text x="342" y="108" class="mode-cmd">agent-bom mcp-server [--transport sse]</text>
   <text x="342" y="124" class="mode-feat">AI agents call scan, check, blast_radius</text>
   <text x="342" y="138" class="mode-feat">Registry lookup for 427+ MCP servers</text>
@@ -215,7 +215,7 @@
   <!-- ═══════════════════════════════════════════════════════════ -->
   <rect x="20" y="640" width="920" height="2" rx="1" fill="#30363d" opacity="0.4"/>
 
-  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#58a6ff">23</text>
+  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#58a6ff">30</text>
   <text x="120" y="680" text-anchor="middle" class="engine-detail">MCP tools</text>
 
   <text x="240" y="666" text-anchor="middle" class="mode-title" fill="#bc8cff">427+</text>
@@ -230,7 +230,7 @@
   <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#f0883e">11</text>
   <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#f85149">4,230+</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#f85149">4,400+</text>
   <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
   <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#bc8cff">12</text>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -49,7 +49,7 @@
   <rect x="330" y="66" width="300" height="3" rx="1.5" fill="#8250df"/>
   <rect x="342" y="80" width="34" height="15" rx="4" fill="#8250df"/>
   <text x="359" y="91" text-anchor="middle" class="badge">MCP</text>
-  <text x="386" y="91" class="mode-title" fill="#8250df">MCP Server — 23 Tools</text>
+  <text x="386" y="91" class="mode-title" fill="#8250df">MCP Server — 30 Tools</text>
   <text x="342" y="108" class="mode-cmd">agent-bom mcp-server [--transport sse]</text>
   <text x="342" y="124" class="mode-feat">AI agents call scan, check, blast_radius</text>
   <text x="342" y="138" class="mode-feat">Registry lookup for 427+ MCP servers</text>
@@ -215,7 +215,7 @@
   <!-- ═══════════════════════════════════════════════════════════ -->
   <rect x="20" y="640" width="920" height="2" rx="1" fill="#d0d7de" opacity="0.4"/>
 
-  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#0969da">23</text>
+  <text x="120" y="666" text-anchor="middle" class="mode-title" fill="#0969da">30</text>
   <text x="120" y="680" text-anchor="middle" class="engine-detail">MCP tools</text>
 
   <text x="240" y="666" text-anchor="middle" class="mode-title" fill="#8250df">427+</text>
@@ -230,7 +230,7 @@
   <text x="600" y="666" text-anchor="middle" class="mode-title" fill="#bc4c00">11</text>
   <text x="600" y="680" text-anchor="middle" class="engine-detail">compliance frameworks</text>
 
-  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#cf222e">4,230+</text>
+  <text x="720" y="666" text-anchor="middle" class="mode-title" fill="#cf222e">4,400+</text>
   <text x="720" y="680" text-anchor="middle" class="engine-detail">test functions</text>
 
   <text x="840" y="666" text-anchor="middle" class="mode-title" fill="#8250df">12</text>

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">23 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">30 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">23 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">30 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scan-output-dark.svg
+++ b/docs/images/scan-output-dark.svg
@@ -26,7 +26,7 @@
   <circle cx="18" cy="18" r="6" class="dot-r"/>
   <circle cx="38" cy="18" r="6" class="dot-y"/>
   <circle cx="58" cy="18" r="6" class="dot-g"/>
-  <text x="440" y="23" text-anchor="middle" class="hdr">agent-bom v0.63.0</text>
+  <text x="440" y="23" text-anchor="middle" class="hdr">agent-bom v0.68.0</text>
 
   <!-- prompt + command -->
   <text x="20" y="62" class="dim">$</text>
@@ -82,7 +82,7 @@
 
   <!-- summary box -->
   <rect x="20" y="462" width="860" height="76" rx="6" fill="#161b22" stroke="#21262d" stroke-width="1"/>
-  <text x="36" y="482" class="grn">AI-BOM Report  v0.63.0</text>
+  <text x="36" y="482" class="grn">AI-BOM Report  v0.68.0</text>
   <text x="36" y="498" class="hdr">────────────────────────────────────────────────</text>
   <text x="36" y="514" class="norm">Agents: </text><text x="90" y="514" class="cyn">3</text>
   <text x="140" y="514" class="norm">Servers: </text><text x="198" y="514" class="cyn">8</text>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -144,7 +144,7 @@
   <text x="742" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
 
   <rect x="782" y="476" width="80" height="24" rx="12" fill="#238636"/>
-  <text x="822" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP (16)</text>
+  <text x="822" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP (30)</text>
 
   <rect x="870" y="476" width="80" height="24" rx="12" fill="#238636"/>
   <text x="910" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  4,300+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">Zero runtime deps  ·  Read-only  ·  Agentless  ·  4,400+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -144,7 +144,7 @@
   <text x="742" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">CLI</text>
 
   <rect x="782" y="476" width="80" height="24" rx="12" fill="#16a34a"/>
-  <text x="822" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP (16)</text>
+  <text x="822" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">MCP (30)</text>
 
   <rect x="870" y="476" width="80" height="24" rx="12" fill="#16a34a"/>
   <text x="910" y="492" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="#fff">Dashboard</text>
@@ -158,5 +158,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER — single line                                   -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  4,300+ tests  ·  Apache 2.0</text>
+  <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">Zero runtime deps  ·  Read-only  ·  Agentless  ·  4,400+ tests  ·  Apache 2.0</text>
 </svg>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (23 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (30 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#0f3f1f"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#7ee787">13+ FORMATS</text>
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#484f58">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  167 modules  ·  4,300+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  171 modules  ·  4,400+ tests  ·  0 runtime deps</text>
 </svg>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (23 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (30 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#d1fae5"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#065f46">13+ FORMATS</text>
@@ -169,5 +169,5 @@
   <text x="600" y="572" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#94a3b8">External feeds: OSV.dev · GHSA · NVD · EPSS · KEV · NVIDIA CSAF · Grype DB · OpenSSF · MCP Registry</text>
 
   <!-- Footer -->
-  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  167 modules  ·  4,300+ tests  ·  0 runtime deps</text>
+  <text x="600" y="612" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">~70 built-in  ·  ~15 hybrid  ·  ~22 external  ·  171 modules  ·  4,400+ tests  ·  0 runtime deps</text>
 </svg>

--- a/integrations/cortex-code/README.md
+++ b/integrations/cortex-code/README.md
@@ -47,7 +47,7 @@ cp integrations/cortex-code/SKILL.md .cortex/skills/agent-bom/SKILL.md
 
 ## What You Get
 
-### As MCP Server (23 tools)
+### As MCP Server (30 tools)
 
 All agent-bom MCP tools become available in Cortex Code:
 

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   and vector database security checks. Use when the user mentions vulnerability
   scanning, MCP server trust, compliance, SBOM generation, CIS benchmarks,
   blast radius, or AI supply chain risk.
-version: 0.64.0
+version: 0.68.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -19,11 +19,11 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4314
+  tests: 4449
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.64.0
+    docker: ghcr.io/msaad00/agent-bom:0.68.0
   openclaw:
     requires:
       bins: []
@@ -199,7 +199,7 @@ agent-bom where             # show all discovery paths
 }
 ```
 
-## Tools (23)
+## Tools (30)
 
 ### Vulnerability Scanning
 | Tool | Description |
@@ -239,6 +239,17 @@ agent-bom where             # show all discovery paths
 | `runtime_correlate` | Cross-reference proxy audit JSONL with CVE findings, risk amplification |
 | `vector_db_scan` | Probe Qdrant/Weaviate/Chroma/Milvus for auth and exposure |
 | `gpu_infra_scan` | GPU container and K8s node inventory + unauthenticated DCGM probe (MAESTRO KC6) |
+
+### Specialized Scans
+| Tool | Description |
+|------|-------------|
+| `dataset_card_scan` | Scan dataset cards for bias, licensing, and provenance issues |
+| `training_pipeline_scan` | Scan training pipeline configs for security risks |
+| `browser_extension_scan` | Scan browser extensions for risky permissions and AI domain access |
+| `model_provenance_scan` | Verify model provenance and supply chain integrity |
+| `prompt_scan` | Scan prompt templates for injection and data leakage risks |
+| `model_file_scan` | Scan model files for unsafe serialization (pickle, etc.) |
+| `license_compliance_scan` | Full SPDX license catalog scan with copyleft and network-copyleft detection |
 
 ### Resources
 | Resource | Description |
@@ -312,6 +323,6 @@ configured credentials and call only the cloud provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.64.0`
-- **4,300+ tests** with CodeQL + OpenSSF Scorecard
+- **Sigstore signed**: `agent-bom verify agent-bom@0.68.0`
+- **4,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   MITRE ATLAS, EU AI Act, NIST AI RMF, and custom policy-as-code rules. Generate
   SBOMs in CycloneDX or SPDX format. Use when the user mentions compliance checking,
   security policy enforcement, SBOM generation, or regulatory frameworks.
-version: 0.67.0
+version: 0.68.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4314
+  tests: 4449
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -130,5 +130,5 @@ No credentials needed.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **4,300+ tests** with CodeQL + OpenSSF Scorecard
+- **4,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.67.0
+version: 0.68.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4314
+  tests: 4449
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -110,5 +110,5 @@ as a string argument (no file system access needed).
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **4,300+ tests** with CodeQL + OpenSSF Scorecard
+- **4,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.67.0
+version: 0.68.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4314
+  tests: 4449
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -90,5 +90,5 @@ ClickHouse endpoint for persistent analytics.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **4,300+ tests** with CodeQL + OpenSSF Scorecard
+- **4,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checks packages for CVEs (OSV, NVD, EPSS, KEV), maps blast radius, and generates
   remediation plans. Use when the user mentions vulnerability scanning, dependency
   security, CVE lookup, blast radius analysis, or AI supply chain risk.
-version: 0.67.0
+version: 0.68.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Grype/Syft for
@@ -16,11 +16,11 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 4314
+  tests: 4449
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.67.0
+    docker: ghcr.io/msaad00/agent-bom:0.68.0
   openclaw:
     requires:
       bins: []
@@ -187,6 +187,6 @@ CVE IDs are sent to vulnerability databases.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.67.0
-- **4,300+ tests** with CodeQL + OpenSSF Scorecard
+- **Sigstore signed**: `agent-bom verify agent-bom@0.68.0
+- **4,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.67.0
+ARG VERSION=0.68.0
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — MCP server mode"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, credential exposure, runtime enforcement across MCP servers, containers, cloud, and GPU",
   "title": "agent-bom",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.67.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.68.0",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.67.0": {
+        "ghcr.io/msaad00/agent-bom:v0.68.0": {
           "tier": "Community",
           "status": "Active",
           "tags": [
@@ -62,7 +62,14 @@
             "runtime_correlate",
             "vector_db_scan",
             "aisvs_benchmark",
-            "gpu_infra_scan"
+            "gpu_infra_scan",
+            "dataset_card_scan",
+            "training_pipeline_scan",
+            "browser_extension_scan",
+            "model_provenance_scan",
+            "prompt_scan",
+            "model_file_scan",
+            "license_compliance_scan"
           ]
         }
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.67.0"
+version = "0.68.0"
 description = "Security scanner for AI infrastructure. Discover MCP configs (20 clients), scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to reachable credentials and tools, runtime proxy with 7 detectors, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, and 10-framework compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/site-docs/architecture/overview.md
+++ b/site-docs/architecture/overview.md
@@ -29,10 +29,10 @@ graph LR
 | Compliance | `src/agent_bom/compliance/` | 11 framework mappings |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP interception |
-| Protection | `src/agent_bom/runtime/` | 5-detector anomaly engine |
+| Protection | `src/agent_bom/runtime/` | 7-detector anomaly engine |
 | Enforcement | `src/agent_bom/enforcement.py` | Tool poisoning detection |
 | Security | `src/agent_bom/security.py` | Path validation, credential redaction |
-| MCP Server | `src/agent_bom/mcp_server.py` | 20-tool FastMCP server |
+| MCP Server | `src/agent_bom/mcp_server.py` | 30-tool FastMCP server |
 | API | `src/agent_bom/api/` | REST API (FastAPI) |
 | Output | `src/agent_bom/output/` | HTML, Prometheus, Mermaid, SVG, STIX |
 

--- a/site-docs/deployment/runtime-monitoring.md
+++ b/site-docs/deployment/runtime-monitoring.md
@@ -7,7 +7,7 @@ For the full runtime monitoring deployment guide, see the [dedicated doc](https:
 The runtime proxy (`agent-bom proxy`) intercepts MCP JSON-RPC messages between client and server, providing:
 
 - JSONL audit logging of all tool calls
-- 5-detector anomaly engine (tool drift, argument analysis, credential leak, rate limiting, sequence analysis)
+- 7-detector anomaly engine (tool drift, argument analysis, credential leak, rate limiting, sequence analysis, response inspector, vector DB injection)
 - Policy enforcement with block/allow rules
 - Prometheus metrics on port 8422
 

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 22 security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 30 security tools to any MCP client.
 
 ## Local (stdio)
 
@@ -88,3 +88,13 @@ Connect with:
 | `cis_benchmark` | CIS benchmark checks (AWS/Snowflake) |
 | `fleet_scan` | Batch registry lookup + risk scoring |
 | `runtime_correlate` | Cross-reference runtime logs with CVEs |
+| `vector_db_scan` | Probe vector DBs for auth misconfigurations |
+| `aisvs_benchmark` | OWASP AISVS v1.0 compliance checks |
+| `gpu_infra_scan` | GPU/AI compute infrastructure scanning |
+| `dataset_card_scan` | Scan dataset cards for supply chain risks |
+| `training_pipeline_scan` | Scan training pipeline configs for risks |
+| `browser_extension_scan` | Scan browser extensions for MCP/AI risks |
+| `model_provenance_scan` | Verify model provenance and integrity |
+| `prompt_scan` | Scan prompts for injection and exfiltration |
+| `model_file_scan` | Scan model files for embedded threats |
+| `license_compliance_scan` | SPDX license compliance and compatibility checks |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-agent-bom exposes 23 tools via its MCP server.
+agent-bom exposes 30 tools via its MCP server.
 
 ## Tools
 
@@ -126,6 +126,54 @@ vector_db_scan()
 Run OWASP AISVS v1.0 compliance checks — 9 AI security verification checks across model, data, and inference layers.
 ```
 aisvs_benchmark()
+```
+
+### gpu_infra_scan
+Scan GPU and AI compute infrastructure — Docker GPU containers, Kubernetes GPU nodes, DCGM unauthenticated endpoint detection.
+```
+gpu_infra_scan()
+```
+
+### dataset_card_scan
+Scan dataset cards (Hugging Face, custom) for supply chain risks, license issues, and data provenance gaps.
+```
+dataset_card_scan(path="/path/to/dataset_card.md")
+```
+
+### training_pipeline_scan
+Scan training pipeline configurations for security risks — untrusted data sources, insecure checkpoints, credential exposure.
+```
+training_pipeline_scan(path="/path/to/training_config.yaml")
+```
+
+### browser_extension_scan
+Scan browser extensions for MCP and AI-related risks — nativeMessaging, broad host permissions, AI assistant domain access.
+```
+browser_extension_scan()
+```
+
+### model_provenance_scan
+Verify model provenance and integrity — check Sigstore signatures, SLSA provenance, and supply chain attestations.
+```
+model_provenance_scan(model="org/model-name")
+```
+
+### prompt_scan
+Scan prompts for injection patterns, exfiltration attempts, and manipulation techniques.
+```
+prompt_scan(prompt="<prompt text>")
+```
+
+### model_file_scan
+Scan model files (ONNX, pickle, SafeTensors, etc.) for embedded threats, unsafe deserialization, and hidden payloads.
+```
+model_file_scan(path="/path/to/model.onnx")
+```
+
+### license_compliance_scan
+SPDX license compliance and compatibility checks — full SPDX catalog support, network-copyleft detection, license conflict identification.
+```
+license_compliance_scan()
 ```
 
 ## Resources

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.67.0"
+    __version__ = "0.68.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.67.0"
+    assert __version__ == "0.68.0"
 
 
 def test_report_version_matches():
@@ -2954,7 +2954,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.67.0"
+    assert data["version"] == "0.68.0"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
- **Version bump**: 0.67.0 → 0.68.0 across 47 files
- **MCP tool count**: 23 → 30 across all surfaces (README, ARCHITECTURE, SVG diagrams, site-docs, integrations, CONTRIBUTING, strategic audit)
- **Stats sync**: 185 test files, ~4,449 tests, 171 modules — reflected in all docs and SVGs
- **SVG fixes**: scan-output v0.63.0 → v0.68.0, data-flow 2,800+ → 4,400+ tests, all architecture/deployment/workflow diagrams updated
- **Integration files**: toolhive server.json now lists all 30 tools, SKILL.md test counts updated, mcp-registry server.json bumped

### Features included since v0.67.0
- Full SPDX license engine + network-copyleft + MCP tool (#500)
- Multi-vendor GPU detection — AMD ROCm, Intel, Windows WDDM (#499)
- Dedicated REST API endpoints for 6 scan types (#494)
- Surface security-blocked servers in reports (#492)
- Cortex Code P0 — skill discovery, permission audit, hook validation (#490)
- VEX suppression enforcement, Alpine/Node filesystem scanning (#491)
- AI-BOM training pipeline lineage + dataset cards (#474)
- SBOM vendor metadata + supply chain enrichment (#473)
- ADR structure with 5 architecture decision records (#501)
- Production hardening: CodeQL fixes (#475), policy validation (#489), credibility audit (#488), MCP truncation (#483)

## Test plan
- [x] `tests/test_core.py` — 222 passed (version alignment verified)
- [x] MCP meta-tests — 205 passed (30 tools confirmed)
- [x] All pre-commit hooks passed (ruff, ruff-format, YAML/JSON/TOML checks)
- [ ] CI: 9 jobs (security, lint, 3 Python versions, Docker, self-scan, Action dogfood, version alignment)