### PR TITLE
fix: add Apache-2.0 license to MCP registry metadata

### DIFF
--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -4,6 +4,7 @@
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
   "version": "0.68.0",
+  "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"


### PR DESCRIPTION
## Summary
- Adds `"license": "Apache-2.0"` to `integrations/mcp-registry/server.json`
- Ensures license metadata is present in the MCP registry listing, consistent with pyproject.toml and root LICENSE

## Why
MCP registry server.json was the only integration metadata file missing the license field. PyPI, Docker Hub, GitHub, Helm, and all Dockerfiles already include it. This closes the gap so the MCP Registry listing shows the correct license.

## Test plan
- [x] JSON schema valid (pre-commit check passed)
- [ ] CI passes