### PR TITLE
fix: update GitHub Action version in SVGs to v0.68.0

### DIFF
--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#3fb950"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#3fb950">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.67.0</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.68.0</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#1a7f37"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#1a7f37">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.67.0</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.68.0</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>


### PR DESCRIPTION
## Summary
- Updates `uses: msaad00/agent-bom@v0.67.0` → `v0.68.0` in modes-flow-dark.svg and modes-flow-light.svg
- Last two files that still referenced v0.67.0

## Test plan
- [x] Pre-commit hooks passed
- [ ] CI passes