### PR TITLE
fix: security audit findings before external review

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,6 +54,10 @@ docs/
 # Logs
 *.log
 
+# Secrets
+.env*
+!.env.example
+
 # Local test files
 test_*.json
 test_*.cdx.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ build/
 *.egg
 .venv/
 venv/
-.env
+.env*
+!.env.example
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -5,6 +5,14 @@ Provides ``AnalyticsStore`` protocol with two implementations:
 * **ClickHouseAnalyticsStore** — real ClickHouse backend for vuln trends,
   runtime events, and posture snapshots.
 * **NullAnalyticsStore** — silent no-op when ClickHouse is not configured.
+
+Security note — SQL injection mitigation:
+  ClickHouse's HTTP interface does not support parameterized queries in the
+  same way as traditional RDBMS drivers.  All numeric parameters are cast via
+  ``int()``/``float()`` before interpolation, and string parameters are
+  sanitized through ``_escape()`` which strips null bytes and escapes
+  backslashes and single quotes.  Bandit ``nosec B608`` annotations suppress
+  the string-concatenation warnings where these guards are in place.
 """
 
 from __future__ import annotations
@@ -211,6 +219,11 @@ class ClickHouseAnalyticsStore:
 
 
 def _escape(value: str) -> str:
-    """Escape a string value for ClickHouse SQL (prevent injection)."""
-    # Strip null bytes which can truncate queries in some drivers
+    """Escape a string value for ClickHouse SQL.
+
+    Defence-in-depth against injection: strips null bytes (which can truncate
+    queries in some drivers), escapes backslashes and single quotes.  All
+    callers also enforce type constraints (int casts for numeric params).
+    See module docstring for full rationale.
+    """
     return value.replace("\x00", "").replace("\\", "\\\\").replace("'", "\\'")

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -496,6 +496,13 @@ def configure_api(
     _api_key = api_key
     _rate_limit_rpm = rate_limit_rpm
 
+    # Warn if API is exposed without authentication
+    if not api_key:
+        _logger.warning(
+            "SECURITY: No AGENT_BOM_API_KEY set — API endpoints are unauthenticated. "
+            "Set AGENT_BOM_API_KEY environment variable for production deployments."
+        )
+
     # Add optional middleware
     if api_key:
         app.add_middleware(APIKeyMiddleware, api_key=api_key)

--- a/src/agent_bom/cli.py
+++ b/src/agent_bom/cli.py
@@ -5743,7 +5743,7 @@ def protect_cmd(mode, port, host, detectors, alert_file, alert_webhook, log_leve
     console.print(f"[bold green]Runtime protection engine starting ({mode} mode)[/bold green]")
 
     async def _run() -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         stop_event = asyncio.Event()
 
         def _signal_handler() -> None:

--- a/src/agent_bom/runtime/server.py
+++ b/src/agent_bom/runtime/server.py
@@ -37,7 +37,7 @@ async def run_stdin_mode(engine: ProtectionEngine) -> None:
     engine.start()
     logger.info("Protection engine running in stdin mode (Ctrl+C to stop)")
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     reader = asyncio.StreamReader()
     protocol = asyncio.StreamReaderProtocol(reader)
     await loop.connect_read_pipe(lambda: protocol, sys.stdin)

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,17 @@
+# Dependencies
+node_modules/
+
+# Build output
+.next/
+out/
+
+# Secrets
+.env*
+!.env.example
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store


### PR DESCRIPTION
## Summary

Security hardening based on automated self-audit before senior engineer review:

- **`.gitignore`**: Exclude `.env*` variants (not just `.env`) — prevents `.env.local`, `.env.staging` etc. from being committed
- **`.dockerignore`**: Add `.env*` exclusion — prevents secrets from leaking into Docker build context
- **`ui/.dockerignore`**: New file excluding `node_modules`, `.next`, `.env*`, IDE files
- **`api/server.py`**: Log `SECURITY` warning when API starts without `AGENT_BOM_API_KEY` set
- **`api/clickhouse_store.py`**: Document SQL injection mitigation strategy (manual escaping trade-off with ClickHouse HTTP interface)
- **`cli.py` + `runtime/server.py`**: Replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` (Python 3.10+ deprecation)

## Test plan

- [ ] Verify `.gitignore` rejects `.env.local` / `.env.staging` (`git check-ignore .env.local`)
- [ ] Verify API logs warning on startup without `AGENT_BOM_API_KEY`
- [ ] Verify `ruff` passes on all modified files
- [ ] CI: all 3 Python versions, lint, security scan pass