### PR TITLE
fix: enforce mypy type checking — zero errors across 28 files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: uv run ruff check src/
 
       - name: MyPy
-        run: uv run mypy src/ --ignore-missing-imports || true
+        run: uv run mypy src/
 
   # 3. Tests
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ dev = [
     "pytest-asyncio>=0.21",
     "ruff>=0.4",
     "mypy>=1.0",
+    "types-PyYAML>=6.0",
+    "types-requests>=2.31",
+    "types-toml>=0.10",
     "pip-audit>=2.10",  # Security dependency scanning
     "bandit>=1.9",      # Static security analysis
     "safety>=3.7",      # Vulnerability checking
@@ -155,6 +158,32 @@ asyncio_mode = "strict"
 markers = [
     "network: tests that require network access (OSV API)",
 ]
+
+[tool.mypy]
+python_version = "3.11"
+warn_unused_configs = true
+disallow_untyped_defs = false          # Phase 2: enable after all functions annotated
+check_untyped_defs = false             # Phase 2: enable after baseline is clean
+ignore_missing_imports = true          # Third-party stubs (yaml, toml, requests)
+no_implicit_optional = true
+warn_redundant_casts = true
+show_error_codes = true
+
+# Phase 1 exclusions — files with 5+ errors, tracked for cleanup in #525/#526
+[[tool.mypy.overrides]]
+module = [
+    "agent_bom.cli",                # 78 errors — needs split (#525)
+    "agent_bom.api.server",         # 42 errors — needs split (#526)
+    "agent_bom.proxy",              # 16 errors
+    "agent_bom.remediate",          # 14 errors
+    "agent_bom.mcp_server",         # 11 errors
+    "agent_bom.scanners",           # 10 errors
+    "agent_bom.output",             # 7 errors
+    "agent_bom.output.html",        # 3 errors
+    "agent_bom.ai_enrich",          # 6 errors — Pydantic type vars
+    "agent_bom.license_policy",     # 5 errors — rich Console typing
+]
+ignore_errors = true
 
 [tool.ruff]
 line-length = 140  # Relaxed from 120 for CLI help strings

--- a/src/agent_bom/agent_identity.py
+++ b/src/agent_bom/agent_identity.py
@@ -149,13 +149,13 @@ def _verify_jwt_signature(token: str, jwks_uri: str) -> tuple[bool, str | None]:
             if kty == "RSA":
                 public_key = RSAAlgorithm.from_jwk(json.dumps(jwk))
             elif kty == "EC":
-                public_key = ECAlgorithm.from_jwk(json.dumps(jwk))
+                public_key = ECAlgorithm.from_jwk(json.dumps(jwk))  # type: ignore[assignment]
             else:
                 continue
             # Verify signature only; expiry is checked separately
             pyjwt.decode(
                 token,
-                public_key,
+                public_key,  # type: ignore[arg-type]
                 algorithms=[alg],
                 options={"verify_exp": False, "verify_aud": False},
             )

--- a/src/agent_bom/alerts/dispatcher.py
+++ b/src/agent_bom/alerts/dispatcher.py
@@ -96,7 +96,7 @@ class SlackChannel:
             from agent_bom.integrations.slack import send_slack_payload
 
             payload = _build_slack_payload(alert)
-            return send_slack_payload(self.webhook_url, payload)
+            return await send_slack_payload(self.webhook_url, payload)
         except Exception:
             logger.exception("Slack channel delivery failed")
             return False

--- a/src/agent_bom/autodiscover.py
+++ b/src/agent_bom/autodiscover.py
@@ -59,10 +59,10 @@ _MEDIUM_RISK_KEYWORDS = frozenset(
 )
 
 
-async def fetch_npm_metadata(name: str, client: object) -> Optional[dict]:
+async def fetch_npm_metadata(name: str, client: object) -> Optional[dict]:  # noqa: ANN001
     """Fetch package metadata from the npm registry."""
     try:
-        resp = await client.get(_NPM_URL.format(name), timeout=10.0)  # type: ignore[union-attr]
+        resp = await client.get(_NPM_URL.format(name), timeout=10.0)  # type: ignore[attr-defined]
         if resp.status_code != 200:
             return None
         data = resp.json()
@@ -81,10 +81,10 @@ async def fetch_npm_metadata(name: str, client: object) -> Optional[dict]:
         return None
 
 
-async def fetch_pypi_metadata(name: str, client: object) -> Optional[dict]:
+async def fetch_pypi_metadata(name: str, client: object) -> Optional[dict]:  # noqa: ANN001
     """Fetch package metadata from PyPI."""
     try:
-        resp = await client.get(_PYPI_URL.format(name), timeout=10.0)  # type: ignore[union-attr]
+        resp = await client.get(_PYPI_URL.format(name), timeout=10.0)  # type: ignore[attr-defined]
         if resp.status_code != 200:
             return None
         data = resp.json()

--- a/src/agent_bom/cloud/aisvs_benchmark.py
+++ b/src/agent_bom/cloud/aisvs_benchmark.py
@@ -556,10 +556,10 @@ def _check_ai_8_1() -> CISCheckResult:
         cis_section=_AGENT_SECTION,
     )
     try:
-        from agent_bom.discovery import discover_agents
+        from agent_bom.discovery import discover_global_configs
 
-        agents = discover_agents()
-        mcp_servers = []
+        agents = discover_global_configs()
+        mcp_servers: list[Any] = []
         for agent in agents:
             mcp_servers.extend(agent.mcp_servers or [])
 

--- a/src/agent_bom/cloud/gpu_infra.py
+++ b/src/agent_bom/cloud/gpu_infra.py
@@ -498,7 +498,7 @@ async def probe_dcgm_endpoint(host: str, port: int = _DCGM_PORT) -> DcgmEndpoint
     except Exception:  # noqa: BLE001
         return None
 
-    if resp.status_code not in (200, 206):
+    if resp is None or resp.status_code not in (200, 206):
         return None
 
     content = resp.text[:4096]  # first 4KB of metrics

--- a/src/agent_bom/cloud/snowflake_cis_benchmark.py
+++ b/src/agent_bom/cloud/snowflake_cis_benchmark.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 from .aws_cis_benchmark import CheckStatus, CISCheckResult
 from .base import CloudDiscoveryError
@@ -546,7 +546,7 @@ def run_benchmark(
 
     report = SnowflakeCISReport(account=resolved_account)
 
-    all_checks: list[tuple[str, callable]] = [
+    all_checks: list[tuple[str, Callable[..., CISCheckResult]]] = [
         ("1.1", _check_1_1),
         ("1.2", _check_1_2),
         ("1.3", _check_1_3),

--- a/src/agent_bom/cloud/snowflake_observability.py
+++ b/src/agent_bom/cloud/snowflake_observability.py
@@ -120,7 +120,7 @@ def aggregate_agent_metrics(
 
         # Top tools
         agent_tools = tool_freq.get(agent_name, {})
-        top_tools = sorted(agent_tools, key=agent_tools.get, reverse=True)[:5]
+        top_tools = sorted(agent_tools, key=lambda k: agent_tools.get(k, 0), reverse=True)[:5]
 
         results.append(
             CortexAgentMetrics(

--- a/src/agent_bom/correlate.py
+++ b/src/agent_bom/correlate.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 
-from agent_bom.models import Agent, Package
+from agent_bom.models import Agent, MCPServer, Package
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ def correlate_agents(agents: list[Agent]) -> tuple[list[Agent], CorrelationResul
         return agents, result
 
     # Build global package index: (name, ecosystem) → list of (agent, server, package)
-    pkg_index: dict[tuple[str, str], list[tuple[Agent, object, Package]]] = {}
+    pkg_index: dict[tuple[str, str], list[tuple[Agent, MCPServer, Package]]] = {}
     for agent in agents:
         for server in agent.mcp_servers:
             for pkg in server.packages:

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -13,8 +13,8 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-import toml
-import yaml
+import toml  # type: ignore[import-untyped]
+import yaml  # type: ignore[import-untyped]
 from rich.console import Console
 
 from agent_bom.models import Agent, AgentStatus, AgentType, MCPServer, TransportType
@@ -495,7 +495,7 @@ def parse_goose_config(config_path: str) -> list[MCPServer]:
         env = sanitize_env_vars(raw_env) if isinstance(raw_env, dict) else {}
 
         server = MCPServer(
-            name=ext_def.get("name", name),
+            name=ext_def.get("name", name) or "",
             command=command,
             args=args if isinstance(args, list) else [args],
             env=env,
@@ -605,7 +605,7 @@ def audit_cortex_permissions(permissions: dict) -> list[dict]:
     for entry in approvals:
         if not isinstance(entry, dict):
             continue
-        tool_name = entry.get("tool", entry.get("name", "unknown")).lower()
+        tool_name = str(entry.get("tool", entry.get("name", "unknown")) or "unknown").lower()
         persist = entry.get("persist", entry.get("always_allow", False))
         server = entry.get("server", entry.get("mcp_server", ""))
 
@@ -832,7 +832,7 @@ def detect_installed_agents(discovered_types: set[AgentType]) -> list[Agent]:
 
 def discover_global_configs(agent_types: Optional[list[AgentType]] = None) -> list[Agent]:
     """Discover all global MCP client configurations."""
-    agents = []
+    agents: list[Agent] = []
     sys_platform = get_platform()
 
     if agent_types is None:

--- a/src/agent_bom/discovery/dynamic.py
+++ b/src/agent_bom/discovery/dynamic.py
@@ -352,7 +352,7 @@ def _detect_yaml_mcp(path: Path, text: str) -> Optional[Agent]:
         return None
 
     try:
-        import yaml
+        import yaml  # type: ignore[import-untyped]
     except ImportError:
         return None
 

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -51,7 +51,7 @@ def _evict_oldest(cache: dict[str, dict], max_entries: int) -> None:
     # Evict entries missing _cached_at first (legacy/corrupt), then oldest
     by_age = sorted(
         cache.items(),
-        key=lambda kv: kv[1].get("_cached_at") if isinstance(kv[1].get("_cached_at"), (int, float)) else 0,
+        key=lambda kv: int(kv[1].get("_cached_at") or 0) if isinstance(kv[1].get("_cached_at"), (int, float)) else 0,
     )
     to_remove = len(cache) - max_entries
     for key, _ in by_age[:to_remove]:
@@ -402,7 +402,7 @@ async def enrich_vulnerabilities(
                 tasks = [fetch_nvd_data(cve_id, client, nvd_api_key) for cve_id in batch]
                 results = await asyncio.gather(*tasks, return_exceptions=True)
                 for cve_id, result in zip(batch, results):
-                    if result and not isinstance(result, Exception):
+                    if result and not isinstance(result, BaseException):
                         nvd_data[cve_id] = result
                 if batch_start + batch_size < len(cve_ids):
                     await asyncio.sleep(sleep_secs)

--- a/src/agent_bom/filesystem.py
+++ b/src/agent_bom/filesystem.py
@@ -248,8 +248,9 @@ def parse_rpm_packages(root: Path) -> list[Package]:
     if not shutil.which("rpm"):
         return []
 
-    rpm_db = root / "var" / "lib" / "rpm"
-    if not rpm_db.exists() and root == Path("/"):
+    rpm_db_candidate = root / "var" / "lib" / "rpm"
+    rpm_db: Path | None = rpm_db_candidate
+    if not rpm_db_candidate.exists() and root == Path("/"):
         # Live system, default db path
         rpm_db = None
 

--- a/src/agent_bom/guard.py
+++ b/src/agent_bom/guard.py
@@ -131,16 +131,16 @@ async def _check_package(name: str, ecosystem: str) -> dict:
     """Check a single package for vulnerabilities using existing scanner."""
     from agent_bom.scanners import scan_packages
 
-    pkg_entry = type("Pkg", (), {"name": name, "version": "latest", "ecosystem": ecosystem})()
+    pkg_entry = type("Pkg", (), {"name": name, "version": "latest", "ecosystem": ecosystem, "vulnerabilities": []})()
     try:
-        vulns = await scan_packages([pkg_entry])
+        await scan_packages([pkg_entry])
     except Exception as e:
         logger.warning("Failed to scan %s: %s", name, e)
         return {"name": name, "ecosystem": ecosystem, "error": str(e), "vulns": [], "blocked": False}
 
     cve_list = []
     blocked = False
-    for v in vulns:
+    for v in getattr(pkg_entry, "vulnerabilities", []):
         severity = getattr(v, "severity", "unknown")
         cve_id = getattr(v, "id", "unknown")
         cve_list.append({"id": cve_id, "severity": severity})

--- a/src/agent_bom/integrations/drata.py
+++ b/src/agent_bom/integrations/drata.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
 from agent_bom.http_client import create_client, request_with_retry
 
@@ -39,7 +39,7 @@ async def upload_evidence(
     total_vulns = scan_result.get("summary", {}).get("total_vulnerabilities", 0)
     total_agents = scan_result.get("summary", {}).get("total_agents", 0)
 
-    payload = {
+    payload: dict[str, Any] = {
         "name": evidence_name,
         "description": (
             f"AI supply chain security scan by agent-bom. {total_agents} agent(s) scanned, {total_vulns} vulnerability(ies) found."

--- a/src/agent_bom/integrations/slack.py
+++ b/src/agent_bom/integrations/slack.py
@@ -6,6 +6,7 @@ Uses Slack Block Kit for structured messages. No SDK — pure httpx.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from agent_bom.http_client import create_client, request_with_retry
 
@@ -20,7 +21,7 @@ _SEVERITY_EMOJI: dict[str, str] = {
 }
 
 
-def _build_slack_blocks(finding: dict) -> list[dict]:
+def _build_slack_blocks(finding: dict) -> list[dict[str, Any]]:
     """Build Slack Block Kit blocks from a blast radius finding."""
     vuln_id = finding.get("vulnerability_id", "Unknown")
     severity = finding.get("severity", "medium")
@@ -28,7 +29,7 @@ def _build_slack_blocks(finding: dict) -> list[dict]:
     risk_score = finding.get("risk_score", 0)
     emoji = _SEVERITY_EMOJI.get(severity, ":question:")
 
-    blocks = [
+    blocks: list[dict[str, Any]] = [
         {
             "type": "header",
             "text": {"type": "plain_text", "text": f"{emoji} agent-bom Security Finding"},

--- a/src/agent_bom/integrity.py
+++ b/src/agent_bom/integrity.py
@@ -258,8 +258,8 @@ def verify_installed_record(package_name: str) -> dict:
 
     # Extract metadata
     meta: dict = {
-        "license": dist.metadata.get("License-Expression") or dist.metadata.get("License", ""),
-        "author": dist.metadata.get("Author", ""),
+        "license": dist.metadata.get("License-Expression") or dist.metadata.get("License", ""),  # type: ignore[attr-defined]
+        "author": dist.metadata.get("Author", ""),  # type: ignore[attr-defined]
     }
     project_urls: dict[str, str] = {}
     for val in dist.metadata.get_all("Project-URL") or []:
@@ -283,7 +283,7 @@ def verify_installed_record(package_name: str) -> dict:
             continue
         try:
             full_path = f.locate()
-            data = full_path.read_bytes()
+            data = full_path.read_bytes()  # type: ignore[attr-defined]
             digest = hashlib.sha256(data).digest()
             b64_digest = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
             if b64_digest == f.hash.value:

--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -177,9 +177,13 @@ async def _introspect_sse(
     from mcp import ClientSession
     from mcp.client.sse import sse_client
 
+    if not server.url:
+        result.error = "Server URL is not set"
+        return result
+
     try:
         async with asyncio.timeout(timeout):
-            async with sse_client(server.url) as (read, write):
+            async with sse_client(server.url) as (read, write):  # type: ignore[arg-type]
                 async with ClientSession(read, write) as session:
                     init_result = await session.initialize()
                     result.protocol_version = getattr(init_result, "protocolVersion", None)
@@ -298,7 +302,7 @@ async def introspect_servers(
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     for i, result in enumerate(results):
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
             report.results.append(
                 ServerIntrospection(
                     server_name=introspectable[i].name,
@@ -307,7 +311,7 @@ async def introspect_servers(
                 )
             )
         else:
-            report.results.append(result)
+            report.results.append(result)  # type: ignore[arg-type]
 
     return report
 

--- a/src/agent_bom/model_files.py
+++ b/src/agent_bom/model_files.py
@@ -51,7 +51,7 @@ _SECURITY_FLAGS: dict[str, dict] = {
 }
 
 
-def _human_size(size_bytes: int) -> str:
+def _human_size(size_bytes: int | float) -> str:
     """Convert bytes to human-readable size string."""
     for unit in ("B", "KB", "MB", "GB", "TB"):
         if size_bytes < 1024:

--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -267,9 +267,9 @@ def parse_poetry_lock(directory: Path) -> list[Package]:
             import tomllib  # Python 3.11+
         except ImportError:
             try:
-                import tomli as tomllib  # type: ignore[no-reattr,import-not-found]
+                import tomli as tomllib  # type: ignore[no-redef,no-reattr,import-not-found]
             except ImportError:
-                import toml as tomllib  # type: ignore[no-reattr,import-not-found]
+                import toml as tomllib  # type: ignore[no-redef,no-reattr,import-not-found,import-untyped]
 
         data = tomllib.loads(lock_file.read_text())
         for pkg in data.get("package", []):
@@ -312,9 +312,9 @@ def parse_uv_lock(directory: Path) -> list[Package]:
             import tomllib
         except ImportError:
             try:
-                import tomli as tomllib  # type: ignore[no-reattr,import-not-found]
+                import tomli as tomllib  # type: ignore[no-redef,no-reattr,import-not-found]
             except ImportError:
-                import toml as tomllib  # type: ignore[no-reattr,import-not-found]
+                import toml as tomllib  # type: ignore[no-redef,no-reattr,import-not-found,import-untyped]
 
         data = tomllib.loads(lock_file.read_text())
         # Collect direct dep names from pyproject.toml if available
@@ -368,7 +368,7 @@ def parse_conda_environment(directory: Path) -> list[Package]:
     packages: list[Package] = []
     try:
         try:
-            import yaml  # PyYAML
+            import yaml  # type: ignore[import-untyped]  # PyYAML
         except ImportError:
             logger.debug("PyYAML not installed; skipping conda environment.yml parsing")
             return []
@@ -468,8 +468,8 @@ def parse_yarn_lock(directory: Path) -> list[Package]:
                     current_names = []
         else:
             # Classic v1: '"name@range, name@range":\n  version "x.y.z"'
-            seen: set[tuple[str, str]] = set()
-            current_names: list[str] = []
+            seen = set()  # type: ignore[no-redef]
+            current_names = []  # type: ignore[no-redef]
             for line in content.splitlines():
                 stripped = line.strip()
                 # Header: one or more "name@range" entries followed by ":"
@@ -898,7 +898,7 @@ def parse_maven_packages(directory: Path) -> list[Package]:
             # Skip unresolved property references and missing versions
             if version_el is None or not (version_el.text or "").strip():
                 continue
-            version = version_el.text.strip()
+            version = (version_el.text or "").strip()
             if version.startswith("${"):
                 continue  # parent POM property — can't resolve statically
 
@@ -951,7 +951,7 @@ def parse_cargo_packages(directory: Path) -> list[Package]:
 
 def detect_npx_package(server: MCPServer) -> list[Package]:
     """Extract package info from npx/npm commands."""
-    packages = []
+    packages: list[Package] = []
     if server.command not in ("npx", "npm"):
         return packages
 
@@ -979,7 +979,7 @@ def detect_npx_package(server: MCPServer) -> list[Package]:
 
 def detect_uvx_package(server: MCPServer) -> list[Package]:
     """Extract package info from uvx/uv commands."""
-    packages = []
+    packages: list[Package] = []
     if server.command not in ("uvx", "uv"):
         return packages
 

--- a/src/agent_bom/parsers/dataset_cards.py
+++ b/src/agent_bom/parsers/dataset_cards.py
@@ -56,9 +56,9 @@ class DatasetInfo:
     security_flags: list[dict] = field(default_factory=list)
     compliance_tags: dict[str, list[str]] = field(default_factory=dict)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, object]:
         """Serialize to plain dict for JSON output."""
-        d = {
+        d: dict[str, object] = {
             "name": self.name,
             "description": self.description[:300] if self.description else "",
             "license": self.license,
@@ -143,7 +143,7 @@ def parse_dataset_info_json(path: Path) -> DatasetInfo | None:
         return None
 
     info = DatasetInfo(
-        name=data.get("dataset_name", data.get("config_name", path.parent.name)),
+        name=data.get("dataset_name", data.get("config_name", path.parent.name)) or "",
         description=(data.get("description", "") or "")[:300],
         version=str(data.get("version", {}).get("version_str", ""))
         if isinstance(data.get("version"), dict)

--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -161,10 +161,12 @@ def _assess_purpose_capability(
     has_bins = bool(meta and meta.required_bins)
 
     if has_name:
+        assert meta is not None
         details.append(f"Name declared: {meta.name}")
     if has_desc:
         details.append("Description provided")
     if has_bins:
+        assert meta is not None
         details.append(f"Required binaries: {', '.join(meta.required_bins)}")
         evidence.append(f"bins: {meta.required_bins}")
 
@@ -323,9 +325,11 @@ def _assess_install_mechanism(
     if install_methods:
         details.append(f"Install methods: {', '.join(install_methods)}")
     if has_source:
+        assert meta is not None
         details.append(f"Source: {meta.source}")
         evidence.append(f"source: {meta.source}")
     if has_homepage:
+        assert meta is not None
         details.append(f"Homepage: {meta.homepage}")
 
     # Check for verification/signing references

--- a/src/agent_bom/registry.py
+++ b/src/agent_bom/registry.py
@@ -467,11 +467,11 @@ def enrich_registry_entries(dry_run: bool = False) -> EnrichResult:
                     entry["risk_justification"] = inferred
 
         if "credential_env_vars" in needs:
-            inferred = _infer_credentials(name, entry)
-            if inferred is not None:
-                enriched_fields["credential_env_vars"] = inferred
+            inferred_creds = _infer_credentials(name, entry)
+            if inferred_creds is not None:
+                enriched_fields["credential_env_vars"] = inferred_creds
                 if not dry_run:
-                    entry["credential_env_vars"] = inferred
+                    entry["credential_env_vars"] = inferred_creds
 
         if "tools" in needs:
             enriched_fields["tools"] = []

--- a/src/agent_bom/sbom.py
+++ b/src/agent_bom/sbom.py
@@ -213,7 +213,7 @@ def parse_spdx(data: dict) -> list[Package]:
             if elem.get("type") not in ("software/Package", "SOFTWARE_PACKAGE"):
                 continue
             name = elem.get("name", "")
-            version = elem.get("software/packageVersion", elem.get("packageVersion", "unknown"))
+            version = str(elem.get("software/packageVersion", elem.get("packageVersion", "unknown")) or "unknown")
             purl = elem.get("software/packageUrl", elem.get("externalIdentifier", {}).get("identifier", ""))
             if not name:
                 continue

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -175,7 +175,7 @@ async def check_github_advisories(
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         for i, result in enumerate(results):
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 logger.debug("GHSA fetch failed for %s: %s", queryable[i].name, result)
                 continue
             if not result:

--- a/src/agent_bom/toxic_combos.py
+++ b/src/agent_bom/toxic_combos.py
@@ -300,7 +300,7 @@ def _detect_lateral_chain(
             if isinstance(node, str):
                 lateral_servers.add(node)
             elif isinstance(node, dict):
-                lateral_servers.add(node.get("id", node.get("name", "")))
+                lateral_servers.add(node.get("id", node.get("name", "")) or "")
 
     results = []
     for br in blast_radii:

--- a/src/agent_bom/vex.py
+++ b/src/agent_bom/vex.py
@@ -121,7 +121,7 @@ def load_vex(path: str) -> VexDocument:
 
         statements.append(
             VexStatement(
-                vulnerability_id=vuln_id,
+                vulnerability_id=vuln_id or "",
                 status=status,
                 justification=justification,
                 impact_statement=stmt_data.get("impact_statement"),
@@ -223,16 +223,16 @@ def apply_vex(report: "AIBOMReport", vex: VexDocument) -> int:
         for server in agent.mcp_servers:
             for pkg in server.packages:
                 for vuln in pkg.vulnerabilities:
-                    stmt = vex_map.get(vuln.id)
-                    if not stmt:
+                    matched_stmt: VexStatement | None = vex_map.get(vuln.id)
+                    if not matched_stmt:
                         # Check aliases
                         for alias in vuln.aliases or []:
-                            stmt = vex_map.get(alias)
-                            if stmt:
+                            matched_stmt = vex_map.get(alias)
+                            if matched_stmt:
                                 break
-                    if stmt:
-                        vuln.vex_status = stmt.status.value
-                        vuln.vex_justification = stmt.justification.value if stmt.justification else None
+                    if matched_stmt:
+                        vuln.vex_status = matched_stmt.status.value
+                        vuln.vex_justification = matched_stmt.justification.value if matched_stmt.justification else None
                         count += 1
 
     return count


### PR DESCRIPTION
## Summary

- **mypy config added** to pyproject.toml with strict settings (no_implicit_optional, warn_redundant_casts, show_error_codes)
- **101 type errors fixed** across 28 files — proper annotations, None guards, Union types, `# type: ignore` for complex crypto/stdlib cases
- **Real bug fixed** in guard.py: `scan_packages()` returns `int` (count), code was iterating over it as a list
- **Type stubs added** as dev dependencies: types-PyYAML, types-requests, types-toml
- **CI now enforces mypy** — removed `|| true` from the mypy CI step
- **10 large files** (cli.py, api/server.py, proxy.py, etc.) have per-module `ignore_errors = true` overrides, tracked for cleanup in #525/#526

## Test plan

- [x] `mypy src/agent_bom/` reports 0 errors
- [x] 4,509 tests pass, 0 failures
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass

Closes #527