### PR TITLE
fix: output format compliance + cloud provider pagination + scale limits

### DIFF
--- a/src/agent_bom/cloud/huggingface.py
+++ b/src/agent_bom/cloud/huggingface.py
@@ -95,7 +95,8 @@ def _discover_models(
     api = HfApi(token=token or None)
 
     try:
-        models = list(api.list_models(author=author, limit=200))
+        # HfApi.list_models returns a paginated iterator — no hardcoded limit
+        models = list(api.list_models(author=author))
     except Exception as exc:
         warnings.append(f"Could not list HF models: {exc}")
         return agents, warnings
@@ -154,7 +155,8 @@ def _discover_spaces(
     api = HfApi(token=token or None)
 
     try:
-        spaces = list(api.list_spaces(author=author, limit=100))
+        # HfApi.list_spaces returns a paginated iterator — no hardcoded limit
+        spaces = list(api.list_spaces(author=author))
     except Exception as exc:
         warnings.append(f"Could not list HF Spaces: {exc}")
         return agents, warnings

--- a/src/agent_bom/cloud/mlflow_provider.py
+++ b/src/agent_bom/cloud/mlflow_provider.py
@@ -77,7 +77,21 @@ def _discover_registered_models(
 
     try:
         client = MlflowClient(tracking_uri=tracking_uri)
-        models = client.search_registered_models(max_results=100)
+        # Paginate through all registered models
+        page_token: str | None = None
+        all_models = []
+        for _page in range(100):  # safety guard: 10,000 models max
+            kwargs_m: dict = {"max_results": 100}
+            if page_token:
+                kwargs_m["page_token"] = page_token
+            result_page = client.search_registered_models(**kwargs_m)
+            all_models.extend(result_page)
+            # MLflow PagedList has .token (str) — must verify it's a real str, not a mock
+            raw_token = getattr(result_page, "token", None)
+            page_token = raw_token if isinstance(raw_token, str) and raw_token else None
+            if not page_token:
+                break
+        models = all_models
 
         for model in models:
             model_name = getattr(model, "name", "unknown")
@@ -154,7 +168,20 @@ def _discover_experiments(
 
     try:
         client = MlflowClient(tracking_uri=tracking_uri)
-        experiments = client.search_experiments(max_results=50)
+        # Paginate through all experiments
+        exp_page_token: str | None = None
+        all_experiments = []
+        for _exp_pg in range(100):  # safety guard: 10,000 experiments max
+            kwargs_e: dict = {"max_results": 100}
+            if exp_page_token:
+                kwargs_e["page_token"] = exp_page_token
+            exp_page = client.search_experiments(**kwargs_e)
+            all_experiments.extend(exp_page)
+            raw_exp_token = getattr(exp_page, "token", None)
+            exp_page_token = raw_exp_token if isinstance(raw_exp_token, str) and raw_exp_token else None
+            if not exp_page_token:
+                break
+        experiments = all_experiments
 
         for exp in experiments:
             exp_id = getattr(exp, "experiment_id", "0")

--- a/src/agent_bom/cloud/openai_provider.py
+++ b/src/agent_bom/cloud/openai_provider.py
@@ -84,67 +84,82 @@ def _discover_assistants(
             kwargs["organization"] = organization
         client = openai.OpenAI(**kwargs)
 
-        assistants = client.beta.assistants.list(limit=100)
+        # Paginate through all assistants (API returns max 100 per page)
+        after_cursor = None
+        _max_pages = 100  # safety guard: 10,000 assistants max
+        for _page in range(_max_pages):
+            kwargs_list: dict = {"limit": 100}
+            if after_cursor:
+                kwargs_list["after"] = after_cursor
+            assistants = client.beta.assistants.list(**kwargs_list)
+            page_data = getattr(assistants, "data", None) or []
+            if not page_data:
+                break
+            for asst in page_data:
+                asst_id = getattr(asst, "id", "unknown")
+                asst_name = getattr(asst, "name", None) or asst_id
+                model = getattr(asst, "model", "unknown")
+                tools = getattr(asst, "tools", []) or []
 
-        for asst in assistants.data:
-            asst_id = getattr(asst, "id", "unknown")
-            asst_name = getattr(asst, "name", None) or asst_id
-            model = getattr(asst, "model", "unknown")
-            tools = getattr(asst, "tools", []) or []
+                # Map assistant tools to MCPTool objects
+                mcp_tools: list[MCPTool] = []
+                packages: list[Package] = []
 
-            # Map assistant tools to MCPTool objects
-            mcp_tools: list[MCPTool] = []
-            packages: list[Package] = []
+                for tool in tools:
+                    tool_type = getattr(tool, "type", "")
 
-            for tool in tools:
-                tool_type = getattr(tool, "type", "")
-
-                if tool_type == "code_interpreter":
-                    mcp_tools.append(
-                        MCPTool(
-                            name="code_interpreter",
-                            description="Executes Python code in a sandbox [HIGH-RISK: code execution]",
-                        )
-                    )
-                elif tool_type == "file_search":
-                    mcp_tools.append(
-                        MCPTool(
-                            name="file_search",
-                            description="Searches through uploaded files using vector store",
-                        )
-                    )
-                elif tool_type == "function":
-                    func = getattr(tool, "function", None)
-                    if func:
-                        func_name = getattr(func, "name", "unknown")
-                        func_desc = getattr(func, "description", "") or ""
+                    if tool_type == "code_interpreter":
                         mcp_tools.append(
                             MCPTool(
-                                name=func_name,
-                                description=func_desc[:200],
+                                name="code_interpreter",
+                                description="Executes Python code in a sandbox [HIGH-RISK: code execution]",
                             )
                         )
+                    elif tool_type == "file_search":
+                        mcp_tools.append(
+                            MCPTool(
+                                name="file_search",
+                                description="Searches through uploaded files using vector store",
+                            )
+                        )
+                    elif tool_type == "function":
+                        func = getattr(tool, "function", None)
+                        if func:
+                            func_name = getattr(func, "name", "unknown")
+                            func_desc = getattr(func, "description", "") or ""
+                            mcp_tools.append(
+                                MCPTool(
+                                    name=func_name,
+                                    description=func_desc[:200],
+                                )
+                            )
 
-            # OpenAI SDK itself is a dependency
-            packages.append(Package(name="openai", version="unknown", ecosystem="pypi"))
+                # OpenAI SDK itself is a dependency
+                packages.append(Package(name="openai", version="unknown", ecosystem="pypi"))
 
-            server = MCPServer(
-                name=f"openai-asst:{asst_name}",
-                transport=TransportType.UNKNOWN,
-                packages=packages,
-                tools=mcp_tools,
-                env={"OPENAI_API_KEY": "***REDACTED***"},
-            )
+                server = MCPServer(
+                    name=f"openai-asst:{asst_name}",
+                    transport=TransportType.UNKNOWN,
+                    packages=packages,
+                    tools=mcp_tools,
+                    env={"OPENAI_API_KEY": "***REDACTED***"},
+                )
 
-            agent = Agent(
-                name=f"openai-asst:{asst_name}",
-                agent_type=AgentType.CUSTOM,
-                config_path=f"openai://assistants/{asst_id}",
-                source="openai-assistant",
-                version=model,
-                mcp_servers=[server],
-            )
-            agents.append(agent)
+                agent = Agent(
+                    name=f"openai-asst:{asst_name}",
+                    agent_type=AgentType.CUSTOM,
+                    config_path=f"openai://assistants/{asst_id}",
+                    source="openai-assistant",
+                    version=model,
+                    mcp_servers=[server],
+                )
+                agents.append(agent)
+
+            # Advance pagination cursor — use getattr with strict bool check
+            if getattr(assistants, "has_more", False) is True and page_data:
+                after_cursor = page_data[-1].id
+            else:
+                break
 
     except Exception as exc:
         warnings.append(f"Could not list OpenAI assistants: {exc}")
@@ -168,46 +183,61 @@ def _discover_fine_tunes(
             kwargs["organization"] = organization
         client = openai.OpenAI(**kwargs)
 
-        jobs = client.fine_tuning.jobs.list(limit=50)
+        # Paginate through all fine-tuning jobs (API returns max 100 per page)
+        ft_after = None
+        _ft_max_pages = 100  # safety guard: 10,000 jobs max
+        for _ft_page in range(_ft_max_pages):
+            ft_kwargs: dict = {"limit": 100}
+            if ft_after:
+                ft_kwargs["after"] = ft_after
+            jobs = client.fine_tuning.jobs.list(**ft_kwargs)
+            ft_page_data = getattr(jobs, "data", None) or []
+            if not ft_page_data:
+                break
+            for job in ft_page_data:
+                job_id = getattr(job, "id", "unknown")
+                model = getattr(job, "model", "unknown")
+                fine_tuned_model = getattr(job, "fine_tuned_model", None)
+                status = getattr(job, "status", "unknown")
+                training_file = getattr(job, "training_file", None) or ""
 
-        for job in jobs.data:
-            job_id = getattr(job, "id", "unknown")
-            model = getattr(job, "model", "unknown")
-            fine_tuned_model = getattr(job, "fine_tuned_model", None)
-            status = getattr(job, "status", "unknown")
-            training_file = getattr(job, "training_file", None) or ""
+                # Only inventory completed fine-tunes
+                if not fine_tuned_model:
+                    continue
 
-            # Only inventory completed fine-tunes
-            if not fine_tuned_model:
-                continue
+                packages = [Package(name="openai", version="unknown", ecosystem="pypi")]
 
-            packages = [Package(name="openai", version="unknown", ecosystem="pypi")]
-
-            server = MCPServer(
-                name=f"openai-ft:{fine_tuned_model}",
-                transport=TransportType.UNKNOWN,
-                packages=packages,
-                env={"OPENAI_API_KEY": "***REDACTED***"},
-            )
-
-            # Add training file info as a tool descriptor
-            if training_file:
-                server.tools.append(
-                    MCPTool(
-                        name="training_data",
-                        description=f"Trained on file {training_file}, base model {model}",
-                    )
+                server = MCPServer(
+                    name=f"openai-ft:{fine_tuned_model}",
+                    transport=TransportType.UNKNOWN,
+                    packages=packages,
+                    env={"OPENAI_API_KEY": "***REDACTED***"},
                 )
 
-            agent = Agent(
-                name=f"openai-ft:{fine_tuned_model}",
-                agent_type=AgentType.CUSTOM,
-                config_path=f"openai://fine-tuning/{job_id}",
-                source="openai-fine-tune",
-                version=f"{status} (base: {model})",
-                mcp_servers=[server],
-            )
-            agents.append(agent)
+                # Add training file info as a tool descriptor
+                if training_file:
+                    server.tools.append(
+                        MCPTool(
+                            name="training_data",
+                            description=f"Trained on file {training_file}, base model {model}",
+                        )
+                    )
+
+                agent = Agent(
+                    name=f"openai-ft:{fine_tuned_model}",
+                    agent_type=AgentType.CUSTOM,
+                    config_path=f"openai://fine-tuning/{job_id}",
+                    source="openai-fine-tune",
+                    version=f"{status} (base: {model})",
+                    mcp_servers=[server],
+                )
+                agents.append(agent)
+
+            # Advance pagination cursor — strict bool check
+            if getattr(jobs, "has_more", False) is True and ft_page_data:
+                ft_after = ft_page_data[-1].id
+            else:
+                break
 
     except Exception as exc:
         warnings.append(f"Could not list OpenAI fine-tuning jobs: {exc}")

--- a/src/agent_bom/cloud/wandb_provider.py
+++ b/src/agent_bom/cloud/wandb_provider.py
@@ -93,12 +93,11 @@ def _discover_runs(
             # Without a specific project, try listing projects first
             try:
                 projects = api.projects(entity)
-                for proj in list(projects)[:5]:
+                for proj in list(projects):
                     proj_name = getattr(proj, "name", None)
                     if proj_name:
-                        proj_runs = api.runs(f"{entity}/{proj_name}", per_page=10)
-                        runs = list(proj_runs)[:10]
-                        for run in runs:
+                        proj_runs = api.runs(f"{entity}/{proj_name}", per_page=50)
+                        for run in list(proj_runs):
                             agent = _run_to_agent(run, entity, proj_name)
                             if agent:
                                 agents.append(agent)
@@ -106,7 +105,7 @@ def _discover_runs(
                 warnings.append(f"Could not list W&B projects: {exc}")
             return agents, warnings
 
-        for run in list(runs)[:50]:
+        for run in list(runs):
             agent = _run_to_agent(run, entity, project)
             if agent:
                 agents.append(agent)
@@ -166,7 +165,7 @@ def _discover_artifacts(
                     type_name=art_type,
                     name=f"{entity}/{project}",
                 )
-                for artifact in list(artifacts)[:20]:
+                for artifact in list(artifacts):
                     art_name = getattr(artifact, "name", "unknown")
                     art_version = getattr(artifact, "version", "latest")
                     art_metadata = getattr(artifact, "metadata", {}) or {}

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -914,8 +914,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                                 "fixed_version": f.fixed_version,
                                 "command": f.command,
                                 "vulns": f.vulns[:5],
+                                "total_vulns": len(f.vulns),
                                 "agents": f.agents[:5],
+                                "total_agents": len(f.agents),
                                 "references": f.references[:10],
+                                "total_references": len(f.references),
                             }
                             for f in plan.package_fixes
                         ],
@@ -923,11 +926,13 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                             {
                                 "credential": f.credential_name,
                                 "locations": f.locations[:5],
+                                "total_locations": len(f.locations),
                                 "risk": f.risk_description,
                                 "fix_steps": f.fix_steps,
                             }
                             for f in plan.credential_fixes
                         ],
+                        "total_unfixable": len(plan.unfixable),
                         "unfixable": plan.unfixable[:10],
                     },
                     indent=2,
@@ -2137,9 +2142,11 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                 json.dumps(
                     {
                         "files_scanned": result.files_scanned,
+                        "total_prompt_files": len(result.prompt_files),
                         "prompt_files": result.prompt_files[:50],
                         "passed": result.passed,
                         "total_findings": len(result.findings),
+                        "findings_shown": min(len(result.findings), 100),
                         "findings": [
                             {
                                 "file": f.source_file,

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1660,6 +1660,17 @@ def export_json(report: AIBOMReport, output_path: str) -> None:
 # ─── CycloneDX Output ──────────────────────────────────────────────────────
 
 
+def _sanitize_bom_ref(raw: str) -> str:
+    """Sanitize a CycloneDX bom-ref to contain only valid characters.
+
+    CycloneDX 1.6 bom-ref should match ``^[a-zA-Z0-9._-]+$``.
+    Replace invalid characters (``@``, ``/``, spaces, etc.) with ``-``.
+    """
+    import re
+
+    return re.sub(r"[^a-zA-Z0-9._-]", "-", raw)
+
+
 def to_cyclonedx(report: AIBOMReport) -> dict:
     """Build CycloneDX 1.6 dict from report."""
     components = []
@@ -1671,7 +1682,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
 
     # Add agents as top-level components
     for agent in report.agents:
-        agent_ref = f"agent-{agent.name}"
+        agent_ref = _sanitize_bom_ref(f"agent-{agent.name}")
         agent_deps = []
 
         components.append(
@@ -1690,7 +1701,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
         )
 
         for server in agent.mcp_servers:
-            server_ref = f"mcp-server-{server.name}-{comp_id}"
+            server_ref = _sanitize_bom_ref(f"mcp-server-{server.name}-{comp_id}")
             comp_id += 1
             server_deps = []
 
@@ -1714,7 +1725,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
             agent_deps.append(server_ref)
 
             for pkg in server.packages:
-                pkg_ref = f"pkg-{pkg.ecosystem}-{pkg.name}-{pkg.version}-{comp_id}"
+                pkg_ref = _sanitize_bom_ref(f"pkg-{pkg.ecosystem}-{pkg.name}-{pkg.version}-{comp_id}")
                 comp_id += 1
 
                 pkg_properties = [
@@ -1887,16 +1898,30 @@ def to_sarif(report: AIBOMReport) -> dict:
 
         config_path = br.affected_agents[0].config_path if br.affected_agents else "unknown"
 
+        # SARIF 2.1.0: fingerprints for dedup, region for location, kind for classification
+        import hashlib
+
+        fp_input = f"{rule_id}:{br.package.name}:{br.package.version}:{config_path}"
+        fingerprint = hashlib.sha256(fp_input.encode()).hexdigest()
+
         result: dict = {
             "ruleId": rule_id,
             "level": level,
+            "kind": "fail",
             "message": {"text": message_text},
+            "fingerprints": {
+                "agent-bom/v1": fingerprint,
+            },
             "locations": [
                 {
                     "physicalLocation": {
                         "artifactLocation": {
                             "uri": config_path,
                             "uriBaseId": "%SRCROOT%",
+                        },
+                        "region": {
+                            "startLine": 1,
+                            "startColumn": 1,
                         },
                     },
                 }
@@ -2381,12 +2406,20 @@ def to_spdx(report: AIBOMReport) -> dict:
     for agent in report.agents:
         agent_id = _next_id("SPDXRef-Agent")
 
-        agent_element = {
-            "type": "ai_bom/Agent",
+        agent_element: dict[str, Any] = {
+            "type": "SOFTWARE_PACKAGE",
             "spdxId": agent_id,
             "name": agent.name,
             "primaryPurpose": "APPLICATION",
             "description": f"AI Agent ({agent.agent_type.value})",
+            "annotation": [
+                {
+                    "type": "Annotation",
+                    "annotationType": "OTHER",
+                    "subject": agent_id,
+                    "statement": f"agent-bom:ai-agent-type={agent.agent_type.value}",
+                }
+            ],
         }
         if agent.config_path:
             agent_element["comment"] = f"config_path: {agent.config_path}, status: {agent.status.value}"

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -482,7 +482,7 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
         severity, cvss_score = parse_osv_severity(vuln_data)
         fixed = parse_fixed_version(vuln_data, package.name)
 
-        references = [ref.get("url", "") for ref in vuln_data.get("references", []) if ref.get("url")][:5]  # Limit to 5 references
+        references = [ref.get("url", "") for ref in vuln_data.get("references", []) if ref.get("url")]
 
         # Use aliases to surface CVE ID when primary ID is GHSA/OSV/RUSTSEC
         aliases = vuln_data.get("aliases", [])


### PR DESCRIPTION
## Summary
- **SARIF 2.1.0 compliance**: fingerprints (SHA-256 dedup), region fields, `kind: "fail"` classification
- **CycloneDX 1.6 compliance**: `_sanitize_bom_ref()` strips `@`/`/`/spaces from bom-ref (spec: `^[a-zA-Z0-9._-]+$`)
- **SPDX 3.0 compliance**: replace invalid `ai_bom/Agent` element type → `SOFTWARE_PACKAGE` with annotation
- **Cloud provider pagination** — eliminates silent data loss at scale:
  - OpenAI: paginate assistants + fine-tunes (was hardcoded `limit=100`/`limit=50`, single page)
  - HuggingFace: remove `limit=200`/`limit=100` (HfApi iterator paginates natively)
  - MLflow: paginate registered models + experiments via `page_token` (was `max_results=100`/`50`)
  - W&B: remove `[:5]`/`[:10]`/`[:50]`/`[:20]` slicing on projects/runs/artifacts
- **MCP server**: add `total_*` counts on all truncated responses (vulns, agents, references, locations, unfixable, findings)
- **Scanner**: remove `[:5]` truncation on vulnerability references

All pagination loops use bounded `for _ in range(100)` with strict type checks on continuation tokens — prevents infinite loops in tests and with unexpected API responses.

## Test plan
- [x] 79/79 cloud provider tests pass (tested in batches to avoid CPU overload)
- [x] 54/54 MCP server tests pass
- [x] 222/222 core tests pass
- [x] 19/19 stats alignment meta-tests pass
- [x] 4,230 remaining tests pass (15 skipped — normal)
- [x] Ruff lint clean on all 7 modified files
- [x] Pre-commit hooks pass