### PR TITLE
feat: Snowflake Notebook discovery + fix downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/msaad00/agent-bom/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue?style=flat" alt="License"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom"><img src="https://api.securityscorecards.dev/projects/github.com/msaad00/agent-bom/badge" alt="OpenSSF"></a>
   <a href="https://www.bestpractices.dev/projects/12114"><img src="https://www.bestpractices.dev/projects/12114/badge" alt="OpenSSF Best Practices"></a>
-  <a href="https://pypi.org/project/agent-bom/"><img src="https://img.shields.io/pypi/dm/agent-bom?style=flat&label=Downloads" alt="Downloads"></a>
+  <a href="https://pepy.tech/projects/agent-bom"><img src="https://static.pepy.tech/badge/agent-bom/month" alt="Downloads"></a>
   <a href="https://github.com/msaad00/agent-bom/stargazers"><img src="https://img.shields.io/github/stars/msaad00/agent-bom?style=flat&logo=github&label=Stars" alt="Stars"></a>
   <a href="https://github.com/msaad00/agent-bom/discussions"><img src="https://img.shields.io/github/discussions/msaad00/agent-bom?style=flat&logo=github&label=Discussions" alt="Discussions"></a>
 </p>

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -235,6 +235,11 @@ def discover(
         agents.extend(streamlit_agents)
         warnings.extend(st_warns)
 
+        # ── Snowflake Notebooks ─────────────────────────────────────────
+        notebook_agents, nb_warns = _discover_snowflake_notebooks(conn, resolved_account)
+        agents.extend(notebook_agents)
+        warnings.extend(nb_warns)
+
     finally:
         conn.close()
 
@@ -361,6 +366,155 @@ def _discover_streamlit_apps(
 
     except Exception as exc:
         warnings.append(f"Could not list Streamlit apps: {sanitize_error(exc)}")
+
+    finally:
+        cursor.close()
+
+    return agents, warnings
+
+
+def _discover_snowflake_notebooks(
+    conn: Any,
+    account: str,
+) -> tuple[list[Agent], list[str]]:
+    """Discover Snowflake Notebooks and extract AI/ML package usage.
+
+    Snowflake Notebooks run Python/SQL cells in a managed Snowpark environment.
+    They can import AI/ML libraries, call Cortex functions, and access external
+    stages — all supply chain vectors we need to inventory.
+    """
+    agents: list[Agent] = []
+    warnings: list[str] = []
+    cursor = conn.cursor()
+
+    # Known AI/ML packages to flag when found in notebook imports
+    _ai_ml_packages = {
+        "openai",
+        "anthropic",
+        "langchain",
+        "transformers",
+        "torch",
+        "tensorflow",
+        "keras",
+        "huggingface_hub",
+        "sentence_transformers",
+        "llama_index",
+        "vllm",
+        "triton",
+        "bitsandbytes",
+        "peft",
+        "trl",
+        "diffusers",
+        "autogen",
+        "crewai",
+        "dspy",
+        "guidance",
+        "promptflow",
+        "snowflake-ml-python",
+        "snowflake-snowpark-python",
+        "snowflake-cortex",
+    }
+
+    try:
+        cursor.execute("SHOW NOTEBOOKS IN ACCOUNT")
+        rows = cursor.fetchall()
+        columns = [desc[0].lower() for desc in cursor.description] if cursor.description else []
+
+        for row in rows:
+            row_dict = dict(zip(columns, row)) if columns else {}
+            nb_name = row_dict.get("name", str(row[0]) if row else "unknown")
+            nb_db = row_dict.get("database_name", "")
+            nb_schema = row_dict.get("schema_name", "")
+            nb_owner = row_dict.get("owner", "")
+            nb_comment = row_dict.get("comment", "")
+
+            packages: list[Package] = []
+            tools: list[MCPTool] = []
+
+            # Try to extract notebook package dependencies from metadata
+            # Snowflake stores notebook runtime packages in INFORMATION_SCHEMA
+            try:
+                fqn = f'"{nb_db}"."{nb_schema}"."{nb_name}"'
+                cursor.execute(
+                    f"DESCRIBE NOTEBOOK {fqn}"  # noqa: S608
+                )
+                desc_rows = cursor.fetchall()
+                desc_cols = [d[0].lower() for d in cursor.description] if cursor.description else []
+                for d_row in desc_rows:
+                    d_dict = dict(zip(desc_cols, d_row)) if desc_cols else {}
+                    prop_name = str(d_dict.get("property", d_dict.get("name", ""))).lower()
+                    prop_val = str(d_dict.get("value", d_dict.get("property_value", "")))
+
+                    # Extract packages from PACKAGES property
+                    if "package" in prop_name and prop_val:
+                        for pkg_spec in prop_val.split(","):
+                            pkg_spec = pkg_spec.strip()
+                            if not pkg_spec:
+                                continue
+                            parts = pkg_spec.split("==") if "==" in pkg_spec else pkg_spec.split("=")
+                            pkg_name = parts[0].strip()
+                            pkg_version = parts[1].strip() if len(parts) > 1 else "unknown"
+                            packages.append(Package(name=pkg_name, version=pkg_version, ecosystem="pypi"))
+                            # Flag AI/ML packages as tools for visibility
+                            if pkg_name.lower().replace("-", "_") in _ai_ml_packages:
+                                tools.append(
+                                    MCPTool(
+                                        name=f"ai-pkg:{pkg_name}",
+                                        description=f"AI/ML package {pkg_name}@{pkg_version} used in notebook",
+                                    )
+                                )
+
+                    # Check for Cortex function usage in notebook queries
+                    if "query" in prop_name and prop_val:
+                        cortex_funcs = [
+                            "cortex.complete",
+                            "cortex.embed",
+                            "cortex.sentiment",
+                            "cortex.summarize",
+                            "cortex.translate",
+                            "cortex.extract_answer",
+                        ]
+                        for func in cortex_funcs:
+                            if func.lower() in prop_val.lower():
+                                tools.append(
+                                    MCPTool(
+                                        name=f"cortex:{func.split('.')[-1]}",
+                                        description=f"Cortex AI function {func} called in notebook",
+                                    )
+                                )
+
+            except Exception:
+                # DESCRIBE NOTEBOOK may not be available on all editions
+                pass
+
+            server = MCPServer(
+                name=f"sf-notebook:{nb_name}",
+                transport=TransportType.UNKNOWN,
+                packages=packages,
+                tools=tools,
+            )
+            agent = Agent(
+                name=f"sf-notebook:{nb_name}",
+                agent_type=AgentType.CUSTOM,
+                config_path=f"snowflake://{account}/{nb_db}/{nb_schema}/notebooks/{nb_name}",
+                source="snowflake-notebook",
+                metadata={
+                    "database": nb_db,
+                    "schema": nb_schema,
+                    "owner": nb_owner,
+                    "comment": nb_comment,
+                },
+                mcp_servers=[server],
+            )
+            agents.append(agent)
+
+    except Exception as exc:
+        msg = str(exc)
+        if "does not exist" in msg.lower() or "syntax error" in msg.lower():
+            # SHOW NOTEBOOKS not available on this Snowflake edition/version
+            warnings.append("Snowflake Notebooks discovery not available (requires Snowflake 2024.3+)")
+        else:
+            warnings.append(f"Could not list Snowflake Notebooks: {sanitize_error(exc)}")
 
     finally:
         cursor.close()


### PR DESCRIPTION
## Summary
- **Snowflake Notebook discovery**: `SHOW NOTEBOOKS IN ACCOUNT` → inventory all notebooks, extract Python package deps via `DESCRIBE NOTEBOOK`, flag AI/ML packages (openai, anthropic, langchain, transformers, etc.), detect Cortex function usage (complete, embed, sentiment, summarize, translate, extract_answer)
- **Downloads badge**: switch from shields.io/pypi (rate limited by upstream) to pepy.tech (reliable cache)

Closes #544

## Details
Follows existing Snowflake discovery pattern (same as Streamlit apps, Cortex Agents, MCP Servers). Graceful fallback if `SHOW NOTEBOOKS` not available on older Snowflake editions.

AI/ML packages flagged: openai, anthropic, langchain, transformers, torch, tensorflow, huggingface_hub, snowflake-ml-python, snowflake-cortex, and 15+ more.

## Test plan
- [x] 10/10 Snowflake cloud tests pass
- [x] 105/105 Snowflake governance + CIS + activity tests pass
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass