### PR TITLE
fix: resolve YAML parse error blocking OpenSSF Scorecard

### DIFF
--- a/.github/workflows/uv-lock-upgrade.yml
+++ b/.github/workflows/uv-lock-upgrade.yml
@@ -50,15 +50,19 @@ jobs:
           git add uv.lock
           git commit -m "chore: weekly uv.lock upgrade"
           git push origin "$BRANCH"
+          BODY=$(cat <<'PREOF'
+          Weekly automated lockfile refresh via `uv lock --upgrade`.
+
+          All packages bumped to latest versions within declared bounds in `pyproject.toml`.
+
+          **Review checklist:**
+          - [ ] CI passes (pip-audit + OSV scanner will catch any new CVEs)
+          - [ ] No unexpected major version bumps
+          PREOF
+          )
           gh pr create \
             --title "chore: weekly uv.lock upgrade $(date +%Y-%m-%d)" \
-            --body "Weekly automated lockfile refresh via \`uv lock --upgrade\`.
-
-All packages bumped to latest versions within declared bounds in \`pyproject.toml\`.
-
-**Review checklist:**
-- [ ] CI passes (pip-audit + OSV scanner will catch any new CVEs)
-- [ ] No unexpected major version bumps" \
+            --body "$BODY" \
             --base main
 
       - name: No changes


### PR DESCRIPTION
## Summary
- Fix YAML parse error in `uv-lock-upgrade.yml` line 57 — backtick escapes in multiline `--body` string broke YAML parsing
- Replace with heredoc to avoid escape issues
- All 17 workflow files now validate cleanly

This resolves the **Dangerous-Workflow CRITICAL** flag on OpenSSF Scorecard, which was caused by the parser being unable to analyze the broken YAML (not by an actual dangerous pattern).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes for all 17 workflow files
- [x] No `pull_request_target` patterns exist (verified via grep)
- [x] Pre-commit hooks pass