### PR TITLE
chore: update demo tape for v0.69.0 + README GIF reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agent-bom scan --enrich      # + NVD CVSS + EPSS + CISA KEV enrichment
 That's it. agent-bom discovers your MCP client configs (Claude Desktop, Cursor, Windsurf, and 18 more), resolves every server's dependencies, checks them against OSV/NVD/GHSA, and maps the blast radius — which agents, credentials, and tools are affected by each vulnerability.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-v0.65.0.gif" alt="agent-bom demo — scan, CVE check before/after, GPU infra scan" width="900" />
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-v0.69.0.gif" alt="agent-bom demo — scan, CVE check, GPU infra, runtime proxy, 30 MCP tools" width="900" />
 </p>
 
 <p align="center">

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.65.0 demo — run with: vhs docs/demo.tape
+# agent-bom v0.69.0 demo — run with: vhs docs/demo.tape
 # Install vhs: brew install vhs  (or https://github.com/charmbracelet/vhs)
 # Prereqs:
 #   pip install agent-bom
@@ -7,7 +7,7 @@
 #     --label com.nvidia.cuda.version=12.3.0 \
 #     node:18-slim sleep 3600
 
-Output docs/images/demo-v0.65.0.gif
+Output docs/images/demo-v0.69.0.gif
 
 Set Shell "bash"
 Set FontSize 14
@@ -19,6 +19,7 @@ Set TypingSpeed 40ms
 Set PlaybackSpeed 1.2
 
 # ── 1. Auto-discover your MCP setup ─────────────────────────────────────────
+# Discovers 21 MCP clients, scans CVEs, maps blast radius, 11-framework compliance
 Type "agent-bom scan"
 Sleep 300ms
 Enter
@@ -37,15 +38,31 @@ Enter
 Sleep 5s
 
 # ── 4. GPU/AI compute infra scan ─────────────────────────────────────────────
-# (requires Docker running with: docker run -d --name gpu-demo \
-#   --label com.nvidia.cuda.version=12.3.0 node:18-slim sleep 3600)
+# Detects CUDA containers, DCGM endpoints, GPU workload security
 Type "agent-bom scan --gpu-scan"
 Sleep 300ms
 Enter
 Sleep 12s
 
-# ── 5. Show 23 MCP server tools ──────────────────────────────────────────────
-Type "agent-bom mcp-server --help | grep -E '^\s{6}\w' | head -25"
+# ── 5. Output formats — SARIF, CycloneDX, SPDX, HTML, Mermaid ──────────────
+Type "agent-bom scan -f sarif -o results.sarif && echo '13 output formats: SARIF, CycloneDX 1.6, SPDX 3.0, HTML, Mermaid, SVG, Prometheus, Badge...'"
+Sleep 300ms
+Enter
+Sleep 4s
+
+# ── 6. Runtime proxy — intercept MCP traffic with 7 detectors ───────────────
+# SQL injection, credential leak, prompt injection, tool drift detection
+Type "agent-bom proxy --detect-credentials --block-undeclared -- npx @modelcontextprotocol/server-fs /tmp &"
+Sleep 300ms
+Enter
+Sleep 3s
+Type "# ↑ Proxy running: 71 security patterns, Cortex AI model tracking, SQL injection detection"
+Sleep 300ms
+Enter
+Sleep 2s
+
+# ── 7. Show 30 MCP server tools ─────────────────────────────────────────────
+Type "agent-bom mcp-server --help | head -5 && echo '30 MCP tools | 12 cloud providers | 7 runtime detectors'"
 Sleep 300ms
 Enter
 Sleep 3s


### PR DESCRIPTION
## Summary
- Update `docs/demo.tape` VHS script to showcase v0.69.0 capabilities: 13 output formats, runtime proxy with 71 security patterns, Cortex AI model tracking, SQL injection detection, 30 MCP tools
- Update README GIF reference from v0.65.0 → v0.69.0
- GIF will be regenerated by running `vhs docs/demo.tape` after merge

## Test plan
- [ ] CI passes
- [ ] After merge, run `vhs docs/demo.tape` to generate the new GIF