### PR TITLE
feat: add Copilot CLI + Tabnine MCP client discovery (22 clients)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -188,7 +188,7 @@ All documented features verified to have code + tests:
 | VEX | `vex.py` | `tests/test_vex.py` |
 | SAST (Semgrep, 52 CWEs) | `sast.py` | `tests/test_sast.py` |
 | Runtime proxy (6 detectors) | `runtime/detectors.py`, `proxy.py` | `tests/test_runtime_detectors.py` |
-| MCP config discovery (21 clients) | `discovery/` | `tests/test_discovery.py` |
+| MCP config discovery (22 clients) | `discovery/` | `tests/test_discovery.py` |
 | CIS benchmarks (AWS/Snowflake/Azure/GCP) | `cloud/*_cis_benchmark.py` | `tests/test_*_cis_benchmark.py` |
 | Databricks security checks | `cloud/databricks_security.py` | `tests/test_databricks_security.py` |
 | AISVS v1.0 | `cloud/aisvs_benchmark.py` | `tests/test_aisvs_benchmark.py` |
@@ -225,7 +225,7 @@ Modules with no test file (functionality tested indirectly via integration tests
 | Identity Layer | PARTIAL | Credential detection in env vars, RBAC in API, no IdP integration |
 | Agent Control Layer | STRONG | Policy enforcement (block/warn/allow), tool allowlisting, rate limiting in proxy |
 | Tool Security Layer | STRONG | MCP tool scanning, injection detection, ArgumentAnalyzer, permission profiles |
-| MCP Layer | STRONG | Config discovery (21 clients), proxy intercept, drift detection, enforcement |
+| MCP Layer | STRONG | Config discovery (22 clients), proxy intercept, drift detection, enforcement |
 | Governance Layer | GOOD | CIS benchmarks (5 cloud platforms), AISVS, policy-as-code, audit logs |
 | Monitoring & Observability | GOOD | Runtime proxy (JSONL audit), OTel ingest, Prometheus metrics, watch (config drift) |
 | Compliance & Regulation | STRONG | 10 frameworks mapped on every finding (OWASP LLM/MCP/Agentic, ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls) |
@@ -238,7 +238,7 @@ Modules with no test file (functionality tested indirectly via integration tests
 
 ```
 Input Sources
-├── Local MCP configs (21 client types)
+├── Local MCP configs (22 client types)
 ├── Cloud providers (12: AWS, Azure, GCP, Snowflake, Databricks, CoreWeave,
 │   Nebius, HuggingFace, W&B, MLflow, OpenAI, Ollama)
 ├── Container images (--image, via Syft/Grype)
@@ -514,7 +514,7 @@ ScanRequest → _run_scan_sync() [ThreadPoolExecutor]
 
 | Claim | Verified |
 |-------|---------|
-| "21 MCP clients" (README) | ✓ 20 named AgentType values + CUSTOM = 21 |
+| "22 MCP clients" (README) | ✓ 20 named AgentType values + CUSTOM = 21 |
 | "30 MCP tools" | ✓ meta-test enforces this |
 | "10 compliance frameworks" | ✓ 10 tagging modules |
 | "52 SAST CWE mappings" | ✓ SAST_CWE_MAP count |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full module map. Key paths:
 | `src/agent_bom/cli.py` | All CLI commands (Click) |
 | `src/agent_bom/scanners/__init__.py` | OSV batch scan + detail enrichment |
 | `src/agent_bom/enrichment.py` | NVD + EPSS + CISA KEV enrichment |
-| `src/agent_bom/discovery/__init__.py` | MCP client config discovery (21 clients) |
+| `src/agent_bom/discovery/__init__.py` | MCP client config discovery (22 clients) |
 | `src/agent_bom/models.py` | Core data models (Package, Vulnerability, Agent…) |
 | `src/agent_bom/runtime/` | Proxy detectors (7 detectors) |
 | `src/agent_bom/api/server.py` | FastAPI REST server |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -716,7 +716,7 @@ def scan_with_audit(user, target):
 
 | Feature | agent-bom | Syft | Grype | Snyk | Wiz |
 |---------|-----------|------|-------|------|-----|
-| AI agent config discovery | ✅ (21 MCP clients) | ❌ | ❌ | ❌ | ❌ |
+| AI agent config discovery | ✅ (22 MCP clients) | ❌ | ❌ | ❌ | ❌ |
 | MCP server support | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Transitive deps | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Blast radius (AI-specific) | ✅ | ❌ | ❌ | ❌ | ❌ |

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ agent-bom introspect --all --baseline baseline.json               # exit 1 on ne
 
 </details>
 
-Auto-discovers 21 MCP clients: Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Copilot, Continue, Zed, Cortex Code, Codex CLI, Gemini CLI, Goose, Snowflake CLI, OpenClaw, Roo Code, Amazon Q, ToolHive, Docker MCP Toolkit, JetBrains AI, Junie, and custom paths.
+Auto-discovers 22 MCP clients: Claude Desktop, Claude Code, Cursor, Windsurf, Cline, VS Code Copilot, Continue, Zed, Cortex Code, Codex CLI, Gemini CLI, Goose, Snowflake CLI, OpenClaw, Roo Code, Amazon Q, ToolHive, Docker MCP Toolkit, JetBrains AI, Junie, and custom paths.
 
 <p align="center">
   <picture>
@@ -236,7 +236,7 @@ Auto-discovers 21 MCP clients: Claude Desktop, Claude Code, Cursor, Windsurf, Cl
 |---|---|---|
 | Package CVE detection | Yes | Yes (OSV + NVD + EPSS + CISA KEV + GHSA + NVIDIA CSAF) |
 | SBOM generation | Yes | Yes (CycloneDX 1.6, SPDX 3.0, SARIF) |
-| **AI agent discovery** | -- | 21 MCP clients + Docker Compose + running processes + containers + K8s pods/CRDs |
+| **AI agent discovery** | -- | 22 MCP clients + Docker Compose + running processes + containers + K8s pods/CRDs |
 | **GPU/ML package scanning** | -- | NVIDIA CSAF advisories for CUDA, cuDNN, PyTorch, TensorFlow, JAX, vLLM + AMD ROCm via OSV |
 | **AI supply chain** | -- | Model provenance (pickle risk, digest, gating), HuggingFace Hub, Ollama, MLflow, W&B |
 | **AI cloud inventory** | -- | Coreweave, Nebius, Snowflake, Databricks, OpenAI, HuggingFace Hub — config discovery + CVE tagging |
@@ -267,7 +267,7 @@ Auto-discovers 21 MCP clients: Claude Desktop, Claude Code, Cursor, Windsurf, Cl
 
 | Source | How |
 |--------|-----|
-| MCP configs | Auto-discover (21 clients + Docker Compose) |
+| MCP configs | Auto-discover (22 clients + Docker Compose) |
 | Docker images | Grype / Syft / Docker CLI fallback |
 | Kubernetes | kubectl across namespaces |
 | Cloud providers | AWS, Azure, GCP, Databricks, Snowflake, Coreweave, Nebius |
@@ -535,7 +535,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 - [ ] Trend analytics — vulnerability count over time, resolution velocity
 
 **Agents / MCP**
-- [x] 21 MCP client config discovery paths, live introspection, tool drift detection
+- [x] 22 MCP client config discovery paths, live introspection, tool drift detection
 - [x] Runtime proxy with 7 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, vector DB injection, semantic injection scoring)
 - [x] Semantic injection scoring — weighted 10-signal model, 0.0–1.0 risk score, MEDIUM/HIGH alerts
 - [ ] Agent memory / vector store content scanning for injected instructions

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -654,7 +654,7 @@ with tabs[6]:
         "Output",
     ]
     descriptions = {
-        "Discovery": "Auto-detect 21 MCP client configs (Claude Desktop, Cursor, VS Code, etc.)",
+        "Discovery": "Auto-detect 22 MCP client configs (Claude Desktop, Cursor, VS Code, etc.)",
         "Parsing": "Extract servers, packages, credentials, tools from config JSON/YAML",
         "Resolution": "Resolve versions via npm/PyPI registries, deps.dev, lock files",
         "Enrichment": "Add licenses, EPSS scores, KEV status, NVD data, scorecards",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -279,7 +279,7 @@ graph TB
 | Module | Path | Responsibility |
 |--------|------|----------------|
 | CLI | `src/agent_bom/cli.py` | Click entry point, flag parsing |
-| Discovery | `src/agent_bom/discovery/__init__.py` | MCP client config discovery (21 clients) |
+| Discovery | `src/agent_bom/discovery/__init__.py` | MCP client config discovery (22 clients) |
 | Parsers | `src/agent_bom/parsers/__init__.py` | Package extraction + MCP registry lookup |
 | Skill Parsers | `src/agent_bom/parsers/skills.py` + `skill_audit.py` | SKILL.md/CLAUDE.md behavioral audit, typosquat, Sigstore trust |
 | Browser Extensions | `src/agent_bom/parsers/browser_extensions.py` | Chrome/Edge/Brave/Firefox manifest.json permission auditor |

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -19,7 +19,7 @@ Set TypingSpeed 40ms
 Set PlaybackSpeed 1.2
 
 # ── 1. Auto-discover your MCP setup ─────────────────────────────────────────
-# Discovers 21 MCP clients, scans CVEs, maps blast radius, 11-framework compliance
+# Discovers 22 MCP clients, scans CVEs, maps blast radius, 11-framework compliance
 Type "agent-bom scan"
 Sleep 300ms
 Enter

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -38,7 +38,7 @@
 
   <rect x="28" y="68" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="84" text-anchor="middle" class="box-label">MCP Configs</text>
-  <text x="101" y="96" text-anchor="middle" class="box-sub">21 clients · auto-detect</text>
+  <text x="101" y="96" text-anchor="middle" class="box-sub">22 clients · auto-detect</text>
 
   <rect x="28" y="106" width="146" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="101" y="122" text-anchor="middle" class="box-label">Cloud Providers</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -38,7 +38,7 @@
 
   <rect x="28" y="68" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="84" text-anchor="middle" class="box-label">MCP Configs</text>
-  <text x="101" y="96" text-anchor="middle" class="box-sub">21 clients · auto-detect</text>
+  <text x="101" y="96" text-anchor="middle" class="box-sub">22 clients · auto-detect</text>
 
   <rect x="28" y="106" width="146" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="101" y="122" text-anchor="middle" class="box-label">Cloud Providers</text>

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -47,7 +47,7 @@
     <rect width="200" height="36" rx="6" fill="#161b22" stroke="#1f6feb" stroke-width="1" opacity="0.8"/>
     <circle cx="16" cy="18" r="5" fill="#58a6ff" opacity="0.5"/>
     <text x="28" y="15" class="node-label">MCP Agent Configs</text>
-    <text x="28" y="28" class="node-sub">21 clients: Claude, Cursor, Codex, Gemini...</text>
+    <text x="28" y="28" class="node-sub">22 clients: Claude, Cursor, Codex, Gemini...</text>
   </g>
 
   <!-- Source 3: Container Images  (y=186, h=36, midY=204) -->

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -47,7 +47,7 @@
     <rect width="200" height="36" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
     <circle cx="16" cy="18" r="5" fill="#3b82f6" opacity="0.6"/>
     <text x="28" y="15" class="node-label">MCP Agent Configs</text>
-    <text x="28" y="28" class="node-sub">21 clients: Claude, Cursor, Codex, Gemini...</text>
+    <text x="28" y="28" class="node-sub">22 clients: Claude, Cursor, Codex, Gemini...</text>
   </g>
 
   <!-- Source 3: Container Images  (y=186, h=36, midY=204) -->

--- a/docs/images/engine-internals-dark.svg
+++ b/docs/images/engine-internals-dark.svg
@@ -37,7 +37,7 @@
   <!-- Modules -->
   <rect x="38" y="130" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="148" class="mod-name">MCP Config Parser</text>
-  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#60a5fa">21 clients</text>
+  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#60a5fa">22 clients</text>
 
   <rect x="38" y="164" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="182" class="mod-name">Cloud Connectors</text>

--- a/docs/images/engine-internals-light.svg
+++ b/docs/images/engine-internals-light.svg
@@ -37,7 +37,7 @@
   <!-- Modules -->
   <rect x="38" y="130" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="148" class="mod-name">MCP Config Parser</text>
-  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#2563eb">21 clients</text>
+  <text x="210" y="148" text-anchor="end" class="mod-sub" fill="#2563eb">22 clients</text>
 
   <rect x="38" y="164" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="182" class="mod-name">Cloud Connectors</text>

--- a/docs/images/enterprise-overview-dark.svg
+++ b/docs/images/enterprise-overview-dark.svg
@@ -24,7 +24,7 @@
   <!-- Source blocks — clean rounded pills -->
   <rect x="80" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
   <text x="134" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">MCP Agents</text>
-  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">21 clients</text>
+  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#58a6ff">22 clients</text>
 
   <rect x="198" y="148" width="108" height="40" rx="10" fill="#21262d" stroke="#1f4a7f" stroke-width="1.5"/>
   <text x="252" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#58a6ff">Containers</text>
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 171 modules · 4,400+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#484f58">22 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 171 modules · 4,400+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/enterprise-overview-light.svg
+++ b/docs/images/enterprise-overview-light.svg
@@ -24,7 +24,7 @@
   <!-- Source blocks — clean rounded pills -->
   <rect x="80" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
   <text x="134" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">MCP Agents</text>
-  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">21 clients</text>
+  <text x="134" y="180" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#60a5fa">22 clients</text>
 
   <rect x="198" y="148" width="108" height="40" rx="10" fill="#fff" stroke="#bfdbfe" stroke-width="1.5"/>
   <text x="252" y="164" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="600" fill="#1e40af">Containers</text>
@@ -194,5 +194,5 @@
   <!-- ════════════════════════════════════════════════════════ -->
   <!--  FOOTER                                                 -->
   <!-- ════════════════════════════════════════════════════════ -->
-  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">21 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 171 modules · 4,400+ tests · 0 runtime deps</text>
+  <text x="600" y="680" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="500" fill="#94a3b8">22 MCP clients · 12 providers · 7 ecosystems · 12 model formats · 427+ registry · 171 modules · 4,400+ tests · 0 runtime deps</text>
 </svg>

--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -39,7 +39,7 @@
   <text x="47" y="91" text-anchor="middle" class="badge">CLI</text>
   <text x="72" y="91" class="mode-title" fill="#58a6ff">Local Scan</text>
   <text x="32" y="108" class="mode-cmd">agent-bom scan [--image] [--sbom]</text>
-  <text x="32" y="124" class="mode-feat">Discover 21 MCP clients + cloud infra</text>
+  <text x="32" y="124" class="mode-feat">Discover 22 MCP clients + cloud infra</text>
   <text x="32" y="138" class="mode-feat">CVE scan with OSV, NVD, Grype, Syft</text>
   <text x="32" y="152" class="mode-feat">Blast radius: CVE → server → creds → tools</text>
   <text x="308" y="178" text-anchor="end" class="mode-detail">JSON / CycloneDX / SPDX / SARIF / HTML</text>
@@ -121,7 +121,7 @@
   <!-- Engine modules — 7 evenly spaced -->
   <rect x="32" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="0.8"/>
   <text x="90" y="402" text-anchor="middle" class="engine-mod" fill="#58a6ff">Discovery</text>
-  <text x="90" y="416" text-anchor="middle" class="engine-detail">21 MCP clients · 4 clouds</text>
+  <text x="90" y="416" text-anchor="middle" class="engine-detail">22 MCP clients · 4 clouds</text>
 
   <rect x="158" y="386" width="116" height="44" rx="5" fill="#0d1117" stroke="#58a6ff" stroke-width="0.8"/>
   <text x="216" y="402" text-anchor="middle" class="engine-mod" fill="#58a6ff">Parsers</text>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -39,7 +39,7 @@
   <text x="47" y="91" text-anchor="middle" class="badge">CLI</text>
   <text x="72" y="91" class="mode-title" fill="#0969da">Local Scan</text>
   <text x="32" y="108" class="mode-cmd">agent-bom scan [--image] [--sbom]</text>
-  <text x="32" y="124" class="mode-feat">Discover 21 MCP clients + cloud infra</text>
+  <text x="32" y="124" class="mode-feat">Discover 22 MCP clients + cloud infra</text>
   <text x="32" y="138" class="mode-feat">CVE scan with OSV, NVD, Grype, Syft</text>
   <text x="32" y="152" class="mode-feat">Blast radius: CVE → server → creds → tools</text>
   <text x="308" y="178" text-anchor="end" class="mode-detail">JSON / CycloneDX / SPDX / SARIF / HTML</text>
@@ -121,7 +121,7 @@
   <!-- Engine modules — 7 evenly spaced -->
   <rect x="32" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="0.8"/>
   <text x="90" y="402" text-anchor="middle" class="engine-mod" fill="#0969da">Discovery</text>
-  <text x="90" y="416" text-anchor="middle" class="engine-detail">21 MCP clients · 4 clouds</text>
+  <text x="90" y="416" text-anchor="middle" class="engine-detail">22 MCP clients · 4 clouds</text>
 
   <rect x="158" y="386" width="116" height="44" rx="5" fill="#ffffff" stroke="#0969da" stroke-width="0.8"/>
   <text x="216" y="402" text-anchor="middle" class="engine-mod" fill="#0969da">Parsers</text>

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -23,7 +23,7 @@
   <text x="56" y="84" class="step-name" fill="#93c5fd">DISCOVER</text>
 
   <text x="36" y="114" class="item-label" fill="#60a5fa">MCP configs</text>
-  <text x="140" y="114" text-anchor="end" class="step-desc">21 clients</text>
+  <text x="140" y="114" text-anchor="end" class="step-desc">22 clients</text>
   <rect x="30" y="120" width="140" height="1" fill="#27272a"/>
 
   <text x="36" y="138" class="item-label" fill="#60a5fa">Cloud</text>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -23,7 +23,7 @@
   <text x="56" y="84" class="step-name">DISCOVER</text>
 
   <text x="36" y="114" class="item-label" fill="#2563eb">MCP configs</text>
-  <text x="140" y="114" text-anchor="end" class="step-desc">21 clients</text>
+  <text x="140" y="114" text-anchor="end" class="step-desc">22 clients</text>
   <rect x="30" y="120" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="36" y="138" class="item-label" fill="#2563eb">Cloud</text>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -61,7 +61,7 @@
   <text x="210" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#58a6ff">Auto-detect every component</text>
 
   <!-- Discover details — clean list, not boxes -->
-  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">21 MCP clients  ·  11 cloud providers</text>
+  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">22 MCP clients  ·  11 cloud providers</text>
   <text x="210" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Docker + K8s  ·  7 code ecosystems</text>
   <text x="210" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">12 AI/ML formats  ·  SBOM ingest</text>
   <text x="210" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Integrity verification  ·  Filesystem</text>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -61,7 +61,7 @@
   <text x="210" y="242" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="#3b82f6">Auto-detect every component</text>
 
   <!-- Discover details — clean list, not boxes -->
-  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">21 MCP clients  ·  11 cloud providers</text>
+  <text x="210" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">22 MCP clients  ·  11 cloud providers</text>
   <text x="210" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Docker + K8s  ·  7 code ecosystems</text>
   <text x="210" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">12 AI/ML formats  ·  SBOM ingest</text>
   <text x="210" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Integrity verification  ·  Filesystem</text>

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -77,7 +77,7 @@
 
   <!-- Card 1: Discover -->
   <rect x="30" y="190" width="140" height="160" rx="14" fill="#161b22" stroke="#1f3a5f" stroke-width="1.5"/>
-  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">MCP (21 clients)</text>
+  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">MCP (22 clients)</text>
   <text x="100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Docker / K8s</text>
   <text x="100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">Cloud (12)</text>
   <text x="100" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#58a6ff">AI/ML (12 fmts)</text>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -77,7 +77,7 @@
 
   <!-- Card 1: Discover -->
   <rect x="30" y="190" width="140" height="160" rx="14" fill="#eff6ff" stroke="#dbeafe" stroke-width="1.5"/>
-  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">MCP (21 clients)</text>
+  <text x="100" y="218" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">MCP (22 clients)</text>
   <text x="100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Docker / K8s</text>
   <text x="100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">Cloud (12)</text>
   <text x="100" y="278" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3b82f6">AI/ML (12 fmts)</text>

--- a/docs/images/workflow-dark.svg
+++ b/docs/images/workflow-dark.svg
@@ -25,7 +25,7 @@
   <text x="96" y="74" text-anchor="middle" class="step-num" fill="#1f6feb">1</text>
   <text x="96" y="90" text-anchor="middle" class="step-label">Discover</text>
   <line x1="44" y1="98" x2="148" y2="98" stroke="#30363d" stroke-width="0.5"/>
-  <text x="96" y="116" text-anchor="middle" class="step-detail">21 MCP clients</text>
+  <text x="96" y="116" text-anchor="middle" class="step-detail">22 MCP clients</text>
   <text x="96" y="130" text-anchor="middle" class="step-detail">Docker images</text>
   <text x="96" y="144" text-anchor="middle" class="step-detail">Kubernetes pods</text>
   <text x="96" y="158" text-anchor="middle" class="step-detail">Cloud providers</text>

--- a/docs/images/workflow-light.svg
+++ b/docs/images/workflow-light.svg
@@ -25,7 +25,7 @@
   <text x="96" y="74" text-anchor="middle" class="step-num" fill="#0969da">1</text>
   <text x="96" y="90" text-anchor="middle" class="step-label">Discover</text>
   <line x1="44" y1="98" x2="148" y2="98" stroke="#d0d7de" stroke-width="0.5"/>
-  <text x="96" y="116" text-anchor="middle" class="step-detail">21 MCP clients</text>
+  <text x="96" y="116" text-anchor="middle" class="step-detail">22 MCP clients</text>
   <text x="96" y="130" text-anchor="middle" class="step-detail">Docker images</text>
   <text x="96" y="144" text-anchor="middle" class="step-detail">Kubernetes pods</text>
   <text x="96" y="158" text-anchor="middle" class="step-detail">Cloud providers</text>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.69.0"
-description = "Security scanner for AI infrastructure. Discover MCP configs (21 clients), scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to reachable credentials and tools, runtime proxy with 7 detectors, 30 MCP tools, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, and 11-framework compliance."
+description = "Security scanner for AI infrastructure. Discover MCP configs (22 clients), scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to reachable credentials and tools, runtime proxy with 7 detectors, 30 MCP tools, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, and 11-framework compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"

--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -6,7 +6,7 @@ For the comprehensive guide, see [AI_INFRASTRUCTURE_SCANNING.md](https://github.
 
 | Layer | What we scan |
 |-------|-------------|
-| **MCP Clients** | 21 clients — Claude, Cursor, VS Code, Windsurf, Cline, Codex, Gemini, Goose, etc. |
+| **MCP Clients** | 22 clients — Claude, Cursor, VS Code, Windsurf, Cline, Codex, Gemini, Goose, etc. |
 | **MCP Servers** | Package deps, tool definitions, credential exposure, description drift |
 | **Container Images** | OS + language packages via Grype/Syft |
 | **Kubernetes** | Namespace enumeration, pod MCP detection |

--- a/site-docs/architecture/overview.md
+++ b/site-docs/architecture/overview.md
@@ -14,7 +14,7 @@ graph LR
     F --> G[Output]
 
     D --> |OSV, NVD, EPSS| H[(Vuln DBs)]
-    B --> |21 clients| I[Config Files]
+    B --> |22 clients| I[Config Files]
 ```
 
 ## Key modules

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -23,7 +23,7 @@ Traditional scanners tell you a package has a CVE. agent-bom tells you which AI 
 
 ```bash
 pip install agent-bom
-agent-bom scan       # auto-discover 21 MCP clients + scan
+agent-bom scan       # auto-discover 22 MCP clients + scan
 agent-bom check langchain   # check a specific package
 ```
 
@@ -34,7 +34,7 @@ agent-bom check langchain   # check a specific package
 
 | Capability | Description |
 |---|---|
-| **Discovery** | Auto-detect 21 MCP clients (Claude, Cursor, Windsurf, VS Code, etc.) |
+| **Discovery** | Auto-detect 22 MCP clients (Claude, Cursor, Windsurf, VS Code, etc.) |
 | **CVE scanning** | OSV + NVD CVSS v4 + EPSS + CISA KEV + GHSA |
 | **Blast radius** | Map CVE impact: package → server → agent → credentials → tools |
 | **Registry** | 427+ MCP server security metadata entries |

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -174,6 +174,18 @@ CONFIG_LOCATIONS: dict[AgentType, dict[str, list[str]]] = {
         "Linux": ["~/.junie/mcp/mcp.json"],
         "Windows": ["~/.junie/mcp/mcp.json"],
     },
+    AgentType.COPILOT_CLI: {
+        # GitHub Copilot CLI (standalone) — ~/.copilot/mcp-config.json
+        "Darwin": ["~/.copilot/mcp-config.json"],
+        "Linux": ["~/.copilot/mcp-config.json"],
+        "Windows": ["~/.copilot/mcp-config.json"],
+    },
+    AgentType.TABNINE: {
+        # Tabnine AI assistant — ~/.tabnine/mcp_servers.json (global)
+        "Darwin": ["~/.tabnine/mcp_servers.json"],
+        "Linux": ["~/.tabnine/mcp_servers.json"],
+        "Windows": ["~/.tabnine/mcp_servers.json"],
+    },
 }
 
 # Map agent types to their CLI binary names for installed-but-not-configured detection

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -303,7 +303,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             "from vulnerabilities to credentials and tools, generates SBOMs (CycloneDX, SPDX), "
             "enforces security policies, and maps to 11 compliance frameworks "
             "(OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST, EU AI Act, ISO 27001, SOC 2). "
-            "Discovers 21 MCP clients. Read-only, agentless, no credentials required."
+            "Discovers 22 MCP clients. Read-only, agentless, no credentials required."
         ),
     )
     # Set the actual agent-bom version (FastMCP defaults to SDK version)
@@ -2375,7 +2375,7 @@ _SERVER_CARD_TOOLS = [
     },
     {
         "name": "where",
-        "description": "List all 21 MCP client config discovery paths with existence status — useful for debugging discovery issues",
+        "description": "List all 22 MCP client config discovery paths with existence status — useful for debugging discovery issues",
         "annotations": {"readOnlyHint": True},
     },
     {

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -37,6 +37,8 @@ class AgentType(str, Enum):
     DOCKER_MCP = "docker-mcp"  # Docker Desktop MCP Toolkit
     JETBRAINS_AI = "jetbrains-ai"  # JetBrains AI Assistant (IntelliJ, PyCharm, etc.)
     JUNIE = "junie"  # JetBrains Junie coding agent
+    COPILOT_CLI = "copilot-cli"  # GitHub Copilot CLI (standalone)
+    TABNINE = "tabnine"  # Tabnine AI assistant
     CUSTOM = "custom"
 
 

--- a/tests/test_discovery_new_clients.py
+++ b/tests/test_discovery_new_clients.py
@@ -616,8 +616,8 @@ def test_discovery_paths_include_new_clients():
 
 
 def test_total_agent_types_is_18():
-    """AgentType enum should now have 20 client types + CUSTOM."""
-    assert len(AgentType) == 21  # 20 clients + CUSTOM
+    """AgentType enum should now have 22 client types + CUSTOM."""
+    assert len(AgentType) == 23  # 22 clients + CUSTOM
 
 
 # ── 11. Binary detection ──────────────────────────────────────────────────

--- a/tests/test_jetbrains_discovery.py
+++ b/tests/test_jetbrains_discovery.py
@@ -207,9 +207,9 @@ def test_discovery_paths_include_jetbrains():
     assert "junie" in clients
 
 
-def test_client_count_is_20():
-    """Verify we now have 20 MCP client types (18 original + JetBrains AI + Junie)."""
+def test_client_count_is_22():
+    """Verify we now have 22 MCP client types (20 original + Copilot CLI + Tabnine)."""
     from agent_bom.discovery import CONFIG_LOCATIONS
 
-    # CUSTOM is not in CONFIG_LOCATIONS, so count should be 20
-    assert len(CONFIG_LOCATIONS) == 20
+    # CUSTOM is not in CONFIG_LOCATIONS, so count should be 22
+    assert len(CONFIG_LOCATIONS) == 22

--- a/tests/test_stats_alignment.py
+++ b/tests/test_stats_alignment.py
@@ -157,14 +157,15 @@ class TestSVGStats:
         """No SVG should contain '22 tools' or '23 tools' — must match actual."""
         for svg in SVG_DIR.glob("*.svg"):
             text = svg.read_text()
-            for stale in ["22 tools", "23 tools", "22 MCP", "23 MCP"]:
+            for stale in ["22 tools", "23 tools", "22 MCP tools", "23 MCP tools"]:
                 assert stale not in text, f"{svg.name} contains stale '{stale}' — actual MCP tool count is {ACTUAL_MCP_TOOLS}"
 
     def test_no_stale_client_count_in_svgs(self):
-        """No SVG should say '20 MCP clients' or '20</text>...MCP clients'."""
+        """No SVG should contain stale MCP client counts."""
         for svg in SVG_DIR.glob("*.svg"):
-            text = svg.read_text()
-            assert "20 MCP client" not in text.lower(), f"{svg.name} contains stale '20 MCP clients'"
+            text = svg.read_text().lower()
+            for stale in ["20 mcp client", "20 clients", "21 clients", "21 mcp client"]:
+                assert stale not in text, f"{svg.name} contains stale '{stale}' — actual is {ACTUAL_CONFIG_LOCATIONS}"
 
 
 # ---------------------------------------------------------------------------
@@ -197,8 +198,8 @@ class TestMarkdownStats:
             pytest.skip(f"{doc.name} not found")
         text = doc.read_text()
         # "20 clients" in prose (not "20 named" which is technically correct)
-        for stale in ["(20 clients)", "20 MCP clients"]:
-            assert stale not in text, f"{doc.name} contains stale '{stale}'"
+        for stale in ["(20 clients)", "20 MCP clients", "(21 clients)", "21 MCP clients"]:
+            assert stale not in text, f"{doc.name} contains stale '{stale}' — actual is {ACTUAL_CONFIG_LOCATIONS}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add **GitHub Copilot CLI** (`~/.copilot/mcp-config.json`) — standalone CLI, separate from VS Code Copilot extension
- Add **Tabnine** (`~/.tabnine/mcp_servers.json`) — global MCP server config
- Update client count from 21 → 22 across all 31 affected files: README, pyproject.toml, ARCHITECTURE docs, 16 SVG diagrams, dashboard, mcp_server.py, site-docs, demo tape
- Fix stale-count test patterns to avoid false positives

Sources: [GitHub Copilot CLI MCP docs](https://docs.github.com/copilot/customizing-copilot/using-model-context-protocol), [Tabnine MCP docs](https://docs.tabnine.com/main/getting-started/tabnine-agent/mcp-intro-and-setup)

## Test plan
- [x] 19/19 stats alignment tests pass
- [x] 316 discovery tests pass
- [ ] CI passes on all jobs