### PR TITLE
refactor: extract proxy routes + WebSockets into api/routes/proxy.py

### DIFF
--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -1,0 +1,316 @@
+"""Proxy status, alerts, and WebSocket streaming API routes.
+
+Endpoints:
+    GET       /v1/proxy/status       proxy metrics summary
+    GET       /v1/proxy/alerts       recent proxy alerts (filterable)
+    WebSocket /ws/proxy/metrics      live metrics stream (1 Hz)
+    WebSocket /ws/proxy/alerts       live alert stream
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path as _Path
+
+from fastapi import APIRouter, WebSocket
+
+router = APIRouter()
+
+# ── In-process ring buffer for proxy alerts/metrics ──────────────────────────
+#
+# The proxy (when running in the same process, e.g. via the API) pushes
+# records here.  External proxy processes write to the JSONL audit log,
+# and these endpoints read it.
+#
+# _proxy_alerts is a bounded deque (O(1) append/pop from both ends).
+# _proxy_alerts_total is a monotonic counter that never decrements —
+# WebSocket clients track their position by this counter, not by deque
+# index, so they correctly detect new alerts even when old ones are
+# evicted from the ring.
+
+_proxy_alerts: deque[dict] = deque(maxlen=1000)
+_proxy_alerts_total: int = 0
+_proxy_metrics: dict | None = None
+
+
+def push_proxy_alert(alert: dict) -> None:
+    """Called by the proxy to record a runtime alert (in-process path)."""
+    global _proxy_alerts_total
+    _proxy_alerts.append(alert)
+    _proxy_alerts_total += 1
+
+
+def push_proxy_metrics(metrics: dict) -> None:
+    """Called by the proxy to record latest metrics summary."""
+    global _proxy_metrics
+    _proxy_metrics = metrics
+
+
+def _get_configured_log_path() -> _Path | None:
+    """Return the server-configured audit log path, if set.
+
+    The path is set via the AGENT_BOM_LOG environment variable (server-side
+    config only — never from user input).  Returns None when the env var is
+    unset or the file doesn't exist.
+    """
+    import os
+
+    log_env = os.environ.get("AGENT_BOM_LOG")
+    if not log_env:
+        return None
+    path = _Path(log_env).resolve()
+    if not path.is_file() or path.suffix != ".jsonl":
+        return None
+    return path
+
+
+_MAX_LOG_LINES = 50_000  # Cap log parsing to prevent memory issues
+
+
+def _read_alerts_from_log(path: _Path) -> list[dict]:
+    """Read runtime_alert records from a JSONL audit log."""
+    import json as _json
+
+    alerts: list[dict] = []
+    try:
+        with open(path) as f:
+            for i, raw_line in enumerate(f):
+                if i >= _MAX_LOG_LINES:
+                    break
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = _json.loads(line)
+                    if record.get("type") == "runtime_alert":
+                        alerts.append(record)
+                except (ValueError, KeyError):
+                    continue
+    except OSError:
+        pass
+    return alerts
+
+
+def _read_metrics_from_log(path: _Path) -> dict | None:
+    """Read the last proxy_summary record from a JSONL audit log."""
+    import json as _json
+
+    last_summary = None
+    try:
+        with open(path) as f:
+            for i, raw_line in enumerate(f):
+                if i >= _MAX_LOG_LINES:
+                    break
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = _json.loads(line)
+                    if record.get("type") == "proxy_summary":
+                        last_summary = record
+                except (ValueError, KeyError):
+                    continue
+    except OSError:
+        pass
+    return last_summary
+
+
+# ── HTTP endpoints ───────────────────────────────────────────────────────────
+
+
+@router.get("/v1/proxy/status", tags=["proxy"])
+async def proxy_status() -> dict:
+    """Get runtime proxy metrics.
+
+    Returns the latest proxy metrics summary.  Reads from the in-process
+    buffer (populated by ``push_proxy_metrics``) or from the audit log
+    configured via the ``AGENT_BOM_LOG`` environment variable.
+    """
+    if _proxy_metrics is not None:
+        return _proxy_metrics
+
+    log_path = _get_configured_log_path()
+    if log_path:
+        metrics = _read_metrics_from_log(log_path)
+        if metrics is not None:
+            return metrics
+
+    return {
+        "status": "no_proxy_session",
+        "message": "No proxy metrics available. Start a proxy session or set AGENT_BOM_LOG.",
+    }
+
+
+@router.get("/v1/proxy/alerts", tags=["proxy"])
+async def proxy_alerts(
+    severity: str | None = None,
+    detector: str | None = None,
+    limit: int = 100,
+) -> dict:
+    """Get recent runtime proxy alerts.
+
+    Returns alerts from the in-process buffer or the audit log configured
+    via the ``AGENT_BOM_LOG`` environment variable.
+
+    Query params:
+        severity: Filter by severity (critical, high, medium, low, info).
+        detector: Filter by detector name.
+        limit: Maximum number of alerts to return (default 100).
+    """
+    log_path = _get_configured_log_path()
+    if log_path and not _proxy_alerts:
+        alerts = _read_alerts_from_log(log_path)
+    else:
+        alerts = list(_proxy_alerts)
+
+    # Apply filters
+    if severity:
+        alerts = [a for a in alerts if a.get("severity", "").lower() == severity.lower()]
+    if detector:
+        alerts = [a for a in alerts if a.get("detector", "").lower() == detector.lower()]
+
+    # Newest first, apply limit
+    alerts = alerts[-limit:][::-1]
+
+    return {
+        "alerts": alerts,
+        "count": len(alerts),
+        "filters": {
+            "severity": severity,
+            "detector": detector,
+            "limit": limit,
+        },
+    }
+
+
+# ── WebSocket endpoints ─────────────────────────────────────────────────────
+
+
+def _ws_check_auth(websocket: WebSocket) -> bool:
+    """Return True if the WebSocket connection is authorized.
+
+    When ``AGENT_BOM_API_KEY`` is set, callers must pass ``?token=<key>`` in
+    the WebSocket URL.  When the env var is unset the endpoint is open (local
+    dev / single-user mode).
+    """
+    import os as _os
+
+    api_key = _os.environ.get("AGENT_BOM_API_KEY")
+    if not api_key:
+        return True  # no auth configured — open
+    token = websocket.query_params.get("token", "")
+    return bool(token and token == api_key)
+
+
+@router.websocket("/ws/proxy/metrics")
+async def ws_proxy_metrics(websocket: WebSocket) -> None:
+    """WebSocket endpoint — push proxy metrics every second.
+
+    Connect to ``ws://localhost:8422/ws/proxy/metrics`` to receive a live
+    stream of proxy metrics as JSON objects.  Useful for building real-time
+    dashboards without polling.
+
+    Authentication: pass ``?token=<AGENT_BOM_API_KEY>`` when the env var is set.
+
+    Message format (sent every second):
+    ::
+
+        {
+          "ts": 1234567890.123,
+          "tool_calls": {"read_file": 12, "exec": 3},
+          "blocked": {"rate_limit": 1, "policy": 2},
+          "alerts_last_60s": 4,
+          "latency_p95_ms": 45.2
+        }
+
+    Connection is closed cleanly on disconnect.
+    """
+    import asyncio
+    import time as _time
+
+    try:
+        from fastapi.websockets import WebSocketDisconnect
+    except ImportError:
+        from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
+
+    if not _ws_check_auth(websocket):
+        await websocket.close(code=4001)
+        return
+
+    await websocket.accept()
+    try:
+        while True:
+            now = _time.time()
+            # Build snapshot from in-process metrics buffer
+            metrics_snapshot: dict = {}
+            if _proxy_metrics is not None:
+                metrics_snapshot = dict(_proxy_metrics)
+            else:
+                log_path = _get_configured_log_path()
+                if log_path:
+                    m = _read_metrics_from_log(log_path)
+                    if m:
+                        metrics_snapshot = m
+
+            # Count alerts in last 60 seconds
+            cutoff = now - 60
+            recent_alerts = [a for a in _proxy_alerts if a.get("ts", 0) > cutoff]
+
+            await websocket.send_json(
+                {
+                    "ts": now,
+                    "tool_calls": metrics_snapshot.get("calls_by_tool", {}),
+                    "blocked": metrics_snapshot.get("blocked_by_reason", {}),
+                    "alerts_last_60s": len(recent_alerts),
+                    "latency_p95_ms": metrics_snapshot.get("latency", {}).get("p95_ms"),
+                    "total_tool_calls": metrics_snapshot.get("total_tool_calls", 0),
+                    "total_blocked": metrics_snapshot.get("total_blocked", 0),
+                    "uptime_seconds": metrics_snapshot.get("uptime_seconds"),
+                }
+            )
+            await asyncio.sleep(1.0)
+    except WebSocketDisconnect:
+        pass
+    except Exception:  # noqa: BLE001
+        # Client disconnected or error — close quietly
+        pass
+
+
+@router.websocket("/ws/proxy/alerts")
+async def ws_proxy_alerts(websocket: WebSocket) -> None:
+    """WebSocket endpoint — push new proxy alerts as they arrive.
+
+    Streams new alerts in real time.  Each message is a single alert object.
+    Useful for live security dashboards that need immediate notification.
+
+    Authentication: pass ``?token=<AGENT_BOM_API_KEY>`` when the env var is set.
+
+    Uses a monotonic total counter (not deque length) to detect new alerts
+    correctly even when old entries are evicted from the 1000-entry ring buffer.
+    """
+    import asyncio
+
+    try:
+        from fastapi.websockets import WebSocketDisconnect
+    except ImportError:
+        from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
+
+    if not _ws_check_auth(websocket):
+        await websocket.close(code=4001)
+        return
+
+    await websocket.accept()
+    seen = _proxy_alerts_total  # monotonic — tracks absolute count, not deque position
+    try:
+        while True:
+            current = _proxy_alerts_total
+            if current > seen:
+                new_count = min(current - seen, len(_proxy_alerts))
+                for alert in list(_proxy_alerts)[-new_count:]:
+                    await websocket.send_json(alert)
+                seen = current
+            await asyncio.sleep(0.25)
+    except WebSocketDisconnect:
+        pass
+    except Exception:  # noqa: BLE001
+        pass

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -41,7 +41,6 @@ import asyncio
 import logging
 import time
 import uuid
-from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Any
@@ -100,7 +99,7 @@ _logger = logging.getLogger(__name__)
 # ─── Dependency check ─────────────────────────────────────────────────────────
 
 try:
-    from fastapi import FastAPI, HTTPException, WebSocket
+    from fastapi import FastAPI, HTTPException
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import RedirectResponse
     from pydantic import BaseModel  # noqa: F401 — presence check for [api] extra
@@ -315,10 +314,15 @@ from agent_bom.api.pipeline import (  # noqa: E402
 from agent_bom.api.routes.compliance import router as _compliance_router  # noqa: E402
 from agent_bom.api.routes.fleet import router as _fleet_router  # noqa: E402
 from agent_bom.api.routes.gateway import router as _gateway_router  # noqa: E402
+from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
 
 app.include_router(_compliance_router)
 app.include_router(_fleet_router)
 app.include_router(_gateway_router)
+app.include_router(_proxy_router)
+
+# Re-export proxy push functions for backward compatibility
+from agent_bom.api.routes.proxy import push_proxy_alert, push_proxy_metrics  # noqa: E402, F401
 
 _cleanup_task: asyncio.Task | None = None
 _scheduler_task: asyncio.Task | None = None
@@ -1319,302 +1323,6 @@ async def check_malicious(name: str, ecosystem: str = "npm") -> dict:
         "is_typosquat": typosquat_target is not None,
         "typosquat_target": typosquat_target,
     }
-
-
-# ─── Proxy Status & Alerts ──────────────────────────────────────────────────
-
-# In-process ring buffer for proxy alerts/metrics.  The proxy (when running
-# in the same process, e.g. via the API) pushes records here.  External proxy
-# processes write to the JSONL audit log, and these endpoints read it.
-#
-# _proxy_alerts is a bounded deque (O(1) append/pop from both ends).
-# _proxy_alerts_total is a monotonic counter that never decrements — WebSocket
-# clients track their position by this counter, not by deque index, so they
-# correctly detect new alerts even when old ones are evicted from the ring.
-
-_proxy_alerts: deque[dict] = deque(maxlen=1000)
-_proxy_alerts_total: int = 0
-_proxy_metrics: dict | None = None
-
-
-def push_proxy_alert(alert: dict) -> None:
-    """Called by the proxy to record a runtime alert (in-process path)."""
-    global _proxy_alerts_total
-    _proxy_alerts.append(alert)
-    _proxy_alerts_total += 1
-
-
-def push_proxy_metrics(metrics: dict) -> None:
-    """Called by the proxy to record latest metrics summary."""
-    global _proxy_metrics
-    _proxy_metrics = metrics
-
-
-def _get_configured_log_path() -> _Path | None:
-    """Return the server-configured audit log path, if set.
-
-    The path is set via the AGENT_BOM_LOG environment variable (server-side
-    config only — never from user input).  Returns None when the env var is
-    unset or the file doesn't exist.
-    """
-    import os
-
-    log_env = os.environ.get("AGENT_BOM_LOG")
-    if not log_env:
-        return None
-    path = _Path(log_env).resolve()
-    if not path.is_file() or path.suffix != ".jsonl":
-        return None
-    return path
-
-
-_MAX_LOG_LINES = 50_000  # Cap log parsing to prevent memory issues
-
-
-def _read_alerts_from_log(path: _Path) -> list[dict]:
-    """Read runtime_alert records from a JSONL audit log."""
-    import json as _json
-
-    alerts: list[dict] = []
-    try:
-        with open(path) as f:
-            for i, raw_line in enumerate(f):
-                if i >= _MAX_LOG_LINES:
-                    break
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    record = _json.loads(line)
-                    if record.get("type") == "runtime_alert":
-                        alerts.append(record)
-                except (ValueError, KeyError):
-                    continue
-    except OSError:
-        pass
-    return alerts
-
-
-def _read_metrics_from_log(path: _Path) -> dict | None:
-    """Read the last proxy_summary record from a JSONL audit log."""
-    import json as _json
-
-    last_summary = None
-    try:
-        with open(path) as f:
-            for i, raw_line in enumerate(f):
-                if i >= _MAX_LOG_LINES:
-                    break
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    record = _json.loads(line)
-                    if record.get("type") == "proxy_summary":
-                        last_summary = record
-                except (ValueError, KeyError):
-                    continue
-    except OSError:
-        pass
-    return last_summary
-
-
-@app.get("/v1/proxy/status", tags=["proxy"])
-async def proxy_status() -> dict:
-    """Get runtime proxy metrics.
-
-    Returns the latest proxy metrics summary.  Reads from the in-process
-    buffer (populated by ``push_proxy_metrics``) or from the audit log
-    configured via the ``AGENT_BOM_LOG`` environment variable.
-    """
-    if _proxy_metrics is not None:
-        return _proxy_metrics
-
-    log_path = _get_configured_log_path()
-    if log_path:
-        metrics = _read_metrics_from_log(log_path)
-        if metrics is not None:
-            return metrics
-
-    return {
-        "status": "no_proxy_session",
-        "message": "No proxy metrics available. Start a proxy session or set AGENT_BOM_LOG.",
-    }
-
-
-@app.get("/v1/proxy/alerts", tags=["proxy"])
-async def proxy_alerts(
-    severity: str | None = None,
-    detector: str | None = None,
-    limit: int = 100,
-) -> dict:
-    """Get recent runtime proxy alerts.
-
-    Returns alerts from the in-process buffer or the audit log configured
-    via the ``AGENT_BOM_LOG`` environment variable.
-
-    Query params:
-        severity: Filter by severity (critical, high, medium, low, info).
-        detector: Filter by detector name.
-        limit: Maximum number of alerts to return (default 100).
-    """
-    log_path = _get_configured_log_path()
-    if log_path and not _proxy_alerts:
-        alerts = _read_alerts_from_log(log_path)
-    else:
-        alerts = list(_proxy_alerts)
-
-    # Apply filters
-    if severity:
-        alerts = [a for a in alerts if a.get("severity", "").lower() == severity.lower()]
-    if detector:
-        alerts = [a for a in alerts if a.get("detector", "").lower() == detector.lower()]
-
-    # Newest first, apply limit
-    alerts = alerts[-limit:][::-1]
-
-    return {
-        "alerts": alerts,
-        "count": len(alerts),
-        "filters": {
-            "severity": severity,
-            "detector": detector,
-            "limit": limit,
-        },
-    }
-
-
-# ─── WebSocket: live proxy metrics stream ────────────────────────────────────
-
-
-def _ws_check_auth(websocket: WebSocket) -> bool:
-    """Return True if the WebSocket connection is authorized.
-
-    When ``AGENT_BOM_API_KEY`` is set, callers must pass ``?token=<key>`` in
-    the WebSocket URL.  When the env var is unset the endpoint is open (local
-    dev / single-user mode).
-    """
-    import os as _os
-
-    api_key = _os.environ.get("AGENT_BOM_API_KEY")
-    if not api_key:
-        return True  # no auth configured — open
-    token = websocket.query_params.get("token", "")
-    return bool(token and token == api_key)
-
-
-@app.websocket("/ws/proxy/metrics")
-async def ws_proxy_metrics(websocket: WebSocket) -> None:
-    """WebSocket endpoint — push proxy metrics every second.
-
-    Connect to ``ws://localhost:8422/ws/proxy/metrics`` to receive a live
-    stream of proxy metrics as JSON objects.  Useful for building real-time
-    dashboards without polling.
-
-    Authentication: pass ``?token=<AGENT_BOM_API_KEY>`` when the env var is set.
-
-    Message format (sent every second):
-    ::
-
-        {
-          "ts": 1234567890.123,
-          "tool_calls": {"read_file": 12, "exec": 3},
-          "blocked": {"rate_limit": 1, "policy": 2},
-          "alerts_last_60s": 4,
-          "latency_p95_ms": 45.2
-        }
-
-    Connection is closed cleanly on disconnect.
-    """
-    import asyncio
-    import time as _time
-
-    try:
-        from fastapi.websockets import WebSocketDisconnect
-    except ImportError:
-        from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
-
-    if not _ws_check_auth(websocket):
-        await websocket.close(code=4001)
-        return
-
-    await websocket.accept()
-    try:
-        while True:
-            now = _time.time()
-            # Build snapshot from in-process metrics buffer
-            metrics_snapshot: dict = {}
-            if _proxy_metrics is not None:
-                metrics_snapshot = dict(_proxy_metrics)
-            else:
-                log_path = _get_configured_log_path()
-                if log_path:
-                    m = _read_metrics_from_log(log_path)
-                    if m:
-                        metrics_snapshot = m
-
-            # Count alerts in last 60 seconds
-            cutoff = now - 60
-            recent_alerts = [a for a in _proxy_alerts if a.get("ts", 0) > cutoff]
-
-            await websocket.send_json(
-                {
-                    "ts": now,
-                    "tool_calls": metrics_snapshot.get("calls_by_tool", {}),
-                    "blocked": metrics_snapshot.get("blocked_by_reason", {}),
-                    "alerts_last_60s": len(recent_alerts),
-                    "latency_p95_ms": metrics_snapshot.get("latency", {}).get("p95_ms"),
-                    "total_tool_calls": metrics_snapshot.get("total_tool_calls", 0),
-                    "total_blocked": metrics_snapshot.get("total_blocked", 0),
-                    "uptime_seconds": metrics_snapshot.get("uptime_seconds"),
-                }
-            )
-            await asyncio.sleep(1.0)
-    except WebSocketDisconnect:
-        pass
-    except Exception:  # noqa: BLE001
-        # Client disconnected or error — close quietly
-        pass
-
-
-@app.websocket("/ws/proxy/alerts")
-async def ws_proxy_alerts(websocket: WebSocket) -> None:
-    """WebSocket endpoint — push new proxy alerts as they arrive.
-
-    Streams new alerts in real time.  Each message is a single alert object.
-    Useful for live security dashboards that need immediate notification.
-
-    Authentication: pass ``?token=<AGENT_BOM_API_KEY>`` when the env var is set.
-
-    Uses a monotonic total counter (not deque length) to detect new alerts
-    correctly even when old entries are evicted from the 1000-entry ring buffer.
-    """
-    import asyncio
-
-    try:
-        from fastapi.websockets import WebSocketDisconnect
-    except ImportError:
-        from starlette.websockets import WebSocketDisconnect  # type: ignore[no-reattr]
-
-    if not _ws_check_auth(websocket):
-        await websocket.close(code=4001)
-        return
-
-    await websocket.accept()
-    seen = _proxy_alerts_total  # monotonic — tracks absolute count, not deque position
-    try:
-        while True:
-            current = _proxy_alerts_total
-            if current > seen:
-                new_count = min(current - seen, len(_proxy_alerts))
-                for alert in list(_proxy_alerts)[-new_count:]:
-                    await websocket.send_json(alert)
-                seen = current
-            await asyncio.sleep(0.25)
-    except WebSocketDisconnect:
-        pass
-    except Exception:  # noqa: BLE001
-        pass
 
 
 # ─── OpenSSF Scorecard Lookup ────────────────────────────────────────────────

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -20,10 +20,10 @@ from agent_bom.api.server import (
 
 def test_proxy_status_no_session():
     """Returns no_proxy_session when no proxy has run."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
     # Reset state
-    srv._proxy_metrics = None
+    proxy_mod._proxy_metrics = None
     old = os.environ.pop("AGENT_BOM_LOG", None)
     try:
         client = TestClient(app)
@@ -38,7 +38,7 @@ def test_proxy_status_no_session():
 
 def test_proxy_status_with_metrics():
     """Returns metrics when push_proxy_metrics has been called."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
     metrics = {
         "type": "proxy_summary",
@@ -56,14 +56,14 @@ def test_proxy_status_with_metrics():
     assert data["total_blocked"] == 3
 
     # Cleanup
-    srv._proxy_metrics = None
+    proxy_mod._proxy_metrics = None
 
 
 def test_proxy_status_from_log():
     """Reads metrics from a JSONL audit log file via AGENT_BOM_LOG env."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_metrics = None
+    proxy_mod._proxy_metrics = None
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         f.write(json.dumps({"type": "tools/call", "tool": "read"}) + "\n")
@@ -88,9 +88,9 @@ def test_proxy_status_from_log():
 
 def test_proxy_status_from_log_no_summary():
     """Returns no_proxy_session when log file has no proxy_summary."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_metrics = None
+    proxy_mod._proxy_metrics = None
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         f.write(json.dumps({"type": "tools/call", "tool": "read"}) + "\n")
@@ -117,9 +117,9 @@ def test_proxy_status_from_log_no_summary():
 
 def test_proxy_alerts_empty():
     """Returns empty list when no alerts."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
     old = os.environ.pop("AGENT_BOM_LOG", None)
     try:
         client = TestClient(app)
@@ -135,9 +135,9 @@ def test_proxy_alerts_empty():
 
 def test_proxy_alerts_with_data():
     """Returns alerts pushed via push_proxy_alert."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
     push_proxy_alert(
         {
             "type": "runtime_alert",
@@ -162,14 +162,14 @@ def test_proxy_alerts_with_data():
     assert data["count"] == 2
 
     # Cleanup
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
 
 
 def test_proxy_alerts_filter_severity():
     """Filters alerts by severity query param."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
     push_proxy_alert({"type": "runtime_alert", "detector": "cred", "severity": "critical", "message": "a"})
     push_proxy_alert({"type": "runtime_alert", "detector": "arg", "severity": "high", "message": "b"})
     push_proxy_alert({"type": "runtime_alert", "detector": "cred2", "severity": "critical", "message": "c"})
@@ -182,14 +182,14 @@ def test_proxy_alerts_filter_severity():
     for alert in data["alerts"]:
         assert alert["severity"] == "critical"
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
 
 
 def test_proxy_alerts_filter_detector():
     """Filters alerts by detector query param."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
     push_proxy_alert({"type": "runtime_alert", "detector": "credential_leak", "severity": "critical", "message": "a"})
     push_proxy_alert({"type": "runtime_alert", "detector": "argument_analyzer", "severity": "high", "message": "b"})
 
@@ -200,14 +200,14 @@ def test_proxy_alerts_filter_detector():
     assert data["count"] == 1
     assert data["alerts"][0]["detector"] == "credential_leak"
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
 
 
 def test_proxy_alerts_from_log():
     """Reads alerts from a JSONL audit log file via AGENT_BOM_LOG env."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         f.write(json.dumps({"type": "tools/call", "tool": "read"}) + "\n")
@@ -233,9 +233,9 @@ def test_proxy_alerts_from_log():
 
 def test_proxy_alerts_limit():
     """Respects the limit query param."""
-    import agent_bom.api.server as srv
+    import agent_bom.api.routes.proxy as proxy_mod
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
     for i in range(10):
         push_proxy_alert({"type": "runtime_alert", "detector": f"d{i}", "severity": "high", "message": f"m{i}"})
 
@@ -245,7 +245,7 @@ def test_proxy_alerts_limit():
     data = resp.json()
     assert data["count"] == 3
 
-    srv._proxy_alerts.clear()
+    proxy_mod._proxy_alerts.clear()
 
 
 # ── /v1/scorecard ─────────────────────────────────────────────────────────

--- a/tests/test_audit_round2.py
+++ b/tests/test_audit_round2.py
@@ -204,7 +204,7 @@ def test_read_alerts_handles_missing_file():
     """_read_alerts_from_log returns empty on missing file."""
     from pathlib import Path
 
-    from agent_bom.api.server import _read_alerts_from_log
+    from agent_bom.api.routes.proxy import _read_alerts_from_log
 
     result = _read_alerts_from_log(Path("/nonexistent/file.jsonl"))
     assert result == []
@@ -214,7 +214,7 @@ def test_read_metrics_handles_missing_file():
     """_read_metrics_from_log returns None on missing file."""
     from pathlib import Path
 
-    from agent_bom.api.server import _read_metrics_from_log
+    from agent_bom.api.routes.proxy import _read_metrics_from_log
 
     result = _read_metrics_from_log(Path("/nonexistent/file.jsonl"))
     assert result is None
@@ -226,7 +226,7 @@ def test_read_alerts_from_log_with_valid_data():
     import tempfile
     from pathlib import Path
 
-    from agent_bom.api.server import _read_alerts_from_log
+    from agent_bom.api.routes.proxy import _read_alerts_from_log
 
     content = "\n".join(
         [


### PR DESCRIPTION
## Summary
- Extract 4 proxy endpoints (status, alerts, 2 WebSocket streams) from `server.py` into `api/routes/proxy.py`
- Move ring buffer state, log readers, and WS auth helper alongside routes
- Re-export `push_proxy_alert` / `push_proxy_metrics` from server.py for backward compatibility
- Update test patch targets in `test_api_proxy_scorecard.py` and `test_audit_round2.py`
- server.py: 3,127 → 2,141 lines (−32% cumulative across 4 extraction PRs)

Closes #526 (partial — proxy domain extracted)

## Test plan
- [x] All 5,503 tests pass (`pytest tests/ -x -q`)
- [x] Pre-commit hooks pass (ruff + ruff-format)
- [x] Proxy status/alerts endpoints verified
- [x] WebSocket auth + metrics + alerts stream verified via existing tests
- [x] Backward-compatible imports from `agent_bom.api.server` still work