### PR TITLE
fix: remove unsupported license field from mcp-registry server.json

### DIFF
--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -4,7 +4,6 @@
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
   "version": "0.70.0",
-  "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"


### PR DESCRIPTION
## Summary
- MCP Registry API returns HTTP 422 with `"unexpected property","location":"body.license"` — their schema as of 2025-12-11 does not allow a `license` field
- Remove the `"license": "Apache-2.0"` line so validation passes and publish succeeds

## Test plan
- [ ] CI passes
- [ ] "Publish to MCP Registry" workflow succeeds after merge

Closes the registry publish failure introduced in v0.70.0 bump