### PR TITLE
fix: parse_fixed_version PEP 503, scan cache LRU cap, pipeline 429 cooldown

### DIFF
--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -159,6 +159,16 @@ SCANNER_BATCH_DELAY = _float("AGENT_BOM_SCANNER_BATCH_DELAY", 0.5)
 SCANNER_BATCH_SIZE = _int("AGENT_BOM_SCANNER_BATCH_SIZE", 1000)  # OSV API max is 1000
 
 
+# ── Scan Cache ────────────────────────────────────────────────────────────────
+# SQLite-backed OSV result cache (~/.agent-bom/scan_cache.db).
+#
+# 100,000 entries covers ~5-10 large enterprise scans before eviction kicks in.
+# Oldest entries are removed first (LRU by insertion time) when the limit is hit.
+# Set to 0 to disable the cap (unbounded growth — not recommended for servers).
+
+SCAN_CACHE_MAX_ENTRIES = _int("AGENT_BOM_SCAN_CACHE_MAX_ENTRIES", 100_000)
+
+
 # ── AI Enrichment ─────────────────────────────────────────────────────────
 # Used by ai_enrich.py for LLM-powered risk narratives.
 #

--- a/src/agent_bom/scan_cache.py
+++ b/src/agent_bom/scan_cache.py
@@ -28,6 +28,7 @@ class ScanCache:
         self,
         db_path: str | Path | None = None,
         ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        max_entries: int | None = None,
     ) -> None:
         if db_path is None:
             db_path = os.environ.get(
@@ -36,6 +37,11 @@ class ScanCache:
             )
         self._db_path = str(db_path)
         self._ttl = ttl_seconds
+        if max_entries is None:
+            from agent_bom.config import SCAN_CACHE_MAX_ENTRIES
+
+            max_entries = SCAN_CACHE_MAX_ENTRIES
+        self._max_entries = max_entries
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -75,6 +81,7 @@ class ScanCache:
             (key, json.dumps(vulns), time.time()),
         )
         self._conn.commit()
+        self._evict_if_needed()
 
     def put_many(self, entries: list[tuple[str, str, str, list[dict]]]) -> None:
         """Batch insert/replace multiple cache entries in one transaction."""
@@ -85,6 +92,7 @@ class ScanCache:
             rows,
         )
         self._conn.commit()
+        self._evict_if_needed()
 
     def evict(self, ecosystem: str, name: str, version: str) -> None:
         """Remove a single entry from the cache, forcing a fresh fetch."""
@@ -112,6 +120,30 @@ class ScanCache:
         cur = self._conn.execute("DELETE FROM osv_cache WHERE cached_at < ?", (cutoff,))
         self._conn.commit()
         return cur.rowcount or 0
+
+    def _evict_if_needed(self) -> None:
+        """Remove the oldest entries when the cache exceeds *max_entries*.
+
+        Uses a single DELETE … WHERE cache_key IN (SELECT … ORDER BY cached_at
+        ASC LIMIT ?) so only one round-trip is needed.  No-op when *max_entries*
+        is 0 (unbounded mode).
+        """
+        if self._max_entries <= 0:
+            return
+        row = self._conn.execute("SELECT COUNT(*) FROM osv_cache").fetchone()
+        count = row[0] if row else 0
+        excess = count - self._max_entries
+        if excess > 0:
+            self._conn.execute(
+                """
+                DELETE FROM osv_cache WHERE cache_key IN (
+                    SELECT cache_key FROM osv_cache ORDER BY cached_at ASC LIMIT ?
+                )
+                """,
+                (excess,),
+            )
+            self._conn.commit()
+            logger.debug("scan_cache: evicted %d oldest entries (limit=%d)", excess, self._max_entries)
 
     def clear(self) -> None:
         """Remove all entries."""

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -47,6 +47,10 @@ _logger = logging.getLogger(__name__)
 
 OSV_API_URL = "https://api.osv.dev/v1"
 OSV_BATCH_URL = f"{OSV_API_URL}/querybatch"
+# Max pipeline-level pause when OSV returns persistent 429 after all per-request retries.
+# Separate from per-request exponential backoff (http_client.py) — this pauses the
+# whole batch queue so subsequent batches don't immediately hammer a throttled API.
+_PIPELINE_429_BACKOFF = 60.0
 OSV_QUERY_URL = f"{OSV_API_URL}/query"
 
 # Map ecosystem names to OSV ecosystem identifiers
@@ -267,16 +271,21 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float]]:
     return severity, cvss_score
 
 
-def parse_fixed_version(vuln_data: dict, package_name: str) -> Optional[str]:
+def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "") -> Optional[str]:
     """Extract fixed version from OSV affected data.
 
-    Prefers stable releases over pre-release versions.
+    Prefers stable releases over pre-release versions.  Uses PEP 503
+    normalization when comparing PyPI package names so that mixed-separator
+    forms (e.g. ``Requests_OAuthlib`` vs ``requests-oauthlib``) always match.
     """
+    norm_input = normalize_package_name(package_name, ecosystem)
     prerelease_candidate: Optional[str] = None
 
     for affected in vuln_data.get("affected", []):
         pkg = affected.get("package", {})
-        if pkg.get("name", "").lower() == package_name.lower():
+        osv_eco = pkg.get("ecosystem", ecosystem)
+        osv_norm = normalize_package_name(pkg.get("name", ""), osv_eco)
+        if osv_norm == norm_input:
             for rng in affected.get("ranges", []):
                 for event in rng.get("events", []):
                     if "fixed" in event:
@@ -447,6 +456,20 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
                                     queried_keys_with_vulns.add(key)
                     except (ValueError, KeyError) as e:
                         console.print(f"  [red]✗[/red] OSV response parse error: {e}")
+                elif response and response.status_code == 429:
+                    # request_with_retry exhausted all retries and still got 429 — apply
+                    # a pipeline-level cooldown before the next batch, respecting any
+                    # Retry-After hint from the server.
+                    retry_after_hdr = response.headers.get("Retry-After")
+                    pipeline_wait = _PIPELINE_429_BACKOFF
+                    if retry_after_hdr:
+                        try:
+                            pipeline_wait = min(float(retry_after_hdr), _PIPELINE_429_BACKOFF)
+                        except ValueError:
+                            pass
+                    console.print(f"  [yellow]⚠[/yellow] OSV rate limit (429) — pausing {pipeline_wait:.0f}s before next batch")
+                    _logger.warning("OSV rate limit hit after all retries; pausing pipeline %.0fs", pipeline_wait)
+                    await asyncio.sleep(pipeline_wait)
                 elif response:
                     console.print(f"  [red]✗[/red] OSV API error: HTTP {response.status_code}")
                 else:
@@ -487,7 +510,7 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
         seen_ids.add(vuln_id)
 
         severity, cvss_score = parse_osv_severity(vuln_data)
-        fixed = parse_fixed_version(vuln_data, package.name)
+        fixed = parse_fixed_version(vuln_data, package.name, package.ecosystem)
 
         references = [ref.get("url", "") for ref in vuln_data.get("references", []) if ref.get("url")]
 

--- a/tests/test_scan_cache.py
+++ b/tests/test_scan_cache.py
@@ -83,3 +83,45 @@ class TestScanCacheTTL:
         removed = cache.cleanup_expired()
         assert removed == 1
         assert cache.size == 1
+
+
+class TestScanCacheMaxEntries:
+    """LRU eviction enforces the max_entries cap."""
+
+    def test_eviction_on_put(self, tmp_path):
+        """Oldest entry is evicted when limit is exceeded via put()."""
+        cache = ScanCache(db_path=tmp_path / "max.db", ttl_seconds=3600, max_entries=3)
+        cache.put("npm", "a", "1.0", [])
+        cache.put("npm", "b", "1.0", [])
+        cache.put("npm", "c", "1.0", [])
+        assert cache.size == 3
+
+        # Adding a 4th should evict the oldest (a)
+        cache.put("npm", "d", "1.0", [])
+        assert cache.size == 3
+        assert cache.get("npm", "a", "1.0") is None  # evicted
+        assert cache.get("npm", "d", "1.0") == []  # present
+
+    def test_eviction_on_put_many(self, tmp_path):
+        """put_many() also triggers eviction when limit is exceeded."""
+        cache = ScanCache(db_path=tmp_path / "many.db", ttl_seconds=3600, max_entries=5)
+        for i in range(5):
+            cache.put("npm", f"pkg{i}", "1.0", [])
+        assert cache.size == 5
+
+        cache.put_many([("npm", "extra1", "1.0", []), ("npm", "extra2", "1.0", [])])
+        assert cache.size == 5  # cap enforced
+
+    def test_unlimited_when_zero(self, tmp_path):
+        """max_entries=0 disables eviction (unbounded mode)."""
+        cache = ScanCache(db_path=tmp_path / "unlimited.db", ttl_seconds=3600, max_entries=0)
+        for i in range(20):
+            cache.put("npm", f"pkg{i}", "1.0", [])
+        assert cache.size == 20
+
+    def test_default_max_entries_from_config(self, tmp_path):
+        """Default max_entries is read from SCAN_CACHE_MAX_ENTRIES config."""
+        from agent_bom.config import SCAN_CACHE_MAX_ENTRIES
+
+        cache = ScanCache(db_path=tmp_path / "cfg.db")
+        assert cache._max_entries == SCAN_CACHE_MAX_ENTRIES

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -217,6 +217,46 @@ def test_parse_fixed_version_empty():
     assert parse_fixed_version({}, "pkg") is None
 
 
+def test_parse_fixed_version_pep503_mixed_separators():
+    """Underscore vs hyphen in OSV name must still match via PEP 503 normalization."""
+    vuln = {
+        "affected": [
+            {
+                "package": {"name": "Requests_OAuthlib", "ecosystem": "PyPI"},
+                "ranges": [{"events": [{"introduced": "0"}, {"fixed": "2.0.0"}]}],
+            }
+        ]
+    }
+    # Input uses hyphen; OSV data uses underscore — should match after normalization
+    assert parse_fixed_version(vuln, "requests-oauthlib", "PyPI") == "2.0.0"
+
+
+def test_parse_fixed_version_pep503_dot_separator():
+    """Dot-separated OSV name must match hyphen input."""
+    vuln = {
+        "affected": [
+            {
+                "package": {"name": "my.package", "ecosystem": "PyPI"},
+                "ranges": [{"events": [{"fixed": "1.5.0"}]}],
+            }
+        ]
+    }
+    assert parse_fixed_version(vuln, "my-package", "PyPI") == "1.5.0"
+
+
+def test_parse_fixed_version_ecosystem_fallback():
+    """Ecosystem defaults to empty string; comparison still works via lowercasing."""
+    vuln = {
+        "affected": [
+            {
+                "package": {"name": "lodash"},
+                "ranges": [{"events": [{"fixed": "4.17.22"}]}],
+            }
+        ]
+    }
+    assert parse_fixed_version(vuln, "lodash") == "4.17.22"
+
+
 # ---------------------------------------------------------------------------
 # build_vulnerabilities
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three scanner hardening fixes — no new features, pure correctness and reliability.

### 1. `parse_fixed_version()` PEP 503 normalization
`parse_fixed_version()` was comparing package names with simple `.lower()`. OSV returns mixed-separator forms (e.g. `Requests_OAuthlib`) that don't match hyphenated inputs (`requests-oauthlib`). The fix-version field would come back `None` even though the CVE was correctly found — so reports showed the vulnerability but couldn't tell users what version to upgrade to.

Now uses `normalize_package_name()` on both sides (input and OSV response), with the OSV record's own ecosystem tag for accurate normalization. Adds 3 regression tests covering underscore, dot, and no-ecosystem cases.

### 2. Scan cache LRU size cap
`ScanCache` had no entry limit — on long-running API servers or large scans, the SQLite file could grow unbounded. Added `SCAN_CACHE_MAX_ENTRIES` (default 100,000 via `AGENT_BOM_SCAN_CACHE_MAX_ENTRIES` env) enforced in `put()` and `put_many()` via a single `DELETE … WHERE cache_key IN (SELECT … ORDER BY cached_at ASC LIMIT ?)`. Set to `0` to disable (legacy unbounded mode). 4 new tests.

### 3. Pipeline-level 429 cooldown for OSV batching
`http_client.request_with_retry` already handles per-request 429s with exponential backoff + `Retry-After`. The gap: if all retries are exhausted and OSV still returns 429, subsequent batches would immediately fire and also get rate-limited. Added a 60s pipeline-level pause (respecting `Retry-After` from the final failed response) before proceeding to the next batch — logged with a warning so operators know the scan is paused, not hung.

## Test plan
- [x] `tests/test_scanners.py` — 3 new PEP 503 regression tests
- [x] `tests/test_scan_cache.py` — 4 new LRU eviction tests
- [x] All 51 tests in both files pass
- [x] `tests/test_scanner_robustness.py` + `tests/test_normalization_gaps.py` — 38 tests pass