### PR TITLE
fix: GHSA PEP 503 normalization for advisory matching + resolver debug logging

### DIFF
--- a/src/agent_bom/resolver.py
+++ b/src/agent_bom/resolver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Optional
 
 import httpx
@@ -12,6 +13,7 @@ from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Package
 
 console = Console(stderr=True)
+_logger = logging.getLogger(__name__)
 
 NPM_REGISTRY = "https://registry.npmjs.org"
 PYPI_API = "https://pypi.org/pypi"
@@ -37,8 +39,8 @@ async def resolve_npm_metadata(
             if isinstance(lic, dict):
                 lic = lic.get("type")
             return version, lic if isinstance(lic, str) else None
-        except (ValueError, KeyError):
-            pass
+        except (ValueError, KeyError) as exc:
+            _logger.debug("Failed to parse npm metadata for %s: %s", package_name, exc)
     return None, None
 
 
@@ -69,8 +71,8 @@ async def resolve_npm_supply_chain(
                 pkg.author = author.get("name")
             elif isinstance(author, str):
                 pkg.author = author
-    except (ValueError, KeyError):
-        pass
+    except (ValueError, KeyError) as exc:
+        _logger.debug("Failed to parse npm supply chain metadata for %s: %s", pkg.name, exc)
 
 
 async def resolve_pypi_metadata(
@@ -92,8 +94,8 @@ async def resolve_pypi_metadata(
             if lic and lic.upper() not in ("UNKNOWN", ""):
                 return version, lic
             return version, None
-        except (ValueError, KeyError):
-            pass
+        except (ValueError, KeyError) as exc:
+            _logger.debug("Failed to parse PyPI metadata for %s: %s", package_name, exc)
     return None, None
 
 
@@ -122,8 +124,8 @@ async def resolve_pypi_supply_chain(
             pkg.author = info.get("author") or info.get("author_email") or None
         if not pkg.supplier:
             pkg.supplier = info.get("maintainer") or None
-    except (ValueError, KeyError):
-        pass
+    except (ValueError, KeyError) as exc:
+        _logger.debug("Failed to parse PyPI supply chain metadata for %s: %s", pkg.name, exc)
 
 
 async def resolve_package_version(pkg: Package, client: httpx.AsyncClient) -> bool:
@@ -227,7 +229,8 @@ async def enrich_supply_chain_metadata(
                 await resolve_pypi_supply_chain(pkg, client)
             if pkg.description or pkg.homepage or pkg.repository_url:
                 count += 1
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning("Failed to enrich supply chain metadata for %s@%s: %s", pkg.name, pkg.version, exc)
             continue
     return count
 

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -13,7 +13,7 @@ import logging
 import httpx
 
 from agent_bom.http_client import create_client, request_with_retry
-from agent_bom.models import Package, Severity, Vulnerability
+from agent_bom.models import Package, Severity, Vulnerability, normalize_package_name
 
 logger = logging.getLogger(__name__)
 
@@ -50,15 +50,21 @@ def _parse_ghsa_severity(advisory: dict) -> tuple[Severity, float | None]:
     return severity, score
 
 
-def _extract_fixed_version(advisory: dict, package_name: str) -> str | None:
+def _extract_fixed_version(advisory: dict, package_name: str, ecosystem: str = "") -> str | None:
     """Extract the first patched version for a specific package.
 
     Handles range strings like ``">= 4.18.0"``, ``">= 4.18.0, < 5.0.0"``,
     and Ruby-style ``"~> 1.2.3"`` by extracting the lower bound.
+
+    Uses PEP 503 normalization for PyPI so that mixed-separator forms like
+    ``Requests_OAuthlib`` match a normalized input of ``requests-oauthlib``.
     """
+    norm_input = normalize_package_name(package_name, ecosystem)
     for vuln in advisory.get("vulnerabilities", []):
         pkg = vuln.get("package", {})
-        if pkg.get("name", "").lower() == package_name.lower():
+        pkg_eco = pkg.get("ecosystem", ecosystem)
+        osv_norm = normalize_package_name(pkg.get("name", ""), pkg_eco)
+        if osv_norm == norm_input:
             patched = vuln.get("patched_versions")
             if patched:
                 return _parse_patched_range(patched)
@@ -202,8 +208,14 @@ async def check_github_advisories(
                     # Verify this advisory actually affects the target package
                     # (GitHub API does substring matching, so "express" returns
                     # advisories for "express-session", "express-validator", etc.)
-                    advisory_pkg_names = {v.get("package", {}).get("name", "").lower() for v in advisory.get("vulnerabilities", [])}
-                    if target_pkg.name.lower() not in advisory_pkg_names:
+                    # Use PEP 503 normalization so "Requests_OAuthlib" matches
+                    # the already-normalized target name "requests-oauthlib".
+                    target_eco = target_pkg.ecosystem
+                    advisory_pkg_names = {
+                        normalize_package_name(v.get("package", {}).get("name", ""), v.get("package", {}).get("ecosystem", target_eco))
+                        for v in advisory.get("vulnerabilities", [])
+                    }
+                    if normalize_package_name(target_pkg.name, target_eco) not in advisory_pkg_names:
                         continue
 
                     existing_ids = {v.id for v in target_pkg.vulnerabilities}
@@ -213,7 +225,7 @@ async def check_github_advisories(
                     if vuln_id in existing_ids or (cve_id and cve_id in existing_ids) or (ghsa_id and ghsa_id in existing_ids):
                         continue
 
-                    fixed = _extract_fixed_version(advisory, target_pkg.name)
+                    fixed = _extract_fixed_version(advisory, target_pkg.name, target_pkg.ecosystem)
                     vuln = Vulnerability(
                         id=vuln_id,
                         summary=summary[:200],


### PR DESCRIPTION
## Summary
Two P0 scanner accuracy bugs + silent failure fixes in the GHSA supplemental advisory pipeline.

### P0: GHSA advisory match skipped for mixed-separator PyPI packages
`check_github_advisories()` was building `advisory_pkg_names` using raw `.lower()` on names returned by the GitHub API. GitHub returns advisory package names in their original form (e.g. `Requests_OAuthlib`). The target package name is already PEP 503-normalized (e.g. `requests-oauthlib`) by the time it reaches GHSA. The comparison `"requests-oauthlib" in {"requests_oauthlib"}` fails, so the entire advisory is silently skipped — a false negative.

**Fix**: Use `normalize_package_name()` on both the advisory name (from GitHub) and the target name before comparison.

### P0: Fixed version not extracted from GHSA for mixed-separator packages
`_extract_fixed_version()` had the same `.lower()` comparison — it would find the right advisory but fail to extract the patched version because the name in the advisory (`Requests_OAuthlib`) didn't match the normalized input (`requests-oauthlib`). Result: reports would show "no fix available" even when one exists.

**Fix**: `_extract_fixed_version()` now accepts an `ecosystem` parameter and uses `normalize_package_name()` for the name comparison. Updated the call site to pass `target_pkg.ecosystem`.

### Resolver silent failures → debug logging
Four `except (ValueError, KeyError): pass` blocks in `resolver.py` swallowed JSON parse failures with no signal. Added `_logger.debug()` to all four so failures appear in debug logs. Also added `_logger.warning()` to the broader `except Exception` in `enrich_supply_chain_metadata()`.

## Impact
- Eliminates false negatives for PyPI packages with mixed underscore/hyphen/dot separators in GHSA database
- Eliminates "no fix version" when a fix exists for those packages  
- Makes registry connectivity failures debuggable

## Test plan
- [x] `tests/test_scanners.py` — 77 tests pass (no regressions in scanner pipeline)
- [x] `tests/test_scanner_robustness.py` + `tests/test_normalization_gaps.py` pass
- [x] ruff lint clean