### PR TITLE
fix: add logging to all bare silent exception handlers

### DIFF
--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -175,5 +175,6 @@ def _check_optional_dep(name: str) -> str:
         result = subprocess.run([path, "version"], capture_output=True, text=True, timeout=3)  # noqa: S603
         ver = (result.stdout or result.stderr).strip().split("\n")[0]
         return f"found ({ver})" if ver else "found"
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not get version for %s: %s", name, exc)
         return "found"

--- a/src/agent_bom/cloud/aisvs_benchmark.py
+++ b/src/agent_bom/cloud/aisvs_benchmark.py
@@ -511,7 +511,8 @@ def _check_ai_7_2() -> CISCheckResult:
                 digest = manifest.get("config", {}).get("digest", "")
                 if not digest:
                     unverifiable.append(f"{tag_path.parent.name}:{tag_path.name}")
-            except Exception:
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Could not parse model manifest %s: %s", tag_path, exc)
                 unverifiable.append(str(tag_path.name))
 
         if total == 0:

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -99,8 +99,8 @@ def _save_enrichment_cache() -> None:
                     os.close(fd)
                 try:
                     os.unlink(tmp_path)
-                except OSError:
-                    pass
+                except OSError as cleanup_exc:
+                    _logger.debug("Failed to remove temp cache file %s: %s", tmp_path, cleanup_exc)
                 raise
         except OSError:
             _logger.warning("Failed to persist %s enrichment cache to disk", name)

--- a/src/agent_bom/mcp_official_registry.py
+++ b/src/agent_bom/mcp_official_registry.py
@@ -205,7 +205,8 @@ async def sync_from_official_registry(
     """
     try:
         local_data = json.loads(_REGISTRY_PATH.read_text())
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not load local MCP registry %s: %s — defaulting to empty", _REGISTRY_PATH, exc)
         local_data = {"servers": {}}
 
     local_servers = local_data.get("servers", {})

--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -54,7 +54,8 @@ def _load_registry() -> dict:
     if _registry_cache is None:
         try:
             _registry_cache = json.loads(_REGISTRY_PATH.read_text()).get("servers", {})
-        except Exception:
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not load MCP registry from %s: %s — server recognition disabled", _REGISTRY_PATH, exc)
             _registry_cache = {}
     return _registry_cache
 

--- a/src/agent_bom/sast.py
+++ b/src/agent_bom/sast.py
@@ -138,7 +138,8 @@ def _get_semgrep_version() -> Optional[str]:
             timeout=10,
         )
         return result.stdout.strip() if result.returncode == 0 else None
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("Could not determine semgrep version: %s", exc)
         return None
 
 

--- a/src/agent_bom/transitive.py
+++ b/src/agent_bom/transitive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from typing import Optional
 
@@ -13,6 +14,7 @@ from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Package
 
 console = Console(stderr=True)
+_logger = logging.getLogger(__name__)
 
 NPM_REGISTRY = "https://registry.npmjs.org"
 PYPI_API = "https://pypi.org/pypi"
@@ -130,7 +132,8 @@ def _resolve_pip_version(version_spec: str, releases: dict) -> str:
                 pv = Version(v)
                 if not pv.is_prerelease and spec.contains(pv):
                     candidates.append(pv)
-            except Exception:
+            except Exception as exc:  # noqa: BLE001
+                _logger.debug("Skipping unparseable version %r for transitive dep: %s", v, exc)
                 continue
         if candidates:
             return str(max(candidates))


### PR DESCRIPTION
## Summary
Eliminates all bare `except Exception: pass/continue/return` blocks that swallowed failures silently across 7 modules. No logic changes — only adds logging so failures appear in debug/warning logs.

### Changes per file

| File | Location | What was silent | Now logs |
|---|---|---|---|
| `sast.py` | `_get_semgrep_version()` | semgrep binary not found / subprocess error | `_logger.debug` |
| `transitive.py` | version string parse loop | unparseable version strings (e.g. non-PEP440 prerelease) | `_logger.debug` |
| `mcp_official_registry.py` | `sync_from_official_registry()` | local registry JSON corrupt/missing → silently empty | `logger.warning` |
| `parsers/__init__.py` | `_load_registry()` | registry JSON load failure → server recognition disabled silently | `logger.warning` |
| `cloud/aisvs_benchmark.py` | model manifest check | malformed manifest JSON → silently marked unverifiable | `logger.debug` |
| `enrichment.py` | temp file cleanup | temp file removal error during cache write | `_logger.debug` |
| `cli/_common.py` | `_check_optional_dep()` | optional binary version probe failure | `logger.debug` |

Also adds `logging` import and `_logger` to `transitive.py` (was missing).

## Why this matters
- `mcp_official_registry.py` and `parsers/__init__.py` failures meant operators had no signal when the bundled MCP registry was corrupt or missing — scanner would silently skip server recognition
- `sast.py` failure meant a broken semgrep install would be indistinguishable from "no semgrep" — users couldn't diagnose SAST not running
- All others: production debugging was blocked because failures left no trace in logs

## Test plan
- [x] 574 tests pass across parser, registry, benchmark, common modules
- [x] ruff lint clean on all 7 files