### PR TITLE
chore: remove dead code + bump to v0.70.1

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           uv run agent-bom scan --sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.70.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.70.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.70.1","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.70.1"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.70.0  # pinned — bump on each release
+        run: uv tool install agent-bom==0.70.1  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -16,14 +16,14 @@ FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf7
 WORKDIR /app
 COPY LICENSE ./
 
-ARG VERSION=0.70.0
+ARG VERSION=0.70.1
 
 RUN pip install --no-cache-dir --prefix=/install agent-bom==${VERSION}
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.70.0
+ARG VERSION=0.70.1
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/Dockerfile.snowpark
+++ b/Dockerfile.snowpark
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11-slim@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
-ARG VERSION=0.70.0
+ARG VERSION=0.70.1
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"

--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.70.0
+ARG VERSION=0.70.1
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="Security scanner for AI infrastructure — MCP server with streamable HTTP transport"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -102,7 +102,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.70.0"
+  --version "0.70.1"
 ```
 
 ### Verification
@@ -138,8 +138,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.70.0
-git push origin v0.70.0
+git tag v0.70.1
+git push origin v0.70.1
 ```
 
 This triggers:

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom scan` | Local audit |
-| GitHub Action | `uses: msaad00/agent-bom@v0.70.0 | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.70.1 | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans (linux/amd64, linux/arm64) |
 | REST API | `agent-bom api` | Dashboards, SIEM |
 | MCP Server | `agent-bom mcp-server` (30 tools) | Inside any MCP client |
@@ -341,7 +341,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 <summary><b>GitHub Action</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.70.0
+- uses: msaad00/agent-bom@v0.70.1
   with:
     severity-threshold: high
     upload-sarif: true
@@ -452,7 +452,7 @@ rm -rf ~/.agent-bom                      # remove local data
 |----------|------|
 | PyPI | `pip install agent-bom` |
 | Docker | `docker run agentbom/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.70.0 |
+| GitHub Action | `uses: msaad00/agent-bom@v0.70.1 |
 | Glama | [glama.ai/mcp/servers/@msaad00/agent-bom](https://glama.ai/mcp/servers/@msaad00/agent-bom) |
 | MCP Registry | [server.json](integrations/mcp-registry/server.json) |
 | ToolHive | [registry entry](integrations/toolhive/server.json) |

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: AI supply chain security scanner — scan containers, MCP servers, and AI agents for CVEs, credential exposure, and compliance violations
 version: 0.1.0
-appVersion: "0.70.0"
+appVersion: "0.70.1"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.70.0"
+  tag: "0.70.1"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.70.0"
+  tag: "0.70.1"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom scan --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.70.0
+- uses: msaad00/agent-bom@v0.70.1
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, compliance, policy, SBOMs",
   "title": "agent-bom",
-  "version": "0.70.0",
+  "version": "0.70.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.70.0",
+      "version": "0.70.1",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   MITRE ATLAS, EU AI Act, NIST AI RMF, and custom policy-as-code rules. Generate
   SBOMs in CycloneDX or SPDX format. Use when the user mentions compliance checking,
   security policy enforcement, SBOM generation, or regulatory frameworks.
-version: 0.70.0
+version: 0.70.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.70.0
+version: 0.70.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.70.0
+version: 0.70.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checks packages for CVEs (OSV, NVD, EPSS, KEV), maps blast radius, and generates
   remediation plans. Use when the user mentions vulnerability scanning, dependency
   security, CVE lookup, blast radius analysis, or AI supply chain risk.
-version: 0.70.0
+version: 0.70.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Grype/Syft for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.70.0
+    docker: ghcr.io/msaad00/agent-bom:0.70.1
   openclaw:
     requires:
       bins: []
@@ -187,6 +187,6 @@ CVE IDs are sent to vulnerability databases.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.70.0
+- **Sigstore signed**: `agent-bom verify agent-bom@0.70.1
 - **4,400+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/toolhive/Dockerfile.mcp
+++ b/integrations/toolhive/Dockerfile.mcp
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12-slim@sha256:39e4e1ccb01578e3c86f7a0cf7b7fd89b8dbe2c27a88de11cf726ba669469f49
 
-ARG VERSION=0.70.0
+ARG VERSION=0.70.1
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — MCP server mode"

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner for AI infrastructure — CVEs, blast radius, credential exposure, runtime enforcement across MCP servers, containers, cloud, and GPU",
   "title": "agent-bom",
-  "version": "0.70.0",
+  "version": "0.70.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/msaad00/agent-bom:v0.70.0",
+      "identifier": "ghcr.io/msaad00/agent-bom:v0.70.1",
       "transport": {
         "type": "stdio"
       },
@@ -28,7 +28,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "io.github.msaad00": {
-        "ghcr.io/msaad00/agent-bom:v0.70.0": {
+        "ghcr.io/msaad00/agent-bom:v0.70.1": {
           "tier": "Community",
           "status": "Active",
           "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.70.0"
+version = "0.70.1"
 description = "Security scanner for AI infrastructure. Discover MCP configs (22 clients), scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to reachable credentials and tools, runtime proxy with 7 detectors, 30 MCP tools, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, and 11-framework compliance."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.70.0"
+    __version__ = "0.70.1"

--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -515,29 +515,6 @@ def _build_threat_chain_prompt(report: AIBOMReport) -> str:
     )
 
 
-def _build_remediation_prompt(items: list[dict]) -> str:
-    """Build a prompt for generating remediation guidance."""
-    package_lines = []
-    for item in items[:10]:
-        fix_str = f" -> {item['fix']}" if item.get("fix") else " (no fix)"
-        package_lines.append(
-            f"- {item['package']}@{item['current']} ({item['ecosystem']}){fix_str} "
-            f"| {len(item['vulns'])} vuln(s) | agents: {', '.join(item['agents'][:3])}"
-        )
-
-    return (
-        "You are an AI security engineer. Generate practical, prioritized "
-        "remediation guidance for these vulnerable packages in AI agent MCP "
-        "server configurations.\n\n"
-        f"Findings:\n{chr(10).join(package_lines)}\n\n"
-        "For each package, provide:\n"
-        "1. Specific upgrade command (npm/pip/etc)\n"
-        "2. Any breaking changes to watch for\n"
-        "3. Temporary mitigation if no fix exists\n\n"
-        "Keep each item to 2-3 lines. Be concrete and actionable."
-    )
-
-
 # ─── Enrichment functions ────────────────────────────────────────────────────
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,7 @@ def empty_report():
 def test_version_sync():
     from agent_bom import __version__
 
-    assert __version__ == "0.70.0"
+    assert __version__ == "0.70.1"
 
 
 def test_report_version_matches():
@@ -2954,7 +2954,7 @@ def test_toolhive_server_json_valid():
     p = Path(__file__).parent.parent / "integrations" / "toolhive" / "server.json"
     data = _json.loads(p.read_text())
     assert data["name"] == "io.github.msaad00/agent-bom"
-    assert data["version"] == "0.70.0"
+    assert data["version"] == "0.70.1"
     assert "packages" in data
     assert data["packages"][0]["registryType"] == "oci"
 


### PR DESCRIPTION
## Summary
- Remove unused `_build_remediation_prompt()` from `ai_enrich.py` — defined but never called (no corresponding `generate_remediation_guidance` function existed to invoke it)
- Bump version to 0.70.1 across all 20 tracked version files

## What was flagged
Independent audit of evallab.ai bot feedback identified `_build_remediation_prompt` as the **only** genuinely unused function in the codebase. All other "unused function" claims were false positives:
- `_lifespan` — used at `server.py:191` as FastAPI lifespan param
- `_check_ai_4_3` — registered in dispatch dict at `aisvs_benchmark.py:593`

Ruff F-category confirms zero unused imports/variables across the full codebase.

## Test plan
- [ ] `ruff check src/agent_bom/ --select F` returns zero violations
- [ ] `python -m pytest tests/test_core.py -x` passes with new version
- [ ] CI green

Closes #548