### PR TITLE
fix: harden local vuln DB security — chmod 0600, HTTPS-only sync, path validation, integrity check + Alpine CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,33 @@ jobs:
       - name: Run tests with coverage
         run: uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=79 -m "not network"
 
-  # 3b. PR Base Branch Guard — prevent stacked PRs targeting feature branches
+  # 3b. Alpine/musl compatibility test
+  # Runs the test suite inside an Alpine Linux container (musl libc) to catch
+  # glibc-only assumptions in code, compiled extensions, or path handling.
+  test-alpine:
+    name: Test (Alpine/musl)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: python:3.12-alpine
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install build deps (Alpine)
+        run: |
+          apk add --no-cache gcc musl-dev libffi-dev openssl-dev git
+
+      - name: Install uv
+        run: pip install uv --quiet
+
+      - name: Install project dependencies
+        run: uv sync --extra dev --extra api --extra mcp-server
+
+      - name: Run tests (musl)
+        run: uv run pytest tests/ -q --tb=short -m "not network" -x
+
+  # 3c. PR Base Branch Guard — prevent stacked PRs targeting feature branches
   base-branch-check:
     name: PR Base Branch Guard
     runs-on: ubuntu-latest

--- a/src/agent_bom/db/schema.py
+++ b/src/agent_bom/db/schema.py
@@ -13,13 +13,49 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+import stat
+import tempfile
 from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
 # Default DB path — overridable via env var
 _DEFAULT_DB_DIR = Path.home() / ".agent-bom" / "db"
-DB_PATH: Path = Path(os.environ.get("AGENT_BOM_DB_PATH", str(_DEFAULT_DB_DIR / "vulns.db")))
+_RAW_DB_PATH = os.environ.get("AGENT_BOM_DB_PATH", str(_DEFAULT_DB_DIR / "vulns.db"))
+
+
+def _validated_db_path(raw: str) -> Path:
+    """Resolve and validate the DB path.
+
+    Accepts paths inside the user's home directory or /tmp (for tests).
+    Rejects path traversal, symlink escapes, and arbitrary filesystem locations.
+    Raises ``ValueError`` on invalid paths so callers get a clear error at startup.
+    """
+    from agent_bom.security import SecurityError, validate_path
+
+    p = Path(raw).expanduser()
+    home = Path.home().resolve()
+    # Use the real system temp dir (macOS: /private/tmp or /private/var/folders/…)
+    tmp = Path(tempfile.gettempdir()).resolve()
+
+    # Allow home subtree or system temp subtree (test fixtures land in temp)
+    try:
+        resolved = p.resolve()
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"AGENT_BOM_DB_PATH is not a valid path: {raw!r}") from exc
+
+    if not (resolved.is_relative_to(home) or resolved.is_relative_to(tmp)):
+        raise ValueError(f"AGENT_BOM_DB_PATH must be inside the home directory or /tmp, got: {raw!r}")
+
+    try:
+        validate_path(p)
+    except SecurityError as exc:
+        raise ValueError(f"AGENT_BOM_DB_PATH failed security check: {exc}") from exc
+
+    return p
+
+
+DB_PATH: Path = _validated_db_path(_RAW_DB_PATH)
 
 # Schema version — bump when DDL changes incompatibly
 _SCHEMA_VERSION = 1
@@ -79,10 +115,33 @@ CREATE TABLE IF NOT EXISTS sync_meta (
 """
 
 
+def _set_db_permissions(db_path: Path) -> None:
+    """Restrict the DB file to owner read/write only (0600).
+
+    No-ops silently on platforms where chmod is not supported (Windows).
+    """
+    try:
+        db_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except (NotImplementedError, OSError):
+        pass  # Windows or read-only filesystem — best effort
+
+
+def _check_integrity(conn: sqlite3.Connection, db_path: Path) -> None:
+    """Run SQLite integrity_check; log a warning if the DB is corrupt."""
+    result = conn.execute("PRAGMA integrity_check").fetchone()
+    if result and result[0] != "ok":
+        _logger.warning(
+            "Local vuln DB at %s failed integrity check: %s — consider deleting and re-running 'agent-bom db update'",
+            db_path,
+            result[0],
+        )
+
+
 def init_db(path: Path | None = None) -> sqlite3.Connection:
     """Open (and initialise if needed) the local vuln DB.
 
     Creates the DB file and parent directories if they don't exist.
+    Applies 0600 file permissions and runs an integrity check on open.
     Returns an open connection with WAL mode and foreign keys enabled.
     """
     db_path = path or DB_PATH
@@ -91,6 +150,12 @@ def init_db(path: Path | None = None) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     conn.executescript(_DDL)
+
+    # Lock down file permissions after first creation
+    _set_db_permissions(db_path)
+
+    # Integrity check — warn on corrupt DB, don't crash (read-only callers are safe)
+    _check_integrity(conn, db_path)
 
     # Seed schema_version on first creation
     row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -26,6 +26,22 @@ from typing import Optional
 
 _logger = logging.getLogger(__name__)
 
+
+def _validate_sync_url(url: str, param_name: str = "url") -> None:
+    """Reject non-HTTPS URLs for sync sources.
+
+    All sync sources must use HTTPS.  Accepting ``file://`` or ``http://``
+    custom URLs would allow an attacker who controls the environment to point
+    the syncer at a malicious local file or a plaintext server.
+
+    Raises ``ValueError`` with a descriptive message on invalid URLs.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(
+            f"{param_name} must use https:// — got {url!r}. Only HTTPS URLs are accepted for vulnerability database sync sources."
+        )
+
+
 # Source URLs — all public, no auth required
 _OSV_ALL_ZIP_URL = "https://osv-vulnerabilities.storage.googleapis.com/all.zip"
 _EPSS_CSV_URL = "https://epss.cyentia.com/epss_scores-current.csv.gz"
@@ -207,6 +223,7 @@ def sync_osv(conn: sqlite3.Connection, url: Optional[str] = None, max_entries: i
     import urllib.request
 
     src = url or _OSV_ALL_ZIP_URL
+    _validate_sync_url(src, "osv url")
     _logger.info("Downloading OSV bulk export from %s …", src)
 
     try:
@@ -252,6 +269,7 @@ def sync_epss(conn: sqlite3.Connection, url: Optional[str] = None) -> int:
     import urllib.request
 
     src = url or _EPSS_CSV_URL
+    _validate_sync_url(src, "epss url")
     _logger.info("Downloading EPSS scores from %s …", src)
 
     try:
@@ -319,6 +337,7 @@ def sync_kev(conn: sqlite3.Connection, url: Optional[str] = None) -> int:
     import urllib.request
 
     src = url or _KEV_JSON_URL
+    _validate_sync_url(src, "kev url")
     _logger.info("Downloading CISA KEV catalog from %s …", src)
 
     try:

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -9,12 +9,14 @@ from unittest.mock import patch
 import pytest
 
 from agent_bom.db.lookup import VulnDB, _version_affected, lookup_package
-from agent_bom.db.schema import DB_PATH, db_stats, init_db
+from agent_bom.db.schema import DB_PATH, _validated_db_path, db_stats, init_db
 from agent_bom.db.sync import (
     _ingest_osv_file,
     _parse_osv_entry,
+    _validate_sync_url,
     sync_epss,
     sync_kev,
+    sync_osv,
 )
 
 # ---------------------------------------------------------------------------
@@ -332,7 +334,7 @@ def test_sync_kev_mocked(tmp_db):
             pass
 
     with patch("urllib.request.urlopen", return_value=_FakeResp()):
-        count = sync_kev(tmp_db, url="http://fake/kev.json")
+        count = sync_kev(tmp_db, url="https://fake/kev.json")
 
     assert count == 2
     rows = tmp_db.execute("SELECT cve_id FROM kev_entries ORDER BY cve_id").fetchall()
@@ -359,8 +361,104 @@ def test_sync_epss_mocked(tmp_db):
             pass
 
     with patch("urllib.request.urlopen", return_value=_FakeResp()):
-        count = sync_epss(tmp_db, url="http://fake/epss.csv.gz")
+        count = sync_epss(tmp_db, url="https://fake/epss.csv.gz")
 
     assert count == 2
     row = tmp_db.execute("SELECT probability FROM epss_scores WHERE cve_id='CVE-2024-1'").fetchone()
     assert row[0] == pytest.approx(0.95)
+
+
+# ---------------------------------------------------------------------------
+# Security hardening — URL validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_sync_url_accepts_https():
+    _validate_sync_url("https://example.com/data.zip")  # must not raise
+
+
+def test_validate_sync_url_rejects_http():
+    with pytest.raises(ValueError, match="https://"):
+        _validate_sync_url("http://example.com/data.zip")
+
+
+def test_validate_sync_url_rejects_file_scheme():
+    with pytest.raises(ValueError, match="https://"):
+        _validate_sync_url("file:///tmp/osv.zip")
+
+
+def test_validate_sync_url_rejects_empty():
+    with pytest.raises(ValueError, match="https://"):
+        _validate_sync_url("")
+
+
+def test_sync_osv_rejects_http_url(tmp_db):
+    with pytest.raises(ValueError, match="https://"):
+        sync_osv(tmp_db, url="http://evil.example.com/osv.zip")
+
+
+def test_sync_epss_rejects_http_url(tmp_db):
+    with pytest.raises(ValueError, match="https://"):
+        sync_epss(tmp_db, url="http://evil.example.com/epss.csv.gz")
+
+
+def test_sync_kev_rejects_http_url(tmp_db):
+    with pytest.raises(ValueError, match="https://"):
+        sync_kev(tmp_db, url="http://evil.example.com/kev.json")
+
+
+# ---------------------------------------------------------------------------
+# Security hardening — DB path validation
+# ---------------------------------------------------------------------------
+
+
+def test_validated_db_path_accepts_home_subpath(tmp_path, monkeypatch):
+    """A path under the home directory is accepted."""
+    # tmp_path is typically under /tmp which is also allowed
+    p = _validated_db_path(str(tmp_path / "vulns.db"))
+    assert p == tmp_path / "vulns.db"
+
+
+def test_validated_db_path_rejects_arbitrary_system_path():
+    with pytest.raises(ValueError, match="home directory or /tmp"):
+        _validated_db_path("/etc/passwd")
+
+
+def test_validated_db_path_rejects_traversal(tmp_path):
+    with pytest.raises(ValueError):
+        _validated_db_path(str(tmp_path / ".." / ".." / "etc" / "passwd"))
+
+
+# ---------------------------------------------------------------------------
+# Security hardening — file permissions (0600)
+# ---------------------------------------------------------------------------
+
+
+def test_init_db_sets_restrictive_permissions(tmp_path):
+    import stat as _stat
+
+    db_file = tmp_path / "perms_test.db"
+    conn = init_db(db_file)
+    conn.close()
+    mode = db_file.stat().st_mode
+    # Owner read+write must be set; group and other must NOT be set
+    assert mode & _stat.S_IRUSR
+    assert mode & _stat.S_IWUSR
+    assert not (mode & _stat.S_IRGRP)
+    assert not (mode & _stat.S_IROTH)
+
+
+# ---------------------------------------------------------------------------
+# Security hardening — integrity check
+# ---------------------------------------------------------------------------
+
+
+def test_init_db_passes_integrity_check(tmp_path, caplog):
+    import logging
+
+    db_file = tmp_path / "integrity_test.db"
+    with caplog.at_level(logging.WARNING, logger="agent_bom.db.schema"):
+        conn = init_db(db_file)
+        conn.close()
+    # A fresh DB should pass — no integrity warning
+    assert "integrity check" not in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.66.0"
+version = "0.70.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -92,6 +92,9 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "safety" },
+    { name = "types-pyyaml" },
+    { name = "types-requests" },
+    { name = "types-toml" },
 ]
 gcp = [
     { name = "google-cloud-aiplatform" },
@@ -221,6 +224,9 @@ requires-dist = [
     { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=2.1" },
     { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.37.0" },
     { name = "toml", specifier = ">=0.10" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31" },
+    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.32" },
     { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.16" },
     { name = "watchdog", marker = "extra == 'watch'", specifier = ">=4.0" },
@@ -5122,6 +5128,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20260107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20240310"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/47/3e4c75042792bff8e90d7991aa5c51812cc668828cc6cce711e97f63a607/types-toml-0.10.8.20240310.tar.gz", hash = "sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331", size = 4392, upload-time = "2024-03-10T02:18:37.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/a2/d32ab58c0b216912638b140ab2170ee4b8644067c293b170e19fba340ccc/types_toml-0.10.8.20240310-py3-none-any.whl", hash = "sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d", size = 4777, upload-time = "2024-03-10T02:18:36.568Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes all four DB security gaps identified post-#631, plus adds the Alpine/musl CI gap.

### Changes

**`db/schema.py`**
- `_validated_db_path()`: validate `AGENT_BOM_DB_PATH` through `security.py`'s `validate_path()` — rejects path traversal, symlink escapes, and paths outside home or system temp directory
- `_set_db_permissions()`: `chmod 0600` on the DB file after `init_db()` creates it — prevents other users on shared machines from reading vulnerability data
- `_check_integrity()`: `PRAGMA integrity_check` on every open — logs a warning if the DB is corrupt with instructions to re-sync

**`db/sync.py`**
- `_validate_sync_url()`: enforces `https://` scheme on all sync source URLs — rejects `file://`, `http://`, and empty strings before any network call
- Wired into `sync_osv`, `sync_epss`, and `sync_kev` (both default and custom `url=` overrides)

**`tests/test_local_vuln_db.py`**
- 12 new security tests covering all four hardening items
- Fixed 2 existing mock tests that used `http://fake/` URLs (now `https://fake/`)

**`.github/workflows/ci.yml`**
- New `test-alpine` job: runs the full test suite inside `python:3.12-alpine` (musl libc)
- Catches glibc-only assumptions, broken compiled extensions, or platform-specific path handling before they reach users

## Test plan
- [ ] All 44 `test_local_vuln_db.py` tests pass locally
- [ ] CI passes including new Alpine job
- [ ] `agent-bom db update` still works (default HTTPS sources unchanged)
- [ ] `AGENT_BOM_DB_PATH=/etc/passwd agent-bom db status` exits with clear error