### PR TITLE
fix: stale local DB warning + OTel hardening (schema validation, 50MB cap, framework expansion)

### DIFF
--- a/src/agent_bom/cli/_db.py
+++ b/src/agent_bom/cli/_db.py
@@ -97,6 +97,19 @@ def db_status(db_path: str | None) -> None:
 
     meta = stats.get("sync_meta", {})
     if meta:
+        from agent_bom.db.schema import db_freshness_days
+
+        age = db_freshness_days(db_file)
+        if age is None:
+            freshness_msg = "[yellow]Never synced — run agent-bom db update[/yellow]"
+        elif age <= 7:
+            freshness_msg = f"[green]Fresh ({age}d ago)[/green]"
+        elif age <= 14:
+            freshness_msg = f"[yellow]Aging ({age}d ago) — consider running db update[/yellow]"
+        else:
+            freshness_msg = f"[red]Stale ({age}d ago) — run agent-bom db update[/red]"
+        con.print(f"  Freshness       : {freshness_msg}")
+
         table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
         table.add_column("Source")
         table.add_column("Last synced")
@@ -104,6 +117,8 @@ def db_status(db_path: str | None) -> None:
         for src, info in sorted(meta.items()):
             table.add_row(src, info.get("last_synced") or "—", f"{info.get('count', 0):,}")
         con.print(table)
+    else:
+        con.print("  [yellow]No sync data — run agent-bom db update to populate.[/yellow]")
 
 
 @db_cmd.command("path")

--- a/src/agent_bom/cli/scan.py
+++ b/src/agent_bom/cli/scan.py
@@ -486,6 +486,35 @@ def scan(
         )
         return
 
+    # Pre-scan: local DB freshness check
+    if not no_scan:
+        try:
+            from agent_bom.db.schema import db_freshness_days
+
+            _db_age = db_freshness_days()
+            if _db_age is None:
+                if not quiet:
+                    con.print(
+                        "[yellow]⚠ No local vulnerability DB found.[/yellow] "
+                        "Falling back to OSV API (slower). "
+                        "Run [bold]agent-bom db update[/bold] to build a local cache."
+                    )
+            elif _db_age > 14:
+                if not quiet:
+                    con.print(
+                        f"[red]⚠ Local vulnerability DB is {_db_age} days old.[/red] "
+                        "Scan results may be incomplete. "
+                        "Run [bold]agent-bom db update[/bold] before scanning."
+                    )
+            elif _db_age > 7:
+                if not quiet:
+                    con.print(
+                        f"[yellow]⚠ Local vulnerability DB is {_db_age} days old.[/yellow] "
+                        "Consider running [bold]agent-bom db update[/bold]."
+                    )
+        except Exception:
+            pass  # Never block a scan due to freshness check failure
+
     # Step 1: Discovery
     from rich.rule import Rule
 

--- a/src/agent_bom/db/schema.py
+++ b/src/agent_bom/db/schema.py
@@ -175,6 +175,47 @@ def init_db(path: Path | None = None) -> sqlite3.Connection:
     return conn
 
 
+def db_freshness_days(path: Path | None = None) -> int | None:
+    """Return the age in days of the oldest synced source, or None if DB absent / never synced.
+
+    Opens a temporary connection — safe to call before the main scan opens VulnDB.
+    """
+    from datetime import datetime, timezone
+
+    db_path = path or DB_PATH
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            rows = conn.execute("SELECT last_synced FROM sync_meta").fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+    if not rows:
+        return None
+
+    oldest: datetime | None = None
+    now = datetime.now(timezone.utc)
+    for (ts,) in rows:
+        if not ts:
+            continue
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            if oldest is None or dt < oldest:
+                oldest = dt
+        except ValueError:
+            continue
+
+    if oldest is None:
+        return None
+    return (now - oldest).days
+
+
 def db_stats(conn: sqlite3.Connection) -> dict:
     """Return a summary dict of record counts and last-sync times."""
     stats: dict = {}

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -55,6 +55,15 @@ async def runtime_correlate_impl(
 
             safe_trace = _safe_path(otel_trace)
             try:
+                from agent_bom.otel_ingest import _MAX_TRACE_FILE_BYTES
+
+                file_size = safe_trace.stat().st_size
+                if file_size > _MAX_TRACE_FILE_BYTES:
+                    result["ml_api_calls"] = []
+                    result["ml_api_error"] = (
+                        f"OTel trace file too large ({file_size / 1024 / 1024:.1f} MB, max {_MAX_TRACE_FILE_BYTES // 1024 // 1024} MB)"
+                    )
+                    return _truncate_response(json.dumps(result, indent=2, default=str))
                 trace_data = _json.loads(safe_trace.read_text())
                 ml_calls = parse_ml_api_spans(trace_data)
                 flagged = flag_deprecated_models(ml_calls)

--- a/src/agent_bom/otel_ingest.py
+++ b/src/agent_bom/otel_ingest.py
@@ -21,6 +21,9 @@ from dataclasses import dataclass, field
 
 _ADK_TOOL_RE = re.compile(r"^adk\.tool\.(.+)$")
 
+# Maximum trace file size (50 MB) — prevents OOM on adversarially large files
+_MAX_TRACE_FILE_BYTES = 50 * 1024 * 1024
+
 # GenAI span name patterns — instrumentation libraries emit these
 _ML_SPAN_PATTERNS = re.compile(
     r"^("
@@ -30,7 +33,15 @@ _ML_SPAN_PATTERNS = re.compile(
     r"ChatOpenAI|ChatAnthropic|ChatCohere|ChatBedrock|ChatVertexAI|"
     r"llm\.chat|llm\.complete|llm\.stream|"
     r"LLMChain|RetrievalQA|"
-    r"gen_ai\."
+    r"gen_ai\.|"
+    # LangGraph
+    r"langgraph\.|"
+    # CrewAI
+    r"crewai\.|"
+    # AutoGen
+    r"autogen\.|"
+    # Haystack
+    r"haystack\."
     r")",
     re.IGNORECASE,
 )
@@ -43,6 +54,10 @@ _ML_SCOPE_NAMES = {
     "opentelemetry.instrumentation.langchain",
     "opentelemetry.instrumentation.llama_index",
     "traceloop.sdk",
+    # Additional framework scopes
+    "opentelemetry.instrumentation.crewai",
+    "opentelemetry.instrumentation.autogen",
+    "haystack.tracing.opentelemetry",
 }
 
 # Known deprecated / end-of-life model patterns (prefix match on model_name)
@@ -163,12 +178,35 @@ def _is_ml_span(span: dict, scope_name: str) -> bool:
     return False
 
 
+def validate_otel_schema(trace_data: dict) -> None:
+    """Validate that trace_data conforms to OTLP JSON structure.
+
+    Raises ``ValueError`` with a clear path if the required structure is absent.
+    Accepts both ``resourceSpans`` (OTLP standard) and flat ``spans`` arrays.
+    """
+    if not isinstance(trace_data, dict):
+        raise ValueError("OTel trace must be a JSON object, got: " + type(trace_data).__name__)
+
+    has_resource_spans = "resourceSpans" in trace_data
+    has_flat_spans = "spans" in trace_data
+
+    if not has_resource_spans and not has_flat_spans:
+        raise ValueError(
+            "OTel trace missing required key 'resourceSpans' (OTLP format) or 'spans' (flat format). "
+            "Ensure the file is a valid OTel JSON export."
+        )
+
+    if has_resource_spans and not isinstance(trace_data["resourceSpans"], list):
+        raise ValueError("'resourceSpans' must be a JSON array")
+
+
 def parse_otel_traces(trace_data: dict) -> list[ToolCallTrace]:
     """Parse OTel JSON export into tool call traces.
 
     Supports OTLP JSON format (resourceSpans → scopeSpans → spans) and
     simple flat span arrays.
     """
+    validate_otel_schema(trace_data)
     traces: list[ToolCallTrace] = []
 
     # Extract spans from OTLP JSON structure
@@ -238,10 +276,11 @@ def parse_ml_api_spans(trace_data: dict) -> list[LLMAPICall]:
     Detects spans representing LLM inference calls using:
     - OpenTelemetry GenAI semantic conventions (``gen_ai.*`` attributes)
     - Instrumentation library scope names (opentelemetry-instrumentation-openai, etc.)
-    - Span name patterns (ChatOpenAI, llm.chat, etc.)
+    - Span name patterns (ChatOpenAI, llm.chat, LangGraph, CrewAI, AutoGen, Haystack, etc.)
 
     Supports OTLP JSON format (resourceSpans → scopeSpans → spans).
     """
+    validate_otel_schema(trace_data)
     calls: list[LLMAPICall] = []
 
     for rs in trace_data.get("resourceSpans", []):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -324,3 +324,64 @@ def test_where_runs():
     """where command shows discovery paths and exits 0."""
     result = _run(["where"])
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# db status — freshness display
+# ---------------------------------------------------------------------------
+
+
+def test_db_status_freshness_fresh(tmp_path):
+    """db status shows green 'Fresh' when synced recently."""
+    from datetime import datetime, timezone
+
+    from agent_bom.db.schema import init_db
+
+    db_file = tmp_path / "test.db"
+    conn = init_db(db_file)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+        ("osv", now_iso, 1000),
+    )
+    conn.commit()
+    conn.close()
+
+    result = _run(["db", "status", "--path", str(db_file)])
+    assert result.exit_code == 0
+    assert "Fresh" in result.output or "ago" in result.output
+
+
+def test_db_status_freshness_stale(tmp_path):
+    """db status shows red 'Stale' when DB is old."""
+    from datetime import datetime, timedelta, timezone
+
+    from agent_bom.db.schema import init_db
+
+    db_file = tmp_path / "stale.db"
+    conn = init_db(db_file)
+    old_iso = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+        ("osv", old_iso, 100),
+    )
+    conn.commit()
+    conn.close()
+
+    result = _run(["db", "status", "--path", str(db_file)])
+    assert result.exit_code == 0
+    assert "Stale" in result.output or "20d" in result.output or "ago" in result.output
+
+
+def test_db_status_no_sync_meta(tmp_path):
+    """db status with empty sync_meta shows 'No sync data' message."""
+    from agent_bom.db.schema import init_db
+
+    db_file = tmp_path / "empty.db"
+    conn = init_db(db_file)
+    conn.close()
+
+    result = _run(["db", "status", "--path", str(db_file)])
+    assert result.exit_code == 0
+    # Should show a 'no sync data' or 'db update' hint
+    assert "update" in result.output.lower() or "sync" in result.output.lower()

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -582,3 +582,67 @@ def test_sync_db_single_epss_source(tmp_path):
         result = sync_db(path=tmp_path / "test.db", sources=["epss"])
     assert result == {"epss": 500}
     mock_epss.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# db_freshness_days — new function
+# ---------------------------------------------------------------------------
+
+
+def test_db_freshness_days_no_db(tmp_path):
+    """Returns None when DB file doesn't exist."""
+    from agent_bom.db.schema import db_freshness_days
+
+    assert db_freshness_days(tmp_path / "nonexistent.db") is None
+
+
+def test_db_freshness_days_never_synced(tmp_path):
+    """Returns None when sync_meta is empty (never synced)."""
+    from agent_bom.db.schema import db_freshness_days, init_db
+
+    db_file = tmp_path / "fresh.db"
+    conn = init_db(db_file)
+    conn.close()
+    assert db_freshness_days(db_file) is None
+
+
+def test_db_freshness_days_just_synced(tmp_path):
+    """Returns 0 days when synced just now."""
+    from datetime import datetime, timezone
+
+    from agent_bom.db.schema import db_freshness_days, init_db
+
+    db_file = tmp_path / "fresh.db"
+    conn = init_db(db_file)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+        ("osv", now_iso, 1000),
+    )
+    conn.commit()
+    conn.close()
+
+    age = db_freshness_days(db_file)
+    assert age is not None
+    assert age == 0
+
+
+def test_db_freshness_days_old_db(tmp_path):
+    """Returns correct age for a stale database."""
+    from datetime import datetime, timedelta, timezone
+
+    from agent_bom.db.schema import db_freshness_days, init_db
+
+    db_file = tmp_path / "stale.db"
+    conn = init_db(db_file)
+    old_iso = (datetime.now(timezone.utc) - timedelta(days=15)).isoformat()
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+        ("osv", old_iso, 100),
+    )
+    conn.commit()
+    conn.close()
+
+    age = db_freshness_days(db_file)
+    assert age is not None
+    assert age >= 14

--- a/tests/test_otel_ingest.py
+++ b/tests/test_otel_ingest.py
@@ -1,5 +1,7 @@
 """Tests for OpenTelemetry trace ingestion."""
 
+import pytest
+
 from agent_bom.otel_ingest import (
     LLMAPICall,
     ToolCallTrace,
@@ -115,8 +117,10 @@ def test_parse_flat_spans_format():
 
 
 def test_malformed_input():
-    traces = parse_otel_traces({})
-    assert traces == []
+    # {} is now rejected by schema validation — use pytest.raises
+    with pytest.raises(ValueError, match="resourceSpans"):
+        parse_otel_traces({})
+    # valid empty structure returns empty list
     traces = parse_otel_traces({"resourceSpans": []})
     assert traces == []
 
@@ -277,9 +281,15 @@ def test_parse_ml_span_non_ml_span_skipped():
 
 
 def test_parse_ml_span_no_spans():
-    """Empty trace returns empty list."""
-    calls = parse_ml_api_spans({})
+    """Empty trace with valid structure returns empty list."""
+    calls = parse_ml_api_spans({"resourceSpans": []})
     assert calls == []
+
+
+def test_parse_ml_span_invalid_schema():
+    """Bare empty dict is rejected by schema validation."""
+    with pytest.raises(ValueError, match="resourceSpans"):
+        parse_ml_api_spans({})
 
 
 def test_parse_ml_span_multiple_calls():
@@ -419,3 +429,43 @@ def test_flag_multiple_deprecated():
     flagged_models = {f.call.model_name for f in flagged}
     assert "text-davinci-003" in flagged_models
     assert "claude-2.0" in flagged_models
+
+
+# ---------------------------------------------------------------------------
+# validate_otel_schema — new function
+# ---------------------------------------------------------------------------
+
+
+def test_validate_otel_schema_valid_resource_spans():
+    from agent_bom.otel_ingest import validate_otel_schema
+
+    # Must not raise
+    validate_otel_schema({"resourceSpans": []})
+    validate_otel_schema({"resourceSpans": [], "extra": "ok"})
+
+
+def test_validate_otel_schema_valid_flat_spans():
+    from agent_bom.otel_ingest import validate_otel_schema
+
+    validate_otel_schema({"spans": []})
+
+
+def test_validate_otel_schema_rejects_non_dict():
+    from agent_bom.otel_ingest import validate_otel_schema
+
+    with pytest.raises(ValueError, match="JSON object"):
+        validate_otel_schema([])  # type: ignore[arg-type]
+
+
+def test_validate_otel_schema_rejects_empty_dict():
+    from agent_bom.otel_ingest import validate_otel_schema
+
+    with pytest.raises(ValueError, match="resourceSpans"):
+        validate_otel_schema({})
+
+
+def test_validate_otel_schema_rejects_non_list_resource_spans():
+    from agent_bom.otel_ingest import validate_otel_schema
+
+    with pytest.raises(ValueError, match="array"):
+        validate_otel_schema({"resourceSpans": "not-a-list"})

--- a/tests/test_protection_engine.py
+++ b/tests/test_protection_engine.py
@@ -182,7 +182,7 @@ def test_alerts_dispatched_to_dispatcher():
 def test_process_trace_empty():
     engine = ProtectionEngine()
     engine.start()
-    alerts = _run(engine.process_trace({}))
+    alerts = _run(engine.process_trace({"resourceSpans": []}))
     assert alerts == []
 
 


### PR DESCRIPTION
## Summary
- **DB freshness warning** (`db/schema.py`, `cli/scan.py`, `cli/_db.py`): pre-scan check warns when local vuln DB is absent (→ OSV API fallback notice), aging (>7d, yellow), or stale (>14d, red). `db status` shows color-coded freshness. Never blocks the scan.
- **OTel schema validation** (`otel_ingest.py`): `validate_otel_schema()` rejects bare `{}`, non-dict input, missing `resourceSpans`/`spans`, non-list `resourceSpans`. Prevents silent misparsing of malformed trace files.
- **OTel 50MB file cap** (`mcp_tools/runtime.py`): rejects oversized trace files before reading into memory.
- **OTel framework expansion** (`otel_ingest.py`): `_ML_SPAN_PATTERNS` and `_ML_SCOPE_NAMES` now cover LangGraph, CrewAI, AutoGen, Haystack in addition to existing LangChain/OpenAI/Anthropic.

## Test plan
- [x] `db_freshness_days()` — 4 new tests (no DB, never synced, just synced, 15d old)
- [x] `validate_otel_schema()` — 5 new tests (valid structures, rejects non-dict/empty/non-list)
- [x] `db status --path` freshness display — 3 new tests (fresh, stale, no sync meta)
- [x] 3 existing tests updated: `{}` → `{"resourceSpans": []}` (correct OTLP structure)
- [x] All 5,784 tests pass, coverage 80.01% (--cov-fail-under=80)

Closes #637
Partial #640