### PR TITLE
fix: multi-arch container rescan — add arm64, upload SARIF to Security tab

### DIFF
--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -1,8 +1,12 @@
 name: Container Re-Scan
 
+# Weekly rescan of published multi-arch images for new CVEs.
+# Trivy scans both linux/amd64 and linux/arm64 variants.
+# SARIF uploaded to GitHub Security tab. Never blocks main.
+
 on:
   schedule:
-    - cron: "0 8 * * 3"
+    - cron: "0 8 * * 3"   # Wednesday 08:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -11,20 +15,45 @@ permissions:
 
 jobs:
   rescan:
-    name: Re-scan published containers
-    runs-on: ubuntu-latest
+    name: Rescan — ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       security-events: write
     strategy:
+      fail-fast: false
       matrix:
-        image:
-          - agentbom/agent-bom:latest
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            sarif_category: container-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            sarif_category: container-arm64
     steps:
-      - name: Trivy scan ${{ matrix.image }}
+      - name: Pull ${{ matrix.platform }} image
+        run: docker pull --platform ${{ matrix.platform }} agentbom/agent-bom:latest
+
+      - name: Trivy scan — table (HIGH/CRITICAL)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
-          image-ref: ${{ matrix.image }}
+          image-ref: agentbom/agent-bom:latest
           format: table
           severity: HIGH,CRITICAL
           exit-code: "0"
+
+      - name: Trivy scan — SARIF
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: agentbom/agent-bom:latest
+          format: sarif
+          output: trivy-${{ matrix.sarif_category }}.sarif
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+        with:
+          sarif_file: trivy-${{ matrix.sarif_category }}.sarif
+          category: ${{ matrix.sarif_category }}


### PR DESCRIPTION
## Summary

- Add `linux/arm64` scanning alongside existing `linux/amd64` — uses `ubuntu-24.04-arm` runner
- Run Trivy twice per arch: table (logs) + SARIF (GitHub Security tab)
- Upload SARIF under separate categories (`container-amd64` / `container-arm64`) for distinct tracking
- `fail-fast: false` so one arch failure doesn't cancel the other

## Before / After

| | Before | After |
|---|---|---|
| Architectures scanned | amd64 only | amd64 + arm64 |
| Output format | table (logs only) | table + SARIF to Security tab |
| SARIF categories | none | `container-amd64`, `container-arm64` |

## Why arm64 matters
Multi-arch images can have different CVE surfaces — OS packages compiled for arm64 use different distro binaries. A vuln present only in the arm64 base layer would be missed by amd64-only scanning.

Closes #643 (partial — container scan gap)