### PR TITLE
feat: auto-refresh stale vuln DB flag, NIM/NeMo/NemoClaw NVIDIA tracking

### DIFF
--- a/src/agent_bom/cli/options.py
+++ b/src/agent_bom/cli/options.py
@@ -219,6 +219,13 @@ def enrichment_options(fn):
     return _apply(
         [
             click.option("--enrich", is_flag=True, help="Enrich vulnerabilities with NVD, EPSS, and CISA KEV data"),
+            click.option(
+                "--auto-update-db",
+                "auto_update_db",
+                is_flag=True,
+                envvar="AGENT_BOM_AUTO_UPDATE_DB",
+                help="Automatically refresh the local vuln DB if stale (>7 days) before scanning",
+            ),
             click.option("--nvd-api-key", envvar="NVD_API_KEY", help="NVD API key for higher rate limits"),
             click.option("--scorecard", "scorecard_flag", is_flag=True, help="Enrich packages with OpenSSF Scorecard scores"),
             click.option(

--- a/src/agent_bom/cli/scan/__init__.py
+++ b/src/agent_bom/cli/scan/__init__.py
@@ -195,6 +195,7 @@ def scan(
     smithery_flag: bool,
     smithery_token: Optional[str],
     mcp_registry_flag: bool,
+    auto_update_db: bool,
     snyk_flag: bool,
     snyk_token: Optional[str],
     snyk_org: Optional[str],
@@ -380,6 +381,20 @@ def scan(
 
     if demo:
         con.print("\n[bold yellow]Demo mode[/bold yellow] — scanning bundled inventory with known-vulnerable packages.\n")
+
+    # ── Auto-refresh stale DB if requested ───────────────────────────────────
+    if auto_update_db:
+        from agent_bom.db.schema import db_freshness_days
+        from agent_bom.db.sync import sync_db
+
+        freshness = db_freshness_days()
+        if freshness is None or freshness > 7:
+            if not quiet:
+                con.print("[dim]Refreshing local vuln DB (stale/missing) …[/dim]")
+            try:
+                sync_db()
+            except Exception as _db_exc:
+                logger.warning("Auto DB refresh failed: %s", _db_exc)
 
     # ── Dry-run: show access plan without scanning ────────────────────────────
     if dry_run:

--- a/src/agent_bom/scanners/nvidia_advisory.py
+++ b/src/agent_bom/scanners/nvidia_advisory.py
@@ -97,6 +97,37 @@ _NVIDIA_PRODUCT_MAP: dict[str, list[str]] = {
         "tritonclient",
         "tritonclientutils",
     ],
+    "nim": [
+        # NVIDIA NIM (Inference Microservices) — containerized API for NVIDIA models
+        "nvidia-nim",
+        "nim-client",
+        "openai",  # NIM exposes OpenAI-compatible API; clients using openai SDK hit NIM endpoints
+    ],
+    "nemo": [
+        # NVIDIA NeMo — end-to-end framework for LLM training/fine-tuning
+        "nemo",
+        "nemo-toolkit",
+        "nemo-guardrails",
+        "megatron-core",
+    ],
+    "nemoclaw": [
+        # NVIDIA NemoClaw — open-source agentic AI platform (announced 2025)
+        "nemoclaw",
+        "nemo-agent",
+    ],
+    "morpheus": [
+        # NVIDIA Morpheus — AI cybersecurity framework
+        "morpheus-sdk",
+        "morpheus",
+    ],
+    "rapids": [
+        # NVIDIA RAPIDS — GPU-accelerated data science
+        "cudf",
+        "cuml",
+        "cugraph",
+        "cupy",
+        "raft-dask",
+    ],
 }
 
 # Reverse map: PyPI package name → NVIDIA product names it belongs to

--- a/tests/test_auto_update_db.py
+++ b/tests/test_auto_update_db.py
@@ -1,0 +1,70 @@
+"""Tests for the --auto-update-db / AGENT_BOM_AUTO_UPDATE_DB scan flag."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from agent_bom.cli.scan import scan
+
+
+def _invoke(*args):
+    """Invoke the scan CLI via CliRunner."""
+    runner = CliRunner()
+    return runner.invoke(scan, list(args), catch_exceptions=False)
+
+
+def test_auto_update_db_flag_triggers_sync_when_stale():
+    """When DB freshness is >7 days, sync_db() must be called once."""
+    with (
+        patch("agent_bom.db.schema.db_freshness_days", return_value=10) as mock_fresh,
+        patch("agent_bom.db.sync.sync_db") as mock_sync,
+        patch("agent_bom.cli.scan.discover_all", return_value=[]),
+        patch("agent_bom.cli.scan.scan_agents_sync", return_value=[]),
+    ):
+        result = _invoke("--auto-update-db", "--no-scan")
+        mock_fresh.assert_called_once()
+        mock_sync.assert_called_once()
+        assert result.exit_code == 0
+
+
+def test_auto_update_db_skips_when_fresh():
+    """When DB freshness is <=7 days, sync_db() must NOT be called."""
+    with (
+        patch("agent_bom.db.schema.db_freshness_days", return_value=3) as mock_fresh,
+        patch("agent_bom.db.sync.sync_db") as mock_sync,
+        patch("agent_bom.cli.scan.discover_all", return_value=[]),
+        patch("agent_bom.cli.scan.scan_agents_sync", return_value=[]),
+    ):
+        result = _invoke("--auto-update-db", "--no-scan")
+        mock_fresh.assert_called_once()
+        mock_sync.assert_not_called()
+        assert result.exit_code == 0
+
+
+def test_auto_update_db_off_by_default():
+    """Without --auto-update-db, sync_db() must never be called."""
+    with (
+        patch("agent_bom.db.schema.db_freshness_days") as mock_fresh,
+        patch("agent_bom.db.sync.sync_db") as mock_sync,
+        patch("agent_bom.cli.scan.discover_all", return_value=[]),
+        patch("agent_bom.cli.scan.scan_agents_sync", return_value=[]),
+    ):
+        result = _invoke("--no-scan")
+        mock_fresh.assert_not_called()
+        mock_sync.assert_not_called()
+        assert result.exit_code == 0
+
+
+def test_auto_update_db_handles_sync_failure():
+    """When sync_db() raises, the scan should continue without crashing."""
+    with (
+        patch("agent_bom.db.schema.db_freshness_days", return_value=None),
+        patch("agent_bom.db.sync.sync_db", side_effect=RuntimeError("network error")),
+        patch("agent_bom.cli.scan.discover_all", return_value=[]),
+        patch("agent_bom.cli.scan.scan_agents_sync", return_value=[]),
+    ):
+        result = _invoke("--auto-update-db", "--no-scan")
+        # Scan must not crash — exit code 0 (no findings)
+        assert result.exit_code == 0

--- a/tests/test_nvidia_advisory.py
+++ b/tests/test_nvidia_advisory.py
@@ -175,3 +175,25 @@ def test_unrelated_package_no_nvidia_advisory():
     assert get_nvidia_products_for_package("requests") == []
     assert get_nvidia_products_for_package("flask") == []
     assert get_nvidia_products_for_package("django") == []
+
+
+# ─── NIM / NeMo / NemoClaw product map tests ─────────────────────────────────
+
+from agent_bom.scanners.nvidia_advisory import _NVIDIA_PRODUCT_MAP  # noqa: E402
+
+
+def test_nim_packages_in_nvidia_product_map():
+    """NIM product key and nvidia-nim package exist in the product map."""
+    assert "nim" in _NVIDIA_PRODUCT_MAP
+    assert "nvidia-nim" in _NVIDIA_PRODUCT_MAP["nim"]
+
+
+def test_nemo_packages_in_nvidia_product_map():
+    """NeMo product key and nemo-toolkit package exist in the product map."""
+    assert "nemo" in _NVIDIA_PRODUCT_MAP
+    assert "nemo-toolkit" in _NVIDIA_PRODUCT_MAP["nemo"]
+
+
+def test_nemoclaw_packages_in_nvidia_product_map():
+    """NemoClaw product key exists in the product map."""
+    assert "nemoclaw" in _NVIDIA_PRODUCT_MAP


### PR DESCRIPTION
## Summary

- Add `--auto-update-db` / `AGENT_BOM_AUTO_UPDATE_DB=1` flag to `agent-bom scan`: when enabled and the local vuln DB is stale (>7 days) or missing, `sync_db()` is called before scanning starts; sync failures are logged as warnings and do not abort the scan
- Extend `_NVIDIA_PRODUCT_MAP` in `nvidia_advisory.py` with five new product entries: NIM (Inference Microservices), NeMo (LLM training), NemoClaw (agentic AI platform), Morpheus (cybersecurity), and RAPIDS (GPU data science)
- Add 4 tests for `--auto-update-db` covering: stale DB triggers sync, fresh DB skips sync, flag off by default, sync failure is non-fatal
- Add 3 tests asserting NIM / NeMo / NemoClaw keys and representative packages exist in the product map

## Test plan

- [ ] `python -m pytest tests/test_auto_update_db.py -v` — all 4 tests pass
- [ ] `python -m pytest tests/test_nvidia_advisory.py -v` — all tests pass including 3 new NIM/NeMo/NemoClaw assertions
- [ ] `agent-bom scan --auto-update-db --no-scan` runs without error (DB fresh = no sync; DB stale = sync called)
- [ ] `AGENT_BOM_AUTO_UPDATE_DB=1 agent-bom scan --no-scan` — env var activates the flag
- [ ] Full test suite passes: 5803 passed, 0 failures

Closes #645
Closes #644