### PR TITLE
feat: deterministic UUID v5 stable IDs for assets and findings

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -11,6 +11,25 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
+# Stable namespace for agent-bom deterministic UUIDs
+# Using a fixed UUID so IDs are reproducible across machines and versions
+_AGENT_BOM_NS = uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
+
+
+def _stable_id(*parts: str) -> str:
+    """Compute a deterministic UUID v5 from content parts.
+
+    Same inputs always produce the same UUID. Use this for asset IDs
+    and finding IDs so the same entity is tracked consistently across scans.
+    """
+    fingerprint = ":".join(p.lower().strip() for p in parts if p)
+    return str(uuid.uuid5(_AGENT_BOM_NS, fingerprint))
+
+
+def stable_id(*parts: str) -> str:
+    """Public alias for _stable_id — importable for use across modules."""
+    return _stable_id(*parts)
+
 
 class FindingType(str, Enum):
     """What category of issue this finding represents."""
@@ -52,6 +71,16 @@ class Asset:
     asset_type: str  # "mcp_server" | "package" | "container" | "cloud_resource" | "agent"
     identifier: Optional[str] = None  # purl, ARN, image digest, etc.
     location: Optional[str] = None  # file path, URL, cloud region
+
+    @property
+    def stable_id(self) -> str:
+        """Deterministic UUID derived from asset content.
+
+        Same asset type + identifier always produces the same ID across scans.
+        This enables tracking: first seen, last seen, resolved, re-emerged.
+        """
+        identifier = self.identifier or f"{self.name}:{self.location or ''}"
+        return _stable_id(self.asset_type, identifier)
 
 
 @dataclass
@@ -106,8 +135,29 @@ class Finding:
     # Risk
     risk_score: float = 0.0  # 0-10 unified risk score
 
-    # Unique ID — auto-generated if not provided
-    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # Unique ID — deterministic UUID v5 based on content (computed in __post_init__)
+    # Pass an explicit id= to override (e.g. when ingesting from external scanner)
+    id: str = field(default="")
+
+    def __post_init__(self) -> None:
+        """Compute stable ID from finding content if not explicitly set."""
+        if not self.id:
+            # Deterministic ID: same CVE on same asset always same ID
+            cve_part = self.cve_id or self.title
+            pkg_name = ""
+            pkg_version = ""
+            if self.asset.asset_type == "package" and self.asset.identifier:
+                # purl like "pkg:pypi/torch@2.3.0" — extract name/version
+                purl = self.asset.identifier
+                pkg_part = purl.split("/")[-1] if "/" in purl else purl
+                if "@" in pkg_part:
+                    pkg_name, pkg_version = pkg_part.rsplit("@", 1)
+            self.id = _stable_id(
+                self.asset.stable_id,
+                cve_part,
+                pkg_name,
+                pkg_version,
+            )
 
     def all_compliance_tags(self) -> list[str]:
         """Return deduplicated union of all compliance tag lists."""

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -186,6 +186,20 @@ class Package:
     source_repo: Optional[str] = None
 
     @property
+    def stable_id(self) -> str:
+        """Deterministic ID for this package instance.
+
+        Same ecosystem/name/version (or purl when available) always produces
+        the same ID across scans — enables first-seen/last-seen tracking.
+        """
+        import uuid as _uuid
+
+        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
+        purl = self.purl or f"pkg:{self.ecosystem}/{self.name}@{self.version}"
+        fingerprint = f"package:{purl.lower().strip()}"
+        return str(_uuid.uuid5(_ns, fingerprint))
+
+    @property
     def has_vulnerabilities(self) -> bool:
         return len(self.vulnerabilities) > 0
 
@@ -272,6 +286,20 @@ class MCPServer:
     security_warnings: list[str] = field(default_factory=list)  # Security issues found during discovery
 
     @property
+    def stable_id(self) -> str:
+        """Deterministic ID for this MCP server.
+
+        Uses registry_id when available (most stable identifier), otherwise
+        falls back to name+command so the same server is always the same ID.
+        """
+        import uuid as _uuid
+
+        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
+        identifier = self.registry_id or f"{self.name}:{self.command}"
+        fingerprint = f"mcp_server:{identifier.lower().strip()}"
+        return str(_uuid.uuid5(_ns, fingerprint))
+
+    @property
     def vulnerable_packages(self) -> list[Package]:
         return [p for p in self.packages if p.has_vulnerabilities]
 
@@ -307,6 +335,19 @@ class Agent:
     status: AgentStatus = AgentStatus.CONFIGURED
     parent_agent: Optional[str] = None  # Parent agent name (for spawn tree / delegation)
     metadata: dict = field(default_factory=dict)  # Extra config data (permissions, hooks, etc.)
+
+    @property
+    def stable_id(self) -> str:
+        """Deterministic ID for this agent.
+
+        Canonical identity: agent_type + name. Same agent configuration
+        always resolves to the same ID across scans.
+        """
+        import uuid as _uuid
+
+        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
+        fingerprint = f"agent:{self.agent_type.value}:{self.name.lower().strip()}"
+        return str(_uuid.uuid5(_ns, fingerprint))
 
     @property
     def total_packages(self) -> int:

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -142,7 +142,8 @@ def test_finding_auto_id():
     assert len(finding.id) == 36  # UUID4 format
 
 
-def test_finding_two_instances_have_different_ids():
+def test_finding_same_content_produces_same_id():
+    """IDs are now deterministic — same content always yields same ID."""
     f1 = Finding(
         finding_type=FindingType.CVE,
         source=FindingSource.MCP_SCAN,
@@ -153,6 +154,23 @@ def test_finding_two_instances_have_different_ids():
         finding_type=FindingType.CVE,
         source=FindingSource.MCP_SCAN,
         asset=Asset(name="pkg", asset_type="package"),
+        severity="HIGH",
+    )
+    assert f1.id == f2.id
+
+
+def test_finding_different_assets_produce_different_ids():
+    """Different assets → different Finding IDs even with same CVE."""
+    f1 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="pkg-a", asset_type="package"),
+        severity="HIGH",
+    )
+    f2 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="pkg-b", asset_type="package"),
         severity="HIGH",
     )
     assert f1.id != f2.id

--- a/tests/test_stable_ids.py
+++ b/tests/test_stable_ids.py
@@ -1,0 +1,187 @@
+"""Tests for deterministic UUID v5 stable IDs on assets and findings (issue: stable IDs)."""
+
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType, stable_id
+from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+
+# ---------------------------------------------------------------------------
+# Finding determinism
+# ---------------------------------------------------------------------------
+
+
+def test_finding_id_is_deterministic():
+    """Same asset + same CVE → same Finding.id on two different instantiations."""
+    asset = Asset(
+        name="requests",
+        asset_type="package",
+        identifier="pkg:pypi/requests@2.0.0",
+    )
+    f1 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=asset,
+        severity="HIGH",
+        cve_id="CVE-2024-1234",
+    )
+    f2 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(
+            name="requests",
+            asset_type="package",
+            identifier="pkg:pypi/requests@2.0.0",
+        ),
+        severity="HIGH",
+        cve_id="CVE-2024-1234",
+    )
+    assert f1.id == f2.id
+    assert len(f1.id) == 36  # valid UUID format
+
+
+def test_finding_id_differs_for_different_cve():
+    """Same asset, different CVE → different Finding.id."""
+    asset = Asset(
+        name="torch",
+        asset_type="package",
+        identifier="pkg:pypi/torch@2.3.0",
+    )
+    f1 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=asset,
+        severity="HIGH",
+        cve_id="CVE-2024-0001",
+    )
+    f2 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(
+            name="torch",
+            asset_type="package",
+            identifier="pkg:pypi/torch@2.3.0",
+        ),
+        severity="HIGH",
+        cve_id="CVE-2024-0002",
+    )
+    assert f1.id != f2.id
+
+
+def test_finding_id_differs_for_different_asset():
+    """Same CVE, different asset → different Finding.id."""
+    f1 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="requests", asset_type="package", identifier="pkg:pypi/requests@2.0.0"),
+        severity="HIGH",
+        cve_id="CVE-2024-9999",
+    )
+    f2 = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="flask", asset_type="package", identifier="pkg:pypi/flask@3.0.0"),
+        severity="HIGH",
+        cve_id="CVE-2024-9999",
+    )
+    assert f1.id != f2.id
+
+
+# ---------------------------------------------------------------------------
+# Asset stable_id
+# ---------------------------------------------------------------------------
+
+
+def test_asset_stable_id_is_deterministic():
+    """Same asset_type + identifier → same stable_id."""
+    a1 = Asset(name="requests", asset_type="package", identifier="pkg:pypi/requests@2.0.0")
+    a2 = Asset(name="requests", asset_type="package", identifier="pkg:pypi/requests@2.0.0")
+    assert a1.stable_id == a2.stable_id
+    assert len(a1.stable_id) == 36
+
+
+def test_asset_stable_id_differs_by_type():
+    """'package' vs 'mcp_server' with same name → different stable_ids."""
+    a1 = Asset(name="my-tool", asset_type="package", identifier="pkg:pypi/my-tool@1.0.0")
+    a2 = Asset(name="my-tool", asset_type="mcp_server", identifier="pkg:pypi/my-tool@1.0.0")
+    assert a1.stable_id != a2.stable_id
+
+
+# ---------------------------------------------------------------------------
+# Package stable_id
+# ---------------------------------------------------------------------------
+
+
+def test_package_stable_id_deterministic():
+    """Same ecosystem/name/version → same stable_id."""
+    p1 = Package(name="numpy", version="1.26.0", ecosystem="pypi")
+    p2 = Package(name="numpy", version="1.26.0", ecosystem="pypi")
+    assert p1.stable_id == p2.stable_id
+    assert len(p1.stable_id) == 36
+
+
+def test_package_stable_id_uses_purl_when_available():
+    """purl takes precedence over ecosystem/name/version for the stable_id."""
+    explicit_purl = "pkg:pypi/numpy@1.26.0"
+    p_with_purl = Package(name="numpy", version="1.26.0", ecosystem="pypi", purl=explicit_purl)
+    p_without_purl = Package(name="numpy", version="1.26.0", ecosystem="pypi")
+    # Both should resolve to the same ID since purl == synthesized purl
+    assert p_with_purl.stable_id == p_without_purl.stable_id
+
+    # But an explicitly different purl should produce a different ID
+    p_different_purl = Package(name="numpy", version="1.26.0", ecosystem="pypi", purl="pkg:conda/numpy@1.26.0")
+    assert p_different_purl.stable_id != p_without_purl.stable_id
+
+
+# ---------------------------------------------------------------------------
+# MCPServer stable_id
+# ---------------------------------------------------------------------------
+
+
+def test_mcpserver_stable_id_deterministic():
+    """Same name+command → same stable_id for MCPServer."""
+    s1 = MCPServer(name="filesystem", command="npx @modelcontextprotocol/server-filesystem", transport=TransportType.STDIO)
+    s2 = MCPServer(name="filesystem", command="npx @modelcontextprotocol/server-filesystem", transport=TransportType.STDIO)
+    assert s1.stable_id == s2.stable_id
+    assert len(s1.stable_id) == 36
+
+
+def test_mcpserver_stable_id_uses_registry_id_when_available():
+    """registry_id takes precedence over name+command."""
+    s_with_registry = MCPServer(
+        name="filesystem",
+        command="npx @modelcontextprotocol/server-filesystem",
+        transport=TransportType.STDIO,
+        registry_id="modelcontextprotocol/filesystem",
+    )
+    s_without_registry = MCPServer(
+        name="filesystem",
+        command="npx @modelcontextprotocol/server-filesystem",
+        transport=TransportType.STDIO,
+    )
+    # registry_id is different from name:command fallback → different IDs
+    assert s_with_registry.stable_id != s_without_registry.stable_id
+
+
+# ---------------------------------------------------------------------------
+# Agent stable_id
+# ---------------------------------------------------------------------------
+
+
+def test_agent_stable_id_deterministic():
+    """Same agent_type+name → same stable_id."""
+    a1 = Agent(name="Claude Desktop", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/path/a")
+    a2 = Agent(name="Claude Desktop", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/path/b")
+    assert a1.stable_id == a2.stable_id
+    assert len(a1.stable_id) == 36
+
+
+# ---------------------------------------------------------------------------
+# Public stable_id function
+# ---------------------------------------------------------------------------
+
+
+def test_stable_id_function_exported():
+    """from agent_bom.finding import stable_id must be callable."""
+    assert callable(stable_id)
+    result = stable_id("asset_type", "my-identifier")
+    assert len(result) == 36
+    # Deterministic
+    assert result == stable_id("asset_type", "my-identifier")


### PR DESCRIPTION
## Summary
- Replace random uuid4 Finding.id with deterministic uuid5 based on asset + CVE content
- Add stable_id property to Asset, Package, MCPServer, Agent — same entity always same ID
- Enable Wiz-style tracking: first-seen/last-seen, suppression, regression detection across scans
- Fully backward compatible — existing code that passes explicit id= continues to work

## How it works
- `_AGENT_BOM_NS` = fixed UUID namespace (deterministic across machines/versions)
- `Asset.stable_id`: uuid5(NS, f"{asset_type}:{identifier}")
- `Finding.id`: uuid5(NS, f"{asset_stable_id}:{cve_id}:{pkg}:{version}") via `__post_init__`
- Same CVE on same package in same asset → identical ID every scan

## Test plan
- [x] Same finding content → same ID (determinism tests)
- [x] Different CVE on same asset → different ID
- [x] Same CVE on different asset → different ID
- [x] Asset.stable_id deterministic and type-discriminated
- [x] Package.stable_id deterministic, prefers purl when set
- [x] MCPServer.stable_id deterministic, prefers registry_id when set
- [x] Agent.stable_id deterministic by type+name
- [x] public stable_id() function exported from finding.py
- [x] No regressions — 5833 passed, 15 skipped