### PR TITLE
fix: documentation accuracy — detector count, architecture client and tool counts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Module dependency map and data flow guide for contributors.
 Discovery ──> Scanning ──> Enrichment ──> Blast Radius ──> Compliance ──> Output
     │              │            │              │                │            │
     ▼              ▼            ▼              ▼                ▼            ▼
- 21 MCP         OSV API      NVD/EPSS      Risk scoring     11 frameworks  JSON/SARIF/
+ 22 MCP         OSV API      NVD/EPSS      Risk scoring     11 frameworks  JSON/SARIF/
  clients        batch        KEV/GHSA      per CVE with     mapped per     CycloneDX/
  parsed         query        enrichment    agent/cred/tool  finding        SPDX/SVG
                                            reachability
@@ -19,7 +19,7 @@ Discovery ──> Scanning ──> Enrichment ──> Blast Radius ──> Compl
 | Entry point | File | Purpose |
 |---|---|---|
 | CLI | `cli.py` | Click-based CLI with 22+ commands and groups |
-| MCP Server | `mcp_server.py` | FastMCP server with 30 tools |
+| MCP Server | `mcp_server.py` | FastMCP server with 31 tools |
 | Proxy | `proxy.py` | MCP JSON-RPC proxy with runtime enforcement |
 | API | `api/server.py` | FastAPI REST server with job queue |
 
@@ -30,7 +30,7 @@ Discovery ──> Scanning ──> Enrichment ──> Blast Radius ──> Compl
 ```
 src/agent_bom/
 ├── discovery/           # MCP client/server discovery
-│   └── __init__.py      # CONFIG_LOCATIONS for 21 agent types, JSON/TOML/YAML parsers;
+│   └── __init__.py      # CONFIG_LOCATIONS for 22 agent types, JSON/TOML/YAML parsers;
 │                        #   discover_running_processes() (psutil), discover_container_labels()
 │                        #   (docker inspect), discover_k8s_mcp_servers() (kubectl pods + CRDs)
 ├── scanners/            # Vulnerability scanning

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ That's it. agent-bom discovers your MCP client configs (Claude Desktop, Cursor, 
 > **Traditional scanners tell you a package has a CVE.**
 > **agent-bom tells you which AI agents are compromised, which credentials leak, which tools an attacker reaches — and then blocks it in real time.**
 
-Three capabilities, one tool: **scanner** (CVEs, blast radius, compliance, supply chain) + **proxy** (intercepts MCP traffic, enforces policy, detects 7 behavioral attack patterns) + **instruction file trust** (audits CLAUDE.md, .cursorrules, AGENTS.md, SKILL.md for malicious patterns, typosquatting, and Sigstore provenance). Read-only. Agentless. Open source.
+Three capabilities, one tool: **scanner** (CVEs, blast radius, compliance, supply chain) + **proxy** (intercepts MCP traffic, enforces policy, detects 6 behavioral attack patterns) + **instruction file trust** (audits CLAUDE.md, .cursorrules, AGENTS.md, SKILL.md for malicious patterns, typosquatting, and Sigstore provenance). Read-only. Agentless. Open source.
 
 ```
 CVE-2025-1234  (CRITICAL . CVSS 9.8 . CISA KEV)
@@ -317,7 +317,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | MCP Server | `agent-bom mcp-server` (31 tools) | Inside any MCP client |
 | Dashboard | `agent-bom serve` · [Full deploy guide](docs/DEPLOYMENT.md) | API + Next.js UI (15 pages) · Postgres/Supabase |
 | Runtime proxy | `agent-bom proxy` | Intercept + enforce MCP traffic in real time |
-| Protect engine | `agent-bom protect` | 7 behavioral detectors (rug pull, injection, exfil, credential leak) |
+| Protect engine | `agent-bom protect` | 6 behavioral detectors (rug pull, injection, exfil, credential leak, response cloaking, vector DB injection) |
 | Config watcher | `agent-bom watch` | Filesystem watch on MCP configs, alert on drift |
 | Pre-install guard | `agent-bom guard pip install <pkg>` | Block vulnerable installs |
 | Snowflake | [DEPLOYMENT.md](DEPLOYMENT.md) | Snowpark + SiS |
@@ -536,7 +536,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 
 **Agents / MCP**
 - [x] 22 MCP client config discovery paths, live introspection, tool drift detection
-- [x] Runtime proxy with 7 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, vector DB injection, semantic injection scoring)
+- [x] Runtime proxy with 6 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, vector DB injection) + semantic injection scoring
 - [x] Semantic injection scoring — weighted 10-signal model, 0.0–1.0 risk score, MEDIUM/HIGH alerts
 - [ ] Agent memory / vector store content scanning for injected instructions
 - [ ] LLM API call tracing (which model was called, with what context)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ High-level view of input sources, the core processing engine, and output channel
 ```mermaid
 graph TB
     subgraph Input["Input Sources"]
-        MCP["MCP Configs\n21 Clients"]
+        MCP["MCP Configs\n22 Clients"]
         Docker["Docker Images"]
         K8s["Kubernetes"]
         Cloud["Cloud APIs\nAWS / Azure / GCP / Snowflake"]
@@ -288,7 +288,7 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine |
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (30 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (31 tools) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |


### PR DESCRIPTION
## Summary
- Fix ARCHITECTURE.md (root): 21 MCP clients → 22 MCP clients; 30 tools → 31 tools
- Fix docs/ARCHITECTURE.md: 21 Clients → 22 Clients in Mermaid diagram; 30 tools → 31 tools
- Fix README.md: behavioral detector count corrected from 7 → 6 to match actual implemented detector classes in `runtime/detectors.py` (ToolDriftDetector, ArgumentAnalyzer, CredentialLeakDetector, SequenceAnalyzer, ResponseInspector, VectorDBInjectionDetector — RateLimitTracker is a utility class, not a detector)

## Test plan
- [x] `test_stats_alignment.py` — all 19 tests pass
- [x] Full test suite — 5855 passed, 15 skipped, 0 failures