### PR TITLE
feat: go.sum integrity verification + GOPROXY version resolution

### DIFF
--- a/src/agent_bom/parsers/compiled_parsers.py
+++ b/src/agent_bom/parsers/compiled_parsers.py
@@ -8,11 +8,217 @@ from __future__ import annotations
 
 import logging
 import re
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
+from typing import Optional
 
 from agent_bom.models import MCPServer, Package
 
 logger = logging.getLogger(__name__)
+
+_GOPROXY_URL = "https://proxy.golang.org"
+_CHECKSUM_DB_URL = "https://sum.golang.org"
+
+# Versions that need resolution via the Go module proxy
+_UNRESOLVED_VERSIONS = frozenset({"latest", "(devel)", "", "unknown"})
+
+
+def _validate_https_url(url: str, param_name: str = "url") -> None:
+    """Raise ValueError if *url* does not use HTTPS.
+
+    All Go public API calls must use HTTPS — no plain-HTTP allowed.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(f"{param_name} must use https:// — got {url!r}. Only HTTPS URLs are accepted.")
+
+
+def verify_go_checksums(
+    go_sum: Path,
+    modules: list[tuple[str, str]],
+    checksum_db_url: str = _CHECKSUM_DB_URL,
+    timeout: int = 10,
+) -> dict[str, str]:
+    """Verify go.sum hashes against the Go checksum database.
+
+    For each module, fetches the expected hash from sum.golang.org and
+    compares against go.sum.  Returns a dict of ``{module@version: status}``
+    where status is one of:
+
+    - ``"ok"``       — hash in go.sum matches the checksum database
+    - ``"mismatch"`` — hash differs; the module may have been tampered with
+      after being published (supply chain attack or corrupted download)
+    - ``"missing"``  — module is not recorded in go.sum at all
+
+    Uses the public Go checksum database (https://sum.golang.org) — no
+    credentials are required.  Rate-limit friendly: only direct dependencies
+    are checked, not every entry in go.sum.
+
+    Security note:
+        A ``"mismatch"`` status means the module content on disk differs from
+        what the checksum database recorded at publish time.  This is a strong
+        signal of either a supply chain compromise or a corrupted download and
+        should be treated as a critical finding.
+
+    Args:
+        go_sum: Path to the ``go.sum`` file.
+        modules: List of ``(module_path, version)`` tuples to verify.
+            Versions must include the ``v`` prefix (e.g. ``"v1.2.3"``).
+        checksum_db_url: Base URL of the Go checksum database.
+            Must be HTTPS.  Defaults to ``https://sum.golang.org``.
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Dict mapping ``"module@version"`` to ``"ok"``, ``"mismatch"``, or
+        ``"missing"``.  Entries where the network request failed are omitted
+        rather than surfaced as errors — a warning is logged instead.
+    """
+    _validate_https_url(checksum_db_url, "checksum_db_url")
+
+    # Build lookup table from go.sum: {module@version: h1:hash}
+    # Skip /go.mod suffix lines — we verify the module zip hash only.
+    sum_entries: dict[str, str] = {}
+    if go_sum.exists():
+        try:
+            for line in go_sum.read_text(encoding="utf-8", errors="replace").splitlines():
+                parts = line.strip().split()
+                if len(parts) < 3:
+                    continue
+                mod, ver_raw, h1 = parts[0], parts[1], parts[2]
+                if ver_raw.endswith("/go.mod"):
+                    continue  # skip go.mod hash lines
+                ver = ver_raw.split("/")[0]
+                sum_entries[f"{mod}@{ver}"] = h1
+        except OSError as exc:
+            logger.warning("Could not read go.sum at %s: %s", go_sum, exc)
+            return {}
+
+    results: dict[str, str] = {}
+    for mod, ver in modules:
+        # Ensure version has the v prefix for the lookup key
+        ver_key = ver if ver.startswith("v") else f"v{ver}"
+        key = f"{mod}@{ver_key}"
+
+        if key not in sum_entries:
+            results[key] = "missing"
+            continue
+
+        local_hash = sum_entries[key]
+
+        # Fetch expected hash from the checksum database
+        lookup_url = f"{checksum_db_url}/lookup/{mod}@{ver_key}"
+        try:
+            req = urllib.request.Request(lookup_url)  # noqa: S310  # nosec B310 — HTTPS enforced above
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310  # nosec B310
+                body = resp.read().decode("utf-8", errors="replace")
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            logger.warning(
+                "go.sum verification skipped for %s — checksum DB unreachable: %s",
+                key,
+                exc,
+            )
+            continue
+
+        # The lookup response format (tile protocol):
+        # Line 0: tree size
+        # Line 1: hash (h1:BASE64=)
+        # Line 2+: signed tree head
+        db_hash: Optional[str] = None
+        for line in body.splitlines():
+            line = line.strip()
+            if line.startswith("h1:"):
+                db_hash = line
+                break
+
+        if db_hash is None:
+            logger.warning("Unexpected checksum DB response format for %s", key)
+            continue
+
+        results[key] = "ok" if local_hash == db_hash else "mismatch"
+
+    return results
+
+
+def resolve_go_version(
+    module: str,
+    version: str,
+    proxy_url: str = _GOPROXY_URL,
+    timeout: int = 5,
+) -> str:
+    """Resolve a Go module version using the Go module proxy.
+
+    Queries ``https://proxy.golang.org/{module}/@v/list`` for the available
+    version list and returns the latest stable release (no pre-release
+    suffixes such as ``-rc``, ``-alpha``, ``-beta``, or ``-pre``).
+
+    If *version* is already pinned (not ``"latest"``, ``"(devel)"``,
+    ``""`` or ``"unknown"``), it is returned immediately without any
+    network call.
+
+    Never raises — any network error causes the original version string to
+    be returned so that parsing can continue uninterrupted.
+
+    Args:
+        module: The Go module path (e.g. ``"github.com/gin-gonic/gin"``).
+        version: Current version string.  Pass ``"latest"`` or ``""`` to
+            trigger resolution.
+        proxy_url: Base URL of the Go module proxy.  Must be HTTPS.
+            Defaults to ``https://proxy.golang.org``.
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Resolved version string (e.g. ``"v1.9.1"``), or *version* unchanged
+        if resolution fails or was not needed.
+    """
+    if version not in _UNRESOLVED_VERSIONS:
+        return version
+
+    _validate_https_url(proxy_url, "proxy_url")
+
+    encoded_module = urllib.parse.quote(module, safe="")
+    list_url = f"{proxy_url}/{encoded_module}/@v/list"
+
+    try:
+        req = urllib.request.Request(list_url)  # noqa: S310  # nosec B310 — HTTPS enforced above
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310  # nosec B310
+            body = resp.read().decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001 — never raise; return original version on any failure
+        logger.warning(
+            "GOPROXY version resolution failed for %s — returning original version: %s",
+            module,
+            exc,
+        )
+        return version
+
+    _prerelease_re = re.compile(r"-(rc|alpha|beta|pre)[\d.]*$", re.IGNORECASE)
+
+    stable_versions: list[str] = []
+    for raw in body.splitlines():
+        v = raw.strip()
+        if not v:
+            continue
+        if _prerelease_re.search(v):
+            continue
+        stable_versions.append(v)
+
+    if not stable_versions:
+        return version
+
+    def _semver_key(v: str) -> tuple[int, ...]:
+        """Return a numeric tuple for semver comparison."""
+        # Strip leading 'v' and any build metadata
+        cleaned = v.lstrip("v").split("+")[0]
+        parts = cleaned.split(".")
+        result = []
+        for part in parts:
+            # Strip any non-numeric suffix (e.g. "1" from "1rc1")
+            numeric = re.match(r"(\d+)", part)
+            result.append(int(numeric.group(1)) if numeric else 0)
+        return tuple(result)
+
+    stable_versions.sort(key=_semver_key)
+    return stable_versions[-1]
 
 
 def _parse_go_mod_requires(
@@ -130,7 +336,12 @@ def parse_go_workspace(directory: Path) -> list[Package]:
     return list(merged.values())
 
 
-def parse_go_packages(directory: Path) -> list[Package]:
+def parse_go_packages(
+    directory: Path,
+    *,
+    verify_checksums: bool = True,
+    resolve_versions: bool = False,
+) -> list[Package]:
     """Parse packages from go.mod and go.sum.
 
     If a ``go.work`` workspace file is present in *directory*, delegates to
@@ -139,6 +350,19 @@ def parse_go_packages(directory: Path) -> list[Package]:
     Otherwise reads go.mod to correctly distinguish direct from indirect
     (transitive) dependencies and to apply ``replace`` directives.  Falls back
     to go.sum only when go.mod is absent, marking all packages as direct.
+
+    Args:
+        directory: Project root containing ``go.mod`` / ``go.sum``.
+        verify_checksums: When ``True`` (default), compares go.sum hashes
+            against the Go checksum database (``sum.golang.org``).  Any
+            module whose hash does not match is flagged with
+            ``is_malicious=True`` and an explanatory ``malicious_reason``.
+            Requires outbound HTTPS access to ``sum.golang.org``.
+        resolve_versions: When ``True``, unpinned versions (``"latest"``,
+            ``"(devel)"``, ``""`` or ``"unknown"``) are resolved via the Go
+            module proxy (``proxy.golang.org``).  Defaults to ``False`` to
+            avoid network calls in pure parse mode — opt-in explicitly when
+            version accuracy is required.
     """
     # Workspace mode takes priority
     go_work = directory / "go.work"
@@ -166,16 +390,44 @@ def parse_go_packages(directory: Path) -> list[Package]:
     if all_mods:
         packages = []
         for mod, (ver, is_direct) in all_mods.items():
+            # Optionally resolve unpinned versions via GOPROXY
+            if resolve_versions and ver in _UNRESOLVED_VERSIONS:
+                resolved = resolve_go_version(mod, ver)
+                if resolved != ver:
+                    ver = resolved
+                    logger.debug("Resolved %s → %s via GOPROXY", mod, ver)
+
             clean_ver = ver[1:] if ver.startswith("v") else ver
-            packages.append(
-                Package(
-                    name=mod,
-                    version=clean_ver,
-                    ecosystem="go",
-                    purl=f"pkg:golang/{mod}@{ver}",
-                    is_direct=is_direct,
-                )
+            pkg = Package(
+                name=mod,
+                version=clean_ver,
+                ecosystem="go",
+                purl=f"pkg:golang/{mod}@{ver}",
+                is_direct=is_direct,
             )
+            if resolve_versions and pkg.version_source == "detected":
+                # Mark the source so callers can distinguish
+                pass  # version_source stays "detected"; proxy resolution is transparent
+            packages.append(pkg)
+
+        # Verify go.sum hashes for all direct modules
+        if verify_checksums and go_sum.exists():
+            modules_to_check = [(pkg.name, f"v{pkg.version}" if not pkg.version.startswith("v") else pkg.version) for pkg in packages]
+            checksum_results = verify_go_checksums(go_sum, modules_to_check)
+            pkg_by_key: dict[str, Package] = {}
+            for pkg in packages:
+                ver_key = f"v{pkg.version}" if not pkg.version.startswith("v") else pkg.version
+                pkg_by_key[f"{pkg.name}@{ver_key}"] = pkg
+            for key, status in checksum_results.items():
+                if status == "mismatch" and key in pkg_by_key:
+                    p = pkg_by_key[key]
+                    p.is_malicious = True
+                    p.malicious_reason = "go.sum hash mismatch: tampered module — hash on disk differs from sum.golang.org record"
+                    logger.warning(
+                        "go.sum hash mismatch for %s — possible supply chain tampering",
+                        key,
+                    )
+
         return packages
 
     # Fallback: go.sum only — all marked direct
@@ -192,9 +444,9 @@ def parse_go_packages(directory: Path) -> list[Package]:
                 name = parts[0]
                 raw_ver = parts[1].split("/")[0]  # strip /go.mod suffix
                 clean_ver = raw_ver[1:] if raw_ver.startswith("v") else raw_ver
-                key = (name, clean_ver)
-                if key not in seen:
-                    seen.add(key)
+                mod_key = (name, clean_ver)
+                if mod_key not in seen:
+                    seen.add(mod_key)
                     packages.append(
                         Package(
                             name=name,

--- a/tests/test_go_integrity.py
+++ b/tests/test_go_integrity.py
@@ -1,0 +1,374 @@
+"""Tests for Go module integrity verification and GOPROXY version resolution.
+
+Covers:
+- verify_go_checksums: ok / mismatch / missing / network failure / HTTPS enforcement
+- resolve_go_version: latest → pinned, pre-release filtering, already-pinned passthrough,
+  network failure handling
+- parse_go_packages integration: mismatch marks package as malicious,
+  resolve_versions updates version via proxy
+"""
+
+from __future__ import annotations
+
+import textwrap
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_bom.parsers.compiled_parsers import (
+    parse_go_packages,
+    resolve_go_version,
+    verify_go_checksums,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+GO_MOD_BASIC = textwrap.dedent("""\
+    module example.com/myapp
+
+    go 1.21
+
+    require (
+        github.com/gin-gonic/gin v1.9.1
+        github.com/stretchr/testify v1.8.4 // indirect
+    )
+""")
+
+# go.sum with real-looking (but synthetic) hashes
+GO_SUM_CONTENT = textwrap.dedent("""\
+    github.com/gin-gonic/gin v1.9.1 h1:AABBCCDD==
+    github.com/gin-gonic/gin v1.9.1/go.mod h1:ZZYYXXWW==
+    github.com/stretchr/testify v1.8.4 h1:EEFFGGHH==
+    github.com/stretchr/testify v1.8.4/go.mod h1:IIJJKKLL==
+""")
+
+# Checksum DB response format (tile protocol):
+#   line 0 — tree size
+#   line 1 — hash matching go.sum
+#   line 2+ — signed tree head (ignored here)
+_DB_RESPONSE_OK = "3\nh1:AABBCCDD==\n\nsome signed tree head\n"
+_DB_RESPONSE_MISMATCH = "3\nh1:TAMPERED==\n\nsome signed tree head\n"
+
+# GOPROXY list response (newline-separated versions)
+_PROXY_LIST_STABLE = "v1.2.3\nv1.3.0\nv2.0.0\n"
+_PROXY_LIST_WITH_PRERELEASE = "v1.2.3\nv1.3.0-rc1\nv1.3.0-alpha\nv1.4.0-beta.2\nv1.2.4\n"
+_PROXY_LIST_EMPTY = ""
+
+
+def _make_urlopen_response(body: str):
+    """Return a mock context-manager response for urllib.request.urlopen."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body.encode("utf-8")
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+# ===========================================================================
+# verify_go_checksums — unit tests
+# ===========================================================================
+
+
+class TestVerifyGoChecksumsOk:
+    """Hash in go.sum matches the checksum database → status 'ok'."""
+
+    def test_returns_ok_for_matching_hash(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(_DB_RESPONSE_OK)):
+            result = verify_go_checksums(go_sum, modules)
+
+        assert result["github.com/gin-gonic/gin@v1.9.1"] == "ok"
+
+    def test_ok_result_does_not_set_malicious(self, tmp_path):
+        """A passing verification must not affect any Package object."""
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(_DB_RESPONSE_OK)):
+            result = verify_go_checksums(go_sum, modules)
+
+        # Just status; callers decide what to do with it
+        assert result["github.com/gin-gonic/gin@v1.9.1"] == "ok"
+
+
+class TestVerifyGoChecksumsMismatch:
+    """Hash in go.sum differs from checksum database → status 'mismatch'."""
+
+    def test_returns_mismatch_for_differing_hash(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_DB_RESPONSE_MISMATCH),
+        ):
+            result = verify_go_checksums(go_sum, modules)
+
+        assert result["github.com/gin-gonic/gin@v1.9.1"] == "mismatch"
+
+    def test_parse_go_packages_mismatch_marks_is_malicious(self, tmp_path):
+        """End-to-end: go.sum mismatch propagates to Package.is_malicious=True."""
+        (tmp_path / "go.mod").write_text(GO_MOD_BASIC)
+        (tmp_path / "go.sum").write_text(GO_SUM_CONTENT)
+
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_DB_RESPONSE_MISMATCH),
+        ):
+            pkgs = parse_go_packages(tmp_path, verify_checksums=True)
+
+        gin_pkg = next(p for p in pkgs if p.name == "github.com/gin-gonic/gin")
+        assert gin_pkg.is_malicious is True
+        assert "mismatch" in gin_pkg.malicious_reason.lower()
+
+    def test_parse_go_packages_mismatch_reason_mentions_tamper(self, tmp_path):
+        (tmp_path / "go.mod").write_text(GO_MOD_BASIC)
+        (tmp_path / "go.sum").write_text(GO_SUM_CONTENT)
+
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_DB_RESPONSE_MISMATCH),
+        ):
+            pkgs = parse_go_packages(tmp_path, verify_checksums=True)
+
+        gin_pkg = next(p for p in pkgs if p.name == "github.com/gin-gonic/gin")
+        assert "tampered" in gin_pkg.malicious_reason.lower()
+
+
+class TestVerifyGoChecksumsMissing:
+    """Module not present in go.sum → status 'missing'."""
+
+    def test_returns_missing_when_not_in_go_sum(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        # go.sum only has testify, not gin
+        go_sum.write_text("github.com/stretchr/testify v1.8.4 h1:EEFFGGHH==\ngithub.com/stretchr/testify v1.8.4/go.mod h1:IIJJKKLL==\n")
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        # No network call expected since the module is missing from go.sum
+        result = verify_go_checksums(go_sum, modules)
+
+        assert result["github.com/gin-gonic/gin@v1.9.1"] == "missing"
+
+    def test_missing_does_not_set_malicious(self, tmp_path):
+        """Missing entry is not the same as tampered — is_malicious stays False."""
+        (tmp_path / "go.mod").write_text(GO_MOD_BASIC)
+        # Provide a go.sum without gin
+        (tmp_path / "go.sum").write_text(
+            "github.com/stretchr/testify v1.8.4 h1:EEFFGGHH==\ngithub.com/stretchr/testify v1.8.4/go.mod h1:IIJJKKLL==\n"
+        )
+
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(_DB_RESPONSE_OK)):
+            pkgs = parse_go_packages(tmp_path, verify_checksums=True)
+
+        gin_pkg = next((p for p in pkgs if p.name == "github.com/gin-gonic/gin"), None)
+        assert gin_pkg is not None
+        assert gin_pkg.is_malicious is False
+
+
+class TestVerifyGoChecksumsNetworkFailure:
+    """Network failure during verification must be handled gracefully."""
+
+    def test_network_failure_returns_empty_not_crash(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            # Must not raise
+            result = verify_go_checksums(go_sum, modules)
+
+        # Entry omitted (not surfaced as error), no crash
+        assert "github.com/gin-gonic/gin@v1.9.1" not in result
+
+    def test_oserror_returns_gracefully(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            result = verify_go_checksums(go_sum, modules)
+
+        assert "github.com/gin-gonic/gin@v1.9.1" not in result
+
+
+class TestVerifyChecksumsHttpsOnly:
+    """Non-HTTPS checksum DB URLs must be rejected."""
+
+    def test_http_url_raises_value_error(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        with pytest.raises(ValueError, match="https://"):
+            verify_go_checksums(go_sum, modules, checksum_db_url="http://sum.golang.org")
+
+    def test_file_url_raises_value_error(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+
+        with pytest.raises(ValueError, match="https://"):
+            verify_go_checksums(go_sum, modules, checksum_db_url="file:///tmp/fake")
+
+
+# ===========================================================================
+# resolve_go_version — unit tests
+# ===========================================================================
+
+
+class TestResolveGoVersionLatest:
+    """'latest' version should be resolved to the highest stable release."""
+
+    def test_resolves_latest_to_highest_stable(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_PROXY_LIST_STABLE),
+        ):
+            result = resolve_go_version("github.com/gin-gonic/gin", "latest")
+
+        assert result == "v2.0.0"
+
+    def test_resolves_empty_string_version(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_PROXY_LIST_STABLE),
+        ):
+            result = resolve_go_version("github.com/gin-gonic/gin", "")
+
+        assert result == "v2.0.0"
+
+    def test_resolves_devel_version(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_PROXY_LIST_STABLE),
+        ):
+            result = resolve_go_version("github.com/gin-gonic/gin", "(devel)")
+
+        assert result == "v2.0.0"
+
+    def test_resolves_unknown_version(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_PROXY_LIST_STABLE),
+        ):
+            result = resolve_go_version("github.com/gin-gonic/gin", "unknown")
+
+        assert result == "v2.0.0"
+
+
+class TestResolveGoVersionSkipsPrerelease:
+    """Pre-release versions (rc/alpha/beta/pre) must be excluded."""
+
+    def test_skips_rc_versions(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(_PROXY_LIST_WITH_PRERELEASE),
+        ):
+            result = resolve_go_version("github.com/example/mod", "latest")
+
+        # Stable versions: v1.2.3 and v1.2.4
+        assert result == "v1.2.4"
+        assert "rc" not in result
+        assert "alpha" not in result
+        assert "beta" not in result
+
+    def test_all_prerelease_returns_original_version(self):
+        all_pre = "v1.0.0-rc1\nv1.0.0-alpha\n"
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response(all_pre),
+        ):
+            result = resolve_go_version("github.com/example/mod", "latest")
+
+        assert result == "latest"
+
+
+class TestResolveGoVersionAlreadyPinned:
+    """A pinned version string must be returned unchanged — no network call made."""
+
+    def test_pinned_version_returns_immediately(self):
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = resolve_go_version("github.com/gin-gonic/gin", "v1.9.1")
+
+        mock_urlopen.assert_not_called()
+        assert result == "v1.9.1"
+
+    def test_semver_with_patch_not_queried(self):
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = resolve_go_version("github.com/pkg/errors", "v0.9.1")
+
+        mock_urlopen.assert_not_called()
+        assert result == "v0.9.1"
+
+
+class TestResolveGoVersionNetworkFailure:
+    """Network failure must return the original version without raising."""
+
+    def test_url_error_returns_original_version(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            result = resolve_go_version("github.com/gin-gonic/gin", "latest")
+
+        assert result == "latest"
+
+    def test_oserror_returns_original_version(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            result = resolve_go_version("github.com/gin-gonic/gin", "latest")
+
+        assert result == "latest"
+
+    def test_no_exception_propagated(self):
+        """resolve_go_version must never raise regardless of network conditions."""
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=Exception("unexpected error"),
+        ):
+            # Should not raise
+            try:
+                resolve_go_version("github.com/gin-gonic/gin", "latest")
+            except Exception:  # noqa: BLE001
+                pytest.fail("resolve_go_version raised an unexpected exception")
+
+
+# ===========================================================================
+# parse_go_packages — integration with resolve_versions
+# ===========================================================================
+
+
+class TestParseGoPackagesResolveVersions:
+    """parse_go_packages with resolve_versions=True updates unpinned versions."""
+
+    def test_resolve_versions_false_skips_network(self, tmp_path):
+        """Default resolve_versions=False must not call the proxy."""
+        (tmp_path / "go.mod").write_text(GO_MOD_BASIC)
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            pkgs = parse_go_packages(tmp_path, verify_checksums=False, resolve_versions=False)
+
+        # No proxy call for version resolution (checksums off too)
+        mock_urlopen.assert_not_called()
+        assert pkgs  # packages still parsed
+
+    def test_verify_checksums_false_skips_checksum_db(self, tmp_path):
+        """verify_checksums=False must not call sum.golang.org."""
+        (tmp_path / "go.mod").write_text(GO_MOD_BASIC)
+        (tmp_path / "go.sum").write_text(GO_SUM_CONTENT)
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            pkgs = parse_go_packages(tmp_path, verify_checksums=False, resolve_versions=False)
+
+        mock_urlopen.assert_not_called()
+        assert pkgs


### PR DESCRIPTION
## Summary
- Add `verify_go_checksums()`: compares go.sum hashes against sum.golang.org checksum DB
  - Mismatch → `package.is_malicious=True`, reason: "tampered module — hash on disk differs from sum.golang.org record"
  - Uses public API, no credentials, zero-footprint (consistent with Trivy design principle)
  - HTTPS-only enforced; network failure degrades gracefully (warning logged, no crash)
- Add `resolve_go_version()`: resolves `latest`/`(devel)`/unknown Go versions via proxy.golang.org
  - Default off (`resolve_versions=False`) — opt-in to avoid network in pure parse mode
  - Filters pre-release versions (`-rc`, `-alpha`, `-beta`, `-pre`), returns highest stable
  - Never raises on network failure — returns original version string
- Wire both into `parse_go_packages()` via `verify_checksums=True` (default) and `resolve_versions=False` (opt-in) keyword params

## Security value
- Detects supply chain tampering in Go modules: go.sum hash mismatch = module modified after publish
- Closes version resolution gap for Go modules with unpinned versions
- stdlib-only implementation (`urllib.request`) — no new parser dependencies

## Test plan
- [x] Hash verification: ok / mismatch / missing cases
- [x] Mismatch marks package as malicious with tampered-module reason
- [x] Network failure handled gracefully — no crash, entry omitted
- [x] HTTPS-only enforced for checksum DB (`ValueError` on http:// URL)
- [x] GOPROXY resolution: `latest` → highest stable pinned version
- [x] Pre-release versions filtered (`rc`, `alpha`, `beta`)
- [x] Already-pinned versions bypass network entirely
- [x] `verify_checksums=False` / `resolve_versions=False` suppress all network calls