### PR TITLE
feat: Bun, NuGet (.NET), and pip-compile parsers

### DIFF
--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -27,10 +27,14 @@ from agent_bom.parsers.compiled_parsers import (  # noqa: F401
     parse_maven_packages,
 )
 
+# Re-export .NET/NuGet parsers
+from agent_bom.parsers.dotnet_parsers import parse_nuget_packages  # noqa: F401
+
 # Re-export Node.js parsers for backward compatibility
 from agent_bom.parsers.node_parsers import (  # noqa: F401
     _npm_purl,
     detect_npx_package,
+    parse_bun_packages,
     parse_npm_packages,
     parse_pnpm_lock,
     parse_yarn_lock,
@@ -39,6 +43,7 @@ from agent_bom.parsers.node_parsers import (  # noqa: F401
 # Re-export Python parsers for backward compatibility
 from agent_bom.parsers.python_parsers import (  # noqa: F401
     parse_conda_environment,
+    parse_pip_compile_inputs,
     parse_pip_environment,
     parse_pip_packages,
     parse_poetry_lock,
@@ -235,13 +240,16 @@ def extract_packages(
         packages.extend(parse_npm_packages(server_dir))
         packages.extend(parse_yarn_lock(server_dir))
         packages.extend(parse_pnpm_lock(server_dir))
+        packages.extend(parse_bun_packages(server_dir))
         packages.extend(parse_pip_packages(server_dir))  # includes poetry.lock + uv.lock
+        packages.extend(parse_pip_compile_inputs(server_dir))
         packages.extend(parse_conda_environment(server_dir))
         packages.extend(parse_conda_packages(server_dir))
         packages.extend(parse_go_packages(server_dir))
         packages.extend(parse_cargo_packages(server_dir))
         packages.extend(parse_maven_packages(server_dir))
         packages.extend(parse_gradle_packages(server_dir))
+        packages.extend(parse_nuget_packages(server_dir))
 
     # If we only got npx/uvx packages (no local directory), resolve transitive deps
     if resolve_transitive and (npx_packages or uvx_packages) and not server_dir:
@@ -329,7 +337,11 @@ _MANIFEST_FILES = frozenset(
         "package-lock.json",
         "yarn.lock",
         "pnpm-lock.yaml",
+        "bun.lock",
+        "bun.lockb",
         "requirements.txt",
+        "requirements.in",
+        "constraints.txt",
         "Pipfile.lock",
         "pyproject.toml",
         "poetry.lock",
@@ -345,6 +357,7 @@ _MANIFEST_FILES = frozenset(
         "build.gradle",
         "build.gradle.kts",
         "gradle.lockfile",
+        "packages.lock.json",
     }
 )
 
@@ -408,13 +421,16 @@ def scan_project_directory(
             pkgs.extend(parse_npm_packages(directory))
             pkgs.extend(parse_yarn_lock(directory))
             pkgs.extend(parse_pnpm_lock(directory))
+            pkgs.extend(parse_bun_packages(directory))
             pkgs.extend(parse_pip_packages(directory))
+            pkgs.extend(parse_pip_compile_inputs(directory))
             pkgs.extend(parse_conda_environment(directory))
             pkgs.extend(parse_conda_packages(directory))
             pkgs.extend(parse_go_packages(directory))
             pkgs.extend(parse_cargo_packages(directory))
             pkgs.extend(parse_maven_packages(directory))
             pkgs.extend(parse_gradle_packages(directory))
+            pkgs.extend(parse_nuget_packages(directory))
 
             # Deduplicate within this directory
             seen: set[tuple] = set()

--- a/src/agent_bom/parsers/dotnet_parsers.py
+++ b/src/agent_bom/parsers/dotnet_parsers.py
@@ -1,0 +1,134 @@
+"""NuGet (.NET) package parsers.
+
+Parses packages.lock.json (preferred — resolved, pinned versions) and
+.csproj files (declared PackageReference elements, no resolved versions).
+
+Relevant for .NET AI workloads using Semantic Kernel, ML.NET, and similar.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from agent_bom.models import Package
+
+logger = logging.getLogger(__name__)
+
+
+def parse_nuget_packages(directory: Path) -> list[Package]:
+    """Parse NuGet packages from packages.lock.json or .csproj files.
+
+    Priority order:
+    1. ``packages.lock.json`` — resolved, pinned versions per target framework.
+    2. ``*.csproj`` — declared ``<PackageReference>`` elements (version may be
+       a range or unpinned).
+
+    packages.lock.json format::
+
+        {
+          "version": 1,
+          "dependencies": {
+            "net8.0": {
+              "Microsoft.SemanticKernel": {
+                "type": "Direct",
+                "resolved": "1.14.1"
+              },
+              "Newtonsoft.Json": {
+                "type": "Transitive",
+                "resolved": "13.0.3"
+              }
+            }
+          }
+        }
+
+    .csproj format::
+
+        <ItemGroup>
+          <PackageReference Include="Microsoft.SemanticKernel" Version="1.14.1" />
+        </ItemGroup>
+    """
+    packages = _parse_nuget_lock_json(directory)
+    if packages:
+        return packages
+    return _parse_csproj_files(directory)
+
+
+def _parse_nuget_lock_json(directory: Path) -> list[Package]:
+    """Parse packages from packages.lock.json."""
+    lock_file = directory / "packages.lock.json"
+    if not lock_file.exists():
+        return []
+
+    packages: list[Package] = []
+    try:
+        lock_data: dict = json.loads(lock_file.read_text(encoding="utf-8"))
+        frameworks: dict = lock_data.get("dependencies", {})
+
+        seen: set[tuple[str, str]] = set()
+        for framework_deps in frameworks.values():
+            if not isinstance(framework_deps, dict):
+                continue
+            for pkg_name, pkg_info in framework_deps.items():
+                if not isinstance(pkg_info, dict):
+                    continue
+                resolved = pkg_info.get("resolved", "")
+                if not resolved:
+                    continue
+                dep_type = pkg_info.get("type", "Transitive")
+                key = (pkg_name, resolved)
+                if key in seen:
+                    continue
+                seen.add(key)
+                packages.append(
+                    Package(
+                        name=pkg_name,
+                        version=resolved,
+                        ecosystem="nuget",
+                        purl=f"pkg:nuget/{pkg_name}@{resolved}",
+                        is_direct=(dep_type == "Direct"),
+                    )
+                )
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        logger.debug("Failed to parse packages.lock.json at %s: %s", lock_file, exc)
+
+    return packages
+
+
+def _parse_csproj_files(directory: Path) -> list[Package]:
+    """Parse PackageReference elements from all .csproj files in *directory*."""
+    packages: list[Package] = []
+    csproj_files = list(directory.glob("*.csproj"))
+    if not csproj_files:
+        return []
+
+    seen: set[tuple[str, str]] = set()
+    for csproj in csproj_files:
+        try:
+            tree = ET.parse(csproj)  # noqa: S314  # nosec B314
+            root = tree.getroot()
+            # ElementTree may or may not have namespace prefixes
+            for ref in root.iter("PackageReference"):
+                pkg_name = ref.get("Include", "").strip()
+                pkg_version = ref.get("Version", "").strip()
+                if not pkg_name or not pkg_version:
+                    continue
+                key = (pkg_name, pkg_version)
+                if key in seen:
+                    continue
+                seen.add(key)
+                packages.append(
+                    Package(
+                        name=pkg_name,
+                        version=pkg_version,
+                        ecosystem="nuget",
+                        purl=f"pkg:nuget/{pkg_name}@{pkg_version}",
+                        is_direct=True,
+                    )
+                )
+        except ET.ParseError as exc:
+            logger.debug("Failed to parse .csproj at %s: %s", csproj, exc)
+
+    return packages

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -240,6 +240,82 @@ def parse_pnpm_lock(directory: Path) -> list[Package]:
     return packages
 
 
+def parse_bun_packages(directory: Path) -> list[Package]:
+    """Parse packages from bun.lock (text format, Bun 1.2+) or fall back gracefully.
+
+    Bun uses a binary ``bun.lockb`` that cannot be read without the Bun
+    runtime.  Bun 1.2+ also writes a text ``bun.lock`` (YAML-like format)
+    which we prefer.  If only the binary lock exists we log a debug message
+    and return an empty list rather than crashing.
+
+    ``bun.lock`` format::
+
+        lockfileVersion: 0
+        packages:
+          "react@19.0.0":
+            resolution: {integrity: sha512-...}
+        dependencies:
+          "react": "19.0.0"
+        devDependencies:
+          "@types/node": "22.0.0"
+
+    We parse the ``dependencies`` and ``devDependencies`` sections by looking
+    for quoted ``"name": "version"`` pairs.  The ``packages:`` metadata block
+    is skipped.
+    """
+    bun_lock = directory / "bun.lock"
+    bun_lockb = directory / "bun.lockb"
+
+    if not bun_lock.exists():
+        if bun_lockb.exists():
+            logger.debug(
+                "bun.lockb found at %s but binary format is unreadable; run 'bun install' with Bun 1.2+ to generate bun.lock",
+                bun_lockb,
+            )
+        return []
+
+    packages: list[Package] = []
+    try:
+        content = bun_lock.read_text(encoding="utf-8")
+        # State machine: track which top-level section we are in.
+        # We only care about "dependencies" and "devDependencies".
+        deps_sections = {"dependencies:", "devDependencies:"}
+        skip_sections = {"packages:", "patchedDependencies:", "workspaces:"}
+        in_deps = False
+
+        for raw_line in content.splitlines():
+            stripped = raw_line.strip()
+
+            # Detect section headers (no leading whitespace on section keys)
+            if not raw_line.startswith(" ") and not raw_line.startswith("\t"):
+                in_deps = stripped in deps_sections
+                if stripped in skip_sections:
+                    in_deps = False
+                continue
+
+            if not in_deps:
+                continue
+
+            # Match: "name": "version" — both quoted
+            bun_entry = re.match(r'^\s*"([^"]+)":\s*"([^"]+)"\s*$', raw_line)
+            if bun_entry:
+                pkg_name = bun_entry.group(1)
+                pkg_version = bun_entry.group(2)
+                packages.append(
+                    Package(
+                        name=pkg_name,
+                        version=pkg_version,
+                        ecosystem="npm",
+                        purl=_npm_purl(pkg_name, pkg_version),
+                        is_direct=True,
+                    )
+                )
+    except Exception as exc:
+        logger.debug("Failed to parse bun.lock at %s: %s", bun_lock, exc)
+
+    return packages
+
+
 def detect_npx_package(server: MCPServer) -> list[Package]:
     """Extract package info from npx/npm commands."""
     packages: list[Package] = []

--- a/src/agent_bom/parsers/python_parsers.py
+++ b/src/agent_bom/parsers/python_parsers.py
@@ -282,6 +282,107 @@ def parse_pip_packages(directory: Path) -> list[Package]:
     return packages
 
 
+def _parse_requirements_lines(lines: list[str], is_direct: bool = True) -> list[Package]:
+    """Parse package entries from requirements-style text lines.
+
+    Shared helper used by ``parse_pip_compile_inputs`` for both ``.in``
+    source files and ``constraints.txt`` files.  Handles pinned (``==``),
+    ranged (``>=``, ``~=``, etc.), and bare name lines.  Comment lines and
+    option flags are silently skipped.
+    """
+    packages: list[Package] = []
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        m = re.match(r"^([a-zA-Z0-9_.-]+)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
+        if m:
+            req_name, _, req_version = m.groups()
+            packages.append(
+                Package(
+                    name=req_name,
+                    version=req_version,
+                    ecosystem="pypi",
+                    purl=f"pkg:pypi/{req_name}@{req_version}",
+                    is_direct=is_direct,
+                )
+            )
+        else:
+            bare = re.match(r"^([a-zA-Z0-9_.-]+)", line)
+            if bare:
+                packages.append(
+                    Package(
+                        name=bare.group(1),
+                        version="unknown",
+                        ecosystem="pypi",
+                        is_direct=is_direct,
+                    )
+                )
+    return packages
+
+
+def parse_pip_compile_inputs(directory: Path) -> list[Package]:
+    """Parse pip-compile source (``.in``) and constraints files.
+
+    pip-tools compiles abstract ``requirements.in`` files into pinned
+    ``requirements.txt`` lockfiles.  This parser handles the following cases:
+
+    * If both ``requirements.in`` and ``requirements.txt`` already exist the
+      compiled ``.txt`` is preferred (handled by ``parse_pip_packages``).
+      This function only runs when ``.in`` files exist *without* a
+      corresponding compiled ``.txt`` to avoid double-counting.
+    * ``constraints.txt`` — version constraints rather than direct installs;
+      marked ``is_direct=False``.
+
+    Candidate ``.in`` file names::
+
+        requirements.in, requirements-dev.in, requirements-prod.in,
+        base.in, dev.in, prod.in
+
+    Returns an empty list when no ``.in`` or ``constraints.txt`` files exist.
+    """
+    in_candidates = [
+        "requirements.in",
+        "requirements-dev.in",
+        "requirements-prod.in",
+        "base.in",
+        "dev.in",
+        "prod.in",
+    ]
+
+    packages: list[Package] = []
+
+    for in_name in in_candidates:
+        in_file = directory / in_name
+        if not in_file.exists():
+            continue
+        # If a compiled .txt counterpart exists, skip: parse_pip_packages handles it.
+        compiled_name = in_name.replace(".in", ".txt")
+        if (directory / compiled_name).exists():
+            logger.debug(
+                "Skipping %s — compiled %s exists and takes precedence",
+                in_file,
+                compiled_name,
+            )
+            continue
+        try:
+            in_lines = in_file.read_text(encoding="utf-8").splitlines()
+            packages.extend(_parse_requirements_lines(in_lines, is_direct=True))
+        except OSError as exc:
+            logger.debug("Failed to read %s: %s", in_file, exc)
+
+    # constraints.txt — version pins for transitive deps; not direct installs
+    constraints_file = directory / "constraints.txt"
+    if constraints_file.exists():
+        try:
+            c_lines = constraints_file.read_text(encoding="utf-8").splitlines()
+            packages.extend(_parse_requirements_lines(c_lines, is_direct=False))
+        except OSError as exc:
+            logger.debug("Failed to read %s: %s", constraints_file, exc)
+
+    return packages
+
+
 def parse_pip_environment(python_exec: str | None = None) -> list[Package]:
     """Scan an installed Python environment via ``pip list --format=json``.
 

--- a/tests/test_bun_nuget_pipcompile_parsers.py
+++ b/tests/test_bun_nuget_pipcompile_parsers.py
@@ -1,0 +1,234 @@
+"""Tests for Bun, NuGet, and pip-compile parsers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_bom.parsers.dotnet_parsers import parse_nuget_packages
+from agent_bom.parsers.node_parsers import parse_bun_packages
+from agent_bom.parsers.python_parsers import parse_pip_compile_inputs
+
+# ---------------------------------------------------------------------------
+# Bun parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bun_lock_basic(tmp_path: Path) -> None:
+    """bun.lock with a dependencies section is parsed correctly."""
+    (tmp_path / "bun.lock").write_text(
+        "lockfileVersion: 0\n"
+        "packages:\n"
+        '  "react@19.0.0":\n'
+        "    resolution: {integrity: sha512-abc}\n"
+        "dependencies:\n"
+        '  "react": "19.0.0"\n'
+        '  "typescript": "5.7.0"\n",\n'
+    )
+
+    pkgs = parse_bun_packages(tmp_path)
+    names = {p.name for p in pkgs}
+    assert "react" in names
+    assert "typescript" in names
+    assert all(p.ecosystem == "npm" for p in pkgs)
+
+
+def test_parse_bun_lock_dev_deps(tmp_path: Path) -> None:
+    """devDependencies section is parsed and included."""
+    (tmp_path / "bun.lock").write_text(
+        'lockfileVersion: 0\ndependencies:\n  "react": "19.0.0"\ndevDependencies:\n  "@types/node": "22.0.0"\n'
+    )
+
+    pkgs = parse_bun_packages(tmp_path)
+    names = {p.name for p in pkgs}
+    assert "react" in names
+    assert "@types/node" in names
+    assert len(pkgs) == 2
+
+
+def test_parse_bun_lock_purl_format(tmp_path: Path) -> None:
+    """purl uses pkg:npm/name@version (scoped packages encoded correctly)."""
+    (tmp_path / "bun.lock").write_text(
+        'lockfileVersion: 0\ndependencies:\n  "react": "18.3.1"\ndevDependencies:\n  "@types/node": "22.0.0"\n'
+    )
+
+    pkgs = parse_bun_packages(tmp_path)
+    by_name = {p.name: p for p in pkgs}
+
+    assert by_name["react"].purl == "pkg:npm/react@18.3.1"
+    # scoped package: @ must be percent-encoded per PURL spec
+    assert by_name["@types/node"].purl == "pkg:npm/%40types/node@22.0.0"
+
+
+def test_parse_bun_lockb_binary_only(tmp_path: Path) -> None:
+    """Only bun.lockb exists (binary) — returns empty list, no exception."""
+    (tmp_path / "bun.lockb").write_bytes(b"\x00\x01binary data")
+
+    pkgs = parse_bun_packages(tmp_path)
+    assert pkgs == []
+
+
+def test_parse_bun_no_files(tmp_path: Path) -> None:
+    """Empty directory returns empty list."""
+    assert parse_bun_packages(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# NuGet parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_nuget_packages_lock_json(tmp_path: Path) -> None:
+    """packages.lock.json with direct and transitive packages is parsed."""
+    lock = {
+        "version": 1,
+        "dependencies": {
+            "net8.0": {
+                "Microsoft.SemanticKernel": {
+                    "type": "Direct",
+                    "requested": "[1.14.1, )",
+                    "resolved": "1.14.1",
+                    "contentHash": "abc123",
+                },
+                "Newtonsoft.Json": {
+                    "type": "Transitive",
+                    "resolved": "13.0.3",
+                },
+            }
+        },
+    }
+    (tmp_path / "packages.lock.json").write_text(json.dumps(lock))
+
+    pkgs = parse_nuget_packages(tmp_path)
+    names = {p.name for p in pkgs}
+    assert "Microsoft.SemanticKernel" in names
+    assert "Newtonsoft.Json" in names
+    assert all(p.ecosystem == "nuget" for p in pkgs)
+
+
+def test_parse_nuget_csproj(tmp_path: Path) -> None:
+    """.csproj PackageReference elements are extracted when no lock file exists."""
+    csproj = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.14.1" />
+    <PackageReference Include="Microsoft.ML" Version="3.0.0" />
+  </ItemGroup>
+</Project>
+"""
+    (tmp_path / "MyApp.csproj").write_text(csproj)
+
+    pkgs = parse_nuget_packages(tmp_path)
+    names = {p.name for p in pkgs}
+    assert "Microsoft.SemanticKernel" in names
+    assert "Microsoft.ML" in names
+    assert all(p.ecosystem == "nuget" for p in pkgs)
+
+
+def test_parse_nuget_lock_prefers_resolved_version(tmp_path: Path) -> None:
+    """packages.lock.json: uses 'resolved' field, not 'requested' range."""
+    lock = {
+        "version": 1,
+        "dependencies": {
+            "net8.0": {
+                "SomeLib": {
+                    "type": "Direct",
+                    "requested": "[1.0.0, 2.0.0)",
+                    "resolved": "1.5.3",
+                }
+            }
+        },
+    }
+    (tmp_path / "packages.lock.json").write_text(json.dumps(lock))
+
+    pkgs = parse_nuget_packages(tmp_path)
+    assert len(pkgs) == 1
+    assert pkgs[0].version == "1.5.3"
+
+
+def test_parse_nuget_direct_vs_transitive(tmp_path: Path) -> None:
+    """Direct packages have is_direct=True; Transitive packages have is_direct=False."""
+    lock = {
+        "version": 1,
+        "dependencies": {
+            "net8.0": {
+                "DirectPkg": {"type": "Direct", "resolved": "2.0.0"},
+                "TransitivePkg": {"type": "Transitive", "resolved": "1.0.0"},
+            }
+        },
+    }
+    (tmp_path / "packages.lock.json").write_text(json.dumps(lock))
+
+    pkgs = parse_nuget_packages(tmp_path)
+    by_name = {p.name: p for p in pkgs}
+    assert by_name["DirectPkg"].is_direct is True
+    assert by_name["TransitivePkg"].is_direct is False
+
+
+def test_parse_nuget_purl_format(tmp_path: Path) -> None:
+    """purl follows pkg:nuget/name@version format."""
+    lock = {
+        "version": 1,
+        "dependencies": {
+            "net8.0": {
+                "Microsoft.SemanticKernel": {
+                    "type": "Direct",
+                    "resolved": "1.14.1",
+                }
+            }
+        },
+    }
+    (tmp_path / "packages.lock.json").write_text(json.dumps(lock))
+
+    pkgs = parse_nuget_packages(tmp_path)
+    assert pkgs[0].purl == "pkg:nuget/Microsoft.SemanticKernel@1.14.1"
+
+
+def test_parse_nuget_no_files(tmp_path: Path) -> None:
+    """Empty directory returns empty list."""
+    assert parse_nuget_packages(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# pip-compile parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pip_compile_in_file(tmp_path: Path) -> None:
+    """requirements.in with unpinned deps is parsed into packages."""
+    (tmp_path / "requirements.in").write_text("# Core dependencies\nrequests>=2.28.0\nfastapi\npydantic>=2.0\n")
+
+    pkgs = parse_pip_compile_inputs(tmp_path)
+    names = {p.name for p in pkgs}
+    assert "requests" in names
+    assert "fastapi" in names
+    assert "pydantic" in names
+    assert all(p.ecosystem == "pypi" for p in pkgs)
+
+
+def test_parse_pip_compile_prefers_txt(tmp_path: Path) -> None:
+    """When both .in and compiled .txt exist, .in is skipped (txt takes precedence)."""
+    (tmp_path / "requirements.in").write_text("requests>=2.28.0\n")
+    (tmp_path / "requirements.txt").write_text("requests==2.31.0\n")
+
+    # parse_pip_compile_inputs should skip requirements.in entirely
+    pkgs = parse_pip_compile_inputs(tmp_path)
+    # No packages returned from .in because compiled txt exists
+    assert pkgs == []
+
+
+def test_parse_pip_compile_constraints(tmp_path: Path) -> None:
+    """constraints.txt entries are parsed with is_direct=False."""
+    (tmp_path / "constraints.txt").write_text("urllib3==1.26.18\ncertifi==2023.11.17\n")
+
+    pkgs = parse_pip_compile_inputs(tmp_path)
+    assert len(pkgs) == 2
+    assert all(p.is_direct is False for p in pkgs)
+    names = {p.name for p in pkgs}
+    assert "urllib3" in names
+    assert "certifi" in names
+
+
+def test_parse_pip_compile_no_files(tmp_path: Path) -> None:
+    """No .in or constraints files → empty list."""
+    assert parse_pip_compile_inputs(tmp_path) == []


### PR DESCRIPTION
## Summary

- **Bun**: `parse_bun_packages()` in `node_parsers.py` — reads `bun.lock` text format (Bun 1.2+), extracts `dependencies` and `devDependencies` sections, applies correct PURL encoding for scoped packages (`pkg:npm/%40scope/name@version`); gracefully skips unreadable binary `bun.lockb` with a debug log
- **NuGet (.NET)**: new `src/agent_bom/parsers/dotnet_parsers.py` with `parse_nuget_packages()` — prefers `packages.lock.json` (resolved pinned versions, `Direct`/`Transitive` distinction) and falls back to `.csproj` `<PackageReference>` XML elements; relevant for Semantic Kernel, ML.NET, and other .NET AI workloads
- **pip-compile**: `parse_pip_compile_inputs()` in `python_parsers.py` — handles `.in` source files (skipped when a compiled `.txt` counterpart exists to avoid double-counting) and `constraints.txt` (marked `is_direct=False`); shared `_parse_requirements_lines()` helper reused for both

All three parsers wired into `extract_packages()`, `scan_project_directory()`, `_MANIFEST_FILES`, and `__init__.py` re-exports.

## Test plan

- [ ] `tests/test_bun_nuget_pipcompile_parsers.py` — 15 tests: 5 Bun, 6 NuGet, 4 pip-compile
- [ ] Full suite: 5870 passed, 15 skipped, 0 failures (verified locally)
- [ ] ruff, ruff-format, bandit, mypy all clean