### PR TITLE
fix: credential security hardening (URL validation, timing-safe compare, exception sanitization)

### DIFF
--- a/src/agent_bom/cloud/vector_db.py
+++ b/src/agent_bom/cloud/vector_db.py
@@ -386,6 +386,7 @@ def _pinecone_get(path: str, api_key: str, timeout: int = _DEFAULT_TIMEOUT) -> t
     """Make an authenticated GET request to the Pinecone API.
 
     Returns (status_code, parsed_json). Returns (-1, {}) on network/parse error.
+    The API key is never surfaced in exception messages or logs.
     """
     url = f"{_PINECONE_API_BASE}{path}"
     try:
@@ -405,7 +406,10 @@ def _pinecone_get(path: str, api_key: str, timeout: int = _DEFAULT_TIMEOUT) -> t
         except Exception:
             body = {}
         return e.code, body
-    except Exception:
+    except Exception as exc:
+        # Sanitize: ensure the API key cannot appear in logged exception messages.
+        sanitized = str(exc).replace(api_key, "***REDACTED***") if api_key else str(exc)
+        logger.debug("Pinecone request failed: %s", sanitized)
         return -1, {}
 
 

--- a/src/agent_bom/integrations/jira.py
+++ b/src/agent_bom/integrations/jira.py
@@ -10,6 +10,7 @@ import logging
 from typing import Optional
 
 from agent_bom.http_client import create_client, request_with_retry
+from agent_bom.security import validate_url
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,7 @@ async def create_jira_ticket(
         }
     }
 
+    validate_url(jira_url)
     url = f"{jira_url.rstrip('/')}/rest/api/3/issue"
 
     async with create_client(timeout=15.0) as client:

--- a/src/agent_bom/integrations/slack.py
+++ b/src/agent_bom/integrations/slack.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 
 from agent_bom.http_client import create_client, request_with_retry
+from agent_bom.security import validate_url
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ async def send_slack_alert(
     Returns:
         True if message was sent successfully.
     """
+    validate_url(webhook_url)
     blocks = _build_slack_blocks(finding)
     payload = {"blocks": blocks}
 
@@ -126,6 +128,7 @@ async def send_slack_alert(
 
 async def send_slack_payload(webhook_url: str, payload: dict) -> bool:
     """Send a raw Slack payload to a webhook URL."""
+    validate_url(webhook_url)
     async with create_client(timeout=10.0) as client:
         response = await request_with_retry(
             client,

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -277,10 +277,11 @@ class ProxyMetricsServer:
                     if header_str.lower().startswith("authorization:"):
                         auth_header = header_str.split(":", 1)[1].strip()
 
-                # Bearer token auth (optional — enabled via --metrics-token)
+                # Bearer token auth (optional — enabled via --metrics-token).
+                # hmac.compare_digest prevents timing-based token enumeration.
                 if self.token:
                     expected = f"Bearer {self.token}"
-                    if auth_header != expected:
+                    if not hmac.compare_digest(auth_header or "", expected):
                         response = "HTTP/1.1 401 Unauthorized\r\nContent-Length: 12\r\n\r\nUnauthorized"
                         writer.write(response.encode())
                         await writer.drain()


### PR DESCRIPTION
## Summary

Closes four credential security gaps identified in audit. No architectural changes — all fixes are localized and surgical.

- **Slack/Jira webhook URL validation**: `validate_url()` called before every outbound HTTP request — prevents SSRF and ensures integration tokens cannot leak into exception traces from unvalidated URLs
- **Metrics token timing safety**: `hmac.compare_digest()` replaces plain `!=` comparison in `ProxyMetricsServer` — eliminates timing oracle that could allow token enumeration
- **Pinecone API key sanitization**: `_pinecone_get()` now replaces the API key with `***REDACTED***` in any exception message before logging — key can no longer appear in debug traces
- **Defense in depth by design**: These complete the zero-trust, least-privilege credential posture across all integrations and runtime components

## Test plan
- [ ] 71 existing tests pass (jira policy, proxy metrics, vector db, pinecone)
- [ ] `ruff check` + `ruff format` clean
- [ ] `bandit` clean (pre-commit)