### PR TITLE
fix: cloud API alignment — Databricks enum, Nebius pagination, CoreWeave/NVIDIA provisioning

### DIFF
--- a/scripts/provision/README.md
+++ b/scripts/provision/README.md
@@ -17,6 +17,8 @@ The files in this directory are tailored per-provider — not generic templates.
 | Weights & Biases (Runs, Artifacts, Model Registry) | `wandb_token_setup.md` | API key (Viewer role) |
 | Nebius AI Cloud (GPU instances, AI Studio, K8s) | `nebius_token_setup.md` | IAM service account key |
 | OpenAI / MLflow / Ollama | `openai_mlflow_ollama_setup.md` | Project API key / token / none |
+| CoreWeave (VirtualServers, KServe, NIM pods) | `coreweave_readonly.md` | kubeconfig + namespace-scoped RBAC |
+| NVIDIA (NIM, NGC, DCGM, GPU infra) | `nvidia_ngc_setup.md` | NGC Viewer key (optional) + kubectl |
 
 ---
 

--- a/scripts/provision/coreweave_readonly.md
+++ b/scripts/provision/coreweave_readonly.md
@@ -1,0 +1,144 @@
+# agent-bom CoreWeave Read-Only Provisioning
+
+CoreWeave is a Kubernetes-native GPU cloud built entirely on Kubernetes.
+There is no proprietary API or SDK — all discovery uses `kubectl` against
+CoreWeave's Kubernetes cluster with CoreWeave-specific CRDs.
+
+Auth: kubeconfig only. CoreWeave provides a kubeconfig file per namespace
+from the CoreWeave Cloud Console. No API keys, no passwords.
+
+Docs:
+- Cluster access: https://docs.coreweave.com/coreweave-kubernetes/getting-started
+- RBAC: https://docs.coreweave.com/coreweave-kubernetes/networking/coreweave-cloud-native-networking/access-control
+
+---
+
+## What agent-bom Discovers on CoreWeave
+
+| Resource | CRD / API | What's scanned |
+|---|---|---|
+| GPU VMs | `virtualservers.virtualservers.coreweave.com` | GPU model (H100/A100/L40S), image, accelerator count |
+| Inference services | `inferenceservices.serving.kserve.io` | vLLM/Triton serving, model name, framework |
+| NVIDIA NIM pods | `pods` (image prefix `nvcr.io/nim/`) | NIM microservice version → CVEs |
+| InfiniBand training jobs | `pods` with `rdma/ib` resource | Multi-node NCCL jobs, framework packages |
+| Standard K8s workloads | `pods`, `deployments` | Any AI container image → package CVEs |
+
+---
+
+## Step 1 — Get Your kubeconfig from CoreWeave Console
+
+1. Log in to https://cloud.coreweave.com
+2. Go to **API & Access** → **Kubeconfig**
+3. Download the kubeconfig for your namespace
+4. Merge into your local kubeconfig:
+
+```bash
+KUBECONFIG=~/.kube/config:~/Downloads/coreweave-kubeconfig.yaml \
+  kubectl config view --flatten > ~/.kube/config
+```
+
+---
+
+## Step 2 — Create a Read-Only Service Account (Namespace-Scoped)
+
+Never use your personal kubeconfig for CI/CD automation. Create a dedicated
+service account with the minimum permissions needed.
+
+```bash
+# Create the service account in your CoreWeave namespace
+kubectl create serviceaccount agent-bom-scanner -n <YOUR_NAMESPACE>
+```
+
+Apply the RBAC:
+
+```yaml
+# coreweave_rbac.yaml — apply with: kubectl apply -f coreweave_rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-bom-readonly
+  namespace: <YOUR_NAMESPACE>
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "services", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+  # CoreWeave VirtualServer CRD
+  - apiGroups: ["virtualservers.coreweave.com"]
+    resources: ["virtualservers"]
+    verbs: ["get", "list", "watch"]
+  # KServe InferenceService CRD
+  - apiGroups: ["serving.kserve.io"]
+    resources: ["inferenceservices"]
+    verbs: ["get", "list", "watch"]
+  # Never: secrets, pods/exec, create/update/delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-bom-readonly-binding
+  namespace: <YOUR_NAMESPACE>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agent-bom-readonly
+subjects:
+  - kind: ServiceAccount
+    name: agent-bom-scanner
+    namespace: <YOUR_NAMESPACE>
+```
+
+```bash
+kubectl apply -f coreweave_rbac.yaml
+```
+
+---
+
+## Step 3 — Generate a Long-Lived Token for CI/CD
+
+```bash
+# Create a token secret bound to the service account
+kubectl create token agent-bom-scanner -n <YOUR_NAMESPACE> --duration=8760h
+```
+
+Or create a long-lived secret (Kubernetes 1.24+ approach):
+
+```bash
+kubectl create secret generic agent-bom-token \
+  --type=kubernetes.io/service-account-token \
+  --from-literal=extra="agent-bom-scanner" \
+  -n <YOUR_NAMESPACE>
+
+kubectl annotate secret agent-bom-token \
+  kubernetes.io/service-account.name=agent-bom-scanner \
+  -n <YOUR_NAMESPACE>
+```
+
+---
+
+## Usage
+
+```bash
+# Default kubectl context (uses current kubeconfig context)
+agent-bom scan --coreweave
+
+# Explicit context (if you have multiple clusters configured)
+agent-bom scan --coreweave --coreweave-context coreweave-<namespace>
+
+# GPU scan across CoreWeave + K8s GPU pods
+agent-bom scan --coreweave --gpu-scan --gpu-k8s-context coreweave-<namespace>
+```
+
+---
+
+## Credential Best Practices
+
+- **Never use your personal kubeconfig in CI/CD** — use the service account token above
+- **Namespace-scoped Role, not ClusterRole** — CoreWeave namespaces are tenant-isolated; namespace scope is sufficient and safer
+- **Rotate tokens annually** — or use short-lived `kubectl create token` (1h–8760h)
+- **Store tokens as CI secrets** — GitHub Secrets, GitLab CI variables, etc. Never commit

--- a/scripts/provision/nvidia_ngc_setup.md
+++ b/scripts/provision/nvidia_ngc_setup.md
@@ -1,0 +1,103 @@
+# agent-bom NVIDIA NGC / NIM Setup
+
+NVIDIA's AI infrastructure spans two surfaces agent-bom scans:
+
+1. **NGC (NVIDIA GPU Cloud)** — private container registry, model catalog, Helm charts
+2. **NVIDIA NIM microservices** — deployed as containers (on CoreWeave, EKS, GKE, bare metal)
+
+NVIDIA does not have a "cloud account" API like AWS/GCP. Discovery is container-based,
+not account-based. The scan detects NIM containers by image prefix (`nvcr.io/nim/`)
+wherever they are deployed.
+
+---
+
+## What agent-bom Discovers for NVIDIA
+
+| Surface | How Discovered | What's Scanned |
+|---|---|---|
+| NIM containers | `kubectl` image prefix `nvcr.io/nim/*` | NIM version → CVEs in NVIDIA advisory |
+| NGC base images | Container image manifest | `nvidia/cuda`, `nvidia/tensorrt`, `nvcr.io/nvidia/*` → CVEs |
+| Triton Inference Server | `nvcr.io/nvidia/tritonserver:*` | Triton version + backend packages |
+| NCCL/InfiniBand jobs | `rdma/ib` resource in pod spec | Multi-node training attack surface |
+| Nebius NVIDIA GPU | Nebius API (`_discover_gpu_pods`) | H100/A100 GPU instance inventory |
+| CoreWeave NVIDIA GPU | VirtualServer CRDs | GPU model, accelerator count |
+| GPU infra scan | `--gpu-scan` flag (gpu_infra.py) | K8s GPU resource requests, DCGM exposure |
+
+---
+
+## NGC API Key (only needed for private NGC catalog access)
+
+Most NIM containers are discovered via `kubectl` — no NGC API key needed.
+An NGC API key is only required to:
+- Pull private NIM containers from `nvcr.io`
+- Access private NGC Catalog models
+
+### Create a Read-Only NGC API Key
+
+1. Log in to https://ngc.nvidia.com
+2. Go to **Account** → **Setup** → **API Keys** → **Generate API Key**
+3. Org Role: **Viewer** (never use **Admin** or **Manager**)
+4. Save the key — shown only once
+
+Docs: https://docs.ngc.nvidia.com/cli/cmd.html#ngc-config-set
+
+### Key Rotation
+
+NGC API keys do not expire. Rotate manually:
+1. Generate a new key
+2. Update the CI secret / env var
+3. Revoke the old key at https://ngc.nvidia.com/setup/api-key
+
+---
+
+## DCGM Exporter (unauthenticated exposure detection)
+
+agent-bom probes for unauthenticated DCGM (Data Center GPU Manager) exporters
+at `http://<pod-ip>:9400/metrics`. This is a common misconfiguration that
+exposes GPU health metrics to the network without auth.
+
+No credential needed — the probe checks if the endpoint is open.
+
+```bash
+# Scan for DCGM exposure + GPU workload CVEs
+agent-bom scan --gpu-scan
+
+# Skip DCGM probe (if you know it's secured)
+agent-bom scan --gpu-scan --no-dcgm-probe
+```
+
+---
+
+## Usage
+
+```bash
+# NIM + GPU pods on EKS
+agent-bom scan --aws --aws-include-eks --gpu-scan
+
+# NIM + GPU pods on CoreWeave
+agent-bom scan --coreweave --gpu-scan
+
+# NIM + GPU pods on GKE
+agent-bom scan --gcp --gpu-scan
+
+# NIM + GPU pods on Nebius
+agent-bom scan --nebius --gpu-scan
+
+# Container image CVE scan for a specific NIM image
+agent-bom scan --image nvcr.io/nim/meta/llama-3.1-8b-instruct:latest
+```
+
+---
+
+## What CVE Sources Cover NVIDIA
+
+agent-bom uses three sources specifically for NVIDIA packages:
+
+| Source | What it covers |
+|---|---|
+| OSV.dev | `nvidia-*`, `cuda-*`, `tensorrt` PyPI packages |
+| NVIDIA Security Bulletin | `nvcr.io/nvidia/*` container CVEs (NVIDIA advisory feed) |
+| NVD enrichment | CVSS scores for all NVIDIA CVEs (90-day cache) |
+
+Packages checked: `torch`, `torchvision`, `triton`, `vllm`, `nemo-toolkit`, `transformers`,
+`nvidia-cuda-runtime-cu*`, `nvidia-cudnn-cu*`, `nvidia-tensorrt`, `nccl`.

--- a/src/agent_bom/cloud/databricks.py
+++ b/src/agent_bom/cloud/databricks.py
@@ -116,7 +116,10 @@ def discover(
         for ep in endpoints:
             ep_name = getattr(ep, "name", "unknown")
             ep_state = getattr(ep, "state", None)
-            state_str = str(getattr(ep_state, "ready", "")).upper() if ep_state else ""
+            # ep_state.ready is an EndpointStateReady enum — use .value to get
+            # the raw string ("READY" / "NOT_READY") rather than the repr.
+            ready_enum = getattr(ep_state, "ready", None) if ep_state else None
+            state_str = getattr(ready_enum, "value", str(ready_enum or "")).upper()
             if state_str not in ("READY", "NOT_READY"):
                 continue
 

--- a/src/agent_bom/cloud/nebius.py
+++ b/src/agent_bom/cloud/nebius.py
@@ -38,6 +38,42 @@ def _nebius_get(url: str, api_key: str, params: dict | None = None) -> dict:
     return resp.json()
 
 
+def _nebius_get_all(url: str, api_key: str, items_key: str, params: dict | None = None) -> list:
+    """Paginate through a Nebius REST API list endpoint.
+
+    Nebius uses ``nextPageToken`` / ``pageToken`` for cursor-based pagination.
+    Fetches all pages and returns the merged items list.
+
+    Args:
+        url: Full endpoint URL.
+        api_key: Nebius API key.
+        items_key: Top-level key containing the list (e.g. ``"models"``, ``"instances"``).
+        params: Additional query parameters.
+    """
+    import requests
+
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    all_items: list = []
+    page_params = dict(params or {})
+    _max_pages = 50  # safety cap — prevents infinite loops on malformed responses
+
+    for _ in range(_max_pages):
+        resp = requests.get(url, headers=headers, params=page_params, timeout=_API_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Nebius API uses both "models"/"instances" keys and a generic "data" fallback
+        items = data.get(items_key, data.get("data", []))
+        all_items.extend(items if isinstance(items, list) else [])
+
+        next_token = data.get("nextPageToken") or data.get("next_page_token", "")
+        if not next_token:
+            break
+        page_params["pageToken"] = next_token
+
+    return all_items
+
+
 def discover(
     api_key: str | None = None,
     project_id: str | None = None,
@@ -123,13 +159,12 @@ def _discover_ai_studio(
     warnings: list[str] = []
 
     try:
-        data = _nebius_get(
+        models = _nebius_get_all(
             "https://api.ai.nebius.cloud/v1/models",
             api_key,
+            items_key="models",
             params={"project_id": project_id},
         )
-
-        models = data.get("models", data.get("data", []))
 
         for model in models:
             model_id = model.get("id", "unknown")
@@ -194,13 +229,12 @@ def _discover_gpu_instances(
     warnings: list[str] = []
 
     try:
-        data = _nebius_get(
+        instances = _nebius_get_all(
             "https://compute.api.nebius.cloud/v1/instances",
             api_key,
+            items_key="instances",
             params={"project_id": project_id},
         )
-
-        instances = data.get("instances", data.get("data", []))
 
         for inst in instances:
             inst_id = inst.get("id", "unknown")
@@ -382,13 +416,12 @@ def _discover_container_services(
     warnings: list[str] = []
 
     try:
-        data = _nebius_get(
+        services = _nebius_get_all(
             "https://serverless.api.nebius.cloud/v1/containers",
             api_key,
+            items_key="containers",
             params={"project_id": project_id},
         )
-
-        services = data.get("containers", data.get("data", []))
 
         for svc in services:
             svc_id = svc.get("id", "unknown")


### PR DESCRIPTION
## Summary

Three code fixes from the cloud provider API audit + two new provisioning docs.

**Databricks — endpoint state enum bug:**
- `str(EndpointStateReady.READY)` yields `"EndpointStateReady.READY"` not `"READY"` — the filter was skipping all serving endpoints silently
- Fix: use `.value` to extract the raw enum string before comparison

**Nebius — missing pagination:**
- All three discovery functions (`_discover_ai_studio`, `_discover_gpu_instances`, `_discover_container_services`) used single-page fetches — results beyond page 1 were silently dropped
- Added `_nebius_get_all()` with `nextPageToken`/`next_page_token` cursor pagination (50-page safety cap)

**CoreWeave provisioning (`scripts/provision/coreweave_readonly.md`):**
- CoreWeave is Kubernetes-native — auth is kubeconfig only, no API keys
- Namespace-scoped `Role` (not `ClusterRole`) for VirtualServer CRDs, KServe InferenceService CRDs, pod/deployment discovery
- Service account token generation for CI/CD automation (never personal kubeconfig)

**NVIDIA provisioning (`scripts/provision/nvidia_ngc_setup.md`):**
- NIM containers discovered via `kubectl` by image prefix — no NGC API key needed for most scans
- NGC Viewer key only needed for private catalog access
- DCGM unauthenticated exposure detection documented
- CVE source coverage: OSV + NVIDIA Security Bulletin + NVD

## Test plan
- [ ] 34 tests passing (cloud_databricks, cloud_nebius, coreweave)
- [ ] ruff + bandit clean