### PR TITLE
docs: consistency cleanup — detector count, CHANGELOG v0.70.x, AISVS framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,49 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.70.4] – 2026-03-11
+
+### Added
+- **Cloud provisioning scripts** — read-only, least-privilege provisioning for all 11 providers (AWS IAM + EKS RBAC, Azure Managed Identity, GCP Workload Identity, Snowflake key-pair JWT, Databricks PAT/OAuth, HuggingFace fine-grained token, W&B Viewer service account, Nebius IAM, CoreWeave namespace RBAC, NVIDIA NGC Viewer key) in `scripts/provision/`
+- **Nebius pagination** — cursor-based pagination with `nextPageToken`/`next_page_token` wired into all 3 discovery functions
+- **Post-merge self-scan** — GitHub Actions workflow scans agent-bom with agent-bom on every merge; blocks release on critical CVE (#648)
+- **Two-tier severity gate** — `--warn-on` for CI warning gates, `--fail-on-severity` for hard failures (#625)
+- **Trivy/Grype/Syft ingestion** — import external scanner JSON output with blast radius enrichment (#624)
+- **Delta scanning** — `--delta` flag reports only new findings since last scan; exit code based on new-only (#630)
+- **Local embedded vulnerability database** — SQLite schema, OSV/EPSS/KEV sync, fast lookup (#631)
+- **Bun, NuGet (.NET), pip-compile parsers** (#660)
+- **Gradle and conda parsers** for AI/ML ecosystems (#659)
+- **go.sum integrity verification** + GOPROXY version resolution (#658)
+- **Maven Central and crates.io** version resolution for unpinned deps (#661)
+- **GHSA and NVD local DB sync** sources (#653)
+- **Multi-source asset deduplication** — cross-cloud dedup with stable IDs (#654)
+- **Deterministic UUID v5 stable IDs** for assets and findings (#655)
+- **Auto-refresh stale vuln DB flag** — `--auto-refresh-db`, NIM/NeMo/NemoClaw NVIDIA tracking
+- **Production-quality Go/Maven/RPM** parser improvements (#656)
+
+### Fixed
+- **Credential security** — URL validation (jira.py, slack.py), timing-safe metrics token compare (proxy.py), API key sanitization from exception messages (vector_db.py) (#662)
+- **Databricks enum bug** — `EndpointStateReady.value` fix; `str(enum)` returned full name not value, causing all serving endpoints to be skipped (#664)
+- **CoreWeave/NVIDIA provisioning** — kubeconfig + namespace RBAC, NGC Viewer key, DCGM exposure detection (#664)
+- **Normalization gaps** — CLI check, scan_agents, rescan, postgres cache (#615)
+- **GHSA PEP 503 normalization** — advisory matching + resolver debug logging (#619)
+- **Multi-arch container rescan** — arm64 support, SARIF to Security tab (#650)
+- **OTel hardening** — schema validation, file size cap, framework expansion (#642)
+- **Stale DB warning** on outdated local cache (#642)
+- **Local vuln DB security** — chmod 0600, HTTPS-only sync, path validation, integrity check (#634)
+- **HTML report** — delta/warn-gate banners, vendor_severity display (#632)
+- **Silent exception handlers** — logging added to all bare `except` blocks (#620)
+- **Documentation accuracy** — detector count (6→7), architecture client and tool counts (#657)
+- **MCP tool count** — replaced hardcoded counts with dynamic assertions (#626)
+
+### Changed
+- **`cli/scan.py` refactored** — 3,079L monolith → modular `scan/` package (#651)
+- **Unified Finding model Phase 1** — core dataclasses, BlastRadius migration shim, dual-write (#628)
+- **PEP 503 name normalization** — configurable batch size, unresolved package warnings (#614)
+- **server.py routes extracted** — scan, discovery, connectors, governance, enterprise, schedules, observability, assets (#612, #613)
+
+---
+
 ## [0.60.1] – 2026-03-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ That's it. agent-bom discovers your MCP client configs (Claude Desktop, Cursor, 
 > **Traditional scanners tell you a package has a CVE.**
 > **agent-bom tells you which AI agents are compromised, which credentials leak, which tools an attacker reaches — and then blocks it in real time.**
 
-Three capabilities, one tool: **scanner** (CVEs, blast radius, compliance, supply chain) + **proxy** (intercepts MCP traffic, enforces policy, detects 6 behavioral attack patterns) + **instruction file trust** (audits CLAUDE.md, .cursorrules, AGENTS.md, SKILL.md for malicious patterns, typosquatting, and Sigstore provenance). Read-only. Agentless. Open source.
+Three capabilities, one tool: **scanner** (CVEs, blast radius, compliance, supply chain) + **proxy** (intercepts MCP traffic, enforces policy, detects 7 behavioral attack patterns) + **instruction file trust** (audits CLAUDE.md, .cursorrules, AGENTS.md, SKILL.md for malicious patterns, typosquatting, and Sigstore provenance). Read-only. Agentless. Open source.
 
 ```
 CVE-2025-1234  (CRITICAL . CVSS 9.8 . CISA KEV)
@@ -317,7 +317,7 @@ agent-bom scan -f graph -o graph.json              # Cytoscape-compatible
 | MCP Server | `agent-bom mcp-server` (31 tools) | Inside any MCP client |
 | Dashboard | `agent-bom serve` · [Full deploy guide](docs/DEPLOYMENT.md) | API + Next.js UI (15 pages) · Postgres/Supabase |
 | Runtime proxy | `agent-bom proxy` | Intercept + enforce MCP traffic in real time |
-| Protect engine | `agent-bom protect` | 6 behavioral detectors (rug pull, injection, exfil, credential leak, response cloaking, vector DB injection) |
+| Protect engine | `agent-bom protect` | 7 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, rate limiting, vector DB injection) |
 | Config watcher | `agent-bom watch` | Filesystem watch on MCP configs, alert on drift |
 | Pre-install guard | `agent-bom guard pip install <pkg>` | Block vulnerable installs |
 | Snowflake | [DEPLOYMENT.md](DEPLOYMENT.md) | Snowpark + SiS |
@@ -536,7 +536,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full diagrams: data flow pi
 
 **Agents / MCP**
 - [x] 22 MCP client config discovery paths, live introspection, tool drift detection
-- [x] Runtime proxy with 6 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, vector DB injection) + semantic injection scoring
+- [x] Runtime proxy with 7 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, rate limiting, vector DB injection) + semantic injection scoring
 - [x] Semantic injection scoring — weighted 10-signal model, 0.0–1.0 risk score, MEDIUM/HIGH alerts
 - [ ] Agent memory / vector store content scanning for injected instructions
 - [ ] LLM API call tracing (which model was called, with what context)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,6 +171,7 @@ graph TD
     OWASP_LLM["OWASP LLM Top 10\nLLM01 - LLM10"]
     OWASP_MCP["OWASP MCP Top 10\nMCP01 - MCP10"]
     OWASP_AGT["OWASP Agentic Top 10\nASI01 - ASI10"]
+    OWASP_AISVS["OWASP AISVS v1.0\nAI Supply Chain / Runtime Controls"]
     ATLAS["MITRE ATLAS\nAML.T0010 / T0043 / T0051"]
     NIST_AI["NIST AI RMF 1.0\nGovern / Map / Measure / Manage"]
     EU_AI["EU AI Act\nART-5 through ART-17"]
@@ -182,6 +183,7 @@ graph TD
     Finding --> OWASP_LLM
     Finding --> OWASP_MCP
     Finding --> OWASP_AGT
+    Finding --> OWASP_AISVS
     Finding --> ATLAS
     Finding --> NIST_AI
     Finding --> EU_AI
@@ -195,6 +197,7 @@ graph TD
     OWASP_LLM --> Tagged
     OWASP_MCP --> Tagged
     OWASP_AGT --> Tagged
+    OWASP_AISVS --> Tagged
     ATLAS --> Tagged
     NIST_AI --> Tagged
     EU_AI --> Tagged


### PR DESCRIPTION
## Summary

- **README**: fix stale behavioral detector count 6→7 in 3 places; add rate limiting to detector list
- **CHANGELOG**: add complete `v0.70.4` release entry documenting all work from PRs #612–664
- **docs/ARCHITECTURE.md**: add OWASP AISVS v1.0 as the 11th compliance framework in the Mermaid compliance diagram (the text already said "11 frameworks" but the diagram only showed 10)

## Test plan
- [ ] Verify `grep -c "behavioral" README.md` shows 7 in all 3 locations
- [ ] Verify CHANGELOG v0.70.4 section is present and accurate
- [ ] Verify docs/ARCHITECTURE.md Mermaid diagram renders with OWASP AISVS node