### PR TITLE
chore: align SVG diagrams and README visuals to v0.70.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agent-bom scan --enrich      # + NVD CVSS + EPSS + CISA KEV enrichment
 That's it. agent-bom discovers your MCP client configs (Claude Desktop, Cursor, Windsurf, and 20 more), resolves every server's dependencies, checks them against OSV/NVD/GHSA, and maps the blast radius — which agents, credentials, and tools are affected by each vulnerability.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-v0.65.0.gif" alt="agent-bom demo — scan, CVE check, blast radius, runtime proxy, 31 MCP tools" width="900" />
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-v0.65.0.gif" alt="agent-bom demo — scan, CVE check, blast radius, runtime proxy, 30 MCP tools" width="900" />
 </p>
 
 <p align="center">

--- a/docs/images/before-after-dark.svg
+++ b/docs/images/before-after-dark.svg
@@ -85,7 +85,7 @@
   </g>
   <g transform="translate(484, 270)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.4"/>
-    <text x="18" y="12" class="bullet">10 compliance frameworks auto-mapped</text>
+    <text x="18" y="12" class="bullet">11 compliance frameworks auto-mapped</text>
   </g>
   <g transform="translate(484, 308)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.4"/>

--- a/docs/images/before-after-light.svg
+++ b/docs/images/before-after-light.svg
@@ -85,7 +85,7 @@
   </g>
   <g transform="translate(484, 270)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.35"/>
-    <text x="18" y="12" class="bullet">10 compliance frameworks auto-mapped</text>
+    <text x="18" y="12" class="bullet">11 compliance frameworks auto-mapped</text>
   </g>
   <g transform="translate(484, 308)">
     <circle cx="6" cy="8" r="4" fill="#3fb950" opacity="0.35"/>

--- a/docs/images/integration-architecture-dark.svg
+++ b/docs/images/integration-architecture-dark.svg
@@ -109,7 +109,7 @@
     </g>
     <!-- Tag pill -->
     <rect x="16" y="158" width="132" height="22" rx="11" fill="#bc8cff" opacity="0.12"/>
-    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#bc8cff">10 compliance frameworks</text>
+    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#bc8cff">11 compliance frameworks</text>
   </g>
 
   <!-- Arrow 3→4 -->

--- a/docs/images/integration-architecture-light.svg
+++ b/docs/images/integration-architecture-light.svg
@@ -109,7 +109,7 @@
     </g>
     <!-- Tag pill -->
     <rect x="16" y="158" width="132" height="22" rx="11" fill="#bc8cff" opacity="0.1"/>
-    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#8250df">10 compliance frameworks</text>
+    <text x="82" y="173" text-anchor="middle" class="engine-tag" fill="#8250df">11 compliance frameworks</text>
   </g>
 
   <!-- Arrow 3→4 -->

--- a/docs/images/modes-flow-dark.svg
+++ b/docs/images/modes-flow-dark.svg
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#3fb950"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#3fb950">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.68.1</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.70.4</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>

--- a/docs/images/modes-flow-light.svg
+++ b/docs/images/modes-flow-light.svg
@@ -86,7 +86,7 @@
   <rect x="342" y="210" width="50" height="15" rx="4" fill="#1a7f37"/>
   <text x="367" y="221" text-anchor="middle" class="badge">ACTION</text>
   <text x="402" y="221" class="mode-title" fill="#1a7f37">GitHub Action</text>
-  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.68.1</text>
+  <text x="342" y="238" class="mode-cmd">uses: msaad00/agent-bom@v0.70.4</text>
   <text x="342" y="254" class="mode-feat">CI/CD gate: fail on severity threshold</text>
   <text x="342" y="268" class="mode-feat">PR comments with scan summary</text>
   <text x="342" y="282" class="mode-feat">SARIF upload to GitHub Code Scanning</text>

--- a/docs/images/scan-output-dark.svg
+++ b/docs/images/scan-output-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="560" viewBox="0 0 900 560">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
   <defs>
     <style>
       .bg    { fill: #0d1117; }
@@ -20,75 +20,78 @@
   </defs>
 
   <!-- window chrome -->
-  <rect width="900" height="560" rx="10" class="bg"/>
+  <rect width="900" height="600" rx="10" class="bg"/>
   <rect width="900" height="36" rx="10" class="bar"/>
   <rect y="26" width="900" height="10" class="bar"/>
   <circle cx="18" cy="18" r="6" class="dot-r"/>
   <circle cx="38" cy="18" r="6" class="dot-y"/>
   <circle cx="58" cy="18" r="6" class="dot-g"/>
-  <text x="440" y="23" text-anchor="middle" class="hdr">agent-bom v0.68.1</text>
+  <text x="440" y="23" text-anchor="middle" class="hdr">agent-bom v0.70.4</text>
 
   <!-- prompt + command -->
   <text x="20" y="62" class="dim">$</text>
-  <text x="32" y="62" class="grn">agent-bom scan --gpu-scan</text>
+  <text x="32" y="62" class="grn">agent-bom scan --gpu-scan --delta --aws --aws-include-eks</text>
 
   <!-- discovery section -->
   <text x="20" y="88" class="blu">🔍 Discovering MCP configurations...</text>
   <text x="20" y="108" class="grn">  ✓</text>
-  <text x="38" y="108" class="norm">Found claude-desktop with 2 MCP server(s)</text>
+  <text x="38" y="108" class="norm">Found claude-desktop with 3 MCP server(s)</text>
   <text x="20" y="124" class="grn">  ✓</text>
   <text x="38" y="124" class="norm">Found cursor with 5 MCP server(s)</text>
   <text x="20" y="140" class="grn">  ✓</text>
   <text x="38" y="140" class="norm">Found docker-mcp with 1 enabled server(s), 22 tool(s)</text>
-  <text x="20" y="160" class="hdr">  Found 3 configured agent(s) with 8 MCP server(s) total</text>
+  <text x="20" y="156" class="grn">  ✓</text>
+  <text x="38" y="156" class="norm">Discovered 2 MCP servers on EKS (pod labels: mcp.io/server=true)</text>
+  <text x="20" y="172" class="hdr">  Found 4 configured agent(s) with 11 MCP server(s) total</text>
 
-  <!-- package resolution -->
-  <text x="20" y="180" class="grn">  ✓</text>
-  <text x="38" y="180" class="norm">Resolved @modelcontextprotocol/server-filesystem → 2026.1.14 (MIT)</text>
-  <text x="20" y="196" class="grn">  ✓</text>
-  <text x="38" y="196" class="norm">Resolved @modelcontextprotocol/server-github → 2025.4.8 (MIT)</text>
-  <text x="20" y="212" class="grn">  ✓</text>
-  <text x="38" y="212" class="norm">Resolved mcp-server-fetch → 2025.4.7 (MIT)</text>
-  <text x="20" y="228" class="grn">  ✓</text>
-  <text x="38" y="228" class="norm">Resolved @modelcontextprotocol/server-postgres → 0.6.2 (MIT)</text>
-  <text x="20" y="244" class="grn">  ✓</text>
-  <text x="38" y="244" class="norm">Resolved agent-bom → 0.63.0 (Apache-2.0)</text>
+  <!-- parser section -->
+  <text x="20" y="192" class="blu">📦 Resolving packages (Go · Gradle · Bun · conda · pip)...</text>
+  <text x="20" y="208" class="grn">  ✓</text>
+  <text x="38" y="208" class="norm">Resolved @modelcontextprotocol/server-filesystem → 2026.1.14 (MIT)</text>
+  <text x="20" y="224" class="grn">  ✓</text>
+  <text x="38" y="224" class="norm">Resolved torch → 2.3.0 (BSD-3-Clause)</text>
+  <text x="20" y="240" class="grn">  ✓</text>
+  <text x="38" y="240" class="norm">Resolved agent-bom → 0.70.4 (Apache-2.0)</text>
+  <text x="20" y="256" class="hdr">  14 packages resolved  |  2 unresolved (latest — warnings logged)</text>
 
   <!-- divider -->
-  <line x1="20" y1="256" x2="880" y2="256" stroke="#21262d" stroke-width="1"/>
+  <line x1="20" y1="268" x2="880" y2="268" stroke="#21262d" stroke-width="1"/>
 
   <!-- GPU scan section -->
-  <text x="20" y="276" class="blu">🖥️  Scanning GPU/AI compute infrastructure...</text>
-  <text x="20" y="296" class="grn">  ✓</text>
-  <text x="38" y="296" class="norm">2 GPU container(s), 1 K8s GPU node(s)</text>
-  <text x="20" y="312" class="hdr">  CUDA versions: 12.3.0, 12.1.0</text>
-  <text x="20" y="328" class="red">  ⚠</text>
-  <text x="36" y="328" class="red">1 unauthenticated DCGM exporter — GPU metrics exposed on :9400</text>
-  <!-- DCGM table -->
-  <rect x="20" y="338" width="860" height="1" fill="#21262d"/>
-  <text x="24" y="356" class="hdr">  Host         Port   Auth   GPUs</text>
-  <text x="24" y="372" class="norm">  localhost    9400 </text>
-  <text x="170" y="372" class="red">  NO  </text>
-  <text x="220" y="372" class="norm">   4</text>
-  <rect x="20" y="378" width="860" height="1" fill="#21262d"/>
-
-  <!-- vuln scan section -->
-  <text x="20" y="402" class="blu">🛡️  Scanning for vulnerabilities...</text>
-  <text x="20" y="420" class="hdr">  Scanning 8 unique packages across 7 agent(s)...</text>
-  <text x="20" y="438" class="grn">  ✓ No known vulnerabilities found</text>
+  <text x="20" y="288" class="blu">🖥️  Scanning GPU/AI compute infrastructure (EKS + local)...</text>
+  <text x="20" y="308" class="grn">  ✓</text>
+  <text x="38" y="308" class="norm">3 GPU container(s), 2 K8s GPU node(s)  |  CUDA: 12.4.0, 12.3.0</text>
+  <text x="20" y="324" class="grn">  ✓</text>
+  <text x="38" y="324" class="norm">2 NIM containers (nvcr.io/nim/meta/llama-3.1-8b-instruct:latest)</text>
+  <text x="20" y="340" class="red">  ⚠</text>
+  <text x="36" y="340" class="red">1 unauthenticated DCGM exporter — GPU metrics exposed on :9400</text>
 
   <!-- divider -->
-  <line x1="20" y1="450" x2="880" y2="450" stroke="#21262d" stroke-width="1"/>
+  <line x1="20" y1="352" x2="880" y2="352" stroke="#21262d" stroke-width="1"/>
+
+  <!-- vuln scan + delta -->
+  <text x="20" y="372" class="blu">🛡️  Scanning 14 packages (local DB + OSV + GHSA)  |  delta mode: new findings only...</text>
+  <text x="20" y="392" class="yel">  ⚠ HIGH</text>
+  <text x="82" y="392" class="norm">  torch 2.3.0 — CVE-2024-5480  CVSS 8.1  EPSS 0.42  [KEV]</text>
+  <text x="20" y="408" class="yel">  ⚠ HIGH</text>
+  <text x="82" y="408" class="norm">  nvidia-cuda-runtime-cu12 — CVE-2024-0085  CVSS 7.8</text>
+  <text x="20" y="424" class="hdr">  2 new finding(s) since last scan  |  compliance: OWASP LLM05, NIST AI RMF MAP-1.5</text>
+
+  <!-- divider -->
+  <line x1="20" y1="436" x2="880" y2="436" stroke="#21262d" stroke-width="1"/>
 
   <!-- summary box -->
-  <rect x="20" y="462" width="860" height="76" rx="6" fill="#161b22" stroke="#21262d" stroke-width="1"/>
-  <text x="36" y="482" class="grn">AI-BOM Report  v0.68.1</text>
-  <text x="36" y="498" class="hdr">────────────────────────────────────────────────</text>
-  <text x="36" y="514" class="norm">Agents: </text><text x="90" y="514" class="cyn">3</text>
-  <text x="140" y="514" class="norm">Servers: </text><text x="198" y="514" class="cyn">8</text>
-  <text x="248" y="514" class="norm">Packages: </text><text x="316" y="514" class="cyn">8</text>
-  <text x="366" y="514" class="norm">CVEs: </text><text x="406" y="514" class="grn">0</text>
-  <text x="456" y="514" class="norm">GPU containers: </text><text x="570" y="514" class="yel">2</text>
-  <text x="620" y="514" class="norm">Unauthenticated DCGM: </text><text x="784" y="514" class="red">1</text>
-  <text x="36" y="530" class="dim">Exit 0 — clean</text>
+  <rect x="20" y="448" width="860" height="132" rx="6" fill="#161b22" stroke="#21262d" stroke-width="1"/>
+  <text x="36" y="468" class="grn">AI-BOM Report  v0.70.4</text>
+  <text x="36" y="484" class="hdr">────────────────────────────────────────────────────────────────────</text>
+  <text x="36" y="500" class="norm">Agents: </text><text x="90" y="500" class="cyn">4</text>
+  <text x="120" y="500" class="norm">Servers: </text><text x="178" y="500" class="cyn">11</text>
+  <text x="208" y="500" class="norm">Packages: </text><text x="276" y="500" class="cyn">14</text>
+  <text x="306" y="500" class="norm">CVEs: </text><text x="346" y="500" class="yel">2</text>
+  <text x="376" y="500" class="norm">GPU containers: </text><text x="490" y="500" class="yel">3</text>
+  <text x="520" y="500" class="norm">DCGM exposed: </text><text x="626" y="500" class="red">1</text>
+  <text x="36" y="516" class="norm">Compliance: </text><text x="110" y="516" class="pur">OWASP LLM · OWASP MCP · OWASP Agentic · OWASP AISVS · MITRE ATLAS · NIST AI RMF</text>
+  <text x="36" y="532" class="norm">           </text><text x="110" y="532" class="pur">EU AI Act · NIST CSF · ISO 27001 · SOC 2 · CIS Controls  (11 frameworks)</text>
+  <text x="36" y="548" class="norm">Cloud: </text><text x="82" y="548" class="cyn">AWS (EC2 · EKS · Bedrock)  |  12 providers supported</text>
+  <text x="36" y="564" class="yel">Exit 2 — 2 new HIGH finding(s)  [--warn-on HIGH]</text>
 </svg>

--- a/docs/images/scan-workflow-dark.svg
+++ b/docs/images/scan-workflow-dark.svg
@@ -106,7 +106,7 @@
   <text x="1010" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Blast radius (6-hop chains)</text>
   <text x="1010" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Context graph + attack paths</text>
   <text x="1010" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">Toxic combos · Posture A-F</text>
-  <text x="1010" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">10 compliance frameworks</text>
+  <text x="1010" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#8b949e">11 compliance frameworks</text>
 
   <rect x="930" y="368" width="160" height="26" rx="13" fill="#3f0f0f"/>
   <text x="1010" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#ff7b72">70+ MODULES</text>

--- a/docs/images/scan-workflow-light.svg
+++ b/docs/images/scan-workflow-light.svg
@@ -106,7 +106,7 @@
   <text x="1010" y="280" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Blast radius (6-hop chains)</text>
   <text x="1010" y="300" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Context graph + attack paths</text>
   <text x="1010" y="320" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">Toxic combos · Posture A-F</text>
-  <text x="1010" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">10 compliance frameworks</text>
+  <text x="1010" y="340" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="#64748b">11 compliance frameworks</text>
 
   <rect x="930" y="368" width="160" height="26" rx="13" fill="#fee2e2"/>
   <text x="1010" y="386" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="700" fill="#991b1b">70+ MODULES</text>


### PR DESCRIPTION
## Summary

All static diagrams and README visuals aligned with v0.70.4 capabilities.

**SVG diagram fixes:**
- `scan-output-dark.svg` — full refresh: v0.70.4, delta mode, NIM container discovery, new parser ecosystems (Go/Gradle/Bun/conda/pip), 11 compliance frameworks including OWASP AISVS, `--warn-on` exit code, local DB + OSV + GHSA sources shown in output
- `before-after-dark/light.svg` — 10 → 11 compliance frameworks
- `integration-architecture-dark/light.svg` — 10 → 11 compliance frameworks
- `scan-workflow-dark/light.svg` — 10 → 11 compliance frameworks
- `modes-flow-dark/light.svg` — `agent-bom@v0.68.1` → `agent-bom@v0.70.4`

**README fix:**
- Alt text on demo GIF: 31 → 30 MCP tools

## What's not in this PR (needs real recording)
- `demo-v0.65.0.gif` — terminal screen recording, needs a new `terminalizer`/`asciinema` session to regenerate. Tracked separately.

## Test plan
- [ ] Verify all SVGs render correctly in GitHub preview
- [ ] `grep -r "10 compliance\|v0.68.1\|31 MCP" docs/images/ README.md` returns 0 matches