### PR TITLE
fix: address toolhive-catalog PR #784 review feedback

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -41,6 +43,7 @@ jobs:
           fi
 
       - name: Build and push MCP container (stdio)
+        id: build-stdio
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
@@ -51,6 +54,13 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/agent-bom:${{ steps.version.outputs.tag }}
             ghcr.io/${{ github.repository_owner }}/agent-bom:latest
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/agent-bom
+          subject-digest: ${{ steps.build-stdio.outputs.digest }}
+          push-to-registry: true
 
   publish-sse:
     runs-on: ubuntu-latest

--- a/integrations/toolhive/server.json
+++ b/integrations/toolhive/server.json
@@ -27,7 +27,7 @@
   ],
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
-      "io.github.msaad00": {
+      "io.github.stacklok": {
         "ghcr.io/msaad00/agent-bom:v0.70.5": {
           "tier": "Community",
           "status": "Active",
@@ -69,7 +69,8 @@
             "model_provenance_scan",
             "prompt_scan",
             "model_file_scan",
-            "license_compliance_scan"
+            "license_compliance_scan",
+            "ingest_external_scan"
           ]
         }
       }


### PR DESCRIPTION
## Summary
Addresses all 4 review points from rdimitrov on stacklok/toolhive-catalog#784.

- **_meta publisher namespace**: `io.github.msaad00` → `io.github.stacklok` (confirmed correct format against Stripe, AWS API, Slack entries in the catalog)
- **SNYK_TOKEN**: already absent from `server.json` — only `NVD_API_KEY` is present. Will update PR description in toolhive-catalog to remove the stale SNYK mention.
- **Build provenance/attestation**: added `actions/attest-build-provenance@a2bbfa25...` to `publish-mcp.yml` `publish-stdio` job — GHCR image gets SLSA attestation on every release going forward
- **Tool count**: added `ingest_external_scan` as the 31st tool in `_meta.tools` (was missing from the list)
- **Image tag**: v0.70.5 (current); renovate automation handles future bumps as reviewer noted

## What was NOT changed
- `actions/attest-build-provenance` was already present in `release.yml` for PyPI packages — this PR extends it to cover the GHCR Docker image as well