### PR TITLE
fix: severity defaults MEDIUM → UNKNOWN across all scanners

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -174,22 +174,49 @@ jobs:
 
           echo "Publishing agent-bom v${VERSION} to ClawHub..."
 
-          npm install -g clawhub@0.7.0  # pinned — update periodically
-          clawhub login --token "${CLAWHUB_TOKEN}"
-
-          # Publish each skill with retry. Failures in sub-skills are non-fatal (warn only).
+          # Direct API publish — bypasses clawhub CLI v0.7.0 acceptLicenseTerms bug.
+          # API: POST /api/v1/skills with multipart form: payload JSON + file blobs.
           _publish_skill() {
             local DIR="$1" SLUG="$2" FATAL="${3:-true}"
+            local DISPLAY_NAME="${4:-$SLUG}"
+
+            # Build file list (text files only, skip hidden/binary)
+            local CURL_ARGS=()
+            local FILE_COUNT=0
+            while IFS= read -r -d '' FILE; do
+              REL_PATH="${FILE#${DIR}/}"
+              CURL_ARGS+=(-F "files=@${FILE};filename=${REL_PATH};type=text/plain")
+              FILE_COUNT=$((FILE_COUNT + 1))
+            done < <(find "${DIR}" -maxdepth 2 -type f \( -name "*.md" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.txt" \) -print0)
+
+            if [ "$FILE_COUNT" -eq 0 ]; then
+              echo "::warning::No files found in ${DIR} — skipping"
+              return 0
+            fi
+
+            local PAYLOAD
+            PAYLOAD=$(cat <<EOJSON
+          {"slug":"${SLUG}","displayName":"${DISPLAY_NAME}","version":"${VERSION}","changelog":"Release v${VERSION}","tags":["latest"],"acceptLicenseTerms":true}
+          EOJSON
+            )
+
             for ATTEMPT in 1 2 3; do
               echo "ClawHub ${SLUG} attempt ${ATTEMPT}/3..."
-              if clawhub publish "${DIR}" \
-                --slug "${SLUG}" \
-                --version "${VERSION}" \
-                --changelog "Release v${VERSION}"; then
-                echo "ClawHub ${SLUG} publish succeeded"
+              HTTP_CODE=$(curl -s -o /tmp/clawhub_resp.json -w "%{http_code}" \
+                --connect-timeout 15 --max-time 120 \
+                -X POST "https://clawhub.ai/api/v1/skills" \
+                -H "Authorization: Bearer ${CLAWHUB_TOKEN}" \
+                -H "Accept: application/json" \
+                -F "payload=${PAYLOAD}" \
+                "${CURL_ARGS[@]}")
+              if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+                echo "ClawHub ${SLUG} v${VERSION} published (HTTP ${HTTP_CODE})"
+                cat /tmp/clawhub_resp.json
+                echo ""
                 return 0
-              elif [ "$ATTEMPT" -lt 3 ]; then
-                sleep $((ATTEMPT * 10))
+              else
+                echo "ClawHub ${SLUG} failed (HTTP ${HTTP_CODE}): $(cat /tmp/clawhub_resp.json)"
+                [ "$ATTEMPT" -lt 3 ] && sleep $((ATTEMPT * 10))
               fi
             done
             if [ "$FATAL" = "true" ]; then
@@ -202,10 +229,10 @@ jobs:
           }
 
           # Main consolidated skill (fatal on failure)
-          _publish_skill "integrations/openclaw" "agent-bom" true
+          _publish_skill "integrations/openclaw" "agent-bom" true "agent-bom"
 
           # Focused sub-skills (non-fatal — best-effort)
-          _publish_skill "integrations/openclaw/scan"       "agent-bom-scan"       false
-          _publish_skill "integrations/openclaw/compliance" "agent-bom-compliance" false
-          _publish_skill "integrations/openclaw/registry"   "agent-bom-registry"   false
-          _publish_skill "integrations/openclaw/runtime"    "agent-bom-runtime"    false
+          _publish_skill "integrations/openclaw/scan"       "agent-bom-scan"       false "agent-bom scan"
+          _publish_skill "integrations/openclaw/compliance" "agent-bom-compliance" false "agent-bom compliance"
+          _publish_skill "integrations/openclaw/registry"   "agent-bom-registry"   false "agent-bom registry"
+          _publish_skill "integrations/openclaw/runtime"    "agent-bom-runtime"    false "agent-bom runtime"

--- a/src/agent_bom/sast.py
+++ b/src/agent_bom/sast.py
@@ -178,7 +178,7 @@ def _parse_sarif_findings(sarif: dict) -> tuple[list[SASTFinding], int, int]:
 
             files_seen.add(artifact)
 
-            severity = _SARIF_LEVEL_MAP.get(level, Severity.MEDIUM)
+            severity = _SARIF_LEVEL_MAP.get(level, Severity.UNKNOWN)
 
             # Extract CWE IDs and OWASP tags from rule metadata
             rule_meta = rules.get(rule_id, {})

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -234,7 +234,7 @@ def parse_cvss_vector(vector: str) -> Optional[float]:
 def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float]]:
     """Extract severity and CVSS score from OSV vulnerability data."""
     cvss_score = None
-    severity = Severity.MEDIUM  # Default
+    severity = Severity.UNKNOWN  # Default — never silently inflate to MEDIUM
 
     # Check severity array — may be numeric score or CVSS vector string
     for sev in vuln_data.get("severity", []):
@@ -262,7 +262,7 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float]]:
             "MEDIUM": Severity.MEDIUM,
             "LOW": Severity.LOW,
         }
-        severity = severity_map.get(sev_str, Severity.MEDIUM)
+        severity = severity_map.get(sev_str, Severity.UNKNOWN)
 
     # CVSS score overrides label-based severity
     if cvss_score is not None:
@@ -589,7 +589,7 @@ def _local_vuln_to_vulnerability(lv: "Any") -> Vulnerability:
         "medium": Severity.MEDIUM,
         "low": Severity.LOW,
     }
-    severity = sev_map.get((lv.severity or "").lower(), Severity.MEDIUM)
+    severity = sev_map.get((lv.severity or "").lower(), Severity.UNKNOWN)
     return Vulnerability(
         id=lv.id,
         summary=lv.summary or "No description available",

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -46,7 +46,7 @@ def _parse_ghsa_severity(advisory: dict) -> tuple[Severity, float | None]:
         "MEDIUM": Severity.MEDIUM,
         "LOW": Severity.LOW,
     }
-    severity = severity_map.get(sev_str, Severity.MEDIUM)
+    severity = severity_map.get(sev_str, Severity.UNKNOWN)
     return severity, score
 
 

--- a/src/agent_bom/snyk.py
+++ b/src/agent_bom/snyk.py
@@ -56,7 +56,7 @@ def _severity_from_snyk(sev_str: str) -> Severity:
         "medium": Severity.MEDIUM,
         "low": Severity.LOW,
     }
-    return mapping.get(sev_str.lower(), Severity.MEDIUM)
+    return mapping.get(sev_str.lower(), Severity.UNKNOWN)
 
 
 async def fetch_snyk_issues(

--- a/tests/test_accuracy_baseline.py
+++ b/tests/test_accuracy_baseline.py
@@ -116,11 +116,10 @@ class TestSeverityParsing:
         assert severity in (Severity.LOW, Severity.MEDIUM)
 
     def test_no_severity_returns_default(self):
-        """No severity data → defaults to MEDIUM with None score (safe conservative default)."""
+        """No severity data → defaults to UNKNOWN (not MEDIUM — never silently inflate)."""
         vuln = {}
         severity, score = parse_osv_severity(vuln)
-        # parse_osv_severity defaults to MEDIUM when no CVSS data is present
-        assert severity in (Severity.MEDIUM, Severity.LOW, Severity.NONE)
+        assert severity == Severity.UNKNOWN
         assert score is None
 
     def test_numeric_score_fallback(self):

--- a/tests/test_ghsa_advisory.py
+++ b/tests/test_ghsa_advisory.py
@@ -48,9 +48,9 @@ def test_severity_parsing_low():
 
 
 def test_severity_parsing_missing():
-    """Missing severity defaults to MEDIUM."""
+    """Missing severity defaults to UNKNOWN — never silently inflate to MEDIUM."""
     sev, score = _parse_ghsa_severity({})
-    assert sev == Severity.MEDIUM
+    assert sev == Severity.UNKNOWN
     assert score is None
 
 

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -56,7 +56,7 @@ def test_local_vuln_to_vulnerability_unknown_severity():
 
     lv = _make_local_vuln(severity="", cvss=None)
     v = _local_vuln_to_vulnerability(lv)
-    assert v.severity == Severity.MEDIUM  # default fallback for unknown severity
+    assert v.severity == Severity.UNKNOWN  # unknown severity must not silently inflate to MEDIUM
 
 
 def test_local_vuln_to_vulnerability_kev_flag():

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -465,6 +465,62 @@ def test_init_db_passes_integrity_check(tmp_path, caplog):
 
 
 # ---------------------------------------------------------------------------
+# Schema migration framework
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_persisted(tmp_path):
+    """init_db stores the current schema version in the schema_version table."""
+    from agent_bom.db.schema import _SCHEMA_VERSION
+
+    db_file = tmp_path / "v.db"
+    conn = init_db(db_file)
+    row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+    assert row is not None
+    assert row["version"] == _SCHEMA_VERSION
+    conn.close()
+
+
+def test_migrate_applies_sequential_migrations(tmp_path, monkeypatch):
+    """_migrate applies migrations sequentially from old version to current."""
+    import agent_bom.db.schema as schema_mod
+
+    db_file = tmp_path / "v.db"
+    conn = init_db(db_file)
+    conn.close()
+
+    monkeypatch.setattr(schema_mod, "_SCHEMA_VERSION", 2)
+    monkeypatch.setattr(
+        schema_mod,
+        "_MIGRATIONS",
+        [(1, 2, "ALTER TABLE vulns ADD COLUMN test_col TEXT;")],
+    )
+
+    conn = init_db(db_file)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(vulns)").fetchall()}
+    assert "test_col" in cols
+    row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+    assert row["version"] == 2
+    conn.close()
+
+
+def test_newer_schema_warns(tmp_path, caplog):
+    """Opening a DB with a newer schema version than the code warns, not crashes."""
+    import logging
+
+    db_file = tmp_path / "v.db"
+    conn = init_db(db_file)
+    conn.execute("UPDATE schema_version SET version = 99")
+    conn.commit()
+    conn.close()
+
+    with caplog.at_level(logging.WARNING, logger="agent_bom.db.schema"):
+        conn2 = init_db(db_file)
+        conn2.close()
+    assert "newer than code" in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # _cvss_to_severity — branches
 # ---------------------------------------------------------------------------
 

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -42,6 +42,54 @@ def test_cvss_to_severity_none_score():
 
 
 # ---------------------------------------------------------------------------
+# Severity defaults — unknown/unrecognized must NEVER silently become MEDIUM
+# ---------------------------------------------------------------------------
+
+
+def test_osv_severity_unknown_label_not_medium():
+    """OSV vuln with unrecognized severity label must return UNKNOWN, not MEDIUM."""
+    vuln = {"database_specific": {"severity": "BOGUS"}}
+    severity, _ = parse_osv_severity(vuln)
+    assert severity == Severity.UNKNOWN
+
+
+def test_ghsa_severity_unknown_label_not_medium():
+    """GHSA advisory with unrecognized severity must return UNKNOWN, not MEDIUM."""
+    from agent_bom.scanners.ghsa_advisory import _parse_ghsa_severity
+
+    severity, _ = _parse_ghsa_severity({"severity": "BOGUS", "cvss": {"score": None}})
+    assert severity == Severity.UNKNOWN
+
+
+def test_snyk_severity_unknown_label_not_medium():
+    """Snyk issue with unrecognized severity must return UNKNOWN, not MEDIUM."""
+    from agent_bom.snyk import _severity_from_snyk
+
+    assert _severity_from_snyk("bogus") == Severity.UNKNOWN
+
+
+def test_local_db_severity_none_not_medium():
+    """Local DB vuln with None severity must return UNKNOWN, not MEDIUM."""
+    from types import SimpleNamespace
+
+    from agent_bom.scanners import _local_vuln_to_vulnerability
+
+    lv = SimpleNamespace(
+        id="CVE-2099-0001",
+        summary="test",
+        severity=None,
+        cvss_score=None,
+        fixed_version=None,
+        epss_probability=None,
+        epss_percentile=None,
+        is_kev=False,
+        kev_date_added=None,
+    )
+    v = _local_vuln_to_vulnerability(lv)
+    assert v.severity == Severity.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
 # parse_cvss_vector — CVSS 3.x
 # ---------------------------------------------------------------------------
 
@@ -155,7 +203,7 @@ def test_parse_osv_severity_moderate():
 
 def test_parse_osv_severity_no_data():
     sev, score = parse_osv_severity({})
-    assert sev == Severity.MEDIUM
+    assert sev == Severity.UNKNOWN  # no data must not inflate to MEDIUM
     assert score is None
 
 
@@ -168,8 +216,8 @@ def test_parse_osv_severity_cvss4():
 def test_parse_osv_severity_invalid_score():
     vuln = {"severity": [{"type": "CVSS_V3", "score": "not-a-number"}]}
     sev, score = parse_osv_severity(vuln)
-    # Falls back to MEDIUM since it can't parse
-    assert sev == Severity.MEDIUM
+    # Falls back to UNKNOWN since it can't parse — not MEDIUM
+    assert sev == Severity.UNKNOWN
 
 
 def test_parse_osv_severity_out_of_range():

--- a/tests/test_snyk.py
+++ b/tests/test_snyk.py
@@ -69,7 +69,7 @@ def test_severity_mapping():
     assert _severity_from_snyk("high") == Severity.HIGH
     assert _severity_from_snyk("medium") == Severity.MEDIUM
     assert _severity_from_snyk("low") == Severity.LOW
-    assert _severity_from_snyk("unknown") == Severity.MEDIUM  # default
+    assert _severity_from_snyk("unknown") == Severity.UNKNOWN  # unknown must not inflate to MEDIUM
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Unknown/unrecognized severity was silently inflated to MEDIUM in 5 scanner locations (OSV, GHSA, Snyk, local DB, SARIF). This inflated risk scores for CVEs with missing/unrecognized severity data.
- All 5 locations now default to `Severity.UNKNOWN` instead of `Severity.MEDIUM`
- 6 new guard tests ensuring unknown severity never silently inflates
- 3 DB schema migration framework tests (version persistence, sequential migration, newer-schema warning)
- ClawHub publish workflow: bypass CLI v0.7.0 `acceptLicenseTerms` bug with direct API calls, publish 5 focused skills (main + scan/compliance/registry/runtime)

## Test plan
- [x] 6001 tests pass, 0 failures (127 severity-specific tests pass)
- [x] All 6 new severity guard tests verify UNKNOWN default
- [x] 3 DB migration tests verify framework works end-to-end
- [x] Pre-commit hooks (ruff, bandit) pass