### PR TITLE
fix: self-scan workflows use wrong CLI flags

### DIFF
--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -41,7 +41,8 @@ jobs:
         id: dep_scan
         run: |
           set +e
-          uv run agent-bom scan --self-scan --output sarif --save sarif/self-dep.sarif --quiet
+          mkdir -p sarif
+          uv run agent-bom scan --self-scan --format sarif -o sarif/self-dep.sarif --quiet
           echo "dep_exit=$?" >> "$GITHUB_OUTPUT"
 
       - name: Run SAST scan on source code (--code)
@@ -50,20 +51,20 @@ jobs:
           set +e
           uv run agent-bom scan \
             --code src/agent_bom \
-            --output sarif \
-            --save sarif/self-sast.sarif \
+            --format sarif \
+            -o sarif/self-sast.sarif \
             --quiet
           echo "sast_exit=$?" >> "$GITHUB_OUTPUT"
 
       - name: Upload dep scan SARIF
-        if: always()
+        if: always() && hashFiles('sarif/self-dep.sarif') != ''
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           sarif_file: sarif/self-dep.sarif
           category: agent-bom-self-dep
 
       - name: Upload SAST SARIF
-        if: always()
+        if: always() && hashFiles('sarif/self-sast.sarif') != ''
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           sarif_file: sarif/self-sast.sarif
@@ -96,7 +97,7 @@ jobs:
         run: |
           mkdir -p sbom
           set +e
-          uv run agent-bom scan --self-scan --output cyclonedx --save sbom/agent-bom.cdx.json --quiet
+          uv run agent-bom scan --self-scan --format cyclonedx -o sbom/agent-bom.cdx.json --quiet
           echo "SBOM generated (exit $?)"
 
       - name: Upload SBOM artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,13 +121,13 @@ jobs:
         run: |
           mkdir -p sarif
           uv run agent-bom scan --self-scan \
-            --output sarif \
-            --save sarif/release-self-dep.sarif \
+            --format sarif \
+            -o sarif/release-self-dep.sarif \
             --fail-on-severity critical \
             --quiet
 
       - name: Upload release self-scan SARIF
-        if: always()
+        if: always() && hashFiles('sarif/release-self-dep.sarif') != ''
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           sarif_file: sarif/release-self-dep.sarif


### PR DESCRIPTION
## Summary
- `--output sarif` → `--format sarif` (format selector, not file path)
- `--save sarif/file.sarif` → `-o sarif/file.sarif` (`--save` is a boolean flag for history, not a path)
- Adds `hashFiles()` guards on SARIF upload steps so they skip gracefully if scan produces no output

## Affected workflows
- `post-merge-self-scan.yml` — 3 commands fixed (dep scan, SAST scan, SBOM generation)
- `release.yml` — 1 command fixed (self-scan gate)

This has been broken since the workflow was created — every run failed with `Error: Got unexpected extra argument`.

## Test plan
- [ ] Post-merge self-scan passes after merge (triggered on push to main)
- [ ] Release self-scan gate works on next release

Closes #0