### PR TITLE
fix: SEVERITY_ORDER missing UNKNOWN + CVSS 0.0 → none

### DIFF
--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -23,7 +23,7 @@ BANNER = r"""
   AI Bill of Materials for Agents & MCP Servers
 """
 
-SEVERITY_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1, "none": 0}
+SEVERITY_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1, "none": 0, "unknown": -1}
 
 
 def _make_console(quiet: bool = False, output_format: str = "console", no_color: bool = False) -> Console:

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -140,6 +140,8 @@ _CVSS_SEVERITY = {
 def _cvss_to_severity(score: Optional[float]) -> str:
     if score is None:
         return "unknown"
+    if score == 0.0:
+        return "none"
     for (lo, hi), sev in _CVSS_SEVERITY.items():
         if lo <= score <= hi:
             return sev

--- a/src/agent_bom/enforcement.py
+++ b/src/agent_bom/enforcement.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+_SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "none": 4, "unknown": -1}
 
 # Zero-width and invisible Unicode characters commonly used for evasion
 _INVISIBLE_RE = re.compile(r"[\u200b\u200c\u200d\u200e\u200f\u2060\u2061\u2062\u2063\u2064\ufeff\u00ad\u034f\u115f\u1160\u17b4\u17b5]")

--- a/src/agent_bom/policy.py
+++ b/src/agent_bom/policy.py
@@ -47,7 +47,7 @@ import operator
 import re
 from pathlib import Path
 
-SEVERITY_ORDER = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1, "NONE": 0}
+SEVERITY_ORDER = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1, "NONE": 0, "UNKNOWN": -1}
 RISK_LEVEL_ORDER = {"high": 3, "medium": 2, "low": 1}
 
 

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -204,6 +204,10 @@ def test_severity_order():
 
     assert SEVERITY_ORDER["critical"] > SEVERITY_ORDER["high"]
     assert SEVERITY_ORDER["high"] > SEVERITY_ORDER["medium"]
+    assert SEVERITY_ORDER["medium"] > SEVERITY_ORDER["low"]
+    assert SEVERITY_ORDER["low"] > SEVERITY_ORDER["none"]
+    assert SEVERITY_ORDER["none"] > SEVERITY_ORDER["unknown"]
+    assert "unknown" in SEVERITY_ORDER, "UNKNOWN must be in SEVERITY_ORDER"
 
 
 def test_banner_is_string():

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -555,10 +555,11 @@ def test_cvss_to_severity_low():
     assert _cvss_to_severity(2.5) == "low"
 
 
-def test_cvss_to_severity_unknown_score():
+def test_cvss_to_severity_zero_is_none():
+    """CVSS 0.0 means 'none' severity, not 'unknown' (unknown = missing data)."""
     from agent_bom.db.sync import _cvss_to_severity
 
-    assert _cvss_to_severity(0.0) == "unknown"
+    assert _cvss_to_severity(0.0) == "none"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -161,6 +161,22 @@ def test_rule_matches_severity_gte():
     assert _rule_matches(rule_high, br_low) is False
 
 
+def test_severity_order_includes_unknown():
+    """UNKNOWN must be in SEVERITY_ORDER and sort below NONE (per FIRST CVSS spec)."""
+    from agent_bom.policy import SEVERITY_ORDER
+
+    assert "UNKNOWN" in SEVERITY_ORDER, "UNKNOWN missing from SEVERITY_ORDER"
+    assert SEVERITY_ORDER["UNKNOWN"] < SEVERITY_ORDER["NONE"]
+    assert SEVERITY_ORDER["NONE"] < SEVERITY_ORDER["LOW"]
+
+
+def test_rule_matches_severity_gte_unknown():
+    """UNKNOWN severity (-1) should NOT match severity_gte: LOW (1)."""
+    br_unknown = _make_blast_radius(severity="unknown")
+    rule_low = {"id": "sev", "severity_gte": "LOW", "action": "fail"}
+    assert _rule_matches(rule_low, br_unknown) is False
+
+
 def test_rule_matches_is_kev():
     """is_kev: matches when vulnerability is in CISA KEV catalog."""
     br_kev = _make_blast_radius(is_kev=True)


### PR DESCRIPTION
## Summary
- Add `UNKNOWN` to all 3 `SEVERITY_ORDER` dicts (`policy.py`, `cli/_common.py`, `enforcement.py`) — UNKNOWN was missing, causing policy engine to conflate UNKNOWN with NONE (both ordinal 0)
- Fix `db/sync.py` `_cvss_to_severity()` — CVSS score 0.0 now correctly maps to `"none"` instead of `"unknown"` per [FIRST CVSS v3.1 spec](https://www.first.org/cvss/v3-1/specification-document)
- Add `"none"` entry to `enforcement.py` `_SEVERITY_ORDER` (was also missing)

### Industry standard (FIRST CVSS v3.1)
| Score | Severity |
|-------|----------|
| 0.0 | **None** (assessed, zero impact) |
| 0.1–3.9 | Low |
| — | ... |
| No score | **Unknown** (not yet assessed) |

Trivy, Grype, and NVD all distinguish these two — our code was conflating them.

## Test plan
- [x] 3 new tests: `test_severity_order_includes_unknown`, `test_rule_matches_severity_gte_unknown`, full chain `test_severity_order`
- [x] 1 corrected test: `test_cvss_to_severity_zero_is_none` (was asserting wrong "unknown")
- [x] 179 tests in affected files pass, 0 regressions

Closes #703, closes #704