### PR TITLE
fix: SARIF security-severity property + UNKNOWN→note

### DIFF
--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -14,6 +14,18 @@ _SARIF_SEVERITY_MAP = {
     Severity.MEDIUM: "warning",
     Severity.LOW: "note",
     Severity.NONE: "none",
+    Severity.UNKNOWN: "note",
+}
+
+# GitHub Security tab uses security-severity (0.0–10.0) for granular sorting.
+# Ranges per docs.github.com: >9.0=critical, 7.0–8.9=high, 4.0–6.9=medium, 0.1–3.9=low
+_SECURITY_SEVERITY_SCORE = {
+    Severity.CRITICAL: "9.5",
+    Severity.HIGH: "7.5",
+    Severity.MEDIUM: "5.5",
+    Severity.LOW: "2.5",
+    Severity.NONE: "0.0",
+    Severity.UNKNOWN: "0.0",
 }
 
 
@@ -30,15 +42,19 @@ def to_sarif(report: AIBOMReport) -> dict:
 
         if rule_id not in seen_rule_ids:
             seen_rule_ids.add(rule_id)
+            # Use actual CVSS score when available, otherwise map from severity
+            sec_sev = str(vuln.cvss_score) if vuln.cvss_score is not None else _SECURITY_SEVERITY_SCORE.get(vuln.severity, "0.0")
+            rule_props: dict = {"security-severity": sec_sev}
+            if vuln.cwe_ids:
+                rule_props["tags"] = vuln.cwe_ids
             rule: dict = {
                 "id": rule_id,
                 "shortDescription": {"text": f"{vuln.severity.value.upper()}: {vuln.id} in {br.package.name}@{br.package.version}"},
                 "fullDescription": {"text": vuln.summary or f"Vulnerability {vuln.id}"},
                 "helpUri": f"https://osv.dev/vulnerability/{vuln.id}",
                 "defaultConfiguration": {"level": level},
+                "properties": rule_props,
             }
-            if vuln.cwe_ids:
-                rule["properties"] = {"tags": vuln.cwe_ids}
             rules.append(rule)
 
         affected = ", ".join(a.name for a in br.affected_agents)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -294,6 +294,46 @@ def test_sarif_severity_mapping(sample_report):
     assert result["level"] == "error"  # HIGH maps to error
 
 
+def test_sarif_security_severity_from_cvss(sample_report):
+    """security-severity uses actual CVSS score when available (GitHub Security tab)."""
+    sarif = to_sarif(sample_report)
+    rule = sarif["runs"][0]["tool"]["driver"]["rules"][0]
+    assert "properties" in rule
+    assert rule["properties"]["security-severity"] == "8.5"
+
+
+def test_sarif_security_severity_fallback():
+    """security-severity falls back to mapped score when CVSS is None."""
+    from agent_bom.output.sarif import _SECURITY_SEVERITY_SCORE
+
+    vuln = Vulnerability(id="CVE-2099-0001", summary="Test", severity=Severity.CRITICAL, cvss_score=None)
+    pkg = Package(name="pkg", version="1.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = MCPServer(name="s", command="x", args=[], packages=[pkg])
+    agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln, package=pkg, affected_agents=[agent], affected_servers=[server], exposed_credentials=[], exposed_tools=[]
+    )
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    sarif = to_sarif(report)
+    rule = sarif["runs"][0]["tool"]["driver"]["rules"][0]
+    assert rule["properties"]["security-severity"] == _SECURITY_SEVERITY_SCORE[Severity.CRITICAL]
+
+
+def test_sarif_unknown_severity_maps_to_note():
+    """UNKNOWN severity maps to SARIF 'note' level, not 'warning'."""
+    vuln = Vulnerability(id="CVE-2099-0002", summary="Test", severity=Severity.UNKNOWN)
+    pkg = Package(name="pkg", version="1.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = MCPServer(name="s", command="x", args=[], packages=[pkg])
+    agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln, package=pkg, affected_agents=[agent], affected_servers=[server], exposed_credentials=[], exposed_tools=[]
+    )
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    sarif = to_sarif(report)
+    result = sarif["runs"][0]["results"][0]
+    assert result["level"] == "note"
+
+
 def test_sarif_empty_report(empty_report):
     sarif = to_sarif(empty_report)
     assert sarif["runs"][0]["results"] == []


### PR DESCRIPTION
## Summary
- Add `properties.security-severity` to every SARIF rule — GitHub Security tab uses this (0.0–10.0) for granular severity sorting. Without it, GitHub falls back to the 3-level `level` field, losing critical vs high distinction
- Uses actual CVSS score when available, falls back to midpoint of GitHub's severity range (e.g. CRITICAL→9.5, HIGH→7.5)
- Map `Severity.UNKNOWN` to SARIF `"note"` level — was defaulting to `"warning"` via `.get()` fallback, making unknown-severity vulns appear as medium in GitHub

### GitHub security-severity ranges (per [docs](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning))
| Score | GitHub shows |
|-------|-------------|
| >9.0 | Critical |
| 7.0–8.9 | High |
| 4.0–6.9 | Medium |
| 0.1–3.9 | Low |

## Test plan
- [x] `test_sarif_security_severity_from_cvss` — CVSS 8.5 passthrough
- [x] `test_sarif_security_severity_fallback` — no CVSS → mapped score
- [x] `test_sarif_unknown_severity_maps_to_note` — UNKNOWN → "note" not "warning"
- [x] All 9 SARIF tests + 3 output coverage tests pass, 0 regressions

Closes #705