### PR TITLE
fix: Docker SSE healthcheck, policy field validation, expanded dogfood CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,9 +368,57 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Run agent-bom action from local checkout
+      # 7a. Basic SARIF scan (clean SBOM)
+      - name: "Dogfood: SARIF format (clean SBOM)"
         uses: ./
         with:
           sbom: tests/fixtures/test-sbom.cdx.json
           format: sarif
           upload-sarif: 'false'
+
+      # 7b. JSON format
+      - name: "Dogfood: JSON format"
+        uses: ./
+        with:
+          sbom: tests/fixtures/test-sbom.cdx.json
+          format: json
+          output: dogfood-results.json
+
+      - name: Verify JSON output exists
+        run: test -f dogfood-results.json && echo "JSON output verified"
+
+      # 7c. Policy gate (should pass — clean SBOM has no critical CVEs)
+      - name: "Dogfood: policy gate (clean SBOM)"
+        uses: ./
+        with:
+          sbom: tests/fixtures/test-sbom.cdx.json
+          policy: tests/fixtures/test-policy.json
+          format: json
+
+      # 7d. Severity threshold (should pass — clean SBOM, no critical CVEs)
+      - name: "Dogfood: severity threshold (clean SBOM)"
+        uses: ./
+        with:
+          sbom: tests/fixtures/test-sbom.cdx.json
+          severity-threshold: critical
+          format: json
+
+      # 7e. Badge generation
+      - name: "Dogfood: badge output"
+        uses: ./
+        with:
+          sbom: tests/fixtures/test-sbom.cdx.json
+          badge: dogfood-badge.json
+          format: json
+
+      - name: Verify badge output exists
+        run: test -f dogfood-badge.json && echo "Badge output verified"
+
+      # 7f. Two-tier severity gates
+      - name: "Dogfood: two-tier severity gates"
+        uses: ./
+        with:
+          sbom: tests/fixtures/test-sbom.cdx.json
+          severity-threshold: critical
+          warn-on-severity: medium
+          format: json

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -49,7 +49,7 @@ ENV PORT=8423
 EXPOSE ${PORT}
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD agent-bom --version || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT:-8423}/health')" || exit 1
 
 # Use shell form so $PORT is expanded at runtime (Railway/Render inject PORT)
 CMD agent-bom mcp-server --transport streamable-http --host 0.0.0.0 --port ${PORT}

--- a/src/agent_bom/policy.py
+++ b/src/agent_bom/policy.py
@@ -409,6 +409,29 @@ def _validate_policy(policy: dict) -> None:
             except ValueError as e:
                 raise ValueError(f"Rule '{rule['id']}' has invalid condition syntax: {e}") from e
 
+        # Validate declarative field types
+        rid = rule.get("id", f"index-{i}")
+        int_fields = ("min_agents", "min_tools")
+        float_fields = ("max_epss_score", "min_scorecard_score")
+        str_fields = ("severity_gte", "ecosystem", "package_name_contains", "owasp_tag", "owasp_mcp_tag", "registry_risk_gte")
+        bool_fields = ("is_kev", "ai_risk", "has_credentials", "unverified_server", "has_fix")
+        for f in int_fields:
+            if f in rule and not isinstance(rule[f], int):
+                raise ValueError(f"Rule '{rid}' field '{f}' must be an integer")
+        for f in float_fields:
+            if f in rule and not isinstance(rule[f], (int, float)):
+                raise ValueError(f"Rule '{rid}' field '{f}' must be a number")
+        for f in str_fields:
+            if f in rule and not isinstance(rule[f], str):
+                raise ValueError(f"Rule '{rid}' field '{f}' must be a string")
+        for f in bool_fields:
+            if f in rule and not isinstance(rule[f], bool):
+                raise ValueError(f"Rule '{rid}' field '{f}' must be a boolean")
+        if "severity_gte" in rule and rule["severity_gte"].upper() not in SEVERITY_ORDER:
+            raise ValueError(f"Rule '{rid}' severity_gte '{rule['severity_gte']}' is not valid. Use: CRITICAL, HIGH, MEDIUM, LOW, NONE")
+        if "registry_risk_gte" in rule and rule["registry_risk_gte"].lower() not in RISK_LEVEL_ORDER:
+            raise ValueError(f"Rule '{rid}' registry_risk_gte '{rule['registry_risk_gte']}' is not valid. Use: high, medium, low")
+
 
 def _rule_matches(rule: dict, br) -> bool:
     """Check if a BlastRadius finding matches a policy rule.

--- a/tests/fixtures/test-policy.json
+++ b/tests/fixtures/test-policy.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "rules": [
+    {
+      "id": "block-critical",
+      "action": "fail",
+      "severity_gte": "CRITICAL"
+    },
+    {
+      "id": "warn-high",
+      "action": "warn",
+      "severity_gte": "HIGH"
+    }
+  ]
+}

--- a/tests/fixtures/test-sbom-vuln.cdx.json
+++ b/tests/fixtures/test-sbom-vuln.cdx.json
@@ -1,0 +1,26 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "ci-dogfood-vuln-test",
+      "version": "1.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "flask",
+      "version": "2.2.0",
+      "purl": "pkg:pypi/flask@2.2.0"
+    },
+    {
+      "type": "library",
+      "name": "werkzeug",
+      "version": "2.2.0",
+      "purl": "pkg:pypi/werkzeug@2.2.0"
+    }
+  ]
+}

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -143,6 +143,61 @@ def test_validate_policy_invalid_action():
         _validate_policy({"rules": [{"id": "bad", "action": "ignore"}]})
 
 
+def test_validate_policy_field_type_int():
+    """min_agents must be an integer."""
+    with pytest.raises(ValueError, match="must be an integer"):
+        _validate_policy({"rules": [{"id": "r1", "action": "fail", "min_agents": "two"}]})
+
+
+def test_validate_policy_field_type_float():
+    """max_epss_score must be a number."""
+    with pytest.raises(ValueError, match="must be a number"):
+        _validate_policy({"rules": [{"id": "r1", "action": "fail", "max_epss_score": "high"}]})
+
+
+def test_validate_policy_field_type_str():
+    """ecosystem must be a string."""
+    with pytest.raises(ValueError, match="must be a string"):
+        _validate_policy({"rules": [{"id": "r1", "action": "fail", "ecosystem": 123}]})
+
+
+def test_validate_policy_field_type_bool():
+    """is_kev must be a boolean."""
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _validate_policy({"rules": [{"id": "r1", "action": "fail", "is_kev": "yes"}]})
+
+
+def test_validate_policy_invalid_severity_gte():
+    """severity_gte with invalid severity value raises ValueError."""
+    with pytest.raises(ValueError, match="is not valid"):
+        _validate_policy({"rules": [{"id": "r1", "action": "fail", "severity_gte": "MEGA"}]})
+
+
+def test_validate_policy_invalid_registry_risk():
+    """registry_risk_gte with invalid risk level raises ValueError."""
+    with pytest.raises(ValueError, match="is not valid"):
+        _validate_policy({"rules": [{"id": "r1", "action": "fail", "registry_risk_gte": "extreme"}]})
+
+
+def test_validate_policy_valid_fields_pass():
+    """Valid declarative fields pass validation."""
+    _validate_policy(
+        {
+            "rules": [
+                {
+                    "id": "r1",
+                    "action": "fail",
+                    "severity_gte": "HIGH",
+                    "min_agents": 2,
+                    "max_epss_score": 0.7,
+                    "ecosystem": "pypi",
+                    "is_kev": True,
+                }
+            ]
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
 # _rule_matches
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Dockerfile.sse** (#711): HTTP healthcheck via `/health` endpoint instead of `--version` — verifies the HTTP server is actually responding, not just that the binary exists
- **policy.py** (#712): validate declarative field types (int, float, str, bool) and enum values (`severity_gte`, `registry_risk_gte`) at load time with clear error messages
- **ci.yml** (#713): expand action dogfood from 1 test to 6 — SARIF, JSON, policy gate, severity threshold, badge output, two-tier severity gates. Adds output file existence checks.
- 7 new policy validation tests, 2 new test fixtures

## Test plan
- [ ] Policy validation tests pass (42 tests in test_policy_engine.py)
- [ ] Full test suite green (5,993 passed locally)
- [ ] Dogfood CI steps execute without error
- [ ] Badge and JSON output files verified in CI

Closes #711, closes #712, closes #713