### PR TITLE
fix: scanner core gaps — conda resolution, npm semver, SARIF enrichment

### DIFF
--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -45,6 +45,10 @@ def to_sarif(report: AIBOMReport) -> dict:
             # Use actual CVSS score when available, otherwise map from severity
             sec_sev = str(vuln.cvss_score) if vuln.cvss_score is not None else _SECURITY_SEVERITY_SCORE.get(vuln.severity, "0.0")
             rule_props: dict = {"security-severity": sec_sev}
+            if vuln.epss_score is not None:
+                rule_props["epss-score"] = round(vuln.epss_score, 5)
+            if vuln.is_kev:
+                rule_props["kev"] = True
             if vuln.cwe_ids:
                 rule_props["tags"] = vuln.cwe_ids
             rule: dict = {
@@ -67,10 +71,11 @@ def to_sarif(report: AIBOMReport) -> dict:
         fp_input = f"{rule_id}:{br.package.name}:{br.package.version}:{config_path}"
         fingerprint = hashlib.sha256(fp_input.encode()).hexdigest()
 
+        kind = "informational" if vuln.severity == Severity.NONE else "fail"
         result: dict = {
             "ruleId": rule_id,
             "level": level,
-            "kind": "fail",
+            "kind": kind,
             "message": {"text": message_text},
             "fingerprints": {
                 "agent-bom/v1": fingerprint,
@@ -115,6 +120,8 @@ def to_sarif(report: AIBOMReport) -> dict:
                 "soc2_tags": br.soc2_tags,
                 "cis_tags": br.cis_tags,
                 "blast_score": br.risk_score,
+                "epss_score": vuln.epss_score,
+                "is_kev": vuln.is_kev,
                 "exposed_credentials": br.exposed_credentials,
             }
         results.append(result)

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -75,7 +75,11 @@ def parse_npm_packages(directory: Path) -> list[Package]:
             pkg_data = json.loads((directory / "package.json").read_text())
             for dep_type in ("dependencies", "devDependencies"):
                 for name, version_spec in pkg_data.get(dep_type, {}).items():
-                    version = version_spec.lstrip("^~>=<")
+                    version = version_spec.lstrip("^~>=< ")
+                    # Validate: must look like a semver (at least major.minor.patch)
+                    # Otherwise mark as "latest" for resolver to handle
+                    if not re.match(r"^\d+\.\d+\.\d+", version):
+                        version = "latest"
                     packages.append(
                         Package(
                             name=name,

--- a/src/agent_bom/resolver.py
+++ b/src/agent_bom/resolver.py
@@ -144,6 +144,9 @@ async def resolve_package_version(pkg: Package, client: httpx.AsyncClient) -> bo
         from agent_bom.version_utils import resolve_cargo_metadata
 
         version, lic = await resolve_cargo_metadata(pkg.name, client)
+    elif pkg.ecosystem == "conda":
+        # Conda packages often have PyPI equivalents — try PyPI resolution
+        version, lic = await resolve_pypi_metadata(pkg.name, client)
     elif pkg.ecosystem == "maven" and ":" in pkg.name:
         from agent_bom.version_utils import resolve_maven_metadata
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -356,7 +356,7 @@ async def _enrich_results_if_needed(results: dict[str, list[dict]]) -> dict[str,
         for key, vuln_list in results.items():
             results[key] = [{**v, **details_map.get(v.get("id", ""), {})} for v in vuln_list]
     except Exception as exc:
-        _logger.debug("OSV detail enrichment skipped: %s", exc)
+        _logger.warning("OSV detail enrichment skipped (vulnerability summaries may be incomplete): %s", exc)
     return results
 
 
@@ -705,7 +705,7 @@ async def scan_packages(packages: list[Package]) -> int:
             pkg.name = normalize_package_name(pkg.name, pkg.ecosystem)
 
     # Auto-resolve "latest"/"unknown" versions before OSV query
-    unresolved = [p for p in packages if p.version in ("latest", "unknown", "") and p.ecosystem.lower() in ("npm", "pypi")]
+    unresolved = [p for p in packages if p.version in ("latest", "unknown", "") and p.ecosystem.lower() in ("npm", "pypi", "conda")]
     if unresolved:
         try:
             from agent_bom.resolver import resolve_all_versions

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -334,6 +334,51 @@ def test_sarif_unknown_severity_maps_to_note():
     assert result["level"] == "note"
 
 
+def test_sarif_epss_in_rule_properties():
+    """SARIF rule properties include EPSS score when available."""
+    vuln = Vulnerability(id="CVE-2099-EPSS", summary="Test", severity=Severity.HIGH, epss_score=0.85)
+    pkg = Package(name="pkg", version="1.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = MCPServer(name="s", command="x", args=[], packages=[pkg])
+    agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln, package=pkg, affected_agents=[agent], affected_servers=[server], exposed_credentials=[], exposed_tools=[]
+    )
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    sarif = to_sarif(report)
+    rule = sarif["runs"][0]["tool"]["driver"]["rules"][0]
+    assert rule["properties"]["epss-score"] == 0.85
+
+
+def test_sarif_none_severity_kind_informational():
+    """NONE severity results use kind='informational', not 'fail'."""
+    vuln = Vulnerability(id="CVE-2099-NONE", summary="Test", severity=Severity.NONE)
+    pkg = Package(name="pkg", version="1.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = MCPServer(name="s", command="x", args=[], packages=[pkg])
+    agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln, package=pkg, affected_agents=[agent], affected_servers=[server], exposed_credentials=[], exposed_tools=[]
+    )
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    sarif = to_sarif(report)
+    result = sarif["runs"][0]["results"][0]
+    assert result["kind"] == "informational"
+
+
+def test_sarif_high_severity_kind_fail():
+    """HIGH severity results use kind='fail'."""
+    vuln = Vulnerability(id="CVE-2099-HIGH", summary="Test", severity=Severity.HIGH)
+    pkg = Package(name="pkg", version="1.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = MCPServer(name="s", command="x", args=[], packages=[pkg])
+    agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln, package=pkg, affected_agents=[agent], affected_servers=[server], exposed_credentials=[], exposed_tools=[]
+    )
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    sarif = to_sarif(report)
+    result = sarif["runs"][0]["results"][0]
+    assert result["kind"] == "fail"
+
+
 def test_sarif_empty_report(empty_report):
     sarif = to_sarif(empty_report)
     assert sarif["runs"][0]["results"] == []

--- a/tests/test_scanner_core_gaps.py
+++ b/tests/test_scanner_core_gaps.py
@@ -1,0 +1,102 @@
+"""Tests for scanner core gap fixes — conda resolution, npm semver, OSV logging."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_bom.models import Package
+
+# ── Conda resolver coverage ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_conda_resolve_package_version():
+    """Conda packages should attempt PyPI resolution for unversioned deps."""
+    from agent_bom.resolver import resolve_package_version
+
+    pkg = Package(name="numpy", version="latest", ecosystem="conda")
+
+    async def mock_pypi_metadata(name, client):
+        return ("1.26.0", "BSD-3-Clause")
+
+    with patch("agent_bom.resolver.resolve_pypi_metadata", side_effect=mock_pypi_metadata):
+        mock_client = AsyncMock()
+        resolved = await resolve_package_version(pkg, mock_client)
+
+    assert resolved is True
+    assert pkg.version == "1.26.0"
+
+
+@pytest.mark.asyncio
+async def test_conda_unresolvable_stays_unresolved():
+    """Conda packages that don't exist on PyPI stay unresolved."""
+    from agent_bom.resolver import resolve_package_version
+
+    pkg = Package(name="cudatoolkit", version="unknown", ecosystem="conda")
+
+    async def mock_pypi_not_found(name, client):
+        return (None, None)
+
+    with patch("agent_bom.resolver.resolve_pypi_metadata", side_effect=mock_pypi_not_found):
+        mock_client = AsyncMock()
+        resolved = await resolve_package_version(pkg, mock_client)
+
+    assert resolved is False
+    assert pkg.version == "unknown"
+
+
+# ── npm semver validation ────────────────────────────────────────────────────
+
+
+def test_npm_package_json_valid_semver(tmp_path):
+    """Valid semver versions are preserved after range stripping."""
+    from agent_bom.parsers.node_parsers import parse_npm_packages
+
+    pkg_json = {"dependencies": {"express": "^4.18.2", "lodash": "~4.17.21"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg_json))
+
+    packages = parse_npm_packages(tmp_path)
+    versions = {p.name: p.version for p in packages}
+    assert versions["express"] == "4.18.2"
+    assert versions["lodash"] == "4.17.21"
+
+
+def test_npm_package_json_incomplete_semver_becomes_latest(tmp_path):
+    """Incomplete semver (e.g. ^1.2) becomes 'latest' for resolver to handle."""
+    from agent_bom.parsers.node_parsers import parse_npm_packages
+
+    pkg_json = {"dependencies": {"foo": "^1.2", "bar": "~1"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg_json))
+
+    packages = parse_npm_packages(tmp_path)
+    versions = {p.name: p.version for p in packages}
+    assert versions["foo"] == "latest"
+    assert versions["bar"] == "latest"
+
+
+def test_npm_package_json_star_becomes_latest(tmp_path):
+    """Wildcard version '*' becomes 'latest'."""
+    from agent_bom.parsers.node_parsers import parse_npm_packages
+
+    pkg_json = {"dependencies": {"wildcard-pkg": "*"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg_json))
+
+    packages = parse_npm_packages(tmp_path)
+    assert packages[0].version == "latest"
+
+
+# ── Conda in auto-resolve filter ─────────────────────────────────────────────
+
+
+def test_conda_in_auto_resolve_filter():
+    """Conda ecosystem should be included in the auto-resolve filter."""
+    # Verify the filter string is present in scanners code
+    import inspect
+
+    from agent_bom.scanners import scan_packages
+
+    source = inspect.getsource(scan_packages)
+    assert "conda" in source, "conda must be in the auto-resolve ecosystem filter"


### PR DESCRIPTION
## Summary
Five verified scanner core gaps fixed:

1. **Conda version resolution** — conda packages now resolve via PyPI registry. Previously: zero CVE coverage for entire conda ecosystem (versions never resolved → skipped silently)
2. **npm semver validation** — incomplete versions from `package.json` range stripping (e.g. `^1.2` → `1.2`) now detected and set to `latest` for resolver. Previously: silent OSV lookup failure
3. **OSV enrichment logging** — `DEBUG` → `WARNING` when detail enrichment fails. Previously: users never knew vulnerability summaries/fix info were missing
4. **SARIF EPSS/KEV** — EPSS score and KEV status now included in SARIF rule and result properties. Previously: computed but dropped from SARIF (present in JSON/HTML/Prometheus)
5. **SARIF kind per spec** — NONE severity uses `kind: informational` per SARIF 2.1.0 spec. Previously: hard-coded `kind: fail` for all severities

9 new tests. 6,002 passed locally, 0 failures.

## Test plan
- [ ] `test_conda_resolve_package_version` — conda resolves via PyPI
- [ ] `test_conda_unresolvable_stays_unresolved` — graceful fallback
- [ ] `test_npm_package_json_valid_semver` — valid versions preserved
- [ ] `test_npm_package_json_incomplete_semver_becomes_latest` — bad semver → latest
- [ ] `test_npm_package_json_star_becomes_latest` — wildcard → latest
- [ ] `test_conda_in_auto_resolve_filter` — conda in scan_packages filter
- [ ] `test_sarif_epss_in_rule_properties` — EPSS in SARIF rules
- [ ] `test_sarif_none_severity_kind_informational` — NONE → informational
- [ ] `test_sarif_high_severity_kind_fail` — HIGH → fail