### PR TITLE
feat: CWE enrichment — OSV extraction, universal compliance tagging, DB schema v2

### DIFF
--- a/src/agent_bom/cis_controls.py
+++ b/src/agent_bom/cis_controls.py
@@ -105,12 +105,12 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.is_kev:
         tags.add("CIS-16.12")
 
-    # CWE-based tagging for SAST findings
-    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
-        from agent_bom.constants import SAST_CWE_MAP
+    # CWE-based compliance tagging (applies to all vulns with CWE data)
+    if br.vulnerability.cwe_ids:
+        from agent_bom.constants import CWE_COMPLIANCE_MAP
 
         for cwe in br.vulnerability.cwe_ids:
-            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("cis", []):
+            for tag in CWE_COMPLIANCE_MAP.get(cwe.upper(), {}).get("cis", []):
                 tags.add(tag)
 
     return sorted(tags)

--- a/src/agent_bom/constants.py
+++ b/src/agent_bom/constants.py
@@ -214,11 +214,11 @@ def is_credential_key(name: str) -> bool:
     return any(pat in low for pat in SENSITIVE_PATTERNS)
 
 
-# ── CWE-to-Compliance Mapping (for SAST findings) ──────────────────────────
+# ── CWE-to-Compliance Mapping ────────────────────────────────────────────────
 # Maps CWE weakness IDs to applicable compliance framework tags.
-# Used by compliance taggers when processing SAST findings (ecosystem="sast").
+# Used by compliance taggers for ALL vulnerabilities with CWE data (OSV, NVD, GHSA, SAST).
 
-SAST_CWE_MAP: dict[str, dict[str, list[str]]] = {
+CWE_COMPLIANCE_MAP: dict[str, dict[str, list[str]]] = {
     "CWE-78": {  # OS Command Injection
         "owasp_llm": ["LLM02"],
         "iso_27001": ["A.8.28"],

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -36,6 +36,7 @@ class LocalVuln:
     package_name: str = ""
     introduced: Optional[str] = None
     aliases: list[str] = field(default_factory=list)
+    cwe_ids: list[str] = field(default_factory=list)
 
 
 def lookup_package(
@@ -58,7 +59,7 @@ def lookup_package(
     rows = conn.execute(
         """
         SELECT
-            v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.source,
+            v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.cwe_ids, v.source,
             a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
             e.probability AS epss_prob, e.percentile AS epss_pct,
             k.date_added AS kev_date
@@ -76,6 +77,10 @@ def lookup_package(
     for row in rows:
         if version and not _version_affected(version, row["introduced"], row["fixed"], row["last_affected"]):
             continue
+        # Parse comma-separated CWE IDs from DB column
+        raw_cwes = row["cwe_ids"] or ""
+        cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
+
         results.append(
             LocalVuln(
                 id=row["id"],
@@ -91,6 +96,7 @@ def lookup_package(
                 ecosystem=row["ecosystem"],
                 package_name=row["package_name"],
                 introduced=row["introduced"],
+                cwe_ids=cwe_list,
             )
         )
     return results

--- a/src/agent_bom/db/schema.py
+++ b/src/agent_bom/db/schema.py
@@ -58,13 +58,13 @@ def _validated_db_path(raw: str) -> Path:
 DB_PATH: Path = _validated_db_path(_RAW_DB_PATH)
 
 # Schema version — bump when DDL changes incompatibly
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 
 # Migration scripts: list of (from_version, to_version, sql) tuples.
 # Add a new entry here whenever _SCHEMA_VERSION is bumped.
 # Each migration must be idempotent (use IF NOT EXISTS / IF EXISTS guards).
 _MIGRATIONS: list[tuple[int, int, str]] = [
-    # (1, 2, "ALTER TABLE vulns ADD COLUMN new_col TEXT;"),  # example
+    (1, 2, "ALTER TABLE vulns ADD COLUMN cwe_ids TEXT DEFAULT '';"),
 ]
 
 _DDL = """
@@ -83,6 +83,7 @@ CREATE TABLE IF NOT EXISTS vulns (
     cvss_score      REAL,
     cvss_vector     TEXT,
     fixed_version   TEXT,
+    cwe_ids         TEXT DEFAULT '',    -- comma-separated CWE IDs (e.g. "CWE-79,CWE-89")
     published       TEXT,               -- ISO-8601
     modified        TEXT,               -- ISO-8601
     source          TEXT NOT NULL       -- osv | nvd | ghsa | nvidia

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -240,6 +240,13 @@ def _parse_osv_entry(data: dict) -> Optional[tuple[dict, list[dict]]]:
                 }
             )
 
+    # Extract CWE IDs from database_specific (GHSA advisories store them here)
+    cwe_ids_list: list[str] = []
+    if isinstance(db_specific, dict):
+        raw_cwes = db_specific.get("cwe_ids", [])
+        if isinstance(raw_cwes, list):
+            cwe_ids_list = [c for c in raw_cwes if isinstance(c, str) and c.startswith("CWE-")]
+
     vuln_row = {
         "id": vuln_id,
         "summary": summary[:500],
@@ -247,6 +254,7 @@ def _parse_osv_entry(data: dict) -> Optional[tuple[dict, list[dict]]]:
         "cvss_score": cvss_score,
         "cvss_vector": cvss_vector,
         "fixed_version": fixed_version,
+        "cwe_ids": ",".join(cwe_ids_list),
         "published": published,
         "modified": modified,
         "source": "osv",
@@ -271,9 +279,9 @@ def _ingest_osv_file(conn: sqlite3.Connection, content: bytes, filename: str) ->
     conn.execute(
         """
         INSERT OR REPLACE INTO vulns
-            (id, summary, severity, cvss_score, cvss_vector, fixed_version, published, modified, source)
+            (id, summary, severity, cvss_score, cvss_vector, fixed_version, cwe_ids, published, modified, source)
         VALUES
-            (:id, :summary, :severity, :cvss_score, :cvss_vector, :fixed_version, :published, :modified, :source)
+            (:id, :summary, :severity, :cvss_score, :cvss_vector, :fixed_version, :cwe_ids, :published, :modified, :source)
         """,
         vuln_row,
     )
@@ -628,12 +636,19 @@ def sync_ghsa(
                     }
                 )
 
+            # Extract CWE IDs from GHSA advisory
+            ghsa_cwes: list[str] = []
+            for cwe_entry in advisory.get("cwes", []):
+                cwe_val = cwe_entry.get("cwe_id", "") if isinstance(cwe_entry, dict) else ""
+                if cwe_val.startswith("CWE-"):
+                    ghsa_cwes.append(cwe_val)
+
             conn.execute(
                 """
                 INSERT OR REPLACE INTO vulns
-                    (id, summary, severity, cvss_score, cvss_vector, fixed_version, published, modified, source)
+                    (id, summary, severity, cvss_score, cvss_vector, fixed_version, cwe_ids, published, modified, source)
                 VALUES
-                    (:id, :summary, :severity, :cvss_score, :cvss_vector, :fixed_version, :published, :modified, :source)
+                    (:id, :summary, :severity, :cvss_score, :cvss_vector, :fixed_version, :cwe_ids, :published, :modified, :source)
                 """,
                 {
                     "id": vuln_id,
@@ -642,6 +657,7 @@ def sync_ghsa(
                     "cvss_score": cvss_score,
                     "cvss_vector": cvss_vector,
                     "fixed_version": fixed_version,
+                    "cwe_ids": ",".join(ghsa_cwes),
                     "published": published,
                     "modified": modified,
                     "source": "ghsa",

--- a/src/agent_bom/iso_27001.py
+++ b/src/agent_bom/iso_27001.py
@@ -93,12 +93,12 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.fixed_version:
         tags.add("A.8.28")
 
-    # CWE-based tagging for SAST findings
-    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
-        from agent_bom.constants import SAST_CWE_MAP
+    # CWE-based compliance tagging (applies to all vulns with CWE data)
+    if br.vulnerability.cwe_ids:
+        from agent_bom.constants import CWE_COMPLIANCE_MAP
 
         for cwe in br.vulnerability.cwe_ids:
-            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("iso_27001", []):
+            for tag in CWE_COMPLIANCE_MAP.get(cwe.upper(), {}).get("iso_27001", []):
                 tags.add(tag)
 
     return sorted(tags)

--- a/src/agent_bom/nist_csf.py
+++ b/src/agent_bom/nist_csf.py
@@ -129,12 +129,12 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.is_kev:
         tags.add("RS.MI-02")
 
-    # CWE-based tagging for SAST findings
-    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
-        from agent_bom.constants import SAST_CWE_MAP
+    # CWE-based compliance tagging (applies to all vulns with CWE data)
+    if br.vulnerability.cwe_ids:
+        from agent_bom.constants import CWE_COMPLIANCE_MAP
 
         for cwe in br.vulnerability.cwe_ids:
-            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("nist_csf", []):
+            for tag in CWE_COMPLIANCE_MAP.get(cwe.upper(), {}).get("nist_csf", []):
                 tags.add(tag)
 
     return sorted(tags)

--- a/src/agent_bom/owasp.py
+++ b/src/agent_bom/owasp.py
@@ -89,12 +89,12 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.package.name.lower() in _AI_PACKAGES and br.vulnerability.severity in _HIGH_RISK_SEVERITIES:
         tags.add("LLM04")
 
-    # CWE-based tagging for SAST findings
-    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
-        from agent_bom.constants import SAST_CWE_MAP
+    # CWE-based compliance tagging (applies to all vulns with CWE data)
+    if br.vulnerability.cwe_ids:
+        from agent_bom.constants import CWE_COMPLIANCE_MAP
 
         for cwe in br.vulnerability.cwe_ids:
-            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("owasp_llm", []):
+            for tag in CWE_COMPLIANCE_MAP.get(cwe.upper(), {}).get("owasp_llm", []):
                 tags.add(tag)
 
     return sorted(tags)

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -532,6 +532,14 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
         if vuln_id != canonical_id:
             all_aliases.append(vuln_id)
 
+        # Extract CWE IDs from database_specific (GHSA entries store them here)
+        cwe_ids: list[str] = []
+        db_specific = vuln_data.get("database_specific", {})
+        if isinstance(db_specific, dict):
+            raw_cwes = db_specific.get("cwe_ids", [])
+            if isinstance(raw_cwes, list):
+                cwe_ids = [c for c in raw_cwes if isinstance(c, str) and c.startswith("CWE-")]
+
         vulns.append(
             Vulnerability(
                 id=canonical_id,
@@ -541,6 +549,7 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
                 fixed_version=fixed,
                 references=references,
                 aliases=all_aliases,
+                cwe_ids=cwe_ids,
             )
         )
 
@@ -604,6 +613,7 @@ def _local_vuln_to_vulnerability(lv: "Any") -> Vulnerability:
         epss_percentile=lv.epss_percentile,
         is_kev=lv.is_kev,
         kev_date_added=lv.kev_date_added,
+        cwe_ids=getattr(lv, "cwe_ids", []),
         aliases=[],
         references=[],
     )

--- a/src/agent_bom/soc2.py
+++ b/src/agent_bom/soc2.py
@@ -95,12 +95,12 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if br.vulnerability.fixed_version:
         tags.add("CC8.1")
 
-    # CWE-based tagging for SAST findings
-    if br.package.ecosystem == "sast" and br.vulnerability.cwe_ids:
-        from agent_bom.constants import SAST_CWE_MAP
+    # CWE-based compliance tagging (applies to all vulns with CWE data)
+    if br.vulnerability.cwe_ids:
+        from agent_bom.constants import CWE_COMPLIANCE_MAP
 
         for cwe in br.vulnerability.cwe_ids:
-            for tag in SAST_CWE_MAP.get(cwe.upper(), {}).get("soc2", []):
+            for tag in CWE_COMPLIANCE_MAP.get(cwe.upper(), {}).get("soc2", []):
                 tags.add(tag)
 
     return sorted(tags)

--- a/src/agent_bom/vuln_compliance.py
+++ b/src/agent_bom/vuln_compliance.py
@@ -9,7 +9,7 @@ level in each framework's ``tag_blast_radius()`` function.
 
 from __future__ import annotations
 
-from agent_bom.constants import AI_PACKAGES, SAST_CWE_MAP, TRAINING_DATA_PACKAGES
+from agent_bom.constants import AI_PACKAGES, CWE_COMPLIANCE_MAP, TRAINING_DATA_PACKAGES
 from agent_bom.models import Package, Severity, Vulnerability
 
 _HIGH_RISK = frozenset({Severity.CRITICAL, Severity.HIGH})
@@ -28,7 +28,6 @@ def tag_vulnerability(vuln: Vulnerability, package: Package) -> dict[str, list[s
     is_ai = pkg_lower in AI_PACKAGES
     is_training = pkg_lower in TRAINING_DATA_PACKAGES
     is_malicious = package.is_malicious
-    is_sast = package.ecosystem == "sast"
     cwe_ids = vuln.cwe_ids
 
     tags: dict[str, list[str]] = {}
@@ -41,9 +40,9 @@ def tag_vulnerability(vuln: Vulnerability, package: Package) -> dict[str, list[s
         owasp_llm.append("LLM03")
     if is_ai and is_high:
         owasp_llm.append("LLM04")
-    if is_sast and cwe_ids:
+    if cwe_ids:
         for cwe in cwe_ids:
-            for t in SAST_CWE_MAP.get(cwe, {}).get("owasp_llm", []):
+            for t in CWE_COMPLIANCE_MAP.get(cwe, {}).get("owasp_llm", []):
                 if t not in owasp_llm:
                     owasp_llm.append(t)
     if owasp_llm:
@@ -83,9 +82,9 @@ def tag_vulnerability(vuln: Vulnerability, package: Package) -> dict[str, list[s
         nist_csf.append("RS.AN-03")
     if is_kev:
         nist_csf.append("RS.MI-02")
-    if is_sast and cwe_ids:
+    if cwe_ids:
         for cwe in cwe_ids:
-            for t in SAST_CWE_MAP.get(cwe, {}).get("nist_csf", []):
+            for t in CWE_COMPLIANCE_MAP.get(cwe, {}).get("nist_csf", []):
                 if t not in nist_csf:
                     nist_csf.append(t)
     tags["nist_csf"] = sorted(set(nist_csf))
@@ -100,9 +99,9 @@ def tag_vulnerability(vuln: Vulnerability, package: Package) -> dict[str, list[s
         cis.append("CIS-07.4")
     if is_kev:
         cis.append("CIS-16.12")
-    if is_sast and cwe_ids:
+    if cwe_ids:
         for cwe in cwe_ids:
-            for t in SAST_CWE_MAP.get(cwe, {}).get("cis", []):
+            for t in CWE_COMPLIANCE_MAP.get(cwe, {}).get("cis", []):
                 if t not in cis:
                     cis.append(t)
     tags["cis"] = sorted(set(cis))
@@ -117,9 +116,9 @@ def tag_vulnerability(vuln: Vulnerability, package: Package) -> dict[str, list[s
         iso.append("A.5.28")
     if has_fix:
         iso.append("A.8.28")
-    if is_sast and cwe_ids:
+    if cwe_ids:
         for cwe in cwe_ids:
-            for t in SAST_CWE_MAP.get(cwe, {}).get("iso_27001", []):
+            for t in CWE_COMPLIANCE_MAP.get(cwe, {}).get("iso_27001", []):
                 if t not in iso:
                     iso.append(t)
     tags["iso_27001"] = sorted(set(iso))
@@ -134,9 +133,9 @@ def tag_vulnerability(vuln: Vulnerability, package: Package) -> dict[str, list[s
         soc2.append("CC7.4")
     if has_fix:
         soc2.append("CC8.1")
-    if is_sast and cwe_ids:
+    if cwe_ids:
         for cwe in cwe_ids:
-            for t in SAST_CWE_MAP.get(cwe, {}).get("soc2", []):
+            for t in CWE_COMPLIANCE_MAP.get(cwe, {}).get("soc2", []):
                 if t not in soc2:
                     soc2.append(t)
     tags["soc2"] = sorted(set(soc2))

--- a/tests/test_cwe_enrichment.py
+++ b/tests/test_cwe_enrichment.py
@@ -1,0 +1,308 @@
+"""Tests for CWE enrichment — OSV extraction, compliance tagging, local DB round-trip."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from agent_bom.models import BlastRadius, Package, Severity, Vulnerability
+
+# ── OSV CWE extraction ──────────────────────────────────────────────────────
+
+
+def test_build_vulnerabilities_extracts_cwe_ids():
+    """build_vulnerabilities() should extract CWE IDs from database_specific."""
+    from agent_bom.scanners import build_vulnerabilities
+
+    pkg = Package(name="flask", version="2.2.0", ecosystem="pypi")
+    vuln_data = [
+        {
+            "id": "GHSA-xxxx-yyyy-zzzz",
+            "summary": "XSS in flask",
+            "aliases": ["CVE-2099-1234"],
+            "database_specific": {
+                "cwe_ids": ["CWE-79", "CWE-80"],
+                "severity": "HIGH",
+            },
+        }
+    ]
+
+    vulns = build_vulnerabilities(vuln_data, pkg)
+    assert len(vulns) == 1
+    assert "CWE-79" in vulns[0].cwe_ids
+    assert "CWE-80" in vulns[0].cwe_ids
+
+
+def test_build_vulnerabilities_no_cwe_ids():
+    """build_vulnerabilities() handles missing CWE IDs gracefully."""
+    from agent_bom.scanners import build_vulnerabilities
+
+    pkg = Package(name="requests", version="2.0.0", ecosystem="pypi")
+    vuln_data = [
+        {
+            "id": "CVE-2099-0001",
+            "summary": "Some vuln",
+        }
+    ]
+
+    vulns = build_vulnerabilities(vuln_data, pkg)
+    assert len(vulns) == 1
+    assert vulns[0].cwe_ids == []
+
+
+def test_build_vulnerabilities_filters_invalid_cwe_ids():
+    """build_vulnerabilities() filters out non-CWE strings from cwe_ids."""
+    from agent_bom.scanners import build_vulnerabilities
+
+    pkg = Package(name="django", version="3.0", ecosystem="pypi")
+    vuln_data = [
+        {
+            "id": "GHSA-test-test-test",
+            "summary": "Test vuln",
+            "database_specific": {
+                "cwe_ids": ["CWE-89", "not-a-cwe", 42, None, "CWE-79"],
+            },
+        }
+    ]
+
+    vulns = build_vulnerabilities(vuln_data, pkg)
+    assert vulns[0].cwe_ids == ["CWE-89", "CWE-79"]
+
+
+# ── CWE-based compliance tagging (no ecosystem guard) ───────────────────────
+
+
+def test_vuln_compliance_cwe_tagging_for_pypi():
+    """CWE-based compliance tags should apply to PyPI packages (not just SAST)."""
+    from agent_bom.vuln_compliance import tag_vulnerability
+
+    vuln = Vulnerability(
+        id="CVE-2099-0001",
+        summary="SQL injection",
+        severity=Severity.HIGH,
+        cwe_ids=["CWE-89"],
+    )
+    pkg = Package(name="sqlalchemy", version="1.0.0", ecosystem="pypi")
+
+    tags = tag_vulnerability(vuln, pkg)
+
+    # CWE-89 should map to owasp_llm tags (via CWE_COMPLIANCE_MAP)
+    assert "owasp_llm" in tags
+    assert "LLM02" in tags["owasp_llm"]
+
+
+def test_vuln_compliance_no_cwe_no_extra_tags():
+    """Without CWE IDs, only severity/context-based tags appear."""
+    from agent_bom.vuln_compliance import tag_vulnerability
+
+    vuln = Vulnerability(
+        id="CVE-2099-0002",
+        summary="Some vuln",
+        severity=Severity.MEDIUM,
+        cwe_ids=[],
+    )
+    pkg = Package(name="requests", version="2.0.0", ecosystem="pypi")
+
+    tags = tag_vulnerability(vuln, pkg)
+
+    # Should still have base tags (nist_csf, cis, iso_27001 etc.) but
+    # no CWE-derived extras
+    assert "nist_csf" in tags
+    # LLM02 is a CWE-derived tag — should NOT appear without CWE data
+    for framework_tags in tags.values():
+        assert "LLM02" not in framework_tags
+
+
+def test_blast_radius_cwe_tagging_owasp():
+    """BlastRadius-level OWASP tagger should use CWE for non-SAST packages."""
+    from agent_bom.models import Agent, AgentType
+    from agent_bom.owasp import tag_blast_radius
+
+    agent = Agent(name="test-agent", agent_type=AgentType.CLAUDE_CODE, config_path="test.json")
+    vuln = Vulnerability(
+        id="CVE-2099-0003",
+        summary="Command injection",
+        severity=Severity.HIGH,
+        cwe_ids=["CWE-78"],
+    )
+    pkg = Package(name="paramiko", version="2.0.0", ecosystem="pypi")
+    br = BlastRadius(
+        package=pkg,
+        vulnerability=vuln,
+        affected_agents=[agent],
+        affected_servers=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+    tags = tag_blast_radius(br)
+    assert "LLM02" in tags
+
+
+def test_blast_radius_cwe_tagging_nist_csf():
+    """BlastRadius-level NIST CSF tagger should use CWE for non-SAST packages."""
+    from agent_bom.models import Agent, AgentType
+    from agent_bom.nist_csf import tag_blast_radius
+
+    agent = Agent(name="test-agent", agent_type=AgentType.CLAUDE_CODE, config_path="test.json")
+    vuln = Vulnerability(
+        id="CVE-2099-0004",
+        summary="SQL injection",
+        severity=Severity.HIGH,
+        cwe_ids=["CWE-89"],
+    )
+    pkg = Package(name="psycopg2", version="2.9.0", ecosystem="pypi")
+    br = BlastRadius(
+        package=pkg,
+        vulnerability=vuln,
+        affected_agents=[agent],
+        affected_servers=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+    tags = tag_blast_radius(br)
+    # CWE-89 should add nist_csf tags via CWE_COMPLIANCE_MAP
+    from agent_bom.constants import CWE_COMPLIANCE_MAP
+
+    expected_nist = CWE_COMPLIANCE_MAP.get("CWE-89", {}).get("nist_csf", [])
+    for t in expected_nist:
+        assert t in tags
+
+
+# ── Local DB round-trip ──────────────────────────────────────────────────────
+
+
+def test_local_db_cwe_round_trip(tmp_path):
+    """CWE IDs survive the DB write → read cycle."""
+    from agent_bom.db.lookup import lookup_package
+    from agent_bom.db.schema import init_db
+
+    db_path = tmp_path / "test_cwe.db"
+    conn = init_db(db_path)
+
+    # Insert a vuln with CWE IDs
+    conn.execute(
+        """
+        INSERT INTO vulns (id, summary, severity, cvss_score, fixed_version, cwe_ids, published, modified, source)
+        VALUES ('CVE-2099-CWE', 'Test CWE', 'high', 7.5, '1.1.0', 'CWE-79,CWE-89', '2099-01-01', '2099-01-01', 'osv')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO affected (vuln_id, ecosystem, package_name, introduced, fixed, last_affected)
+        VALUES ('CVE-2099-CWE', 'pypi', 'flask', '0', '1.1.0', '')
+        """
+    )
+    conn.commit()
+
+    results = lookup_package(conn, "PyPI", "flask", "1.0.0")
+    assert len(results) == 1
+    assert results[0].cwe_ids == ["CWE-79", "CWE-89"]
+    conn.close()
+
+
+def test_local_db_empty_cwe(tmp_path):
+    """Empty CWE column returns empty list."""
+    from agent_bom.db.lookup import lookup_package
+    from agent_bom.db.schema import init_db
+
+    db_path = tmp_path / "test_no_cwe.db"
+    conn = init_db(db_path)
+
+    conn.execute(
+        """
+        INSERT INTO vulns (id, summary, severity, cvss_score, fixed_version, cwe_ids, published, modified, source)
+        VALUES ('CVE-2099-NOCWE', 'No CWE', 'medium', 5.0, NULL, '', '2099-01-01', '2099-01-01', 'osv')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO affected (vuln_id, ecosystem, package_name, introduced, fixed, last_affected)
+        VALUES ('CVE-2099-NOCWE', 'pypi', 'requests', '0', '', '')
+        """
+    )
+    conn.commit()
+
+    results = lookup_package(conn, "PyPI", "requests", "1.0.0")
+    assert len(results) == 1
+    assert results[0].cwe_ids == []
+    conn.close()
+
+
+# ── DB schema migration ─────────────────────────────────────────────────────
+
+
+def test_db_migration_v1_to_v2(tmp_path):
+    """Schema v1 → v2 migration adds cwe_ids column."""
+    db_path = tmp_path / "test_migrate.db"
+
+    # Create a v1 database manually (no cwe_ids column)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        PRAGMA journal_mode = WAL;
+        CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+        INSERT INTO schema_version(version) VALUES (1);
+
+        CREATE TABLE IF NOT EXISTS vulns (
+            id TEXT PRIMARY KEY,
+            summary TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            cvss_score REAL,
+            cvss_vector TEXT,
+            fixed_version TEXT,
+            published TEXT,
+            modified TEXT,
+            source TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS affected (
+            vuln_id TEXT NOT NULL,
+            ecosystem TEXT NOT NULL,
+            package_name TEXT NOT NULL,
+            introduced TEXT,
+            fixed TEXT,
+            last_affected TEXT,
+            PRIMARY KEY (vuln_id, ecosystem, package_name, introduced)
+        );
+
+        CREATE TABLE IF NOT EXISTS epss_scores (
+            cve_id TEXT PRIMARY KEY,
+            probability REAL NOT NULL,
+            percentile REAL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS kev_entries (
+            cve_id TEXT PRIMARY KEY,
+            date_added TEXT,
+            due_date TEXT,
+            product TEXT,
+            vendor_project TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS sync_meta (
+            source TEXT PRIMARY KEY,
+            last_synced TEXT,
+            record_count INTEGER DEFAULT 0
+        );
+
+        INSERT INTO vulns (id, summary, severity, source) VALUES ('CVE-OLD', 'old vuln', 'high', 'osv');
+    """)
+    conn.commit()
+    conn.close()
+
+    # Now open via init_db — should trigger migration
+    from agent_bom.db.schema import init_db
+
+    conn = init_db(db_path)
+
+    # Verify schema version bumped
+    version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
+    assert version == 2
+
+    # Verify cwe_ids column exists and old data has default
+    row = conn.execute("SELECT cwe_ids FROM vulns WHERE id = 'CVE-OLD'").fetchone()
+    assert row is not None
+    assert row[0] == ""  # default empty string
+
+    conn.close()

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -489,18 +489,21 @@ def test_migrate_applies_sequential_migrations(tmp_path, monkeypatch):
     conn = init_db(db_file)
     conn.close()
 
-    monkeypatch.setattr(schema_mod, "_SCHEMA_VERSION", 2)
+    # Current schema is v2; simulate a v2→v3 migration
+    current_version = schema_mod._SCHEMA_VERSION
+    target_version = current_version + 1
+    monkeypatch.setattr(schema_mod, "_SCHEMA_VERSION", target_version)
     monkeypatch.setattr(
         schema_mod,
         "_MIGRATIONS",
-        [(1, 2, "ALTER TABLE vulns ADD COLUMN test_col TEXT;")],
+        schema_mod._MIGRATIONS + [(current_version, target_version, "ALTER TABLE vulns ADD COLUMN test_col TEXT;")],
     )
 
     conn = init_db(db_file)
     cols = {r[1] for r in conn.execute("PRAGMA table_info(vulns)").fetchall()}
     assert "test_col" in cols
     row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
-    assert row["version"] == 2
+    assert row["version"] == target_version
     conn.close()
 
 

--- a/tests/test_sast.py
+++ b/tests/test_sast.py
@@ -390,26 +390,26 @@ def test_scan_code_clean(monkeypatch, tmp_path):
 
 
 def test_sast_cwe_map_has_common_weaknesses():
-    """SAST_CWE_MAP covers common OWASP Top 10 weakness types."""
-    from agent_bom.constants import SAST_CWE_MAP
+    """CWE_COMPLIANCE_MAP covers common OWASP Top 10 weakness types."""
+    from agent_bom.constants import CWE_COMPLIANCE_MAP
 
-    assert "CWE-89" in SAST_CWE_MAP  # SQL injection
-    assert "CWE-79" in SAST_CWE_MAP  # XSS
-    assert "CWE-798" in SAST_CWE_MAP  # hardcoded creds
-    assert "CWE-78" in SAST_CWE_MAP  # OS command injection
-    assert "CWE-22" in SAST_CWE_MAP  # path traversal
+    assert "CWE-89" in CWE_COMPLIANCE_MAP  # SQL injection
+    assert "CWE-79" in CWE_COMPLIANCE_MAP  # XSS
+    assert "CWE-798" in CWE_COMPLIANCE_MAP  # hardcoded creds
+    assert "CWE-78" in CWE_COMPLIANCE_MAP  # OS command injection
+    assert "CWE-22" in CWE_COMPLIANCE_MAP  # path traversal
 
 
 def test_sast_cwe_map_frameworks():
     """CWE mappings include expected framework keys."""
-    from agent_bom.constants import SAST_CWE_MAP
+    from agent_bom.constants import CWE_COMPLIANCE_MAP
 
-    sql_inj = SAST_CWE_MAP["CWE-89"]
+    sql_inj = CWE_COMPLIANCE_MAP["CWE-89"]
     assert "iso_27001" in sql_inj
     assert "nist_csf" in sql_inj
     assert "owasp_llm" in sql_inj
 
-    hardcoded = SAST_CWE_MAP["CWE-798"]
+    hardcoded = CWE_COMPLIANCE_MAP["CWE-798"]
     assert "soc2" in hardcoded
     assert "owasp_llm" in hardcoded
 

--- a/tests/test_vuln_compliance.py
+++ b/tests/test_vuln_compliance.py
@@ -270,13 +270,13 @@ class TestCweMappingTags:
         assert "PR.AA-01" in tags["nist_csf"]
         assert "CIS-16.1" in tags["cis"]
 
-    def test_non_sast_ecosystem_skips_cwe_mapping(self):
+    def test_non_sast_ecosystem_gets_cwe_mapping(self):
         tags = tag_vulnerability(
             _vuln(cwe_ids=["CWE-79"], fixed_version=None),
             _pkg(name="lodash", ecosystem="npm"),
         )
-        # CWE mapping only applies to SAST ecosystem
-        assert "LLM02" not in tags.get("owasp_llm", [])
+        # CWE mapping applies to ALL ecosystems (not just SAST)
+        assert "LLM02" in tags.get("owasp_llm", [])
 
     def test_multiple_cwes(self):
         tags = tag_vulnerability(


### PR DESCRIPTION
## Summary
- Extract CWE IDs from OSV/GHSA `database_specific.cwe_ids` in `build_vulnerabilities()` — vulns now carry CWE data from scan time
- Remove `ecosystem == "sast"` guard from all 6 compliance taggers — CWE-based framework mapping (OWASP, NIST CSF, ISO 27001, SOC 2, CIS Controls) now applies to **all** vulns with CWE data, not just SAST findings
- Rename `SAST_CWE_MAP` → `CWE_COMPLIANCE_MAP` to reflect universal scope
- Add `cwe_ids` column to local DB (schema v1→v2 migration), populate in OSV + GHSA sync, return in lookup, pass through `_local_vuln_to_vulnerability()`

## Why
This is the foundation for the compliance mapping kill chain: CVE → CWE → framework controls. Previously CWE-based compliance tagging only worked for SAST ecosystem, meaning 99% of vulns (from OSV/NVD/GHSA) never got CWE-derived compliance tags even when CWE data was available.

## Test plan
- [x] 10 new tests in `test_cwe_enrichment.py`: OSV extraction, invalid CWE filtering, compliance tagging for PyPI, blast radius taggers (OWASP + NIST CSF), DB round-trip, empty CWE, schema migration v1→v2
- [x] Updated `test_vuln_compliance.py` — flipped assertion to verify non-SAST ecosystems now get CWE mapping
- [x] Updated `test_local_vuln_db.py` — migration test is now version-agnostic
- [x] Full suite: 6,024 passed, 0 failed

Closes #721