### PR TITLE
fix: ClawHub skill accuracy — resolve compliance contradictions, align metadata

### DIFF
--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -517,7 +517,7 @@ ScanRequest → _run_scan_sync() [ThreadPoolExecutor]
 | "22 MCP clients" (README) | ✓ 20 named AgentType values + CUSTOM = 21 |
 | "31 MCP tools" | ✓ meta-test enforces this |
 | "10 compliance frameworks" | ✓ 10 tagging modules |
-| "52 SAST CWE mappings" | ✓ SAST_CWE_MAP count |
+| "52 CWE compliance mappings" | ✓ CWE_COMPLIANCE_MAP count |
 | "12 cloud providers" | ✓ cloud/__init__.py _PROVIDERS |
 | OSV as primary vuln source | ✓ |
 | scrypt KDF for API keys | ✓ auth.py (n=16384, r=8, p=1) |

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "AI supply chain security scanner — CVEs, blast radius, compliance, policy, SBOMs",
-  "version": "0.58.1",
+  "version": "0.70.6",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 5987
+  tests: 6040
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -91,12 +91,16 @@ metadata:
       ***REDACTED*** by sanitize_env_vars() in the installed code. Verify at
       https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/security.py#L159
     data_flow: >-
-      All scanning is local-first. Only public package names and CVE IDs are
-      sent to vulnerability databases (OSV, NVD, EPSS, GitHub Advisories).
-      Registry data (427+ MCP server metadata) is bundled in the package —
-      lookups are in-memory with zero network calls. CIS benchmark checks call
-      cloud provider APIs using locally configured credentials only. No config
-      files, credentials, or env var values ever leave the machine.
+      Scanning is local-first. What leaves the machine: (1) public package names
+      and CVE IDs sent to vulnerability databases (OSV, NVD, EPSS, GitHub
+      Advisories) for CVE lookup; (2) CIS benchmark checks make read-only API
+      calls to cloud providers (AWS/Azure/GCP/Snowflake) using your locally
+      configured credentials, only when explicitly invoked. What stays local:
+      all config file contents, env var values, credentials, scan results,
+      compliance tags, and SBOM data. Registry lookups (427+ MCP servers) are
+      bundled in-package with zero network calls. Env var values in discovered
+      config files are replaced with ***REDACTED*** by sanitize_env_vars() in
+      the installed code.
     file_reads:
       # Claude Desktop
       - "~/Library/Application Support/Claude/claude_desktop_config.json"
@@ -160,6 +164,22 @@ metadata:
       - url: "https://api.snyk.io"
         purpose: "Snyk vulnerability enrichment for code_scan (requires SNYK_TOKEN)"
         auth: true
+      - url: "https://*.amazonaws.com"
+        purpose: "AWS CIS benchmark checks — read-only API calls (optional, user-initiated)"
+        auth: true
+        optional: true
+      - url: "https://management.azure.com"
+        purpose: "Azure CIS benchmark checks — read-only API calls (optional, user-initiated)"
+        auth: true
+        optional: true
+      - url: "https://*.googleapis.com"
+        purpose: "GCP CIS benchmark checks — read-only API calls (optional, user-initiated)"
+        auth: true
+        optional: true
+      - url: "https://*.snowflakecomputing.com"
+        purpose: "Snowflake CIS benchmark checks — read-only API calls (optional, user-initiated)"
+        auth: true
+        optional: true
     telemetry: false
     persistence: false
     privilege_escalation: false
@@ -339,5 +359,5 @@ configured credentials and call only the cloud provider's own APIs.
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.70.6`
-- **5,987+ tests** with CodeQL + OpenSSF Scorecard
+- **6,040+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -8,16 +8,17 @@ description: >-
 version: 0.70.6
 license: Apache-2.0
 compatibility: >-
-  Requires Python 3.11+. Install via pipx or pip. No credentials required for
-  OWASP/NIST/EU AI Act evaluation. CIS benchmark checks optionally use cloud
-  SDK credentials (AWS/Azure/GCP/Snowflake) if provided.
+  Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
+  evaluation and SBOM generation are fully local with zero credentials. CIS
+  benchmark checks optionally use cloud SDK credentials (AWS/Azure/GCP/Snowflake)
+  and make read-only API calls to cloud providers when explicitly invoked.
 metadata:
   author: msaad00
   homepage: https://github.com/msaad00/agent-bom
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 5939
+  tests: 6040
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -64,12 +65,33 @@ metadata:
       - darwin
       - linux
       - windows
-    data_flow: "Purely local for OWASP/NIST/EU AI Act/MITRE/SBOM features. CIS benchmark checks call cloud provider APIs (AWS/Azure/GCP/Snowflake) using locally configured credentials — no data is stored or transmitted beyond the cloud provider's own API. Zero file reads beyond user-provided SBOMs."
+    data_flow: >-
+      OWASP/NIST/EU AI Act/MITRE/SBOM evaluation is purely local — zero network
+      calls. CIS benchmark checks (optional, user-initiated) call cloud provider
+      APIs (AWS/Azure/GCP/Snowflake) using locally configured credentials. No data
+      is stored or transmitted beyond the cloud provider's own API. File reads are
+      limited to user-provided SBOMs and policy files.
     file_reads:
       - "user-provided SBOM files (CycloneDX/SPDX JSON)"
       - "user-provided policy files (YAML/JSON policy-as-code)"
     file_writes: []
-    network_endpoints: []
+    network_endpoints:
+      - url: "https://*.amazonaws.com"
+        purpose: "AWS CIS benchmark checks — read-only API calls (IAM, S3, CloudTrail, etc.)"
+        auth: true
+        optional: true
+      - url: "https://management.azure.com"
+        purpose: "Azure CIS benchmark checks — read-only API calls (Azure Resource Manager)"
+        auth: true
+        optional: true
+      - url: "https://*.googleapis.com"
+        purpose: "GCP CIS benchmark checks — read-only API calls (Cloud Resource Manager, IAM, etc.)"
+        auth: true
+        optional: true
+      - url: "https://*.snowflakecomputing.com"
+        purpose: "Snowflake CIS benchmark checks — read-only API calls (ACCOUNT_USAGE views)"
+        auth: true
+        optional: true
     telemetry: false
     persistence: false
     privilege_escalation: false
@@ -123,12 +145,18 @@ generate_sbom(format="cyclonedx")
 
 ## Privacy & Data Handling
 
-All compliance evaluation runs **locally on scan data already in memory**.
-No files are read from disk (except user-provided SBOMs). No network calls.
-No credentials needed.
+**OWASP, NIST, EU AI Act, MITRE ATLAS, SBOM generation, and policy checks**
+run entirely locally on scan data already in memory. No network calls, no
+credentials needed for these features.
+
+**CIS benchmark checks** (optional, user-initiated) call cloud provider APIs
+using your locally configured credentials. These are read-only API calls to
+AWS, Azure, GCP, or Snowflake. No data is stored or transmitted beyond the
+cloud provider's own API. You must explicitly run `cis_benchmark(provider=...)`
+and confirm before any cloud API calls are made.
 
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **4,400+ tests** with CodeQL + OpenSSF Scorecard
+- **6,040+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 5939
+  tests: 6040
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -110,5 +110,5 @@ as a string argument (no file system access needed).
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **4,400+ tests** with CodeQL + OpenSSF Scorecard
+- **6,040+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 5939
+  tests: 6040
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -90,5 +90,5 @@ ClickHouse endpoint for persistent analytics.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **4,400+ tests** with CodeQL + OpenSSF Scorecard
+- **6,040+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 5939
+  tests: 6040
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -184,6 +184,6 @@ CVE IDs are sent to vulnerability databases.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.70.6
-- **4,400+ tests** with CodeQL + OpenSSF Scorecard
+- **Sigstore signed**: `agent-bom verify agent-bom@0.70.6`
+- **6,040+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics


### PR DESCRIPTION
## Summary

- **Compliance SKILL.md**: Removed contradictory "No network calls" / "No credentials needed" claims that triggered OpenClaw HIGH confidence suspicious rating. CIS benchmark checks DO make read-only cloud API calls — now explicitly documented with `network_endpoints` for AWS/Azure/GCP/Snowflake. Privacy section rewritten to clearly separate local-only features (OWASP/NIST/EU AI Act/MITRE/SBOM) from network-dependent CIS checks.
- **Main SKILL.md**: Clarified `data_flow` — explicitly lists what leaves the machine (package names + CVE IDs to vuln DBs, CIS API calls) vs what stays local (config contents, env vars, credentials, scan results). Added missing cloud provider endpoints for CIS benchmarks.
- **Scan SKILL.md**: Fixed broken Sigstore backtick syntax, updated test count.
- **All 5 skills**: Updated test counts from stale 4,400/5,939/5,987 → 6,040+.
- **Glama server.json**: Bumped stale version 0.58.1 → 0.70.6.
- **docs/AUDIT.md**: Renamed stale `SAST_CWE_MAP` → `CWE_COMPLIANCE_MAP`.

## Test plan

- [x] `test_stats_alignment.py` — 15/16 pass (1 pre-existing `ModuleNotFoundError` unrelated)
- [x] Pre-commit hooks pass (JSON, formatting, trailing whitespace)
- [ ] Verify compliance skill re-scan on ClawHub shows benign after re-publish
- [ ] Verify main skill re-scan improves after re-publish