### PR TITLE
feat: add JUnit XML, CSV, and Markdown output formats

### DIFF
--- a/src/agent_bom/cli/options.py
+++ b/src/agent_bom/cli/options.py
@@ -133,6 +133,9 @@ def output_options(fn):
                         "sarif",
                         "cyclonedx",
                         "spdx",
+                        "junit",
+                        "csv",
+                        "markdown",
                         "plain",
                         "text",
                         "prometheus",
@@ -148,6 +151,7 @@ def output_options(fn):
                     "Output format.\n\n"
                     "Core: console (default, colored terminal), json, html, sarif (GitHub/GitLab Security tab), cyclonedx (SBOM).\n"
                     "SBOM: spdx (alternate SBOM standard).\n"
+                    "CI/CD: junit (JUnit XML for Jenkins/GitLab/Azure DevOps), csv (spreadsheet/SIEM), markdown (PR comments/wiki).\n"
                     "Plain: plain (no color, for piping/logging) — alias: text.\n"
                     "Monitoring: prometheus (Prometheus exposition format).\n"
                     "Visualization: mermaid, graph-html (interactive), svg.\n"

--- a/src/agent_bom/cli/scan/_output.py
+++ b/src/agent_bom/cli/scan/_output.py
@@ -11,9 +11,12 @@ from agent_bom.cli.scan._context import ScanContext
 from agent_bom.models import AIBOMReport
 from agent_bom.output import (
     export_badge,
+    export_csv,
     export_cyclonedx,
     export_html,
     export_json,
+    export_junit,
+    export_markdown,
     export_prometheus,
     export_sarif,
     export_spdx,
@@ -33,8 +36,11 @@ from agent_bom.output import (
     print_threat_frameworks,
     push_otlp,
     push_to_gateway,
+    to_csv,
     to_cyclonedx,
     to_json,
+    to_junit,
+    to_markdown,
     to_prometheus,
     to_sarif,
     to_spdx,
@@ -101,6 +107,12 @@ def render_output(
             from agent_bom.output.svg import to_svg
 
             sys.stdout.write(to_svg(report, blast_radii))
+        elif output_format == "junit":
+            sys.stdout.write(to_junit(report, blast_radii))
+        elif output_format == "csv":
+            sys.stdout.write(to_csv(report, blast_radii))
+        elif output_format == "markdown":
+            sys.stdout.write(to_markdown(report, blast_radii))
         elif output_format == "graph-html":
             import click
 
@@ -197,6 +209,18 @@ def render_output(
         out_path = output or "agent-bom.spdx.json"
         export_spdx(report, out_path)
         con.print(f"\n  [green]✓[/green] SPDX 3.0 BOM: {out_path}")
+    elif output_format == "junit":
+        out_path = output or "agent-bom-results.xml"
+        export_junit(report, out_path, blast_radii)
+        con.print(f"\n  [green]✓[/green] JUnit XML: {out_path}")
+    elif output_format == "csv":
+        out_path = output or "agent-bom-results.csv"
+        export_csv(report, out_path, blast_radii)
+        con.print(f"\n  [green]✓[/green] CSV report: {out_path}")
+    elif output_format == "markdown":
+        out_path = output or "agent-bom-report.md"
+        export_markdown(report, out_path, blast_radii)
+        con.print(f"\n  [green]✓[/green] Markdown report: {out_path}")
     elif output_format == "html":
         out_path = output or "agent-bom-report.html"
         export_html(report, out_path, blast_radii)
@@ -274,6 +298,12 @@ def render_output(
             export_spdx(report, output)
         elif output.endswith(".html"):
             export_html(report, output, blast_radii)
+        elif output.endswith(".xml"):
+            export_junit(report, output, blast_radii)
+        elif output.endswith(".csv"):
+            export_csv(report, output, blast_radii)
+        elif output.endswith(".md"):
+            export_markdown(report, output, blast_radii)
         else:
             export_json(report, output)
         con.print(f"\n  [green]✓[/green] Report: {output}")

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -381,7 +381,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         ] = None,
         output_format: Annotated[
             str,
-            Field(description="Output format: 'json' (default) or 'sarif' for GitHub Security tab integration."),
+            Field(description="Output format: 'json' (default), 'sarif', 'cyclonedx', 'spdx', 'junit', 'csv', or 'markdown'."),
         ] = "json",
         policy: Annotated[
             dict | None,

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -96,6 +96,26 @@ async def scan_impl(
 
             sarif_result = to_sarif(report)
             return _truncate_response(json.dumps(sarif_result, indent=2, default=str))
+        if output_format == "cyclonedx":
+            from agent_bom.output import to_cyclonedx
+
+            return _truncate_response(json.dumps(to_cyclonedx(report), indent=2, default=str))
+        if output_format == "spdx":
+            from agent_bom.output import to_spdx
+
+            return _truncate_response(json.dumps(to_spdx(report), indent=2, default=str))
+        if output_format == "junit":
+            from agent_bom.output import to_junit
+
+            return _truncate_response(to_junit(report, blast_radii))
+        if output_format == "csv":
+            from agent_bom.output import to_csv
+
+            return _truncate_response(to_csv(report, blast_radii))
+        if output_format == "markdown":
+            from agent_bom.output import to_markdown
+
+            return _truncate_response(to_markdown(report, blast_radii))
 
         result = to_json(report)
 

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1592,6 +1592,10 @@ from agent_bom.output.badge import (  # noqa: E402
 from agent_bom.output.compliance_export import (  # noqa: E402
     export_compliance_bundle,  # noqa: F401
 )
+from agent_bom.output.csv_fmt import (  # noqa: E402
+    export_csv,  # noqa: F401
+    to_csv,  # noqa: F401
+)
 from agent_bom.output.cyclonedx_fmt import (  # noqa: E402
     export_cyclonedx,  # noqa: F401
     to_cyclonedx,  # noqa: F401
@@ -1602,6 +1606,14 @@ from agent_bom.output.json_fmt import (  # noqa: E402
     _risk_narrative,  # noqa: F401
     export_json,  # noqa: F401
     to_json,  # noqa: F401
+)
+from agent_bom.output.junit import (  # noqa: E402
+    export_junit,  # noqa: F401
+    to_junit,  # noqa: F401
+)
+from agent_bom.output.markdown import (  # noqa: E402
+    export_markdown,  # noqa: F401
+    to_markdown,  # noqa: F401
 )
 from agent_bom.output.sarif import (  # noqa: E402
     export_sarif,  # noqa: F401

--- a/src/agent_bom/output/csv_fmt.py
+++ b/src/agent_bom/output/csv_fmt.py
@@ -1,0 +1,71 @@
+"""CSV output for spreadsheet/SIEM ingestion and executive reporting.
+
+One row per vulnerability finding with all enrichment data.
+UTF-8 BOM included for Excel compatibility.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+
+from agent_bom.models import AIBOMReport, BlastRadius
+
+_COLUMNS = [
+    "cve_id",
+    "package",
+    "version",
+    "ecosystem",
+    "severity",
+    "cvss_score",
+    "epss_score",
+    "is_kev",
+    "fixed_version",
+    "cwe_ids",
+    "affected_agents",
+    "affected_servers",
+    "exposed_credentials",
+    "summary",
+]
+
+
+def to_csv(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
+    """Convert an AIBOMReport to CSV string with UTF-8 BOM."""
+    brs = blast_radii or report.blast_radii
+
+    buf = io.StringIO()
+    # UTF-8 BOM for Excel auto-detection
+    buf.write("\ufeff")
+
+    writer = csv.DictWriter(buf, fieldnames=_COLUMNS, quoting=csv.QUOTE_MINIMAL)
+    writer.writeheader()
+
+    for br in brs:
+        v = br.vulnerability
+        writer.writerow(
+            {
+                "cve_id": v.id,
+                "package": br.package.name,
+                "version": br.package.version or "",
+                "ecosystem": br.package.ecosystem or "",
+                "severity": v.severity.value,
+                "cvss_score": v.cvss_score if v.cvss_score is not None else "",
+                "epss_score": f"{v.epss_score:.4f}" if v.epss_score is not None else "",
+                "is_kev": "yes" if v.is_kev else "no",
+                "fixed_version": v.fixed_version or "",
+                "cwe_ids": ";".join(v.cwe_ids) if v.cwe_ids else "",
+                "affected_agents": ";".join(a.name for a in br.affected_agents),
+                "affected_servers": ";".join(s.name for s in br.affected_servers),
+                "exposed_credentials": str(len(br.exposed_credentials)),
+                "summary": v.summary or "",
+            }
+        )
+
+    return buf.getvalue()
+
+
+def export_csv(report: AIBOMReport, output_path: str, blast_radii: list[BlastRadius] | None = None) -> None:
+    """Write CSV report to file."""
+    from pathlib import Path
+
+    Path(output_path).write_text(to_csv(report, blast_radii), encoding="utf-8")

--- a/src/agent_bom/output/junit.py
+++ b/src/agent_bom/output/junit.py
@@ -1,0 +1,102 @@
+"""JUnit XML output for CI/CD integration (Jenkins, GitLab CI, Azure DevOps).
+
+Each vulnerability maps to a JUnit test case:
+- Test suite = ecosystem
+- Test case  = CVE ID + package
+- Failure    = CRITICAL or HIGH severity
+- Error      = MEDIUM severity
+- Skipped    = LOW or UNKNOWN severity (informational)
+"""
+
+from __future__ import annotations
+
+from xml.etree.ElementTree import Element, SubElement, indent, tostring
+
+from agent_bom.models import AIBOMReport, BlastRadius, Severity
+
+
+def to_junit(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
+    """Convert an AIBOMReport to JUnit XML string."""
+    brs = blast_radii or report.blast_radii
+
+    testsuites = Element("testsuites")
+    testsuites.set("name", "agent-bom")
+    testsuites.set("tests", str(len(brs)))
+    testsuites.set("failures", str(sum(1 for br in brs if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH))))
+    testsuites.set("errors", str(sum(1 for br in brs if br.vulnerability.severity == Severity.MEDIUM)))
+    testsuites.set("time", "0")
+
+    # Group by ecosystem
+    eco_map: dict[str, list[BlastRadius]] = {}
+    for br in brs:
+        eco = br.package.ecosystem or "unknown"
+        eco_map.setdefault(eco, []).append(br)
+
+    for eco, eco_brs in sorted(eco_map.items()):
+        suite = SubElement(testsuites, "testsuite")
+        suite.set("name", eco)
+        suite.set("tests", str(len(eco_brs)))
+        suite.set("failures", str(sum(1 for br in eco_brs if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH))))
+        suite.set("errors", str(sum(1 for br in eco_brs if br.vulnerability.severity == Severity.MEDIUM)))
+        suite.set("time", "0")
+
+        for br in eco_brs:
+            v = br.vulnerability
+            tc = SubElement(suite, "testcase")
+            tc.set("classname", f"{eco}.{br.package.name}")
+            tc.set("name", f"{v.id} ({br.package.name}@{br.package.version})")
+            tc.set("time", "0")
+
+            sev = v.severity
+            detail = _build_detail(br)
+
+            if sev in (Severity.CRITICAL, Severity.HIGH):
+                fail = SubElement(tc, "failure")
+                fail.set("message", f"{sev.value.upper()}: {v.summary or v.id}")
+                fail.set("type", sev.value)
+                fail.text = detail
+            elif sev == Severity.MEDIUM:
+                err = SubElement(tc, "error")
+                err.set("message", f"MEDIUM: {v.summary or v.id}")
+                err.set("type", "medium")
+                err.text = detail
+            else:
+                skipped = SubElement(tc, "skipped")
+                skipped.set("message", f"{sev.value.upper()}: {v.summary or v.id}")
+                skipped.text = detail
+
+    indent(testsuites, space="  ")
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(testsuites, encoding="unicode")
+
+
+def _build_detail(br: BlastRadius) -> str:
+    """Build detail text for a JUnit test case."""
+    v = br.vulnerability
+    lines = [
+        f"CVE: {v.id}",
+        f"Package: {br.package.name}@{br.package.version}",
+        f"Ecosystem: {br.package.ecosystem or 'unknown'}",
+        f"Severity: {v.severity.value}",
+    ]
+    if v.cvss_score is not None:
+        lines.append(f"CVSS: {v.cvss_score}")
+    if v.epss_score is not None:
+        lines.append(f"EPSS: {v.epss_score:.4f}")
+    if v.fixed_version:
+        lines.append(f"Fix: {v.fixed_version}")
+    if v.cwe_ids:
+        lines.append(f"CWE: {', '.join(v.cwe_ids)}")
+    if br.affected_agents:
+        lines.append(f"Affected agents: {', '.join(a.name for a in br.affected_agents)}")
+    if br.exposed_credentials:
+        lines.append(f"Exposed credentials: {len(br.exposed_credentials)}")
+    if v.summary:
+        lines.append(f"Summary: {v.summary}")
+    return "\n".join(lines)
+
+
+def export_junit(report: AIBOMReport, output_path: str, blast_radii: list[BlastRadius] | None = None) -> None:
+    """Write JUnit XML report to file."""
+    from pathlib import Path
+
+    Path(output_path).write_text(to_junit(report, blast_radii), encoding="utf-8")

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -1,0 +1,120 @@
+"""Markdown output for PR comments, wiki pages, and GitHub issue bodies.
+
+Produces a self-contained Markdown report with summary table and detailed findings.
+"""
+
+from __future__ import annotations
+
+from agent_bom.models import AIBOMReport, BlastRadius, Severity
+
+
+def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
+    """Convert an AIBOMReport to Markdown string."""
+    brs = blast_radii or report.blast_radii
+    lines: list[str] = []
+
+    # Header
+    lines.append("# agent-bom Scan Report")
+    lines.append("")
+    lines.append(f"**Generated**: {report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC')}  ")
+    lines.append(f"**Version**: agent-bom v{report.tool_version}")
+    lines.append("")
+
+    # Summary
+    sev_counts = _severity_counts(brs)
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Count |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Agents discovered | {report.total_agents} |")
+    lines.append(f"| MCP servers | {report.total_servers} |")
+    lines.append(f"| Packages scanned | {report.total_packages} |")
+    lines.append(f"| Vulnerabilities | {len(brs)} |")
+    lines.append(f"| Critical | {sev_counts.get('critical', 0)} |")
+    lines.append(f"| High | {sev_counts.get('high', 0)} |")
+    lines.append(f"| Medium | {sev_counts.get('medium', 0)} |")
+    lines.append(f"| Low | {sev_counts.get('low', 0)} |")
+    lines.append("")
+
+    if not brs:
+        lines.append("No vulnerabilities found.")
+        return "\n".join(lines) + "\n"
+
+    # Findings table
+    lines.append("## Findings")
+    lines.append("")
+    lines.append("| Severity | CVE | Package | Version | Fix | CVSS | Agents |")
+    lines.append("|----------|-----|---------|---------|-----|------|--------|")
+
+    for br in sorted(brs, key=lambda b: _sev_order(b.vulnerability.severity)):
+        v = br.vulnerability
+        sev_badge = _severity_badge(v.severity)
+        cvss = f"{v.cvss_score}" if v.cvss_score is not None else "-"
+        fix = v.fixed_version or "-"
+        agents = str(len(br.affected_agents))
+        lines.append(f"| {sev_badge} | {v.id} | {br.package.name} | {br.package.version or '-'} | {fix} | {cvss} | {agents} |")
+
+    lines.append("")
+
+    # Critical/High details
+    critical_high = [br for br in brs if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
+    if critical_high:
+        lines.append("## Critical & High Findings")
+        lines.append("")
+        for br in critical_high:
+            v = br.vulnerability
+            lines.append(f"### {v.id} — {br.package.name}@{br.package.version or '?'}")
+            lines.append("")
+            if v.summary:
+                lines.append(f"> {v.summary}")
+                lines.append("")
+            lines.append(f"- **Severity**: {v.severity.value.upper()}")
+            if v.cvss_score is not None:
+                lines.append(f"- **CVSS**: {v.cvss_score}")
+            if v.epss_score is not None:
+                lines.append(f"- **EPSS**: {v.epss_score:.4f}")
+            if v.is_kev:
+                lines.append("- **KEV**: Yes (CISA Known Exploited)")
+            if v.fixed_version:
+                lines.append(f"- **Fix**: Upgrade to {v.fixed_version}")
+            if v.cwe_ids:
+                lines.append(f"- **CWE**: {', '.join(v.cwe_ids)}")
+            if br.affected_agents:
+                lines.append(f"- **Affected agents**: {', '.join(a.name for a in br.affected_agents)}")
+            if br.exposed_credentials:
+                lines.append(f"- **Exposed credentials**: {len(br.exposed_credentials)}")
+            lines.append("")
+
+    # Footer
+    lines.append("---")
+    lines.append(f"*Scanned by [agent-bom](https://github.com/msaad00/agent-bom) v{report.tool_version}*")
+
+    return "\n".join(lines) + "\n"
+
+
+def export_markdown(report: AIBOMReport, output_path: str, blast_radii: list[BlastRadius] | None = None) -> None:
+    """Write Markdown report to file."""
+    from pathlib import Path
+
+    Path(output_path).write_text(to_markdown(report, blast_radii), encoding="utf-8")
+
+
+def _severity_counts(brs: list[BlastRadius]) -> dict[str, int]:
+    """Count findings by severity."""
+    counts: dict[str, int] = {}
+    for br in brs:
+        key = br.vulnerability.severity.value
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+_SEV_ORDER = {Severity.CRITICAL: 0, Severity.HIGH: 1, Severity.MEDIUM: 2, Severity.LOW: 3, Severity.UNKNOWN: 4, Severity.NONE: 5}
+
+
+def _sev_order(sev: Severity) -> int:
+    return _SEV_ORDER.get(sev, 99)
+
+
+def _severity_badge(sev: Severity) -> str:
+    """Return a text badge for severity."""
+    return f"**{sev.value.upper()}**"

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -1,0 +1,303 @@
+"""Tests for JUnit XML, CSV, and Markdown output reporters."""
+
+from __future__ import annotations
+
+import csv
+import io
+import xml.etree.ElementTree as ET
+from datetime import datetime
+
+from agent_bom.models import (
+    Agent,
+    AgentStatus,
+    AgentType,
+    AIBOMReport,
+    BlastRadius,
+    MCPServer,
+    Package,
+    Severity,
+    TransportType,
+    Vulnerability,
+)
+from agent_bom.output import to_csv, to_junit, to_markdown
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+def _make_report(
+    agents: list[Agent] | None = None,
+    blast_radii: list[BlastRadius] | None = None,
+) -> AIBOMReport:
+    return AIBOMReport(
+        agents=agents or [],
+        blast_radii=blast_radii or [],
+        generated_at=datetime(2026, 1, 1, 12, 0, 0),
+        tool_version="0.70.6",
+    )
+
+
+def _make_agent(
+    name: str = "claude",
+    servers: list[MCPServer] | None = None,
+) -> Agent:
+    return Agent(
+        name=name,
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/test.json",
+        mcp_servers=servers or [],
+        status=AgentStatus.CONFIGURED,
+    )
+
+
+def _make_server(
+    name: str = "test-server",
+    packages: list[Package] | None = None,
+) -> MCPServer:
+    return MCPServer(
+        name=name,
+        command="npx",
+        args=[name],
+        transport=TransportType.STDIO,
+        packages=packages or [],
+        env={},
+    )
+
+
+def _make_pkg(
+    name: str = "lodash",
+    version: str = "4.17.20",
+    ecosystem: str = "npm",
+) -> Package:
+    return Package(name=name, version=version, ecosystem=ecosystem)
+
+
+def _make_vuln(
+    cve_id: str = "CVE-2024-0001",
+    severity: Severity = Severity.CRITICAL,
+    cvss_score: float | None = 9.8,
+    fixed_version: str | None = "4.17.21",
+    cwe_ids: list[str] | None = None,
+) -> Vulnerability:
+    return Vulnerability(
+        id=cve_id,
+        severity=severity,
+        summary="Test vulnerability",
+        cvss_score=cvss_score,
+        fixed_version=fixed_version,
+        cwe_ids=cwe_ids or [],
+    )
+
+
+def _make_blast_radius(
+    pkg: Package | None = None,
+    vuln: Vulnerability | None = None,
+    agents: list[Agent] | None = None,
+) -> BlastRadius:
+    return BlastRadius(
+        package=pkg or _make_pkg(),
+        vulnerability=vuln or _make_vuln(),
+        affected_agents=agents or [_make_agent()],
+        affected_servers=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+
+def _report_with_vulns() -> tuple[AIBOMReport, list[BlastRadius]]:
+    """Report with mixed-severity findings across ecosystems."""
+    agent = _make_agent(servers=[_make_server(packages=[_make_pkg()])])
+    brs = [
+        _make_blast_radius(
+            pkg=_make_pkg("lodash", "4.17.20", "npm"),
+            vuln=_make_vuln("CVE-2024-0001", Severity.CRITICAL, 9.8, "4.17.21", ["CWE-1321"]),
+            agents=[agent],
+        ),
+        _make_blast_radius(
+            pkg=_make_pkg("requests", "2.28.0", "pypi"),
+            vuln=_make_vuln("CVE-2024-0002", Severity.HIGH, 7.5, "2.31.0"),
+            agents=[agent],
+        ),
+        _make_blast_radius(
+            pkg=_make_pkg("express", "4.18.0", "npm"),
+            vuln=_make_vuln("CVE-2024-0003", Severity.MEDIUM, 5.3),
+            agents=[agent],
+        ),
+        _make_blast_radius(
+            pkg=_make_pkg("debug", "4.3.0", "npm"),
+            vuln=_make_vuln("CVE-2024-0004", Severity.LOW, 2.1),
+            agents=[agent],
+        ),
+    ]
+    report = _make_report(agents=[agent], blast_radii=brs)
+    return report, brs
+
+
+# ── JUnit XML ────────────────────────────────────────────────────────────────
+
+
+class TestJUnit:
+    def test_empty_report(self):
+        report = _make_report()
+        xml_str = to_junit(report)
+        assert xml_str.startswith("<?xml")
+        root = ET.fromstring(xml_str)
+        assert root.tag == "testsuites"
+
+    def test_valid_xml_structure(self):
+        report, brs = _report_with_vulns()
+        xml_str = to_junit(report, brs)
+        root = ET.fromstring(xml_str)
+        assert root.tag == "testsuites"
+        suites = root.findall("testsuite")
+        assert len(suites) >= 1
+
+    def test_ecosystems_become_suites(self):
+        report, brs = _report_with_vulns()
+        xml_str = to_junit(report, brs)
+        root = ET.fromstring(xml_str)
+        suite_names = {s.get("name") for s in root.findall("testsuite")}
+        assert "npm" in suite_names
+        assert "pypi" in suite_names
+
+    def test_critical_becomes_failure(self):
+        report, brs = _report_with_vulns()
+        xml_str = to_junit(report, brs)
+        root = ET.fromstring(xml_str)
+        # Find the npm suite and look for a failure element
+        for suite in root.findall("testsuite"):
+            for tc in suite.findall("testcase"):
+                if "CVE-2024-0001" in (tc.get("name") or ""):
+                    assert tc.find("failure") is not None
+
+    def test_medium_becomes_error(self):
+        report, brs = _report_with_vulns()
+        xml_str = to_junit(report, brs)
+        root = ET.fromstring(xml_str)
+        for suite in root.findall("testsuite"):
+            for tc in suite.findall("testcase"):
+                if "CVE-2024-0003" in (tc.get("name") or ""):
+                    assert tc.find("error") is not None
+
+    def test_low_becomes_skipped(self):
+        report, brs = _report_with_vulns()
+        xml_str = to_junit(report, brs)
+        root = ET.fromstring(xml_str)
+        for suite in root.findall("testsuite"):
+            for tc in suite.findall("testcase"):
+                if "CVE-2024-0004" in (tc.get("name") or ""):
+                    assert tc.find("skipped") is not None
+
+    def test_testcase_has_classname(self):
+        report, brs = _report_with_vulns()
+        xml_str = to_junit(report, brs)
+        root = ET.fromstring(xml_str)
+        for suite in root.findall("testsuite"):
+            for tc in suite.findall("testcase"):
+                assert tc.get("classname")
+
+
+# ── CSV ──────────────────────────────────────────────────────────────────────
+
+
+class TestCSV:
+    def test_empty_report(self):
+        report = _make_report()
+        csv_str = to_csv(report)
+        # Should have header row only (after BOM)
+        content = csv_str.lstrip("\ufeff")
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        assert len(rows) == 1  # header only
+        assert "cve_id" in rows[0]
+
+    def test_utf8_bom(self):
+        report = _make_report()
+        csv_str = to_csv(report)
+        assert csv_str.startswith("\ufeff")
+
+    def test_column_count(self):
+        report, brs = _report_with_vulns()
+        csv_str = to_csv(report, brs)
+        content = csv_str.lstrip("\ufeff")
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        header = rows[0]
+        assert len(header) >= 10  # at least core columns
+        # All data rows have same column count
+        for row in rows[1:]:
+            assert len(row) == len(header)
+
+    def test_data_rows(self):
+        report, brs = _report_with_vulns()
+        csv_str = to_csv(report, brs)
+        content = csv_str.lstrip("\ufeff")
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        assert len(rows) == 5  # 1 header + 4 vulns
+
+    def test_severity_values(self):
+        report, brs = _report_with_vulns()
+        csv_str = to_csv(report, brs)
+        content = csv_str.lstrip("\ufeff")
+        reader = csv.DictReader(io.StringIO(content))
+        severities = {row["severity"] for row in reader}
+        assert "critical" in severities
+        assert "high" in severities
+
+    def test_cve_ids_present(self):
+        report, brs = _report_with_vulns()
+        csv_str = to_csv(report, brs)
+        assert "CVE-2024-0001" in csv_str
+        assert "CVE-2024-0002" in csv_str
+
+
+# ── Markdown ─────────────────────────────────────────────────────────────────
+
+
+class TestMarkdown:
+    def test_empty_report(self):
+        report = _make_report()
+        md = to_markdown(report)
+        assert "# agent-bom Scan Report" in md
+        assert "No vulnerabilities found" in md
+
+    def test_summary_table(self):
+        report, brs = _report_with_vulns()
+        md = to_markdown(report, brs)
+        assert "| Metric | Count |" in md
+        assert "Vulnerabilities" in md
+
+    def test_findings_table(self):
+        report, brs = _report_with_vulns()
+        md = to_markdown(report, brs)
+        assert "## Findings" in md
+        assert "CVE-2024-0001" in md
+        assert "CVE-2024-0002" in md
+
+    def test_critical_high_details(self):
+        report, brs = _report_with_vulns()
+        md = to_markdown(report, brs)
+        assert "## Critical & High Findings" in md
+        assert "### CVE-2024-0001" in md
+
+    def test_severity_badges(self):
+        report, brs = _report_with_vulns()
+        md = to_markdown(report, brs)
+        assert "**CRITICAL**" in md
+        assert "**HIGH**" in md
+
+    def test_fix_version_shown(self):
+        report, brs = _report_with_vulns()
+        md = to_markdown(report, brs)
+        assert "4.17.21" in md
+        assert "2.31.0" in md
+
+    def test_footer(self):
+        report, brs = _report_with_vulns()
+        md = to_markdown(report, brs)
+        assert "agent-bom" in md.split("---")[-1]
+
+    def test_version_in_header(self):
+        report = _make_report()
+        md = to_markdown(report)
+        assert "0.70.6" in md


### PR DESCRIPTION
## Summary
- Add 3 new output reporters: JUnit XML (CI/CD), CSV (spreadsheet/SIEM), Markdown (PR comments/wiki)
- Wire all 3 into CLI `--format`, MCP scan tool, stdout pipe mode, and file extension auto-detection
- 21 new tests covering XML structure, CSV columns/BOM, and Markdown content

## Changes
- **New**: `output/junit.py` — ecosystem→suite, CVE→testcase, CRITICAL/HIGH→failure, MEDIUM→error, LOW→skipped
- **New**: `output/csv_fmt.py` — UTF-8 BOM, 14-column findings table
- **New**: `output/markdown.py` — summary table, findings table, critical/high detail sections
- **Modified**: `output/__init__.py` — re-exports for new modules
- **Modified**: `cli/options.py` — added junit/csv/markdown to `--format` choices
- **Modified**: `cli/scan/_output.py` — dispatch for stdout, file, and extension auto-detect
- **Modified**: `mcp_tools/scanning.py` — format dispatch for junit/csv/markdown/cyclonedx/spdx
- **Modified**: `mcp_server.py` — updated format description in scan tool schema

## Test plan
- [x] 21 new tests in `test_output_formats.py` (7 JUnit, 6 CSV, 8 Markdown)
- [x] Full test suite: 6045 passed, 0 failures
- [x] Lint clean (ruff + bandit)
- [ ] CI pipeline (9 jobs)

Closes #737