### PR TITLE
fix: update MCP tool count 31→32 across all surfaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full module map. Key paths:
 | `src/agent_bom/models.py` | Core data models (Package, Vulnerability, Agent…) |
 | `src/agent_bom/runtime/` | Proxy detectors (7 detectors) |
 | `src/agent_bom/api/server.py` | FastAPI REST server |
-| `src/agent_bom/mcp_server.py` | MCP server (31 tools) |
+| `src/agent_bom/mcp_server.py` | MCP server (32 tools) |
 
 The scan pipeline: **discover** MCP configs → **parse** packages → **scan** via OSV batch API → **enrich** full vuln details → **optional** NVD/EPSS/KEV enrichment → **output** (table, JSON, SARIF, CycloneDX…).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agent-bom scan --enrich      # + NVD CVSS + EPSS + CISA KEV enrichment
 That's it. agent-bom discovers your MCP client configs (Claude Desktop, Cursor, Windsurf, and 20 more), resolves every server's dependencies, checks them against OSV/NVD/GHSA, and maps the blast radius — which agents, credentials, and tools are affected by each vulnerability.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-v0.70.4.gif" alt="agent-bom demo — scan, CVE check, blast radius, GPU scan, delta mode, runtime proxy, 31 MCP tools" width="900" />
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-v0.70.4.gif" alt="agent-bom demo — scan, CVE check, blast radius, GPU scan, delta mode, runtime proxy, 32 MCP tools" width="900" />
 </p>
 
 <p align="center">
@@ -83,7 +83,7 @@ CVE-2025-1234  (CRITICAL . CVSS 9.8 . CISA KEV)
 
 ## MCP server
 
-31 tools available to any MCP-compatible AI assistant.
+32 tools available to any MCP-compatible AI assistant.
 
 ```bash
 pip install 'agent-bom[mcp-server]'
@@ -364,7 +364,7 @@ agent-bom scan -o -                                # Pipe any format to stdout
 | GitHub Action | `uses: msaad00/agent-bom@v0.70.7 | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom scan` | Isolated scans (linux/amd64, linux/arm64) |
 | REST API | `agent-bom api` | Dashboards, SIEM |
-| MCP Server | `agent-bom mcp-server` (31 tools) | Inside any MCP client |
+| MCP Server | `agent-bom mcp-server` (32 tools) | Inside any MCP client |
 | Dashboard | `agent-bom serve` · [Full deploy guide](docs/DEPLOYMENT.md) | API + Next.js UI (15 pages) · Postgres/Supabase |
 | Runtime proxy | `agent-bom proxy` | Intercept + enforce MCP traffic in real time |
 | Protect engine | `agent-bom protect` | 7 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, rate limiting, vector DB injection) |

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 31 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 32 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,7 +291,7 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine |
 | SBOM | `src/agent_bom/sbom.py` | SBOM ingestion (CycloneDX, SPDX) |
 | Image | `src/agent_bom/image.py` | Docker image scanning |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (31 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (32 tools) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, Nebius |

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -515,7 +515,7 @@ ScanRequest → _run_scan_sync() [ThreadPoolExecutor]
 | Claim | Verified |
 |-------|---------|
 | "22 MCP clients" (README) | ✓ 20 named AgentType values + CUSTOM = 21 |
-| "31 MCP tools" | ✓ meta-test enforces this |
+| "32 MCP tools" | ✓ meta-test enforces this |
 | "10 compliance frameworks" | ✓ 10 tagging modules |
 | "52 CWE compliance mappings" | ✓ CWE_COMPLIANCE_MAP count |
 | "12 cloud providers" | ✓ cloud/__init__.py _PROVIDERS |

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -196,7 +196,7 @@ max_response_size_kb: 512
 agent-bom mcp-server
 ```
 
-Exposes 31 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query the registry, and generate compliance reports without leaving the chat:
+Exposes 32 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query the registry, and generate compliance reports without leaving the chat:
 
 ```
 scan_agents         — full scan, returns JSON report

--- a/docs/STRATEGIC_AUDIT_2026_03.md
+++ b/docs/STRATEGIC_AUDIT_2026_03.md
@@ -206,7 +206,7 @@ Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Cop
 1. **Full-spectrum AI infra scanning**: CVE + MCP tool security + skill trust + blast radius + compliance — in one tool
 2. **Blast radius analysis**: No competitor does dependency blast radius with compliance framework mapping
 3. **Runtime proxy with enforcement**: Not just scanning — real-time interception, rate limiting, credential leak blocking, rug pull detection
-4. **31 MCP tools**: Deepest MCP server integration — usable by any AI assistant
+4. **32 MCP tools**: Deepest MCP server integration — usable by any AI assistant
 5. **12 cloud provider coverage**: AWS/Azure/GCP + AI-specific (CoreWeave, Databricks, Snowflake, HuggingFace, W&B, MLflow, OpenAI, Ollama, Nebius)
 6. **10 compliance frameworks**: Every finding mapped to OWASP LLM/MCP/Agentic, ATLAS, NIST, EU AI Act, ISO 27001, SOC 2, CIS
 7. **Enrichment depth**: OSV + GHSA + NVD + EPSS + CISA KEV + NVIDIA + OpenSSF Scorecard + MITRE ATT&CK
@@ -276,7 +276,7 @@ Cortex Code has a sophisticated security model that agent-bom should integrate w
 
 1. **agent-bom as Cortex Code MCP server**
    - Cortex Code supports MCP via `mcp.json` — agent-bom can be added as an MCP server
-   - All 31 tools become available to Cortex Code users
+   - All 32 tools become available to Cortex Code users
    - Users can scan their Snowflake pipelines for CVEs, check MCP server trust, run compliance audits — all through natural language in Cortex Code
    - Config: add agent-bom to `~/.snowflake/cortex/mcp.json`
 
@@ -327,7 +327,7 @@ Cortex Code has a sophisticated security model that agent-bom should integrate w
 
 | Coco Security Gap | agent-bom Solution |
 |-------------------|--------------------|
-| "Verify MCP server integrity" — manual guidance only | Automated MCP server scanning (31 tools) |
+| "Verify MCP server integrity" — manual guidance only | Automated MCP server scanning (32 tools) |
 | No CVE scanning of MCP server dependencies | Full enrichment pipeline (OSV+GHSA+NVD+EPSS+KEV) |
 | No blast radius analysis | Blast radius with compliance mapping |
 | Permission caching risks (permissions.json) | Audit cached approvals, flag overly permissive |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -13,7 +13,7 @@ agent-bom operates in four modes:
 1. **Scanner** — reads local config files + public APIs, produces reports
 2. **Proxy** — sits between an MCP client and server, inspects STDIO traffic
 3. **API server** — exposes REST/WebSocket endpoints for the dashboard
-4. **MCP server** — exposes 31 tools to AI assistants (Claude, Cursor, etc.)
+4. **MCP server** — exposes 32 tools to AI assistants (Claude, Cursor, etc.)
 
 ## Trust boundaries
 

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -86,7 +86,7 @@ Enter
 Sleep 4s
 
 # ── 9. What you get ───────────────────────────────────────────────────────────
-Type "echo '31 MCP tools  |  21 MCP client types  |  12 cloud providers  |  7 runtime detectors'"
+Type "echo '32 MCP tools  |  21 MCP client types  |  12 cloud providers  |  7 runtime detectors'"
 Enter
 Sleep 2s
 Type "echo '11 compliance frameworks  |  delta scanning  |  local SQLite DB  |  Trivy/Grype ingestion'"

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">31 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">32 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -182,7 +182,7 @@
 
   <rect x="808" y="106" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="122" text-anchor="middle" class="box-label">MCP Server</text>
-  <text x="870" y="134" text-anchor="middle" class="box-sub">31 tools · stdio/SSE</text>
+  <text x="870" y="134" text-anchor="middle" class="box-sub">32 tools · stdio/SSE</text>
 
   <rect x="808" y="144" width="124" height="32" rx="5" fill="#ffffff" stroke="#d1d9e0" stroke-width="1"/>
   <text x="870" y="160" text-anchor="middle" class="box-label">GitHub Action</text>

--- a/docs/images/deployment-dark.svg
+++ b/docs/images/deployment-dark.svg
@@ -167,7 +167,7 @@
       <rect width="286" height="48" rx="5" fill="#0d1117" stroke="#30363d" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#6e7681">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">31 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">32 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/deployment-light.svg
+++ b/docs/images/deployment-light.svg
@@ -166,7 +166,7 @@
       <rect width="286" height="48" rx="5" fill="#ffffff" stroke="#d0d7de" stroke-width="1" stroke-dasharray="4,3"/>
       <text x="143" y="17" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#94a3b8">PIPELINE FLOW</text>
       <text x="143" y="32" text-anchor="middle" class="node-sub">Ingest -> Parse -> Scan -> Enrich -> Assess -> Remediate</text>
-      <text x="143" y="43" text-anchor="middle" class="node-sub">31 MCP tools  |  100% async  |  streaming output</text>
+      <text x="143" y="43" text-anchor="middle" class="node-sub">32 MCP tools  |  100% async  |  streaming output</text>
     </g>
   </g>
 

--- a/docs/images/offerings-map-dark.svg
+++ b/docs/images/offerings-map-dark.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#bc8cff">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">31 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">32 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/offerings-map-light.svg
+++ b/docs/images/offerings-map-light.svg
@@ -57,7 +57,7 @@
   <rect x="630" y="78" width="170" height="56" rx="12" fill="#f6f8fa" stroke="#bc8cff" stroke-width="1.5"/>
   <rect x="630" y="78" width="170" height="4" rx="2" fill="#bc8cff" opacity="0.6"/>
   <text x="715" y="102" text-anchor="middle" class="spoke-title" fill="#8250df">MCP Server</text>
-  <text x="715" y="116" text-anchor="middle" class="spoke-line1">31 tools for AI agents</text>
+  <text x="715" y="116" text-anchor="middle" class="spoke-line1">32 tools for AI agents</text>
   <text x="715" y="128" text-anchor="middle" class="spoke-line2">stdio + SSE transport</text>
 
   <!-- ── Spoke 4: Docker (right) ── -->

--- a/docs/images/scanner-architecture-dark.svg
+++ b/docs/images/scanner-architecture-dark.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#3fb950">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (31 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">MCP (32 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#7ee787">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#0f3f1f"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#7ee787">13+ FORMATS</text>

--- a/docs/images/scanner-architecture-light.svg
+++ b/docs/images/scanner-architecture-light.svg
@@ -144,7 +144,7 @@
   <text x="1100" y="238" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">CDX · SPDX</text>
   <text x="1100" y="258" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#059669">HTML · SVG</text>
   <text x="1100" y="286" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">REST API (25+)</text>
-  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (31 tools)</text>
+  <text x="1100" y="306" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">MCP (32 tools)</text>
   <text x="1100" y="326" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="#065f46">Dashboard (15)</text>
   <rect x="1048" y="338" width="104" height="16" rx="8" fill="#d1fae5"/>
   <text x="1100" y="350" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8" font-weight="700" fill="#065f46">13+ FORMATS</text>

--- a/integrations/cortex-code/README.md
+++ b/integrations/cortex-code/README.md
@@ -47,7 +47,7 @@ cp integrations/cortex-code/SKILL.md .cortex/skills/agent-bom/SKILL.md
 
 ## What You Get
 
-### As MCP Server (31 tools)
+### As MCP Server (32 tools)
 
 All agent-bom MCP tools become available in Cortex Code:
 

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -216,7 +216,7 @@ agent-bom where             # show all discovery paths
 }
 ```
 
-## Tools (31)
+## Tools (32)
 
 ### Vulnerability Scanning
 | Tool | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.70.7"
-description = "Security scanner for AI infrastructure and supply chain. Discover MCP configs (22 clients), generate SBOMs, scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to credentials and tools, runtime proxy with 7 detectors, 31 MCP tools, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, 11-framework compliance, and 16 output formats."
+description = "Security scanner for AI infrastructure and supply chain. Discover MCP configs (22 clients), generate SBOMs, scan for CVEs (OSV/NVD/EPSS/KEV), map blast radius to credentials and tools, runtime proxy with 7 detectors, 32 MCP tools, CIS benchmarks (AWS/Azure/GCP/Snowflake), MITRE ATT&CK mapping, 11-framework compliance, and 16 output formats."
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-agent-bom exposes 31 tools via its MCP server.
+agent-bom exposes 32 tools via its MCP server.
 
 ## Tools
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -300,7 +300,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         host=host,
         port=port,
         instructions=(
-            f"agent-bom v{__version__} — AI infrastructure security scanner with 31 tools. "
+            f"agent-bom v{__version__} — AI infrastructure security scanner with 32 tools. "
             "Scans packages and images for CVEs (OSV, NVD, EPSS, CISA KEV), maps blast radius "
             "from vulnerabilities to credentials and tools, generates SBOMs (CycloneDX, SPDX), "
             "enforces security policies, and maps to 11 compliance frameworks "

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3109,7 +3109,7 @@ def test_openclaw_registry_skill_minimal_surface():
 
 
 def test_openclaw_skills_all_tools_covered():
-    """Core 31 MCP tools should be covered in the consolidated skill."""
+    """Core 32 MCP tools should be covered in the consolidated skill."""
     from pathlib import Path
 
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"

--- a/tests/test_stats_alignment.py
+++ b/tests/test_stats_alignment.py
@@ -157,7 +157,7 @@ class TestSVGStats:
         """No SVG should contain '22 tools' or '23 tools' — must match actual."""
         for svg in SVG_DIR.glob("*.svg"):
             text = svg.read_text()
-            for stale in ["22 tools", "23 tools", "30 tools", "22 MCP tools", "23 MCP tools", "30 MCP tools"]:
+            for stale in ["22 tools", "23 tools", "30 tools", "31 tools", "22 MCP tools", "23 MCP tools", "30 MCP tools", "31 MCP tools"]:
                 assert stale not in text, f"{svg.name} contains stale '{stale}' — actual MCP tool count is {ACTUAL_MCP_TOOLS}"
 
     def test_no_stale_client_count_in_svgs(self):
@@ -189,7 +189,7 @@ class TestMarkdownStats:
         if not doc.exists():
             pytest.skip(f"{doc.name} not found")
         text = doc.read_text()
-        for stale in ["22 tools", "23 tools", "30 tools", "22 MCP tool", "23 MCP tool", "30 MCP tool"]:
+        for stale in ["22 tools", "23 tools", "30 tools", "31 tools", "22 MCP tool", "23 MCP tool", "30 MCP tool", "31 MCP tool"]:
             assert stale not in text, f"{doc.name} contains stale '{stale}' — actual is {ACTUAL_MCP_TOOLS} tools"
 
     @pytest.mark.parametrize("doc", DOCS_TO_CHECK, ids=lambda p: p.name)
@@ -216,7 +216,7 @@ class TestIntegrationStats:
         if not path.exists():
             pytest.skip("toolhive server.json not found")
         text = path.read_text()
-        for stale in ["22 tools", "23 tools", "30 tools", "22 MCP", "23 MCP", "30 MCP"]:
+        for stale in ["22 tools", "23 tools", "30 tools", "31 tools", "22 MCP", "23 MCP", "30 MCP", "31 MCP"]:
             assert stale not in text, f"toolhive server.json contains stale '{stale}'"
 
     def test_mcp_registry_version_matches(self):
@@ -243,7 +243,7 @@ class TestPyProjectStats:
         assert desc_match, "No description in pyproject.toml"
         desc = desc_match.group(1)
         assert "20 clients" not in desc, "pyproject.toml description has stale '20 clients'"
-        for _stale in ["22 tools", "23 tools", "30 tools"]:
+        for _stale in ["22 tools", "23 tools", "30 tools", "31 tools"]:
             assert _stale not in desc, f"pyproject.toml description has stale '{_stale}'"
 
 


### PR DESCRIPTION
## Summary
- Updates MCP tool count from 31→32 across 24 files (docs, SVGs, integrations, pyproject.toml, Dockerfile, tests)
- Tool 32 (`scan_ai_components`) was added in #745 but doc surfaces were not updated
- Adds "31 tools" to stale-count guards in `test_stats_alignment.py` so CI catches this drift automatically

## Files updated
- README.md, CONTRIBUTING.md, pyproject.toml
- docs/: ARCHITECTURE.md, AUDIT.md, THREAT_MODEL.md, MCP_SECURITY_MODEL.md, STRATEGIC_AUDIT_2026_03.md, demo.tape
- docs/images/: 8 SVG diagrams
- integrations/: openclaw/SKILL.md, cortex-code/README.md
- deploy/docker/Dockerfile.sse
- site-docs/reference/mcp-tools.md
- src/agent_bom/mcp_server.py (server card description string)
- tests/: test_core.py, test_stats_alignment.py

## Test plan
- [x] `pytest tests/test_stats_alignment.py -k tool` — 9/9 pass
- [x] `grep -r "31 tools"` — only hits are stale-count guard lists in test file