### PR TITLE
fix: log warnings for skipped unknown/latest versions

### DIFF
--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -372,6 +372,7 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
     cache = _get_scan_cache()
     results: dict[str, list[dict]] = {}
     packages_to_query: list[Package] = []
+    skipped_versions = 0
 
     # Check cache first
     for pkg in packages:
@@ -380,6 +381,14 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         eco_key = pkg.ecosystem.lower()
         osv_ecosystem = ECOSYSTEM_MAP.get(eco_key)
         if not osv_ecosystem or pkg.version in ("unknown", "latest"):
+            if pkg.version in ("unknown", "latest"):
+                _logger.warning(
+                    "Skipping package %s/%s: unresolvable version %r",
+                    pkg.ecosystem,
+                    pkg.name,
+                    pkg.version,
+                )
+                skipped_versions += 1
             continue
         norm_name = normalize_package_name(pkg.name, eco_key)
         if cache:
@@ -392,6 +401,13 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         packages_to_query.append(pkg)
 
     if not packages_to_query:
+        scanned = len(packages) - skipped_versions
+        if skipped_versions:
+            _logger.info(
+                "Scan complete: %d packages scanned, %d skipped (unresolvable versions)",
+                scanned,
+                skipped_versions,
+            )
         return await _enrich_results_if_needed(results)
 
     queries = []
@@ -500,6 +516,13 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         ]
         await asyncio.to_thread(cache.put_many, cache_writes)
 
+    scanned = len(packages) - skipped_versions
+    if skipped_versions:
+        _logger.info(
+            "Scan complete: %d packages scanned, %d skipped (unresolvable versions)",
+            scanned,
+            skipped_versions,
+        )
     return results
 
 

--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -7,9 +7,12 @@ Maven (flexible versioning).
 
 from __future__ import annotations
 
+import logging
 import re
 
 from agent_bom.http_client import request_with_retry
+
+_logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Validation patterns
@@ -46,6 +49,7 @@ def validate_version(version: str, ecosystem: str) -> bool:
     Returns True if the version matches the ecosystem's version format.
     """
     if not version or version in ("latest", "unknown"):
+        _logger.debug("Invalid version %r for ecosystem %s", version, ecosystem)
         return False
 
     if ecosystem in ("npm", "cargo"):

--- a/tests/test_version_skip_logging.py
+++ b/tests/test_version_skip_logging.py
@@ -1,0 +1,77 @@
+"""Tests for version-skip warning logs in OSV batch queries."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from agent_bom.models import Package
+
+
+@pytest.fixture()
+def _no_scan_cache():
+    """Disable ScanCache so tests don't need SQLite."""
+    with patch("agent_bom.scanners._get_scan_cache", return_value=None):
+        yield
+
+
+@pytest.mark.asyncio()
+@pytest.mark.usefixtures("_no_scan_cache")
+async def test_unknown_version_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A package with version 'unknown' should emit a warning log."""
+    packages = [Package(name="requests", version="unknown", ecosystem="pypi")]
+    with caplog.at_level(logging.WARNING, logger="agent_bom.scanners"):
+        from agent_bom.scanners import query_osv_batch
+
+        await query_osv_batch(packages)
+
+    assert any("Skipping package" in rec.message and "'unknown'" in rec.message for rec in caplog.records), (
+        f"Expected warning about 'unknown' version, got: {[r.message for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio()
+@pytest.mark.usefixtures("_no_scan_cache")
+async def test_latest_version_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A package with version 'latest' should emit a warning log."""
+    packages = [Package(name="express", version="latest", ecosystem="npm")]
+    with caplog.at_level(logging.WARNING, logger="agent_bom.scanners"):
+        from agent_bom.scanners import query_osv_batch
+
+        await query_osv_batch(packages)
+
+    assert any("Skipping package" in rec.message and "'latest'" in rec.message for rec in caplog.records), (
+        f"Expected warning about 'latest' version, got: {[r.message for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio()
+@pytest.mark.usefixtures("_no_scan_cache")
+async def test_skip_count_accurate(caplog: pytest.LogCaptureFixture) -> None:
+    """Skip count in summary log should match number of skipped packages."""
+    packages = [
+        Package(name="requests", version="unknown", ecosystem="pypi"),
+        Package(name="flask", version="latest", ecosystem="pypi"),
+        Package(name="express", version="unknown", ecosystem="npm"),
+    ]
+    with caplog.at_level(logging.INFO, logger="agent_bom.scanners"):
+        from agent_bom.scanners import query_osv_batch
+
+        await query_osv_batch(packages)
+
+    summary = [r for r in caplog.records if "skipped" in r.message and "Scan complete" in r.message]
+    assert len(summary) == 1, f"Expected 1 summary log, got {len(summary)}: {[r.message for r in caplog.records]}"
+    assert "3 skipped" in summary[0].message
+
+
+def test_validate_version_debug_log(caplog: pytest.LogCaptureFixture) -> None:
+    """validate_version should emit debug log for unknown/latest."""
+    from agent_bom.version_utils import validate_version
+
+    with caplog.at_level(logging.DEBUG, logger="agent_bom.version_utils"):
+        result = validate_version("unknown", "pypi")
+
+    assert result is False
+    assert any("Invalid version" in r.message and "'unknown'" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Add warning-level logs when packages with `unknown` or `latest` versions are skipped from OSV vulnerability querying
- Add info-level summary log with scanned/skipped counts after batch query completes
- Add debug-level logging in `validate_version()` for unresolvable version strings
- Add 4 tests verifying warning logs, skip count accuracy, and debug output

Closes #763

## Test plan
- [x] `test_unknown_version_logs_warning` — verifies warning emitted for `unknown` version
- [x] `test_latest_version_logs_warning` — verifies warning emitted for `latest` version
- [x] `test_skip_count_accurate` — verifies summary log shows correct skip count (3 skipped)
- [x] `test_validate_version_debug_log` — verifies debug log in `validate_version()`