### PR TITLE
feat: multi-hop blast radius with delegation chain tracking

### DIFF
--- a/src/agent_bom/cli/options.py
+++ b/src/agent_bom/cli/options.py
@@ -214,6 +214,18 @@ def scan_control_options(fn):
                 help="Scan only against local DB — skip all network calls. Use after 'db update'.",
             ),
             click.option("--no-scan", is_flag=True, help="Skip vulnerability scanning (inventory only)"),
+            click.option(
+                "--blast-radius-depth",
+                type=int,
+                default=1,
+                show_default=True,
+                metavar="N",
+                help=(
+                    "Multi-hop blast radius depth (1-5). Traces agent-to-agent delegation chains "
+                    "through shared MCP servers. Higher values reveal transitive risk but increase "
+                    "analysis time. Default 1 = direct impact only."
+                ),
+            ),
             click.option("--no-tree", is_flag=True, help="Skip dependency tree output"),
             click.option("--transitive", is_flag=True, help="Resolve transitive dependencies for npx/uvx packages"),
             click.option("--max-depth", type=int, default=3, help="Maximum depth for transitive dependency resolution"),

--- a/src/agent_bom/cli/scan/__init__.py
+++ b/src/agent_bom/cli/scan/__init__.py
@@ -78,6 +78,7 @@ def scan(
     dry_run: bool,
     offline: bool,
     no_scan: bool,
+    blast_radius_depth: int,
     no_tree: bool,
     transitive: bool,
     max_depth: int,
@@ -999,7 +1000,12 @@ def scan(
                     phase="local DB + OSV + GHSA",
                 )
                 progress.update(scan_task, completed=1, phase="querying vulnerability databases...")
-                blast_radii = scan_agents_sync(agents, enable_enrichment=enrich, nvd_api_key=nvd_api_key)
+                blast_radii = scan_agents_sync(
+                    agents,
+                    enable_enrichment=enrich,
+                    nvd_api_key=nvd_api_key,
+                    blast_radius_depth=blast_radius_depth,
+                )
                 progress.update(scan_task, completed=3, phase="building blast radius analysis")
                 progress.update(scan_task, completed=4, phase="done")
             if blast_radii:

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -392,6 +392,13 @@ class BlastRadius:
     cis_tags: list[str] = field(default_factory=list)  # CIS Controls v8, e.g. ["CIS-07.1"]
     ai_summary: Optional[str] = None  # LLM-generated contextual risk narrative
 
+    # Multi-hop delegation fields
+    hop_depth: int = 1  # How many hops from the vulnerable package (1 = direct)
+    delegation_chain: list[str] = field(default_factory=list)  # e.g. ["server1→agent1→server2→agent2"]
+    transitive_agents: list[dict] = field(default_factory=list)  # Agents reached via delegation
+    transitive_credentials: list[str] = field(default_factory=list)  # Credentials exposed transitively
+    transitive_risk_score: float = 0.0  # Risk score weighted by hop distance
+
     def calculate_risk_score(self) -> float:
         """Calculate contextual risk score based on blast radius.
 

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1392,7 +1392,11 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10) -> None:
         fix = f"[green]{br.vulnerability.fixed_version}[/green]" if br.vulnerability.fixed_version else "[red dim]—[/red dim]"
         n_agents = len(br.affected_agents)
         n_creds = len(br.exposed_credentials)
+        n_transitive = len(getattr(br, "transitive_agents", []))
         blast = f"{n_agents}A"
+        if n_transitive:
+            hop = getattr(br, "hop_depth", 1)
+            blast += f"+[cyan]{n_transitive}T({hop}h)[/cyan]"
         if n_creds:
             blast += f"/[yellow]{n_creds}C[/yellow]"
         kev = " [red]KEV[/red]" if br.vulnerability.is_kev else ""

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -369,6 +369,11 @@ def to_json(report: AIBOMReport) -> dict:
                 "iso_27001_tags": br.iso_27001_tags,
                 "soc2_tags": br.soc2_tags,
                 "cis_tags": br.cis_tags,
+                "hop_depth": getattr(br, "hop_depth", 1),
+                "delegation_chain": getattr(br, "delegation_chain", []),
+                "transitive_agents": getattr(br, "transitive_agents", []),
+                "transitive_credentials": getattr(br, "transitive_credentials", []),
+                "transitive_risk_score": getattr(br, "transitive_risk_score", 0.0),
             }
             for br in report.blast_radii
         ],

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -1163,8 +1163,131 @@ async def scan_agents_with_enrichment(
     return blast_radii
 
 
-def scan_agents_sync(agents: list[Agent], enable_enrichment: bool = False, nvd_api_key: Optional[str] = None) -> list[BlastRadius]:
+# ── Multi-hop risk amplification factors per hop distance ─────────────────
+_HOP_RISK_FACTORS: dict[int, float] = {
+    1: 1.0,
+    2: 0.7,
+    3: 0.5,
+    4: 0.35,
+    5: 0.25,
+}
+
+
+def expand_blast_radius_hops(
+    blast_radii: list[BlastRadius],
+    agents: list[Agent],
+    max_depth: int = 1,
+) -> None:
+    """Expand blast radii with multi-hop delegation chain analysis.
+
+    For each blast radius, traces agent→server→agent delegation chains
+    beyond the initial (1-hop) affected agents. Uses BFS with cycle
+    detection to avoid infinite loops.
+
+    When ``max_depth`` is 1 (default), this is a no-op — zero overhead.
+
+    Args:
+        blast_radii: Existing 1-hop blast radius findings (mutated in place).
+        agents: All discovered agents (for cross-referencing servers).
+        max_depth: Maximum hop depth (1-5). Clamped to [1, 5].
+    """
+    max_depth = max(1, min(max_depth, 5))
+    if max_depth <= 1:
+        return
+
+    # Build lookup: server_name → list of agents that use that server
+    server_to_agents: dict[str, list[Agent]] = {}
+    for agent in agents:
+        for server in agent.mcp_servers:
+            server_to_agents.setdefault(server.name, []).append(agent)
+
+    # Build lookup: agent_name → list of server names it uses
+    agent_to_servers: dict[str, list[str]] = {}
+    for agent in agents:
+        agent_to_servers[agent.name] = [s.name for s in agent.mcp_servers]
+
+    for br in blast_radii:
+        direct_agent_names = {a.name for a in br.affected_agents}
+        direct_server_names = {s.name for s in br.affected_servers}
+
+        # BFS: queue items are (agent_name, current_hop, chain_so_far)
+        visited_agents: set[str] = set(direct_agent_names)
+        visited_servers: set[str] = set(direct_server_names)
+        transitive_agents: list[dict] = []
+        transitive_creds: list[str] = []
+        chains: list[str] = []
+
+        # Seed BFS from direct agents
+        queue: list[tuple[str, int, list[str]]] = []
+        for agent in br.affected_agents:
+            for srv_name in agent_to_servers.get(agent.name, []):
+                if srv_name not in direct_server_names:
+                    queue.append((agent.name, 1, [agent.name, srv_name]))
+                    visited_servers.add(srv_name)
+
+        max_hop_reached = 1
+        while queue:
+            agent_name, hop, chain = queue.pop(0)
+            if hop >= max_depth:
+                continue
+
+            # The last element in chain is a server name — find agents on it
+            current_server = chain[-1]
+            for next_agent in server_to_agents.get(current_server, []):
+                if next_agent.name in visited_agents:
+                    continue
+                visited_agents.add(next_agent.name)
+                next_hop = hop + 1
+                max_hop_reached = max(max_hop_reached, next_hop)
+
+                new_chain = chain + [next_agent.name]
+                chain_str = "\u2192".join(new_chain)
+                chains.append(chain_str)
+
+                # Collect transitive agent info
+                agent_creds = []
+                for srv in next_agent.mcp_servers:
+                    agent_creds.extend(srv.credential_names)
+                agent_creds = list(set(agent_creds))
+
+                transitive_agents.append(
+                    {
+                        "name": next_agent.name,
+                        "type": next_agent.agent_type.value,
+                        "hop": next_hop,
+                        "chain": chain_str,
+                    }
+                )
+                transitive_creds.extend(agent_creds)
+
+                # Continue BFS: look at servers this agent connects to
+                if next_hop < max_depth:
+                    for srv_name in agent_to_servers.get(next_agent.name, []):
+                        if srv_name not in visited_servers:
+                            visited_servers.add(srv_name)
+                            queue.append((next_agent.name, next_hop, new_chain + [srv_name]))
+
+        if transitive_agents:
+            br.hop_depth = max_hop_reached
+            br.delegation_chain = chains
+            br.transitive_agents = transitive_agents
+            br.transitive_credentials = list(set(transitive_creds))
+            # Transitive risk = base risk * hop factor
+            factor = _HOP_RISK_FACTORS.get(max_hop_reached, 0.25)
+            br.transitive_risk_score = round(br.risk_score * factor, 2)
+
+
+def scan_agents_sync(
+    agents: list[Agent],
+    enable_enrichment: bool = False,
+    nvd_api_key: Optional[str] = None,
+    blast_radius_depth: int = 1,
+) -> list[BlastRadius]:
     """Synchronous wrapper for scan_agents."""
     if enable_enrichment:
-        return asyncio.run(scan_agents_with_enrichment(agents, nvd_api_key, enable_enrichment))
-    return asyncio.run(scan_agents(agents))
+        blast_radii = asyncio.run(scan_agents_with_enrichment(agents, nvd_api_key, enable_enrichment))
+    else:
+        blast_radii = asyncio.run(scan_agents(agents))
+    if blast_radius_depth > 1:
+        expand_blast_radius_hops(blast_radii, agents, max_depth=blast_radius_depth)
+    return blast_radii

--- a/tests/test_multi_hop_blast_radius.py
+++ b/tests/test_multi_hop_blast_radius.py
@@ -1,0 +1,253 @@
+"""Tests for multi-hop blast radius delegation chain tracking.
+
+Covers:
+- 1-hop default behavior (unchanged)
+- 2-hop delegation chain discovery
+- Cycle detection (agent A → server B → agent C → server B)
+- Risk amplification decreases with hops
+- Depth limit enforcement
+"""
+
+from __future__ import annotations
+
+from agent_bom.models import (
+    Agent,
+    AgentStatus,
+    AgentType,
+    BlastRadius,
+    MCPServer,
+    MCPTool,
+    Package,
+    Severity,
+    TransportType,
+    Vulnerability,
+)
+from agent_bom.scanners import expand_blast_radius_hops
+
+
+def _make_agent(name: str, servers: list[MCPServer]) -> Agent:
+    return Agent(
+        name=name,
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/test",
+        source="test",
+        status=AgentStatus.CONFIGURED,
+        mcp_servers=servers,
+    )
+
+
+def _make_server(name: str, packages: list[Package] | None = None, cred_names: list[str] | None = None) -> MCPServer:
+    srv = MCPServer(
+        name=name,
+        command="node",
+        args=[f"{name}.js"],
+        transport=TransportType.STDIO,
+        packages=packages or [],
+    )
+    # Set credential env vars via env dict for credential_names property
+    if cred_names:
+        srv.env = {k: "***" for k in cred_names}
+    return srv
+
+
+def _make_vuln(vuln_id: str = "CVE-2025-0001", severity: Severity = Severity.HIGH) -> Vulnerability:
+    return Vulnerability(id=vuln_id, summary="Test vuln", severity=severity)
+
+
+def _make_pkg(name: str = "test-pkg", version: str = "1.0.0") -> Package:
+    return Package(name=name, version=version, ecosystem="npm")
+
+
+def _make_blast_radius(
+    vuln: Vulnerability,
+    pkg: Package,
+    servers: list[MCPServer],
+    agents: list[Agent],
+) -> BlastRadius:
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=servers,
+        affected_agents=agents,
+        exposed_credentials=[],
+        exposed_tools=[MCPTool(name="read_file", description="Read a file")],
+    )
+    br.risk_score = 6.0
+    return br
+
+
+class TestDefaultOneHop:
+    """When depth=1 (default), no multi-hop expansion happens."""
+
+    def test_no_op_at_depth_1(self):
+        srv = _make_server("srv1")
+        agent1 = _make_agent("agent1", [srv])
+        pkg = _make_pkg()
+        vuln = _make_vuln()
+        br = _make_blast_radius(vuln, pkg, [srv], [agent1])
+
+        expand_blast_radius_hops([br], [agent1], max_depth=1)
+
+        assert br.hop_depth == 1
+        assert br.delegation_chain == []
+        assert br.transitive_agents == []
+        assert br.transitive_risk_score == 0.0
+
+    def test_no_op_at_depth_0(self):
+        """Depth < 1 is clamped to 1."""
+        srv = _make_server("srv1")
+        agent1 = _make_agent("agent1", [srv])
+        br = _make_blast_radius(_make_vuln(), _make_pkg(), [srv], [agent1])
+
+        expand_blast_radius_hops([br], [agent1], max_depth=0)
+
+        assert br.hop_depth == 1
+        assert br.transitive_agents == []
+
+
+class TestTwoHopDelegation:
+    """Two-hop: vuln → pkg → server1 → agent1 → server2 → agent2."""
+
+    def test_finds_transitive_agent(self):
+        shared_srv = _make_server("shared-server")
+        other_srv = _make_server("other-server")
+
+        agent1 = _make_agent("agent1", [shared_srv, other_srv])
+        agent2 = _make_agent("agent2", [other_srv])
+
+        pkg = _make_pkg()
+        vuln = _make_vuln()
+        br = _make_blast_radius(vuln, pkg, [shared_srv], [agent1])
+
+        expand_blast_radius_hops([br], [agent1, agent2], max_depth=2)
+
+        assert br.hop_depth == 2
+        assert len(br.transitive_agents) == 1
+        assert br.transitive_agents[0]["name"] == "agent2"
+        assert br.transitive_agents[0]["hop"] == 2
+        assert len(br.delegation_chain) == 1
+
+    def test_transitive_credentials_collected(self):
+        shared_srv = _make_server("shared-server")
+        secret_srv = _make_server("secret-server", cred_names=["AWS_SECRET_KEY"])
+
+        agent1 = _make_agent("agent1", [shared_srv, secret_srv])
+        agent2 = _make_agent("agent2", [secret_srv])
+
+        br = _make_blast_radius(_make_vuln(), _make_pkg(), [shared_srv], [agent1])
+
+        expand_blast_radius_hops([br], [agent1, agent2], max_depth=2)
+
+        assert "AWS_SECRET_KEY" in br.transitive_credentials
+
+
+class TestCycleDetection:
+    """BFS should not loop when agents share servers cyclically."""
+
+    def test_no_infinite_loop(self):
+        srv_a = _make_server("srv-a")
+        srv_b = _make_server("srv-b")
+
+        agent1 = _make_agent("agent1", [srv_a, srv_b])
+        agent2 = _make_agent("agent2", [srv_b, srv_a])
+
+        br = _make_blast_radius(_make_vuln(), _make_pkg(), [srv_a], [agent1])
+
+        # Should complete without hanging
+        expand_blast_radius_hops([br], [agent1, agent2], max_depth=3)
+
+        # agent2 found once via srv_b
+        assert len(br.transitive_agents) == 1
+        assert br.transitive_agents[0]["name"] == "agent2"
+
+
+class TestRiskAmplification:
+    """Risk score decreases with hop distance."""
+
+    def test_hop2_factor(self):
+        srv1 = _make_server("srv1")
+        srv2 = _make_server("srv2")
+        agent1 = _make_agent("agent1", [srv1, srv2])
+        agent2 = _make_agent("agent2", [srv2])
+
+        br = _make_blast_radius(_make_vuln(), _make_pkg(), [srv1], [agent1])
+        br.risk_score = 8.0
+
+        expand_blast_radius_hops([br], [agent1, agent2], max_depth=2)
+
+        assert br.transitive_risk_score == 8.0 * 0.7  # hop 2 factor
+
+    def test_hop3_factor(self):
+        srv1 = _make_server("srv1")
+        srv2 = _make_server("srv2")
+        srv3 = _make_server("srv3")
+
+        agent1 = _make_agent("agent1", [srv1, srv2])
+        agent2 = _make_agent("agent2", [srv2, srv3])
+        agent3 = _make_agent("agent3", [srv3])
+
+        br = _make_blast_radius(_make_vuln(), _make_pkg(), [srv1], [agent1])
+        br.risk_score = 10.0
+
+        expand_blast_radius_hops([br], [agent1, agent2, agent3], max_depth=3)
+
+        assert br.hop_depth == 3
+        assert br.transitive_risk_score == 10.0 * 0.5  # hop 3 factor
+        assert len(br.transitive_agents) == 2
+
+    def test_risk_decreases_with_depth(self):
+        """Higher hop depth = lower transitive risk factor."""
+        from agent_bom.scanners import _HOP_RISK_FACTORS
+
+        prev = 1.1
+        for hop in range(1, 6):
+            factor = _HOP_RISK_FACTORS[hop]
+            assert factor < prev, f"Factor at hop {hop} ({factor}) should be less than {prev}"
+            prev = factor
+
+
+class TestDepthLimit:
+    """Max depth is clamped to [1, 5]."""
+
+    def test_depth_clamped_to_5(self):
+        srv1 = _make_server("srv1")
+        srv2 = _make_server("srv2")
+        agent1 = _make_agent("agent1", [srv1, srv2])
+        agent2 = _make_agent("agent2", [srv2])
+
+        br = _make_blast_radius(_make_vuln(), _make_pkg(), [srv1], [agent1])
+
+        # max_depth=10 should clamp to 5
+        expand_blast_radius_hops([br], [agent1, agent2], max_depth=10)
+
+        assert br.hop_depth <= 5
+
+    def test_no_transitive_at_depth_1(self):
+        """Even with shared servers, depth=1 returns no transitive agents."""
+        srv = _make_server("shared")
+        agent1 = _make_agent("a1", [srv])
+        agent2 = _make_agent("a2", [srv])
+
+        br = _make_blast_radius(_make_vuln(), _make_pkg(), [srv], [agent1])
+
+        expand_blast_radius_hops([br], [agent1, agent2], max_depth=1)
+
+        assert br.transitive_agents == []
+
+
+class TestMultipleBlastRadii:
+    """expand_blast_radius_hops handles multiple blast radius entries."""
+
+    def test_multiple_brs_expanded(self):
+        srv1 = _make_server("srv1")
+        srv2 = _make_server("srv2")
+        agent1 = _make_agent("agent1", [srv1, srv2])
+        agent2 = _make_agent("agent2", [srv2])
+
+        br1 = _make_blast_radius(_make_vuln("CVE-1"), _make_pkg("pkg1"), [srv1], [agent1])
+        br2 = _make_blast_radius(_make_vuln("CVE-2"), _make_pkg("pkg2"), [srv1], [agent1])
+
+        expand_blast_radius_hops([br1, br2], [agent1, agent2], max_depth=2)
+
+        assert len(br1.transitive_agents) == 1
+        assert len(br2.transitive_agents) == 1


### PR DESCRIPTION
## Summary

- Add multi-hop blast radius analysis that traces agent-to-agent delegation chains through shared MCP servers
- BFS traversal with cycle detection discovers transitive agents exposed beyond the initial 1-hop blast radius
- Risk amplification decays per hop (1.0x direct, 0.7x at 2 hops, 0.5x at 3 hops) — farther agents = lower direct exploitability
- New `--blast-radius-depth N` CLI flag (default 1, max 5) — zero performance regression for existing users

### Changes

- **models.py**: Add `hop_depth`, `delegation_chain`, `transitive_agents`, `transitive_credentials`, `transitive_risk_score` fields to `BlastRadius`
- **scanners/__init__.py**: Add `expand_blast_radius_hops()` BFS function with cycle-safe traversal
- **cli/options.py**: Add `--blast-radius-depth` option to scan control group
- **cli/scan/__init__.py**: Wire depth parameter through to `scan_agents_sync()`
- **output/json_fmt.py**: Include multi-hop fields in JSON output
- **output/__init__.py**: Show transitive agent count in compact blast radius table

## Test plan

- [x] 11 tests in `tests/test_multi_hop_blast_radius.py`
- [x] 1-hop default behavior unchanged (no-op, zero overhead)
- [x] 2-hop and 3-hop delegation chain discovery
- [x] Cycle detection (shared server loops terminate correctly)
- [x] Risk amplification decreases monotonically with hop distance
- [x] Depth clamped to [1, 5]
- [x] Multiple blast radii expanded independently
- [x] Stats alignment tests still pass (19/19)

Closes #761