### PR TITLE
fix: OpenSSF Scorecard — upgrade flatted, suppress false positives, tighten permissions

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -15,7 +15,7 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   rescan:
@@ -19,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      security-events: write
+      security-events: write  # required: SARIF upload to GitHub Security tab
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   cve-check:
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
+      security-events: write  # required: SARIF upload to GitHub Security tab
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -18,7 +18,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write   # required for SARIF upload to GitHub Security tab
 
 jobs:
   self-sast-scan:
@@ -26,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
+      security-events: write  # required: SARIF upload to GitHub Security tab
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -1,0 +1,52 @@
+# OSV-Scanner configuration — suppress false positives
+#
+# The OpenSSF Scorecard Vulnerabilities check runs osv-scanner against the repo.
+# Some advisories are flagged even though our pinned versions already include fixes.
+# Each ignore entry below documents the advisory, the affected package, and why
+# the suppression is safe.
+#
+# Re-audit this file on every dependency bump.
+
+[[IgnoredVulns]]
+id = "GHSA-2g68-c3qc-8985"
+reason = "Werkzeug debugger RCE — fixed in 3.0.3; we pin >= 3.1.6 (uv.lock: 3.1.6)"
+
+[[IgnoredVulns]]
+id = "GHSA-29vq-49wr-vm6x"
+reason = "Werkzeug safe_join Windows device names — fixed in 3.1.6; we pin 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-87hc-h4r5-73f7"
+reason = "Werkzeug safe_join compound extensions — fixed in 3.1.5; we pin >= 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-f9vj-2wh5-fj8j"
+reason = "Werkzeug safe_join Windows — fixed in 3.0.6; we pin >= 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-hgf8-39gv-g3f2"
+reason = "Werkzeug safe_join Windows device — fixed in 3.1.4; we pin >= 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-hrfv-mqp8-q5rw"
+reason = "Werkzeug multipart DoS — fixed in 3.0.1; we pin >= 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-px8h-6qxv-m22q"
+reason = "Werkzeug nameless cookies — fixed in 2.2.3; we pin >= 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-q34m-jh98-gwm2"
+reason = "Werkzeug form resource exhaustion — fixed in 3.0.6; we pin >= 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-xg9f-g7g7-2323"
+reason = "Werkzeug multipart high resource — fixed in 2.2.3; we pin >= 3.1.6"
+
+[[IgnoredVulns]]
+id = "GHSA-68rp-wp8r-4726"
+reason = "Flask Vary:Cookie low-severity — fixed in 3.1.1; we pin 3.1.3 (uv.lock)"
+
+[[IgnoredVulns]]
+id = "GHSA-m2qf-hxjv-5gpq"
+reason = "Flask session cookie disclosure — fixed in 2.3.8; we pin 3.1.3 (uv.lock)"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4072,9 +4073,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary
- **Vulnerabilities 0/10 → should recover to 10/10**: Upgrade `flatted` 3.3.3 → 3.4.1 (GHSA-25h7-pfq9-p65f) + add `.osv-scanner.toml` to suppress 11 false-positive werkzeug/flask GHSAs (all already fixed in our pinned versions)
- **Token-Permissions 7/10 → should improve to 8-9/10**: Remove top-level `security-events: write` from 3 workflows, remove from cflite-pr Build job (only fuzzing/SARIF jobs need it)
- **Maintained 0/10**: Auto-resolves after repo > 90 days old — no code change possible

## Changes
| File | Change |
|---|---|
| `ui/package-lock.json` | flatted 3.3.3 → 3.4.1 (fixes GHSA-25h7-pfq9-p65f) |
| `.osv-scanner.toml` | New — suppress 11 false-positive GHSAs with per-entry justification |
| `cflite-pr.yml` | Build job: `security-events: write` → `contents: read` |
| `container-rescan.yml` | Remove top-level `security-events: write` (keep job-level) |
| `cve-freshness.yml` | Remove top-level `security-events: write` (keep job-level) |
| `post-merge-self-scan.yml` | Remove top-level `security-events: write` (keep job-level) |

## Why false positives?
OSV-Scanner flags werkzeug/flask advisories against our repo, but our pinned versions (`werkzeug>=3.1.6`, `flask 3.1.3` in `uv.lock`) already include all fixes. OSV.dev confirms 0 vulns for both versions. The scanner likely can't resolve versions from `uv.lock` format.

## Test plan
- [ ] CI passes (no workflow permission regressions)
- [ ] `npm audit` in `ui/` returns 0 vulnerabilities
- [ ] Scorecard re-run shows improved Vulnerabilities + Token-Permissions scores