### PR TITLE
feat: compact output — remove banner, progressive disclosure

### DIFF
--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -14,7 +14,7 @@ import click
 
 from agent_bom import __version__
 from agent_bom.cli._common import (
-    BANNER,
+    BANNER,  # noqa: F401 — re-export for backward compatibility
     SEVERITY_ORDER,
     _build_agents_from_inventory,
     _check_for_update_bg,

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -10,7 +10,6 @@ import click
 from rich.console import Console
 
 from agent_bom import __version__
-from agent_bom.cli._common import BANNER
 
 
 def _parse_package_spec(
@@ -199,8 +198,6 @@ def verify(package_spec: Optional[str], ecosystem: Optional[str], as_json: bool,
     from agent_bom.models import Package
 
     console = Console()
-    if not quiet:
-        console.print(BANNER, style="bold blue")
 
     # Determine target
     if package_spec is None:

--- a/src/agent_bom/cli/_history.py
+++ b/src/agent_bom/cli/_history.py
@@ -10,7 +10,6 @@ from typing import Optional
 import click
 from rich.console import Console
 
-from agent_bom.cli._common import BANNER
 from agent_bom.output import print_diff
 
 logger = logging.getLogger(__name__)
@@ -23,7 +22,6 @@ def history_cmd(limit: int):
     from agent_bom.history import list_reports, load_report
 
     console = Console()
-    console.print(BANNER, style="bold blue")
 
     reports = list_reports()
     if not reports:

--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -10,7 +10,7 @@ from typing import Optional
 import click
 from rich.console import Console
 
-from agent_bom.cli._common import BANNER, _make_console
+from agent_bom.cli._common import _make_console
 from agent_bom.discovery import discover_all
 from agent_bom.models import AIBOMReport
 from agent_bom.output import print_agent_tree, print_summary
@@ -30,8 +30,6 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
     import agent_bom.output as _out
 
     _out.console = con
-
-    con.print(BANNER, style="bold blue")
 
     if config:
         config_path = Path(config)
@@ -89,7 +87,6 @@ def validate(inventory_file: str):
       1  Invalid — schema violations found
     """
     console = Console()
-    console.print(BANNER, style="bold blue")
 
     try:
         import jsonschema
@@ -182,7 +179,6 @@ def where(as_json: bool):
         return
 
     console = Console()
-    console.print(BANNER, style="bold blue")
     console.print("\n[bold]MCP Client Configuration Locations[/bold]\n")
 
     total_paths = 0

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -7,8 +7,6 @@ import sys
 import click
 from rich.console import Console
 
-from agent_bom.cli._common import BANNER
-
 
 @click.command("proxy")
 @click.option("--policy", type=click.Path(exists=True), help="Policy file for runtime enforcement")
@@ -350,7 +348,6 @@ def watch_cmd(webhook, alert_log, interval):
     )
 
     console = Console()
-    console.print(BANNER, style="bold blue")
 
     sinks = [ConsoleAlertSink()]
     if webhook:

--- a/src/agent_bom/cli/scan/__init__.py
+++ b/src/agent_bom/cli/scan/__init__.py
@@ -16,7 +16,6 @@ from typing import Any, Optional
 import click
 
 from agent_bom.cli._common import (
-    BANNER,
     SEVERITY_ORDER,
     _build_agents_from_inventory,
     _make_console,
@@ -383,8 +382,6 @@ def scan(
     import agent_bom.output as _out
 
     _out.console = con
-
-    con.print(BANNER, style="bold blue")
 
     if demo:
         con.print("\n[bold yellow]Demo mode[/bold yellow] — scanning bundled inventory with known-vulnerable packages.\n")

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1404,13 +1404,23 @@ def print_compact_agents(report: AIBOMReport) -> None:
 
 
 def print_compact_blast_radius(report: AIBOMReport, limit: int = 10) -> None:
-    """Show top N blast radius findings in a compact table."""
+    """Show top N blast radius findings in a compact table.
+
+    Default mode shows only critical/high findings. Use --verbose for all.
+    """
     if not report.blast_radii:
         return
 
+    # Filter: show critical/high by default, count the rest
+    priority = [br for br in report.blast_radii if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
+    rest_count = len(report.blast_radii) - len(priority)
+    # If no critical/high, fall back to showing all
+    display_list = priority if priority else report.blast_radii
+    shown = display_list[:limit]
+
     console.print()
-    total = len(report.blast_radii)
-    title = f"Top Findings ({min(limit, total)} of {total})" if total > limit else f"Findings ({total})"
+    total = len(display_list)
+    title = f"Top Findings ({min(limit, total)} of {total})" if total > limit else f"Findings ({len(shown)})"
     console.print(Rule(f"[bold]{title}[/bold]", style="dim"))
 
     table = Table(expand=True, padding=(0, 1))
@@ -1423,7 +1433,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10) -> None:
     table.add_column("Frameworks", ratio=2)
     table.add_column("Fix", ratio=1)
 
-    for br in report.blast_radii[:limit]:
+    for br in shown:
         fix = f"[green]{br.vulnerability.fixed_version}[/green]" if br.vulnerability.fixed_version else "[red dim]—[/red dim]"
         n_agents = len(br.affected_agents)
         n_creds = len(br.exposed_credentials)
@@ -1483,8 +1493,14 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10) -> None:
         )
 
     console.print(table)
-    if total > limit:
-        console.print(f"  [dim]... {total - limit} more (use --verbose for full list)[/dim]")
+    overflow = total - len(shown)
+    if overflow > 0 or rest_count > 0:
+        parts = []
+        if overflow > 0:
+            parts.append(f"{overflow} more critical/high")
+        if rest_count > 0:
+            parts.append(f"{rest_count} medium/low hidden")
+        console.print(f"  [dim]+ {' · '.join(parts)} — use --verbose for full list[/dim]")
 
     # Status bar
     console.print()


### PR DESCRIPTION
## Summary
- **Remove ASCII banner** from all 6 command outputs (scan, check, history, inventory, where, proxy) — banner stays in `_common.py` for `--help`/`--version`
- **Progressive disclosure**: compact blast radius shows only critical/high findings by default, collapses medium/low with count: `+ 8 medium/low hidden — use --verbose`
- Clean up unused BANNER imports across CLI modules

## Why
Default scan output was too long and overwhelming. Users want a dashboard, not a research paper. The banner alone consumed 6 lines of screen. Medium/low findings buried the critical ones.

## Before → After
- Before: banner (6 lines) + summary panel + agents table + full findings table
- After: summary panel + agents table + critical/high findings only + collapsed count

## Test plan
- [x] `ruff check` + `ruff format` pass
- [x] `bandit` pass
- [x] Pre-commit hooks pass
- [ ] CI pipeline validates no regressions
- [x] `test_cli_common.py` BANNER test still passes (constant still exists in `_common.py`)

Closes #790