### PR TITLE
fix: add npm audit to CI + release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,13 @@ jobs:
           scan-ref: .
           format: table
           severity: HIGH,CRITICAL
-          exit-code: '0'
+          exit-code: '1'
+
+      - name: npm audit (ui/ transitive deps)
+        run: |
+          cd ui
+          npm ci --ignore-scripts
+          npm audit --audit-level=high
 
   # 2. Linting + Type Checking
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,12 @@ jobs:
       - name: Install agent-bom (from source)
         run: uv sync --extra dev
 
+      - name: npm audit (ui/ deps) — block release on high/critical
+        run: |
+          cd ui
+          npm ci --ignore-scripts
+          npm audit --audit-level=high
+
       - name: Self dep scan — block release on critical CVE
         run: |
           mkdir -p sarif


### PR DESCRIPTION
## Summary
- Add `npm audit --audit-level=high` to CI security job for `ui/` deps
- Add `npm audit` to release self-scan gate (blocks release on HIGH/CRITICAL npm vulns)
- Change Trivy `exit-code` from `0` to `1` (now blocks CI on HIGH/CRITICAL filesystem vulns)

## Why
The flatted 3.3.3 vulnerability (GHSA-25h7-pfq9-p65f) shipped because:
1. Dependabot detected it but auto-dismissed (transitive dev dep)
2. CI had no `npm audit` — Python had `pip-audit` blocking, npm had nothing
3. Trivy scanned but `exit-code: 0` meant it never blocked

Now npm deps get the same treatment as Python deps.

## Test plan
- [x] YAML syntax valid (pre-commit check)
- [ ] CI runs npm audit on ui/ successfully (0 vulns expected after flatted upgrade)

Closes #803