### PR TITLE
feat: Swift Package Manager parser — Package.resolved v2/v3

### DIFF
--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -51,8 +51,9 @@ from agent_bom.parsers.python_parsers import (  # noqa: F401
     parse_uv_lock,
 )
 
-# Re-export Ruby and PHP parsers
+# Re-export Ruby, PHP, and Swift parsers
 from agent_bom.parsers.ruby_parsers import parse_ruby_packages  # noqa: F401
+from agent_bom.parsers.swift_parsers import parse_swift_packages  # noqa: F401
 
 # Path to bundled MCP registry (parsers/ is a subdir of agent_bom/)
 _REGISTRY_PATH = Path(__file__).parent.parent / "mcp_registry.json"
@@ -366,6 +367,7 @@ _MANIFEST_FILES = frozenset(
         "Gemfile.lock",
         "composer.json",
         "composer.lock",
+        "Package.resolved",
     }
 )
 
@@ -441,6 +443,7 @@ def scan_project_directory(
             pkgs.extend(parse_nuget_packages(directory))
             pkgs.extend(parse_ruby_packages(directory))
             pkgs.extend(parse_php_packages(directory))
+            pkgs.extend(parse_swift_packages(directory))
 
             # Deduplicate within this directory
             seen: set[tuple] = set()

--- a/src/agent_bom/parsers/swift_parsers.py
+++ b/src/agent_bom/parsers/swift_parsers.py
@@ -1,0 +1,124 @@
+"""Swift Package Manager parser — extracts packages from Package.resolved.
+
+Parses Package.resolved (SPM lock file, v2 and v3 format) to extract
+Swift package names, versions, and repository URLs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from agent_bom.models import Package
+
+logger = logging.getLogger(__name__)
+
+
+def parse_package_resolved(directory: str | Path) -> list[Package]:
+    """Parse Swift packages from Package.resolved in *directory*.
+
+    Package.resolved v2 format::
+
+        {
+          "pins": [
+            {
+              "identity": "swift-argument-parser",
+              "kind": "remoteSourceControl",
+              "location": "https://github.com/apple/swift-argument-parser.git",
+              "state": { "revision": "...", "version": "1.3.0" }
+            }
+          ],
+          "version": 2
+        }
+
+    Package.resolved v3 format (Xcode 15.3+) uses ``originHash``
+    instead of ``revision`` and adds ``packageRef``.
+
+    Returns
+    -------
+    list[Package]
+        Parsed packages with ecosystem ``swift``.
+    """
+    # Check both root and .package/ locations
+    candidates = [
+        Path(directory) / "Package.resolved",
+        Path(directory) / ".package.resolved",
+    ]
+    resolved = None
+    for candidate in candidates:
+        if candidate.is_file():
+            resolved = candidate
+            break
+
+    if resolved is None:
+        return []
+
+    try:
+        data = json.loads(resolved.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Cannot read %s: %s", resolved, exc)
+        return []
+
+    packages: list[Package] = []
+    seen: set[tuple[str, str]] = set()
+
+    # v2 and v3 both use "pins" array at top level or under "object"
+    pins = data.get("pins", [])
+    if not pins and "object" in data:
+        pins = data["object"].get("pins", [])
+
+    for pin in pins:
+        identity = pin.get("identity", "")
+        location = pin.get("location", pin.get("repositoryURL", ""))
+        state = pin.get("state", {})
+        version = state.get("version") or "unknown"
+
+        # Derive name from identity or location
+        name = identity
+        if not name and location:
+            # Extract from URL: https://github.com/apple/swift-argument-parser.git
+            name = location.rstrip("/").rsplit("/", 1)[-1]
+            if name.endswith(".git"):
+                name = name[:-4]
+
+        if not name:
+            continue
+
+        key = (name.lower(), version)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        packages.append(
+            Package(
+                name=name,
+                version=version,
+                ecosystem="swift",
+                version_source="detected",
+                purl=f"pkg:swift/{name}@{version}",
+                is_direct=True,  # Package.resolved doesn't distinguish
+                repository_url=location or None,
+            ),
+        )
+
+    if packages:
+        logger.info("Parsed %d packages from %s", len(packages), resolved)
+
+    return packages
+
+
+def parse_swift_packages(directory: str | Path) -> list[Package]:
+    """Parse Swift packages from a project directory.
+
+    Parameters
+    ----------
+    directory:
+        Project root containing Package.resolved.
+
+    Returns
+    -------
+    list[Package]
+        All discovered Swift packages.
+    """
+    return parse_package_resolved(directory)

--- a/tests/test_swift_parser.py
+++ b/tests/test_swift_parser.py
@@ -1,0 +1,95 @@
+"""Tests for Swift Package Manager parser."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_bom.parsers.swift_parsers import parse_package_resolved, parse_swift_packages
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path):
+    return tmp_path
+
+
+def test_parse_package_resolved_v2(tmp_project: Path):
+    """Parse v2 format Package.resolved."""
+    data = {
+        "pins": [
+            {
+                "identity": "swift-argument-parser",
+                "kind": "remoteSourceControl",
+                "location": "https://github.com/apple/swift-argument-parser.git",
+                "state": {"revision": "abc123", "version": "1.3.0"},
+            },
+            {
+                "identity": "vapor",
+                "kind": "remoteSourceControl",
+                "location": "https://github.com/vapor/vapor.git",
+                "state": {"revision": "def456", "version": "4.89.0"},
+            },
+        ],
+        "version": 2,
+    }
+    (tmp_project / "Package.resolved").write_text(json.dumps(data), encoding="utf-8")
+
+    packages = parse_package_resolved(tmp_project)
+    assert len(packages) == 2
+
+    names = {p.name for p in packages}
+    assert "swift-argument-parser" in names
+    assert "vapor" in names
+
+    sap = next(p for p in packages if p.name == "swift-argument-parser")
+    assert sap.version == "1.3.0"
+    assert sap.ecosystem == "swift"
+    assert sap.purl == "pkg:swift/swift-argument-parser@1.3.0"
+    assert sap.repository_url == "https://github.com/apple/swift-argument-parser.git"
+
+
+def test_parse_package_resolved_no_version(tmp_project: Path):
+    """Handle pins with branch/revision but no version."""
+    data = {
+        "pins": [
+            {
+                "identity": "swift-testing",
+                "location": "https://github.com/apple/swift-testing.git",
+                "state": {"branch": "main", "revision": "abc123"},
+            },
+        ],
+        "version": 3,
+    }
+    (tmp_project / "Package.resolved").write_text(json.dumps(data), encoding="utf-8")
+
+    packages = parse_package_resolved(tmp_project)
+    assert len(packages) == 1
+    assert packages[0].version == "unknown"
+
+
+def test_parse_no_swift_files(tmp_project: Path):
+    """No packages when no Swift files exist."""
+    assert parse_swift_packages(tmp_project) == []
+
+
+def test_parse_deduplication(tmp_project: Path):
+    """No duplicate packages."""
+    data = {
+        "pins": [
+            {
+                "identity": "vapor",
+                "location": "https://github.com/vapor/vapor.git",
+                "state": {"version": "4.89.0"},
+            },
+            {
+                "identity": "vapor",
+                "location": "https://github.com/vapor/vapor.git",
+                "state": {"version": "4.89.0"},
+            },
+        ],
+        "version": 2,
+    }
+    (tmp_project / "Package.resolved").write_text(json.dumps(data), encoding="utf-8")
+
+    packages = parse_package_resolved(tmp_project)
+    assert len(packages) == 1


### PR DESCRIPTION
## Summary
Add Swift Package Manager parser supporting:
- `Package.resolved` v2 format (Xcode 14+)
- `Package.resolved` v3 format (Xcode 15.3+)  
- Name extraction from identity or repository URL
- Repository URL preserved for provenance tracking
- Deduplication

## Ecosystem count: 9 → 11 (with PHP PR #815)
Python, Node.js, Go, Rust, Java, .NET, Ruby, Conda, MCP → **+ PHP + Swift**

## Test plan
- [x] 4 tests pass (v2, no-version, empty, dedup)
- [x] `ruff check` + `ruff format` + `bandit` pass
- [ ] CI validates

Closes #784