### PR TITLE
fix: remove Snowflake deployment row from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,6 @@ agent-bom scan -o -                                # Pipe any format to stdout
 | Protect engine | `agent-bom protect` | 7 behavioral detectors (rug pull, injection, credential leak, exfil sequences, response cloaking, rate limiting, vector DB injection) |
 | Config watcher | `agent-bom watch` | Filesystem watch on MCP configs, alert on drift |
 | Pre-install guard | `agent-bom guard pip install <pkg>` | Block vulnerable installs |
-| Snowflake | [DEPLOYMENT.md](docs/DEPLOYMENT.md) | Snowpark + SiS |
 
 <details>
 <summary><b>Install extras</b></summary>


### PR DESCRIPTION
## Summary
Remove the Snowflake deployment row (`Snowpark + SiS`) from the README deployment table. Snowflake integration is scanning-only — Cortex CLI, CoCo skills, Snowflake CLI scanning. The Snowpark deployment is a reference architecture in DEPLOYMENT.md, not an active offering.

Snowflake cloud provider scanning (`--snowflake-account`) remains unchanged.