### PR TITLE
fix: remove packaging dependency from upgrade command

### DIFF
--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -153,8 +153,10 @@ def upgrade_cmd(check_only: bool) -> None:
     import subprocess as sp
     import urllib.request
 
-    from packaging.version import Version
     from rich.console import Console
+
+    def _ver_tuple(v: str) -> tuple[int, ...]:
+        return tuple(int(x) for x in v.split(".") if x.isdigit())
 
     con = Console(stderr=True)
     con.print(f"  Current version: [bold]{__version__}[/bold]")
@@ -172,7 +174,7 @@ def upgrade_cmd(check_only: bool) -> None:
         con.print("  [red]Could not reach PyPI to check for updates.[/red]")
         raise SystemExit(1)
 
-    if Version(latest) <= Version(__version__):
+    if _ver_tuple(latest) <= _ver_tuple(__version__):
         con.print(f"  Latest version:  [bold]{latest}[/bold]")
         con.print("  [green]You are up to date.[/green]")
         return

--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -138,9 +138,10 @@ def _check_for_update_bg() -> None:
             data = json.loads(resp.read())
         latest = data["info"]["version"]
 
-        from packaging.version import Version
+        def _vt(v: str) -> tuple[int, ...]:
+            return tuple(int(x) for x in v.split(".") if x.isdigit())
 
-        if Version(latest) > Version(__version__):
+        if _vt(latest) > _vt(__version__):
             msg = (
                 f"[yellow]Update available:[/yellow] agent-bom {__version__} → [bold]{latest}[/bold]\n"
                 f"  Run: [cyan]pip install --upgrade agent-bom[/cyan]"


### PR DESCRIPTION
upgrade command and background version check used packaging.Version which isn't in our dependencies. Replace with simple tuple comparison — zero external deps needed.