### PR TITLE
perf: 3x scan speed — fix DB query bottleneck

### DIFF
--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -67,7 +67,7 @@ def lookup_package(
         JOIN vulns v ON v.id = a.vuln_id
         LEFT JOIN epss_scores e ON e.cve_id = v.id
         LEFT JOIN kev_entries k ON k.cve_id = v.id
-        WHERE LOWER(a.ecosystem) = ? AND a.package_name = ?
+        WHERE a.ecosystem = ? AND a.package_name = ?
         ORDER BY v.cvss_score DESC NULLS LAST
         """,
         (eco_lower, norm_name),
@@ -196,7 +196,7 @@ def lookup_packages_batch(
             JOIN vulns v ON v.id = a.vuln_id
             LEFT JOIN epss_scores e ON e.cve_id = v.id
             LEFT JOIN kev_entries k ON k.cve_id = v.id
-            WHERE (LOWER(a.ecosystem), a.package_name) IN (VALUES {placeholders})
+            WHERE (a.ecosystem, a.package_name) IN (VALUES {placeholders})
             ORDER BY v.cvss_score DESC NULLS LAST
         """  # nosec B608
         all_rows.extend(conn.execute(query, params).fetchall())
@@ -255,7 +255,7 @@ def package_in_db(conn: sqlite3.Connection, ecosystem: str, name: str) -> bool:
 
     norm_name = normalize_package_name(name, ecosystem)
     row = conn.execute(
-        "SELECT 1 FROM affected WHERE LOWER(ecosystem) = ? AND package_name = ? LIMIT 1",
+        "SELECT 1 FROM affected WHERE ecosystem = ? AND package_name = ? LIMIT 1",
         (ecosystem.lower(), norm_name),
     ).fetchone()
     return row is not None

--- a/src/agent_bom/db/schema.py
+++ b/src/agent_bom/db/schema.py
@@ -137,8 +137,13 @@ def _set_db_permissions(db_path: Path) -> None:
 
 
 def _check_integrity(conn: sqlite3.Connection, db_path: Path) -> None:
-    """Run SQLite integrity_check; log a warning if the DB is corrupt."""
-    result = conn.execute("PRAGMA integrity_check").fetchone()
+    """Run SQLite quick_check (fast header-only validation).
+
+    Full ``integrity_check`` scans every page (~4s on 700K records) —
+    too expensive for every scan.  Use ``quick_check`` which validates
+    the B-tree structure without reading every row.
+    """
+    result = conn.execute("PRAGMA quick_check").fetchone()
     if result and result[0] != "ok":
         _logger.warning(
             "Local vuln DB at %s failed integrity check: %s — consider deleting and re-running 'agent-bom db update'",

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -949,7 +949,7 @@ async def scan_packages(packages: list[Package]) -> int:
         for p in scannable
         if p.name.lower().replace("-", "_") in _AI_FRAMEWORK_PACKAGES or p.name.lower().replace("-", "") in _AI_FRAMEWORK_PACKAGES
     ]
-    if nvidia_packages:
+    if nvidia_packages and not offline_mode:
         try:
             from agent_bom.scanners.nvidia_advisory import check_nvidia_advisories
 
@@ -962,7 +962,7 @@ async def scan_packages(packages: list[Package]) -> int:
             console.print(f"  [yellow]⚠[/yellow] NVIDIA advisory check skipped: {exc}")
 
     # Supplemental: check GitHub Security Advisories for all packages
-    if scannable:
+    if scannable and not offline_mode:
         try:
             from agent_bom.scanners.ghsa_advisory import check_github_advisories
 


### PR DESCRIPTION
## Summary
Three fixes that reduce scan time from 9.8s → 2.9s offline (3.4x faster):

1. **Remove LOWER() from SQL** — data already stored lowercase, LOWER() bypassed index causing full 3.5M row scan
2. **PRAGMA quick_check** — replaces integrity_check which read every DB page (3.85s → 0.57s)
3. **Skip GHSA/NVIDIA network in offline mode** — were running even with --offline

| Mode | Before | After |
|---|---|---|
| Offline | 9.8s | **2.9s** |
| Network | 9.8s | **3.7s** |

Closes #827

## Test plan
- [x] Offline scan: 2.9s
- [x] Network scan: 3.7s
- [x] Lint + mypy + bandit pass
- [ ] CI validates