### PR TITLE
fix: scan guard accounts for all scan modes

### DIFF
--- a/src/agent_bom/cli/scan/_discovery.py
+++ b/src/agent_bom/cli/scan/_discovery.py
@@ -134,6 +134,9 @@ def run_local_discovery(
         and not agent_projects
         and not jupyter_dirs
         and not any_cloud
+        and not filesystem_paths
+        and not image_tars
+        and not os_packages
     ):
         con.print("\n[bold yellow]No MCP configurations found on this machine.[/bold yellow]")
         con.print()


### PR DESCRIPTION
## Problem
`--filesystem`, `--image-tar`, and `--os-packages` flags were missing from the "no MCP configs" guard. In CI/server environments without MCP clients, `agent-bom scan --filesystem /path` would exit with "No MCP configurations found" instead of scanning.

## Fix
Added `filesystem_paths`, `image_tars`, and `os_packages` to the early-exit guard. These scan modes now work independently.

## Test
- [x] `agent-bom scan --filesystem /tmp/e2e-test --offline` → 86 CVEs found (was exiting with 0)
- [x] Compared with Trivy: 86 vs 75 CVEs (100% Trivy overlap + 11 extra)