### PR TITLE
feat: agent-bom mcp command group

### DIFF
--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -109,6 +109,7 @@ from agent_bom.cli._registry import registry, schedule  # noqa: E402
 main.add_command(schedule)
 main.add_command(registry)
 
+
 from agent_bom.cli._runtime import (  # noqa: E402
     _NoOpDetector,
     audit_replay_cmd,
@@ -139,6 +140,18 @@ main.add_command(introspect_cmd, "introspect")
 from agent_bom.cli._db import db_cmd  # noqa: E402
 
 main.add_command(db_cmd, "db")
+
+# ---------------------------------------------------------------------------
+# MCP command group — `agent-bom mcp [inventory|introspect|registry|server]`
+# ---------------------------------------------------------------------------
+from agent_bom.cli._mcp_group import mcp_group  # noqa: E402
+
+mcp_group.add_command(inventory, "inventory")
+mcp_group.add_command(introspect_cmd, "introspect")
+mcp_group.add_command(registry, "registry")
+mcp_group.add_command(mcp_server_cmd, "server")
+mcp_group.add_command(where, "where")
+main.add_command(mcp_group)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cli/_mcp_group.py
+++ b/src/agent_bom/cli/_mcp_group.py
@@ -1,0 +1,35 @@
+"""MCP command group — discover, scan, and manage MCP agents and servers.
+
+Usage::
+
+    agent-bom mcp                    # discover + scan MCP agents
+    agent-bom mcp inventory          # discover only, no CVE scan
+    agent-bom mcp introspect         # live server tool listing
+    agent-bom mcp registry           # browse server registry
+    agent-bom mcp server             # start agent-bom as MCP server
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.group("mcp", invoke_without_command=True)
+@click.pass_context
+def mcp_group(ctx: click.Context) -> None:
+    """Discover, scan, and manage MCP agents and servers.
+
+    Run without a subcommand to discover all MCP agents and scan for CVEs.
+
+    \b
+    Subcommands:
+      inventory    Discover agents and servers (no CVE scan)
+      introspect   Connect to live servers, list their tools
+      registry     Browse the MCP server security registry
+      server       Start agent-bom as an MCP server
+    """
+    if ctx.invoked_subcommand is None:
+        # Default: run full MCP scan (same as `agent-bom scan` but MCP-focused)
+        from agent_bom.cli.scan import scan
+
+        ctx.invoke(scan)


### PR DESCRIPTION
## Summary
Groups MCP-related commands under `agent-bom mcp`:

```bash
agent-bom mcp              # discover + scan (default)
agent-bom mcp inventory    # discover only
agent-bom mcp introspect   # live server tools
agent-bom mcp registry     # browse registry
agent-bom mcp server       # start MCP server
agent-bom mcp where        # config paths
```

**Backward compatible** — `agent-bom inventory`, `agent-bom introspect` etc. still work.

Part 1 of 5 for #848 (CLI refactor)

## Test plan
- [x] `agent-bom mcp --help` shows subcommands
- [x] `agent-bom mcp inventory` works
- [x] `agent-bom mcp where` works  
- [x] `agent-bom mcp` (no subcommand) runs full scan
- [x] Old commands still work (backward compat)