### PR TITLE
fix: skip CWD auto-detect when scanning images

### DIFF
--- a/src/agent_bom/cli/scan/_discovery.py
+++ b/src/agent_bom/cli/scan/_discovery.py
@@ -293,7 +293,8 @@ def run_local_discovery(
                 con.print(f"  [yellow]⚠[/yellow] {tar_path}: {e}")
 
     # Auto-detect: scan current directory for lockfiles and IaC (always, not just when no MCP)
-    if not filesystem_paths and not project and not skill_only:
+    # Skip auto-detect when explicitly scanning images — avoid mixing local CWD with image contents.
+    if not filesystem_paths and not project and not skill_only and not images and not image_tars:
         cwd = Path.cwd()
         _lockfile_patterns = [
             "requirements.txt",
@@ -314,7 +315,7 @@ def run_local_discovery(
             filesystem_paths = (str(cwd),)
             con.print(f"\n[bold blue]Auto-detected lockfiles in {cwd}[/bold blue]")
 
-    if not iac_paths and not skill_only:
+    if not iac_paths and not skill_only and not images and not image_tars:
         cwd = Path.cwd()
         _auto_iac: list[str] = []
         for name in ["Dockerfile", "docker-compose.yml", "docker-compose.yaml"]:


### PR DESCRIPTION
## Summary

When `--image` or `--image-tar` is provided, the lockfile and IaC auto-detect from CWD was still running, mixing local filesystem packages into image scan results. This caused image scans to include unrelated packages from the operator's working directory.

Now skips auto-detect for both lockfiles and IaC when images are the explicit scan target.

## Test plan

- [x] `agent-bom scan --image python:3.12-slim` now shows only image contents (1 agent, 89 packages)
- [x] No `fs:/Users/...` server leaking into image results
- [x] 66 scan CLI tests pass
- [x] Pre-commit hooks pass