### PR TITLE
fix: remediation plan no longer suggests package downgrades

### DIFF
--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -929,12 +929,23 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
     severity_order = {Severity.CRITICAL: 4, Severity.HIGH: 3, Severity.MEDIUM: 2, Severity.LOW: 1, Severity.NONE: 0}
 
     for br in blast_radii:
-        key = (br.package.name, br.package.ecosystem, br.package.version, br.vulnerability.fixed_version)
+        key = (br.package.name, br.package.ecosystem, br.package.version)
         g = groups[key]
         g["package"] = br.package.name
         g["ecosystem"] = br.package.ecosystem
         g["current"] = br.package.version
-        g["fix"] = br.vulnerability.fixed_version
+        # Only accept fixed_version that is a forward upgrade; pick the minimum valid fix
+        fv = br.vulnerability.fixed_version
+        if fv:
+            try:
+                from packaging.version import Version as _PkgV
+
+                if _PkgV(fv) > _PkgV(br.package.version):
+                    if g["fix"] is None or _PkgV(fv) < _PkgV(g["fix"]):
+                        g["fix"] = fv
+            except Exception:
+                if g["fix"] is None:
+                    g["fix"] = fv
         g["vulns"].append(br.vulnerability.id)
         for a in br.affected_agents:
             g["agents"].add(a.name)

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -558,6 +558,29 @@ def test_build_remediation_plan_with_items():
     assert plan[0]["package"] == "lodash"
 
 
+def test_build_remediation_plan_no_downgrade():
+    """Regression: multi-branch OSV advisories must not produce downgrade entries.
+
+    Django 3.2.0 CVE has two fix branches: 2.2.26 (older branch) and 3.2.14.
+    The remediation plan must emit exactly ONE entry for django@3.2.0 pointing
+    to 3.2.14 — not a second entry pointing backward to 2.2.26.
+    """
+    pkg = Package(name="django", version="3.2.0", ecosystem="pypi", vulnerabilities=[])
+    vuln_downgrade = Vulnerability(
+        id="CVE-2025-9999", severity=Severity.HIGH, summary="Django XSS", fixed_version="2.2.26"
+    )
+    vuln_valid = Vulnerability(
+        id="CVE-2025-9999", severity=Severity.HIGH, summary="Django XSS", fixed_version="3.2.14"
+    )
+    br1 = BlastRadius(vulnerability=vuln_downgrade, package=pkg, affected_agents=[], affected_servers=[], exposed_credentials=[], exposed_tools=[])
+    br2 = BlastRadius(vulnerability=vuln_valid, package=pkg, affected_agents=[], affected_servers=[], exposed_credentials=[], exposed_tools=[])
+    plan = build_remediation_plan([br1, br2])
+    # Must be exactly one entry (grouped by package+ecosystem+version)
+    assert len(plan) == 1
+    # fix must be the forward upgrade, not the downgrade
+    assert plan[0]["fix"] == "3.2.14"
+
+
 # ── to_json (from cov2) ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Multi-branch OSV advisories (e.g. Django 3.2.0 with fix branches 2.2.26 and 3.2.14) were producing duplicate remediation entries, one of which pointed backward to an older release branch
- `build_remediation_plan()` grouped by `(package, ecosystem, version, fixed_version)` — the `fixed_version` in the key caused separate groups per OSV fix branch
- Result: remediation plan showed "upgrade django 3.2.0 → 2.2.26" alongside "upgrade django 3.2.0 → 3.2.14", confusing users and undermining trust

## What changed
- Group key in `output/__init__.py:932` now uses `(package, ecosystem, version)` only
- `fixed_version` is selected separately: only values strictly greater than `current_version` are accepted, using `packaging.version.Version` comparison; the minimum qualifying forward-upgrade wins
- Non-PEP-440 versions fall back to first-seen (no silent drop)

## Test plan
- [ ] `test_build_remediation_plan_no_downgrade` — regression test with Django 3.2.0 + two fix branches; asserts exactly one group with `fix == "3.2.14"`
- [ ] `test_build_remediation_plan_empty` — still passes
- [ ] `test_build_remediation_plan_with_items` — still passes

Closes #912