### PR TITLE
fix: downgrade docker/non-OSV ecosystem log from WARNING to DEBUG

### DIFF
--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -88,6 +88,26 @@ ECOSYSTEM_MAP = {
     "rpm": "Linux",
 }
 
+# Known non-OSV ecosystems: valid discovery artifacts that cannot be queried
+# against OSV/NVD. These are silently skipped (DEBUG) rather than flagged as
+# errors — the scanner handles them through other pipelines (OCI image scan,
+# model provenance checks, cloud runtime inventory, etc.).
+_NON_OSV_ECOSYSTEMS: frozenset[str] = frozenset(
+    {
+        "docker",  # Image stubs from MCP configs / docker-compose / running containers
+        "container",  # GPU infra image refs (cuda-toolkit, cudnn)
+        "container-image",  # CoreWeave / Nebius pod images
+        "ollama",  # Ollama model names — no OSV advisory DB
+        "smithery",  # Smithery MCP marketplace stubs
+        "mcp-registry",  # MCP Registry stubs
+        "azure-runtime",  # Azure Functions / ACA runtime images
+        "nebius-ai-studio",  # Nebius AI Studio model artifacts
+        "nebius-compute-image",  # Nebius compute node images
+        "sast",  # SAST findings represented as packages
+        "unknown",  # Packages with unresolvable ecosystem (e.g. --sbom ingest)
+    }
+)
+
 
 def _get_api_semaphore() -> asyncio.Semaphore:
     """Create a semaphore bound to the current event loop.
@@ -404,12 +424,20 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         eco_key = pkg.ecosystem.lower()
         osv_ecosystem = ECOSYSTEM_MAP.get(eco_key)
         if not osv_ecosystem:
-            _logger.warning(
-                "Skipping package %s/%s: unknown ecosystem %r (not in ECOSYSTEM_MAP)",
-                pkg.ecosystem,
-                pkg.name,
-                pkg.ecosystem,
-            )
+            if eco_key in _NON_OSV_ECOSYSTEMS:
+                _logger.debug(
+                    "Skipping package %s/%s: ecosystem %r is not OSV-queryable (handled by other pipeline)",
+                    pkg.ecosystem,
+                    pkg.name,
+                    pkg.ecosystem,
+                )
+            else:
+                _logger.warning(
+                    "Skipping package %s/%s: unknown ecosystem %r — add to ECOSYSTEM_MAP or _NON_OSV_ECOSYSTEMS",
+                    pkg.ecosystem,
+                    pkg.name,
+                    pkg.ecosystem,
+                )
             skipped_ecosystems += 1
             continue
         if pkg.version in ("unknown", "latest"):

--- a/tests/test_scanner_ecosystems.py
+++ b/tests/test_scanner_ecosystems.py
@@ -224,3 +224,36 @@ async def test_scan_packages_maven_vuln_attached():
     assert len(pkg.vulnerabilities) >= 1
     vuln_ids = [v.id for v in pkg.vulnerabilities]
     assert "CVE-2021-44228" in vuln_ids
+
+
+def test_non_osv_ecosystems_not_empty():
+    """_NON_OSV_ECOSYSTEMS must cover docker and other known non-queryable ecosystems."""
+    from agent_bom.scanners import _NON_OSV_ECOSYSTEMS
+
+    for eco in ("docker", "container", "container-image", "ollama", "smithery", "sast", "unknown"):
+        assert eco in _NON_OSV_ECOSYSTEMS, f"Expected {eco!r} in _NON_OSV_ECOSYSTEMS"
+
+
+@pytest.mark.asyncio
+async def test_docker_ecosystem_skipped_at_debug_not_warning(caplog):
+    """Packages with ecosystem='docker' should be skipped silently (DEBUG) not WARNING."""
+    import logging
+
+    from agent_bom.scanners import scan_packages
+
+    pkg = Package(name="mcp/playwright", version="1.0.0", ecosystem="docker")
+
+    with (
+        patch("agent_bom.scanners._get_scan_cache", return_value=None),
+        patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())),
+        caplog.at_level(logging.DEBUG, logger="agent_bom.scanners"),
+    ):
+        await scan_packages([pkg])
+
+    # Must not emit a WARNING for docker ecosystem
+    warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING and "docker" in r.message]
+    assert not warning_msgs, f"Unexpected WARNING for docker ecosystem: {warning_msgs}"
+
+    # Should emit a DEBUG skip message
+    debug_msgs = [r for r in caplog.records if r.levelno == logging.DEBUG and "not OSV-queryable" in r.message]
+    assert debug_msgs, "Expected a DEBUG skip message for docker ecosystem"


### PR DESCRIPTION
## Summary
- Adds `_NON_OSV_ECOSYSTEMS` frozenset in `scanners/__init__.py` for 11 known non-OSV-queryable ecosystems (docker, container, ollama, smithery, mcp-registry, azure-runtime, nebius-*, sast, unknown)
- Known non-OSV ecosystems → DEBUG log (handled by OCI/model/cloud pipelines — not an error)
- Truly unknown ecosystems → WARNING with actionable message
- Eliminates the spurious `WARNING agent_bom.scanners: Skipping package docker/mcp/playwright` noise on every scan

## Test plan
- [ ] `test_non_osv_ecosystems_not_empty` — coverage of all 7 expected ecosystems
- [ ] `test_docker_ecosystem_skipped_at_debug_not_warning` — asserts WARNING absent, DEBUG present
- [ ] All 22 scanner ecosystem tests pass