### PR TITLE
feat: native Helm chart security scanner (Chart.yaml + values.yaml)

### DIFF
--- a/src/agent_bom/iac/__init__.py
+++ b/src/agent_bom/iac/__init__.py
@@ -1,4 +1,4 @@
-"""IaC misconfiguration scanning — Dockerfile, Kubernetes, Terraform, CloudFormation.
+"""IaC misconfiguration scanning — Dockerfile, Kubernetes, Terraform, CloudFormation, Helm.
 
 Coordinator module that discovers and scans IaC files across all supported
 formats.  Each scanner is regex/YAML-based with zero external dependencies.
@@ -16,13 +16,21 @@ Usage::
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from agent_bom.iac.cloudformation import _is_cloudformation, scan_cloudformation
 from agent_bom.iac.dockerfile import scan_dockerfile
+from agent_bom.iac.helm import scan_chart_yaml, scan_values_yaml
 from agent_bom.iac.kubernetes import scan_k8s_manifest
 from agent_bom.iac.models import IaCFinding
 from agent_bom.iac.terraform_security import scan_terraform_security
+
+__all__ = [
+    "scan_iac_directory",
+    "scan_chart_yaml",
+    "scan_values_yaml",
+]
 
 # Dockerfile filename patterns
 _DOCKERFILE_NAMES = frozenset(
@@ -38,6 +46,22 @@ _DOCKERFILE_NAMES = frozenset(
 
 # K8s manifest filename suffixes + directory hints
 _K8S_DIRS = frozenset({"k8s", "kubernetes", "deploy", "manifests", "helm"})
+
+# Helm Chart.yaml names (case-insensitive)
+_CHART_YAML_NAMES = frozenset({"Chart.yaml", "chart.yaml"})
+
+# values.yaml / values-*.yaml pattern
+_VALUES_YAML_RE = re.compile(r"^values(?:-[a-zA-Z0-9_-]+)?\.ya?ml$")
+
+
+def _is_chart_yaml(path: Path) -> bool:
+    """Check if a file is a Helm Chart.yaml."""
+    return path.name in _CHART_YAML_NAMES
+
+
+def _is_values_yaml(path: Path) -> bool:
+    """Check if a file is a Helm values file (values.yaml or values-*.yaml)."""
+    return bool(_VALUES_YAML_RE.match(path.name))
 
 
 def _is_dockerfile(path: Path) -> bool:
@@ -100,7 +124,11 @@ def scan_iac_directory(root: str | Path) -> list[IaCFinding]:
         if "node_modules" in path.parts or "__pycache__" in path.parts:
             continue
 
-        if _is_dockerfile(path):
+        if _is_chart_yaml(path):
+            findings.extend(scan_chart_yaml(path))
+        elif _is_values_yaml(path):
+            findings.extend(scan_values_yaml(path))
+        elif _is_dockerfile(path):
             findings.extend(scan_dockerfile(path))
         elif path.suffix == ".tf":
             findings.extend(scan_terraform_security(path))

--- a/src/agent_bom/iac/helm.py
+++ b/src/agent_bom/iac/helm.py
@@ -1,0 +1,323 @@
+"""Helm chart misconfiguration scanner.
+
+Scans ``Chart.yaml`` and ``values.yaml`` for common security misconfigurations
+using ``yaml.safe_load``.  No external tools required.
+
+Rules
+-----
+HELM-001  Chart.yaml uses apiVersion: v1 (deprecated Helm 2 format)
+HELM-002  Chart.yaml missing appVersion field
+HELM-003  values.yaml has hardcoded secret values (password/token/secret/key/credential/auth)
+HELM-004  values.yaml has image tag set to "latest" (unpinned mutable tag)
+HELM-005  values.yaml has service.type: NodePort (exposes on all node IPs/ports)
+HELM-006  values.yaml has networkPolicy.enabled: false (disables network isolation)
+HELM-007  values.yaml has rbac.create: false or serviceAccount.create: false
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from agent_bom.iac.models import IaCFinding
+
+# Secret-like field name patterns for values.yaml
+_SECRET_FIELD_RE = re.compile(
+    r"(?:password|token|secret|key|credential|auth)",
+    re.IGNORECASE,
+)
+
+# Placeholder values that should NOT be flagged
+_PLACEHOLDER_VALUES = frozenset(
+    {
+        "",
+        "changeme",
+        "CHANGEME",
+        "replace",
+        "placeholder",
+        "TODO",
+    }
+)
+
+_PLACEHOLDER_PREFIX_RE = re.compile(r"^your[-_]", re.IGNORECASE)
+
+
+def _find_line(content: str, key: str, value: Any, start_line: int = 1) -> int:
+    """Best-effort line number search for a key-value pair in YAML text."""
+    if isinstance(value, bool):
+        val_str = "true" if value else "false"
+    else:
+        val_str = str(value)
+    pattern = rf"{re.escape(key)}\s*:\s*{re.escape(val_str)}"
+    for i, line in enumerate(content.splitlines(), 1):
+        if re.search(pattern, line):
+            return i
+    return start_line
+
+
+def _find_key_line(content: str, key: str, start_line: int = 1) -> int:
+    """Best-effort line number search for a key in YAML text."""
+    for i, line in enumerate(content.splitlines(), 1):
+        if re.search(rf"\b{re.escape(key)}\s*:", line):
+            return i
+    return start_line
+
+
+def _is_placeholder(value: str) -> bool:
+    """Return True if the value is a known non-secret placeholder."""
+    if value in _PLACEHOLDER_VALUES:
+        return True
+    if _PLACEHOLDER_PREFIX_RE.match(value):
+        return True
+    return False
+
+
+def _walk_secret_fields(obj: Any, content: str, file_path: str, findings: list[IaCFinding]) -> None:
+    """Recursively walk a parsed YAML object and flag secret-like fields with real values."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str) and _SECRET_FIELD_RE.search(k):
+                if isinstance(v, str) and v and not _is_placeholder(v):
+                    findings.append(
+                        IaCFinding(
+                            rule_id="HELM-003",
+                            severity="critical",
+                            title=f"Hardcoded secret in values.yaml: '{k}'",
+                            message=(
+                                f"Field '{k}' in values.yaml contains a hardcoded secret value. "
+                                "Use environment variable substitution, a Secrets Store CSI driver, "
+                                "or reference a Kubernetes Secret instead of hardcoding credentials."
+                            ),
+                            file_path=file_path,
+                            line_number=_find_key_line(content, k),
+                            category="helm",
+                            compliance=["CIS-K8s-5.4.1", "NIST-IA-5"],
+                        )
+                    )
+            # Recurse into nested structures regardless
+            if isinstance(v, (dict, list)):
+                _walk_secret_fields(v, content, file_path, findings)
+    elif isinstance(obj, list):
+        for item in obj:
+            if isinstance(item, (dict, list)):
+                _walk_secret_fields(item, content, file_path, findings)
+
+
+def scan_chart_yaml(file_path: str | Path) -> list[IaCFinding]:
+    """Scan a Helm ``Chart.yaml`` file for misconfigurations.
+
+    Parameters
+    ----------
+    file_path:
+        Path to a ``Chart.yaml`` file.
+
+    Returns
+    -------
+    list[IaCFinding]
+        Detected misconfigurations.
+    """
+    path = Path(file_path)
+    if not path.is_file():
+        return []
+
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    rel_path = str(path)
+    findings: list[IaCFinding] = []
+
+    try:
+        doc = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return []
+
+    if not isinstance(doc, dict):
+        return []
+
+    # HELM-001: deprecated apiVersion: v1
+    api_version = doc.get("apiVersion")
+    if api_version == "v1":
+        findings.append(
+            IaCFinding(
+                rule_id="HELM-001",
+                severity="high",
+                title="Deprecated Helm 2 apiVersion in Chart.yaml",
+                message=(
+                    "Chart.yaml uses 'apiVersion: v1' which is the deprecated Helm 2 format. "
+                    "Upgrade to 'apiVersion: v2' to use Helm 3 features and avoid compatibility issues."
+                ),
+                file_path=rel_path,
+                line_number=_find_line(content, "apiVersion", "v1"),
+                category="helm",
+                compliance=["CIS-K8s-5.1.1", "NIST-CM-6"],
+            )
+        )
+
+    # HELM-002: missing appVersion
+    if "appVersion" not in doc:
+        findings.append(
+            IaCFinding(
+                rule_id="HELM-002",
+                severity="low",
+                title="Missing appVersion in Chart.yaml",
+                message=(
+                    "Chart.yaml does not define 'appVersion'. "
+                    "Set appVersion to track the upstream application version being deployed, "
+                    "improving release auditing and traceability."
+                ),
+                file_path=rel_path,
+                line_number=1,
+                category="helm",
+                compliance=["NIST-CM-8"],
+            )
+        )
+
+    return findings
+
+
+def scan_values_yaml(file_path: str | Path) -> list[IaCFinding]:
+    """Scan a Helm ``values.yaml`` (or ``values-*.yaml``) file for misconfigurations.
+
+    Parameters
+    ----------
+    file_path:
+        Path to a Helm values file.
+
+    Returns
+    -------
+    list[IaCFinding]
+        Detected misconfigurations.
+    """
+    path = Path(file_path)
+    if not path.is_file():
+        return []
+
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    rel_path = str(path)
+    findings: list[IaCFinding] = []
+
+    try:
+        doc = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return []
+
+    if not isinstance(doc, dict):
+        return []
+
+    # HELM-003: hardcoded secrets (recursive walk)
+    _walk_secret_fields(doc, content, rel_path, findings)
+
+    # HELM-004: image tag set to "latest"
+    image_section = doc.get("image")
+    if isinstance(image_section, dict):
+        tag = image_section.get("tag")
+        if tag == "latest":
+            findings.append(
+                IaCFinding(
+                    rule_id="HELM-004",
+                    severity="medium",
+                    title="Image tag set to 'latest' in values.yaml",
+                    message=(
+                        "values.yaml sets image.tag to 'latest'. The latest tag is mutable and can "
+                        "cause unexpected version changes on re-deploy. Pin to a specific immutable digest or version tag."
+                    ),
+                    file_path=rel_path,
+                    line_number=_find_line(content, "tag", "latest"),
+                    category="helm",
+                    compliance=["CIS-K8s-5.5.1", "NIST-CM-6"],
+                )
+            )
+
+    # HELM-005: service.type: NodePort
+    service_section = doc.get("service")
+    if isinstance(service_section, dict):
+        svc_type = service_section.get("type")
+        if svc_type == "NodePort":
+            findings.append(
+                IaCFinding(
+                    rule_id="HELM-005",
+                    severity="medium",
+                    title="service.type set to NodePort",
+                    message=(
+                        "values.yaml sets service.type to 'NodePort'. NodePort exposes the service "
+                        "on all node IPs on a static port, increasing the attack surface. "
+                        "Use ClusterIP with an Ingress controller or LoadBalancer instead."
+                    ),
+                    file_path=rel_path,
+                    line_number=_find_line(content, "type", "NodePort"),
+                    category="helm",
+                    compliance=["CIS-K8s-5.3.1", "NIST-SC-7"],
+                )
+            )
+
+    # HELM-006: networkPolicy.enabled: false
+    network_policy = doc.get("networkPolicy")
+    if isinstance(network_policy, dict):
+        if network_policy.get("enabled") is False:
+            findings.append(
+                IaCFinding(
+                    rule_id="HELM-006",
+                    severity="medium",
+                    title="networkPolicy.enabled set to false",
+                    message=(
+                        "values.yaml explicitly disables NetworkPolicy (networkPolicy.enabled: false). "
+                        "Enable NetworkPolicy to enforce network isolation and restrict pod-to-pod traffic."
+                    ),
+                    file_path=rel_path,
+                    line_number=_find_line(content, "enabled", False),
+                    category="helm",
+                    compliance=["CIS-K8s-5.3.2", "NIST-SC-7"],
+                )
+            )
+
+    # HELM-007: rbac.create: false or serviceAccount.create: false
+    rbac_section = doc.get("rbac")
+    if isinstance(rbac_section, dict):
+        if rbac_section.get("create") is False:
+            findings.append(
+                IaCFinding(
+                    rule_id="HELM-007",
+                    severity="medium",
+                    title="rbac.create set to false",
+                    message=(
+                        "values.yaml sets rbac.create to false. Disabling RBAC resource creation "
+                        "may leave the workload relying on overly permissive pre-existing roles. "
+                        "Enable RBAC to enforce least-privilege access control."
+                    ),
+                    file_path=rel_path,
+                    line_number=_find_line(content, "create", False),
+                    category="helm",
+                    compliance=["CIS-K8s-5.1.5", "NIST-AC-6"],
+                )
+            )
+
+    service_account = doc.get("serviceAccount")
+    if isinstance(service_account, dict):
+        if service_account.get("create") is False:
+            findings.append(
+                IaCFinding(
+                    rule_id="HELM-007",
+                    severity="medium",
+                    title="serviceAccount.create set to false",
+                    message=(
+                        "values.yaml sets serviceAccount.create to false. Disabling service account "
+                        "creation may reuse the default service account, which is often over-privileged. "
+                        "Create a dedicated service account with only the required permissions."
+                    ),
+                    file_path=rel_path,
+                    line_number=_find_line(content, "create", False),
+                    category="helm",
+                    compliance=["CIS-K8s-5.1.6", "NIST-AC-6"],
+                )
+            )
+
+    return findings

--- a/tests/test_iac_helm.py
+++ b/tests/test_iac_helm.py
@@ -1,0 +1,474 @@
+"""Tests for the Helm chart IaC security scanner (iac/helm.py)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from agent_bom.iac import scan_iac_directory
+from agent_bom.iac.helm import scan_chart_yaml, scan_values_yaml
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    """Write content to a file inside tmp_path and return the path."""
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+def _rule_ids(findings) -> list[str]:
+    return [f.rule_id for f in findings]
+
+
+# ---------------------------------------------------------------------------
+# scan_chart_yaml — HELM-001 (deprecated apiVersion)
+# ---------------------------------------------------------------------------
+
+
+class TestChartYamlApiVersion:
+    def test_v1_api_version_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "Chart.yaml",
+            """\
+            apiVersion: v1
+            name: my-chart
+            version: 1.0.0
+            appVersion: "1.2.3"
+        """,
+        )
+        findings = scan_chart_yaml(p)
+        assert "HELM-001" in _rule_ids(findings)
+
+    def test_v2_api_version_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "Chart.yaml",
+            """\
+            apiVersion: v2
+            name: my-chart
+            version: 1.0.0
+            appVersion: "1.2.3"
+        """,
+        )
+        findings = scan_chart_yaml(p)
+        assert "HELM-001" not in _rule_ids(findings)
+
+    def test_helm001_finding_has_correct_fields(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "Chart.yaml",
+            """\
+            apiVersion: v1
+            name: my-chart
+            version: 1.0.0
+            appVersion: "1.2.3"
+        """,
+        )
+        findings = scan_chart_yaml(p)
+        helm001 = [f for f in findings if f.rule_id == "HELM-001"][0]
+        assert helm001.severity == "high"
+        assert helm001.category == "helm"
+        assert helm001.line_number >= 1
+
+
+# ---------------------------------------------------------------------------
+# scan_chart_yaml — HELM-002 (missing appVersion)
+# ---------------------------------------------------------------------------
+
+
+class TestChartYamlAppVersion:
+    def test_missing_app_version_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "Chart.yaml",
+            """\
+            apiVersion: v2
+            name: my-chart
+            version: 1.0.0
+        """,
+        )
+        findings = scan_chart_yaml(p)
+        assert "HELM-002" in _rule_ids(findings)
+
+    def test_present_app_version_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "Chart.yaml",
+            """\
+            apiVersion: v2
+            name: my-chart
+            version: 1.0.0
+            appVersion: "2.3.4"
+        """,
+        )
+        findings = scan_chart_yaml(p)
+        assert "HELM-002" not in _rule_ids(findings)
+
+    def test_helm002_finding_has_correct_fields(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "Chart.yaml",
+            """\
+            apiVersion: v2
+            name: my-chart
+            version: 1.0.0
+        """,
+        )
+        findings = scan_chart_yaml(p)
+        helm002 = [f for f in findings if f.rule_id == "HELM-002"][0]
+        assert helm002.severity == "low"
+        assert helm002.category == "helm"
+
+
+# ---------------------------------------------------------------------------
+# scan_chart_yaml — non-YAML / unreadable input
+# ---------------------------------------------------------------------------
+
+
+class TestChartYamlEdgeCases:
+    def test_non_yaml_returns_empty(self, tmp_path):
+        p = _write(tmp_path, "Chart.yaml", "this: is: not: valid: yaml: :: :")
+        findings = scan_chart_yaml(p)
+        # Non-YAML must not raise; empty list or findings without crash
+        assert isinstance(findings, list)
+
+    def test_nonexistent_file_returns_empty(self, tmp_path):
+        findings = scan_chart_yaml(tmp_path / "does_not_exist.yaml")
+        assert findings == []
+
+    def test_clean_chart_produces_no_findings(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "Chart.yaml",
+            """\
+            apiVersion: v2
+            name: my-chart
+            version: 1.0.0
+            appVersion: "3.0.0"
+        """,
+        )
+        findings = scan_chart_yaml(p)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# scan_values_yaml — HELM-003 (hardcoded secrets)
+# ---------------------------------------------------------------------------
+
+
+class TestValuesYamlSecrets:
+    def test_hardcoded_password_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            db:
+              password: super-secret-value
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-003" in _rule_ids(findings)
+
+    def test_empty_password_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            db:
+              password: ""
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-003" not in _rule_ids(findings)
+
+    def test_changeme_placeholder_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            db:
+              password: changeme
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-003" not in _rule_ids(findings)
+
+    def test_your_prefix_placeholder_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            api:
+              token: your-api-token-here
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-003" not in _rule_ids(findings)
+
+    def test_hardcoded_token_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            api:
+              token: ghp_realtoken1234567890
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-003" in _rule_ids(findings)
+
+    def test_helm003_finding_has_critical_severity(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            db:
+              password: actually-a-real-password
+        """,
+        )
+        findings = scan_values_yaml(p)
+        helm003 = [f for f in findings if f.rule_id == "HELM-003"][0]
+        assert helm003.severity == "critical"
+        assert helm003.category == "helm"
+
+
+# ---------------------------------------------------------------------------
+# scan_values_yaml — HELM-004 (latest image tag)
+# ---------------------------------------------------------------------------
+
+
+class TestValuesYamlImageTag:
+    def test_latest_tag_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            image:
+              repository: nginx
+              tag: latest
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-004" in _rule_ids(findings)
+
+    def test_pinned_tag_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            image:
+              repository: nginx
+              tag: "1.25.3"
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-004" not in _rule_ids(findings)
+
+    def test_helm004_finding_has_medium_severity(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            image:
+              repository: nginx
+              tag: latest
+        """,
+        )
+        findings = scan_values_yaml(p)
+        helm004 = [f for f in findings if f.rule_id == "HELM-004"][0]
+        assert helm004.severity == "medium"
+
+
+# ---------------------------------------------------------------------------
+# scan_values_yaml — HELM-005 (NodePort)
+# ---------------------------------------------------------------------------
+
+
+class TestValuesYamlServiceType:
+    def test_nodeport_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            service:
+              type: NodePort
+              port: 80
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-005" in _rule_ids(findings)
+
+    def test_clusterip_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            service:
+              type: ClusterIP
+              port: 80
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-005" not in _rule_ids(findings)
+
+
+# ---------------------------------------------------------------------------
+# scan_values_yaml — HELM-006 (networkPolicy.enabled: false)
+# ---------------------------------------------------------------------------
+
+
+class TestValuesYamlNetworkPolicy:
+    def test_network_policy_disabled_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            networkPolicy:
+              enabled: false
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-006" in _rule_ids(findings)
+
+    def test_network_policy_enabled_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            networkPolicy:
+              enabled: true
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-006" not in _rule_ids(findings)
+
+
+# ---------------------------------------------------------------------------
+# scan_values_yaml — HELM-007 (rbac.create / serviceAccount.create false)
+# ---------------------------------------------------------------------------
+
+
+class TestValuesYamlRbac:
+    def test_rbac_create_false_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            rbac:
+              create: false
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-007" in _rule_ids(findings)
+
+    def test_rbac_create_true_ok(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            rbac:
+              create: true
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-007" not in _rule_ids(findings)
+
+    def test_service_account_create_false_flagged(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "values.yaml",
+            """\
+            serviceAccount:
+              create: false
+        """,
+        )
+        findings = scan_values_yaml(p)
+        assert "HELM-007" in _rule_ids(findings)
+
+
+# ---------------------------------------------------------------------------
+# scan_iac_directory — end-to-end integration
+# ---------------------------------------------------------------------------
+
+
+class TestScanIacDirectoryHelm:
+    def _make_helm_chart(self, tmp_path: Path) -> Path:
+        """Create a minimal Helm chart directory with intentional misconfigurations."""
+        chart_dir = tmp_path / "mychart"
+        chart_dir.mkdir()
+        templates_dir = chart_dir / "templates"
+        templates_dir.mkdir()
+
+        # Chart.yaml: v1 apiVersion (HELM-001) + no appVersion (HELM-002)
+        (chart_dir / "Chart.yaml").write_text(
+            textwrap.dedent("""\
+            apiVersion: v1
+            name: mychart
+            version: 0.1.0
+        """)
+        )
+
+        # values.yaml: hardcoded password (HELM-003) + latest tag (HELM-004)
+        (chart_dir / "values.yaml").write_text(
+            textwrap.dedent("""\
+            image:
+              repository: myapp
+              tag: latest
+            db:
+              password: realpassword123
+            service:
+              type: ClusterIP
+              port: 80
+        """)
+        )
+
+        # A template file (not scanned by Helm scanner, but present in dir)
+        (templates_dir / "deployment.yaml").write_text(
+            textwrap.dedent("""\
+            apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: mychart
+            spec:
+              replicas: 1
+              template:
+                spec:
+                  containers:
+                  - name: app
+                    image: myapp:latest
+        """)
+        )
+
+        return chart_dir
+
+    def test_helm_findings_present_in_directory_scan(self, tmp_path):
+        chart_dir = self._make_helm_chart(tmp_path)
+        findings = scan_iac_directory(chart_dir)
+        rule_ids = _rule_ids(findings)
+        assert "HELM-001" in rule_ids, f"Expected HELM-001 in {rule_ids}"
+        assert "HELM-002" in rule_ids, f"Expected HELM-002 in {rule_ids}"
+        assert "HELM-003" in rule_ids, f"Expected HELM-003 in {rule_ids}"
+        assert "HELM-004" in rule_ids, f"Expected HELM-004 in {rule_ids}"
+
+    def test_values_env_file_also_scanned(self, tmp_path):
+        """values-prod.yaml should also be picked up by the scanner."""
+        chart_dir = tmp_path / "chart"
+        chart_dir.mkdir()
+        (chart_dir / "Chart.yaml").write_text("apiVersion: v2\nname: x\nversion: 1.0.0\nappVersion: '1.0'\n")
+        (chart_dir / "values-prod.yaml").write_text(
+            textwrap.dedent("""\
+            image:
+              tag: latest
+        """)
+        )
+        findings = scan_iac_directory(chart_dir)
+        assert "HELM-004" in _rule_ids(findings)
+
+    def test_directory_scan_returns_list(self, tmp_path):
+        findings = scan_iac_directory(tmp_path)
+        assert isinstance(findings, list)


### PR DESCRIPTION
## Summary
- Add `iac/helm.py`: native Helm chart scanner (7 rules, zero external deps)
- Scans `Chart.yaml` (deprecated apiVersion, missing appVersion) and `values.yaml` (hardcoded secrets, latest image tag, NodePort exposure, disabled network policies/RBAC)
- Wire into `scan_iac_directory()` coordinator — `Chart.yaml` and `values.yaml` now auto-discovered
- 28 tests covering all rules and the directory scanner integration

## Test plan
- [ ] All new tests pass: `pytest tests/test_iac_helm.py -v`
- [ ] Imports clean: `python -c "from agent_bom.iac.helm import scan_chart_yaml, scan_values_yaml"`
- [ ] `scan_iac_directory` on a real Helm chart dir returns HELM findings