### PR TITLE
fix: patch OS CVEs in Docker images + add supply chain attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write       # required for SLSA provenance attestation
+      attestations: write   # required for SBOM + provenance attestations
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Extract version from tag
         id: meta
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -91,6 +96,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: VERSION=${{ steps.meta.outputs.version }}
+          provenance: true   # SLSA provenance attestation — enables Docker Scout policy evaluation
+          sbom: true         # SBOM attestation — enables Docker Scout supply chain policies
           tags: |
             agentbom/agent-bom:${{ steps.meta.outputs.version }}
             agentbom/agent-bom:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
+# Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom
 

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -24,6 +24,9 @@ LABEL io.modelcontextprotocol.server.name="io.github.msaad00/agent-bom"
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
+# Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom
 USER abom

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -35,6 +35,9 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
+# Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom
 

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -38,6 +38,9 @@ LABEL io.modelcontextprotocol.server.transport="streamable-http"
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
+# Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom
 USER abom


### PR DESCRIPTION
## Summary

- Add \`apt-get upgrade\` to all runtime Dockerfile stages — fixes CVE-2026-0861 (8.4H), CVE-2025-15281 (7.5H), CVE-2026-0915 (7.5H), CVE-2025-8869 (5.9M) in python:3.12-slim base layer
- Add \`provenance: true\` + \`sbom: true\` to \`docker/build-push-action\` in release.yml — enables Docker Scout policy evaluation for both amd64 and arm64 (amd64 was showing "No data" on all 7 policies)
- Add \`id-token: write\` + \`attestations: write\` permissions to docker-publish job
- Add missing \`setup-qemu\` step to docker-publish job for correct multi-arch builds

## Test plan
- [ ] CI passes
- [ ] After merge + next release, Docker Scout shows 0 fixable high/critical CVEs
- [ ] Docker Scout policy shows real data for both amd64 + arm64