### PR TITLE
fix: mask Docker Hub token + pin Alpine digest + Glama healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: python:3.12-alpine  # Scorecard: pinning by digest breaks CI cache; version tag is acceptable
+      image: python:3.12-alpine@sha256:7747d47f92cfca63a6e2b50275e23dba8407c30d8ae929a88ddd49a5d3f2d331
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,10 +113,15 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login" \
+          TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
             -H "Content-Type: application/json" \
             -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
             | jq -r '.token')
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "::error::Docker Hub login failed"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
           DESCRIPTION=$(cat DOCKER_HUB_README.md | jq -Rs .)
           curl -s -o /dev/null -w "%{http_code}" -X PATCH \
             "https://hub.docker.com/v2/repositories/agentbom/agent-bom/" \

--- a/integrations/glama/Dockerfile
+++ b/integrations/glama/Dockerfile
@@ -33,4 +33,7 @@ USER abom
 # Verify entry point is on PATH
 RUN agent-bom --version
 
+HEALTHCHECK --interval=60s --timeout=10s --start-period=10s --retries=3 \
+    CMD agent-bom --version || exit 1
+
 ENTRYPOINT ["agent-bom", "mcp-server"]


### PR DESCRIPTION
## Summary
- **release.yml**: Mask Docker Hub API token with `::add-mask::` to prevent log leakage (resolves critical credential exposure gap), add `-f` flag to fail on HTTP errors, validate token before use
- **ci.yml**: Pin `python:3.12-alpine` container image by SHA256 digest — resolves Scorecard Pinned-Dependencies finding
- **integrations/glama/Dockerfile**: Add `HEALTHCHECK` — was the only production Dockerfile missing one

## Context
Post-v0.71.2 security audit found the Docker Hub login token in `release.yml` was not masked, meaning it could appear in workflow logs if any subsequent step failed. The Alpine CI image was also the last unpinned container image. All 8 Dockerfiles now have: digest-pinned base images, OS patching, non-root user, and healthchecks.

## Test plan
- [ ] CI passes (lint, tests, security scan)
- [ ] Verify release workflow still syncs Docker Hub README on next tag
- [ ] Verify Alpine test job still runs correctly with digest-pinned image