### PR TITLE
fix: self-scan gate blocks all publish jobs in release pipeline (#943)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
   pypi-publish:
     name: Publish to PyPI
-    needs: build
+    needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -63,7 +63,7 @@ jobs:
 
   docker-publish:
     name: Publish to Docker Hub
-    needs: build
+    needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -158,7 +158,7 @@ jobs:
           uv run agent-bom scan --self-scan \
             --format sarif \
             -o sarif/release-self-dep.sarif \
-            --fail-on-severity critical \
+            --fail-on-severity high \
             --quiet
 
       - name: Upload release self-scan SARIF
@@ -170,7 +170,7 @@ jobs:
 
   sbom:
     name: Generate CycloneDX SBOM
-    needs: build
+    needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -195,7 +195,7 @@ jobs:
 
   sign:
     name: Sign distribution with Sigstore
-    needs: build
+    needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -224,7 +224,7 @@ jobs:
 
   provenance:
     name: Generate SLSA provenance
-    needs: build
+    needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- All publish jobs (PyPI, Docker Hub, SBOM, Sigstore, SLSA) now depend on `self-scan-gate` passing
- Bump self-scan from `--fail-on-severity critical` to `--fail-on-severity high`
- If self-scan finds HIGH+ CVE in own deps, entire release is blocked

## Before
```
build → [self-scan-gate | pypi | docker | sign | ...] (parallel)
```

## After  
```
build → self-scan-gate → [pypi | docker | sign | ...] (only if gate passes)
```

Closes #943

## Test plan
- [ ] CI passes (yaml validation, no syntax errors)
- [ ] Next release tag triggers correct job ordering