### PR TITLE
fix: harden fleet min_trust filter for Python 3.14 compat

### DIFF
--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -42,7 +42,8 @@ async def list_fleet(
     if environment:
         agents = [a for a in agents if a.environment == environment]
     if min_trust is not None:
-        agents = [a for a in agents if a.trust_score >= min_trust]
+        _threshold = float(min_trust)
+        agents = [a for a in agents if (a.trust_score or 0.0) >= _threshold]
     total = len(agents)
     page = agents[offset : offset + limit]
     return {

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -96,10 +96,12 @@ def test_list_filter_state():
 
 def test_list_filter_min_trust():
     client, store = _fresh_client()
-    store.put(_make(agent_id="a-1", trust_score=30.0))
-    store.put(_make(agent_id="a-2", trust_score=80.0))
+    store.put(_make(agent_id="a-1", trust_score=10.0))
+    store.put(_make(agent_id="a-2", trust_score=90.0))
     resp = client.get("/v1/fleet?min_trust=50")
-    assert resp.json()["count"] == 1
+    data = resp.json()
+    assert data["count"] == 1, f"Expected 1 agent with trust >= 50, got {data['count']}: {[a.get('trust_score') for a in data['agents']]}"
+    assert data["agents"][0]["agent_id"] == "a-2"
 
 
 # ── Get ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Explicit `float()` coercion on `min_trust` query param in fleet list endpoint
- Defensive `(trust_score or 0.0)` for None edge case on Pydantic model
- Wider score gap in test (10/90 vs 30/80) + explicit `agent_id` assertion

Fixes CI failure on Python 3.14: `test_api_fleet.py::test_list_filter_min_trust`

## Test plan

- [x] `tests/test_api_fleet.py` — 15/15 pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)