### PR TITLE
fix: suppress CVE-2026-33231 (nltk wordnet_app — not reachable)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -20,6 +20,10 @@ reason = "nltk 3.9.3 — XSS in WordNet Browser. No fix available upstream. Re-e
 id = "GHSA-rf74-v2fm-23pw"
 reason = "nltk 3.9.3 — unbounded recursion in JSONTaggedDecoder. No fix available upstream. Re-evaluate when nltk ships a new release."
 
+[[IgnoredVulns]]
+id = "CVE-2026-33231"
+reason = "nltk 3.9.3 — unauthenticated remote shutdown in wordnet_app. No fix upstream. NOT REACHABLE: agent-bom never imports nltk.app.wordnet_app."
+
 # ── Werkzeug — FIXED in 3.1.6 (our locked version) ──────────────────────────
 
 [[IgnoredVulns]]


### PR DESCRIPTION
## Summary

- Add CVE-2026-33231 to `osv-scanner.toml` suppression list
- nltk 3.9.3 is latest — no upstream fix available
- agent-bom **never imports** `nltk.app.wordnet_app` — code path not reachable
- VEX justification: `VULNERABLE_CODE_NOT_IN_EXECUTE_PATH`
- Dependabot alert #21 and code scanning alert #1267 dismissed

## Test plan

- [x] osv-scanner.toml validates (check-toml passes)
- [x] No code changes — suppression only

🤖 Generated with [Claude Code](https://claude.com/claude-code)