### PR TITLE
fix: MCP Registry description length (422 validation)

### DIFF
--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "AI infrastructure and supply chain security — 30 MCP clients, AST source analysis, AI BOM (CycloneDX ML), blast radius mapping, 112-pattern runtime proxy, Shield SDK, secret scanning, 14-framework compliance",
+  "description": "Security scanner for AI infrastructure — blast radius mapping, AI BOM, runtime proxy, compliance",
   "title": "agent-bom",
   "version": "0.74.0",
   "repository": {


### PR DESCRIPTION
MCP Registry added 100-char limit on description. Shortened from 215 to 96 chars. Validated: `{"valid": true}`