### PR TITLE
fix: audit P0/P1 — offline strict, AST FPs, doctor command, vitest

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -128,49 +128,70 @@ class ASTAnalysisResult:
 
 # ── Prompt extraction patterns ───────────────────────────────────────────────
 
-# Variable/parameter names that typically hold system prompts
-_PROMPT_VAR_NAMES = frozenset(
+# Field names that are NOT system prompts — excluded from prompt detection
+# to prevent false positives on common documentation/UI fields.
+_NON_PROMPT_KEYS = frozenset(
     {
-        "system_prompt",
-        "system_message",
-        "instructions",
-        "system_instructions",
-        "system_content",
-        "prefix",
-        "suffix",
-        "preamble",
-        "context",
-        "system",
-        "prompt_template",
-        "template",
-        "system_template",
-        "initial_message",
-        "persona",
-        "role_description",
         "description",
+        "help",
+        "help_text",
+        "__doc__",
+        "title",
+        "label",
+        "placeholder",
+        "tooltip",
+        "error_message",
+        "docstring",
     }
 )
 
+# Variable/parameter names that typically hold system prompts
+_PROMPT_VAR_NAMES = (
+    frozenset(
+        {
+            "system_prompt",
+            "system_message",
+            "instructions",
+            "system_instructions",
+            "system_content",
+            "prefix",
+            "suffix",
+            "preamble",
+            "context",
+            "system",
+            "prompt_template",
+            "template",
+            "system_template",
+            "initial_message",
+            "persona",
+            "role_description",
+        }
+    )
+    - _NON_PROMPT_KEYS
+)
+
 # Keyword argument names in agent/LLM constructors that hold prompts
-_PROMPT_KWARG_NAMES = frozenset(
-    {
-        "system_prompt",
-        "instructions",
-        "system_message",
-        "system",
-        "prefix",
-        "preamble",
-        "prompt",
-        "template",
-        "system_template",
-        "instruction",
-        "backstory",
-        "goal",
-        "role",
-        "description",
-        "system_instruction",
-        "safety_settings",
-    }
+_PROMPT_KWARG_NAMES = (
+    frozenset(
+        {
+            "system_prompt",
+            "instructions",
+            "system_message",
+            "system",
+            "prefix",
+            "preamble",
+            "prompt",
+            "template",
+            "system_template",
+            "instruction",
+            "backstory",
+            "goal",
+            "role",
+            "system_instruction",
+            "safety_settings",
+        }
+    )
+    - _NON_PROMPT_KEYS
 )
 
 # ── Guardrail patterns ───────────────────────────────────────────────────────

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -227,6 +227,13 @@ from agent_bom.cli.run import run_cmd  # noqa: E402
 main.add_command(run_cmd, "run")
 main.commands["run"].hidden = True  # Use `proxy` instead
 
+# ---------------------------------------------------------------------------
+# Doctor / preflight command
+# ---------------------------------------------------------------------------
+from agent_bom.cli._doctor import doctor_cmd  # noqa: E402
+
+main.add_command(doctor_cmd, "doctor")
+
 
 # ---------------------------------------------------------------------------
 # Upgrade command

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -1,0 +1,110 @@
+"""Preflight diagnostic command — checks environment readiness."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+import click
+from rich.console import Console
+
+
+@click.command("doctor")
+def doctor_cmd() -> None:
+    """Check environment readiness for scanning.
+
+    \b
+    Verifies:  Python, agent-bom version, local vuln DB, network,
+               Docker, kubectl, MCP configs, API keys.
+    """
+    console = Console()
+    console.print()
+
+    from agent_bom import __version__
+
+    checks: list[tuple[str, str, str]] = []  # (label, value, status)
+
+    # Python version
+    py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    py_ok = sys.version_info >= (3, 11)
+    checks.append(("Python", py_ver, "ok" if py_ok else "warn"))
+
+    # agent-bom version
+    checks.append(("agent-bom", __version__, "ok"))
+
+    # Local vulnerability DB
+    try:
+        from agent_bom.scan_cache import ScanCache
+
+        cache = ScanCache()
+        stats = cache.stats()
+        entries = stats.get("entries", 0)
+        checks.append(("Local DB", f"{entries} cached entries", "ok" if entries > 0 else "info"))
+    except Exception:
+        checks.append(("Local DB", "not available", "info"))
+
+    # Network — OSV API
+    try:
+        import urllib.request
+
+        urllib.request.urlopen("https://api.osv.dev/v1", timeout=5)  # nosec B310 — hardcoded HTTPS URL
+        checks.append(("Network", "api.osv.dev reachable", "ok"))
+    except Exception:
+        checks.append(("Network", "api.osv.dev unreachable", "warn"))
+
+    # Docker
+    docker_path = shutil.which("docker")
+    if docker_path:
+        checks.append(("Docker", "available", "ok"))
+    else:
+        checks.append(("Docker", "not found", "info"))
+
+    # kubectl
+    kubectl_path = shutil.which("kubectl")
+    if kubectl_path:
+        checks.append(("kubectl", "available", "ok"))
+    else:
+        checks.append(("kubectl", "not found", "info"))
+
+    # MCP configs
+    try:
+        from agent_bom.discovery import discover_global_configs
+
+        configs = discover_global_configs()
+        checks.append(("MCP configs", f"{len(configs)} found", "ok" if configs else "info"))
+    except Exception:
+        checks.append(("MCP configs", "discovery error", "warn"))
+
+    # API keys
+    api_keys = {
+        "NVD_API_KEY": "NVD enrichment",
+        "GITHUB_TOKEN": "GitHub advisories",
+        "SNOWFLAKE_ACCOUNT": "Snowflake governance",
+    }
+    for key, label in api_keys.items():
+        if os.environ.get(key):
+            checks.append((label, "configured", "ok"))
+        else:
+            checks.append((label, "not set", "info"))
+
+    # Print results
+    console.print("  [bold]agent-bom doctor[/bold]")
+    console.print()
+    for label, value, status in checks:
+        if status == "ok":
+            icon = "[green]✓[/green]"
+        elif status == "warn":
+            icon = "[yellow]⚠[/yellow]"
+        else:
+            icon = "[dim]○[/dim]"
+        console.print(f"  {icon}  {label + ':':<20s} {value}")
+
+    console.print()
+
+    warns = sum(1 for _, _, s in checks if s == "warn")
+    if warns == 0:
+        console.print("  [green]Ready to scan.[/green]")
+    else:
+        console.print(f"  [yellow]{warns} warning(s) — scanning may be limited.[/yellow]")
+    console.print()

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -35,12 +35,16 @@ def doctor_cmd() -> None:
 
     # Local vulnerability DB
     try:
-        from agent_bom.scan_cache import ScanCache
+        from pathlib import Path
 
-        cache = ScanCache()
-        stats = cache.stats()
-        entries = stats.get("entries", 0)
-        checks.append(("Local DB", f"{entries} cached entries", "ok" if entries > 0 else "info"))
+        from agent_bom.config import SCAN_CACHE_DIR
+
+        db_path = Path(SCAN_CACHE_DIR) / "scan_cache.db"
+        if db_path.exists():
+            size_kb = db_path.stat().st_size // 1024
+            checks.append(("Local DB", f"exists ({size_kb} KB)", "ok"))
+        else:
+            checks.append(("Local DB", "not yet created (run a scan first)", "info"))
     except Exception:
         checks.append(("Local DB", "not available", "info"))
 

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -37,9 +37,7 @@ def doctor_cmd() -> None:
     try:
         from pathlib import Path
 
-        from agent_bom.config import SCAN_CACHE_DIR
-
-        db_path = Path(SCAN_CACHE_DIR) / "scan_cache.db"
+        db_path = Path.home() / ".agent-bom" / "scan_cache.db"
         if db_path.exists():
             size_kb = db_path.stat().st_size // 1024
             checks.append(("Local DB", f"exists ({size_kb} KB)", "ok"))

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -1180,8 +1180,9 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
 
     # ── Registry fallback for still-unresolved versions ──────────────────
     # Only hit npm/PyPI registries for packages we couldn't resolve locally.
+    # In offline mode, skip all registry calls entirely.
     still_unresolved = [p for p in packages if p.version in ("latest", "unknown", "") and p.ecosystem.lower() in ("npm", "pypi", "conda")]
-    if still_unresolved:
+    if still_unresolved and not offline_mode:
         try:
             from agent_bom.resolver import resolve_all_versions
 
@@ -1195,6 +1196,8 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
         except Exception as exc:
             _logger.warning("Version resolution failed for %d package(s): %s", len(still_unresolved), exc)
             console.print(f"  [yellow]⚠[/yellow] Version resolution skipped: {exc}")
+    elif still_unresolved and offline_mode:
+        _logger.info("Offline mode: skipping registry version resolution for %d package(s)", len(still_unresolved))
 
     # ── Transitive dependency resolution (npm / PyPI / Go) ───────────────────
     if resolve_transitive and not offline_mode:
@@ -1255,6 +1258,12 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
     if offline_mode or (prefer_local_db and not osv_targets):
         if osv_targets and offline_mode:
             _logger.info("Offline mode: skipping OSV API for %d package(s) not in local DB", len(osv_targets))
+            skipped_count = len(osv_targets)
+            covered_count = len(scannable) - skipped_count
+            console.print(
+                f"  [dim]Offline mode: using local cache only. "
+                f"{covered_count} packages checked, {skipped_count} skipped (no cached data).[/dim]"
+            )
         results = {}
     elif prefer_local_db and osv_targets:
         # DB is fresh — only query OSV for packages genuinely missing from DB

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     setupFiles: ['./tests/setup.ts'],
     globals: true,
     css: false,
+    include: ['tests/**/*.{test,spec}.{ts,tsx}'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Addresses product quality findings from Codex deep audit.

### P0: Strict offline mode
Scanner skips OSV API and registry lookups entirely when `--offline` is set. No silent network fallback.

### P0: AST prompt detector false positives
`description`, `help`, `title`, `label`, `placeholder`, `tooltip`, `error_message`, `docstring` no longer classified as system prompts.

### P1: `agent-bom doctor` command
Preflight diagnostic: Python version, agent-bom version, local DB status, network connectivity, Docker/kubectl availability, MCP configs found, API keys configured.

### P1: Vitest config fix
Test include pattern now correctly matches `tests/**/*.{test,spec}.{ts,tsx}`.

## Still TODO (follow-up PR)
- Count alignment across README/docs/pyproject.toml
- Homepage dashboard rework (blast radius hero)
- Workstation posture summary mode

## Test plan
- [x] All pre-commit hooks green (ruff, mypy, bandit)
- [x] `npx next build` — 23 pages compile
- [ ] CI running