### PR TITLE
fix: audit v3 — no-scan network, offline messaging, skills sync

### DIFF
--- a/docs/STRATEGIC_AUDIT_2026_03.md
+++ b/docs/STRATEGIC_AUDIT_2026_03.md
@@ -78,7 +78,7 @@
 | **OpenSSF Scorecard** | Project health → risk boost | On-demand |
 | **MITRE ATT&CK** | CWE→CAPEC→ATT&CK via STIX | 30 days |
 
-### 2.3 MCP Server (23 Tools)
+### 2.3 MCP Server (33 Tools)
 
 | # | Tool | Purpose |
 |---|------|---------|
@@ -168,7 +168,7 @@ Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Cop
 
 ### 2.10 UI/Dashboard
 
-- **Next.js**: 15 pages including SupplyChainTreemap, BlastRadiusRadial, PipelineFlow, EpssVsCvssChart, VulnTrendChart, Insights page
+- **Next.js**: 20 pages including SupplyChainTreemap, BlastRadiusRadial, PipelineFlow, EpssVsCvssChart, VulnTrendChart, Insights page
 - **Streamlit**: Legacy dashboard, Snowflake Native App compatible
 - **Validators**: Runtime JSON validation for file imports (size limit, schema, pollution guard)
 
@@ -206,7 +206,7 @@ Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Cop
 1. **Full-spectrum AI infra scanning**: CVE + MCP tool security + skill trust + blast radius + compliance — in one tool
 2. **Blast radius analysis**: No competitor does dependency blast radius with compliance framework mapping
 3. **Runtime proxy with enforcement**: Not just scanning — real-time interception, rate limiting, credential leak blocking, rug pull detection
-4. **32 MCP tools**: Deepest MCP server integration — usable by any AI assistant
+4. **33 MCP tools**: Deepest MCP server integration — usable by any AI assistant
 5. **12 cloud provider coverage**: AWS/Azure/GCP + AI-specific (CoreWeave, Databricks, Snowflake, HuggingFace, W&B, MLflow, OpenAI, Ollama, Nebius)
 6. **14 compliance frameworks**: Every finding mapped to OWASP LLM/MCP/Agentic, ATLAS, NIST, EU AI Act, ISO 27001, SOC 2, CIS
 7. **Enrichment depth**: OSV + GHSA + NVD + EPSS + CISA KEV + NVIDIA + OpenSSF Scorecard + MITRE ATT&CK
@@ -231,7 +231,7 @@ Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Cop
 | Compliance mapping | ✅ (10) | ❌ | ❌ | ❌ | ❌ | ✅ (partial) |
 | Cloud scanning | ✅ (12) | ❌ | ❌ | ❌ | ❌ | ✅ (IaC) |
 | SBOM/VEX | ✅ | ❌ | ❌ | ❌ | ✅ (SBOM) | ✅ (SBOM) |
-| MCP server (AI tool) | ✅ (23) | ❌ | ❌ | ❌ | ❌ | ❌ |
+| MCP server (AI tool) | ✅ (33) | ❌ | ❌ | ❌ | ❌ | ❌ |
 | GPU/AI compute | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | SIEM integration | ✅ | Via Snyk | ❌ | ❌ | ❌ | ❌ |
 | Browser extensions | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   v1.0, MAESTRO layer tagging, and vector database security checks. Use when the
   user mentions vulnerability scanning, MCP server trust, compliance, SBOM
   generation, CIS benchmarks, blast radius, or AI supply chain risk.
-version: 0.75.0
+version: 0.75.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -24,7 +24,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []
@@ -398,6 +398,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.75.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.75.2`
 - **6,533+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.75.0
+version: 0.75.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.75.0
+version: 0.75.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.75.0
+version: 0.75.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.75.0
+version: 0.75.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.75.0
+version: 0.75.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.75.0
+version: 0.75.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.0
+    docker: ghcr.io/msaad00/agent-bom:0.75.2
   openclaw:
     requires:
       bins: []
@@ -103,7 +103,7 @@ db_status()
 agent-bom doctor
 
   Python        3.12.2   OK
-  agent-bom     0.75.0   OK
+  agent-bom     0.75.2   OK
   pip           24.0     OK
   semgrep       not found  (optional — SAST scanning unavailable)
   kubectl       not found  (optional — K8s context unavailable)

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -584,8 +584,8 @@ def scan(
         )
         return
 
-    # Pre-scan: local DB freshness check
-    if not no_scan:
+    # Pre-scan: local DB freshness check (skip in offline mode — uses scan cache instead)
+    if not no_scan and not offline:
         try:
             from agent_bom.db.schema import db_freshness_days
 
@@ -1059,10 +1059,10 @@ def scan(
             con.print(f"\n  Enforcement: {status} ({enforce_result.critical_count} critical, {enforce_result.high_count} high)")
             ctx.enforcement_data = _enforcement_data
 
-        # Step 3: Resolve unknown versions (skip in offline mode)
+        # Step 3: Resolve unknown versions (skip in offline mode AND --no-scan)
         all_packages = [p for a in agents for s in a.mcp_servers for p in s.packages]
         unresolved = [p for p in all_packages if p.version in ("latest", "unknown", "")]
-        if unresolved and not offline:
+        if unresolved and not offline and not no_scan:
             if not quiet:
                 con.print(f"\n[bold blue]Resolving {len(unresolved)} package version(s)...[/bold blue]\n")
             with con.status("[bold]Querying package registries...[/bold]", spinner="dots") if not quiet else _nullcontext():


### PR DESCRIPTION
## Codex Audit v3 Findings — All Fixed and Runtime-Verified

### Fix 1: `--no-scan` still made network calls
Version resolution at line 1065 was not gated by `no_scan`. Now it is.
**Verified:** `agents --no-scan --demo` produces zero network call output.

### Fix 2: Offline DB messaging inconsistent
`--offline` showed "No local vulnerability DB found" because the DB freshness check ran before offline mode was handled. Now the freshness check is skipped in offline mode.
**Verified:** `agents --demo --offline` shows no stale warning.

### Fix 3: Skills metadata stale (0.75.0)
All 8 OpenClaw skills bumped from 0.75.0 to 0.75.2.
**Verified:** `grep -rn "0.75.0" integrations/openclaw/` returns 0 matches.

### Fix 4: Strategic docs count drift
Fixed: 23→33 MCP tools, 15→20 dashboard pages.
**Verified:** `grep "33 Tools" docs/STRATEGIC_AUDIT_2026_03.md` matches.