### PR TITLE
fix: final audit polish — fix version filter + inventory isolation

### DIFF
--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -419,10 +419,34 @@ def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "")
                             if prerelease_candidate is None:
                                 prerelease_candidate = fixed
                         except Exception as exc:  # noqa: BLE001
-                            # Can't parse (e.g. non-PEP440 npm version) — return as-is
-                            _logger.debug("Version parse failed for %r (returning as-is): %s", fixed, exc)
-                            return fixed
+                            # Can't parse — check if it looks like a usable version
+                            # Skip git commit SHAs (40 hex chars) and other non-version strings
+                            _logger.debug("Version parse failed for %r: %s", fixed, exc)
+                            if _is_valid_fix_version(fixed):
+                                return fixed
+                            # Not a usable version — skip silently
     return prerelease_candidate
+
+
+def _is_valid_fix_version(version: str) -> bool:
+    """Check if a string looks like a usable package version (not a git SHA or random hash).
+
+    Returns False for:
+    - Git commit SHAs (40 hex chars)
+    - Short SHAs (7-12 hex chars with no dots/dashes)
+    - Empty strings
+    - Strings with no digits at all
+    """
+    if not version or not any(c.isdigit() for c in version):
+        return False
+    # Git SHA: 40 hex chars
+    stripped = version.lstrip("v")
+    if len(stripped) == 40 and all(c in "0123456789abcdef" for c in stripped):
+        return False
+    # Short SHA: 7-12 hex chars with no version separators
+    if 7 <= len(stripped) <= 12 and all(c in "0123456789abcdef" for c in stripped):
+        return False
+    return True
 
 
 async def _enrich_vuln_details(client: httpx.AsyncClient, vuln_ids: list[str]) -> dict[str, dict]:


### PR DESCRIPTION
## Fixes

1. **Fix version filter** — filter raw git SHAs and commit hashes from fix recommendations. Users see clean semver versions only.
2. **Inventory isolation** — `--inventory` no longer auto-detects CWD lockfiles/IaC (from PR #1053, already on main)

Once merged, tag v0.75.4 → release pipeline pushes updated DOCKER_HUB_README.md automatically.