### PR TITLE
fix: cross-package fix version bleed + 12 regression tests

### DIFF
--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -390,20 +390,38 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float], Opti
     return severity, cvss_score, severity_source
 
 
-def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "") -> Optional[str]:
+def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "", current_version: str = "") -> Optional[str]:
     """Extract fixed version from OSV affected data.
 
     Prefers stable releases over pre-release versions.  Uses PEP 503
     normalization when comparing PyPI package names so that mixed-separator
     forms (e.g. ``Requests_OAuthlib`` vs ``requests-oauthlib``) always match.
+
+    Guards against cross-package fix bleed: skips affected entries with no
+    package name and skips fix versions lower than ``current_version``.
     """
     norm_input = normalize_package_name(package_name, ecosystem)
     prerelease_candidate: Optional[str] = None
 
+    # Parse current version for downgrade detection
+    current_pv = None
+    if current_version and current_version not in ("unknown", "latest", ""):
+        try:
+            from packaging.version import Version
+
+            current_pv = Version(current_version)
+        except Exception:  # noqa: BLE001
+            pass
+
     for affected in vuln_data.get("affected", []):
         pkg = affected.get("package", {})
+        pkg_name = pkg.get("name", "")
+        # Skip entries with no package name — can't match, causes false fix bleed
+        if not pkg_name:
+            _logger.debug("Skipping affected entry with empty package name in %s", vuln_data.get("id", "?"))
+            continue
         osv_eco = pkg.get("ecosystem", ecosystem)
-        osv_norm = normalize_package_name(pkg.get("name", ""), osv_eco)
+        osv_norm = normalize_package_name(pkg_name, osv_eco)
         if osv_norm == norm_input:
             for rng in affected.get("ranges", []):
                 for event in rng.get("events", []):
@@ -413,6 +431,15 @@ def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "")
                             from packaging.version import Version
 
                             pv = Version(fixed)
+                            # Skip fix versions lower than current (belongs to sibling package)
+                            if current_pv is not None and pv < current_pv:
+                                _logger.debug(
+                                    "Skipping fix %s < current %s for %s",
+                                    fixed,
+                                    current_version,
+                                    package_name,
+                                )
+                                continue
                             if not pv.is_prerelease:
                                 return fixed
                             # Remember pre-release as fallback
@@ -870,7 +897,7 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
             seen_ids.add(alias)
 
         severity, cvss_score, sev_source = parse_osv_severity(vuln_data)
-        fixed = parse_fixed_version(vuln_data, package.name, package.ecosystem)
+        fixed = parse_fixed_version(vuln_data, package.name, package.ecosystem, current_version=package.version or "")
 
         references = [ref.get("url", "") for ref in vuln_data.get("references", []) if ref.get("url")]
 

--- a/tests/test_fix_version.py
+++ b/tests/test_fix_version.py
@@ -1,0 +1,114 @@
+"""Regression tests for fix-version parsing — cross-package bleed prevention."""
+
+from agent_bom.scanners import parse_fixed_version
+
+
+def _vuln(affected_entries):
+    return {"id": "TEST-001", "affected": affected_entries}
+
+
+def _affected(name="", ecosystem="", fixed="1.0.0"):
+    return {
+        "package": {"name": name, "ecosystem": ecosystem},
+        "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": fixed}]}],
+    }
+
+
+def test_empty_name_skipped():
+    """Affected entries with no package name should be skipped."""
+    vuln = _vuln([_affected(name="", ecosystem="PyPI", fixed="0.1.8")])
+    assert parse_fixed_version(vuln, "pillow", "PyPI") is None
+
+
+def test_correct_package_matched_alongside_empty():
+    """When one entry has no name and another matches, the match wins."""
+    vuln = _vuln(
+        [
+            _affected(name="", ecosystem="", fixed="0.1.8"),
+            _affected(name="pillow", ecosystem="PyPI", fixed="10.2.0"),
+        ]
+    )
+    assert parse_fixed_version(vuln, "pillow", "PyPI") == "10.2.0"
+
+
+def test_fix_lower_than_current_skipped():
+    """Fix version lower than current belongs to a sibling package — skip it."""
+    vuln = _vuln([_affected(name="pillow", ecosystem="PyPI", fixed="0.1.8")])
+    result = parse_fixed_version(vuln, "pillow", "PyPI", current_version="9.0.0")
+    assert result is None
+
+
+def test_fix_equal_to_current_returned():
+    """OSV 'fixed' means first non-affected — equal to current is valid."""
+    vuln = _vuln([_affected(name="pillow", ecosystem="PyPI", fixed="9.0.0")])
+    # Equal means "this version is the fix" — should NOT be skipped
+    # Actually 9.0.0 < 9.0.0 is False, so it passes through
+    result = parse_fixed_version(vuln, "pillow", "PyPI", current_version="9.0.0")
+    assert result == "9.0.0"
+
+
+def test_fix_higher_than_current_returned():
+    """Normal case: fix version is an upgrade."""
+    vuln = _vuln([_affected(name="requests", ecosystem="PyPI", fixed="2.32.0")])
+    result = parse_fixed_version(vuln, "requests", "PyPI", current_version="2.28.0")
+    assert result == "2.32.0"
+
+
+def test_no_current_version_skips_guard():
+    """When current_version is empty, downgrade guard is bypassed."""
+    vuln = _vuln([_affected(name="pillow", ecosystem="PyPI", fixed="0.1.8")])
+    result = parse_fixed_version(vuln, "pillow", "PyPI", current_version="")
+    assert result == "0.1.8"
+
+
+def test_current_version_unknown_skips_guard():
+    """When current_version is 'unknown', downgrade guard is bypassed."""
+    vuln = _vuln([_affected(name="pillow", ecosystem="PyPI", fixed="0.1.8")])
+    result = parse_fixed_version(vuln, "pillow", "PyPI", current_version="unknown")
+    assert result == "0.1.8"
+
+
+def test_current_version_latest_skips_guard():
+    """When current_version is 'latest', downgrade guard is bypassed."""
+    vuln = _vuln([_affected(name="pillow", ecosystem="PyPI", fixed="0.1.8")])
+    result = parse_fixed_version(vuln, "pillow", "PyPI", current_version="latest")
+    assert result == "0.1.8"
+
+
+def test_git_sha_filtered():
+    """40-char hex git SHAs should not be returned as fix versions."""
+    vuln = _vuln([_affected(name="libwebp", ecosystem="", fixed="ca332209cb5567c9b249c86788cb2dbf8847e760")])
+    result = parse_fixed_version(vuln, "libwebp", "")
+    assert result is None
+
+
+def test_short_sha_filtered():
+    """Short commit hashes should not be returned."""
+    vuln = _vuln([_affected(name="libwebp", ecosystem="", fixed="abcdef1234")])
+    result = parse_fixed_version(vuln, "libwebp", "")
+    assert result is None
+
+
+def test_cve_2023_4863_scenario():
+    """CVE-2023-4863: libwebp has no ecosystem, pillow should not get its fix."""
+    vuln = _vuln(
+        [
+            # Entry 1: no name/ecosystem, git SHA fix
+            _affected(name="", ecosystem="", fixed="ca332209cb5567c9b249c86788cb2dbf8847e760"),
+            # Entry 2: pillow with real fix
+            _affected(name="Pillow", ecosystem="PyPI", fixed="10.0.1"),
+        ]
+    )
+    result = parse_fixed_version(vuln, "pillow", "PyPI", current_version="9.0.0")
+    assert result == "10.0.1"
+
+
+def test_cve_2023_4863_no_pillow_entry():
+    """CVE-2023-4863: if only the unnamed entry exists, pillow gets no fix."""
+    vuln = _vuln(
+        [
+            _affected(name="", ecosystem="", fixed="ca332209cb5567c9b249c86788cb2dbf8847e760"),
+        ]
+    )
+    result = parse_fixed_version(vuln, "pillow", "PyPI", current_version="9.0.0")
+    assert result is None

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -5,6 +5,13 @@
   --foreground: #171717;
   --sidebar-width: 240px;
   --sidebar-collapsed-width: 60px;
+
+  /* Architecture diagram color semantics */
+  --color-discover: #58a6ff;
+  --color-scan: #f85149;
+  --color-analyze: #d29922;
+  --color-output: #3fb950;
+  --color-protect: #f778ba;
 }
 
 @theme inline {

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -487,9 +487,9 @@ export default function Dashboard() {
       {/* Key stats bar */}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
         <StatCard icon={Layers} label="Total scans" value={isLoading ? "—" : String(doneJobs.length)} color="zinc" href="/jobs" />
-        <StatCard icon={Server} label="Agents" value={isLoading ? "—" : String(effectiveAgentCount)} color="emerald" href="/agents" />
-        <StatCard icon={Package} label="Packages" value={isLoading ? "—" : String(totalPackages)} color="blue" href="/vulns" />
-        <StatCard icon={Bug} label="Unique CVEs" value={isLoading ? "—" : String(uniqueCVEs)} color="orange" href="/vulns" />
+        <StatCard icon={Server} label="Agents" value={isLoading ? "—" : String(effectiveAgentCount)} color="blue" href="/agents" />
+        <StatCard icon={Package} label="Packages" value={isLoading ? "—" : String(totalPackages)} color="orange" href="/vulns" />
+        <StatCard icon={Bug} label="Unique CVEs" value={isLoading ? "—" : String(uniqueCVEs)} color="red" href="/vulns" />
         <StatCard icon={Zap} label="Critical" value={isLoading ? "—" : String(severity.critical)} color="red" href="/vulns?severity=critical" />
       </div>
 
@@ -701,16 +701,20 @@ function StatCard({
   href?: string;
   trend?: { direction: "up" | "down" | "flat"; label: string };
 }) {
+  // Architecture diagram colors as top borders
   const colors = {
-    emerald: { text: "text-emerald-400", glow: "shadow-emerald-500/5", accent: "bg-emerald-500" },
-    blue: { text: "text-blue-400", glow: "shadow-blue-500/5", accent: "bg-blue-500" },
-    orange: { text: "text-orange-400", glow: "shadow-orange-500/5", accent: "bg-orange-500" },
-    red: { text: "text-red-400", glow: "shadow-red-500/5", accent: "bg-red-500" },
-    zinc: { text: "text-zinc-400", glow: "shadow-zinc-500/5", accent: "bg-zinc-500" },
+    emerald: { text: "text-emerald-400", glow: "shadow-emerald-500/5", accent: "bg-emerald-500", topBorder: "#3fb950" },
+    blue:    { text: "text-blue-400",    glow: "shadow-blue-500/5",    accent: "bg-blue-500",    topBorder: "#58a6ff" },
+    orange:  { text: "text-orange-400",  glow: "shadow-orange-500/5",  accent: "bg-orange-500",  topBorder: "#d29922" },
+    red:     { text: "text-red-400",     glow: "shadow-red-500/5",     accent: "bg-red-500",     topBorder: "#f85149" },
+    zinc:    { text: "text-zinc-400",    glow: "shadow-zinc-500/5",    accent: "bg-zinc-500",    topBorder: "#52525b" },
   };
   const c = colors[color];
   const inner = (
-    <div className={`bg-zinc-900 border border-zinc-800 rounded-xl p-4 ${href ? "hover:border-zinc-600 transition-all cursor-pointer" : ""} shadow-lg ${c.glow}`}>
+    <div
+      className={`bg-zinc-900 border border-zinc-800 rounded-xl p-4 ${href ? "hover:border-zinc-600 transition-all cursor-pointer" : ""} shadow-lg ${c.glow}`}
+      style={{ borderTop: `2px solid ${c.topBorder}` }}
+    >
       <div className="flex items-center justify-between mb-2">
         <Icon className={`w-4 h-4 ${c.text}`} />
         {trend && (

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -22,20 +22,21 @@ const ROW_SPACING = 100;
 // ── Legend ────────────────────────────────────────────────────────────────────
 
 const SECURITY_LEGEND = [
-  { label: "Agent",      color: "#10b981" },
-  { label: "MCP Server", color: "#3b82f6" },
-  { label: "Package",    color: "#71717a" },
-  { label: "Vulnerable", color: "#ef4444" },
+  { label: "Agent",      color: "#58a6ff" },   // blue  — discover layer
+  { label: "MCP Server", color: "#60a5fa" },   // blue-400
+  { label: "Package",    color: "#d29922" },   // amber — analyze layer
+  { label: "Vulnerable", color: "#f85149" },   // red   — scan layer
   { label: "Credential", color: "#eab308", dashed: true },
 ];
 
 // ── Custom Node ──────────────────────────────────────────────────────────────
 
 function SecurityNode({ data }: { data: any }) {
+  // Architecture color semantics: scan=red, analyze=amber, discover=blue, neutral=zinc
   const borderColor = data.dimmed
     ? "#27272a"
     : data.vulnCount > 0
-      ? data.hasCritical ? "#ef4444" : "#f97316"
+      ? data.hasCritical ? "#f85149" : "#f97316"  // scan-red / orange
       : data.hasCredentials ? "#eab308" : "#3f3f46";
 
   const riskBorderColor = data.riskBorder ?? borderColor;
@@ -168,11 +169,11 @@ export default function SecurityGraphPage() {
       })
     );
 
-    // Helper: risk layer border color for a vuln count
+    // Helper: risk layer border color for a vuln count — architecture color semantics
     function riskBorder(vulnCount: number): string {
-      if (vulnCount > 5) return "#ef4444"; // red
+      if (vulnCount > 5) return "#f85149"; // scan-red
       if (vulnCount > 0) return "#f97316"; // orange
-      return "#10b981"; // green
+      return "#3fb950"; // output-green (safe)
     }
 
     latestResult.agents.forEach((agent, ai) => {
@@ -250,12 +251,12 @@ export default function SecurityGraphPage() {
           target: serverId,
           type: "smoothstep",
           style: {
-            stroke: dimEdge ? "#18181b" : (edgeIsCredPath && insightLayer === "credentials") ? "#eab308" : hasCredentials ? "#eab308" : "#10b981",
+            stroke: dimEdge ? "#18181b" : (edgeIsCredPath && insightLayer === "credentials") ? "#eab308" : hasCredentials ? "#eab308" : "#58a6ff",
             strokeWidth: dimEdge ? 1 : 2,
             opacity: dimEdge ? 0.15 : 0.85,
           },
           animated: insightLayer === "credentials" ? edgeIsCredPath : hasCredentials,
-          markerEnd: { type: MarkerType.ArrowClosed, color: dimEdge ? "#18181b" : "#10b981", width: 16, height: 12 },
+          markerEnd: { type: MarkerType.ArrowClosed, color: dimEdge ? "#18181b" : "#58a6ff", width: 16, height: 12 },
         });
 
         (server.packages ?? []).forEach((pkg) => {
@@ -402,10 +403,10 @@ export default function SecurityGraphPage() {
           <MiniMap
             nodeColor={(n) => {
               const d = n.data as any;
-              if (d?.hasCritical) return "#ef4444";
-              if (d?.vulnCount > 0) return "#f97316";
-              if (d?.hasCredentials) return "#eab308";
-              return "#3f3f46";
+              if (d?.hasCritical) return "#f85149"; // scan-red
+              if (d?.vulnCount > 0) return "#f97316"; // orange
+              if (d?.hasCredentials) return "#eab308"; // amber credential
+              return "#3f3f46"; // zinc neutral
             }}
             className={MINIMAP_CLASS}
           />

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -270,16 +270,17 @@ export function Nav() {
               {/* Group Header */}
               <button
                 onClick={() => collapsed ? setCollapsed(false) : toggleGroup(group.label)}
-                className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-medium transition-colors ${
+                className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-medium transition-colors border-l-2 ${
                   hasActiveChild
                     ? "text-zinc-200"
                     : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800/40"
                 }`}
+                style={{ borderLeftColor: group.accent }}
                 title={collapsed ? group.label : undefined}
               >
                 <GroupIcon
                   className="w-4 h-4 shrink-0"
-                  style={{ color: hasActiveChild ? group.accent : undefined }}
+                  style={{ color: hasActiveChild ? group.accent : group.accent + "99" }}
                 />
                 {!collapsed && (
                   <>

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -7,9 +7,13 @@ interface PostureGradeProps {
 }
 
 export function PostureGrade({ grade, score, dimensions }: PostureGradeProps) {
-  // Color based on grade
+  // Color based on grade — matches architecture diagram semantics
   const gradeColor = {
-    A: "#22c55e", B: "#3b82f6", C: "#eab308", D: "#f97316", F: "#ef4444",
+    A: "#3fb950", // green  — output/governance layer
+    B: "#58a6ff", // blue   — discover layer
+    C: "#d29922", // amber  — analyze layer
+    D: "#f97316", // orange — degraded
+    F: "#f85149", // red    — scan/critical layer
   }[grade] ?? "#71717a";
 
   // SVG radial progress ring (120px)


### PR DESCRIPTION
Fixes pillow CVE-2023-4863 showing wrong fix version (0.1.8). Skips empty-name OSV entries and fix versions lower than current. 12 new tests.