### PR TITLE
Add MCP runtime diffs and deterministic AI BOM entities

### DIFF
--- a/src/agent_bom/history.py
+++ b/src/agent_bom/history.py
@@ -102,6 +102,7 @@ def diff_reports(baseline: dict, current: dict) -> dict:
         "unchanged": unchanged,
         "new_packages": new_pkgs,
         "removed_packages": removed_pkgs,
+        "inventory_diff": _diff_inventory(baseline, current),
         "summary": {
             "new_findings": len(new),
             "resolved_findings": len(resolved),
@@ -121,3 +122,98 @@ def _extract_packages(report: dict) -> set[str]:
                 key = f"{pkg.get('ecosystem', 'unknown')}:{pkg.get('name', '')}@{pkg.get('version', '')}"
                 pkgs.add(key)
     return pkgs
+
+
+def _get_inventory_snapshot(report: dict) -> dict:
+    """Return inventory snapshot from a report, deriving a minimal one if absent."""
+    snapshot = report.get("inventory_snapshot")
+    if snapshot:
+        return snapshot
+
+    agents: list[dict] = []
+    servers: list[dict] = []
+    tools: list[dict] = []
+    resources: list[dict] = []
+    packages: list[dict] = []
+
+    seen_servers: set[str] = set()
+    seen_tools: set[str] = set()
+    seen_resources: set[str] = set()
+    seen_packages: set[str] = set()
+
+    for agent in report.get("agents", []):
+        agent_id = agent.get("stable_id") or agent.get("name", "")
+        agents.append({"id": agent_id, "name": agent.get("name", ""), "status": agent.get("status", "")})
+        for server in agent.get("mcp_servers", []):
+            server_id = server.get("stable_id") or server.get("name", "")
+            if server_id and server_id not in seen_servers:
+                servers.append(
+                    {
+                        "id": server_id,
+                        "name": server.get("name", ""),
+                        "fingerprint": server.get("fingerprint", ""),
+                    }
+                )
+                seen_servers.add(server_id)
+            for tool in server.get("tools", []):
+                tool_id = tool.get("stable_id") or tool.get("name", "")
+                if tool_id and tool_id not in seen_tools:
+                    tools.append({"id": tool_id, "name": tool.get("name", "")})
+                    seen_tools.add(tool_id)
+            for resource in server.get("resources", []):
+                resource_id = resource.get("stable_id") or resource.get("uri", "")
+                if resource_id and resource_id not in seen_resources:
+                    resources.append({"id": resource_id, "uri": resource.get("uri", "")})
+                    seen_resources.add(resource_id)
+            for pkg in server.get("packages", []):
+                pkg_id = pkg.get("stable_id") or f"{pkg.get('ecosystem', 'unknown')}:{pkg.get('name', '')}@{pkg.get('version', '')}"
+                if pkg_id and pkg_id not in seen_packages:
+                    packages.append({"id": pkg_id, "name": pkg.get("name", ""), "version": pkg.get("version", "")})
+                    seen_packages.add(pkg_id)
+
+    return {
+        "agents": agents,
+        "servers": servers,
+        "tools": tools,
+        "resources": resources,
+        "packages": packages,
+    }
+
+
+def _diff_inventory(baseline: dict, current: dict) -> dict:
+    """Diff deterministic inventory entities across two reports."""
+    base_snapshot = _get_inventory_snapshot(baseline)
+    curr_snapshot = _get_inventory_snapshot(current)
+
+    result: dict[str, object] = {"changed_servers": []}
+    summary: dict[str, int] = {}
+
+    for entity_type in ("agents", "servers", "tools", "resources", "packages"):
+        base_map = {item.get("id", ""): item for item in base_snapshot.get(entity_type, []) if item.get("id")}
+        curr_map = {item.get("id", ""): item for item in curr_snapshot.get(entity_type, []) if item.get("id")}
+        new_ids = sorted(set(curr_map) - set(base_map))
+        removed_ids = sorted(set(base_map) - set(curr_map))
+        result[f"new_{entity_type}"] = [curr_map[i] for i in new_ids]
+        result[f"removed_{entity_type}"] = [base_map[i] for i in removed_ids]
+        summary[f"new_{entity_type}"] = len(new_ids)
+        summary[f"removed_{entity_type}"] = len(removed_ids)
+
+    base_servers = {item.get("id", ""): item for item in base_snapshot.get("servers", []) if item.get("id")}
+    curr_servers = {item.get("id", ""): item for item in curr_snapshot.get("servers", []) if item.get("id")}
+    changed_servers = []
+    for server_id in sorted(set(base_servers) & set(curr_servers)):
+        base_fp = base_servers[server_id].get("fingerprint")
+        curr_fp = curr_servers[server_id].get("fingerprint")
+        if base_fp and curr_fp and base_fp != curr_fp:
+            changed_servers.append(
+                {
+                    "id": server_id,
+                    "name": curr_servers[server_id].get("name", ""),
+                    "previous_fingerprint": base_fp,
+                    "current_fingerprint": curr_fp,
+                }
+            )
+    result["changed_servers"] = changed_servers
+    summary["changed_servers"] = len(changed_servers)
+    result["summary"] = summary
+    return result

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -288,6 +288,21 @@ class MCPTool:
     def fingerprint(self) -> str:
         return self.stable_id
 
+    @property
+    def risk_score(self) -> int:
+        """Heuristic risk score for the tool based on schema findings."""
+        score = 0
+        for finding in self.schema_findings:
+            if "shell-execution-capability" in finding:
+                score += 4
+            elif "network-egress-capability" in finding:
+                score += 3
+            elif "filesystem-capability" in finding:
+                score += 2
+            else:
+                score += 1
+        return min(score, 10)
+
 
 @dataclass
 class MCPResource:
@@ -311,6 +326,19 @@ class MCPResource:
     @property
     def fingerprint(self) -> str:
         return self.stable_id
+
+    @property
+    def risk_score(self) -> int:
+        """Heuristic risk score for the resource based on content findings."""
+        score = 0
+        for finding in self.content_findings:
+            if "hidden-instruction-surface" in finding or "prompt-bearing-resource" in finding:
+                score += 3
+            elif "mutable-resource" in finding:
+                score += 2
+            else:
+                score += 1
+        return min(score, 10)
 
 
 @dataclass
@@ -673,6 +701,7 @@ class AIBOMReport:
     ai_inventory_data: Optional[dict] = None  # AI component source scan results (SDK imports, models, keys)
     introspection_data: Optional[dict] = None  # Runtime MCP introspection results (tools, resources, drift)
     health_check_data: Optional[dict] = None  # MCP server reachability/health results
+    runtime_session_graph: Optional[dict] = None  # Structured runtime session graph/timeline evidence
 
     # Unified Finding stream (issue #566 — Phase 1).
     # Populated alongside blast_radii for backward compatibility.

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1619,6 +1619,18 @@ def print_diff(diff: dict) -> None:
         parts.append(f"[yellow]{summary['new_packages']} new package(s)[/yellow]")
     if summary["removed_packages"]:
         parts.append(f"[dim]{summary['removed_packages']} removed package(s)[/dim]")
+    inventory_diff = diff.get("inventory_diff", {})
+    inv_summary = inventory_diff.get("summary", {}) if isinstance(inventory_diff, dict) else {}
+    if inv_summary.get("new_servers"):
+        parts.append(f"[cyan]{inv_summary['new_servers']} new server(s)[/cyan]")
+    if inv_summary.get("removed_servers"):
+        parts.append(f"[dim]{inv_summary['removed_servers']} removed server(s)[/dim]")
+    if inv_summary.get("changed_servers"):
+        parts.append(f"[magenta]{inv_summary['changed_servers']} changed server fingerprint(s)[/magenta]")
+    if inv_summary.get("new_tools"):
+        parts.append(f"[cyan]{inv_summary['new_tools']} new tool(s)[/cyan]")
+    if inv_summary.get("new_resources"):
+        parts.append(f"[cyan]{inv_summary['new_resources']} new resource(s)[/cyan]")
 
     if parts:
         console.print("  " + "  •  ".join(parts) + "\n")
@@ -1664,6 +1676,24 @@ def print_diff(diff: dict) -> None:
         console.print(f"  [dim]Packages removed ({len(diff['removed_packages'])}):[/dim]")
         for pkg in diff["removed_packages"][:10]:
             console.print(f"    [-] [dim]{pkg}[/dim]")
+        console.print()
+
+    if isinstance(inventory_diff, dict) and inventory_diff.get("changed_servers"):
+        console.print(f"  [magenta]Server fingerprint changes ({len(inventory_diff['changed_servers'])}):[/magenta]")
+        for server in inventory_diff["changed_servers"][:10]:
+            console.print(f"    [~] [dim]{server.get('name') or server.get('id')}[/dim]")
+        console.print()
+
+    if isinstance(inventory_diff, dict) and inventory_diff.get("new_tools"):
+        console.print(f"  [cyan]New tools ({len(inventory_diff['new_tools'])}):[/cyan]")
+        for tool in inventory_diff["new_tools"][:10]:
+            console.print(f"    [+] [dim]{tool.get('name') or tool.get('id')}[/dim]")
+        console.print()
+
+    if isinstance(inventory_diff, dict) and inventory_diff.get("new_resources"):
+        console.print(f"  [cyan]New resources ({len(inventory_diff['new_resources'])}):[/cyan]")
+        for resource in inventory_diff["new_resources"][:10]:
+            console.print(f"    [+] [dim]{resource.get('uri') or resource.get('id')}[/dim]")
         console.print()
 
 

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -228,8 +228,183 @@ def _build_framework_summary(blast_radii: list[BlastRadius]) -> dict:
     }
 
 
+def _build_inventory_snapshot(report: AIBOMReport) -> dict:
+    """Build a deterministic inventory snapshot for diffing and BOM operations."""
+    agents: list[dict] = []
+    servers: dict[str, dict] = {}
+    tools: dict[str, dict] = {}
+    resources: dict[str, dict] = {}
+    packages: dict[str, dict] = {}
+    relationships: list[dict] = []
+
+    for agent in report.agents:
+        server_ids: list[str] = []
+        agents.append(
+            {
+                "id": agent.stable_id,
+                "name": agent.name,
+                "type": agent.agent_type.value,
+                "status": agent.status.value,
+                "config_path": agent.config_path,
+                "server_ids": server_ids,
+            }
+        )
+
+        for server in agent.mcp_servers:
+            server_ids.append(server.stable_id)
+            if server.stable_id not in servers:
+                servers[server.stable_id] = {
+                    "id": server.stable_id,
+                    "name": server.name,
+                    "fingerprint": server.fingerprint,
+                    "auth_mode": server.auth_mode,
+                    "transport": server.transport.value,
+                    "command": server.command,
+                    "url": server.url,
+                    "tool_ids": [],
+                    "resource_ids": [],
+                    "package_ids": [],
+                }
+            relationships.append({"from": agent.stable_id, "to": server.stable_id, "type": "uses"})
+
+            for tool in server.tools:
+                if tool.stable_id not in tools:
+                    tools[tool.stable_id] = {
+                        "id": tool.stable_id,
+                        "name": tool.name,
+                        "fingerprint": tool.fingerprint,
+                        "description": tool.description,
+                        "schema_findings": tool.schema_findings,
+                        "risk_score": tool.risk_score,
+                    }
+                if tool.stable_id not in servers[server.stable_id]["tool_ids"]:
+                    servers[server.stable_id]["tool_ids"].append(tool.stable_id)
+                relationships.append({"from": server.stable_id, "to": tool.stable_id, "type": "exposes_tool"})
+
+            for resource in server.resources:
+                if resource.stable_id not in resources:
+                    resources[resource.stable_id] = {
+                        "id": resource.stable_id,
+                        "uri": resource.uri,
+                        "name": resource.name,
+                        "fingerprint": resource.fingerprint,
+                        "mime_type": resource.mime_type,
+                        "content_findings": resource.content_findings,
+                        "risk_score": resource.risk_score,
+                    }
+                if resource.stable_id not in servers[server.stable_id]["resource_ids"]:
+                    servers[server.stable_id]["resource_ids"].append(resource.stable_id)
+                relationships.append({"from": server.stable_id, "to": resource.stable_id, "type": "exposes_resource"})
+
+            for pkg in server.packages:
+                if pkg.stable_id not in packages:
+                    packages[pkg.stable_id] = {
+                        "id": pkg.stable_id,
+                        "name": pkg.name,
+                        "version": pkg.version,
+                        "ecosystem": pkg.ecosystem,
+                        "purl": pkg.purl,
+                        "vulnerability_count": len(pkg.vulnerabilities),
+                    }
+                if pkg.stable_id not in servers[server.stable_id]["package_ids"]:
+                    servers[server.stable_id]["package_ids"].append(pkg.stable_id)
+                relationships.append({"from": server.stable_id, "to": pkg.stable_id, "type": "depends_on"})
+
+    return {
+        "summary": {
+            "agents": len(agents),
+            "servers": len(servers),
+            "tools": len(tools),
+            "resources": len(resources),
+            "packages": len(packages),
+            "relationships": len(relationships),
+        },
+        "agents": agents,
+        "servers": sorted(servers.values(), key=lambda x: x["id"]),
+        "tools": sorted(tools.values(), key=lambda x: x["id"]),
+        "resources": sorted(resources.values(), key=lambda x: x["id"]),
+        "packages": sorted(packages.values(), key=lambda x: x["id"]),
+        "relationships": relationships,
+    }
+
+
+def _build_mcp_runtime_diff(report: AIBOMReport) -> dict | None:
+    """Compare configured servers against observed/runtime evidence."""
+    introspection_results = {
+        item.get("server_name"): item for item in (report.introspection_data or {}).get("results", []) if item.get("server_name")
+    }
+    runtime_used: dict[str, set[str]] = {}
+    for finding in (report.runtime_correlation or {}).get("correlated_findings", []):
+        server_name = finding.get("server_name")
+        tool_name = finding.get("tool_name")
+        if server_name and tool_name:
+            runtime_used.setdefault(server_name, set()).add(tool_name)
+
+    if not introspection_results and not runtime_used:
+        return None
+
+    server_diffs: list[dict] = []
+    for agent in report.agents:
+        for server in agent.mcp_servers:
+            intro = introspection_results.get(server.name, {})
+            observed_tools = {tool.name for tool in server.tools}
+            used_tools = sorted(runtime_used.get(server.name, set()))
+            server_diffs.append(
+                {
+                    "agent_name": agent.name,
+                    "agent_stable_id": agent.stable_id,
+                    "server_name": server.name,
+                    "server_stable_id": server.stable_id,
+                    "transport": server.transport.value,
+                    "auth_mode": intro.get("auth_mode", server.auth_mode),
+                    "configured_fingerprint": intro.get("configured_fingerprint", server.fingerprint),
+                    "runtime_fingerprint": intro.get("runtime_fingerprint"),
+                    "configured_tool_count": intro.get("configured_tool_count", len(server.tools)),
+                    "observed_tool_count": intro.get("tool_count", len(server.tools)),
+                    "configured_resource_count": intro.get("configured_resource_count", len(server.resources)),
+                    "observed_resource_count": intro.get("resource_count", len(server.resources)),
+                    "tools_added": intro.get("tools_added", []),
+                    "tools_removed": intro.get("tools_removed", []),
+                    "resources_added": intro.get("resources_added", []),
+                    "resources_removed": intro.get("resources_removed", []),
+                    "tool_schema_findings": intro.get(
+                        "tool_schema_findings",
+                        sorted({finding for tool in server.tools for finding in tool.schema_findings}),
+                    ),
+                    "resource_findings": intro.get(
+                        "resource_findings",
+                        sorted({finding for resource in server.resources for finding in resource.content_findings}),
+                    ),
+                    "max_tool_risk_score": max((tool.risk_score for tool in server.tools), default=0),
+                    "max_resource_risk_score": max((resource.risk_score for resource in server.resources), default=0),
+                    "runtime_used_tools": used_tools,
+                    "observed_not_used_tools": sorted(observed_tools - set(used_tools)),
+                    "configured_vs_observed_changed": bool(
+                        intro.get("has_drift")
+                        or intro.get("configured_fingerprint")
+                        and intro.get("runtime_fingerprint")
+                        and intro.get("configured_fingerprint") != intro.get("runtime_fingerprint")
+                    ),
+                    "observed_vs_runtime_gap": bool(observed_tools - set(used_tools)),
+                    "has_runtime_usage": bool(used_tools),
+                }
+            )
+
+    return {
+        "summary": {
+            "servers_with_introspection": sum(1 for diff in server_diffs if diff["runtime_fingerprint"]),
+            "servers_changed": sum(1 for diff in server_diffs if diff["configured_vs_observed_changed"]),
+            "servers_with_runtime_usage": sum(1 for diff in server_diffs if diff["has_runtime_usage"]),
+            "runtime_used_tools": sum(len(diff["runtime_used_tools"]) for diff in server_diffs),
+        },
+        "servers": server_diffs,
+    }
+
+
 def to_json(report: AIBOMReport) -> dict:
     """Convert report to JSON-serializable dict."""
+    inventory_snapshot = _build_inventory_snapshot(report)
+    mcp_runtime_diff = _build_mcp_runtime_diff(report)
     result = {
         "document_type": "AI-BOM",
         "spec_version": "1.0",
@@ -239,6 +414,10 @@ def to_json(report: AIBOMReport) -> dict:
         "scan_sources": report.scan_sources,
         "has_mcp_context": report.has_mcp_context,
         "has_agent_context": report.has_agent_context,
+        "ai_bom_entities": {
+            "schema_version": "1.0",
+            **inventory_snapshot,
+        },
         "summary": {
             "total_agents": report.total_agents,
             "total_mcp_servers": report.total_servers,
@@ -246,6 +425,7 @@ def to_json(report: AIBOMReport) -> dict:
             "total_vulnerabilities": report.total_vulnerabilities,
             "critical_findings": len(report.critical_vulns),
         },
+        "inventory_snapshot": inventory_snapshot,
         "agents": [
             {
                 "name": agent.name,
@@ -277,6 +457,7 @@ def to_json(report: AIBOMReport) -> dict:
                                 "fingerprint": t.fingerprint,
                                 "description": t.description,
                                 "schema_findings": t.schema_findings,
+                                "risk_score": t.risk_score,
                             }
                             for t in server.tools
                         ],
@@ -289,6 +470,7 @@ def to_json(report: AIBOMReport) -> dict:
                                 "description": r.description,
                                 "mime_type": r.mime_type,
                                 "content_findings": r.content_findings,
+                                "risk_score": r.risk_score,
                             }
                             for r in server.resources
                         ],
@@ -492,6 +674,10 @@ def to_json(report: AIBOMReport) -> dict:
 
     if report.runtime_correlation:
         result["runtime_correlation"] = report.runtime_correlation
+    if report.runtime_session_graph:
+        result["runtime_session_graph"] = report.runtime_session_graph
+    if mcp_runtime_diff:
+        result["mcp_runtime_diff"] = mcp_runtime_diff
 
     # Training pipeline lineage + dataset cards
     if report.training_pipelines:

--- a/src/agent_bom/runtime/protection.py
+++ b/src/agent_bom/runtime/protection.py
@@ -215,11 +215,37 @@ class RuntimeSessionGraph:
         )
 
     def to_dict(self) -> dict[str, object]:
+        timeline: list[dict[str, object]] = []
+        for node in self.nodes.values():
+            if node.kind in {"tool_call", "tool_response", "alert"}:
+                timeline.append(
+                    {
+                        "timestamp": node.first_seen,
+                        "kind": node.kind,
+                        "id": node.id,
+                        "label": node.label,
+                        "metadata": node.metadata,
+                    }
+                )
+        for edge in self.edges:
+            timeline.append(
+                {
+                    "timestamp": edge.timestamp,
+                    "kind": "interaction",
+                    "source": edge.source,
+                    "target": edge.target,
+                    "relation": edge.relation,
+                    "metadata": edge.metadata,
+                }
+            )
+        timeline.sort(key=lambda item: str(item.get("timestamp", "")))
         return {
             "node_count": len(self.nodes),
             "edge_count": len(self.edges),
             "nodes": [node.to_dict() for node in self.nodes.values()],
             "edges": [edge.to_dict() for edge in self.edges],
+            "timeline_event_count": len(timeline),
+            "timeline": timeline,
         }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -571,6 +571,43 @@ def test_diff_resolved_finding():
     assert len(diff["resolved"]) == 1
 
 
+def test_diff_reports_inventory_changes():
+    from agent_bom.history import diff_reports
+
+    baseline = {
+        "generated_at": "2025-01-01T00:00:00",
+        "inventory_snapshot": {
+            "agents": [{"id": "agent-1", "name": "claude"}],
+            "servers": [{"id": "srv-1", "name": "filesystem", "fingerprint": "fp-1"}],
+            "tools": [{"id": "tool-1", "name": "read_file"}],
+            "resources": [],
+            "packages": [{"id": "pkg-1", "name": "requests", "version": "2.31.0"}],
+        },
+        "agents": [],
+        "blast_radius": [],
+    }
+    current = {
+        "generated_at": "2025-01-02T00:00:00",
+        "inventory_snapshot": {
+            "agents": [{"id": "agent-1", "name": "claude"}],
+            "servers": [
+                {"id": "srv-1", "name": "filesystem", "fingerprint": "fp-2"},
+                {"id": "srv-2", "name": "sqlite", "fingerprint": "fp-3"},
+            ],
+            "tools": [{"id": "tool-1", "name": "read_file"}, {"id": "tool-2", "name": "write_file"}],
+            "resources": [{"id": "res-1", "uri": "file:///workspace"}],
+            "packages": [{"id": "pkg-1", "name": "requests", "version": "2.31.0"}],
+        },
+        "agents": [],
+        "blast_radius": [],
+    }
+    diff = diff_reports(baseline, current)
+    assert diff["inventory_diff"]["summary"]["new_servers"] == 1
+    assert diff["inventory_diff"]["summary"]["changed_servers"] == 1
+    assert diff["inventory_diff"]["summary"]["new_tools"] == 1
+    assert diff["inventory_diff"]["summary"]["new_resources"] == 1
+
+
 def test_cli_check_help():
     runner = CliRunner()
     result = runner.invoke(main, ["check", "--help"])

--- a/tests/test_discovery_enhanced.py
+++ b/tests/test_discovery_enhanced.py
@@ -382,6 +382,57 @@ def test_json_includes_stable_ids_and_resources():
     assert data["agents"][0]["mcp_servers"][0]["tools"][0]["stable_id"] == server.tools[0].stable_id
     assert data["agents"][0]["mcp_servers"][0]["resources"][0]["stable_id"] == server.resources[0].stable_id
     assert data["agents"][0]["mcp_servers"][0]["packages"][0]["stable_id"] == server.packages[0].stable_id
+    assert data["agents"][0]["mcp_servers"][0]["tools"][0]["risk_score"] >= 1
+    assert data["agents"][0]["mcp_servers"][0]["resources"][0]["risk_score"] >= 1
+    snapshot = data["inventory_snapshot"]
+    assert snapshot["summary"]["agents"] == 1
+    assert snapshot["summary"]["servers"] == 1
+    assert snapshot["summary"]["tools"] == 1
+    assert snapshot["summary"]["resources"] == 1
+    assert snapshot["summary"]["packages"] == 1
+
+
+def test_json_includes_mcp_runtime_diff():
+    from agent_bom.models import AIBOMReport, MCPServer
+    from agent_bom.output import to_json
+
+    server = MCPServer(name="filesystem", command="npx")
+    agent = Agent(name="claude-desktop", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/claude.json", mcp_servers=[server])
+    report = AIBOMReport(
+        agents=[agent],
+        introspection_data={
+            "results": [
+                {
+                    "server_name": "filesystem",
+                    "auth_mode": "local-stdio",
+                    "configured_fingerprint": "cfg-1",
+                    "runtime_fingerprint": "rt-2",
+                    "configured_tool_count": 1,
+                    "configured_resource_count": 0,
+                    "tool_count": 2,
+                    "resource_count": 1,
+                    "tools_added": ["write_file"],
+                    "tools_removed": [],
+                    "resources_added": ["file:///workspace"],
+                    "resources_removed": [],
+                    "tool_schema_findings": ["write_file.path: filesystem-capability"],
+                    "resource_findings": ["file:///workspace: mutable-resource"],
+                    "has_drift": True,
+                }
+            ]
+        },
+        runtime_correlation={
+            "correlated_findings": [
+                {"server_name": "filesystem", "tool_name": "read_file"},
+            ]
+        },
+    )
+    data = to_json(report)
+    assert data["mcp_runtime_diff"]["summary"]["servers_changed"] == 1
+    diff = data["mcp_runtime_diff"]["servers"][0]
+    assert diff["configured_vs_observed_changed"] is True
+    assert diff["runtime_used_tools"] == ["read_file"]
+    assert diff["max_tool_risk_score"] == 0
 
 
 # ── CycloneDX output includes status ────────────────────────────────────────

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -19,7 +19,7 @@ from agent_bom.models import (
     TransportType,
     Vulnerability,
 )
-from agent_bom.output import to_csv, to_junit, to_markdown
+from agent_bom.output import to_csv, to_json, to_junit, to_markdown
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -262,6 +262,27 @@ class TestCSV:
         assert "modified_at" in reader.fieldnames
         assert rows[0]["published_at"] == "2026-03-21T12:00:00Z"
         assert rows[0]["modified_at"] == "2026-03-23T09:00:00Z"
+
+
+def test_json_runtime_session_graph_passthrough():
+    report = _make_report()
+    report.runtime_session_graph = {
+        "node_count": 1,
+        "edge_count": 0,
+        "nodes": [{"id": "tool:read_file", "kind": "tool"}],
+        "edges": [],
+    }
+    data = to_json(report)
+    assert "runtime_session_graph" in data
+    assert data["runtime_session_graph"]["node_count"] == 1
+
+
+def test_json_includes_ai_bom_entities():
+    report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[_make_pkg()])])])
+    data = to_json(report)
+    assert "ai_bom_entities" in data
+    assert data["ai_bom_entities"]["schema_version"] == "1.0"
+    assert data["ai_bom_entities"]["summary"]["agents"] == 1
 
 
 # ── Markdown ─────────────────────────────────────────────────────────────────

--- a/tests/test_protection_engine.py
+++ b/tests/test_protection_engine.py
@@ -121,6 +121,8 @@ def test_process_tool_call_records_session_graph():
     assert any(node["kind"] == "agent" for node in graph["nodes"])
     assert any(node["kind"] == "tool_call" for node in graph["nodes"])
     assert any(edge["relation"] == "invokes" for edge in graph["edges"])
+    assert graph["timeline_event_count"] >= 3
+    assert any(event["kind"] == "tool_call" for event in graph["timeline"])
 
 
 # ─── Tool Response Processing ────────────────────────────────────────────────
@@ -148,6 +150,8 @@ def test_process_tool_response_credential_leak():
     graph = engine.status()["session_graph"]
     assert any(node["kind"] == "tool_response" for node in graph["nodes"])
     assert any(node["kind"] == "alert" for node in graph["nodes"])
+    assert any(event["kind"] == "tool_response" for event in graph["timeline"])
+    assert any(event["kind"] == "alert" for event in graph["timeline"])
 
 
 # ─── Tool Drift ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add deterministic AI BOM entity snapshots to JSON output for agents, servers, tools, resources, packages, and relationships
- add configured vs observed vs runtime-used MCP diff output with server fingerprint change detection and risk summaries
- add runtime session timeline output on top of the session graph for downstream UI/runtime visualization
- extend history diffing and console diff output to track inventory changes, new tools/resources, and changed servers

## Validation
- pytest -q tests/test_core.py tests/test_discovery_enhanced.py tests/test_output_formats.py tests/test_protection_engine.py tests/test_mcp_introspect.py tests/test_aibom_e2e.py
- python -m compileall src/agent_bom

## Why
This makes the BOM/inventory layer deterministic enough to diff across runs, gives MCP runtime evidence a clearer configured-vs-observed-vs-used model, and produces better primitives for graph/timeline UI work.