### PR TITLE
Add runtime incident summaries and proxy alert rollups

### DIFF
--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -12,7 +12,7 @@ Endpoints:
 
 from __future__ import annotations
 
-from collections import deque
+from collections import Counter, deque
 from pathlib import Path as _Path
 from typing import TYPE_CHECKING
 
@@ -98,6 +98,49 @@ def _read_alerts_from_log(path: _Path) -> list[dict]:
     return alerts
 
 
+def _load_proxy_alerts() -> list[dict]:
+    """Return in-memory alerts, or fall back to the configured audit log."""
+    log_path = _get_configured_log_path()
+    if log_path and not _proxy_alerts:
+        return _read_alerts_from_log(log_path)
+    return list(_proxy_alerts)
+
+
+def _summarize_proxy_alerts(alerts: list[dict]) -> dict:
+    """Build a compact summary for proxy status and alert APIs."""
+    severity_counts: Counter[str] = Counter()
+    detector_counts: Counter[str] = Counter()
+    blocked_alerts = 0
+    recent_alerts: list[dict] = []
+
+    for alert in sorted(alerts, key=lambda item: str(item.get("ts", "")), reverse=True):
+        severity = str(alert.get("severity", "unknown")).lower()
+        detector = str(alert.get("detector", "unknown"))
+        severity_counts[severity] += 1
+        detector_counts[detector] += 1
+        details = alert.get("details", {})
+        if isinstance(details, dict) and details.get("action") == "blocked":
+            blocked_alerts += 1
+        if len(recent_alerts) < 5:
+            recent_alerts.append(
+                {
+                    "ts": alert.get("ts", ""),
+                    "detector": detector,
+                    "severity": severity,
+                    "message": alert.get("message", ""),
+                }
+            )
+
+    return {
+        "total_alerts": len(alerts),
+        "blocked_alerts": blocked_alerts,
+        "alerts_by_severity": dict(sorted(severity_counts.items())),
+        "alerts_by_detector": dict(sorted(detector_counts.items())),
+        "latest_alert_at": recent_alerts[0]["ts"] if recent_alerts else "",
+        "recent_alerts": recent_alerts,
+    }
+
+
 def _read_metrics_from_log(path: _Path) -> dict | None:
     """Read the last proxy_summary record from a JSONL audit log."""
     import json as _json
@@ -133,14 +176,21 @@ async def proxy_status() -> dict:
     buffer (populated by ``push_proxy_metrics``) or from the audit log
     configured via the ``AGENT_BOM_LOG`` environment variable.
     """
+    metrics: dict | None = None
     if _proxy_metrics is not None:
-        return _proxy_metrics
+        metrics = dict(_proxy_metrics)
+    else:
+        log_path = _get_configured_log_path()
+        if log_path:
+            metrics = _read_metrics_from_log(log_path)
+            if metrics is not None:
+                metrics = dict(metrics)
 
-    log_path = _get_configured_log_path()
-    if log_path:
-        metrics = _read_metrics_from_log(log_path)
-        if metrics is not None:
-            return metrics
+    if metrics is not None:
+        alert_summary = _summarize_proxy_alerts(_load_proxy_alerts())
+        metrics["alert_summary"] = {key: value for key, value in alert_summary.items() if key != "recent_alerts"}
+        metrics["recent_alerts"] = alert_summary["recent_alerts"]
+        return metrics
 
     return {
         "status": "no_proxy_session",
@@ -164,11 +214,7 @@ async def proxy_alerts(
         detector: Filter by detector name.
         limit: Maximum number of alerts to return (default 100).
     """
-    log_path = _get_configured_log_path()
-    if log_path and not _proxy_alerts:
-        alerts = _read_alerts_from_log(log_path)
-    else:
-        alerts = list(_proxy_alerts)
+    alerts = _load_proxy_alerts()
 
     # Apply filters
     if severity:
@@ -182,6 +228,7 @@ async def proxy_alerts(
     return {
         "alerts": alerts,
         "count": len(alerts),
+        "summary": _summarize_proxy_alerts(alerts),
         "filters": {
             "severity": severity,
             "detector": detector,

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -79,6 +79,10 @@ class SummaryEntry:
     replay_rejections: int
     relay_errors: int
     runtime_alerts: int
+    runtime_alerts_by_severity: dict = field(default_factory=dict)
+    runtime_alerts_by_detector: dict = field(default_factory=dict)
+    blocked_runtime_alerts: int = 0
+    latest_runtime_alert_at: str = ""
 
 
 @dataclass
@@ -152,6 +156,10 @@ def parse_audit_log(path: Path) -> AuditLog:
                 replay_rejections=entry.get("replay_rejections", 0),
                 relay_errors=entry.get("relay_errors", 0),
                 runtime_alerts=entry.get("runtime_alerts", 0),
+                runtime_alerts_by_severity=entry.get("runtime_alerts_by_severity", {}),
+                runtime_alerts_by_detector=entry.get("runtime_alerts_by_detector", {}),
+                blocked_runtime_alerts=entry.get("blocked_runtime_alerts", 0),
+                latest_runtime_alert_at=entry.get("latest_runtime_alert_at", ""),
             )
 
         elif "severity" in entry and "detector" in entry:
@@ -268,6 +276,13 @@ def display_rich(
             summary_lines.append("[bold]Top tools:[/bold] " + "  ".join(f"{t}×{c}" for t, c in top))
         if s.blocked_by_reason:
             summary_lines.append("[bold red]Blocked by:[/bold red] " + "  ".join(f"{r}×{c}" for r, c in s.blocked_by_reason.items()))
+        if s.runtime_alerts_by_severity:
+            summary_lines.append(
+                "[bold yellow]Alert severities:[/bold yellow] "
+                + "  ".join(f"{severity}×{count}" for severity, count in s.runtime_alerts_by_severity.items())
+            )
+        if s.latest_runtime_alert_at:
+            summary_lines.append(f"[bold]Latest alert:[/bold] {s.latest_runtime_alert_at[:19].replace('T', ' ')}")
 
         console.print(
             Panel(
@@ -387,6 +402,10 @@ def display_json(log: AuditLog) -> int:
             "latency": s.latency,
             "calls_by_tool": s.calls_by_tool,
             "blocked_by_reason": s.blocked_by_reason,
+            "runtime_alerts_by_severity": s.runtime_alerts_by_severity,
+            "runtime_alerts_by_detector": s.runtime_alerts_by_detector,
+            "blocked_runtime_alerts": s.blocked_runtime_alerts,
+            "latest_runtime_alert_at": s.latest_runtime_alert_at,
         }
         if s
         else None,

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -20,7 +20,7 @@ import os
 import re
 import sys
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -420,6 +420,34 @@ def log_tool_call(
 
     log_file.write(json.dumps(record) + "\n")
     log_file.flush()
+
+
+def summarize_runtime_alerts(alerts: list[dict]) -> dict[str, object]:
+    """Aggregate runtime alerts for audit-log summaries and status surfaces."""
+    severity_counts: Counter[str] = Counter()
+    detector_counts: Counter[str] = Counter()
+    blocked_alerts = 0
+
+    for alert in alerts:
+        severity = str(alert.get("severity", "unknown")).lower()
+        detector = str(alert.get("detector", "unknown"))
+        severity_counts[severity] += 1
+        detector_counts[detector] += 1
+        details = alert.get("details", {})
+        if isinstance(details, dict) and details.get("action") == "blocked":
+            blocked_alerts += 1
+
+    latest_ts = ""
+    if alerts:
+        latest_ts = max(str(alert.get("ts", "")) for alert in alerts)
+
+    return {
+        "runtime_alerts": len(alerts),
+        "runtime_alerts_by_severity": dict(sorted(severity_counts.items())),
+        "runtime_alerts_by_detector": dict(sorted(detector_counts.items())),
+        "blocked_runtime_alerts": blocked_alerts,
+        "latest_runtime_alert_at": latest_ts,
+    }
 
 
 def _truncate_args(args: dict, max_value_len: int = 200) -> dict:
@@ -1416,7 +1444,7 @@ async def run_proxy(
         # Write metrics summary + runtime alerts to audit log before closing
         if log_file:
             summary = metrics.summary()
-            summary["runtime_alerts"] = len(runtime_alerts)
+            summary.update(summarize_runtime_alerts(runtime_alerts))
             summary_line = json.dumps(summary) + "\n"
             log_file.write(summary_line)
             log_file.close()

--- a/src/agent_bom/runtime/protection.py
+++ b/src/agent_bom/runtime/protection.py
@@ -19,7 +19,7 @@ import json
 import logging
 import os
 import time
-from collections import deque
+from collections import Counter, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -409,6 +409,7 @@ class ProtectionEngine:
             ],
             "detectors_active": self._stats.detectors_active,
             "session_graph": self._session_graph.to_dict(),
+            "incident_summary": self._build_incident_summary(),
         }
         if self._shield:
             base["shield"] = {
@@ -421,6 +422,45 @@ class ProtectionEngine:
                 "alerts_in_window": self._count_window_alerts(),
             }
         return base
+
+    def _build_incident_summary(self) -> dict[str, object]:
+        """Aggregate runtime incidents into a compact API/UI-friendly summary."""
+        alert_nodes = [node for node in self._session_graph.nodes.values() if node.kind == "alert"]
+        severity_counts: Counter[str] = Counter()
+        detector_counts: Counter[str] = Counter()
+        recent_incidents: list[dict[str, object]] = []
+        blocked_incidents = 0
+
+        for node in sorted(alert_nodes, key=lambda item: item.first_seen, reverse=True):
+            metadata = node.metadata or {}
+            details = metadata.get("details", {})
+            if not isinstance(details, dict):
+                details = {}
+            severity = str(metadata.get("severity") or "unknown").lower()
+            detector = str(node.label or "unknown")
+            severity_counts[severity] += 1
+            detector_counts[detector] += 1
+            if details.get("action") == "blocked" or detector == "shield_killswitch":
+                blocked_incidents += 1
+            if len(recent_incidents) < 5:
+                recent_incidents.append(
+                    {
+                        "ts": node.first_seen,
+                        "detector": detector,
+                        "severity": severity,
+                        "message": metadata.get("message", ""),
+                        "action": details.get("action", ""),
+                    }
+                )
+
+        return {
+            "total_incidents": len(alert_nodes),
+            "blocked_incidents": blocked_incidents,
+            "alerts_by_severity": dict(sorted(severity_counts.items())),
+            "alerts_by_detector": dict(sorted(detector_counts.items())),
+            "latest_incident_at": recent_incidents[0]["ts"] if recent_incidents else "",
+            "recent_incidents": recent_incidents,
+        }
 
     def _record_tool_call_graph(self, tool_name: str, arguments: dict, agent_id: str = "") -> None:
         agent_key = f"agent:{agent_id or 'unknown'}"

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -54,6 +54,8 @@ def test_proxy_status_with_metrics():
     data = resp.json()
     assert data["total_tool_calls"] == 42
     assert data["total_blocked"] == 3
+    assert data["alert_summary"]["total_alerts"] == 0
+    assert data["recent_alerts"] == []
 
     # Cleanup
     proxy_mod._proxy_metrics = None
@@ -68,6 +70,12 @@ def test_proxy_status_from_log():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         f.write(json.dumps({"type": "tools/call", "tool": "read"}) + "\n")
         f.write(json.dumps({"type": "proxy_summary", "total_tool_calls": 10, "total_blocked": 1}) + "\n")
+        f.write(
+            json.dumps(
+                {"type": "runtime_alert", "detector": "cred", "severity": "critical", "message": "leak", "ts": "2026-03-24T10:00:00+00:00"}
+            )
+            + "\n"
+        )
         log_path = f.name
 
     old = os.environ.get("AGENT_BOM_LOG")
@@ -78,6 +86,8 @@ def test_proxy_status_from_log():
         assert resp.status_code == 200
         data = resp.json()
         assert data["total_tool_calls"] == 10
+        assert data["alert_summary"]["total_alerts"] == 1
+        assert data["alert_summary"]["alerts_by_severity"]["critical"] == 1
     finally:
         if old is not None:
             os.environ["AGENT_BOM_LOG"] = old
@@ -160,6 +170,8 @@ def test_proxy_alerts_with_data():
     assert resp.status_code == 200
     data = resp.json()
     assert data["count"] == 2
+    assert data["summary"]["total_alerts"] == 2
+    assert data["summary"]["alerts_by_severity"]["critical"] == 1
 
     # Cleanup
     proxy_mod._proxy_alerts.clear()

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -95,6 +95,10 @@ PROXY_SUMMARY = {
     "replay_rejections": 0,
     "relay_errors": 0,
     "runtime_alerts": 1,
+    "runtime_alerts_by_severity": {"critical": 1},
+    "runtime_alerts_by_detector": {"ToolDrift": 1},
+    "blocked_runtime_alerts": 0,
+    "latest_runtime_alert_at": "2026-03-09T10:00:02.000000+00:00",
 }
 
 
@@ -157,6 +161,8 @@ def test_parse_proxy_summary():
     assert s.total_blocked == 3
     assert s.uptime_seconds == 300.5
     assert s.latency["p95_ms"] == 150.0
+    assert s.runtime_alerts_by_severity["critical"] == 1
+    assert s.latest_runtime_alert_at == "2026-03-09T10:00:02.000000+00:00"
 
 
 def test_parse_full_log():

--- a/tests/test_protection_engine.py
+++ b/tests/test_protection_engine.py
@@ -61,6 +61,8 @@ def test_engine_status():
     assert "VectorDBInjectionDetector" in status["detectors"]
     assert "session_graph" in status
     assert status["session_graph"]["node_count"] == 0
+    assert "incident_summary" in status
+    assert status["incident_summary"]["total_incidents"] == 0
 
 
 # ─── Tool Call Processing ─────────────────────────────────────────────────────
@@ -152,6 +154,10 @@ def test_process_tool_response_credential_leak():
     assert any(node["kind"] == "alert" for node in graph["nodes"])
     assert any(event["kind"] == "tool_response" for event in graph["timeline"])
     assert any(event["kind"] == "alert" for event in graph["timeline"])
+    incident_summary = engine.status()["incident_summary"]
+    assert incident_summary["total_incidents"] >= 1
+    assert incident_summary["alerts_by_severity"]["critical"] >= 1
+    assert incident_summary["latest_incident_at"] != ""
 
 
 # ─── Tool Drift ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add runtime incident rollups to protection engine status
- expose proxy alert summaries and recent alerts in API status/alerts responses
- include runtime alert severity/detector summaries in proxy audit summaries and audit replay

## Validation
- pytest -q tests/test_protection_engine.py tests/test_api_proxy_scorecard.py tests/test_audit_replay.py tests/test_proxy.py tests/test_proxy_cov.py tests/test_ocsf.py tests/test_output_formats.py
- python -m compileall src/agent_bom