### PR TITLE
Gate release images with documented base CVE exceptions

### DIFF
--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -40,6 +40,7 @@ jobs:
           format: table
           severity: HIGH,CRITICAL
           exit-code: "1"
+          trivyignores: .trivyignore
         continue-on-error: true
 
       - name: Trivy scan — SARIF
@@ -50,6 +51,7 @@ jobs:
           output: trivy-${{ matrix.sarif_category }}.sarif
           severity: HIGH,CRITICAL
           exit-code: "0"
+          trivyignores: .trivyignore
 
       - name: Upload SARIF to GitHub Security tab
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
   pypi-publish:
     name: Publish to PyPI
-    needs: [build, self-scan-gate]
+    needs: [build, self-scan-gate, container-gate]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -63,7 +63,7 @@ jobs:
 
   docker-publish:
     name: Publish to Docker Hub
-    needs: [build, self-scan-gate]
+    needs: [build, self-scan-gate, container-gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -155,6 +155,30 @@ jobs:
               "https://hub.docker.com/v2/repositories/${REPO}/tags/${tag}" \
               -H "Authorization: Bearer $TOKEN" || true
           done
+
+  container-gate:
+    name: Container release gate
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build release candidate image
+        run: docker build -t agent-bom:release-test .
+
+      - name: Smoke test release image
+        run: docker run --rm agent-bom:release-test --version
+
+      - name: Trivy image scan gate
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: agent-bom:release-test
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          trivyignores: .trivyignore
 
   self-scan-gate:
     name: Self-scan release gate

--- a/.trivyignore
+++ b/.trivyignore
@@ -8,3 +8,12 @@
 # Blocked by: snowflake-connector-python requires pyopenssl<26.0.0
 # Revisit: when snowflake-connector-python releases support for pyopenssl>=26.0.0
 CVE-2026-27459
+
+# Debian ncurses base-image issue inherited from python:3.12.13-slim.
+# Docker Scout surfaced CVE-2025-69720 against debian/ncurses 6.5+20250216-2;
+# Debian's security tracker currently exposes the ncurses issue on this base
+# lineage as CVE-2025-6141, with no patched trixie/bookworm package available
+# as of 2026-03-24. Revisit on every base digest refresh and remove as soon as
+# Debian publishes a fixed ncurses package in the supported suite.
+CVE-2025-69720
+CVE-2025-6141


### PR DESCRIPTION
## Summary
- document the current Debian ncurses base-image exception in .trivyignore
- apply the same exception file to scheduled container rescans
- add a container release gate so Docker publishes are blocked by any non-allowlisted HIGH/CRITICAL image CVEs

## Why
Debian has not yet published a patched ncurses package for the current base-image lineage, so this PR formalizes the temporary exception while still blocking new container vulnerabilities from reaching release.

## Validation
- python - <<'PY'
import yaml
for path in ['.github/workflows/container-rescan.yml', '.github/workflows/release.yml']:
    with open(path) as f:
        yaml.safe_load(f)
print('yaml ok')
PY