### PR TITLE
Align OS package trust across check, DB, and image scans

### DIFF
--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -10,6 +10,7 @@ import click
 from rich.console import Console
 
 from agent_bom import __version__
+from agent_bom.ecosystems import SUPPORTED_PACKAGE_ECOSYSTEMS
 
 
 def _detect_ecosystem(name: str) -> Optional[str]:
@@ -86,7 +87,7 @@ def _parse_package_spec(
 @click.option(
     "--ecosystem",
     "-e",
-    type=click.Choice(["npm", "pypi", "go", "cargo", "maven", "nuget"]),
+    type=click.Choice(SUPPORTED_PACKAGE_ECOSYSTEMS),
     help="Package ecosystem (inferred from name/command if omitted)",
 )
 @click.option("--quiet", "-q", is_flag=True, help="Only print vuln count, no details")
@@ -98,21 +99,22 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
     Examples:
       agent-bom check express@4.18.2 --ecosystem npm
       agent-bom check requests@2.28.0 --ecosystem pypi
+      agent-bom check ncurses-bin@6.5+20250216-2 --ecosystem deb
       agent-bom check "npx @modelcontextprotocol/server-filesystem"
 
     \b
     Exit codes:
       0  Clean — no known vulnerabilities
       1  Unsafe — vulnerabilities found
+      2  Incomplete — OS package context insufficient for a trustworthy verdict
     """
-    import asyncio
-
     console = Console(no_color=no_color)
 
     name, version, detected_eco = _parse_package_spec(package_spec, ecosystem)
 
-    from agent_bom.models import Package, normalize_package_name
-    from agent_bom.scanners import build_vulnerabilities, query_osv_batch
+    from agent_bom.models import Package
+    from agent_bom.parsers.os_parsers import enrich_os_package_context
+    from agent_bom.scanners import scan_packages
 
     if version == "unknown":
         console.print(f"[yellow]⚠ No version specified for {name} — skipping OSV lookup.[/yellow]")
@@ -120,12 +122,18 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
         sys.exit(0)
 
     # Scan both pypi+npm for ambiguous packages (no dots, no underscores, no @)
-    # This catches packages like lodash that exist on both registries
+    # This catches packages like lodash that exist on both registries.
+    # OS package ecosystems must be explicit to avoid silently inventing a
+    # registry-backed meaning for distro package names.
     if not ecosystem and not name.startswith("@") and "." not in name and "_" not in name:
         ecosystems: list[str] = ["pypi", "npm"]
     else:
         ecosystems = [detected_eco]
     pkgs = [Package(name=name, version=version, ecosystem=eco) for eco in ecosystems]
+    os_context_complete = True
+    for pkg in pkgs:
+        if pkg.ecosystem in {"deb", "apk", "rpm"}:
+            os_context_complete = enrich_os_package_context(pkg) and os_context_complete
 
     # Resolve "latest" / empty version from registry
     if version in ("latest", ""):
@@ -140,6 +148,8 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
                 return False
 
         with console.status("[bold]Resolving version from registry...[/bold]", spinner="dots"):
+            import asyncio
+
             resolved = asyncio.run(_resolve())
         if resolved:
             version = next((p.version for p in pkgs if p.version not in ("unknown", "latest", "")), version)
@@ -155,27 +165,25 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
     eco_display = "/".join(ecosystems)
     console.print(f"\n[bold blue]🔍 Checking {name}@{version} ({eco_display})[/bold blue]\n")
 
-    with console.status("[bold]Querying OSV...[/bold]", spinner="dots"):
-        results = asyncio.run(query_osv_batch(pkgs))
+    with console.status("[bold]Scanning package risk...[/bold]", spinner="dots"):
+        import asyncio
 
-    # Merge results from all ecosystems
-    vuln_data: list[dict] = []
-    matched_eco = ecosystems[0]
-    for eco in ecosystems:
-        key = f"{eco}:{normalize_package_name(name, eco)}@{version}"
-        eco_vulns = results.get(key, [])
-        if eco_vulns:
-            vuln_data.extend(eco_vulns)
-            matched_eco = eco
+        asyncio.run(scan_packages(pkgs))
 
-    ecosystem = matched_eco
-    pkg = Package(name=name, version=version, ecosystem=ecosystem)
+    matched_pkg = next((p for p in pkgs if p.vulnerabilities), pkgs[0])
+    vulns = matched_pkg.vulnerabilities
 
-    if not vuln_data:
+    if not vulns and matched_pkg.ecosystem in {"deb", "apk", "rpm"} and not os_context_complete:
+        console.print(f"  [yellow]⚠ Incomplete OS package context for {name}@{version}[/yellow]")
+        console.print(
+            "  Best-effort matching found no vulnerabilities, but source/distro metadata was "
+            "insufficient for a trustworthy clean verdict.\n"
+        )
+        sys.exit(2)
+
+    if not vulns:
         console.print(f"  [green]✓ No known vulnerabilities in {name}@{version}[/green]\n")
         sys.exit(0)
-
-    vulns = build_vulnerabilities(vuln_data, pkg)
 
     if not quiet:
         from rich.table import Table

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -3,8 +3,9 @@
 The primary query pattern is:
     vulns = lookup_package(conn, ecosystem="PyPI", name="requests", version="2.0.0")
 
-Version range matching uses a simple string comparison (semver-like).
-For precise semver ordering the caller should use packaging.version.Version.
+Version range matching uses the shared ecosystem-aware comparator from
+``agent_bom.version_utils`` so Debian, Alpine, and RPM advisories use the
+same semantics as CLI, image, and OSV scans.
 """
 
 from __future__ import annotations
@@ -78,7 +79,7 @@ def lookup_package(
 
     results: list[LocalVuln] = []
     for row in rows:
-        if version and not _version_affected(version, row["introduced"], row["fixed"], row["last_affected"]):
+        if version and not _version_affected(version, row["introduced"], row["fixed"], row["last_affected"], row["ecosystem"]):
             continue
         # Parse comma-separated CWE IDs from DB column
         raw_cwes = row["cwe_ids"] or ""
@@ -115,103 +116,12 @@ def _version_affected(
     introduced: Optional[str],
     fixed: Optional[str],
     last_affected: Optional[str],
+    ecosystem: str = "",
 ) -> bool:
-    """Semantic version-in-range check.
+    """Ecosystem-aware version-in-range check."""
+    from agent_bom.version_utils import version_in_range
 
-    Returns True when ``version`` is in [introduced, fixed) or [introduced, last_affected].
-    Empty/None introduced means "since beginning of time" (all earlier versions).
-    Empty/None fixed means "no fix yet" (all later versions affected).
-
-    When range boundaries are unparseable (e.g. git commit hashes from OSV GIT
-    ranges), the advisory is skipped (return False) to avoid false positives.
-    Lexicographic comparison is only used when the installed version itself is
-    non-standard (e.g. a nightly tag).
-    """
-    # Normalise: empty string = None
-    intro = introduced or None
-    fix = fixed or None
-    last = last_affected or None
-
-    import re
-
-    from packaging.version import InvalidVersion, Version
-
-    _go_pseudo_re = re.compile(r"^v\d+\.\d+\.\d+-(\d{14})-[0-9a-f]{12}$")
-
-    def _is_commit_sha(v: str) -> bool:
-        """Detect git commit SHAs that leaked from OSV data as version boundaries."""
-        return bool(re.fullmatch(r"[0-9a-f]{40}", v))
-
-    def _go_pseudo_timestamp(v: str) -> str | None:
-        """Extract YYYYMMDDHHMMSS timestamp from Go pseudo-version for comparison."""
-        m = _go_pseudo_re.match(v)
-        return m.group(1) if m else None
-
-    def _try_parse(v: str) -> Version | None:
-        """Parse a version string, returning None for commit SHAs or unparseable values."""
-        if _is_commit_sha(v):
-            return None  # Not a version boundary — skip silently
-        try:
-            return Version(v)
-        except InvalidVersion:
-            return None
-
-    # Go pseudo-version comparison (v0.0.0-YYYYMMDDHHMMSS-abcdef123456)
-    # These encode timestamps — compare by timestamp, not semver.
-    ver_ts = _go_pseudo_timestamp(version)
-    if ver_ts:
-        for boundary, is_lower in [(intro, True), (fix, False), (last, False)]:
-            if not boundary:
-                continue
-            bnd_ts = _go_pseudo_timestamp(boundary)
-            if bnd_ts:
-                if is_lower and ver_ts < bnd_ts:
-                    return False  # installed predates introduced
-                if not is_lower and boundary == fix and ver_ts >= bnd_ts:
-                    return False  # installed at or after fix
-                if not is_lower and boundary == last and ver_ts > bnd_ts:
-                    return False  # installed after last_affected
-        return True  # within affected range or boundaries are non-pseudo
-
-    # Try to parse the installed version first
-    try:
-        ver = Version(version)
-    except InvalidVersion:
-        # Installed version is non-standard — fall back to lexicographic
-        _logger.debug("Non-standard installed version %r, falling back to lexicographic", version)
-        if intro and version < intro:
-            return False
-        if fix and not _is_commit_sha(fix) and version >= fix:
-            return False
-        if last and not _is_commit_sha(last) and version > last:
-            return False
-        return True
-
-    # Installed version is valid semver — compare each boundary individually.
-    # Skip boundaries that are commit SHAs or unparseable (prevents false positives).
-    if intro:
-        intro_ver = _try_parse(intro)
-        if intro_ver is not None and ver < intro_ver:
-            return False
-
-    if fix:
-        fix_ver = _try_parse(fix)
-        if fix_ver is not None:
-            if ver >= fix_ver:
-                return False
-        elif not _is_commit_sha(fix):
-            # Non-SHA, non-parseable (e.g., "canary") — log but don't assume affected
-            _logger.debug("Skipping unparseable fixed version %r for %r", fix, version)
-
-    if last:
-        last_ver = _try_parse(last)
-        if last_ver is not None:
-            if ver > last_ver:
-                return False
-        elif not _is_commit_sha(last):
-            _logger.debug("Skipping unparseable last_affected %r for %r", last, version)
-
-    return True
+    return version_in_range(version, introduced, fixed, last_affected, ecosystem)
 
 
 def lookup_packages_batch(
@@ -285,7 +195,7 @@ def lookup_packages_batch(
 
         vulns: list[LocalVuln] = []
         for row in rows:
-            if version and not _version_affected(version, row["introduced"], row["fixed"], row["last_affected"]):
+            if version and not _version_affected(version, row["introduced"], row["fixed"], row["last_affected"], row["ecosystem"]):
                 continue
             raw_cwes = row["cwe_ids"] or ""
             cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []

--- a/src/agent_bom/ecosystems.py
+++ b/src/agent_bom/ecosystems.py
@@ -1,0 +1,23 @@
+"""Shared package ecosystem constants."""
+
+from __future__ import annotations
+
+SUPPORTED_PACKAGE_ECOSYSTEMS: tuple[str, ...] = (
+    "npm",
+    "pypi",
+    "go",
+    "cargo",
+    "maven",
+    "nuget",
+    "rubygems",
+    "composer",
+    "swift",
+    "pub",
+    "hex",
+    "conda",
+    "deb",
+    "apk",
+    "rpm",
+)
+
+SUPPORTED_PACKAGE_ECOSYSTEM_SET = frozenset(SUPPORTED_PACKAGE_ECOSYSTEMS)

--- a/src/agent_bom/filesystem.py
+++ b/src/agent_bom/filesystem.py
@@ -31,7 +31,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from agent_bom.models import Package
+from agent_bom.models import Package, parse_debian_source_name
 from agent_bom.sbom import parse_cyclonedx
 from agent_bom.security import validate_path
 
@@ -40,6 +40,26 @@ logger = logging.getLogger(__name__)
 
 class FilesystemScanError(Exception):
     """Raised when a filesystem path cannot be scanned."""
+
+
+def read_os_release_metadata(root: Path) -> tuple[str | None, str | None]:
+    """Read distro ``ID`` and ``VERSION_ID`` from ``etc/os-release``."""
+    os_release = root / "etc" / "os-release"
+    if not os_release.exists():
+        return None, None
+
+    distro_name: str | None = None
+    distro_version: str | None = None
+    try:
+        for line in os_release.read_text(errors="replace").splitlines():
+            if line.startswith("ID="):
+                distro_name = line.split("=", 1)[1].strip().strip('"').strip("'").lower() or None
+            elif line.startswith("VERSION_ID="):
+                distro_version = line.split("=", 1)[1].strip().strip('"').strip("'") or None
+    except OSError:
+        return None, None
+
+    return distro_name, distro_version
 
 
 def detect_linux_distro(root: Path) -> str:
@@ -55,20 +75,8 @@ def detect_linux_distro(root: Path) -> str:
     Returns:
         Lowercase distro identifier string.
     """
-    os_release = root / "etc" / "os-release"
-    if not os_release.exists():
-        return "linux"
-
-    try:
-        for line in os_release.read_text(errors="replace").splitlines():
-            if line.startswith("ID="):
-                # ID may be quoted: ID="rocky" or ID=alpine
-                value = line.split("=", 1)[1].strip().strip('"').strip("'")
-                return value.lower() if value else "linux"
-    except OSError:
-        pass
-
-    return "linux"
+    distro_name, _distro_version = read_os_release_metadata(root)
+    return distro_name or "linux"
 
 
 # ── Syft-based scanning ───────────────────────────────────────────────────────
@@ -197,6 +205,7 @@ def parse_dpkg_status(status_file: Path) -> list[Package]:
                 if "install ok installed" in status:
                     name = current["Package"]
                     version = current["Version"]
+                    source_package = parse_debian_source_name(current.get("Source", ""))
                     # Strip epoch prefix (e.g. "1:2.3.4" → "2.3.4")
                     version = re.sub(r"^\d+:", "", version)
                     packages.append(
@@ -205,6 +214,7 @@ def parse_dpkg_status(status_file: Path) -> list[Package]:
                             version=version,
                             ecosystem="deb",
                             purl=f"pkg:deb/debian/{name}@{version}",
+                            source_package=source_package,
                             is_direct=True,
                         )
                     )
@@ -493,6 +503,7 @@ def scan_disk_path_native(root: Path) -> list[Package]:
         Deduplicated list of :class:`~agent_bom.models.Package` objects.
     """
     packages: list[Package] = []
+    distro_name, distro_version = read_os_release_metadata(root)
 
     # APT / Debian
     dpkg_status = root / "var" / "lib" / "dpkg" / "status"
@@ -561,6 +572,9 @@ def scan_disk_path_native(root: Path) -> list[Package]:
     seen: set[tuple[str, str, str]] = set()
     unique: list[Package] = []
     for pkg in packages:
+        if pkg.ecosystem in {"deb", "apk", "rpm"}:
+            pkg.distro_name = pkg.distro_name or distro_name
+            pkg.distro_version = pkg.distro_version or distro_version
         key = (pkg.name, pkg.version, pkg.ecosystem)
         if key not in seen:
             seen.add(key)

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -58,6 +58,7 @@ from pydantic import Field
 
 from agent_bom.config import MCP_MAX_FILE_SIZE as _MAX_FILE_SIZE
 from agent_bom.config import MCP_MAX_RESPONSE_CHARS as _MAX_RESPONSE_CHARS
+from agent_bom.ecosystems import SUPPORTED_PACKAGE_ECOSYSTEM_SET
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,7 @@ logger = logging.getLogger(__name__)
 # Input validation helpers
 # ---------------------------------------------------------------------------
 
-_VALID_ECOSYSTEMS = frozenset({"npm", "pypi", "go", "cargo", "maven", "nuget", "rubygems"})
+_VALID_ECOSYSTEMS = SUPPORTED_PACKAGE_ECOSYSTEM_SET
 
 _CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
 _GHSA_RE = re.compile(r"^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$", re.IGNORECASE)

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -182,7 +182,8 @@ async def check_impl(
     """Implementation of the check tool."""
     try:
         from agent_bom.models import Package as Pkg
-        from agent_bom.scanners import build_vulnerabilities, query_osv_batch
+        from agent_bom.parsers.os_parsers import enrich_os_package_context
+        from agent_bom.scanners import scan_packages
 
         # Parse name@version
         spec = package.strip()
@@ -199,6 +200,18 @@ async def check_impl(
         except ValueError as exc:
             raise ToolError(sanitize_error(exc)) from exc
         pkg = Pkg(name=name, version=version, ecosystem=eco)
+        os_context_complete = True
+        if eco in {"deb", "apk", "rpm"}:
+            os_context_complete = enrich_os_package_context(pkg)
+
+        if eco in {"deb", "apk", "rpm"} and version in ("latest", ""):
+            return json.dumps(
+                {
+                    "package": name,
+                    "ecosystem": eco,
+                    "error": f"Explicit version required for {eco} packages",
+                }
+            )
 
         # Resolve "latest" via registry
         if version in ("latest", ""):
@@ -218,11 +231,24 @@ async def check_impl(
                     }
                 )
 
-        results = await query_osv_batch([pkg])
-        key = f"{eco}:{name}@{version}"
-        vuln_data = results.get(key, [])
+        await scan_packages([pkg])
 
-        if not vuln_data:
+        if not pkg.vulnerabilities and eco in {"deb", "apk", "rpm"} and not os_context_complete:
+            return json.dumps(
+                {
+                    "package": name,
+                    "version": version,
+                    "ecosystem": eco,
+                    "vulnerabilities": 0,
+                    "status": "incomplete",
+                    "message": "OS package context was insufficient for a trustworthy clean verdict",
+                    "source_package": pkg.source_package,
+                    "distro_name": pkg.distro_name,
+                    "distro_version": pkg.distro_version,
+                }
+            )
+
+        if not pkg.vulnerabilities:
             return json.dumps(
                 {
                     "package": name,
@@ -234,7 +260,7 @@ async def check_impl(
                 }
             )
 
-        vulns = build_vulnerabilities(vuln_data, pkg)
+        vulns = pkg.vulnerabilities
         return _truncate_response(
             json.dumps(
                 {

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -37,6 +37,16 @@ def normalize_package_name(name: str, ecosystem: str = "") -> str:
     return name.lower()
 
 
+def parse_debian_source_name(source_field: str) -> Optional[str]:
+    """Extract the Debian source package name from a ``Source:`` field."""
+    if not source_field:
+        return None
+    source_name = source_field.split("(", 1)[0].strip()
+    if source_name.startswith("${") and source_name.endswith("}"):
+        return None
+    return source_name or None
+
+
 class Severity(str, Enum):
     CRITICAL = "critical"
     HIGH = "high"
@@ -199,6 +209,9 @@ class Package:
     version: str
     ecosystem: str  # npm, pypi, cargo, go, etc.
     purl: Optional[str] = None  # Package URL
+    source_package: Optional[str] = None  # Debian/OS source package name for advisory matching
+    distro_name: Optional[str] = None  # OS distribution family for OS packages (e.g. debian, ubuntu, alpine)
+    distro_version: Optional[str] = None  # OS distribution version for OS packages (e.g. 13, 24.04, 3.21)
     vulnerabilities: list[Vulnerability] = field(default_factory=list)
     is_direct: bool = True  # vs transitive dependency
     parent_package: Optional[str] = None  # Name of parent package (for transitive deps)
@@ -249,6 +262,16 @@ class Package:
         purl = self.purl or f"pkg:{self.ecosystem}/{self.name}@{self.version}"
         fingerprint = f"package:{purl.lower().strip()}"
         return str(_uuid.uuid5(_ns, fingerprint))
+
+    @property
+    def lookup_names(self) -> list[str]:
+        """Candidate package names for vulnerability matching."""
+        names = [self.name]
+        if self.source_package:
+            source_name = self.source_package.strip()
+            if source_name and normalize_package_name(source_name, self.ecosystem) != normalize_package_name(self.name, self.ecosystem):
+                names.append(source_name)
+        return names
 
     @property
     def has_vulnerabilities(self) -> bool:

--- a/src/agent_bom/oci_parser.py
+++ b/src/agent_bom/oci_parser.py
@@ -44,7 +44,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from agent_bom.models import Package
+from agent_bom.models import Package, parse_debian_source_name
 
 _logger = logging.getLogger(__name__)
 
@@ -189,6 +189,33 @@ def _add_package(
         )
 
 
+def _read_os_release_from_layer(layer_tf: tarfile.TarFile, deleted_paths: set[str]) -> tuple[str | None, str | None]:
+    """Read distro metadata from ``etc/os-release`` inside a layer."""
+    for os_release_path in ("etc/os-release", "./etc/os-release"):
+        if os_release_path in deleted_paths:
+            continue
+        try:
+            member = layer_tf.getmember(os_release_path)
+        except KeyError:
+            continue
+        try:
+            f = layer_tf.extractfile(member)
+            if f is None:
+                continue
+            distro_name: str | None = None
+            distro_version: str | None = None
+            for raw_line in f:
+                line = raw_line.decode("utf-8", errors="ignore").strip()
+                if line.startswith("ID="):
+                    distro_name = line.split("=", 1)[1].strip().strip('"').strip("'").lower() or None
+                elif line.startswith("VERSION_ID="):
+                    distro_version = line.split("=", 1)[1].strip().strip('"').strip("'") or None
+            return distro_name, distro_version
+        except Exception:
+            _logger.debug("Failed to parse os-release: %s", os_release_path)
+    return None, None
+
+
 def _extract_packages_from_layer(
     layer_tf: tarfile.TarFile,
     seen: set[tuple[str, str]],
@@ -287,17 +314,47 @@ def _extract_packages_from_layer(
             if f:
                 content = f.read().decode("utf-8", errors="ignore")
                 pkg_name = pkg_version = ""
+                source_package: str | None = None
                 for line in content.splitlines():
                     if line.startswith("Package:"):
                         pkg_name = line.split(":", 1)[1].strip()
                     elif line.startswith("Version:"):
                         pkg_version = line.split(":", 1)[1].strip()
+                    elif line.startswith("Source:"):
+                        source_package = parse_debian_source_name(line.split(":", 1)[1].strip())
                     elif line == "" and pkg_name and pkg_version:
-                        _add_package(seen, packages, pkg_name, pkg_version, "deb", f"pkg:deb/debian/{pkg_name}@{pkg_version}")
+                        key = (pkg_name.lower(), "deb")
+                        if key not in seen:
+                            seen.add(key)
+                            packages.append(
+                                Package(
+                                    name=pkg_name,
+                                    version=pkg_version,
+                                    ecosystem="deb",
+                                    purl=f"pkg:deb/debian/{pkg_name}@{pkg_version}",
+                                    is_direct=False,
+                                    resolved_from_registry=False,
+                                    source_package=source_package,
+                                )
+                            )
                         pkg_name = pkg_version = ""
+                        source_package = None
                 # Flush last entry
                 if pkg_name and pkg_version:
-                    _add_package(seen, packages, pkg_name, pkg_version, "deb", f"pkg:deb/debian/{pkg_name}@{pkg_version}")
+                    key = (pkg_name.lower(), "deb")
+                    if key not in seen:
+                        seen.add(key)
+                        packages.append(
+                            Package(
+                                name=pkg_name,
+                                version=pkg_version,
+                                ecosystem="deb",
+                                purl=f"pkg:deb/debian/{pkg_name}@{pkg_version}",
+                                is_direct=False,
+                                resolved_from_registry=False,
+                                source_package=source_package,
+                            )
+                        )
         except Exception:
             _logger.debug("Failed to parse dpkg status")
         break
@@ -625,6 +682,8 @@ def _parse_layers_from_tarball(
     seen: set[tuple[str, str]] = set()
     packages: list[Package] = []
     warnings: list[str] = []
+    detected_distro_name: str | None = None
+    detected_distro_version: str | None = None
 
     # First pass: collect all whiteouts per layer (in order)
     # Then second pass: extract packages respecting accumulated deletions.
@@ -662,11 +721,22 @@ def _parse_layers_from_tarball(
             continue
         try:
             with tarfile.open(fileobj=io.BytesIO(layer_bytes), mode="r:*") as layer_tf:
+                layer_distro_name, layer_distro_version = _read_os_release_from_layer(layer_tf, all_deleted)
+                if layer_distro_name:
+                    detected_distro_name = layer_distro_name
+                if layer_distro_version:
+                    detected_distro_version = layer_distro_version
                 whiteouts = _extract_packages_from_layer(layer_tf, seen, packages, all_deleted)
                 all_deleted.update(whiteouts)
         except tarfile.TarError as e:
             warnings.append(f"Failed to read layer {layer_path}: {e}")
             continue
+
+    if detected_distro_name or detected_distro_version:
+        for pkg in packages:
+            if pkg.ecosystem in {"deb", "apk", "rpm"}:
+                pkg.distro_name = pkg.distro_name or detected_distro_name
+                pkg.distro_version = pkg.distro_version or detected_distro_version
 
     return packages, warnings
 

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -304,6 +304,9 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                         "version": pkg.version,
                         "ecosystem": pkg.ecosystem,
                         "purl": pkg.purl,
+                        "source_package": pkg.source_package,
+                        "distro_name": pkg.distro_name,
+                        "distro_version": pkg.distro_version,
                         "vulnerability_count": len(pkg.vulnerabilities),
                     }
                 if pkg.stable_id not in servers[server.stable_id]["package_ids"]:
@@ -481,6 +484,9 @@ def to_json(report: AIBOMReport) -> dict:
                                 "version": pkg.version,
                                 "ecosystem": pkg.ecosystem,
                                 "purl": pkg.purl,
+                                "source_package": pkg.source_package,
+                                "distro_name": pkg.distro_name,
+                                "distro_version": pkg.distro_version,
                                 "is_direct": pkg.is_direct,
                                 "parent_package": pkg.parent_package,
                                 "dependency_depth": pkg.dependency_depth,

--- a/src/agent_bom/parsers/os_parsers.py
+++ b/src/agent_bom/parsers/os_parsers.py
@@ -6,10 +6,67 @@ import logging
 import re
 import subprocess
 from pathlib import Path
+from typing import Optional
 
-from agent_bom.models import Package
+from agent_bom.filesystem import read_os_release_metadata
+from agent_bom.models import Package, parse_debian_source_name
 
 _logger = logging.getLogger(__name__)
+
+
+def enrich_os_package_context(pkg: Package, root: Path = Path("/")) -> bool:
+    """Best-effort enrichment of distro/source context for a single OS package.
+
+    Returns True when the resulting package has enough context to make a
+    high-confidence advisory match for its ecosystem.
+    """
+    distro_name, distro_version = read_os_release_metadata(root)
+    pkg.distro_name = pkg.distro_name or distro_name
+    pkg.distro_version = pkg.distro_version or distro_version
+
+    if pkg.ecosystem == "deb":
+        pkg.source_package = pkg.source_package or _resolve_debian_source_package(pkg.name)
+        return bool(pkg.distro_version and pkg.source_package)
+    if pkg.ecosystem == "apk":
+        return bool(pkg.distro_version)
+    if pkg.ecosystem == "rpm":
+        return bool(pkg.distro_name or pkg.distro_version)
+    return True
+
+
+def _resolve_debian_source_package(package_name: str) -> Optional[str]:
+    """Resolve Debian source package for a binary package name when possible."""
+    try:
+        result = subprocess.run(
+            ["dpkg-query", "-W", "-f=${source:Package}\\n", package_name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            source_package = parse_debian_source_name(result.stdout.strip())
+            if source_package:
+                return source_package
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    try:
+        result = subprocess.run(
+            ["apt-cache", "show", package_name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if line.startswith("Source:"):
+                    source_package = parse_debian_source_name(line.split(":", 1)[1].strip())
+                    if source_package:
+                        return source_package
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return None
 
 
 def parse_dpkg_packages(root: Path = Path("/")) -> list[Package]:
@@ -32,7 +89,7 @@ def parse_dpkg_packages(root: Path = Path("/")) -> list[Package]:
     # Method 1: dpkg-query (live system, installed-only, clean output)
     try:
         result = subprocess.run(
-            ["dpkg-query", "-W", "-f=${Package}\t${Version}\t${Architecture}\n"],
+            ["dpkg-query", "-W", "-f=${Package}\t${Version}\t${source:Package}\n"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -41,12 +98,14 @@ def parse_dpkg_packages(root: Path = Path("/")) -> list[Package]:
             for line in result.stdout.splitlines():
                 parts = line.strip().split("\t")
                 if len(parts) >= 2 and parts[0] and parts[1]:
+                    source_package = parse_debian_source_name(parts[2]) if len(parts) >= 3 else None
                     packages.append(
                         Package(
                             name=parts[0],
                             version=parts[1],
                             ecosystem="deb",
                             purl=f"pkg:deb/debian/{parts[0]}@{parts[1]}",
+                            source_package=source_package,
                         )
                     )
             if packages:
@@ -89,11 +148,14 @@ def _parse_dpkg_status_file(path: Path, packages: list[Package]) -> None:
         return
 
     pkg_name = pkg_version = ""
+    source_package: str | None = None
     for line in content.splitlines():
         if line.startswith("Package:"):
             pkg_name = line.split(":", 1)[1].strip()
         elif line.startswith("Version:"):
             pkg_version = line.split(":", 1)[1].strip()
+        elif line.startswith("Source:"):
+            source_package = parse_debian_source_name(line.split(":", 1)[1].strip())
         elif line == "" and pkg_name and pkg_version:
             packages.append(
                 Package(
@@ -101,9 +163,11 @@ def _parse_dpkg_status_file(path: Path, packages: list[Package]) -> None:
                     version=pkg_version,
                     ecosystem="deb",
                     purl=f"pkg:deb/debian/{pkg_name}@{pkg_version}",
+                    source_package=source_package,
                 )
             )
             pkg_name = pkg_version = ""
+            source_package = None
 
     # Handle last stanza without a trailing blank line
     if pkg_name and pkg_version:
@@ -113,6 +177,7 @@ def _parse_dpkg_status_file(path: Path, packages: list[Package]) -> None:
                 version=pkg_version,
                 ecosystem="deb",
                 purl=f"pkg:deb/debian/{pkg_name}@{pkg_version}",
+                source_package=source_package,
             )
         )
 
@@ -282,20 +347,29 @@ def scan_os_packages(root: Path = Path("/")) -> list[Package]:
         Deduplicated list of :class:`~agent_bom.models.Package` objects with
         ``ecosystem`` set to ``"deb"``, ``"rpm"``, or ``"apk"``.
     """
+    distro_name, distro_version = read_os_release_metadata(root)
+
+    def _apply_distro(packages: list[Package]) -> list[Package]:
+        for pkg in packages:
+            if pkg.ecosystem in {"deb", "apk", "rpm"}:
+                pkg.distro_name = pkg.distro_name or distro_name
+                pkg.distro_version = pkg.distro_version or distro_version
+        return packages
+
     os_type = detect_os_type(root)
     if os_type == "deb":
-        return parse_dpkg_packages(root)
+        return _apply_distro(parse_dpkg_packages(root))
     if os_type == "rpm":
-        return parse_rpm_packages(root)
+        return _apply_distro(parse_rpm_packages(root))
     if os_type == "apk":
-        return parse_apk_packages(root)
+        return _apply_distro(parse_apk_packages(root))
 
     # Unknown OS — try all parsers and return the first successful result
     for fn in (parse_dpkg_packages, parse_rpm_packages, parse_apk_packages):
         try:
             pkgs = fn(root)
             if pkgs:
-                return pkgs
+                return _apply_distro(pkgs)
         except Exception:  # noqa: BLE001
             continue
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -93,7 +93,9 @@ ECOSYSTEM_MAP = {
     "hex": "Hex",
     # conda packages are pip-installable and tracked under PyPI in OSV
     "conda": "PyPI",
-    # OS package ecosystems (native dpkg/rpm/apk parsers in filesystem.py)
+    # OS package ecosystems are distro-versioned in OSV, so query_osv_batch
+    # resolves them dynamically from package distro metadata rather than using
+    # these flat placeholders directly.
     "deb": "Debian",
     "apk": "Alpine",
     # RPM covers RHEL, CentOS, Fedora, Rocky, Alma — OSV "Linux" is the
@@ -120,6 +122,41 @@ _NON_OSV_ECOSYSTEMS: frozenset[str] = frozenset(
         "unknown",  # Packages with unresolvable ecosystem (e.g. --sbom ingest)
     }
 )
+
+_DEBIAN_OSV_FALLBACKS = ("Debian:11", "Debian:12", "Debian:13", "Debian:14")
+_ALPINE_OSV_FALLBACKS = ("Alpine:v3.18", "Alpine:v3.19", "Alpine:v3.20", "Alpine:v3.21", "Alpine:v3.22")
+
+
+def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
+    """Return one or more OSV ecosystem identifiers for a package."""
+    eco_key = pkg.ecosystem.lower()
+
+    if eco_key == "deb":
+        distro_name = (pkg.distro_name or "").lower()
+        distro_version = (pkg.distro_version or "").strip()
+        if distro_name == "debian" and distro_version:
+            return [f"Debian:{distro_version.split('.', 1)[0]}"]
+        if distro_name == "ubuntu" and distro_version:
+            normalized = distro_version
+            if normalized.count(".") == 1:
+                return [f"Ubuntu:{normalized}:LTS", f"Ubuntu:{normalized}"]
+            return [f"Ubuntu:{normalized}"]
+        return list(_DEBIAN_OSV_FALLBACKS)
+
+    if eco_key == "apk":
+        distro_version = (pkg.distro_version or "").strip()
+        if distro_version:
+            normalized = distro_version if distro_version.startswith("v") else f"v{distro_version}"
+            return [f"Alpine:{normalized}"]
+        return list(_ALPINE_OSV_FALLBACKS)
+
+    osv_ecosystem = ECOSYSTEM_MAP.get(eco_key)
+    return [osv_ecosystem] if osv_ecosystem else []
+
+
+def _db_ecosystems_for_package(pkg: Package) -> list[str]:
+    """Return normalized DB ecosystem keys for a package."""
+    return [eco.lower() for eco in _osv_ecosystems_for_package(pkg)]
 
 
 _MAX_CACHED_LOOPS = 8  # Bound stale entries in long-running servers
@@ -390,7 +427,23 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float], Opti
     return severity, cvss_score, severity_source
 
 
-def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "", current_version: str = "") -> Optional[str]:
+def _candidate_package_names(package_name: str, ecosystem: str = "", source_package: str | None = None) -> set[str]:
+    """Normalized candidate package names for matching advisories."""
+    names = {normalize_package_name(package_name, ecosystem)}
+    if source_package:
+        source_norm = normalize_package_name(source_package, ecosystem)
+        if source_norm:
+            names.add(source_norm)
+    return names
+
+
+def parse_fixed_version(
+    vuln_data: dict,
+    package_name: str,
+    ecosystem: str = "",
+    current_version: str = "",
+    source_package: str | None = None,
+) -> Optional[str]:
     """Extract fixed version from OSV affected data.
 
     Prefers stable releases over pre-release versions.  Uses PEP 503
@@ -400,18 +453,10 @@ def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "",
     Guards against cross-package fix bleed: skips affected entries with no
     package name and skips fix versions lower than ``current_version``.
     """
-    norm_input = normalize_package_name(package_name, ecosystem)
+    from agent_bom.version_utils import compare_version_order
+
+    norm_inputs = _candidate_package_names(package_name, ecosystem, source_package)
     prerelease_candidate: Optional[str] = None
-
-    # Parse current version for downgrade detection
-    current_pv = None
-    if current_version and current_version not in ("unknown", "latest", ""):
-        try:
-            from packaging.version import Version
-
-            current_pv = Version(current_version)
-        except Exception:  # noqa: BLE001
-            pass
 
     for affected in vuln_data.get("affected", []):
         pkg = affected.get("package", {})
@@ -422,33 +467,36 @@ def parse_fixed_version(vuln_data: dict, package_name: str, ecosystem: str = "",
             continue
         osv_eco = pkg.get("ecosystem", ecosystem)
         osv_norm = normalize_package_name(pkg_name, osv_eco)
-        if osv_norm == norm_input:
+        if osv_norm in norm_inputs:
             for rng in affected.get("ranges", []):
                 for event in rng.get("events", []):
                     if "fixed" in event:
                         fixed = event["fixed"]
                         try:
+                            if current_version and current_version not in ("unknown", "latest", ""):
+                                current_cmp = compare_version_order(current_version, fixed, ecosystem)
+                                if current_cmp is not None and current_cmp > 0:
+                                    _logger.debug(
+                                        "Skipping fix %s < current %s for %s",
+                                        fixed,
+                                        current_version,
+                                        package_name,
+                                    )
+                                    continue
                             from packaging.version import Version
 
                             pv = Version(fixed)
-                            # Skip fix versions lower than current (belongs to sibling package)
-                            if current_pv is not None and pv < current_pv:
-                                _logger.debug(
-                                    "Skipping fix %s < current %s for %s",
-                                    fixed,
-                                    current_version,
-                                    package_name,
-                                )
-                                continue
                             if not pv.is_prerelease:
                                 return fixed
                             # Remember pre-release as fallback
                             if prerelease_candidate is None:
                                 prerelease_candidate = fixed
                         except Exception as exc:  # noqa: BLE001
-                            # Can't parse — check if it looks like a usable version
-                            # Skip git commit SHAs (40 hex chars) and other non-version strings
                             _logger.debug("Version parse failed for %r: %s", fixed, exc)
+                            if current_version and current_version not in ("unknown", "latest", ""):
+                                current_cmp = compare_version_order(current_version, fixed, ecosystem)
+                                if current_cmp is not None and current_cmp > 0:
+                                    continue
                             if _is_valid_fix_version(fixed):
                                 return fixed
                             # Not a usable version — skip silently
@@ -474,6 +522,18 @@ def _is_valid_fix_version(version: str) -> bool:
     if 7 <= len(stripped) <= 12 and all(c in "0123456789abcdef" for c in stripped):
         return False
     return True
+
+
+def _package_lookup_names(pkg: Package) -> list[str]:
+    """Lookup names for a package, preserving the primary package name first."""
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for name in pkg.lookup_names:
+        norm = normalize_package_name(name, pkg.ecosystem)
+        if norm and norm not in seen:
+            ordered.append(norm)
+            seen.add(norm)
+    return ordered
 
 
 async def _enrich_vuln_details(client: httpx.AsyncClient, vuln_ids: list[str]) -> dict[str, dict]:
@@ -549,11 +609,9 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
 
     # Check cache first
     for pkg in packages:
-        # Normalize ecosystem case — ECOSYSTEM_MAP keys are all lowercase.
-        # Accepts "PyPI", "NPM", "PYPI", etc. from external callers.
         eco_key = pkg.ecosystem.lower()
-        osv_ecosystem = ECOSYSTEM_MAP.get(eco_key)
-        if not osv_ecosystem:
+        osv_ecosystems = _osv_ecosystems_for_package(pkg)
+        if not osv_ecosystems:
             if eco_key in _NON_OSV_ECOSYSTEMS:
                 _logger.debug(
                     "Skipping package %s/%s: ecosystem %r is not OSV-queryable (handled by other pipeline)",
@@ -580,8 +638,9 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
             skipped_versions += 1
             continue
         norm_name = normalize_package_name(pkg.name, eco_key)
+        cache_key_eco = eco_key if len(osv_ecosystems) == 1 else f"{eco_key}|{'|'.join(osv_ecosystems)}"
         if cache:
-            cached = cache.get(eco_key, norm_name, pkg.version)
+            cached = cache.get(cache_key_eco, norm_name, pkg.version)
             if cached is not None:
                 if cached:  # non-empty vuln list
                     key = f"{eco_key}:{norm_name}@{pkg.version}"
@@ -605,29 +664,30 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         return await _enrich_results_if_needed(results)
 
     queries = []
-    pkg_index = {}  # Map query index to package
+    pkg_index = {}  # Map query index to (package, queried_name)
 
     for pkg in packages_to_query:
         eco_key = pkg.ecosystem.lower()
-        osv_ecosystem = ECOSYSTEM_MAP.get(eco_key)
-        if not osv_ecosystem or pkg.version in ("unknown", "latest"):
+        osv_ecosystems = _osv_ecosystems_for_package(pkg)
+        if not osv_ecosystems or pkg.version in ("unknown", "latest"):
             continue  # already logged in cache-check loop above
 
         # Normalize name for consistent OSV matching (PEP 503 for PyPI)
-        norm_name = normalize_package_name(pkg.name, eco_key)
         # Go module versions are stored without 'v' prefix internally but OSV
         # Go ecosystem expects the canonical semver 'v' prefix.
         osv_version = f"v{pkg.version}" if eco_key == "go" and not pkg.version.startswith("v") else pkg.version
-        queries.append(
-            {
-                "version": osv_version,
-                "package": {
-                    "name": norm_name,
-                    "ecosystem": osv_ecosystem,
-                },
-            }
-        )
-        pkg_index[len(queries) - 1] = pkg
+        for osv_ecosystem in osv_ecosystems:
+            for norm_name in _package_lookup_names(pkg):
+                queries.append(
+                    {
+                        "version": osv_version,
+                        "package": {
+                            "name": norm_name,
+                            "ecosystem": osv_ecosystem,
+                        },
+                    }
+                )
+                pkg_index[len(queries) - 1] = (pkg, norm_name)
 
     if not queries:
         return await _enrich_results_if_needed(results)
@@ -684,16 +744,22 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
                                 actual_idx = batch_start + i
                                 pkg_match = pkg_index.get(actual_idx)
                                 if pkg_match:
-                                    norm = normalize_package_name(pkg_match.name, pkg_match.ecosystem)
-                                    key = f"{pkg_match.ecosystem.lower()}:{norm}@{pkg_match.version}"
-                                    results[key] = vulns
+                                    pkg_obj, _queried_name = pkg_match
+                                    norm = normalize_package_name(pkg_obj.name, pkg_obj.ecosystem)
+                                    key = f"{pkg_obj.ecosystem.lower()}:{norm}@{pkg_obj.version}"
+                                    existing = results.setdefault(key, [])
+                                    seen_ids = {item.get("id") for item in existing}
+                                    for vuln in vulns:
+                                        if vuln.get("id") not in seen_ids:
+                                            existing.append(vuln)
+                                            seen_ids.add(vuln.get("id"))
                                     queried_keys_with_vulns.add(key)
                     except (ValueError, KeyError) as e:
                         console.print(f"  [red]✗[/red] OSV response parse error: {e}")
                         for idx in range(batch_start, min(batch_start + len(batch), len(queries))):
                             pkg_err = pkg_index.get(idx)
                             if pkg_err:
-                                _lookup_errors.append((pkg_err.name, pkg_err.ecosystem, f"parse error: {e}"))
+                                _lookup_errors.append((pkg_err[0].name, pkg_err[0].ecosystem, f"parse error: {e}"))
                 elif response and response.status_code == 429:
                     # request_with_retry exhausted all retries and still got 429 — apply
                     # a pipeline-level cooldown before the next batch, respecting any
@@ -713,13 +779,13 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
                     for idx in range(batch_start, min(batch_start + len(batch), len(queries))):
                         pkg_err = pkg_index.get(idx)
                         if pkg_err:
-                            _lookup_errors.append((pkg_err.name, pkg_err.ecosystem, f"HTTP {response.status_code}"))
+                            _lookup_errors.append((pkg_err[0].name, pkg_err[0].ecosystem, f"HTTP {response.status_code}"))
                 else:
                     console.print("  [red]✗[/red] OSV API unreachable after retries")
                     for idx in range(batch_start, min(batch_start + len(batch), len(queries))):
                         pkg_err = pkg_index.get(idx)
                         if pkg_err:
-                            _lookup_errors.append((pkg_err.name, pkg_err.ecosystem, "unreachable"))
+                            _lookup_errors.append((pkg_err[0].name, pkg_err[0].ecosystem, "unreachable"))
 
             # Rate limit: delay between batches
             if batch_start + batch_size < len(queries):
@@ -732,7 +798,9 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
     if cache:
         cache_writes = [
             (
-                pkg.ecosystem.lower(),
+                pkg.ecosystem.lower()
+                if len(_osv_ecosystems_for_package(pkg)) == 1
+                else f"{pkg.ecosystem.lower()}|{'|'.join(_osv_ecosystems_for_package(pkg))}",
                 normalize_package_name(pkg.name, pkg.ecosystem),
                 pkg.version,
                 results.get(f"{pkg.ecosystem.lower()}:{normalize_package_name(pkg.name, pkg.ecosystem)}@{pkg.version}", []),
@@ -764,7 +832,13 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
     return results
 
 
-def _is_version_affected(vuln_data: dict, package_name: str, package_version: str, ecosystem: str = "") -> bool:
+def _is_version_affected(
+    vuln_data: dict,
+    package_name: str,
+    package_version: str,
+    ecosystem: str = "",
+    source_package: str | None = None,
+) -> bool:
     """Check if a specific version falls within the OSV affected ranges.
 
     Walks the ``affected[].ranges[].events[]`` structure and applies
@@ -778,15 +852,9 @@ def _is_version_affected(vuln_data: dict, package_name: str, package_version: st
     or is outside all affected ranges.  Returns True (conservative) if
     version parsing fails or no range data is available.
     """
-    from packaging.version import InvalidVersion, Version
+    from agent_bom.version_utils import compare_version_order
 
-    norm_name = normalize_package_name(package_name, ecosystem)
-
-    try:
-        pkg_ver = Version(package_version)
-    except InvalidVersion:
-        # Can't parse — assume affected (conservative)
-        return True
+    norm_names = _candidate_package_names(package_name, ecosystem, source_package)
 
     found_package = False
 
@@ -794,7 +862,7 @@ def _is_version_affected(vuln_data: dict, package_name: str, package_version: st
         pkg = affected.get("package", {})
         osv_eco = pkg.get("ecosystem", ecosystem)
         osv_name = normalize_package_name(pkg.get("name", ""), osv_eco)
-        if osv_name != norm_name:
+        if osv_name not in norm_names:
             continue
 
         found_package = True
@@ -829,22 +897,16 @@ def _is_version_affected(vuln_data: dict, package_name: str, package_version: st
                     if intro == "0":
                         is_affected = True
                     else:
-                        try:
-                            is_affected = pkg_ver >= Version(intro)
-                        except InvalidVersion:
-                            is_affected = True  # conservative
+                        intro_cmp = compare_version_order(package_version, intro, ecosystem)
+                        is_affected = True if intro_cmp is None else intro_cmp >= 0
                 elif "fixed" in event:
-                    try:
-                        if pkg_ver >= Version(event["fixed"]):
-                            is_affected = False
-                    except InvalidVersion:
-                        pass
+                    fixed_cmp = compare_version_order(package_version, event["fixed"], ecosystem)
+                    if fixed_cmp is not None and fixed_cmp >= 0:
+                        is_affected = False
                 elif "last_affected" in event:
-                    try:
-                        if pkg_ver > Version(event["last_affected"]):
-                            is_affected = False
-                    except InvalidVersion:
-                        pass
+                    last_cmp = compare_version_order(package_version, event["last_affected"], ecosystem)
+                    if last_cmp is not None and last_cmp > 0:
+                        is_affected = False
 
             if is_affected:
                 return True
@@ -873,7 +935,13 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
 
         # Version-range filter: skip vulns that don't affect our version
         if package.version and package.version not in ("unknown", "latest"):
-            if not _is_version_affected(vuln_data, package.name, package.version, package.ecosystem):
+            if not _is_version_affected(
+                vuln_data,
+                package.name,
+                package.version,
+                package.ecosystem,
+                source_package=package.source_package,
+            ):
                 _logger.debug(
                     "Filtered %s: version %s not in affected range for %s",
                     vuln_id,
@@ -897,7 +965,13 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
             seen_ids.add(alias)
 
         severity, cvss_score, sev_source = parse_osv_severity(vuln_data)
-        fixed = parse_fixed_version(vuln_data, package.name, package.ecosystem, current_version=package.version or "")
+        fixed = parse_fixed_version(
+            vuln_data,
+            package.name,
+            package.ecosystem,
+            current_version=package.version or "",
+            source_package=package.source_package,
+        )
 
         references = [ref.get("url", "") for ref in vuln_data.get("references", []) if ref.get("url")]
 
@@ -1050,37 +1124,30 @@ def _scan_packages_local_db(packages: list[Package]) -> tuple[int, set[str]]:
     covered: set[str] = set()
     total = 0
 
-    # Map agent-bom ecosystem names to DB ecosystem names (OSV-style)
-    _eco_map = {
-        "pypi": "PyPI",
-        "npm": "npm",
-        "go": "Go",
-        "cargo": "crates.io",
-        "maven": "Maven",
-        "nuget": "NuGet",
-        "rubygems": "RubyGems",
-        "conda": "PyPI",
-    }
-
     try:
         from agent_bom.db.lookup import package_in_db
 
         if len(packages) > _BATCH_DB_THRESHOLD:
-            total = _scan_packages_local_db_batch(conn, packages, _eco_map, covered)
+            total = _scan_packages_local_db_batch(conn, packages, covered)
         else:
             for pkg in packages:
                 eco_key = pkg.ecosystem.lower()
-                db_eco = _eco_map.get(eco_key, pkg.ecosystem)
-                norm_name = normalize_package_name(pkg.name, pkg.ecosystem)
+                db_ecos = _db_ecosystems_for_package(pkg) or [pkg.ecosystem.lower()]
+                candidate_names = _package_lookup_names(pkg)
+                norm_name = candidate_names[0]
                 db_key = f"{eco_key}:{norm_name}@{pkg.version}"
-
-                local_vulns = lookup_package(conn, db_eco, norm_name, pkg.version)
+                local_vulns = []
+                db_hit = False
+                for db_eco in db_ecos:
+                    for candidate_name in candidate_names:
+                        local_vulns.extend(lookup_package(conn, db_eco, candidate_name, pkg.version))
+                        db_hit = db_hit or package_in_db(conn, db_eco, candidate_name)
 
                 # Only mark as "covered by DB" when the package name actually exists in the
                 # affected table — not just because the ecosystem is mapped. This prevents
                 # false negatives where a package has no DB entry but is silently skipped
                 # (no OSV fallback) because the ecosystem is present.
-                if package_in_db(conn, db_eco, norm_name):
+                if db_hit:
                     covered.add(db_key)
 
                 if local_vulns:
@@ -1112,7 +1179,6 @@ def _scan_packages_local_db(packages: list[Package]) -> tuple[int, set[str]]:
 def _scan_packages_local_db_batch(
     conn: Any,
     packages: list[Package],
-    eco_map: dict[str, str],
     covered: set[str],
 ) -> int:
     """Batch variant of the local DB scan — fewer SQL round-trips.
@@ -1123,24 +1189,30 @@ def _scan_packages_local_db_batch(
     from agent_bom.db.lookup import lookup_packages_batch, package_in_db
 
     # Build batch keys: (db_ecosystem, normalized_name, version)
-    pkg_index: list[tuple[Package, str, str, str]] = []  # (pkg, db_eco, norm_name, db_key)
+    pkg_index: list[tuple[Package, list[str], str, str, list[str]]] = []  # (pkg, db_ecos, primary_norm_name, db_key, candidate_names)
     batch_keys: list[tuple[str, str, str]] = []
 
     for pkg in packages:
         eco_key = pkg.ecosystem.lower()
-        db_eco = eco_map.get(eco_key, pkg.ecosystem)
-        norm_name = normalize_package_name(pkg.name, pkg.ecosystem)
+        db_ecos = _db_ecosystems_for_package(pkg) or [pkg.ecosystem.lower()]
+        candidate_names = _package_lookup_names(pkg)
+        norm_name = candidate_names[0]
         db_key = f"{eco_key}:{norm_name}@{pkg.version}"
-        pkg_index.append((pkg, db_eco, norm_name, db_key))
-        batch_keys.append((db_eco, norm_name, pkg.version))
+        pkg_index.append((pkg, db_ecos, norm_name, db_key, candidate_names))
+        for db_eco in db_ecos:
+            for candidate_name in candidate_names:
+                batch_keys.append((db_eco, candidate_name, pkg.version))
 
     batch_results = lookup_packages_batch(conn, batch_keys)
 
     total = 0
-    for (pkg, db_eco, norm_name, db_key), batch_key in zip(pkg_index, batch_keys):
-        local_vulns = batch_results.get(batch_key, [])
+    for pkg, db_ecos, norm_name, db_key, candidate_names in pkg_index:
+        local_vulns = []
+        for db_eco in db_ecos:
+            for candidate_name in candidate_names:
+                local_vulns.extend(batch_results.get((db_eco, candidate_name, pkg.version), []))
 
-        if package_in_db(conn, db_eco, norm_name):
+        if any(package_in_db(conn, db_eco, candidate_name) for db_eco in db_ecos for candidate_name in candidate_names):
             covered.add(db_key)
 
         if local_vulns:

--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -1,8 +1,13 @@
-"""Version validation, normalization, and ecosystem-specific resolution.
+"""Version validation, normalization, comparison, and ecosystem-specific resolution.
 
-Ensures accurate package version handling across all ecosystems:
-npm (semver), PyPI (PEP 440), Go (v-prefix semver), Cargo (semver),
-Maven (flexible versioning).
+Ensures accurate package version handling across ecosystems, including
+OS package managers where lexicographic or PEP 440 comparison is wrong:
+
+- npm / Cargo / NuGet: semver
+- PyPI: PEP 440
+- Go: v-prefixed semver and pseudo-versions
+- Maven: flexible dotted versions
+- Debian / Alpine / RPM: distro-native ordering
 """
 
 from __future__ import annotations
@@ -43,6 +48,9 @@ _GO_VERSION_RE = re.compile(r"^v\d+\.\d+\.\d+(?:-[0-9A-Za-z\-.]+)?(?:\+[0-9A-Za-
 # Maven: flexible (major.minor.patch.qualifier or major.minor.patch-qualifier)
 _MAVEN_RE = re.compile(r"^\d+(?:\.\d+){0,3}(?:[.-][A-Za-z0-9\-.]+)?$")
 
+_GO_PSEUDO_RE = re.compile(r"^v\d+\.\d+\.\d+-(\d{14})-[0-9a-f]{12}$")
+_HEXISH_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
 
 def validate_version(version: str, ecosystem: str) -> bool:
     """Check if a version string is valid for the given ecosystem.
@@ -63,6 +71,8 @@ def validate_version(version: str, ecosystem: str) -> bool:
         return _MAVEN_RE.match(version) is not None
     elif ecosystem == "nuget":
         return _SEMVER_RE.match(version) is not None
+    elif ecosystem in ("deb", "apk", "rpm"):
+        return bool(version.strip())
 
     # Unknown ecosystem — accept any non-empty version
     return True
@@ -124,16 +134,9 @@ def compare_versions(current: str, fixed: str, ecosystem: str) -> bool:
     Pre-release handling: ``1.0.0rc1 < 1.0.0`` (correct per PEP 440
     and semver).
     """
-    current = normalize_version(current, ecosystem)
-    fixed = normalize_version(fixed, ecosystem)
-
-    # Try packaging.version first — handles pre-release correctly
-    try:
-        from packaging.version import Version
-
-        return Version(fixed) > Version(current)
-    except Exception:  # noqa: BLE001
-        pass
+    order = compare_version_order(current, fixed, ecosystem)
+    if order is not None:
+        return order < 0
 
     # Fallback: numeric tuple (splits pre-release from base version)
     def _version_tuple(v: str) -> tuple[tuple[int, ...], bool]:
@@ -155,6 +158,293 @@ def compare_versions(current: str, fixed: str, ecosystem: str) -> bool:
         return False  # same base, both pre or both stable
     except (ValueError, TypeError):
         return False
+
+
+def _looks_like_commit_sha(version: str) -> bool:
+    stripped = version.strip().lower().lstrip("v")
+    return bool(_HEXISH_RE.fullmatch(stripped))
+
+
+def _go_pseudo_timestamp(version: str) -> str | None:
+    match = _GO_PSEUDO_RE.match(version)
+    return match.group(1) if match else None
+
+
+def _compare_go_versions(left: str, right: str) -> int | None:
+    left_ts = _go_pseudo_timestamp(left)
+    right_ts = _go_pseudo_timestamp(right)
+    if left_ts and right_ts:
+        return (left_ts > right_ts) - (left_ts < right_ts)
+    try:
+        from packaging.version import Version
+
+        left_norm = left[1:] if left.startswith("v") else left
+        right_norm = right[1:] if right.startswith("v") else right
+        return (Version(left_norm) > Version(right_norm)) - (Version(left_norm) < Version(right_norm))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _debian_order_char(ch: str | None) -> int:
+    if ch is None:
+        return 0
+    if ch == "~":
+        return -1
+    if ch.isalpha():
+        return ord(ch)
+    return ord(ch) + 256
+
+
+def _compare_debian_part(left: str, right: str) -> int:
+    i = j = 0
+    while i < len(left) or j < len(right):
+        while (i < len(left) and not left[i].isdigit()) or (j < len(right) and not right[j].isdigit()):
+            lc = left[i] if i < len(left) and not left[i].isdigit() else None
+            rc = right[j] if j < len(right) and not right[j].isdigit() else None
+            if lc == rc:
+                if lc is not None:
+                    i += 1
+                if rc is not None:
+                    j += 1
+                continue
+            lo = _debian_order_char(lc)
+            ro = _debian_order_char(rc)
+            if lo != ro:
+                return (lo > ro) - (lo < ro)
+            if lc is not None:
+                i += 1
+            if rc is not None:
+                j += 1
+
+        left_digits = ""
+        while i < len(left) and left[i].isdigit():
+            left_digits += left[i]
+            i += 1
+        right_digits = ""
+        while j < len(right) and right[j].isdigit():
+            right_digits += right[j]
+            j += 1
+
+        left_digits = left_digits.lstrip("0") or "0"
+        right_digits = right_digits.lstrip("0") or "0"
+        if len(left_digits) != len(right_digits):
+            return (len(left_digits) > len(right_digits)) - (len(left_digits) < len(right_digits))
+        if left_digits != right_digits:
+            return (left_digits > right_digits) - (left_digits < right_digits)
+    return 0
+
+
+def _split_debian_version(version: str) -> tuple[int, str, str]:
+    epoch_str, _, remainder = version.partition(":")
+    if remainder:
+        try:
+            epoch = int(epoch_str)
+        except ValueError:
+            epoch = 0
+    else:
+        epoch = 0
+        remainder = version
+    if "-" in remainder:
+        upstream, revision = remainder.rsplit("-", 1)
+    else:
+        upstream, revision = remainder, "0"
+    return epoch, upstream, revision
+
+
+def _compare_debian_versions(left: str, right: str) -> int:
+    left_epoch, left_upstream, left_revision = _split_debian_version(left)
+    right_epoch, right_upstream, right_revision = _split_debian_version(right)
+    if left_epoch != right_epoch:
+        return (left_epoch > right_epoch) - (left_epoch < right_epoch)
+    upstream_cmp = _compare_debian_part(left_upstream, right_upstream)
+    if upstream_cmp:
+        return upstream_cmp
+    return _compare_debian_part(left_revision, right_revision)
+
+
+def _consume_rpm_segment(value: str, start: int) -> tuple[str, int]:
+    end = start
+    kind = value[start].isdigit()
+    while end < len(value) and value[end].isdigit() == kind and value[end].isalnum():
+        end += 1
+    return value[start:end], end
+
+
+def _compare_rpm_like(left: str, right: str) -> int:
+    i = j = 0
+    while True:
+        while i < len(left) and not left[i].isalnum() and left[i] not in "~^":
+            i += 1
+        while j < len(right) and not right[j].isalnum() and right[j] not in "~^":
+            j += 1
+
+        if i < len(left) and left[i] == "~" or j < len(right) and right[j] == "~":
+            if not (i < len(left) and left[i] == "~"):
+                return 1
+            if not (j < len(right) and right[j] == "~"):
+                return -1
+            i += 1
+            j += 1
+            continue
+
+        if i < len(left) and left[i] == "^" or j < len(right) and right[j] == "^":
+            if i >= len(left):
+                return -1
+            if j >= len(right):
+                return 1
+            if left[i] != "^":
+                return 1
+            if right[j] != "^":
+                return -1
+            i += 1
+            j += 1
+            continue
+
+        if i >= len(left) or j >= len(right):
+            break
+
+        left_seg, i = _consume_rpm_segment(left, i)
+        right_seg, j = _consume_rpm_segment(right, j)
+        left_is_num = left_seg[0].isdigit()
+        right_is_num = right_seg[0].isdigit()
+
+        if left_is_num != right_is_num:
+            return 1 if left_is_num else -1
+
+        if left_is_num:
+            left_norm = left_seg.lstrip("0") or "0"
+            right_norm = right_seg.lstrip("0") or "0"
+            if len(left_norm) != len(right_norm):
+                return (len(left_norm) > len(right_norm)) - (len(left_norm) < len(right_norm))
+            if left_norm != right_norm:
+                return (left_norm > right_norm) - (left_norm < right_norm)
+        else:
+            if left_seg != right_seg:
+                return (left_seg > right_seg) - (left_seg < right_seg)
+
+    if i >= len(left) and j >= len(right):
+        return 0
+    return -1 if i >= len(left) else 1
+
+
+def _split_epoch(version: str) -> tuple[int, str]:
+    epoch_str, sep, rest = version.partition(":")
+    if not sep:
+        return 0, version
+    try:
+        return int(epoch_str), rest
+    except ValueError:
+        return 0, version
+
+
+def _compare_rpm_versions(left: str, right: str) -> int:
+    left_epoch, left_rest = _split_epoch(left)
+    right_epoch, right_rest = _split_epoch(right)
+    if left_epoch != right_epoch:
+        return (left_epoch > right_epoch) - (left_epoch < right_epoch)
+    return _compare_rpm_like(left_rest, right_rest)
+
+
+def _compare_apk_versions(left: str, right: str) -> int:
+    def _split_revision(value: str) -> tuple[str, int]:
+        if "-r" in value:
+            base, revision = value.rsplit("-r", 1)
+            try:
+                return base, int(revision)
+            except ValueError:
+                return base, 0
+        return value, 0
+
+    left_base, left_rev = _split_revision(left)
+    right_base, right_rev = _split_revision(right)
+    base_cmp = _compare_rpm_like(left_base, right_base)
+    if base_cmp:
+        return base_cmp
+    return (left_rev > right_rev) - (left_rev < right_rev)
+
+
+def compare_version_order(left: str, right: str, ecosystem: str) -> int | None:
+    """Compare two versions using ecosystem-specific semantics.
+
+    Returns ``-1`` when ``left < right``, ``0`` when equal, ``1`` when
+    ``left > right``, and ``None`` when the versions should not be compared
+    (for example git commit SHAs leaking from advisory ranges).
+    """
+    eco = (ecosystem or "").lower()
+    if eco == "debian":
+        eco = "deb"
+    elif eco == "alpine":
+        eco = "apk"
+    elif eco == "linux":
+        eco = "rpm"
+    left = (left or "").strip()
+    right = (right or "").strip()
+    if not left or not right:
+        return None
+    if _looks_like_commit_sha(left) or _looks_like_commit_sha(right):
+        return None
+
+    if eco == "deb":
+        return _compare_debian_versions(left, right)
+    if eco == "rpm":
+        return _compare_rpm_versions(left, right)
+    if eco == "apk":
+        return _compare_apk_versions(left, right)
+    if eco == "go":
+        return _compare_go_versions(left, right)
+
+    try:
+        from packaging.version import Version
+
+        left_norm = normalize_version(left, eco)
+        right_norm = normalize_version(right, eco)
+        return (Version(left_norm) > Version(right_norm)) - (Version(left_norm) < Version(right_norm))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def version_in_range(
+    version: str,
+    introduced: str | None,
+    fixed: str | None,
+    last_affected: str | None,
+    ecosystem: str,
+) -> bool:
+    """Return whether ``version`` is affected by the supplied advisory bounds."""
+    intro = introduced or None
+    fix = fixed or None
+    last = last_affected or None
+
+    if ecosystem.lower() == "go":
+        ver_ts = _go_pseudo_timestamp(version)
+        if ver_ts:
+            for boundary, is_lower in ((intro, True), (fix, False), (last, False)):
+                if not boundary:
+                    continue
+                boundary_ts = _go_pseudo_timestamp(boundary)
+                if not boundary_ts:
+                    continue
+                if is_lower and ver_ts < boundary_ts:
+                    return False
+                if not is_lower and boundary == fix and ver_ts >= boundary_ts:
+                    return False
+                if not is_lower and boundary == last and ver_ts > boundary_ts:
+                    return False
+            return True
+
+    if intro:
+        intro_cmp = compare_version_order(version, intro, ecosystem)
+        if intro_cmp is not None and intro_cmp < 0:
+            return False
+    if fix:
+        fix_cmp = compare_version_order(version, fix, ecosystem)
+        if fix_cmp is not None and fix_cmp >= 0:
+            return False
+    if last:
+        last_cmp = compare_version_order(version, last, ecosystem)
+        if last_cmp is not None and last_cmp > 0:
+            return False
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -139,6 +139,21 @@ def test_version_affected_last_affected():
     assert _version_affected("2.1.0", "2.0.0", None, "2.0.9") is False
 
 
+def test_version_affected_debian_range():
+    assert _version_affected("6.5+20250216-2", "0", "6.5+20250216-3", None, "debian") is True
+    assert _version_affected("6.5+20250216-3", "0", "6.5+20250216-3", None, "debian") is False
+
+
+def test_version_affected_apk_range():
+    assert _version_affected("1.2.4-r2", "0", "1.2.4-r10", None, "apk") is True
+    assert _version_affected("1.2.4-r10", "0", "1.2.4-r10", None, "apk") is False
+
+
+def test_version_affected_rpm_range():
+    assert _version_affected("3.0.7-24.el9", "0", "3.0.7-25.el9", None, "linux") is True
+    assert _version_affected("3.0.7-25.el9", "0", "3.0.7-25.el9", None, "linux") is False
+
+
 # ---------------------------------------------------------------------------
 # lookup_package
 # ---------------------------------------------------------------------------
@@ -171,6 +186,34 @@ def test_lookup_package_ecosystem_case_insensitive(tmp_db):
     _insert_affected(tmp_db, ecosystem="pypi")
     results = lookup_package(tmp_db, "PyPI", "requests", "2.0.5")
     assert len(results) == 1
+
+
+def test_lookup_package_debian_version_match(tmp_db):
+    _insert_vuln(tmp_db, vuln_id="CVE-2025-NCURSES")
+    _insert_affected(
+        tmp_db,
+        vuln_id="CVE-2025-NCURSES",
+        ecosystem="debian",
+        pkg="ncurses-bin",
+        introduced="0",
+        fixed="6.5+20250216-3",
+    )
+    results = lookup_package(tmp_db, "Debian", "ncurses-bin", "6.5+20250216-2")
+    assert len(results) == 1
+
+
+def test_lookup_package_debian_fixed_version_not_affected(tmp_db):
+    _insert_vuln(tmp_db, vuln_id="CVE-2025-NCURSES")
+    _insert_affected(
+        tmp_db,
+        vuln_id="CVE-2025-NCURSES",
+        ecosystem="debian",
+        pkg="ncurses-bin",
+        introduced="0",
+        fixed="6.5+20250216-3",
+    )
+    results = lookup_package(tmp_db, "Debian", "ncurses-bin", "6.5+20250216-3")
+    assert results == []
 
 
 def test_lookup_package_name_normalized(tmp_db):

--- a/tests/test_mcp_check_impl.py
+++ b/tests/test_mcp_check_impl.py
@@ -1,0 +1,61 @@
+"""Regression tests for MCP check tool consistency."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_bom.mcp_tools.scanning import check_impl
+from agent_bom.models import Package, Severity, Vulnerability
+
+
+@pytest.mark.asyncio
+async def test_check_impl_requires_explicit_os_package_version():
+    result = await check_impl(
+        package="ncurses-bin",
+        ecosystem="deb",
+        _validate_ecosystem=lambda eco: eco,
+        _truncate_response=lambda response: response,
+    )
+    payload = json.loads(result)
+    assert payload["ecosystem"] == "deb"
+    assert "Explicit version required" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_check_impl_uses_full_scan_pipeline():
+    async def fake_scan(packages: list[Package]):
+        packages[0].vulnerabilities.append(Vulnerability(id="CVE-2026-TEST", summary="test", severity=Severity.HIGH))
+
+    with patch("agent_bom.scanners.scan_packages", side_effect=fake_scan):
+        result = await check_impl(
+            package="Django@3.2.0",
+            ecosystem="pypi",
+            _validate_ecosystem=lambda eco: eco,
+            _truncate_response=lambda response: response,
+        )
+
+    payload = json.loads(result)
+    assert payload["package"] == "Django"
+    assert payload["version"] == "3.2.0"
+    assert payload["vulnerabilities"] == 1
+
+
+@pytest.mark.asyncio
+async def test_check_impl_marks_os_packages_incomplete_when_context_missing():
+    with (
+        patch("agent_bom.parsers.os_parsers.enrich_os_package_context", return_value=False),
+        patch("agent_bom.scanners.scan_packages", new=AsyncMock()),
+    ):
+        result = await check_impl(
+            package="ncurses-bin@6.5+20250216-2",
+            ecosystem="deb",
+            _validate_ecosystem=lambda eco: eco,
+            _truncate_response=lambda response: response,
+        )
+
+    payload = json.loads(result)
+    assert payload["status"] == "incomplete"
+    assert payload["vulnerabilities"] == 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -167,15 +167,15 @@ def test_check_vulnerable_package(mock_osv):
     assert result["details"][0]["id"] == "CVE-2025-9999"
 
 
-@patch("agent_bom.scanners.query_osv_batch")
-def test_check_scoped_npm_package(mock_osv):
+@patch("agent_bom.scanners.scan_packages")
+def test_check_scoped_npm_package(mock_scan):
     """Check parses scoped npm package correctly."""
     from agent_bom.mcp_server import create_mcp_server
 
-    async def _fake_osv(pkgs):
-        return {}
+    async def _fake_scan(pkgs):
+        return None
 
-    mock_osv.side_effect = _fake_osv
+    mock_scan.side_effect = _fake_scan
     server = create_mcp_server()
     result = _call_tool(
         server,
@@ -855,7 +855,7 @@ def test_validate_ecosystem_valid():
     """All supported ecosystems should pass validation."""
     from agent_bom.mcp_server import _validate_ecosystem
 
-    for eco in ("npm", "pypi", "go", "cargo", "maven", "nuget", "rubygems"):
+    for eco in ("npm", "pypi", "go", "cargo", "maven", "nuget", "rubygems", "composer", "swift", "deb", "apk", "rpm"):
         assert _validate_ecosystem(eco) == eco
     # Case insensitive + whitespace trimmed
     assert _validate_ecosystem("NPM") == "npm"
@@ -866,7 +866,7 @@ def test_validate_ecosystem_invalid():
     """Invalid ecosystems should raise ValueError."""
     from agent_bom.mcp_server import _validate_ecosystem
 
-    for bad in ("pip", "", "python", "composer", "  "):
+    for bad in ("pip", "", "python", "gem", "  "):
         with pytest.raises(ValueError, match="Invalid ecosystem"):
             _validate_ecosystem(bad)
 

--- a/tests/test_native_disk_scan.py
+++ b/tests/test_native_disk_scan.py
@@ -26,6 +26,7 @@ Package: libssl3
 Status: install ok installed
 Architecture: amd64
 Version: 3.0.11-1~deb12u2
+Source: openssl
 Description: Secure Sockets Layer toolkit - shared libraries
 
 Package: python3-requests
@@ -83,6 +84,13 @@ class TestParseDpkgStatus:
         pkgs = parse_dpkg_status(f)
         by_name = {p.name: p for p in pkgs}
         assert by_name["libssl3"].purl == "pkg:deb/debian/libssl3@3.0.11-1~deb12u2"
+
+    def test_extracts_debian_source_package(self, tmp_path):
+        f = tmp_path / "status"
+        f.write_text(DPKG_STATUS)
+        pkgs = parse_dpkg_status(f)
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["libssl3"].source_package == "openssl"
 
     def test_missing_file_returns_empty(self, tmp_path):
         assert parse_dpkg_status(tmp_path / "nonexistent") == []
@@ -200,6 +208,17 @@ class TestScanDiskPathNative:
     def test_empty_directory_returns_empty(self, tmp_path):
         pkgs = scan_disk_path_native(tmp_path)
         assert pkgs == []
+
+    def test_applies_os_release_metadata_to_os_packages(self, tmp_path):
+        (tmp_path / "etc").mkdir(parents=True)
+        (tmp_path / "etc" / "os-release").write_text('ID=debian\nVERSION_ID="13"\n')
+        status_dir = tmp_path / "var" / "lib" / "dpkg"
+        status_dir.mkdir(parents=True)
+        (status_dir / "status").write_text("Package: openssl\nStatus: install ok installed\nVersion: 3.1.0\n\n")
+        pkgs = scan_disk_path_native(tmp_path)
+        openssl = next(p for p in pkgs if p.name == "openssl")
+        assert openssl.distro_name == "debian"
+        assert openssl.distro_version == "13"
 
 
 # ── parse_pip_environment ─────────────────────────────────────────────────────

--- a/tests/test_os_package_scanning.py
+++ b/tests/test_os_package_scanning.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from agent_bom.db.schema import init_db
 from agent_bom.filesystem import detect_linux_distro
 from agent_bom.models import Package
-from agent_bom.scanners import ECOSYSTEM_MAP
+from agent_bom.scanners import ECOSYSTEM_MAP, _scan_packages_local_db
 
 # ── ECOSYSTEM_MAP coverage ───────────────────────────────────────────────────
 
@@ -182,3 +183,59 @@ class TestOSPackagesFlag:
                 break
         else:
             pytest.fail("os_packages parameter not found")
+
+
+class TestCheckEcosystemSurfaces:
+    """CLI and MCP package checks must accept OS package ecosystems too."""
+
+    def test_cli_check_accepts_os_package_ecosystems(self):
+        from agent_bom.cli._check import check
+
+        for param in check.params:
+            if param.name == "ecosystem":
+                choices = set(param.type.choices)
+                assert {"deb", "apk", "rpm", "composer", "swift", "pub", "hex", "conda"} <= choices
+                break
+        else:
+            pytest.fail("check ecosystem option not found")
+
+    def test_mcp_check_accepts_os_package_ecosystems(self):
+        from agent_bom.mcp_server import _validate_ecosystem
+
+        assert _validate_ecosystem("deb") == "deb"
+        assert _validate_ecosystem("apk") == "apk"
+        assert _validate_ecosystem("rpm") == "rpm"
+        assert _validate_ecosystem("composer") == "composer"
+        assert _validate_ecosystem("swift") == "swift"
+
+
+def test_local_db_scan_uses_debian_source_package_alias(tmp_path, monkeypatch):
+    db_path = tmp_path / "vulns.db"
+    conn = init_db(db_path)
+    conn.execute(
+        "INSERT INTO vulns(id, summary, severity, source) VALUES (?, ?, ?, ?)",
+        ("CVE-2025-NCURSES", "ncurses source package issue", "critical", "osv"),
+    )
+    conn.execute(
+        "INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed, last_affected) VALUES (?, ?, ?, ?, ?, ?)",
+        ("CVE-2025-NCURSES", "debian:13", "ncurses", "0", "6.5+20250216-3", None),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr("agent_bom.db.schema.DB_PATH", db_path)
+    monkeypatch.setattr("agent_bom.db.schema.db_freshness_days", lambda path=None: 0)
+
+    pkg = Package(
+        name="ncurses-bin",
+        version="6.5+20250216-2",
+        ecosystem="deb",
+        source_package="ncurses",
+        distro_name="debian",
+        distro_version="13",
+    )
+    total, covered = _scan_packages_local_db([pkg])
+
+    assert total == 1
+    assert pkg.vulnerabilities[0].id == "CVE-2025-NCURSES"
+    assert f"deb:ncurses-bin@{pkg.version}" in covered

--- a/tests/test_os_parsers.py
+++ b/tests/test_os_parsers.py
@@ -21,11 +21,13 @@ Package: libc6
 Version: 2.35-0ubuntu3
 Status: install ok installed
 Architecture: amd64
+Source: glibc
 
 Package: libssl3
 Version: 3.0.2-0ubuntu1.12
 Status: install ok installed
 Architecture: amd64
+Source: openssl
 
 """
 
@@ -95,6 +97,15 @@ def test_parse_dpkg_status_file_purl_format(tmp_path: Path) -> None:
     packages: list = []
     _parse_dpkg_status_file(f, packages)
     assert packages[0].purl == "pkg:deb/debian/libc6@2.35-0ubuntu3"
+
+
+def test_parse_dpkg_status_file_source_package(tmp_path: Path) -> None:
+    f = tmp_path / "status"
+    f.write_text(DPKG_STATUS)
+    packages: list = []
+    _parse_dpkg_status_file(f, packages)
+    assert packages[0].source_package == "glibc"
+    assert packages[1].source_package == "openssl"
 
 
 # ─── detect_os_type ────────────────────────────────────────────────────────────

--- a/tests/test_osv_os_package_matching.py
+++ b/tests/test_osv_os_package_matching.py
@@ -1,0 +1,50 @@
+"""Regressions for OSV matching on OS package ecosystems."""
+
+from __future__ import annotations
+
+from agent_bom.models import Package
+from agent_bom.scanners import _is_version_affected, build_vulnerabilities, parse_fixed_version
+
+
+def _deb_advisory() -> dict:
+    return {
+        "id": "CVE-2025-NCURSES",
+        "summary": "Debian ncurses issue",
+        "affected": [
+            {
+                "package": {"ecosystem": "Debian", "name": "ncurses"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "0"},
+                            {"fixed": "6.5+20250216-3"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_osv_range_matching_uses_debian_version_order():
+    advisory = _deb_advisory()
+    assert _is_version_affected(advisory, "ncurses-bin", "6.5+20250216-2", "deb", source_package="ncurses") is True
+    assert _is_version_affected(advisory, "ncurses-bin", "6.5+20250216-3", "deb", source_package="ncurses") is False
+
+
+def test_build_vulnerabilities_filters_fixed_debian_version():
+    package = Package(name="ncurses-bin", version="6.5+20250216-3", ecosystem="deb", source_package="ncurses")
+    vulns = build_vulnerabilities([_deb_advisory()], package)
+    assert vulns == []
+
+
+def test_parse_fixed_version_preserves_higher_debian_fix():
+    fixed = parse_fixed_version(
+        _deb_advisory(),
+        "ncurses-bin",
+        "deb",
+        current_version="6.5+20250216-2",
+        source_package="ncurses",
+    )
+    assert fixed == "6.5+20250216-3"

--- a/tests/test_scanner_ecosystems.py
+++ b/tests/test_scanner_ecosystems.py
@@ -180,6 +180,79 @@ async def test_scan_packages_maven_go_query_construction():
 
 
 @pytest.mark.asyncio
+async def test_query_osv_batch_uses_debian_distro_context():
+    """Debian OS packages should query distro-specific OSV ecosystems when known."""
+    from agent_bom.scanners import query_osv_batch
+
+    pkg = Package(
+        name="ncurses-bin",
+        version="6.5+20250216-2",
+        ecosystem="deb",
+        source_package="ncurses",
+        distro_name="debian",
+        distro_version="13",
+    )
+    captured_queries: list[dict] = []
+
+    async def mock_request_with_retry(client, method, url, json=None, **kwargs):
+        if json and "queries" in json:
+            captured_queries.extend(json["queries"])
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"results": [{"vulns": []} for _ in captured_queries]}
+        return resp
+
+    with (
+        patch("agent_bom.scanners._get_scan_cache", return_value=None),
+        patch("agent_bom.scanners.request_with_retry", side_effect=mock_request_with_retry),
+        patch("agent_bom.scanners.create_client") as mock_create_client,
+    ):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_create_client.return_value = mock_client
+
+        await query_osv_batch([pkg])
+
+    ecosystems = {q["package"]["ecosystem"] for q in captured_queries}
+    names = {q["package"]["name"] for q in captured_queries}
+    assert ecosystems == {"Debian:13"}
+    assert names == {"ncurses-bin", "ncurses"}
+
+
+@pytest.mark.asyncio
+async def test_query_osv_batch_debian_fallbacks_when_distro_unknown():
+    """Direct deb checks without distro metadata should query supported Debian suites."""
+    from agent_bom.scanners import query_osv_batch
+
+    pkg = Package(name="ncurses-bin", version="6.5+20250216-2", ecosystem="deb", source_package="ncurses")
+    captured_queries: list[dict] = []
+
+    async def mock_request_with_retry(client, method, url, json=None, **kwargs):
+        if json and "queries" in json:
+            captured_queries.extend(json["queries"])
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"results": [{"vulns": []} for _ in captured_queries]}
+        return resp
+
+    with (
+        patch("agent_bom.scanners._get_scan_cache", return_value=None),
+        patch("agent_bom.scanners.request_with_retry", side_effect=mock_request_with_retry),
+        patch("agent_bom.scanners.create_client") as mock_create_client,
+    ):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_create_client.return_value = mock_client
+
+        await query_osv_batch([pkg])
+
+    ecosystems = {q["package"]["ecosystem"] for q in captured_queries}
+    assert ecosystems == {"Debian:11", "Debian:12", "Debian:13", "Debian:14"}
+
+
+@pytest.mark.asyncio
 async def test_scan_packages_maven_vuln_attached():
     """Vulnerabilities from OSV are attached to Maven packages after scan."""
     from agent_bom.scanners import scan_packages

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from agent_bom.version_utils import (
+    compare_version_order,
     compare_versions,
     normalize_version,
     strip_pip_extras,
     validate_version,
+    version_in_range,
 )
 
 # ---------------------------------------------------------------------------
@@ -185,3 +187,30 @@ def test_compare_versions_maven():
 
 def test_compare_versions_with_v_prefix():
     assert compare_versions("v1.0.0", "v2.0.0", "npm") is True
+
+
+def test_compare_version_order_deb_numeric_segments():
+    assert compare_version_order("6.5+20250216-2", "6.5+20250216-10", "deb") == -1
+
+
+def test_compare_version_order_apk_revision_segments():
+    assert compare_version_order("1.2.4-r2", "1.2.4-r10", "apk") == -1
+
+
+def test_compare_version_order_rpm_release_segments():
+    assert compare_version_order("3.0.7-24.el9", "3.0.7-25.el9", "rpm") == -1
+
+
+def test_version_in_range_deb():
+    assert version_in_range("6.5+20250216-2", "0", "6.5+20250216-3", None, "deb") is True
+    assert version_in_range("6.5+20250216-3", "0", "6.5+20250216-3", None, "deb") is False
+
+
+def test_version_in_range_apk():
+    assert version_in_range("1.2.4-r2", "0", "1.2.4-r10", None, "apk") is True
+    assert version_in_range("1.2.4-r10", "0", "1.2.4-r10", None, "apk") is False
+
+
+def test_version_in_range_rpm():
+    assert version_in_range("3.0.7-24.el9", "0", "3.0.7-25.el9", None, "rpm") is True
+    assert version_in_range("3.0.7-25.el9", "0", "3.0.7-25.el9", None, "rpm") is False


### PR DESCRIPTION
## Summary
- route CLI `check` and MCP `check` through the full scanner pipeline instead of shortcut paths
- carry distro and Debian source-package context through filesystem and image inventory
- align local DB lookup and OSV filtering on the same distro-aware OS package matching logic
- return an incomplete result for OS package checks when context is insufficient instead of a false clean verdict
- share supported package ecosystems between CLI and MCP validation to prevent drift

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache UV_FROZEN=1 uv run pytest -q tests/test_os_package_scanning.py tests/test_mcp_check_impl.py tests/test_scanner_ecosystems.py tests/test_local_vuln_db.py tests/test_osv_os_package_matching.py tests/test_version_utils.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python - <<'PY' ... scan_packages(Package(name='ncurses-bin', version='6.5+20250216-2', ecosystem='deb', source_package='ncurses', distro_name='debian', distro_version='13')) ... PY`
