### PR TITLE
Fix Dependabot auto-approve workflow pin

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -16,12 +16,16 @@ permissions:
 
 jobs:
   auto-approve:
-    if: github.actor == 'dependabot[bot]'
+    if: >-
+      github.actor == 'dependabot[bot]' ||
+      github.actor == 'app/dependabot' ||
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'app/dependabot'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@dbb049abf0d677abbd7571e8891e1a20b1f1da32 # v2.3.0
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
## Summary
- repin dependabot/fetch-metadata to the current valid upstream release commit
- recognize both dependabot[bot] and app/dependabot identities in the workflow gate
- restore auto-approve behavior for Dependabot security/version PRs without touching release logic

## Why
The current workflow is pinned to a fetch-metadata commit that no longer exists upstream, which causes the auto-approve job to fail during setup on Dependabot PRs like #1079.

## Validation
- inspected the failed #1079 auto-approve log and confirmed the missing upstream commit
- confirmed current latest fetch-metadata release is v2.5.0
- git diff --check