### PR TITLE
Keep dependency submission off pull requests

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,9 +1,12 @@
 name: Dependency Submission
 
+# Keep dependency submission off pull_request runs.
+# Dependency Review already handles statically-declared ecosystems on PRs,
+# and submitting head snapshots in parallel introduces a GitHub-side race
+# where review sees head/base snapshot mismatches (base=0, head=1).
+# We only submit authoritative snapshots on main and on manual runs.
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- stop running dependency submission on pull_request events
- keep dependency graph submission on main and manual runs only
- document the reason in the workflow so the split does not drift back

## Why
Dependency Review already works on statically-declared lockfiles/manifests in PRs. Submitting dependency snapshots in parallel on pull_request introduced a GitHub-side race where review saw base/head snapshot mismatches (, ) and produced bogus diffs.

## Validation
- git diff --check
- verified current origin/main dependency workflows and recent PR logs to confirm the race pattern
- scoped the fix to the submission workflow only