### PR TITLE
Harden scheduled Trivy rescan workflow

### DIFF
--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -15,6 +15,8 @@ jobs:
   rescan:
     name: Rescan — ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
       security-events: write  # required: SARIF upload to GitHub Security tab
@@ -29,6 +31,9 @@ jobs:
             runner: ubuntu-24.04-arm
             sarif_category: container-arm64
     steps:
+      - name: Check out repository
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v5
+
       - name: Pull ${{ matrix.platform }} image
         run: docker pull --platform ${{ matrix.platform }} agentbom/agent-bom:latest
 
@@ -44,6 +49,7 @@ jobs:
         continue-on-error: true
 
       - name: Trivy scan — SARIF
+        continue-on-error: true
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: agentbom/agent-bom:latest
@@ -54,11 +60,16 @@ jobs:
           trivyignores: .trivyignore
 
       - name: Upload SARIF to GitHub Security tab
-        if: always()
+        if: always() && hashFiles(format('trivy-{0}.sarif', matrix.sarif_category)) != ''
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           sarif_file: trivy-${{ matrix.sarif_category }}.sarif
           category: ${{ matrix.sarif_category }}
+
+      - name: Warn when SARIF was not generated
+        if: always() && hashFiles(format('trivy-{0}.sarif', matrix.sarif_category)) == ''
+        run: |
+          echo "::warning::Trivy SARIF was not generated for ${{ matrix.platform }}. Check the preceding Trivy step for workflow/config errors."
 
       - name: Flag HIGH/CRITICAL CVEs found
         if: steps.trivy-table.outcome == 'failure'


### PR DESCRIPTION
## Summary
- check out the repository before scheduled Trivy rescans so .trivyignore is available
- keep the SARIF scan from failing the workflow when Trivy fails before producing an output file
- warn explicitly when SARIF was not generated instead of surfacing a misleading GitHub Security upload error

## Validation
- uv run python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/container-rescan.yml').read_text())"
- git diff --check