### PR TITLE
Harden public release image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 ## ── Builder stage ────────────────────────────────────────────────────────────
-FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9 AS builder
+FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510 AS builder
 
 WORKDIR /app
 
-# Install build-time deps (git needed for setuptools-scm / VCS installs)
-RUN apt-get update && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
+# Build-time deps for wheel compilation when musllinux wheels are unavailable.
+RUN apk add --no-cache build-base git linux-headers
 
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
@@ -13,7 +12,7 @@ COPY src/ ./src/
 RUN pip install --no-cache-dir --prefix=/install ".[api]"
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
-FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
+FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
 ARG VERSION=dev
 
@@ -23,16 +22,14 @@ LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.source="https://github.com/msaad00/agent-bom"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-# Copy only installed packages from builder (no git, curl, pip, setuptools)
+# Copy only installed packages from builder (no compiler toolchain or git)
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
-# Apply latest OS security patches + upgrade pip (fixes CVE-2025-8869, CVE-2026-1703)
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir --upgrade pip
 
 # Create non-root user for least-privilege execution
-RUN addgroup --system abom && adduser --system --ingroup abom abom
+RUN addgroup -S abom && adduser -S -G abom abom
 
 WORKDIR /workspace
 RUN chown abom:abom /workspace


### PR DESCRIPTION
## Summary
- switch the release Docker image from Debian slim to a pinned Alpine Python base
- preserve the existing multi-stage/non-root packaging flow while removing the current public critical from the image base lineage
- keep the release image functional while materially reducing the published package/vulnerability surface

## Validation
- docker build -t agent-bom:release-alpine-test .
- docker run --rm agent-bom:release-alpine-test --version
- docker scout quickview agentbom/agent-bom:latest
- docker scout quickview agent-bom:release-alpine-test
- uv run agent-bom image agentbom/agent-bom:latest --format json -o /tmp/agent-bom-latest-image-scan.json
- uv run agent-bom image agent-bom:release-alpine-test --format json -o /tmp/agent-bom-release-alpine-test-scan.json