### PR TITLE
Finalize 0.75.5 release cut

### DIFF
--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -16,7 +16,7 @@ Set PlaybackSpeed 1.5
 
 # Setup
 Hide
-Type "export PS1='$ ' && mkdir -p /tmp/agent-bom-demo && cp /Users/mohamedsaad/.agent-bom/db/vulns.db /tmp/agent-bom-demo/vulns.db && alias abdemo='docker run --rm -e AGENT_BOM_DB_PATH=/tmp/vulns.db -v /tmp/agent-bom-demo/vulns.db:/tmp/vulns.db:ro agent-bom:release-alpine-test' && clear"
+Type "export PS1='$ ' && mkdir -p /tmp/agent-bom-demo && cp \"$HOME/.agent-bom/db/vulns.db\" /tmp/agent-bom-demo/vulns.db && alias abdemo='docker run --rm -e AGENT_BOM_DB_PATH=/tmp/vulns.db -v /tmp/agent-bom-demo/vulns.db:/tmp/vulns.db:ro agent-bom:release-alpine-test' && clear"
 Enter
 Sleep 500ms
 Show


### PR DESCRIPTION
## Summary
- scrub the published demo source so docs/demo.tape no longer contains a personal workstation path
- keep the rendered 0.75.5 GIF and demo flow aligned with the merged release candidate state
- package the last release-surface fix before tagging v0.75.5

## Release Readiness
- public image hardening merged in #1083
- scrubbed demo and README refresh merged in #1084
- requests moderate bump merged in #1079
- dependency/workflow hardening merged in #1080, #1081, #1082
- remaining known advisory is the low/no-fix Pygments issue tracked in GitHub Security

## Validation
- rg -n "mohamedsaad|/Users/|agent-bom 0.75.3|demo-v0.75.[34]" README.md docs scripts ui deploy src
- verified only docs/demo.tape needed cleanup
