### PR TITLE
Raise dashboard Streamlit floor for release

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,3 +1,3 @@
-streamlit>=1.37.0
+streamlit>=1.55.0
 plotly>=5.18.0
 pandas>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ mcp-server = [
     "mcp>=1.26",
     "smithery>=0.4",
 ]
-dashboard = ["streamlit>=1.37.0", "plotly>=5.18", "pillow>=12.1.1"]  # GHSA-rxff-vr5r-8cj5 (fixed in 1.37.0); pillow>=12.1.1 fixes CVE-2023-50447, CVE-2024-28219, CVE-2026-25990 (PSD OOB write)
+dashboard = ["streamlit>=1.55.0", "plotly>=5.18", "pillow>=12.1.1"]  # Track the resolved dashboard floor to avoid vulnerable lower-bound installs; pillow>=12.1.1 fixes CVE-2023-50447, CVE-2024-28219, CVE-2026-25990 (PSD OOB write)
 snyk = []  # Uses existing httpx dependency, no additional packages needed
 oidc = [
     "PyJWT>=2.8",

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ requires-dist = [
     { name = "smithery", marker = "extra == 'mcp-server'", specifier = ">=0.4" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.6" },
     { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=2.1" },
-    { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.37.0" },
+    { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.55.0" },
     { name = "toml", specifier = ">=0.10" },
     { name = "tornado", specifier = ">=6.5.5" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary
- raise the dashboard Streamlit floor from 1.37.0 to 1.55.0 in release-facing manifests
- keep pyproject, dashboard requirements, and uv.lock aligned
- stop release metadata from advertising the older vulnerable minimum when the resolved lock already uses the newer line

## Why
The GitHub Security alert is being raised from the dashboard lower-bound specifier in pyproject.toml / dashboard/requirements.txt, not from the hardened default image. This keeps the optional dashboard surface aligned before tagging v0.75.5.

## Validation
- rg -n "streamlit>=|dashboard =" pyproject.toml dashboard/requirements.txt
- verified uv.lock keeps requests at 2.33.0 while updating the dashboard streamlit specifier to 1.55.0
