### PR TITLE
Upgrade runtime zlib for release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
+RUN apk upgrade --no-cache zlib
 RUN pip install --no-cache-dir --upgrade pip
 
 # Create non-root user for least-privilege execution


### PR DESCRIPTION
## Summary
- upgrade Alpine runtime zlib during image build so the release image picks up 1.3.2-r0
- clear the exact Trivy blocker that caused the v0.75.5 release workflow to fail
- keep the fix narrow to the runtime package instead of widening the image refresh scope

## Validation
- docker run --rm --entrypoint sh python:3.14.3-alpine3.23 -lc "apk update >/dev/null && apk policy zlib"
- docker build -t agent-bom:zlib-fix .
- docker run --rm --entrypoint sh agent-bom:zlib-fix -lc "apk list --installed zlib"
- verified installed version is zlib-1.3.2-r0

## Release Note
After this merges, cut v0.75.6 instead of reusing the failed v0.75.5 tag.
