### PR TITLE
Split PyPI storefront from GitHub README

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -66,7 +66,7 @@ docker run --rm agentbom/agent-bom:latest doctor
 - **30 MCP client types** — Claude Desktop, Cursor, Windsurf, VS Code Copilot, Cline, Continue, Zed, Cortex Code, and more
 - Packages, container images, IaC, secrets, AI source code, and cloud AI environments
 - Blast radius from package to server to agent to credentials and tools
-- Runtime MCP proxy with 7 behavioral detectors
+- Runtime MCP proxy with 8 behavioral detectors
 - 14 compliance frameworks
 - 33 MCP server tools
 - 20-page Next.js dashboard
@@ -88,7 +88,7 @@ agent-bom answers:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `v0.75.5` | Current stable version (pinned) |
+| `v0.75.7` | Current stable version (pinned) |
 
 ## Links
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=dev
+ARG VERSION=0.75.7
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — CVEs, blast radius, credential exposure, runtime enforcement"

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,0 +1,64 @@
+# agent-bom
+
+**AI security scanner for agents, MCP, containers, cloud, and runtime.**
+
+agent-bom discovers AI agents and MCP servers, maps CVEs into real blast radius from package to server to agent to credentials and tools, scans packages, container images, filesystems, IaC, secrets, and cloud AI infrastructure, and protects MCP traffic at runtime.
+
+![agent-bom demo](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif)
+
+## Quick start
+
+```bash
+pip install agent-bom
+
+# AI agent and MCP scan
+agent-bom agents
+
+# Workstation posture summary
+agent-bom agents --posture
+
+# Pre-install CVE and supply chain gate
+agent-bom check flask@2.0.0
+```
+
+## What it scans
+
+- **30 MCP client types** across real local developer environments
+- **Packages and supply chain** with OSV, NVD, GHSA, EPSS, and CISA KEV
+- **Container images and filesystems** with native image and inventory scanning
+- **IaC and Kubernetes** including Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes manifests
+- **Cloud AI and AI infrastructure** across AWS, Azure, GCP, Databricks, Snowflake, Hugging Face, Ollama, W&B, OpenAI, and vector databases
+- **Runtime MCP traffic** with an enforcement proxy, 112 detection patterns, PII redaction, and evidence collection
+
+## How it works
+
+![How agent-bom works](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-light.svg)
+
+## Blast radius
+
+![agent-bom blast radius](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg)
+
+## More common commands
+
+```bash
+# Container image scan
+agent-bom image nginx:latest
+
+# IaC and Kubernetes scan
+agent-bom iac Dockerfile k8s/ infra/main.tf
+
+# Cloud AI and infrastructure inventory
+agent-bom cloud aws
+
+# AI BOM / SBOM export
+agent-bom agents -p . -f cyclonedx -o ai-bom.json
+
+# Runtime proxy
+agent-bom proxy "npx @mcp/server-filesystem /tmp"
+```
+
+For the full GitHub README, Mermaid diagrams, release history, and live project status, see:
+
+- GitHub: https://github.com/msaad00/agent-bom
+- Documentation: https://github.com/msaad00/agent-bom#readme
+- Docker Hub: https://hub.docker.com/r/agentbom/agent-bom

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/msaad00/agent-bom/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/msaad00/agent-bom/ci.yml?branch=main&style=flat&label=Build" alt="Build"></a>
   <a href="https://pypi.org/project/agent-bom/"><img src="https://img.shields.io/pypi/v/agent-bom?style=flat&label=Latest%20version" alt="PyPI"></a>
   <a href="https://hub.docker.com/r/agentbom/agent-bom"><img src="https://img.shields.io/docker/pulls/agentbom/agent-bom?style=flat&label=Docker%20pulls" alt="Docker"></a>
   <a href="https://github.com/msaad00/agent-bom/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue?style=flat" alt="License"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom"><img src="https://img.shields.io/ossf-scorecard/github.com/msaad00/agent-bom?style=flat&label=OpenSSF%20scorecard" alt="OpenSSF Scorecard"></a>
   <a href="https://github.com/msaad00/agent-bom/stargazers"><img src="https://img.shields.io/github/stars/msaad00/agent-bom?style=flat&logo=github&label=Stars" alt="Stars"></a>
   <a href="https://github.com/msaad00/agent-bom/discussions"><img src="https://img.shields.io/github/discussions/msaad00/agent-bom?style=flat&logo=github&label=Discussions" alt="Discussions"></a>
 </p>
@@ -205,7 +207,7 @@ Read-only. Agentless. No secrets leave your machine.
 ## Extended quick start
 
 ```bash
-# MCP security proxy (112 patterns, 7 detectors, PII redaction)
+# MCP security proxy (112 patterns, 8 detectors, PII redaction)
 agent-bom proxy "npx @mcp/server-filesystem /tmp"
 
 # Dependency graph export (Neo4j, GraphML, Graphviz, Mermaid)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ graph TB
 
     subgraph Shield["agent-shield — Runtime Protection"]
         Proxy["proxy\nMCP proxy + audit"]
-        Protect["protect --shield\n7 detectors + deep defense"]
+        Protect["protect --shield\n8 detectors + deep defense"]
         Run_Cmd["run\nZero-config proxy"]
     end
 
@@ -56,7 +56,7 @@ graph TB
         Console["Console\nTable / verbose"]
         Formats["Formats\nJSON / SARIF / HTML / CycloneDX"]
         API["REST API + MCP\n33 tools"]
-        Proxy["Runtime Proxy\n7 detectors"]
+        Proxy["Runtime Proxy\n8 detectors"]
     end
 
     Scan & MCP_Cmd --> Discovery
@@ -225,7 +225,7 @@ graph TB
 | Models | `src/agent_bom/models.py` | Core data models (Package, Vulnerability, Agent, BlastRadius) |
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
-| Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 behavioral detectors) |
+| Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (8 behavioral detectors) |
 | MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (33 tools) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -187,7 +187,7 @@ All documented features verified to have code + tests:
 | SBOM ingest (CycloneDX/SPDX) | `sbom.py` | `tests/test_sbom.py` |
 | VEX | `vex.py` | `tests/test_vex.py` |
 | SAST (Semgrep, 52 CWEs) | `sast.py` | `tests/test_sast.py` |
-| Runtime proxy (7 detectors) | `runtime/detectors.py`, `proxy.py` | `tests/test_runtime_detectors.py` |
+| Runtime proxy (8 detectors) | `runtime/detectors.py`, `proxy.py` | `tests/test_runtime_detectors.py` |
 | MCP config discovery (30 clients) | `discovery/` | `tests/test_discovery.py` |
 | CIS benchmarks (AWS/Snowflake/Azure/GCP) | `cloud/*_cis_benchmark.py` | `tests/test_*_cis_benchmark.py` |
 | Databricks security checks | `cloud/databricks_security.py` | `tests/test_databricks_security.py` |
@@ -329,7 +329,7 @@ log_tool_call() — JSONL audit log, 0o600 permissions, payload SHA-256, policy 
 _send_webhook() — SSRF-protected (validate_url()), fire-and-forget async POST
 ```
 
-**runtime/detectors.py** — 7 detectors:
+**runtime/detectors.py** — 8 detectors:
 
 | Detector | What it checks |
 |----------|----------------|
@@ -348,7 +348,7 @@ _send_webhook() — SSRF-protected (validate_url()), fire-and-forget async POST
 | F5 | `runtime/__init__.py` | `VectorDBInjectionDetector` was not exported from the public runtime API — added to `__all__` |
 | F6 | `proxy.py` | `VectorDBInjectionDetector` was never instantiated in `run_proxy()` — added `vector_detector` alongside `response_inspector`; now fires for every tool response with CRITICAL severity upgrade for confirmed vector tool names |
 
-**Test coverage**: 88 tests in `test_runtime_detectors.py` + `test_proxy.py` + `test_proxy_metrics.py`, plus `test_protect.py`, `test_protection_engine.py`. All 7 detectors are tested individually.
+**Test coverage**: 88 tests in `test_runtime_detectors.py` + `test_proxy.py` + `test_proxy_metrics.py`, plus `test_protect.py`, `test_protection_engine.py`. All 8 detectors are tested individually.
 
 ---
 
@@ -508,7 +508,7 @@ ScanRequest → _run_scan_sync() [ThreadPoolExecutor]
 | F9 | `ARCHITECTURE.md` | Detector list now includes `VectorDBInjectionDetector` |
 | F10 | `ARCHITECTURE.md` | `CLI with 15+ commands` → `22+ commands and groups` |
 | F11 | `ARCHITECTURE.md` | `enforcement.py — 10 checks` → `8 checks` |
-| F12 | SVGs (7 files) | `7 detectors` → `7 detectors`: engine-internals, modes-flow, offerings-map, scanner-architecture (dark + light variants) |
+| F12 | SVGs (7 files) | `7 detectors` → `8 detectors`: engine-internals, modes-flow, offerings-map, scanner-architecture (dark + light variants) |
 
 ### Verified accurate (no changes needed)
 

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -111,7 +111,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/root/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:v0.74.1 agents --format json
+  agentbom/agent-bom:v0.75.7 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -166,7 +166,7 @@ agent-bom proxy "uvx mcp-server-filesystem /" --policy policy.yml
 agent-bom proxy --url http://localhost:3000 --policy policy.yml
 ```
 
-**7 behavioral detectors running on every message:**
+**8 behavioral detectors running on every message:**
 
 | Detector | What it catches | Framework reference |
 |----------|----------------|---------------------|
@@ -177,6 +177,7 @@ agent-bom proxy --url http://localhost:3000 --policy policy.yml
 | `SequenceAnalyzer` | Read → send → delete exfiltration sequences | MITRE ATLAS AML.T0025 |
 | `ResponseInspector` | Cloaking (invisible unicode), SVG injection, metadata poisoning | OWASP LLM05 |
 | `VectorDBInjectionDetector` | Prompt injection from retrieved vector DB chunks | OWASP LLM RAG-03 |
+| `CrossAgentCorrelator` | Cross-agent tool convergence and lateral movement patterns | OWASP Agentic AI ASI07, runtime lateral movement detection |
 
 Policy conditions (17 declarative + expression engine):
 
@@ -224,7 +225,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.74.0
+- uses: msaad00/agent-bom@v0.75.7
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -57,7 +57,7 @@ The proxy sits between the MCP client and server on the **stdio transport layer*
 1. Reads JSON-RPC messages from the client
 2. Inspects message content (tool calls, tool responses)
 3. Applies policy rules (allow/deny/log)
-4. Runs 7 detectors (PII, secrets, SQL injection, SSRF, path traversal, command injection, XSS)
+4. Runs 8 detectors (tool drift, prompt injection, credential/PII leak, rate-limit abuse, exfiltration sequences, response cloaking, vector DB injection, cross-agent correlation)
 5. Forwards allowed messages to the server
 6. Logs all activity to JSONL audit file
 

--- a/docs/STRATEGIC_AUDIT_2026_03.md
+++ b/docs/STRATEGIC_AUDIT_2026_03.md
@@ -121,7 +121,7 @@
 | Component | Capabilities |
 |-----------|-------------|
 | **proxy.py** | stdio MCP proxy, policy enforcement, credential leak detection, replay detection, per-tool rate limiting (sliding window), Prometheus metrics, JSONL audit, HMAC signing, JWKS signature verification (RS256/RS384/RS512/ES256/ES384/ES512), OIDC discovery, client readline timeout (120s), relay task exception logging |
-| **protect** | 7 detectors: ToolDrift (rug pull), ArgumentAnalyzer (injection), CredentialLeak, RateLimit, SequenceAnalyzer (exfil patterns), ResponseInspector (cloaking/SVG/invisible chars), VectorDBInjectionDetector |
+| **protect** | 8 detectors: ToolDrift (rug pull), ArgumentAnalyzer (injection), CredentialLeak, RateLimit, SequenceAnalyzer (exfil patterns), ResponseInspector (cloaking/SVG/invisible chars), VectorDBInjectionDetector, CrossAgentCorrelator |
 | **watch** | Filesystem watchers on MCP configs, diff-on-change, webhook alerts (Slack/Teams/PagerDuty) |
 | **introspect** | Live MCP server connection, tools/list + resources/list, drift detection |
 | **enforcement** | Tool poisoning detection, unicode normalization, description drift, inputSchema injection scanning |
@@ -332,7 +332,7 @@ Cortex Code has a sophisticated security model that agent-bom should integrate w
 | No blast radius analysis | Blast radius with compliance mapping |
 | Permission caching risks (permissions.json) | Audit cached approvals, flag overly permissive |
 | AGENTS.md/SKILL.md trust unknown | 17 behavioral risk patterns + typosquat detection |
-| No runtime MCP traffic inspection | Proxy with 7 detectors, JSONL audit |
+| No runtime MCP traffic inspection | Proxy with 8 detectors, JSONL audit |
 | SQL injection via MCP tool descriptions | InputSchema injection scanning |
 | No supply chain visibility | SBOM generation, dependency graph, context graph |
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -39,7 +39,7 @@ agent-bom operates in four modes:
 | Local filesystem | Trusted | User's own config files; validated with `validate_path(restrict_to_home=True)` |
 | Public vuln APIs (OSV, NVD, EPSS, KEV) | Untrusted input | Responses are parsed defensively; no code execution from API data |
 | Cloud provider APIs (AWS, Azure, GCP, Snowflake) | Authenticated, semi-trusted | Read-only API calls; credentials from environment; responses parsed defensively |
-| Upstream MCP servers (via proxy) | Untrusted | All traffic inspected by 7 detectors; policy enforcement before relay |
+| Upstream MCP servers (via proxy) | Untrusted | All traffic inspected by 8 detectors; policy enforcement before relay |
 | AI clients (via MCP server) | Semi-trusted | Tool inputs validated; no shell execution from AI-provided arguments |
 | Docker daemon socket | Privileged | Only accessed with explicit `--image` flag; user must opt in |
 | Kubernetes API | Privileged | Only accessed with explicit `--k8s-mcp` flag; uses kubeconfig auth |

--- a/docs/WINDOWS_CONTAINERS.md
+++ b/docs/WINDOWS_CONTAINERS.md
@@ -111,7 +111,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.74.0`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.75.7`) which
    runs on Linux runners
 
 ---

--- a/docs/decisions/004-proxy-runtime-enforcement.md
+++ b/docs/decisions/004-proxy-runtime-enforcement.md
@@ -24,7 +24,7 @@ and server, intercepting all JSON-RPC messages. The proxy:
 3. **Enforces** policies (block/allow/audit per tool, per argument pattern)
 4. **Logs** all traffic to JSONL audit files for forensic replay
 
-**Detector pipeline (7 detectors):**
+**Detector pipeline (8 detectors):**
 
 | Detector | Threat |
 |----------|--------|

--- a/integrations/docker-mcp-registry/readme.md
+++ b/integrations/docker-mcp-registry/readme.md
@@ -28,7 +28,7 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom scan -p /workspace -f 
 ## Key features
 
 - **Blast radius mapping** — package → server → agent → credentials → tools
-- **Runtime MCP proxy** — 7 behavioral detectors (rug pull, injection, credential leak, exfil, cloaking, rate limiting, vector DB injection)
+- **Runtime MCP proxy** — 8 behavioral detectors (rug pull, injection, credential leak, exfil, cloaking, rate limiting, vector DB injection, cross-agent correlation)
 - **14 compliance frameworks** — OWASP LLM Top 10, OWASP Agentic Top 10, MITRE ATLAS, MITRE ATT&CK, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CMMC, FedRAMP, CIS Benchmarks, AISVS
 - **32 MCP tools** — available to any MCP-compatible AI assistant
 

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "AI infrastructure and supply chain security — blast radius mapping, AST source analysis, AI BOM, 8-detector runtime proxy with 112 patterns, Shield SDK, secret scanning, 14-framework compliance",
-  "version": "0.75.4",
+  "version": "0.75.7",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -103,7 +103,7 @@ db_status()
 agent-bom doctor
 
   Python        3.12.2   OK
-  agent-bom     0.75.4   OK
+  agent-bom     0.75.7   OK
   pip           24.0     OK
   semgrep       not found  (optional — SAST scanning unavailable)
   kubectl       not found  (optional — K8s context unavailable)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "agent-bom"
 version = "0.75.7"
 description = "Security scanner for AI infrastructure and supply chain. AI agent discovery (30 MCP clients), AST source code analysis, AI BOM generation (CycloneDX 1.6 ML extensions), CVE scanning (OSV/NVD/EPSS/KEV), blast radius mapping (CVE → package → MCP server → agent → credentials → tools), runtime proxy (112 detection patterns, PII redaction), Shield SDK, secret scanning, red team simulator, 33 MCP tools, CIS benchmarks, 14-framework compliance, 19 output formats, 20-page Next.js dashboard."
-readme = "README.md"
+readme = "PYPI_README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
@@ -104,7 +104,7 @@ mcp-server = [
     "mcp>=1.26",
     "smithery>=0.4",
 ]
-dashboard = ["streamlit>=1.55.0", "plotly>=5.18", "pillow>=12.1.1"]  # Track the resolved dashboard floor to avoid vulnerable lower-bound installs; pillow>=12.1.1 fixes CVE-2023-50447, CVE-2024-28219, CVE-2026-25990 (PSD OOB write)
+dashboard = ["streamlit>=1.55.0", "plotly>=5.18.0", "pandas>=2.0.0"]
 snyk = []  # Uses existing httpx dependency, no additional packages needed
 oidc = [
     "PyJWT>=2.8",

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 README = ROOT / "README.md"
+PYPI_README = ROOT / "PYPI_README.md"
 DEMO_TAPE = ROOT / "docs" / "demo.tape"
 DEMO_LATEST = ROOT / "docs" / "images" / "demo-latest.gif"
 
@@ -29,32 +30,49 @@ def _fail(message: str) -> None:
 def main() -> int:
     version = _load_version()
     readme = README.read_text()
+    pypi_readme = PYPI_README.read_text()
     demo_tape = DEMO_TAPE.read_text()
 
-    required_readme_markers = [
+    required_github_markers = [
+        "img.shields.io/github/actions/workflow/status",
         "img.shields.io/pypi/v/agent-bom",
         "img.shields.io/docker/pulls/agentbom/agent-bom",
+        "img.shields.io/ossf-scorecard",
         "docs/images/demo-latest.gif",
     ]
-    for marker in required_readme_markers:
+    for marker in required_github_markers:
         if marker not in readme:
             _fail(f"README is missing required storefront marker: {marker}")
 
-    forbidden_readme_markers = [
-        "github/actions/workflow/status",
-        "api.securityscorecards.dev",
-        "img.shields.io/badge/OpenSSF",
+    required_pypi_markers = [
+        "docs/images/demo-latest.gif",
+        "docs/images/scan-pipeline-light.svg",
+        "docs/images/blast-radius-light.svg",
+    ]
+    for marker in required_pypi_markers:
+        if marker not in pypi_readme:
+            _fail(f"PYPI_README.md is missing required storefront marker: {marker}")
+
+    forbidden_pypi_markers = [
+        "img.shields.io/github/actions/workflow/status",
         "img.shields.io/ossf-scorecard",
+        "api.securityscorecards.dev",
+        "```mermaid",
+        "flowchart ",
         "demo-v0.",
     ]
-    for marker in forbidden_readme_markers:
-        if marker in readme:
-            _fail(f"README contains forbidden stale/noisy storefront marker: {marker}")
+    for marker in forbidden_pypi_markers:
+        if marker in pypi_readme:
+            _fail(f"PYPI_README.md contains forbidden storefront marker: {marker}")
 
     if "demo-latest.gif" not in readme:
         _fail("README must reference docs/images/demo-latest.gif")
+    if "demo-latest.gif" not in pypi_readme:
+        _fail("PYPI_README.md must reference docs/images/demo-latest.gif")
     if re.search(r"demo-v\d+\.\d+\.\d+\.gif", readme):
         _fail("README must not reference versioned demo GIF filenames")
+    if re.search(r"demo-v\d+\.\d+\.\d+\.gif", pypi_readme):
+        _fail("PYPI_README.md must not reference versioned demo GIF filenames")
     if "Output docs/images/demo-latest.gif" not in demo_tape:
         _fail("docs/demo.tape must render to docs/images/demo-latest.gif")
     if not DEMO_LATEST.exists():
@@ -64,7 +82,7 @@ def main() -> int:
         r"/Users/[^/\s]+",
         r"[A-Za-z]:\\Users\\[^\\\s]+",
     ]
-    scan_roots = [ROOT / "README.md", ROOT / "docs"]
+    scan_roots = [ROOT / "README.md", ROOT / "PYPI_README.md", ROOT / "docs"]
     for path in scan_roots:
         files = [path] if path.is_file() else [p for p in path.rglob("*") if p.is_file()]
         for file in files:
@@ -78,7 +96,7 @@ def main() -> int:
     if f"agent-bom v{version}" not in demo_tape:
         _fail(f"docs/demo.tape header must include v{version}")
 
-    print("README/docs release consistency checks passed")
+    print("README/PyPI/docs release consistency checks passed")
     return 0
 
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @agent-bom/runtime — Runtime security detectors for MCP traffic.
  *
- * 7 detectors that analyze MCP JSON-RPC traffic in real-time:
+ * 8 detectors that analyze MCP JSON-RPC traffic in real-time:
  * - ToolDriftDetector — rug pull detection (new tools after baseline)
  * - ArgumentAnalyzer — shell injection, path traversal, credential values
  * - CredentialLeakDetector — API keys/tokens in tool responses

--- a/security/image-exceptions.yaml
+++ b/security/image-exceptions.yaml
@@ -1,29 +1,4 @@
 exceptions:
-  - id: debian-ncurses-trixie-no-fix
-    vulnerability_ids:
-      - CVE-2025-69720
-      - CVE-2025-6141
-    package: debian/ncurses
-    version: 6.5+20250216-2
-    images:
-      - agentbom/agent-bom:latest
-      - agentbom/agent-bom:v0.75.5
-    architectures:
-      - linux/amd64
-      - linux/arm64
-    severity: critical
-    owner: msaad00
-    status: temporary_exception
-    reason: >-
-      Inherited from the current python:3.12.13-slim Debian lineage. Docker Scout
-      surfaces the issue publicly; Debian's supported base lineage did not yet
-      expose a patched package for this suite when this exception was added.
-    opened_at: 2026-03-24
-    review_after: 2026-03-31
-    expires_at: 2026-04-14
-    remove_when: >-
-      Remove immediately after a refreshed approved base digest clears the ncurses
-      issue or the public runtime image moves to a cleaner promoted base.
   - id: pyopenssl-snowflake-pin
     vulnerability_ids:
       - CVE-2026-27459

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -85,8 +85,10 @@ main.commands["scan"] = _scan_hidden
 from agent_bom.cli._inventory import completions_cmd, inventory, validate, where  # noqa: E402
 
 # inventory + where are under `mcp` group — no top-level duplicate
-main.add_command(validate)
-main.commands["validate"].hidden = True  # Use `mcp validate` or `iac validate`
+_validate_hidden = _copy.copy(validate)
+_validate_hidden.hidden = True  # Use `mcp validate` or `iac validate`
+_validate_hidden.name = "validate"
+main.commands["validate"] = _validate_hidden
 main.add_command(completions_cmd, "completions")
 
 from agent_bom.cli._check import check, guard_cmd, verify  # noqa: E402
@@ -191,6 +193,7 @@ mcp_group.add_command(introspect_cmd, "introspect")
 mcp_group.add_command(registry, "registry")
 mcp_group.add_command(mcp_server_cmd, "server")
 mcp_group.add_command(where, "where")
+mcp_group.add_command(validate, "validate")
 main.add_command(mcp_group)
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cli/_policy_group.py
+++ b/src/agent_bom/cli/_policy_group.py
@@ -1,7 +1,8 @@
-"""Policy command group — templates and remediation.
+"""Policy command group — checks, templates, and remediation.
 
 Usage::
 
+    agent-bom policy check report.json   # evaluate report against policy
     agent-bom policy template            # generate starter policy file
     agent-bom policy apply <scan.json>   # apply remediation fixes
 """
@@ -14,10 +15,11 @@ import click
 @click.group("policy", invoke_without_command=True)
 @click.pass_context
 def policy_group(ctx: click.Context) -> None:
-    """Policy management — templates and remediation.
+    """Policy management — checks, templates, and remediation.
 
     \b
     Subcommands:
+      check       Evaluate a report against policy rules
       template    Generate a starter policy file with common rules
       apply       Apply remediation fixes from scan result JSON
     """

--- a/src/agent_bom/cli/_runtime_group.py
+++ b/src/agent_bom/cli/_runtime_group.py
@@ -1,13 +1,10 @@
-"""Runtime command group — proxy, protect, watch, and audit MCP traffic.
+"""Runtime command group — proxy and audit MCP traffic.
 
 Usage::
 
     agent-bom runtime                    # show runtime subcommands
     agent-bom runtime proxy "npx srv"    # MCP traffic enforcement proxy
-    agent-bom runtime protect            # standalone protection engine
-    agent-bom runtime watch              # filesystem watch on MCP configs
     agent-bom runtime audit              # replay proxy audit log
-    agent-bom runtime configure          # auto-configure proxy for servers
 """
 
 from __future__ import annotations
@@ -18,14 +15,16 @@ import click
 @click.group("runtime", invoke_without_command=True)
 @click.pass_context
 def runtime_group(ctx: click.Context) -> None:
-    """Runtime enforcement — proxy, protect, watch, and audit MCP traffic.
+    """Runtime enforcement — proxy and audit MCP traffic.
 
     \b
     Subcommands:
       proxy       Run MCP server through security proxy
-      protect     Runtime protection engine (7 behavioral detectors)
-      watch       Watch MCP configs for drift and alert
       audit       View and analyze proxy audit log
+
+    Hidden compatibility commands:
+      protect     Runtime protection engine (8 behavioral detectors)
+      watch       Watch MCP configs for drift and alert
       configure   Auto-configure proxy for discovered servers
     """
     if ctx.invoked_subcommand is None:

--- a/src/agent_bom/cli/shield.py
+++ b/src/agent_bom/cli/shield.py
@@ -1,6 +1,6 @@
 """agent-shield — Runtime protection for AI agents.
 
-Monitors MCP traffic in real-time with 7 behavioral detectors,
+Monitors MCP traffic in real-time with 8 behavioral detectors,
 enforces security policies, and provides deep defense mode with
 correlated threat scoring and automatic kill-switch.
 
@@ -45,7 +45,7 @@ def shield():
     """agent-shield — Runtime protection for AI agents.
 
     \b
-    MCP security proxy with 112 detection patterns across 7 detectors:
+    MCP security proxy with 112 detection patterns across 8 detectors:
     · Tool drift (rug pull)    · Shell injection     · Credential leaks
     · Rate limiting            · Attack sequences    · Response cloaking
     · Vector DB injection      · PII redaction

--- a/src/agent_bom/shield.py
+++ b/src/agent_bom/shield.py
@@ -37,7 +37,7 @@ from agent_bom.runtime.protection import (
 class Shield:
     """In-process AI agent security middleware.
 
-    Drop-in protection for any AI agent pipeline. Runs all 7 detectors
+    Drop-in protection for any AI agent pipeline. Runs all 8 detectors
     locally with 112 patterns. No proxy needed, no network, no config.
 
     Args:

--- a/src/agent_bom/smithery.py
+++ b/src/agent_bom/smithery.py
@@ -1,6 +1,6 @@
 """Smithery.ai registry integration — live lookup, risk enrichment, registry sync.
 
-Extends agent-bom's bundled 112-server MCP registry with Smithery's 2,800+ servers.
+Extends agent-bom's bundled 427-server MCP registry with Smithery's 2,800+ servers.
 Used as a fallback when a discovered MCP server is not in the local registry.
 
 API docs: https://smithery.ai/docs/concepts/registry_search_servers

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.74.1' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.75.7' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.75.5"
+version = "0.75.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -74,7 +74,7 @@ cloud = [
     { name = "wandb" },
 ]
 dashboard = [
-    { name = "pillow" },
+    { name = "pandas" },
     { name = "plotly" },
     { name = "streamlit" },
 ]
@@ -220,9 +220,9 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20" },
     { name = "packageurl-python", specifier = ">=0.17" },
     { name = "packaging", specifier = ">=24.0" },
-    { name = "pillow", marker = "extra == 'dashboard'", specifier = ">=12.1.1" },
+    { name = "pandas", marker = "extra == 'dashboard'", specifier = ">=2.0.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10" },
-    { name = "plotly", marker = "extra == 'dashboard'", specifier = ">=5.18" },
+    { name = "plotly", marker = "extra == 'dashboard'", specifier = ">=5.18.0" },
     { name = "protobuf", marker = "extra == 'otel'", specifier = ">=6.33.5" },
     { name = "psutil", marker = "extra == 'runtime'", specifier = ">=5.9" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },


### PR DESCRIPTION
## Summary
- split the published PyPI long description into  while keeping a richer GitHub README
- replace raw Mermaid on the PyPI surface with static images and fix the remaining release-surface drift on current 
- sync CLI/help text, dashboard dependencies, detector counts, and current version references across docs and metadata

## Validation
- 
- 
- 
- 
