### PR TITLE
Harden workflow permissions and review noise

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 4 * * 1'  # Weekly batch fuzzing — Monday 04:00 UTC
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 jobs:
   Build:
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -50,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,18 +157,16 @@ jobs:
           apk add --no-cache gcc musl-dev libffi-dev openssl-dev git curl
 
       - name: Install uv
-        run: |
-          # Pin uv version for reproducibility (Scorecard Pinned-Dependencies)
-          curl -LsSf https://astral.sh/uv/0.7.12/install.sh | sh
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.7.12"
 
       - name: Install project dependencies
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           uv sync --extra dev --extra api --extra mcp-server
 
       - name: Run tests (musl)
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           uv run pytest tests/ -q --tb=short -m "not network" -x
 
   # 3c. PR Base Branch Guard — prevent stacked PRs targeting feature branches

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -48,7 +48,6 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
-          comment-summary-in-pr: always
           retry-on-snapshot-warnings: true
           allow-licenses: >-
             Apache-2.0, MIT, MIT-0, MIT-CMU, BSD-2-Clause, BSD-3-Clause,

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -10,14 +10,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   dependency-submission:
     name: Submit dependency snapshots
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
     - cron: '30 1 * * 1'  # Every Monday at 01:30 UTC
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 jobs:
   scorecard:


### PR DESCRIPTION
## Summary
- tighten workflow permissions by removing broad top-level defaults and scoping write access to the exact jobs that need it
- stop dependency-review from posting noisy PR summary comments for harmless snapshot-warning cases
- replace the Alpine CI uv curl installer with the pinned setup action used elsewhere in the repo

## Validation
- parsed the changed workflow YAML files successfully
- rg -n "read-all|comment-summary-in-pr|curl -LsSf https://astral.sh/uv/0.7.12/install.sh" .github/workflows .clusterfuzzlite
