### PR TITLE
Fix MCP registry publish diagnostics

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -80,6 +80,17 @@ jobs:
 
       - name: Publish to MCP Registry
         run: |
+          print_publish_error() {
+            if jq -e . >/dev/null 2>&1 </tmp/publish-response.json; then
+              echo "::group::MCP Registry publish error details"
+              jq -c '{error, message, detail, details, code, status}' /tmp/publish-response.json
+              echo "::endgroup::"
+            else
+              echo "::warning::MCP Registry returned a non-JSON error body"
+              head -c 1024 /tmp/publish-response.json || true
+            fi
+          }
+
           # Retry up to 3 times with exponential backoff
           for ATTEMPT in 1 2 3; do
             HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
@@ -103,8 +114,7 @@ jobs:
               sleep "$DELAY"
             else
               echo "::error::MCP Registry publish failed (HTTP $HTTP_STATUS)"
-              # Log only error message, not full response (may contain tokens/sensitive data)
-              jq -r '.error // .message // "unknown error"' /tmp/publish-response.json 2>/dev/null || echo "(non-JSON response)"
+              print_publish_error
               exit 1
             fi
           done

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "Security scanner for AI infrastructure — blast radius mapping, AI BOM, runtime proxy, compliance",
+  "description": "AI security scanner for agents, MCP, containers, cloud, and runtime",
   "title": "agent-bom",
   "version": "0.75.8",
   "repository": {


### PR DESCRIPTION
## Summary
- shorten the MCP registry description to an ASCII-safe 67-character string
- improve publish-mcp-registry logging so HTTP 400 responses show structured error details
- keep the fix limited to the remaining live post-release blocker

## Validation
- JSON parse of integrations/mcp-registry/server.json
- YAML parse of .github/workflows/publish-mcp-registry.yml