### PR TITLE
Fix MCP Registry PyPI publish marker

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,5 +1,7 @@
 # agent-bom
 
+<!-- mcp-name: io.github.msaad00/agent-bom -->
+
 **AI security scanner for agents, MCP, containers, cloud, and runtime.**
 
 agent-bom discovers AI agents and MCP servers, maps CVEs into real blast radius from package to server to agent to credentials and tools, scans packages, container images, filesystems, IaC, secrets, and cloud AI infrastructure, and protects MCP traffic at runtime.
@@ -54,7 +56,7 @@ agent-bom cloud aws
 agent-bom agents -p . -f cyclonedx -o ai-bom.json
 
 # Runtime proxy
-agent-bom proxy "npx @mcp/server-filesystem /tmp"
+agent-bom proxy "npx @mcp/server-filesystem /workspace"
 ```
 
 For the full GitHub README, Mermaid diagrams, release history, and live project status, see:

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -47,6 +47,14 @@ Automated via `publish-mcp-registry.yml` using GitHub OIDC — no secrets needed
 # Validates and publishes automatically on each release
 ```
 
+For PyPI-backed MCP Registry publishing, keep the ownership marker in the
+file referenced by `project.readme` in `pyproject.toml`, not only in
+`README.md`:
+
+```md
+<!-- mcp-name: io.github.msaad00/agent-bom -->
+```
+
 ### Verification
 
 Search for "agent-bom" at: https://registry.modelcontextprotocol.io


### PR DESCRIPTION
## Summary
- add the MCP ownership marker to `PYPI_README.md`, which is the published package readme
- replace the PyPI-facing runtime proxy example path with `/workspace`
- document the MCP Registry PyPI publish requirement in `docs/PUBLISHING.md`

## Validation
- `python -m build --sdist --wheel --no-isolation`
- `uv run python scripts/check_release_consistency.py`
- `uv run --with twine python -m twine check dist/*`
- verified built sdist and wheel metadata both contain `mcp-name: io.github.msaad00/agent-bom` and no longer contain `/tmp`
