### PR TITLE
Harden final OpenSSF release surfaces

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -4,7 +4,7 @@
 # Installs atheris and agent-bom, then copies fuzz targets to $OUT.
 # Runs inside the ClusterFuzzLite Docker container (Ubuntu + Python 3.11+).
 
-python3 -m pip install "pip==25.1.0" "pyyaml==6.0.3"  # pinned — update periodically
+python3 -m pip install "pip==26.0.1" "pyyaml==6.0.3"  # pinned — update periodically
 python3 -m pip install .
 
 for fuzzer in $SRC/agent-bom/fuzz/fuzz_*.py; do

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -30,11 +28,14 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install MkDocs
-        run: uv pip install --system mkdocs-material==9.7.4  # mkdocs-material ships no CLI; install into system env
-
       - name: Build site
-        run: mkdocs build --strict
+        run: >-
+          uv tool run
+          --from mkdocs==1.6.1
+          --with mkdocs-material==9.7.5
+          --with mkdocstrings==1.0.3
+          --with mkdocstrings-python==2.0.3
+          mkdocs build --strict
 
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,7 +14,6 @@ jobs:
     name: Scorecard
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       id-token: write
       contents: read
       actions: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
 RUN apk upgrade --no-cache zlib
-RUN pip install --no-cache-dir --upgrade "pip==25.1.0"
+RUN pip install --no-cache-dir "pip==26.0.1"
 
 # Create non-root user for least-privilege execution
 RUN addgroup -S abom && adduser -S -G abom abom

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -26,7 +26,7 @@ COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --upgrade "pip==25.1.0"
+    && pip install --no-cache-dir "pip==26.0.1"
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -37,7 +37,7 @@ COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --upgrade "pip==25.1.0"
+    && pip install --no-cache-dir "pip==26.0.1"
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -25,7 +25,7 @@ COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --upgrade "pip==25.1.0"
+    && pip install --no-cache-dir "pip==26.0.1"
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -40,7 +40,7 @@ COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --upgrade "pip==25.1.0"
+    && pip install --no-cache-dir "pip==26.0.1"
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom


### PR DESCRIPTION
## Summary
- reduce remaining workflow write scopes for docs, scorecard, and dependency submission
- pin the docs build toolchain explicitly so it no longer works by accident
- bump pip bootstrap/install surfaces to 26.0.1 across the release and deploy images

## Validation
- python - <<'PY' ... yaml.safe_load(...) ... PY
- bash -n /tmp/agent-bom-openssf-final/.clusterfuzzlite/build.sh
- docker build -f /tmp/agent-bom-openssf-final/Dockerfile -t agent-bom:openssf-final-test /tmp/agent-bom-openssf-final
- docker build -f /tmp/agent-bom-openssf-final/deploy/docker/Dockerfile.runtime -t agent-bom-runtime:openssf-final-test /tmp/agent-bom-openssf-final
- cd /tmp/agent-bom-openssf-final && uv tool run --from mkdocs==1.6.1 --with mkdocs-material==9.7.5 --with mkdocstrings==1.0.3 --with mkdocstrings-python==2.0.3 mkdocs build --strict
- cd /tmp/agent-bom-openssf-final && uv run python scripts/check_release_consistency.py
