### PR TITLE
chore: bump version to 0.75.9

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.75.8","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.75.8"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.75.9","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.75.9"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.75.8  # pinned — bump on each release
+        run: uv tool install agent-bom==0.75.9  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -88,7 +88,7 @@ agent-bom answers:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `v0.75.8` | Current stable version (pinned) |
+| `v0.75.9` | Current stable version (pinned) |
 
 ## Links
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.75.8
+ARG VERSION=0.75.9
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — CVEs, blast radius, credential exposure, runtime enforcement"

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ docker run --rm agentbom/agent-bom agents  # Docker (linux/amd64 + arm64)
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom agents` | Local audit |
-| GitHub Action | `uses: msaad00/agent-bom@v0.75.8` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.75.9` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom agents` | Isolated scans |
 | MCP Server | `agent-bom mcp server` | Inside any AI assistant |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
@@ -310,7 +310,7 @@ docker run --rm agentbom/agent-bom agents  # Docker (linux/amd64 + arm64)
 <summary><b>GitHub Action</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.8
+- uses: msaad00/agent-bom@v0.75.9
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.75.8
+ARG VERSION=0.75.9
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — MCP server mode"

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -16,14 +16,14 @@ FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb
 WORKDIR /app
 COPY LICENSE ./
 
-ARG VERSION=0.75.8
+ARG VERSION=0.75.9
 
 RUN pip install --no-cache-dir --prefix=/install agent-bom==${VERSION}
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.75.8
+ARG VERSION=0.75.9
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.75.8
+ARG VERSION=0.75.9
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.75.8
+ARG VERSION=0.75.9
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="Security scanner for AI infrastructure — MCP server with streamable HTTP transport"

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: Open security platform for agentic infrastructure — scan agents, MCP servers, containers, and runtime blast radius
 version: 0.1.0
-appVersion: "0.75.8"
+appVersion: "0.75.9"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.75.8"
+  tag: "0.75.9"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.75.8"
+  tag: "0.75.9"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.8
+- uses: msaad00/agent-bom@v0.75.9
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -19,7 +19,7 @@ agent-bom is built on four security principles:
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.75.8
+- uses: msaad00/agent-bom@v0.75.9
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -111,7 +111,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/root/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.75.8 agents --format json
+  agentbom/agent-bom:0.75.9 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -225,7 +225,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.8
+- uses: msaad00/agent-bom@v0.75.9
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -72,7 +72,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.75.8"
+  --version "0.75.9"
 ```
 
 ### Verification
@@ -108,8 +108,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.75.8
-git push origin v0.75.8
+git tag v0.75.9
+git push origin v0.75.9
 ```
 
 This triggers:

--- a/docs/WINDOWS_CONTAINERS.md
+++ b/docs/WINDOWS_CONTAINERS.md
@@ -111,7 +111,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.75.8`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.75.9`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.75.8 demo — run with: vhs docs/demo.tape
+# agent-bom v0.75.9 demo — run with: vhs docs/demo.tape
 #
 # HIGH RES, READABLE. Large font, focused output.
 # No personal paths, configs, or credentials.

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Open security platform for agentic infrastructure — scan, blast radius, runtime proxy, and compliance",
-  "version": "0.75.8",
+  "version": "0.75.9",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "AI security scanner for agents, MCP, containers, cloud, and runtime",
   "title": "agent-bom",
-  "version": "0.75.8",
+  "version": "0.75.9",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.75.8",
+      "version": "0.75.9",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   v1.0, MAESTRO layer tagging, and vector database security checks. Use when the
   user mentions vulnerability scanning, MCP server trust, compliance, SBOM
   generation, CIS benchmarks, blast radius, or AI supply chain risk.
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -24,7 +24,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []
@@ -398,6 +398,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.75.8`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.75.9`
 - **6,533+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   EU AI Act, and AISVS v1.0. Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   EPSS, KEV), scans container images, verifies provenance, scans filesystems,
   and generates SBOMs. Use when: "check package", "scan image", "verify",
   "is this safe", "scan dependencies", "CVE lookup", "blast radius".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -21,7 +21,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []
@@ -215,6 +215,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.75.8`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.75.9`
 - **6,533+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.75.8
+version: 0.75.9
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.8
+    docker: ghcr.io/msaad00/agent-bom:0.75.9
   openclaw:
     requires:
       bins: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.75.8"
+version = "0.75.9"
 description = "Open security platform for agentic infrastructure — discover, scan, and govern agents, MCP, and runtime."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -5,7 +5,7 @@
 | **CLI** | Local scanning, CI/CD | `pip install agent-bom` |
 | **MCP Server** | AI agent integration | `agent-bom mcp server` |
 | **Docker** | Isolated scanning | `docker run ghcr.io/msaad00/agent-bom scan` |
-| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.75.8` |
+| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.75.9` |
 | **Kubernetes** | Fleet monitoring | Helm chart |
 | **REST API** | Platform integration | `agent-bom serve` |
 | **Runtime Proxy** | Real-time enforcement | `agent-bom runtime proxy` |

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.75.8
+  uses: msaad00/agent-bom@v0.75.9
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -50,6 +50,6 @@ agent-bom check langchain   # check a specific package
 | CLI | `pip install agent-bom` |
 | MCP server | `agent-bom mcp server` |
 | Docker | `docker run ghcr.io/msaad00/agent-bom scan` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.75.8` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.75.9` |
 | Kubernetes | Helm chart + CronJob + DaemonSet |
 | Remote SSE | Self-host or use hosted endpoint |

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.75.8"
+    __version__ = "0.75.9"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.75.8' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.75.9' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.75.8"
+version = "0.75.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump version-managed release surfaces from `0.75.8` to `0.75.9`
- carry the post-0.75.8 stability fixes into one clean publishable patch
- keep PyPI, Docker, MCP registry metadata, docs, and release-managed references aligned

## Validation
- `python scripts/bump-version.py 0.75.9 --check`
- `uv run python scripts/check_release_consistency.py`
- `uv run pytest -q tests/test_resolver_cov.py tests/test_project_mode.py tests/test_discovery_process_container.py tests/test_discovery_k8s_mcp.py tests/test_core.py -k 'project or discover_all or mcp_registry_lookup_by_arg or resolve or version_sync'`
- `python -m build --sdist --wheel --no-isolation`
- `uv run --with twine python -m twine check dist/*`
