### PR TITLE
Align release-facing surfaces before 0.75.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ agent-bom agents -p . -f cyclonedx -o ai-bom.json
 
 | Tool | Best at | Limits |
 |------|---------|--------|
-| **Trivy** | General vulnerability, misconfiguration, secret, and SBOM scanning | Stops at the artifact; no AI-agent blast radius |
-| **Grype** | Vulnerability matching from packages and SBOMs | No MCP, agent, runtime, or trust modeling |
-| **Syft** | SBOM generation and software inventory | Not a runtime or blast-radius security tool |
-| **Snyk AI-BOM** | Enterprise AI BOM workflows | Narrower local AI-agent/MCP discovery and runtime coverage |
-| **agent-bom** | Broad security scanning plus AI agent, MCP, blast-radius, runtime protection, and governance | Built for agentic infrastructure, MCP trust, and runtime evidence |
+| **Trivy** | Broad vulnerability, misconfiguration, secret, and SBOM scanning | General artifact focus; does not model agent runtime, MCP trust, or AI blast radius |
+| **Grype** | Vulnerability matching from packages and SBOMs | Package-centric findings without MCP, agent, or runtime context |
+| **Syft** | SBOM generation and software inventory | Inventory-first; not built for runtime or blast-radius analysis |
+| **Snyk AI-BOM** | Enterprise AI BOM workflows | Narrower local agent/MCP discovery and runtime coverage |
+| **agent-bom** | Broad security scanning plus agent, MCP, blast-radius, runtime protection, and governance | Built for agentic infrastructure, trust, and runtime evidence |
 
 Traditional scanners often stop at CVE -> package. **agent-bom extends that model to agentic infrastructure with MCP discovery, runtime evidence, trust, and blast radius** while still covering packages, images, filesystems, IaC, cloud AI infrastructure, and secrets.
 

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ inputs:
     required: false
     default: '3.11'
   agent-bom-version:
-    description: 'agent-bom package version to install (for example 0.75.8). Empty = latest from PyPI.'
+    description: 'agent-bom package version to install (for example 0.75.x). Empty = latest from PyPI.'
     required: false
     default: ''
   install-from-source:

--- a/integrations/cortex-code/README.md
+++ b/integrations/cortex-code/README.md
@@ -28,7 +28,7 @@ Or if installed via pip/pipx:
 }
 ```
 
-This gives Cortex Code access to 23 security scanning tools via natural language.
+This gives Cortex Code access to agent-bom's MCP security and analysis tools via natural language.
 
 ## Install as a Cortex Code Skill
 
@@ -47,7 +47,7 @@ cp integrations/cortex-code/SKILL.md .cortex/skills/agent-bom/SKILL.md
 
 ## What You Get
 
-### As MCP Server (33 tools)
+### As MCP Server
 
 All agent-bom MCP tools become available in Cortex Code:
 
@@ -59,14 +59,14 @@ All agent-bom MCP tools become available in Cortex Code:
 | `policy_check` | Evaluate security policy against findings |
 | `registry_lookup` | Query 427+ MCP server security metadata |
 | `generate_sbom` | Generate CycloneDX or SPDX SBOM |
-| `compliance` | Map findings to 14 compliance frameworks |
+| `compliance` | Map findings to OWASP, NIST, MITRE, EU AI Act, and related frameworks |
 | `remediate` | Prioritized remediation plan |
 | `skill_trust` | Trust assessment for SKILL.md files |
 | `code_scan` | SAST scanning with CWE mapping |
 | `context_graph` | Lateral movement analysis |
 | `cis_benchmark` | CIS benchmark for AWS/Azure/GCP/Snowflake |
 | `gpu_infra_scan` | GPU/AI compute infrastructure scanning |
-| ... and 10 more | See `agent-bom mcp server --help` |
+| ... and more | See `agent-bom mcp server --help` |
 
 ### As Skill
 
@@ -86,8 +86,8 @@ agent-bom fills these security gaps in Cortex Code:
 | "Only install from trusted sources" | Trust assessment with 17 behavioral risk patterns |
 | Manual permission review | Blast radius analysis showing credential exposure |
 | No CVE scanning | Full enrichment: OSV + NVD + EPSS + CISA KEV |
-| No compliance mapping | 11 frameworks: OWASP, NIST, EU AI Act, ISO 27001, SOC 2, CIS |
-| No runtime enforcement | Proxy with 7 real-time detectors |
+| No compliance mapping | Framework-aware evidence across OWASP, NIST, EU AI Act, ISO 27001, SOC 2, CIS, and more |
+| No runtime enforcement | Runtime proxy with behavioral detectors and policy enforcement |
 
 ## Auto-Discovery
 

--- a/integrations/cortex-code/SKILL.md
+++ b/integrations/cortex-code/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: agent-bom
 description: >-
-  Security scanner for AI infrastructure — scan MCP servers and packages for CVEs,
-  map blast radius from packages to credentials and tools, detect credential exposure,
-  and enforce runtime policy. Works with Cortex Code's MCP servers, skills, and agents.
+  Open security platform for agentic infrastructure — broad scanning plus MCP
+  servers, CVEs, blast radius, credential exposure analysis, and runtime policy.
+  Works with Cortex Code's MCP servers, skills, and agents.
 tools:
   - bash
 ---
 
-# agent-bom — Security Scanner for AI Infrastructure
+# agent-bom — Security Platform for Agentic Infrastructure
 
 Scan your MCP servers, packages, and AI agent configurations for CVEs,
 credential exposure, and supply chain risks. Maps blast radius from
@@ -26,9 +26,9 @@ vulnerable packages to the credentials and tools they can reach.
 ## What This Skill Provides
 
 - **CVE scanning** with enrichment from OSV, NVD, EPSS, CISA KEV
-- **MCP server discovery** across 21 AI tools (including Cortex Code)
+- **MCP server discovery** across real AI developer tools, including Cortex Code
 - **Blast radius mapping** — which agents, credentials, and tools are exposed
-- **14 compliance frameworks** per finding (OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST, EU AI Act)
+- **Compliance mapping** across OWASP, NIST, MITRE, EU AI Act, and related frameworks
 - **Runtime proxy** for MCP traffic interception and policy enforcement
 - **SKILL.md trust assessment** with 17 behavioral risk patterns
 

--- a/integrations/docker-mcp-registry/readme.md
+++ b/integrations/docker-mcp-registry/readme.md
@@ -1,8 +1,8 @@
 # agent-bom
 
-Security scanner for AI infrastructure — from agent to runtime.
+Open security platform for agentic infrastructure — from scanner to runtime.
 
-Discovers AI agents and MCP servers, scans all dependencies against OSV/NVD/GHSA, maps blast radius showing which credentials and tools each CVE reaches, enforces policy in real time, and generates compliance evidence for 11 frameworks.
+Discovers AI agents and MCP servers, scans packages, images, filesystems, IaC, and cloud AI infrastructure, maps blast radius showing which credentials and tools each CVE reaches, enforces policy in real time, and generates compliance evidence.
 
 ## Quick start
 
@@ -21,7 +21,7 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom scan -p /workspace -f 
 
 - **30 MCP client types** — Claude Desktop, Cursor, Windsurf, VS Code Copilot, and more
 - **Packages** — npm, pip, cargo, go modules, OS packages via OSV, NVD, EPSS, CISA KEV
-- **Containers** — Docker images via Grype + Syft
+- **Containers** — Docker images with native OCI package discovery
 - **IaC** — Dockerfile, Kubernetes, Terraform, CloudFormation, Helm (89 rules)
 - **Cloud AI** — 12 providers including AWS Bedrock, Azure OpenAI, GCP Vertex AI
 
@@ -29,8 +29,8 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom scan -p /workspace -f 
 
 - **Blast radius mapping** — package → server → agent → credentials → tools
 - **Runtime MCP proxy** — 8 behavioral detectors (rug pull, injection, credential leak, exfil, cloaking, rate limiting, vector DB injection, cross-agent correlation)
-- **11 compliance frameworks** — OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10, MITRE ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls, CMMC
-- **32 MCP tools** — available to any MCP-compatible AI assistant
+- **Framework-aware evidence** — OWASP, MITRE, NIST, EU AI Act, ISO 27001, SOC 2, CIS, CMMC, and more
+- **MCP tools** — available to any MCP-compatible AI assistant
 
 ## Source
 

--- a/integrations/docker-mcp-registry/server.yaml
+++ b/integrations/docker-mcp-registry/server.yaml
@@ -17,11 +17,10 @@ meta:
 about:
   title: agent-bom
   description: >-
-    Security scanner for AI infrastructure. Discovers MCP servers and AI agents,
-    scans all dependencies for CVEs (OSV/NVD/GHSA/EPSS/CISA KEV), maps blast radius
-    showing which credentials and tools each vulnerability reaches, enforces policy,
-    and generates SBOMs + compliance evidence for 11 frameworks including OWASP
-    LLM Top 10, MITRE ATLAS, NIST AI RMF, and EU AI Act.
+    Open security platform for agentic infrastructure. Discovers MCP servers and
+    AI agents, scans packages, images, filesystems, IaC, and cloud AI infrastructure,
+    maps blast radius showing which credentials and tools each vulnerability reaches,
+    enforces runtime policy, and generates SBOMs plus framework-aware security evidence.
   icon: https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/logo-dark.svg
 
 source:

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "AI security scanner for agents, MCP, containers, cloud, and runtime",
+  "description": "Open security platform for agentic infrastructure — broad scanning, blast radius, runtime, and trust",
   "title": "agent-bom",
   "version": "0.75.9",
   "repository": {

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: agent-bom-compliance
 description: >-
-  AI compliance and policy engine — evaluate scan results against 14 security
-  frameworks including OWASP LLM Top 10, NIST AI RMF, SOC 2, ISO 27001, CMMC,
-  EU AI Act, and AISVS v1.0. Generate SBOMs and compliance reports. Use when:
+  AI compliance and policy engine — evaluate scan results against OWASP, NIST,
+  SOC 2, ISO 27001, CMMC, EU AI Act, AISVS v1.0, and related frameworks.
+  Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
 version: 0.75.9

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: agent-bom-scan
 description: >-
-  Security scanner for AI infrastructure — checks packages for CVEs (OSV, NVD,
-  EPSS, KEV), scans container images, verifies provenance, scans filesystems,
-  and generates SBOMs. Use when: "check package", "scan image", "verify",
-  "is this safe", "scan dependencies", "CVE lookup", "blast radius".
+  Open security platform for agentic infrastructure — checks packages for CVEs
+  (OSV, NVD, EPSS, KEV), scans container images, verifies provenance, scans
+  filesystems, and generates SBOMs. Use when: "check package", "scan image",
+  "verify", "is this safe", "scan dependencies", "CVE lookup", "blast radius".
 version: 0.75.9
 license: Apache-2.0
 compatibility: >-

--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -8,7 +8,7 @@ For the comprehensive guide, see [AI_INFRASTRUCTURE_SCANNING.md](https://github.
 |-------|-------------|
 | **MCP Clients** | 30 clients — Claude, Cursor, VS Code, Windsurf, Cline, Codex, Gemini, Goose, etc. |
 | **MCP Servers** | Package deps, tool definitions, credential exposure, description drift |
-| **Container Images** | OS + language packages via Grype/Syft |
+| **Container Images** | Native OCI package discovery across OS and language packages |
 | **Kubernetes** | Namespace enumeration, pod MCP detection |
 | **Cloud** | AWS, Snowflake, Azure ML, GCP Vertex AI, Databricks, HuggingFace, Ollama |
 | **Code** | SAST via Semgrep with CWE mapping |

--- a/site-docs/features/scanning.md
+++ b/site-docs/features/scanning.md
@@ -55,4 +55,4 @@ Config files are parsed for server definitions. Environment variable **values** 
 agent-bom scan --image python:3.12-slim
 ```
 
-Uses Grype/Syft under the hood for OS and language package scanning within container images.
+Uses agent-bom's native image scanning pipeline to enumerate OS and language packages within container images.

--- a/site-docs/getting-started/install.md
+++ b/site-docs/getting-started/install.md
@@ -48,7 +48,7 @@ agent-bom scan --help
 ## Requirements
 
 - Python 3.11+
-- Optional: Docker (for container image scanning via Grype/Syft)
+- Optional: Docker (for container image scanning)
 - Optional: kubectl (for Kubernetes scanning)
 - Optional: semgrep (for SAST code scanning)
 - No external API keys required for basic operation

--- a/site-docs/getting-started/quickstart.md
+++ b/site-docs/getting-started/quickstart.md
@@ -44,7 +44,7 @@ agent-bom scan --compliance all
 agent-bom scan --image python:3.12-slim
 ```
 
-Requires Grype and Syft installed locally.
+Uses agent-bom's native container scanning path for image analysis.
 
 ## Output formats
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-agent-bom exposes 32 tools via its MCP server.
+agent-bom exposes MCP tools for scanning, blast radius, trust, compliance, runtime, and remediation.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
- align release-facing positioning across README, action, MCP registry, Docker MCP listing, Cortex Code, and scoped OpenClaw skills
- remove stale container-scanning wording that still implied Grype/Syft for the core image path
- make GitHub Action version example non-stale

## Validation
- python scripts/check_release_consistency.py
- python scripts/bump-version.py 0.75.9 --check
