### PR TITLE
Add CWE impact classification engine and CLI UX improvements

### DIFF
--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -199,33 +199,35 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
         from rich.table import Table
 
         table = Table(title=f"{name}@{version} — {len(vulns)} vulnerability/ies found")
-        table.add_column("ID", width=20)
-        table.add_column("Severity", width=10)
-        table.add_column("CVSS", width=6, justify="right")
-        table.add_column("Fix", width=15)
-        table.add_column("Summary", max_width=50)
+        table.add_column("Sev", width=10, no_wrap=True)
+        table.add_column("ID", width=20, no_wrap=True)
+        table.add_column("CVSS", width=5, justify="right")
+        table.add_column("Fix", width=10)
+        table.add_column("Summary", max_width=42)
 
         severity_styles = {
             "critical": "red bold",
-            "high": "red",
+            "high": "#e67e22 bold",
             "medium": "yellow",
             "low": "dim",
         }
         for v in vulns:
             sev = v.severity.value.lower()
             style = severity_styles.get(sev, "white")
-            fix_display = f"[green]✓ {v.fixed_version}[/green]" if v.fixed_version else "[red dim]No fix[/red dim]"
-            # Show summary; fall back to aliases list if empty
+            fix_display = f"[green]{v.fixed_version}[/green]" if v.fixed_version else "[dim]no fix[/dim]"
+            # Concise summary — truncate to keep table compact
             summary_text = v.summary or ""
             if not summary_text or summary_text == "No description available":
                 aliases_str = ", ".join(v.aliases[:3]) if v.aliases else ""
-                summary_text = f"[dim]See {aliases_str}[/dim]" if aliases_str else "[dim]No description[/dim]"
+                summary_text = f"[dim]See {aliases_str}[/dim]" if aliases_str else "[dim]—[/dim]"
+            elif len(summary_text) > 55:
+                summary_text = summary_text[:52] + "..."
             table.add_row(
+                f"[{style}]{v.severity.value.upper()}[/{style}]",
                 v.id,
-                f"[{style} reverse] {v.severity.value.upper()} [/{style} reverse]",
                 f"{v.cvss_score:.1f}" if v.cvss_score else "—",
                 fix_display,
-                summary_text[:100],
+                summary_text,
             )
         console.print(table)
         console.print()

--- a/src/agent_bom/cwe_impact.py
+++ b/src/agent_bom/cwe_impact.py
@@ -1,0 +1,334 @@
+"""CWE-aware impact classification for blast radius accuracy.
+
+Maps CWE weakness types to impact categories that determine which
+credentials and tools a vulnerability can realistically reach.
+A CWE-79 (XSS) client-side bug does not expose server-side DATABASE_URL.
+A CWE-94 (code injection) RCE does.
+
+Conservative default: when CWE data is missing, assume worst case
+(code-execution) so no risk is hidden.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# ── Impact categories ────────────────────────────────────────────────────────
+#
+# Each category describes what a vulnerability *can* reach on the server
+# where the vulnerable package runs.
+#
+#   code-execution   — attacker runs arbitrary code → full env/file/tool access
+#   credential-access — direct credential compromise (auth bypass, hardcoded)
+#   file-access      — read/write files on disk → can read config/env files
+#   injection        — inject into DB/LDAP/etc → DB credential scope
+#   ssrf             — forge requests to internal services
+#   data-leak        — information disclosure → possible credential exposure
+#   availability     — denial of service → no credential access
+#   client-side      — browser-side only → no server credential access
+
+IMPACT_CODE_EXECUTION = "code-execution"
+IMPACT_CREDENTIAL_ACCESS = "credential-access"
+IMPACT_FILE_ACCESS = "file-access"
+IMPACT_INJECTION = "injection"
+IMPACT_SSRF = "ssrf"
+IMPACT_DATA_LEAK = "data-leak"
+IMPACT_AVAILABILITY = "availability"
+IMPACT_CLIENT_SIDE = "client-side"
+
+# Ordered from most to least severe — used for worst-case selection
+_IMPACT_SEVERITY_ORDER = [
+    IMPACT_CODE_EXECUTION,
+    IMPACT_CREDENTIAL_ACCESS,
+    IMPACT_FILE_ACCESS,
+    IMPACT_SSRF,
+    IMPACT_INJECTION,
+    IMPACT_DATA_LEAK,
+    IMPACT_AVAILABILITY,
+    IMPACT_CLIENT_SIDE,
+]
+
+# ── CWE → Impact mapping ────────────────────────────────────────────────────
+#
+# Sources: MITRE CWE, NVD, OWASP Top 10
+# Only maps CWEs that appear in real-world OSV/NVD/GHSA advisories.
+
+CWE_IMPACT_CATEGORIES: dict[str, str] = {
+    # Code execution — full server access
+    "CWE-77": IMPACT_CODE_EXECUTION,  # Command injection
+    "CWE-78": IMPACT_CODE_EXECUTION,  # OS command injection
+    "CWE-94": IMPACT_CODE_EXECUTION,  # Code injection
+    "CWE-95": IMPACT_CODE_EXECUTION,  # Eval injection
+    "CWE-96": IMPACT_CODE_EXECUTION,  # Static code injection
+    "CWE-98": IMPACT_CODE_EXECUTION,  # PHP remote file inclusion
+    "CWE-502": IMPACT_CODE_EXECUTION,  # Deserialization of untrusted data
+    "CWE-787": IMPACT_CODE_EXECUTION,  # Out-of-bounds write
+    "CWE-788": IMPACT_CODE_EXECUTION,  # Out-of-bounds write (buffer end)
+    "CWE-416": IMPACT_CODE_EXECUTION,  # Use after free
+    "CWE-119": IMPACT_CODE_EXECUTION,  # Buffer overflow
+    "CWE-120": IMPACT_CODE_EXECUTION,  # Classic buffer overflow
+    "CWE-122": IMPACT_CODE_EXECUTION,  # Heap-based buffer overflow
+    "CWE-125": IMPACT_CODE_EXECUTION,  # Out-of-bounds read (can chain to RCE)
+    "CWE-190": IMPACT_CODE_EXECUTION,  # Integer overflow
+    "CWE-434": IMPACT_CODE_EXECUTION,  # Unrestricted file upload
+    "CWE-917": IMPACT_CODE_EXECUTION,  # Expression language injection
+    "CWE-1321": IMPACT_CODE_EXECUTION,  # Prototype pollution
+    "CWE-913": IMPACT_CODE_EXECUTION,  # Improper control of dynamic code
+    # Credential access — direct credential compromise
+    "CWE-287": IMPACT_CREDENTIAL_ACCESS,  # Improper authentication
+    "CWE-306": IMPACT_CREDENTIAL_ACCESS,  # Missing authentication
+    "CWE-307": IMPACT_CREDENTIAL_ACCESS,  # Brute force
+    "CWE-347": IMPACT_CREDENTIAL_ACCESS,  # Signature verification
+    "CWE-384": IMPACT_CREDENTIAL_ACCESS,  # Session fixation
+    "CWE-522": IMPACT_CREDENTIAL_ACCESS,  # Insufficiently protected credentials
+    "CWE-798": IMPACT_CREDENTIAL_ACCESS,  # Hardcoded credentials
+    "CWE-862": IMPACT_CREDENTIAL_ACCESS,  # Missing authorization
+    "CWE-863": IMPACT_CREDENTIAL_ACCESS,  # Incorrect authorization
+    "CWE-1259": IMPACT_CREDENTIAL_ACCESS,  # Improper restriction of security token
+    # File access — can read/write files on disk
+    "CWE-22": IMPACT_FILE_ACCESS,  # Path traversal
+    "CWE-23": IMPACT_FILE_ACCESS,  # Relative path traversal
+    "CWE-36": IMPACT_FILE_ACCESS,  # Absolute path traversal
+    "CWE-59": IMPACT_FILE_ACCESS,  # Symlink following
+    "CWE-73": IMPACT_FILE_ACCESS,  # External control of file name
+    "CWE-67": IMPACT_FILE_ACCESS,  # Improper handling of Windows device names
+    # Injection — DB/LDAP/template injection
+    "CWE-89": IMPACT_INJECTION,  # SQL injection
+    "CWE-90": IMPACT_INJECTION,  # LDAP injection
+    "CWE-91": IMPACT_INJECTION,  # XML injection
+    "CWE-943": IMPACT_INJECTION,  # Improper neutralization in data query
+    "CWE-1236": IMPACT_INJECTION,  # CSV injection
+    # SSRF — server-side request forgery
+    "CWE-918": IMPACT_SSRF,  # SSRF
+    # Data leak — information disclosure
+    "CWE-200": IMPACT_DATA_LEAK,  # Exposure of sensitive information
+    "CWE-209": IMPACT_DATA_LEAK,  # Error message information exposure
+    "CWE-215": IMPACT_DATA_LEAK,  # Debug information exposure
+    "CWE-532": IMPACT_DATA_LEAK,  # Insertion of sensitive info into log
+    "CWE-538": IMPACT_DATA_LEAK,  # Insertion of sensitive info into file
+    "CWE-312": IMPACT_DATA_LEAK,  # Cleartext storage of sensitive info
+    "CWE-319": IMPACT_DATA_LEAK,  # Cleartext transmission
+    "CWE-327": IMPACT_DATA_LEAK,  # Broken/risky crypto algorithm
+    "CWE-326": IMPACT_DATA_LEAK,  # Inadequate encryption strength
+    "CWE-330": IMPACT_DATA_LEAK,  # Insufficient randomness
+    "CWE-331": IMPACT_DATA_LEAK,  # Insufficient entropy
+    "CWE-338": IMPACT_DATA_LEAK,  # Weak PRNG
+    # Availability — denial of service
+    "CWE-400": IMPACT_AVAILABILITY,  # Uncontrolled resource consumption
+    "CWE-770": IMPACT_AVAILABILITY,  # Allocation without limits
+    "CWE-674": IMPACT_AVAILABILITY,  # Uncontrolled recursion
+    "CWE-834": IMPACT_AVAILABILITY,  # Excessive iteration
+    "CWE-835": IMPACT_AVAILABILITY,  # Infinite loop
+    "CWE-1333": IMPACT_AVAILABILITY,  # ReDoS
+    "CWE-410": IMPACT_AVAILABILITY,  # Insufficient resource pool
+    "CWE-404": IMPACT_AVAILABILITY,  # Resource leak
+    "CWE-407": IMPACT_AVAILABILITY,  # Algorithmic complexity
+    "CWE-409": IMPACT_AVAILABILITY,  # Improper handling of compressed data
+    # Client-side — does not affect server credentials
+    "CWE-79": IMPACT_CLIENT_SIDE,  # XSS
+    "CWE-80": IMPACT_CLIENT_SIDE,  # Basic XSS
+    "CWE-352": IMPACT_CLIENT_SIDE,  # CSRF
+    "CWE-601": IMPACT_CLIENT_SIDE,  # Open redirect
+    "CWE-1021": IMPACT_CLIENT_SIDE,  # Clickjacking
+    "CWE-524": IMPACT_CLIENT_SIDE,  # Sensitive info in cache
+    "CWE-539": IMPACT_CLIENT_SIDE,  # Session cookie in persistent storage
+    "CWE-614": IMPACT_CLIENT_SIDE,  # Sensitive cookie without secure flag
+    "CWE-1004": IMPACT_CLIENT_SIDE,  # Sensitive cookie without HttpOnly
+    "CWE-1275": IMPACT_CLIENT_SIDE,  # Sensitive cookie with SameSite=None
+    # Input validation — ambiguous, treat as data-leak (conservative mid-ground)
+    "CWE-20": IMPACT_DATA_LEAK,  # Improper input validation
+    "CWE-116": IMPACT_DATA_LEAK,  # Improper encoding/escaping
+    "CWE-173": IMPACT_DATA_LEAK,  # Improper handling of alternate encoding
+    "CWE-670": IMPACT_DATA_LEAK,  # Always-incorrect control flow
+    "CWE-754": IMPACT_DATA_LEAK,  # Improper check for exceptional conditions
+    "CWE-1286": IMPACT_DATA_LEAK,  # Improper validation of syntactic correctness
+}
+
+
+def classify_cwe_impact(cwe_ids: list[str]) -> str:
+    """Classify the worst-case impact category from a list of CWE IDs.
+
+    Returns the most severe impact category found. If no CWE data is
+    available, returns ``code-execution`` (conservative default — we don't
+    hide risk we can't disprove).
+    """
+    if not cwe_ids:
+        return IMPACT_CODE_EXECUTION
+
+    best_rank = len(_IMPACT_SEVERITY_ORDER)
+    for cwe in cwe_ids:
+        cwe_upper = cwe.upper() if not cwe.startswith("CWE-") else cwe
+        category = CWE_IMPACT_CATEGORIES.get(cwe_upper)
+        if category is not None:
+            rank = _IMPACT_SEVERITY_ORDER.index(category)
+            if rank < best_rank:
+                best_rank = rank
+
+    if best_rank < len(_IMPACT_SEVERITY_ORDER):
+        return _IMPACT_SEVERITY_ORDER[best_rank]
+
+    # CWE IDs present but none recognized — conservative default
+    return IMPACT_CODE_EXECUTION
+
+
+# ── Credential filters ───────────────────────────────────────────────────────
+#
+# Patterns for identifying credential types by env var name.
+
+_DB_CREDENTIAL_PATTERNS = frozenset(
+    {
+        "database",
+        "db_",
+        "mysql",
+        "postgres",
+        "mongo",
+        "redis",
+        "dsn",
+        "sql",
+        "clickhouse",
+        "snowflake",
+        "supabase",
+    }
+)
+
+
+def _is_db_credential(name: str) -> bool:
+    """Check if a credential name looks database-related."""
+    lower = name.lower()
+    return any(pat in lower for pat in _DB_CREDENTIAL_PATTERNS)
+
+
+def filter_credentials_by_impact(
+    category: str,
+    all_credentials: list[str],
+) -> list[str]:
+    """Filter exposed credentials based on CWE impact category.
+
+    Returns only credentials that the vulnerability type can realistically
+    reach. For categories that don't affect server-side state (client-side,
+    availability), returns an empty list.
+
+    Args:
+        category: Impact category from :func:`classify_cwe_impact`.
+        all_credentials: Full list of credentials from the MCP server config.
+
+    Returns:
+        Filtered list of credentials actually at risk.
+    """
+    if not all_credentials:
+        return []
+
+    if category in (IMPACT_CODE_EXECUTION, IMPACT_CREDENTIAL_ACCESS, IMPACT_DATA_LEAK):
+        # Full access — can read env vars, config files, or disclose data
+        return list(all_credentials)
+
+    if category == IMPACT_FILE_ACCESS:
+        # Can read config files — all credentials potentially in .env or config
+        return list(all_credentials)
+
+    if category == IMPACT_SSRF:
+        # Can reach internal services — all credentials potentially usable
+        return list(all_credentials)
+
+    if category == IMPACT_INJECTION:
+        # DB injection — only DB credentials are in scope
+        return [c for c in all_credentials if _is_db_credential(c)]
+
+    if category in (IMPACT_AVAILABILITY, IMPACT_CLIENT_SIDE):
+        # No server-side credential access
+        return []
+
+    # Unknown category — conservative default
+    return list(all_credentials)
+
+
+def filter_tools_by_impact(
+    category: str,
+    all_tools: list,
+) -> list:
+    """Filter exposed tools based on CWE impact category.
+
+    Returns only tools that the vulnerability type can realistically invoke.
+
+    Args:
+        category: Impact category from :func:`classify_cwe_impact`.
+        all_tools: Full list of MCPTool objects from the server.
+
+    Returns:
+        Filtered list of tools actually reachable.
+    """
+    if not all_tools:
+        return []
+
+    if category in (IMPACT_CODE_EXECUTION, IMPACT_CREDENTIAL_ACCESS):
+        # Full access — can invoke any tool
+        return list(all_tools)
+
+    if category in (IMPACT_FILE_ACCESS, IMPACT_SSRF, IMPACT_DATA_LEAK):
+        # Partial access — can potentially invoke tools
+        return list(all_tools)
+
+    if category == IMPACT_INJECTION:
+        # DB injection — only DB/query tools
+        db_keywords = {"query", "sql", "execute", "database", "db", "select", "insert"}
+        return [t for t in all_tools if any(kw in t.name.lower() for kw in db_keywords)]
+
+    if category in (IMPACT_AVAILABILITY, IMPACT_CLIENT_SIDE):
+        # No tool access
+        return []
+
+    return list(all_tools)
+
+
+def build_attack_vector_summary(
+    cwe_ids: list[str],
+    category: str,
+    filtered_creds: list[str],
+    filtered_tools: list,
+    severity: Optional[str] = None,
+    is_kev: bool = False,
+) -> str:
+    """Build a human-readable attack vector summary.
+
+    Returns a one-sentence description of what this vulnerability enables
+    in the context of the MCP server it runs in.
+    """
+    cwe_str = cwe_ids[0] if cwe_ids else "Unknown CWE"
+    n_creds = len(filtered_creds)
+    n_tools = len(filtered_tools)
+
+    kev_prefix = "Actively exploited. " if is_kev else ""
+
+    summaries = {
+        IMPACT_CODE_EXECUTION: (
+            f"{kev_prefix}Code execution ({cwe_str}) grants full server access"
+            + (f": {n_creds} credential(s) and {n_tools} tool(s) reachable." if n_creds or n_tools else ".")
+        ),
+        IMPACT_CREDENTIAL_ACCESS: (
+            f"{kev_prefix}Authentication bypass ({cwe_str}) enables direct credential compromise"
+            + (f": {n_creds} credential(s) at risk." if n_creds else ".")
+        ),
+        IMPACT_FILE_ACCESS: (
+            f"{kev_prefix}File access ({cwe_str}) may expose configuration and credentials"
+            + (f": {n_creds} credential(s) potentially readable." if n_creds else ".")
+        ),
+        IMPACT_INJECTION: (
+            f"{kev_prefix}Injection ({cwe_str}) targets data stores" + (f": {n_creds} database credential(s) in scope." if n_creds else ".")
+        ),
+        IMPACT_SSRF: (
+            f"{kev_prefix}SSRF ({cwe_str}) enables internal service access" + (f": {n_creds} credential(s) reachable." if n_creds else ".")
+        ),
+        IMPACT_DATA_LEAK: (
+            f"{kev_prefix}Information disclosure ({cwe_str}) may expose sensitive data"
+            + (f": {n_creds} credential(s) potentially visible." if n_creds else ".")
+        ),
+        IMPACT_AVAILABILITY: (
+            f"{kev_prefix}Denial of service ({cwe_str}) may disrupt service availability. Does not expose credentials or tools."
+        ),
+        IMPACT_CLIENT_SIDE: (
+            f"{kev_prefix}Client-side vulnerability ({cwe_str}) affects end-user browsers. "
+            "Does not expose server-side credentials or tools."
+        ),
+    }
+
+    return summaries.get(category, f"{kev_prefix}Vulnerability ({cwe_str}) with {category} impact.")

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -18,14 +18,14 @@ console = Console()
 
 SEVERITY_BADGES: dict[Severity, str] = {
     Severity.CRITICAL: "white on red",
-    Severity.HIGH: "white on #c0392b",
+    Severity.HIGH: "white on #e67e22",
     Severity.MEDIUM: "black on yellow",
     Severity.LOW: "white on #555555",
 }
 
 SEVERITY_TEXT: dict[Severity, str] = {
     Severity.CRITICAL: "red bold",
-    Severity.HIGH: "red",
+    Severity.HIGH: "#e67e22 bold",
     Severity.MEDIUM: "yellow",
     Severity.LOW: "dim",
 }
@@ -538,7 +538,7 @@ def print_attack_flow_tree(report: AIBOMReport) -> None:
 
     severity_styles = {
         Severity.CRITICAL: "red bold",
-        Severity.HIGH: "red",
+        Severity.HIGH: "#e67e22 bold",
         Severity.MEDIUM: "yellow",
         Severity.LOW: "dim",
     }
@@ -1033,7 +1033,7 @@ def print_remediation_plan(report: AIBOMReport) -> None:
 
     sev_style = {
         Severity.CRITICAL: "red bold",
-        Severity.HIGH: "red",
+        Severity.HIGH: "#e67e22 bold",
         Severity.MEDIUM: "yellow",
         Severity.LOW: "dim",
         Severity.NONE: "white",
@@ -1425,9 +1425,11 @@ def print_compact_agents(report: AIBOMReport) -> None:
 
 
 def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_only: bool = False) -> None:
-    """Show top N blast radius findings in a compact table.
+    """Show top N findings in a compact table.
 
-    Default mode shows only critical/high findings. Use --verbose for all.
+    Context-aware: shows blast radius chain (agent → server → credential) only
+    when MCP agent context is available. Falls back to a clean vuln table for
+    scan types without agent context (image, check, iac, CI/CD).
     """
     if not report.blast_radii:
         return
@@ -1435,91 +1437,83 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     # Filter: show actionable findings by default, count the rest
     priority = [br for br in report.blast_radii if br.is_actionable]
     rest_count = len(report.blast_radii) - len(priority)
-    # --fixable-only: keep only entries that have a fix available
     if fixable_only:
         priority = [br for br in priority if br.vulnerability.fixed_version]
-    # If no actionable, fall back to showing all (respecting fixable_only)
     if not priority:
         display_list = [br for br in report.blast_radii if br.vulnerability.fixed_version] if fixable_only else report.blast_radii
     else:
         display_list = priority
     shown = display_list[:limit]
 
+    # Detect if we have blast radius context (agents/servers/credentials)
+    has_blast_context = any(br.affected_agents and (br.affected_servers or br.exposed_credentials) for br in shown)
+
     console.print()
     total = len(display_list)
     title = f"Top Findings ({min(limit, total)} of {total})" if total > limit else f"Findings ({len(shown)})"
     console.print(Rule(f"[bold]{title}[/bold]", style="dim"))
 
+    # Context-aware table layout
     table = Table(expand=True, padding=(0, 1))
-    table.add_column("Vuln", no_wrap=True, ratio=2)
     table.add_column("Sev", no_wrap=True)
-    table.add_column("EPSS", justify="center", no_wrap=True)
+    table.add_column("Vulnerability", no_wrap=True, ratio=2)
     table.add_column("Package", ratio=2)
-    table.add_column("Agent", ratio=1)
-    table.add_column("Blast", justify="center")
-    table.add_column("Frameworks", ratio=2)
+    if has_blast_context:
+        table.add_column("Blast Radius", ratio=3, no_wrap=True)
+    table.add_column("EPSS", justify="center", no_wrap=True)
     table.add_column("Fix", ratio=1)
 
     for br in shown:
-        fix = f"[green]{br.vulnerability.fixed_version}[/green]" if br.vulnerability.fixed_version else "[red dim]—[/red dim]"
-        n_agents = len(br.affected_agents)
-        n_creds = len(br.exposed_credentials)
-        n_transitive = len(getattr(br, "transitive_agents", []))
-        blast = f"{n_agents}A"
-        if n_transitive:
-            hop = getattr(br, "hop_depth", 1)
-            blast += f"+[cyan]{n_transitive}T({hop}h)[/cyan]"
-        if n_creds:
-            blast += f"/[yellow]{n_creds}C[/yellow]"
-        kev = " [red]KEV[/red]" if br.vulnerability.is_kev else ""
+        fix = f"[green]{br.vulnerability.fixed_version}[/green]" if br.vulnerability.fixed_version else "[dim]no fix[/dim]"
+        kev = " [red bold]KEV[/red bold]" if br.vulnerability.is_kev else ""
 
-        # EPSS score
         epss_display = "[dim]—[/dim]"
         if br.vulnerability.epss_score is not None:
             epss_pct = int(br.vulnerability.epss_score * 100)
             epss_style = "red bold" if epss_pct >= 70 else "yellow" if epss_pct >= 30 else "dim"
             epss_display = f"[{epss_style}]{epss_pct}%[/{epss_style}]"
 
-        # Agent names (first agent + count)
-        agent_names = [a.name for a in br.affected_agents]
-        agent_display = agent_names[0] if agent_names else "—"
-        if len(agent_names) > 1:
-            agent_display += f" +{len(agent_names) - 1}"
+        pkg_display = f"{br.package.name}@{br.package.version}" + ("" if br.package.is_direct else " [dim]T[/dim]")
 
-        # Framework tags (compact — max 3 frameworks, 1 tag each)
-        _fw_sources = [
-            ("owasp_tags", "purple", "OWASP"),
-            ("owasp_mcp_tags", "yellow", "MCP"),
-            ("atlas_tags", "cyan", "ATLAS"),
-            ("nist_csf_tags", "bright_green", "NIST"),
-            ("cis_tags", "bright_magenta", "CIS"),
-            ("iso_27001_tags", "bright_cyan", "ISO"),
-            ("soc2_tags", "bright_yellow", "SOC2"),
-        ]
-        tags = []
-        for attr, color, _label in _fw_sources:
-            fw_tags = getattr(br, attr, None)
-            if fw_tags:
-                tags.append(f"[{color}]{list(fw_tags)[0]}[/{color}]")
-            if len(tags) >= 3:
-                break
-        total_fw = sum(1 for attr, _, _ in _fw_sources if getattr(br, attr, None))
-        if total_fw > 3:
-            tags.append(f"[dim]+{total_fw - 3}[/dim]")
-        fw_display = " ".join(tags) if tags else "[dim]—[/dim]"
-
-        table.add_row(
-            f"{br.vulnerability.id}{kev}",
-            _sev_badge(br.vulnerability.severity),
-            epss_display,
-            f"{br.package.name}@{br.package.version}" + ("" if br.package.is_direct else " [dim]T[/dim]"),
-            agent_display,
-            blast,
-            fw_display,
-            fix,
-        )
+        if has_blast_context:
+            # Build single-line blast chain: agent → server → credential
+            agent_names = [a.name for a in br.affected_agents]
+            cred_names = list(br.exposed_credentials)
+            server_names = [s.name for s in br.affected_servers] if br.affected_servers else []
+            chain_parts: list[str] = []
+            if agent_names:
+                name = agent_names[0][:16]
+                chain_parts.append(f"[bold]{name}[/bold]")
+                if len(agent_names) > 1:
+                    chain_parts[-1] += f"+{len(agent_names) - 1}"
+            if server_names:
+                name = server_names[0][:16]
+                chain_parts.append(f"{name}")
+            if cred_names:
+                name = cred_names[0][:20]
+                chain_parts.append(f"[yellow]{name}[/yellow]")
+                if len(cred_names) > 1:
+                    chain_parts[-1] += f"+{len(cred_names) - 1}"
+            blast_display = " → ".join(chain_parts) if chain_parts else "[dim]—[/dim]"
+            table.add_row(
+                _sev_badge(br.vulnerability.severity),
+                f"{br.vulnerability.id}{kev}",
+                pkg_display,
+                blast_display,
+                epss_display,
+                fix,
+            )
+        else:
+            table.add_row(
+                _sev_badge(br.vulnerability.severity),
+                f"{br.vulnerability.id}{kev}",
+                pkg_display,
+                epss_display,
+                fix,
+            )
 
     console.print(table)
+
     overflow = total - len(shown)
     if overflow > 0 or rest_count > 0:
         parts = []
@@ -1528,6 +1522,37 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
         if rest_count > 0:
             parts.append(f"{rest_count} medium/low hidden")
         console.print(f"  [dim]+ {' · '.join(parts)} — use --verbose for full list[/dim]")
+
+    # Critical details section — show description and blast chain for CRIT/HIGH only
+    critical_findings = [br for br in shown if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
+    if critical_findings:
+        console.print()
+        console.print(Rule("[bold]Critical Details[/bold]", style="dim"))
+        sev_style_map = {Severity.CRITICAL: "red bold", Severity.HIGH: "#e67e22 bold"}
+        for br in critical_findings[:5]:
+            style = sev_style_map.get(br.vulnerability.severity, "white")
+            summary = br.vulnerability.summary or ""
+            if len(summary) > 80:
+                summary = summary[:77] + "..."
+            sev_label = br.vulnerability.severity.value.upper()
+            pkg_ref = f"{br.package.name}@{br.package.version}"
+            console.print(f"\n  [{style}]{br.vulnerability.id}[/{style}] · {pkg_ref} · [{style}]{sev_label}[/{style}]")
+            if summary:
+                console.print(f"  {summary}")
+            if br.vulnerability.fixed_version:
+                console.print(f"  Fix: [green]upgrade to ≥ {br.vulnerability.fixed_version}[/green]")
+            if has_blast_context and (br.affected_agents or br.exposed_credentials):
+                agent_str = ", ".join(a.name for a in br.affected_agents[:3])
+                cred_str = ", ".join(br.exposed_credentials[:3])
+                blast_parts = []
+                if agent_str:
+                    blast_parts.append(agent_str)
+                if br.affected_servers:
+                    blast_parts.append(", ".join(s.name for s in br.affected_servers[:2]))
+                if cred_str:
+                    blast_parts.append(f"[yellow]{cred_str}[/yellow]")
+                if blast_parts:
+                    console.print(f"  Blast: {' → '.join(blast_parts)}")
 
     # Status bar
     console.print()
@@ -1562,7 +1587,7 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
 
     sev_style = {
         Severity.CRITICAL: "red bold",
-        Severity.HIGH: "red",
+        Severity.HIGH: "#e67e22 bold",
         Severity.MEDIUM: "yellow",
         Severity.LOW: "dim",
         Severity.NONE: "white",
@@ -1648,7 +1673,7 @@ def print_diff(diff: dict) -> None:
 
     severity_styles = {
         "CRITICAL": "red bold",
-        "HIGH": "red",
+        "HIGH": "#e67e22 bold",
         "MEDIUM": "yellow",
         "LOW": "dim",
     }
@@ -1785,7 +1810,7 @@ def print_severity_chart(report: AIBOMReport) -> None:
     bar_width = 30
     styles = {
         "CRITICAL": "red bold",
-        "HIGH": "red",
+        "HIGH": "#e67e22 bold",
         "MEDIUM": "yellow",
         "LOW": "dim",
     }

--- a/tests/test_cwe_impact.py
+++ b/tests/test_cwe_impact.py
@@ -1,0 +1,258 @@
+"""Tests for CWE-aware impact classification engine."""
+
+from __future__ import annotations
+
+from agent_bom.cwe_impact import (
+    IMPACT_AVAILABILITY,
+    IMPACT_CLIENT_SIDE,
+    IMPACT_CODE_EXECUTION,
+    IMPACT_CREDENTIAL_ACCESS,
+    IMPACT_DATA_LEAK,
+    IMPACT_FILE_ACCESS,
+    IMPACT_INJECTION,
+    IMPACT_SSRF,
+    build_attack_vector_summary,
+    classify_cwe_impact,
+    filter_credentials_by_impact,
+    filter_tools_by_impact,
+)
+
+# ── classify_cwe_impact ──────────────────────────────────────────────────────
+
+
+def test_no_cwe_returns_code_execution():
+    """Conservative default: no CWE data assumes worst case."""
+    assert classify_cwe_impact([]) == IMPACT_CODE_EXECUTION
+
+
+def test_unknown_cwe_returns_code_execution():
+    """Unrecognized CWE IDs assume worst case."""
+    assert classify_cwe_impact(["CWE-999999"]) == IMPACT_CODE_EXECUTION
+
+
+def test_single_rce_cwe():
+    assert classify_cwe_impact(["CWE-94"]) == IMPACT_CODE_EXECUTION
+
+
+def test_single_xss_cwe():
+    assert classify_cwe_impact(["CWE-79"]) == IMPACT_CLIENT_SIDE
+
+
+def test_single_dos_cwe():
+    assert classify_cwe_impact(["CWE-400"]) == IMPACT_AVAILABILITY
+
+
+def test_single_sqli_cwe():
+    assert classify_cwe_impact(["CWE-89"]) == IMPACT_INJECTION
+
+
+def test_single_ssrf_cwe():
+    assert classify_cwe_impact(["CWE-918"]) == IMPACT_SSRF
+
+
+def test_single_path_traversal():
+    assert classify_cwe_impact(["CWE-22"]) == IMPACT_FILE_ACCESS
+
+
+def test_single_auth_bypass():
+    assert classify_cwe_impact(["CWE-287"]) == IMPACT_CREDENTIAL_ACCESS
+
+
+def test_single_info_disclosure():
+    assert classify_cwe_impact(["CWE-200"]) == IMPACT_DATA_LEAK
+
+
+def test_mixed_cwes_returns_worst_case():
+    """When multiple CWEs present, return the most severe."""
+    # XSS + RCE → RCE wins
+    assert classify_cwe_impact(["CWE-79", "CWE-94"]) == IMPACT_CODE_EXECUTION
+
+
+def test_mixed_dos_and_sqli():
+    # DoS + SQL injection → injection wins (more severe)
+    assert classify_cwe_impact(["CWE-400", "CWE-89"]) == IMPACT_INJECTION
+
+
+def test_mixed_client_side_and_data_leak():
+    # XSS + info disclosure → data-leak wins
+    assert classify_cwe_impact(["CWE-79", "CWE-200"]) == IMPACT_DATA_LEAK
+
+
+def test_mixed_unknown_and_known():
+    # Unknown + XSS → XSS (don't escalate just because one is unknown)
+    assert classify_cwe_impact(["CWE-999999", "CWE-79"]) == IMPACT_CLIENT_SIDE
+
+
+def test_deserialization_is_code_execution():
+    assert classify_cwe_impact(["CWE-502"]) == IMPACT_CODE_EXECUTION
+
+
+def test_prototype_pollution_is_code_execution():
+    assert classify_cwe_impact(["CWE-1321"]) == IMPACT_CODE_EXECUTION
+
+
+def test_hardcoded_credentials():
+    assert classify_cwe_impact(["CWE-798"]) == IMPACT_CREDENTIAL_ACCESS
+
+
+def test_csrf_is_client_side():
+    assert classify_cwe_impact(["CWE-352"]) == IMPACT_CLIENT_SIDE
+
+
+def test_redos_is_availability():
+    assert classify_cwe_impact(["CWE-1333"]) == IMPACT_AVAILABILITY
+
+
+# ── filter_credentials_by_impact ─────────────────────────────────────────────
+
+_TEST_CREDS = ["DATABASE_URL", "ANTHROPIC_API_KEY", "GITHUB_TOKEN", "SLACK_WEBHOOK"]
+
+
+def test_code_execution_returns_all_creds():
+    result = filter_credentials_by_impact(IMPACT_CODE_EXECUTION, _TEST_CREDS)
+    assert set(result) == set(_TEST_CREDS)
+
+
+def test_credential_access_returns_all_creds():
+    result = filter_credentials_by_impact(IMPACT_CREDENTIAL_ACCESS, _TEST_CREDS)
+    assert set(result) == set(_TEST_CREDS)
+
+
+def test_client_side_returns_no_creds():
+    result = filter_credentials_by_impact(IMPACT_CLIENT_SIDE, _TEST_CREDS)
+    assert result == []
+
+
+def test_availability_returns_no_creds():
+    result = filter_credentials_by_impact(IMPACT_AVAILABILITY, _TEST_CREDS)
+    assert result == []
+
+
+def test_injection_returns_only_db_creds():
+    result = filter_credentials_by_impact(IMPACT_INJECTION, _TEST_CREDS)
+    assert "DATABASE_URL" in result
+    assert "GITHUB_TOKEN" not in result
+    assert "ANTHROPIC_API_KEY" not in result
+
+
+def test_injection_with_postgres_cred():
+    creds = ["POSTGRES_PASSWORD", "SLACK_TOKEN", "MONGO_URI"]
+    result = filter_credentials_by_impact(IMPACT_INJECTION, creds)
+    assert "POSTGRES_PASSWORD" in result
+    assert "MONGO_URI" in result
+    assert "SLACK_TOKEN" not in result
+
+
+def test_file_access_returns_all_creds():
+    """File access can read .env files — all credentials potentially exposed."""
+    result = filter_credentials_by_impact(IMPACT_FILE_ACCESS, _TEST_CREDS)
+    assert set(result) == set(_TEST_CREDS)
+
+
+def test_ssrf_returns_all_creds():
+    result = filter_credentials_by_impact(IMPACT_SSRF, _TEST_CREDS)
+    assert set(result) == set(_TEST_CREDS)
+
+
+def test_data_leak_returns_all_creds():
+    result = filter_credentials_by_impact(IMPACT_DATA_LEAK, _TEST_CREDS)
+    assert set(result) == set(_TEST_CREDS)
+
+
+def test_empty_creds_returns_empty():
+    result = filter_credentials_by_impact(IMPACT_CODE_EXECUTION, [])
+    assert result == []
+
+
+# ── filter_tools_by_impact ───────────────────────────────────────────────────
+
+
+class _MockTool:
+    def __init__(self, name: str):
+        self.name = name
+
+
+_TEST_TOOLS = [_MockTool("run_query"), _MockTool("execute_sql"), _MockTool("read_file"), _MockTool("send_message")]
+
+
+def test_code_execution_returns_all_tools():
+    result = filter_tools_by_impact(IMPACT_CODE_EXECUTION, _TEST_TOOLS)
+    assert len(result) == 4
+
+
+def test_client_side_returns_no_tools():
+    result = filter_tools_by_impact(IMPACT_CLIENT_SIDE, _TEST_TOOLS)
+    assert result == []
+
+
+def test_availability_returns_no_tools():
+    result = filter_tools_by_impact(IMPACT_AVAILABILITY, _TEST_TOOLS)
+    assert result == []
+
+
+def test_injection_returns_only_db_tools():
+    result = filter_tools_by_impact(IMPACT_INJECTION, _TEST_TOOLS)
+    names = [t.name for t in result]
+    assert "run_query" in names
+    assert "execute_sql" in names
+    assert "read_file" not in names
+    assert "send_message" not in names
+
+
+def test_empty_tools_returns_empty():
+    result = filter_tools_by_impact(IMPACT_CODE_EXECUTION, [])
+    assert result == []
+
+
+# ── build_attack_vector_summary ──────────────────────────────────────────────
+
+
+def test_rce_summary():
+    summary = build_attack_vector_summary(
+        ["CWE-94"],
+        IMPACT_CODE_EXECUTION,
+        ["DB_URL", "API_KEY"],
+        [_MockTool("run")],
+    )
+    assert "Code execution" in summary
+    assert "CWE-94" in summary
+    assert "2 credential(s)" in summary
+
+
+def test_xss_summary():
+    summary = build_attack_vector_summary(["CWE-79"], IMPACT_CLIENT_SIDE, [], [])
+    assert "Client-side" in summary
+    assert "Does not expose server-side credentials" in summary
+
+
+def test_dos_summary():
+    summary = build_attack_vector_summary(["CWE-400"], IMPACT_AVAILABILITY, [], [])
+    assert "Denial of service" in summary
+    assert "Does not expose credentials" in summary
+
+
+def test_kev_prefix():
+    summary = build_attack_vector_summary(
+        ["CWE-94"],
+        IMPACT_CODE_EXECUTION,
+        ["KEY"],
+        [],
+        is_kev=True,
+    )
+    assert summary.startswith("Actively exploited.")
+
+
+def test_no_cwe_summary():
+    summary = build_attack_vector_summary([], IMPACT_CODE_EXECUTION, [], [])
+    assert "Unknown CWE" in summary
+
+
+def test_injection_summary_with_db_creds():
+    summary = build_attack_vector_summary(
+        ["CWE-89"],
+        IMPACT_INJECTION,
+        ["DATABASE_URL"],
+        [_MockTool("query")],
+    )
+    assert "Injection" in summary
+    assert "1 database credential(s)" in summary


### PR DESCRIPTION
## Summary

- Introduces CWE-to-impact classification engine (`cwe_impact.py`) mapping ~80 CWE IDs to 8 impact categories (code-execution, credential-access, file-access, injection, ssrf, data-leak, availability, client-side)
- Enables accurate credential/tool filtering in blast radius — a DoS vuln (CWE-400) will no longer falsely show DATABASE_URL exposed
- Improves CLI output: HIGH severity is now orange (distinct from CRITICAL red), findings table shows blast radius chains inline, Critical Details section for CRIT/HIGH drill-down
- Phase 1 of multi-phase CWE-aware blast radius work — this PR is pure addition + display changes, no behavioral change to scanning yet

## Changes

**New files:**
- `src/agent_bom/cwe_impact.py` — CWE classification engine (8 categories, ~80 CWEs, credential/tool filters, attack vector summaries)
- `tests/test_cwe_impact.py` — 40 unit tests covering all categories, edge cases, mixed CWEs

**Modified files:**
- `src/agent_bom/output/__init__.py` — severity colors (HIGH=orange), context-aware findings table (blast radius column only when MCP data exists), Critical Details section
- `src/agent_bom/cli/_check.py` — check command table cleanup (truncated summaries, cleaner layout)

## Test plan

- [x] 40 new CWE impact tests pass
- [x] Full suite: 6,985 pass, 0 fail
- [x] `agent-bom agents --demo` renders correctly with new table layout
- [x] `agent-bom check pillow@9.0.0` shows truncated summaries
- [x] Pre-commit hooks pass (ruff, mypy, bandit)
- [ ] CI pipeline validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)