### PR TITLE
Polish CLI output, fix Dockerfile hash pinning, refresh demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
 RUN apk upgrade --no-cache zlib
-RUN pip install --no-cache-dir "pip==26.0.1" --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b
+COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
+RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
 
 # Create non-root user for least-privilege execution
 RUN addgroup -S abom && adduser -S -G abom abom

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -25,8 +25,9 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "pip==26.0.1" --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
+RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -36,8 +36,9 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "pip==26.0.1" --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
+RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -24,8 +24,9 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "pip==26.0.1" --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
+RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -39,8 +39,9 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "pip==26.0.1" --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
+RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/deploy/docker/pip-requirements.txt
+++ b/deploy/docker/pip-requirements.txt
@@ -1,0 +1,3 @@
+# Hash-pinned pip for Docker runtime stages.
+# Regenerate: pip download pip==26.0.1 -d /tmp && pip hash /tmp/pip-*.whl
+pip==26.0.1 --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b

--- a/integrations/glama/Dockerfile
+++ b/integrations/glama/Dockerfile
@@ -24,8 +24,9 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
-RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --upgrade "pip==26.0.1" --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
+RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
 
 # Create non-root user for least-privilege execution
 RUN addgroup --system abom && adduser --system --ingroup abom abom

--- a/scripts/render_demo.sh
+++ b/scripts/render_demo.sh
@@ -13,8 +13,7 @@ export AGENT_BOM_DEMO_REPO_ROOT="$PWD"
 . "$(dirname "$0")/demo-env.sh"
 export TERM=dumb
 
-# Clear the launch command from the terminal so the asset starts with
-# agent-bom output, not the demo harness invocation itself.
+# Clear screen for clean recording
 printf '\033[H\033[2J'
 
 run_step() {
@@ -29,6 +28,14 @@ run_step() {
   sleep 1
 }
 
-run_step "agent-bom agents --demo --posture --offline" agent-bom agents --demo --posture --offline
-run_step "agent-bom check pillow@9.0.0 --ecosystem pypi" agent-bom check pillow@9.0.0 --ecosystem pypi
-run_step "agent-bom check express@4.17.1 --ecosystem npm" agent-bom check express@4.17.1 --ecosystem npm
+# ── Demo flow: scan → check → verify ──
+# Shows three core workflows in sequence
+
+# 1. Full agent scan — blast radius, credentials, remediation
+run_step "agent-bom agents --demo --offline" agent-bom agents --demo --offline
+
+# 2. Pre-install check — catch vulns before they land
+run_step "agent-bom check pillow@9.0.0" agent-bom check pillow@9.0.0 --ecosystem pypi
+
+# 3. Package integrity verification
+run_step "agent-bom verify requests@2.33.0" agent-bom verify requests@2.33.0 --ecosystem pypi

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -2054,38 +2054,15 @@ def scan(
             _breakdown = " · ".join(_timing_parts)
             con.print(f"  [dim]{_breakdown}[/dim]")
 
-        # Next-steps suggestions based on findings
-        _next_steps: list[str] = []
+        # Concise next-step hint (1-2 lines max)
         if blast_radii:
-            _crit_count = sum(1 for br in blast_radii if br.vulnerability.severity.value == "critical")
-            _high_count = sum(1 for br in blast_radii if br.vulnerability.severity.value == "high")
-            _kev_count = sum(1 for br in blast_radii if getattr(br.vulnerability, "kev", False))
             _fixable = sum(1 for br in blast_radii if br.vulnerability.fixed_version)
-
-            if _crit_count or _high_count:
-                _next_steps.append(
-                    f"[red bold]→[/red bold] {_crit_count} critical + {_high_count} high — "
-                    "run [bold]agent-bom scan --fail-on critical[/bold] in CI to gate deployments"
-                )
             if _fixable:
-                _next_steps.append(
-                    f"[green]→[/green] {_fixable} fixable — run [bold]agent-bom scan --remediate plan.md[/bold] for upgrade steps"
+                con.print(
+                    f"\n  [green]→[/green] {_fixable} fixable — [bold]-f html[/bold] for full report · [bold]--verbose[/bold] for details"
                 )
-            if not enrich:
-                _next_steps.append("[cyan]→[/cyan] run with [bold]--enrich[/bold] for EPSS exploit probability + KEV + CVSS v4 data")
-            _next_steps.append(
-                "[blue]→[/blue] export: [bold]-f html[/bold] (interactive report) · "
-                "[bold]-f sarif[/bold] (GitHub Security) · [bold]-f cyclonedx[/bold] (SBOM)"
-            )
         elif not no_scan and total_packages > 0:
-            _next_steps.append("[green]→[/green] no vulnerabilities found — your supply chain looks clean")
-            _next_steps.append("[cyan]→[/cyan] run [bold]agent-bom scan --enrich --transitive[/bold] for deeper analysis")
-
-        if _next_steps:
-            con.print()
-            con.print("  [bold]Next steps:[/bold]")
-            for _ns in _next_steps:
-                con.print(f"    {_ns}")
+            con.print("\n  [green]→[/green] no vulnerabilities found — supply chain looks clean")
 
     # Step 8: Enterprise integrations + SIEM + policy (post-scan)
     run_integrations(

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1608,18 +1608,14 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
 
 
 def print_compact_export_hint(report: AIBOMReport) -> None:
-    """Minimal 3-line export hint."""
+    """Single-line summary with key metrics."""
     vuln_color = "red" if report.total_vulnerabilities > 0 else "green"
-    lines = [
+    console.print(
         f"\n  [bold]{report.total_agents} agents[/bold] · "
         f"[bold]{report.total_servers} servers[/bold] · "
         f"[bold]{report.total_packages} packages[/bold] · "
-        f"[bold {vuln_color}]{report.total_vulnerabilities} vulns[/bold {vuln_color}]",
-        "",
-        "  [green]-f[/green] json | cyclonedx | spdx | sarif | html | junit   [dim]18 formats[/dim]",
-        "  [green]--verbose[/green]  [dim]full tree & details[/dim]    [green]agent-bom serve[/green]  [dim]dashboard[/dim]",
-    ]
-    console.print(Panel("\n".join(lines), border_style="blue", padding=(0, 1)))
+        f"[bold {vuln_color}]{report.total_vulnerabilities} vulns[/bold {vuln_color}]"
+    )
 
 
 # ─── Diff Output ─────────────────────────────────────────────────────────────

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -241,12 +241,11 @@ def test_compact_remediation_empty():
 
 
 def test_compact_export_hint():
-    """Shows export formats and serve hint."""
+    """Shows key metrics summary."""
     agent = _make_agent(servers=[_make_server()])
     report = AIBOMReport(agents=[agent])
     output = _capture(print_compact_export_hint, report)
-    assert "json" in output
-    assert "cyclonedx" in output
-    assert "sarif" in output
-    assert "serve" in output
-    assert "--verbose" in output
+    assert "agents" in output
+    assert "servers" in output
+    assert "packages" in output
+    assert "vulns" in output


### PR DESCRIPTION
## Summary

- Condense CLI "Next steps" from 4-5 lines to 1 concise hint
- Simplify export hint from boxed panel to single summary line
- Fix Dockerfile hash pinning: use `--require-hashes -r requirements.txt` (inline `--hash` not supported by pip)
- Fixes Railway deploy failure introduced in #1119
- Refresh demo script: streamlined 3-step flow (scan → check → verify)

## Before → After (CLI footer)

**Before** (9 lines):
```
╭────────────────────────────╮
│ 2 agents · 4 servers · ... │
│ -f json | cyclonedx | ...  │
│ --verbose ...              │
╰────────────────────────────╯
→ 2 critical + 19 high — run agent-bom scan --fail-on critical...
→ 53 fixable — run agent-bom scan --remediate plan.md...
→ run with --enrich for EPSS...
→ export: -f html · -f sarif · -f cyclonedx
```

**After** (3 lines):
```
  2 agents · 4 servers · 12 packages · 59 vulns

  → 53 fixable — -f html for full report · --verbose for details
```

## Test plan

- [x] Full suite: 7,010 pass, 0 fail
- [x] `agent-bom agents --demo` renders correctly
- [x] Pre-commit hooks pass
- [ ] CI validates
- [ ] Railway deploy succeeds (Dockerfile fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)