### PR TITLE
Add CWE impact to check command, condense discovery output

### DIFF
--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -198,12 +198,14 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
     if not quiet:
         from rich.table import Table
 
+        from agent_bom.cwe_impact import classify_cwe_impact
+
         table = Table(title=f"{name}@{version} — {len(vulns)} vulnerability/ies found")
         table.add_column("Sev", width=10, no_wrap=True)
         table.add_column("ID", width=20, no_wrap=True)
-        table.add_column("CVSS", width=5, justify="right")
+        table.add_column("Impact", width=14, no_wrap=True)
         table.add_column("Fix", width=10)
-        table.add_column("Summary", max_width=42)
+        table.add_column("Summary", max_width=38)
 
         severity_styles = {
             "critical": "red bold",
@@ -211,21 +213,37 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
             "medium": "yellow",
             "low": "dim",
         }
+        _impact_styles = {
+            "code-execution": "red",
+            "credential-access": "red",
+            "file-access": "#e67e22",
+            "injection": "#e67e22",
+            "ssrf": "#e67e22",
+            "data-leak": "yellow",
+            "availability": "dim",
+            "client-side": "dim",
+        }
         for v in vulns:
             sev = v.severity.value.lower()
             style = severity_styles.get(sev, "white")
             fix_display = f"[green]{v.fixed_version}[/green]" if v.fixed_version else "[dim]no fix[/dim]"
+            # CWE impact category
+            impact = classify_cwe_impact(v.cwe_ids)
+            impact_style = _impact_styles.get(impact, "dim")
+            impact_label = impact.replace("-", " ").replace("code execution", "RCE")
+            # KEV badge
+            kev = " [red bold]KEV[/red bold]" if v.is_kev else ""
             # Concise summary — truncate to keep table compact
             summary_text = v.summary or ""
             if not summary_text or summary_text == "No description available":
                 aliases_str = ", ".join(v.aliases[:3]) if v.aliases else ""
                 summary_text = f"[dim]See {aliases_str}[/dim]" if aliases_str else "[dim]—[/dim]"
-            elif len(summary_text) > 55:
-                summary_text = summary_text[:52] + "..."
+            elif len(summary_text) > 50:
+                summary_text = summary_text[:47] + "..."
             table.add_row(
-                f"[{style}]{v.severity.value.upper()}[/{style}]",
+                f"[{style}]{v.severity.value.upper()}[/{style}]{kev}",
                 v.id,
-                f"{v.cvss_score:.1f}" if v.cvss_score else "—",
+                f"[{impact_style}]{impact_label}[/{impact_style}]",
                 fix_display,
                 summary_text,
             )

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -908,7 +908,7 @@ def scan(
                 server.packages = merged
 
                 total_packages += len(server.packages)
-                if server.packages:
+                if verbose and server.packages:
                     direct_count = sum(1 for p in server.packages if p.is_direct)
                     transitive_count = len(server.packages) - direct_count
                     transitive_str = f" ({transitive_count} transitive)" if transitive_count > 0 else ""
@@ -917,10 +917,15 @@ def scan(
                         f"  [green]✓[/green] {server.name}: {len(server.packages)} package(s) "
                         f"({server.packages[0].ecosystem}){transitive_str}{pre_str}"
                     )
-                else:
-                    con.print(f"  [dim]  {server.name}: no local packages found[/dim]")
 
-        con.print(f"\n  [bold]{total_packages} total packages.[/bold]")
+        # Compact summary (non-verbose shows one line, verbose shows per-server)
+        eco_counts: dict[str, int] = {}
+        for a in ctx.agents:
+            for s in a.mcp_servers:
+                for p in s.packages:
+                    eco_counts[p.ecosystem] = eco_counts.get(p.ecosystem, 0) + 1
+        eco_str = ", ".join(f"{c} {e}" for e, c in sorted(eco_counts.items(), key=lambda x: -x[1]))
+        con.print(f"\n  [bold]{total_packages}[/bold] packages ({eco_str})" if eco_str else f"\n  [bold]{total_packages}[/bold] packages")
 
         # Step 2a: deps.dev transitive resolution + license enrichment (--deps-dev)
         if deps_dev:

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -83,15 +83,15 @@ def run_local_discovery(
             label = "stdin"
         elif "agent-bom-demo-" in inventory:
             label = "bundled demo inventory"
+        elif "agent-bom-self-scan" in inventory:
+            label = "self-scan"
         else:
             label = inventory
-        con.print(f"\n[bold blue]Loading inventory from {label}...[/bold blue]\n")
-
         from agent_bom.inventory import load_inventory
 
         inventory_data = load_inventory(inventory)
         ctx.agents = _build_agents_from_inventory(inventory_data, inventory)
-        con.print(f"  [green]✓[/green] Loaded {len(ctx.agents)} agent(s) from inventory")
+        con.print(f"\n  [green]✓[/green] {len(ctx.agents)} agent(s) from {label}")
     elif config_dir:
         con.print(f"\n[bold blue]Scanning config directory: {config_dir}...[/bold blue]\n")
         with con.status("[bold]Discovering agents and MCP servers...[/bold]", spinner="dots"):


### PR DESCRIPTION
## Summary

- `check` command now shows CWE impact category per vulnerability (RCE, availability, file access, etc.)
- Discovery/extraction output condensed: single summary line in non-verbose mode
- Clean labels for self-scan and demo inventory paths

## Check command — Before vs After

**Before:** `Sev | ID | CVSS | Fix | Summary`
**After:** `Sev | ID | Impact | Fix | Summary`

Impact column shows: `RCE`, `availability`, `file access`, `data leak`, `client side`, `injection`, `ssrf`, `credential access` — color-coded by severity.

## Discovery output — Before vs After

**Before** (8 lines):
```
  ✓ filesystem-server: 3 package(s) (npm) (3 from inventory)
  ✓ database-server: 5 package(s) (pypi) (5 from inventory)
  ✓ github-server: 2 package(s) (npm) (2 from inventory)
  ✓ team-chat-server: 2 package(s) (pypi) (2 from inventory)

  12 total packages.
```

**After** (1 line):
```
  12 packages (7 pypi, 5 npm)
```

## Test plan

- [x] Full suite: 7,022 pass, 0 fail
- [x] `agent-bom check pillow@9.0.0` shows impact column
- [x] `agent-bom agents --demo --offline` shows condensed output
- [x] `agent-bom agents --self-scan` shows "self-scan" not temp path
- [x] Pre-commit hooks pass
- [ ] CI validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)