### PR TITLE
Fix self-scan, provenance export, and release surface alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,14 +329,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           mkdir -p provenance
           for f in dist/*.whl dist/*.tar.gz; do
             [ -f "$f" ] || continue
             name=$(basename "$f")
+            digest=$(sha256sum "$f" | awk '{print $1}')
             gh attestation download "$f" \
               --repo "${{ github.repository }}" \
-              --format json \
-              -o "provenance/${name}.intoto.jsonl" 2>/dev/null || true
+              --format json
+            src="sha256:${digest}.jsonl"
+            [ -f "$src" ] || src="sha256-${digest}.jsonl"
+            if [ ! -f "$src" ]; then
+              echo "Expected provenance bundle for $name was not downloaded" >&2
+              exit 1
+            fi
+            mv "$src" "provenance/${name}.intoto.jsonl"
           done
 
       - name: Upload provenance artifacts
@@ -344,7 +352,7 @@ jobs:
         with:
           name: slsa-provenance
           path: provenance/
-          if-no-files-found: warn
+          if-no-files-found: error
 
   github-release:
     name: Create GitHub Release
@@ -373,7 +381,6 @@ jobs:
         with:
           name: slsa-provenance
           path: dist/
-        continue-on-error: true
 
       - name: Create or update GitHub Release
         env:

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -1,6 +1,8 @@
 # agent-bom
 
-**Find which AI agents, MCP servers, credentials, tools, images, and cloud AI components are exposed by a vulnerability.**
+**Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.**
+
+Your AI agent's dependencies have a CVE. Which credentials leak?
 
 agent-bom helps developers, security teams, and enterprises discover AI agent and MCP environments,
 map CVEs into real blast radius, scan packages, container images, Kubernetes, IaC, and cloud AI infrastructure, and protect MCP traffic at runtime.
@@ -73,7 +75,7 @@ docker run --rm agentbom/agent-bom:latest doctor
 
 ## Why It Is Different
 
-Traditional scanners stop at the artifact.
+Traditional scanners often stop at `CVE -> package`.
 
 agent-bom answers:
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -2,9 +2,24 @@
 
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-**Security scanner for AI agents, MCP servers, containers, cloud, and runtime.**
+**Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.**
 
-Your AI agent's dependencies have a CVE. Which credentials leak? agent-bom maps the full blast radius: CVE → package → MCP server → AI agent → credentials → tools — with CWE-aware impact classification.
+Your AI agent's dependencies have a CVE. Which credentials leak?
+
+```text
+CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
+  |── better-sqlite3@9.0.0  (npm)
+       |── sqlite-mcp  (MCP Server · unverified · root)
+            |── Cursor IDE  (Agent · 4 servers · 12 tools)
+            |── ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credentials exposed)
+            |── query_db, read_file, write_file, run_shell  (Tools at risk)
+
+ Fix: upgrade better-sqlite3 → 11.7.0
+```
+
+agent-bom maps the blast radius: CVE → package → MCP server → AI agent → credentials → tools.
+
+Traditional scanners often stop at `CVE → package`. agent-bom shows which credentials and tools are actually at risk — with CWE-aware impact classification so a DoS vuln doesn't falsely claim credential exposure.
 
 ![agent-bom demo](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif)
 
@@ -13,10 +28,11 @@ Your AI agent's dependencies have a CVE. Which credentials leak? agent-bom maps 
 ```bash
 pip install agent-bom
 
-agent-bom agents                      # Discover + scan AI agents
-agent-bom check flask@2.0.0           # Pre-install CVE gate
-agent-bom image nginx:latest          # Container image scan
-agent-bom iac Dockerfile k8s/         # IaC misconfigurations
+agent-bom agents                              # Discover + scan local AI agents and MCP servers
+agent-bom agents -p .                         # Scan project manifests plus agent/MCP context
+agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
+agent-bom image nginx:latest                  # Container image scan
+agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC misconfigurations
 ```
 
 ## What it scans
@@ -32,7 +48,7 @@ agent-bom iac Dockerfile k8s/         # IaC misconfigurations
 
 ## Key features
 
-- **Blast radius mapping** — CVE → package → MCP server → agent → credentials
+- **Blast radius mapping** — CVE → package → MCP server → agent → credentials → tools
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not
 - **19 output formats** — SARIF, CycloneDX 1.6, SPDX 3.0, HTML, Prometheus, and more
 - **MCP server** — 33 security tools for Claude, Cursor, Windsurf

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
+<p align="center"><b>Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.</b></p>
+
 <p align="center"><b>Your AI agent's dependencies have a CVE. Which credentials leak?</b></p>
 
 ```text
@@ -29,7 +31,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
 
 **agent-bom maps the blast radius**: CVE → package → MCP server → AI agent → credentials → tools.
 
-Traditional scanners stop at `CVE → Package`. agent-bom shows which credentials and tools are actually at risk — with CWE-aware impact classification so a DoS vuln doesn't falsely claim credential exposure.
+Traditional scanners often stop at `CVE → package`. agent-bom shows which credentials and tools are actually at risk — with CWE-aware impact classification so a DoS vuln doesn't falsely claim credential exposure.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom demo" width="900" />
@@ -40,10 +42,11 @@ Traditional scanners stop at `CVE → Package`. agent-bom shows which credential
 ```bash
 pip install agent-bom
 
-agent-bom agents                        # Discover + scan AI agents and MCP servers
-agent-bom check flask@2.0.0             # Pre-install CVE gate
-agent-bom image nginx:latest            # Container image scan
-agent-bom iac Dockerfile k8s/ main.tf   # IaC misconfigurations
+agent-bom agents                              # Discover + scan local AI agents and MCP servers
+agent-bom agents -p .                         # Scan project manifests plus agent/MCP context
+agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
+agent-bom image nginx:latest                  # Container image scan
+agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC misconfigurations
 ```
 
 <details>
@@ -66,10 +69,10 @@ agent-bom serve                         # API + Next.js dashboard
 
 ```mermaid
 flowchart LR
-    DISCOVER["🔍 Discover\n30 MCP clients\nCloud · Images · IaC"] --> SCAN["🛡️ Scan\nCVE · EPSS · KEV\nSecrets · IaC rules"]
-    SCAN --> ANALYZE["📊 Analyze\nBlast Radius\n14 frameworks\nCWE impact"]
-    ANALYZE --> OUTPUT["📤 Output\nSBOM · SARIF\nDashboard · CI gate"]
-    DISCOVER -.-> PROTECT["🔒 Runtime\nMCP Proxy\nShield SDK"]
+    DISCOVER["🔍 Discover\n30 MCP clients\nProjects · Images · Cloud"] --> SCAN["🛡️ Scan\n15 ecosystems\nCVE · Secrets · IaC"]
+    SCAN --> ANALYZE["📊 Analyze\nBlast radius\n14 frameworks · CWE impact"]
+    ANALYZE --> OUTPUT["📤 Output\nCI/CD gates · SARIF · SBOM\nAPI · Dashboard · MCP tools"]
+    DISCOVER -.-> PROTECT["🔒 Protect\nRuntime proxy\nShield SDK · policy"]
 
     style DISCOVER stroke:#58a6ff,stroke-width:2px
     style SCAN stroke:#f85149,stroke-width:2px
@@ -142,22 +145,22 @@ safe = shield.redact(response_text)  # [REDACTED:OpenAI API Key]
 
 ## Compliance (14 frameworks)
 
-Every finding is tagged with applicable controls:
+Every finding is tagged with mapped framework controls:
 
 | Framework | Coverage |
 |-----------|----------|
-| OWASP LLM Top 10 | 7/10 categories |
-| OWASP MCP Top 10 | 10/10 categories |
-| OWASP Agentic Top 10 | 10/10 categories |
-| MITRE ATLAS | 30+ techniques |
-| MITRE ATT&CK Enterprise | Technique mapping |
-| NIST AI RMF 1.0 | All subcategories |
-| NIST CSF 2.0 | All functions |
-| NIST 800-53 Rev 5 | 24 controls |
-| FedRAMP Moderate | Baseline controls |
+| OWASP LLM Top 10 | 10 mapped categories |
+| OWASP MCP Top 10 | 10 mapped categories |
+| OWASP Agentic Top 10 | 10 mapped categories |
+| MITRE ATLAS | 65 mapped techniques |
+| MITRE ATT&CK Enterprise | Official MITRE catalog via fetched ATT&CK data |
+| NIST AI RMF 1.0 | 14 mapped subcategories |
+| NIST CSF 2.0 | 14 mapped categories |
+| NIST 800-53 Rev 5 | 29 mapped controls |
+| FedRAMP Moderate | 25 mapped controls |
 | ISO 27001:2022 | 9 controls |
-| SOC 2 TSC | All 5 criteria |
-| CIS Controls v8 | 12 controls |
+| SOC 2 TSC | 9 mapped criteria |
+| CIS Controls v8 | 10 mapped controls |
 | EU AI Act | 6 articles |
 | CMMC 2.0 Level 2 | 17 practices |
 
@@ -239,11 +242,14 @@ Also on [Glama](https://glama.ai/mcp/servers/@msaad00/agent-bom), [Smithery](int
 
 | When | What's sent | Where | Opt out |
 |---|---|---|---|
-| `agent-bom agents` | Package names + versions | OSV API | `--offline` |
-| `--enrich` | CVE IDs | NVD, EPSS, KEV | Don't use `--enrich` |
-| Everything else | **Nothing** | Nowhere | N/A |
+| Default CVE lookups (`agents`, `scan`, `check`, `image`) | Package names + versions | OSV API | `--offline` |
+| Floating version resolution | Package names, requested version/latest lookup | npm, PyPI, Go proxy | `--offline` |
+| `--enrich` | CVE IDs | NVD, EPSS; KEV catalog download from CISA | Don't use `--enrich` |
+| `--deps-dev` | Package names + versions | deps.dev | Don't use `--deps-dev` |
+| `verify` | Package name + version | PyPI or npm integrity endpoints | Don't run `verify` |
+| Optional push/integrations | Finding summaries or evidence bundles | Slack, Jira, Vanta, Drata | Don't pass those flags |
 
-No source code, no secrets, no telemetry. [Sigstore-signed](docs/PERMISSIONS.md) releases. See [SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) for the full trust model.
+No source code, config contents, or credential values are sent. No telemetry or analytics. [Sigstore-signed](docs/PERMISSIONS.md) releases. See [SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) and [PERMISSIONS.md](docs/PERMISSIONS.md) for the full trust model.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'agent-bom Scan'
-description: 'Open security platform for agentic infrastructure — blast radius, runtime governance, AI BOM, and supply-chain evidence.'
+description: 'Run agent-bom in CI/CD to scan AI agents, MCP servers, images, and IaC. Emit SARIF and map blast radius from packages to credentials and tools.'
 author: 'agent-bom'
 
 branding:

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document answers the security questions enterprise teams ask before adoptin
 
 ## Data Flow — What Leaves Your Machine?
 
-agent-bom sends **package names and versions only** to external APIs. No source code, no configuration files, no credentials ever leave your machine.
+agent-bom sends only the minimum data needed for the feature in use: package names and versions for CVE lookups and version resolution, CVE IDs for enrichment, and finding summaries only for explicitly enabled push integrations. No source code, configuration contents, or credential values leave your machine.
 
 ### External API Calls
 
@@ -16,6 +16,7 @@ agent-bom sends **package names and versions only** to external APIs. No source 
 | **EPSS** (FIRST) | Bulk download (no query) | Exploit probability scores | `db update --source epss` |
 | **KEV** (CISA) | Bulk download (no query) | Known-exploited CVE list | `db update --source kev` |
 | **deps.dev** (Google) | Package name + version | Transitive dependencies | `--deps-dev` flag |
+| **npm / PyPI / Go proxy** | Package name (+ version/latest lookup) | Package metadata / latest version | Floating version resolution |
 | **PyPI** | Package name | Latest version number | Update check (1x/24h) |
 
 ### Offline Mode

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -13,7 +13,7 @@
   <rect width="960" height="420" rx="12" fill="#09090b"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Scan pipeline</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No secrets leave your machine — only package names + versions are sent to public APIs.</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No source code or credential values leave your machine. External calls are limited to package metadata, version lookups, and CVE enrichment.</text>
 
   <!-- ═══ STEP 1: DISCOVER ═══ -->
   <rect x="20" y="64" width="160" height="304" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
@@ -31,7 +31,7 @@
   <rect x="30" y="144" width="140" height="1" fill="#27272a"/>
 
   <text x="36" y="162" class="item-label" fill="#60a5fa">Containers</text>
-  <text x="140" y="162" text-anchor="end" class="step-desc">Grype + Syft</text>
+  <text x="140" y="162" text-anchor="end" class="step-desc">native OCI parser</text>
   <rect x="30" y="168" width="140" height="1" fill="#27272a"/>
 
   <text x="36" y="186" class="item-label" fill="#60a5fa">Packages</text>
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="138" class="item-label" fill="#fb7185">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">11 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
   <rect x="422" y="144" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="162" class="item-label" fill="#fb7185">Policy engine</text>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -13,7 +13,7 @@
   <rect width="960" height="420" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Scan pipeline</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No secrets leave your machine — only package names + versions are sent to public APIs.</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No source code or credential values leave your machine. External calls are limited to package metadata, version lookups, and CVE enrichment.</text>
 
   <!-- ═══ STEP 1: DISCOVER ═══ -->
   <rect x="20" y="64" width="160" height="304" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
@@ -31,7 +31,7 @@
   <rect x="30" y="144" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="36" y="162" class="item-label" fill="#2563eb">Containers</text>
-  <text x="140" y="162" text-anchor="end" class="step-desc">Grype + Syft</text>
+  <text x="140" y="162" text-anchor="end" class="step-desc">native OCI parser</text>
   <rect x="30" y="168" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="36" y="186" class="item-label" fill="#2563eb">Packages</text>
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="138" class="item-label" fill="#e11d48">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">11 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
   <rect x="422" y="144" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="162" class="item-label" fill="#e11d48">Policy engine</text>

--- a/integrations/cortex-code/SKILL.md
+++ b/integrations/cortex-code/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: agent-bom
 description: >-
-  Open security platform for agentic infrastructure — broad scanning plus MCP
-  servers, CVEs, blast radius, credential exposure analysis, and runtime policy.
-  Works with Cortex Code's MCP servers, skills, and agents.
+  Open security platform for agentic infrastructure — broad scanning,
+  blast radius, runtime, and trust across MCP servers, skills, packages,
+  and agents in Cortex Code.
 tools:
   - bash
 ---

--- a/integrations/docker-mcp-registry/readme.md
+++ b/integrations/docker-mcp-registry/readme.md
@@ -1,8 +1,10 @@
 # agent-bom
 
-Open security platform for agentic infrastructure — from scanner to runtime.
+Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.
 
 Discovers AI agents and MCP servers, scans packages, images, filesystems, IaC, and cloud AI infrastructure, maps blast radius showing which credentials and tools each CVE reaches, enforces policy in real time, and generates compliance evidence.
+
+Traditional scanners often stop at CVE -> package. agent-bom shows which MCP servers, AI agents, credentials, and tools are actually at risk.
 
 ## Quick start
 

--- a/integrations/docker-mcp-registry/server.yaml
+++ b/integrations/docker-mcp-registry/server.yaml
@@ -17,10 +17,9 @@ meta:
 about:
   title: agent-bom
   description: >-
-    Open security platform for agentic infrastructure. Discovers MCP servers and
-    AI agents, scans packages, images, filesystems, IaC, and cloud AI infrastructure,
-    maps blast radius showing which credentials and tools each vulnerability reaches,
-    enforces runtime policy, and generates SBOMs plus framework-aware security evidence.
+    Open security platform for agentic infrastructure. Broad scanning,
+    blast radius, runtime, and trust for MCP servers, AI agents,
+    packages, images, IaC, and cloud AI infrastructure.
   icon: https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/logo-dark.svg
 
 source:

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-bom",
-  "description": "Open security platform for agentic infrastructure — broad scanning, blast radius, runtime proxy, and compliance",
+  "description": "Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.",
   "version": "0.75.11",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "Open security platform for agentic infrastructure — broad scanning, blast radius, runtime, and trust",
+  "description": "Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.",
   "title": "agent-bom",
   "version": "0.75.11",
   "repository": {

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: agent-bom
 description: >-
-  Open security platform for agentic infrastructure — broad scanning plus MCP
-  discovery, CVEs, blast radius, SBOMs, CIS benchmarks (AWS, Azure, GCP,
-  Snowflake), OWASP/NIST/MITRE compliance, AISVS v1.0, MAESTRO layer tagging,
-  and vector database security checks. Use when the user mentions vulnerability
-  scanning, MCP server trust, compliance, SBOM generation, CIS benchmarks,
-  blast radius, or AI supply chain risk.
+  Open security platform for agentic infrastructure — broad scanning,
+  blast radius, runtime, and trust across MCP discovery, CVEs, SBOMs,
+  CIS benchmarks (AWS, Azure, GCP, Snowflake), OWASP/NIST/MITRE
+  compliance, AISVS v1.0, MAESTRO layer tagging, and vector database
+  security checks. Use when the user mentions vulnerability scanning,
+  MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
+  radius, or AI supply chain risk.
 version: 0.75.11
 license: Apache-2.0
 compatibility: >-

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: agent-bom-scan
 description: >-
-  Open security platform for agentic infrastructure — checks packages for CVEs
-  (OSV, NVD, EPSS, KEV), scans container images, verifies provenance, scans
-  filesystems, and generates SBOMs. Use when: "check package", "scan image",
-  "verify", "is this safe", "scan dependencies", "CVE lookup", "blast radius".
+  Open security platform for agentic infrastructure — broad scanning,
+  blast radius, runtime, and trust for package CVEs (OSV, NVD, EPSS,
+  KEV), container images, provenance, filesystems, and SBOMs. Use
+  when: "check package", "scan image", "verify", "is this safe",
+  "scan dependencies", "CVE lookup", "blast radius".
 version: 0.75.11
 license: Apache-2.0
 compatibility: >-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.75.11"
-description = "Open security platform for agentic infrastructure — discover, scan, and govern agents, MCP, and runtime."
+description = "Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,6 +1,6 @@
 # agent-bom
 
-**Open security platform for agentic infrastructure.**
+**Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.**
 
 Find CVEs, map blast radius, detect credential exposure across MCP agents, containers, Kubernetes, cloud, and GPU workloads.
 
@@ -17,14 +17,14 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Traditional scanners often stop at CVE -> package. agent-bom shows which MCP servers, AI agents, credentials, and tools are actually exposed.
+Traditional scanners often stop at CVE -> package. agent-bom shows which MCP servers, AI agents, credentials, and tools are actually at risk.
 
 ## Quick start
 
 ```bash
 pip install agent-bom
-agent-bom scan       # auto-discover 30 MCP clients + scan
-agent-bom check langchain   # check a specific package
+agent-bom agents                         # auto-discover local AI agents + MCP servers
+agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 ```
 
 [Get started](getting-started/install.md){ .md-button .md-button--primary }

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -898,6 +898,15 @@ def scan(
                         con.print(f"    [yellow]⚠ {server.name}: blocked — {', '.join(server.security_warnings)}[/yellow]")
                     continue
                 pre_populated = list(server.packages)
+                if self_scan and pre_populated:
+                    server.packages = pre_populated
+                    total_packages += len(server.packages)
+                    if verbose and server.packages:
+                        con.print(
+                            f"  [green]✓[/green] {server.name}: {len(server.packages)} package(s) "
+                            f"({server.packages[0].ecosystem}) [dim](self-scan inventory)[/dim]"
+                        )
+                    continue
                 _smithery_tok = smithery_token if smithery_flag else None
                 discovered = extract_packages(
                     server, resolve_transitive=transitive, max_depth=max_depth, smithery_token=_smithery_tok, mcp_registry=mcp_registry_flag

--- a/tests/test_self_scan.py
+++ b/tests/test_self_scan.py
@@ -104,6 +104,11 @@ class TestSelfScanCLI:
         assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
         data = json.loads(out_file.read_text())
         assert "agents" in data or "inventory" in data or "vulnerabilities" in data
+        agents = data.get("agents", [])
+        assert agents, "expected self-scan to produce at least one agent"
+        packages = agents[0]["mcp_servers"][0]["packages"]
+        assert len(packages) >= 5, f"expected self-scan to retain multiple dependencies, got {len(packages)}"
+        assert all(pkg.get("ecosystem") != "mcp-registry" for pkg in packages), "self-scan should not collapse to MCP registry fallback"
 
     def test_self_scan_shows_packages(self):
         """--self-scan discovers agent-bom dependencies."""


### PR DESCRIPTION
## Summary
- fix the real self-scan CLI path so self-scan preserves agent-bom dependency inventory instead of collapsing to MCP registry fallback
- fail the release workflow loudly when provenance bundles are missing and export attestation files correctly for release assets
- align README, PyPI, Docker, Action, site docs, and MCP listing copy around one accurate CI/CD-capable agent-bom story

## Validation
- python -m pytest -q tests/test_self_scan.py
- python scripts/check_release_consistency.py
- manual self-scan CLI check confirmed 39 self-scan packages end to end
- verified pipeline SVG drift removed for native OCI parser and 14 frameworks

## Notes
- leaves local demo/report artifacts unstaged
- keeps scope to release truthfulness, provenance, and self-scan correctness only