### PR TITLE
feat(cli): add first-class skills scan and verify

### DIFF
--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -515,7 +515,7 @@ ScanRequest → _run_scan_sync() [ThreadPoolExecutor]
 | Claim | Verified |
 |-------|---------|
 | "30 MCP clients" (README) | ✓ 30 named MCP client config locations |
-| "33 MCP tools" | ✓ meta-test enforces this |
+| "35 MCP tools" | ✓ meta-test enforces this |
 | "14 compliance frameworks" | ✓ 10 tagging modules |
 | "52 CWE compliance mappings" | ✓ CWE_COMPLIANCE_MAP count |
 | "12 cloud providers" | ✓ cloud/__init__.py _PROVIDERS |

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -138,7 +138,7 @@ An agent operating autonomously can be steered into a multi-step exfiltration se
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 32 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 35 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/STRATEGIC_AUDIT_2026_03.md
+++ b/docs/STRATEGIC_AUDIT_2026_03.md
@@ -78,7 +78,7 @@
 | **OpenSSF Scorecard** | Project health → risk boost | On-demand |
 | **MITRE ATT&CK** | CWE→CAPEC→ATT&CK via STIX | 30 days |
 
-### 2.3 MCP Server (33 Tools)
+### 2.3 MCP Server (35 Tools)
 
 | # | Tool | Purpose |
 |---|------|---------|
@@ -94,17 +94,19 @@
 | 10 | `where` | Locate packages in dependency tree |
 | 11 | `inventory` | Full dependency inventory |
 | 12 | `diff` | Compare scan results |
-| 13 | `skill_trust` | SKILL.md trust assessment |
-| 14 | `marketplace_check` | Check marketplace listings |
-| 15 | `code_scan` | SAST code scanning |
-| 16 | `context_graph` | BFS lateral movement graph |
-| 17 | `analytics_query` | Analytics/metrics query |
-| 18 | `cis_benchmark` | CIS benchmark scanning |
-| 19 | `fleet_scan` | Fleet/batch scanning |
-| 20 | `runtime_correlate` | Cross-reference proxy audit with CVEs |
-| 21 | `vector_db_scan` | Pinecone/vector DB scanning |
-| 22 | `aisvs_benchmark` | AI security verification standard |
-| 23 | `gpu_infra_scan` | GPU/AI compute infrastructure |
+| 13 | `skill_scan` | Instruction/skill surface scan |
+| 14 | `skill_verify` | Sigstore provenance verification for instruction files |
+| 15 | `skill_trust` | SKILL.md trust assessment |
+| 16 | `marketplace_check` | Check marketplace listings |
+| 17 | `code_scan` | SAST code scanning |
+| 18 | `context_graph` | BFS lateral movement graph |
+| 19 | `analytics_query` | Analytics/metrics query |
+| 20 | `cis_benchmark` | CIS benchmark scanning |
+| 21 | `fleet_scan` | Fleet/batch scanning |
+| 22 | `runtime_correlate` | Cross-reference proxy audit with CVEs |
+| 23 | `vector_db_scan` | Pinecone/vector DB scanning |
+| 24 | `aisvs_benchmark` | AI security verification standard |
+| 25 | `gpu_infra_scan` | GPU/AI compute infrastructure |
 
 ### 2.4 CLI UX
 
@@ -206,7 +208,7 @@ Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Cop
 1. **Full-spectrum AI infra scanning**: CVE + MCP tool security + skill trust + blast radius + compliance — in one tool
 2. **Blast radius analysis**: No competitor does dependency blast radius with compliance framework mapping
 3. **Runtime proxy with enforcement**: Not just scanning — real-time interception, rate limiting, credential leak blocking, rug pull detection
-4. **33 MCP tools**: Deepest MCP server integration — usable by any AI assistant
+4. **35 MCP tools**: Deepest MCP server integration — usable by any AI assistant
 5. **12 cloud provider coverage**: AWS/Azure/GCP + AI-specific (CoreWeave, Databricks, Snowflake, HuggingFace, W&B, MLflow, OpenAI, Ollama, Nebius)
 6. **14 compliance frameworks**: Every finding mapped to OWASP LLM/MCP/Agentic, ATLAS, NIST, EU AI Act, ISO 27001, SOC 2, CIS
 7. **Enrichment depth**: OSV + GHSA + NVD + EPSS + CISA KEV + NVIDIA + OpenSSF Scorecard + MITRE ATT&CK

--- a/integrations/cortex-code/README.md
+++ b/integrations/cortex-code/README.md
@@ -61,6 +61,8 @@ All agent-bom MCP tools become available in Cortex Code:
 | `generate_sbom` | Generate CycloneDX or SPDX SBOM |
 | `compliance` | Map findings to OWASP, NIST, MITRE, EU AI Act, and related frameworks |
 | `remediate` | Prioritized remediation plan |
+| `skill_scan` | Scan CLAUDE.md, AGENTS.md, and other instruction files |
+| `skill_verify` | Verify Sigstore provenance for instruction files |
 | `skill_trust` | Trust assessment for SKILL.md files |
 | `code_scan` | SAST scanning with CWE mapping |
 | `context_graph` | Lateral movement analysis |

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 32 MCP tools with descriptions and parameters
+- `tools.json` — all 35 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -64,6 +64,20 @@
     ]
   },
   {
+    "name": "skill_scan",
+    "description": "Scan instruction files such as CLAUDE.md, AGENTS.md, .cursorrules, and skills/*.md for package refs, MCP servers, trust verdicts, and findings.",
+    "arguments": [
+      {"name": "path", "type": "string", "desc": "Path to a skill/instruction file or directory to scan"}
+    ]
+  },
+  {
+    "name": "skill_verify",
+    "description": "Verify Sigstore provenance for instruction and skill files.",
+    "arguments": [
+      {"name": "path", "type": "string", "desc": "Path to a skill/instruction file or directory to verify"}
+    ]
+  },
+  {
     "name": "skill_trust",
     "description": "Assess the trust level of a SKILL (AI agent skill/extension) — checks provenance, permissions, and risk.",
     "arguments": [

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -245,7 +245,7 @@ agent-bom where             # show all discovery paths
 | [analyze](analyze/SKILL.md) | Blast radius, attack paths, context graph | "blast radius", "threat intel", "attack path" |
 | [troubleshoot](troubleshoot/SKILL.md) | Diagnostics, doctor, config validation | "doctor", "debug", "why failing", "validate config" |
 
-## Tools (32)
+## Tools (33)
 
 ### Vulnerability Scanning
 | Tool | Description |
@@ -274,6 +274,8 @@ agent-bom where             # show all discovery paths
 | `registry_lookup` | Look up MCP server in 427+ server security metadata registry |
 | `marketplace_check` | Pre-install trust check with registry cross-reference |
 | `fleet_scan` | Batch registry lookup + risk scoring for MCP server inventories |
+| `skill_scan` | Scan instruction files for package refs, trust, and findings |
+| `skill_verify` | Verify Sigstore provenance for instruction files |
 | `skill_trust` | Assess skill file trust level (5-category analysis) |
 | `code_scan` | SAST scanning via Semgrep with CWE-based compliance mapping |
 
@@ -327,8 +329,9 @@ vector_db_scan()
 # Discover GPU containers, K8s GPU nodes, and unauthenticated DCGM endpoints
 gpu_infra_scan()
 
-# Assess trust of a skill file
-skill_trust(skill_content="<paste SKILL.md content>")
+# Scan instruction files and then inspect trust
+skill_scan(path=".")
+skill_trust(skill_path="./SKILL.md")
 ```
 
 ## Guardrails

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -69,13 +69,15 @@ agent-bom registry-lookup brave-search
 agent-bom marketplace-check @anthropic/server-filesystem
 ```
 
-## Tools (5)
+## Tools (7)
 
 | Tool | Description |
 |------|-------------|
 | `registry_lookup` | Look up MCP server in 427+ server security metadata registry |
 | `marketplace_check` | Pre-install trust check with registry cross-reference |
 | `fleet_scan` | Batch registry lookup + risk scoring for MCP server inventories |
+| `skill_scan` | Scan instruction files for package refs, trust, and findings |
+| `skill_verify` | Verify Sigstore provenance for instruction files |
 | `skill_trust` | Assess skill file trust level (5-category analysis) |
 | `code_scan` | SAST scanning via Semgrep with CWE-based compliance mapping |
 
@@ -88,8 +90,9 @@ registry_lookup(server_name="brave-search")
 # Pre-install trust check
 marketplace_check(package="@modelcontextprotocol/server-filesystem")
 
-# Assess trust of a skill file
-skill_trust(skill_content="<paste SKILL.md content>")
+# Scan instruction files and then assess a specific skill file
+skill_scan(path=".")
+skill_trust(skill_path="./SKILL.md")
 
 # Batch risk scoring
 fleet_scan(servers=["brave-search", "github", "slack"])

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 32 security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 35 security tools to any MCP client.
 
 ## Local (stdio)
 
@@ -74,6 +74,8 @@ Connect with:
 | `registry_lookup` | Look up MCP server security metadata |
 | `compliance` | Run compliance framework checks |
 | `remediate` | Prioritized remediation plan |
+| `skill_scan` | Scan instruction files for trust, findings, and provenance |
+| `skill_verify` | Verify Sigstore provenance for instruction files |
 | `verify` | Package integrity + SLSA provenance |
 | `skill_trust` | Assess skill file trust level |
 | `generate_sbom` | Generate SBOM (CycloneDX / SPDX) |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -34,6 +34,18 @@ compliance(frameworks=["owasp-llm", "eu-ai-act"])
 ### remediate
 Generate a prioritized remediation plan for discovered vulnerabilities.
 
+### skill_scan
+Scan instruction files such as `CLAUDE.md`, `.cursorrules`, `AGENTS.md`, and `skills/*.md` for package references, MCP server configs, credential env vars, trust verdicts, and audit findings.
+```
+skill_scan(path=".")
+```
+
+### skill_verify
+Verify Sigstore provenance for instruction and skill files.
+```
+skill_verify(path=".")
+```
+
 ### verify
 Package integrity check with Sigstore signature and SLSA provenance verification.
 ```
@@ -56,7 +68,7 @@ Runs 17 behavioral risk patterns (credential file access, confirmation bypass, m
 Returns a verdict (`benign` / `suspicious` / `malicious`), confidence level, per-category results, and all findings with severity and recommendations.
 
 ```
-skill_trust(skill_content="<paste full file content>")
+skill_trust(skill_path="./SKILL.md")
 # → {
 #     "verdict": "suspicious",
 #     "confidence": "high",

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -52,6 +52,7 @@ def main():
     \b
     Quick start:
       agent-bom agents                      AI agent discovery + scan
+      agent-bom skills scan                skill / instruction trust scan
       agent-bom image nginx:latest          container image scan
       agent-bom iac Dockerfile k8s/         IaC misconfigurations
       agent-bom cloud aws                   cloud posture + CIS
@@ -207,6 +208,13 @@ main.add_command(iac_cmd)
 main.add_command(sbom_cmd)
 main.add_command(secrets_cmd)
 main.add_command(code_cmd)
+
+# ---------------------------------------------------------------------------
+# Skills command group — `agent-bom skills [scan|verify]`
+# ---------------------------------------------------------------------------
+from agent_bom.cli._skills_group import skills_group  # noqa: E402
+
+main.add_command(skills_group)
 
 # ---------------------------------------------------------------------------
 # Cloud command group — `agent-bom cloud [aws|azure|gcp]`

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -12,7 +12,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
     [
         (
             "Scanning",
-            ["agents", "image", "fs", "iac", "sbom", "cloud", "check", "verify", "secrets", "code"],
+            ["agents", "skills", "image", "fs", "iac", "sbom", "cloud", "check", "verify", "secrets", "code"],
         ),
         (
             "Runtime",

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -223,7 +223,7 @@ def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_jso
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 32 security tools via MCP protocol:
+    Exposes 35 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE
@@ -232,6 +232,8 @@ def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_jso
       generate_sbom          Generate CycloneDX or SPDX SBOM
       compliance             14-framework compliance posture
       remediate              Generate actionable remediation plan
+      skill_scan             Scan instruction files for trust, provenance, and findings
+      skill_verify           Verify Sigstore provenance for instruction files
       skill_trust            Trust assessment for SKILL.md files
       verify                 Package integrity + SLSA provenance verification
       where                  Show all MCP discovery paths + existence status

--- a/src/agent_bom/cli/_skills_group.py
+++ b/src/agent_bom/cli/_skills_group.py
@@ -1,0 +1,210 @@
+"""First-class skills command group for instruction/skill scanning."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from agent_bom.skills_service import scan_skill_targets, verify_skill_targets
+
+_VERDICT_ORDER = {"benign": 0, "suspicious": 1, "malicious": 2}
+
+
+def _display_path(path: str) -> str:
+    """Render a concise path for console output."""
+    p = Path(path)
+    try:
+        return str(p.relative_to(Path.cwd()))
+    except ValueError:
+        return p.name or str(p)
+
+
+@click.group("skills", invoke_without_command=True)
+@click.pass_context
+def skills_group(ctx: click.Context) -> None:
+    """Scan and verify AI instruction files, skills, and agent prompts.
+
+    Covers `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `skills/*.md`,
+    and other supported skill/instruction files.
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@skills_group.command("scan")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True, path_type=Path))
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console", show_default=True)
+@click.option("-o", "--output", "output_path", type=click.Path(path_type=Path), help="Write output to this file")
+@click.option(
+    "--fail-on-verdict",
+    type=click.Choice(["suspicious", "malicious"]),
+    help="Exit 1 if any scanned file reaches this trust verdict or worse",
+)
+def skills_scan_cmd(paths: tuple[Path, ...], output_format: str, output_path: Path | None, fail_on_verdict: str | None) -> None:
+    """Scan skill and instruction files for trust, risk, and provenance.
+
+    \b
+    Examples:
+      agent-bom skills scan
+      agent-bom skills scan CLAUDE.md .cursor/rules
+      agent-bom skills scan . --fail-on-verdict suspicious -f json
+    """
+    report = scan_skill_targets(paths)
+    payload = report.to_dict()
+
+    if output_format == "json":
+        rendered = json.dumps(payload, indent=2)
+        if output_path:
+            output_path.write_text(rendered)
+        else:
+            click.echo(rendered)
+    else:
+        console = Console()
+        summary = payload["summary"]
+
+        console.print("\n[bold]agent-bom skills scan[/bold]\n")
+        if not report.files:
+            console.print("  [yellow]⚠ No supported skill or instruction files found.[/yellow]\n")
+            if output_path:
+                output_path.write_text("")
+            sys.exit(2)
+
+        console.print(
+            "  "
+            f"[green]{summary['files_scanned']}[/green] file(s) · "
+            f"[green]{summary['packages_found']}[/green] package ref(s) · "
+            f"[green]{summary['servers_found']}[/green] server ref(s) · "
+            f"[yellow]{summary['credential_env_vars']}[/yellow] credential var(s)\n"
+        )
+
+        files_table = Table(title="Instruction Surface", expand=True)
+        files_table.add_column("File")
+        files_table.add_column("Verdict", no_wrap=True)
+        files_table.add_column("Prov.", no_wrap=True)
+        files_table.add_column("Findings", justify="right", no_wrap=True)
+        files_table.add_column("Refs", justify="right", no_wrap=True)
+
+        verdict_style = {"benign": "green", "suspicious": "yellow", "malicious": "red"}
+        prov_style = {"verified": "green", "unsigned": "yellow", "bundle_found_but_invalid": "red", "missing": "red"}
+
+        for file_report in report.files:
+            verdict = file_report.trust.verdict.value
+            provenance = str(file_report.provenance.get("status", "unknown"))
+            files_table.add_row(
+                _display_path(str(file_report.path)),
+                f"[{verdict_style.get(verdict, 'white')}]{verdict}[/{verdict_style.get(verdict, 'white')}]",
+                f"[{prov_style.get(provenance, 'white')}]{provenance}[/{prov_style.get(provenance, 'white')}]",
+                str(len(file_report.audit.findings)),
+                str(len(file_report.scan.packages) + len(file_report.scan.servers)),
+            )
+        console.print(files_table)
+
+        all_findings = [finding for file_report in report.files for finding in file_report.audit.findings]
+        if all_findings:
+            finding_table = Table(title="Top Findings", expand=True)
+            finding_table.add_column("Sev", no_wrap=True)
+            finding_table.add_column("File", no_wrap=True)
+            finding_table.add_column("Category", no_wrap=True)
+            finding_table.add_column("Title")
+            sev_style = {"critical": "red bold", "high": "red", "medium": "yellow", "low": "dim"}
+            ordered = sorted(
+                all_findings,
+                key=lambda finding: ({"critical": 0, "high": 1, "medium": 2, "low": 3}.get(finding.severity, 4), finding.title.lower()),
+            )
+            for finding in ordered[:8]:
+                style = sev_style.get(finding.severity, "white")
+                finding_table.add_row(
+                    f"[{style}]{finding.severity.upper()}[/{style}]",
+                    _display_path(finding.source_file),
+                    finding.category,
+                    finding.title,
+                )
+            console.print()
+            console.print(finding_table)
+
+        recommendations = []
+        seen_recommendations: set[str] = set()
+        for file_report in report.files:
+            for recommendation in file_report.trust.recommendations:
+                if recommendation not in seen_recommendations:
+                    seen_recommendations.add(recommendation)
+                    recommendations.append(recommendation)
+
+        if recommendations:
+            console.print("\n[bold]Recommended next steps[/bold]")
+            for recommendation in recommendations[:5]:
+                console.print(f"  • {recommendation}")
+        console.print()
+
+        if output_path:
+            output_path.write_text(json.dumps(payload, indent=2))
+
+    if fail_on_verdict:
+        threshold = _VERDICT_ORDER[fail_on_verdict]
+        worst = max((_VERDICT_ORDER[file_report.trust.verdict.value] for file_report in report.files), default=0)
+        if worst >= threshold:
+            sys.exit(1)
+
+
+@skills_group.command("verify")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True, path_type=Path))
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console", show_default=True)
+@click.option("-o", "--output", "output_path", type=click.Path(path_type=Path), help="Write output to this file")
+def skills_verify_cmd(paths: tuple[Path, ...], output_format: str, output_path: Path | None) -> None:
+    """Verify Sigstore provenance for skill and instruction files.
+
+    \b
+    Examples:
+      agent-bom skills verify
+      agent-bom skills verify CLAUDE.md skills/
+      agent-bom skills verify . -f json
+    """
+    results = verify_skill_targets(paths)
+
+    if output_format == "json":
+        rendered = json.dumps({"files": results}, indent=2)
+        if output_path:
+            output_path.write_text(rendered)
+        else:
+            click.echo(rendered)
+    else:
+        console = Console()
+        console.print("\n[bold]agent-bom skills verify[/bold]\n")
+        if not results:
+            console.print("  [yellow]⚠ No supported skill or instruction files found.[/yellow]\n")
+            if output_path:
+                output_path.write_text("")
+            sys.exit(2)
+
+        table = Table(title="Instruction Provenance", expand=True)
+        table.add_column("File")
+        table.add_column("Status", no_wrap=True)
+        table.add_column("Signer")
+        table.add_column("Bundle", no_wrap=True)
+        table.add_column("SHA-256", no_wrap=True)
+
+        style_map = {"verified": "green", "unsigned": "yellow", "bundle_found_but_invalid": "red", "missing": "red"}
+
+        for result in results:
+            status = str(result["status"])
+            style = style_map.get(status, "white")
+            table.add_row(
+                _display_path(str(result["path"])),
+                f"[{style}]{status}[/{style}]",
+                str(result.get("signer") or "—"),
+                "yes" if result.get("has_sigstore_bundle") else "no",
+                str(result.get("sha256", ""))[:16] + "..." if result.get("sha256") else "—",
+            )
+        console.print(table)
+        console.print()
+
+        if output_path:
+            output_path.write_text(json.dumps({"files": results}, indent=2))
+
+    if any(result["status"] != "verified" for result in results):
+        sys.exit(1)

--- a/src/agent_bom/cli/options.py
+++ b/src/agent_bom/cli/options.py
@@ -432,7 +432,11 @@ def discovery_options(fn):
             click.option(
                 "--no-skill", is_flag=True, help="Skip all skill/instruction file scanning (auto-discovery + explicit --skill paths)"
             ),
-            click.option("--skill-only", is_flag=True, help="Scan ONLY skill/instruction files; skip agent/package/CVE scanning"),
+            click.option(
+                "--skill-only",
+                is_flag=True,
+                help="Scan ONLY skill/instruction files; skip agent/package/CVE scanning (focused workflow: `agent-bom skills scan`)",
+            ),
             click.option(
                 "--scan-prompts", is_flag=True, help="Scan prompt template files (.prompt, system_prompt.*, prompts/) for security risks"
             ),
@@ -527,7 +531,7 @@ def runtime_options(fn):
             click.option(
                 "--verify-instructions",
                 is_flag=True,
-                help="Verify instruction file provenance (CLAUDE.md, .cursorrules, SKILL.md) via Sigstore bundles",
+                help="Verify instruction file provenance via Sigstore bundles (dedicated workflow: `agent-bom skills verify`)",
             ),
             click.option(
                 "--context-graph", "context_graph_flag", is_flag=True, help="Compute agent context graph with lateral movement analysis"

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -4,7 +4,7 @@ Start with:
     agent-bom mcp server              # stdio (for Claude Desktop, Cursor, etc.)
     agent-bom mcp server --sse        # SSE transport (for remote clients)
 
-Tools (33):
+Tools (35):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE
@@ -13,6 +13,8 @@ Tools (33):
     generate_sbom       — Generate CycloneDX or SPDX SBOM
     compliance          — OWASP/ATLAS/NIST AI RMF compliance posture
     remediate           — Generate actionable remediation plan
+    skill_scan          — Scan instruction files for packages, servers, trust, and findings
+    skill_verify        — Verify instruction file Sigstore provenance
     skill_trust         — ClawHub-style trust assessment for SKILL.md files
     verify              — Package integrity + SLSA provenance verification
     where               — Show all MCP discovery paths + existence status
@@ -338,7 +340,9 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
     from agent_bom.mcp_tools.runtime import (
         inventory_impl,
         runtime_correlate_impl,
+        skill_scan_impl,
         skill_trust_impl,
+        skill_verify_impl,
         verify_impl,
         where_impl,
     )
@@ -664,7 +668,38 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             _truncate_response=_truncate_response,
         )
 
-    # ── Tool 9: skill_trust ──────────────────────────────────────────
+    # ── Tool 9: skill_scan ───────────────────────────────────────────
+
+    @mcp.tool(annotations=_READ_ONLY, title="Skill Scan")
+    def skill_scan(
+        path: Annotated[str, Field(description="Path to a skill/instruction file or directory to scan.")] = ".",
+    ) -> str:
+        """Scan skill and instruction files for trust, findings, and provenance.
+
+        Discovers supported files such as `CLAUDE.md`, `AGENTS.md`,
+        `.cursorrules`, and `skills/*.md`, then parses referenced packages,
+        MCP servers, credential env vars, audit findings, and trust verdicts.
+        """
+        return skill_scan_impl(
+            path=path,
+            _safe_path=_safe_path,
+            _truncate_response=_truncate_response,
+        )
+
+    # ── Tool 10: skill_verify ────────────────────────────────────────
+
+    @mcp.tool(annotations=_READ_ONLY, title="Skill Provenance Verify")
+    def skill_verify(
+        path: Annotated[str, Field(description="Path to a skill/instruction file or directory to verify.")] = ".",
+    ) -> str:
+        """Verify Sigstore provenance for skill and instruction files."""
+        return skill_verify_impl(
+            path=path,
+            _safe_path=_safe_path,
+            _truncate_response=_truncate_response,
+        )
+
+    # ── Tool 11: skill_trust ──────────────────────────────────────────
 
     @mcp.tool(annotations=_READ_ONLY, title="Skill Trust Assessment")
     def skill_trust(
@@ -692,7 +727,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             _truncate_response=_truncate_response,
         )
 
-    # ── Tool 10: verify ─────────────────────────────────────────────
+    # ── Tool 12: verify ─────────────────────────────────────────────
 
     @mcp.tool(annotations=_READ_ONLY, title="Package Integrity Verify")
     async def verify(
@@ -716,7 +751,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             _truncate_response=_truncate_response,
         )
 
-    # ── Tool 11: where ────────────────────────────────────────────
+    # ── Tool 13: where ────────────────────────────────────────────
 
     @mcp.tool(annotations=_READ_ONLY, title="Discovery Paths")
     def where() -> str:
@@ -731,7 +766,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
         """
         return where_impl(_truncate_response=_truncate_response)
 
-    # ── Tool 12: inventory ────────────────────────────────────────
+    # ── Tool 14: inventory ────────────────────────────────────────
 
     @mcp.tool(annotations=_READ_ONLY, title="Agent Inventory")
     def inventory(
@@ -1606,6 +1641,16 @@ _SERVER_CARD_TOOLS = [
         "annotations": {"readOnlyHint": True},
     },
     {"name": "remediate", "description": "Generate actionable remediation plan", "annotations": {"readOnlyHint": True}},
+    {
+        "name": "skill_scan",
+        "description": "Scan instruction files for packages, MCP servers, trust verdicts, and findings",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "skill_verify",
+        "description": "Verify Sigstore provenance for instruction and skill files",
+        "annotations": {"readOnlyHint": True},
+    },
     {"name": "skill_trust", "description": "ClawHub-style trust assessment for SKILL.md files", "annotations": {"readOnlyHint": True}},
     {
         "name": "verify",

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -1,4 +1,4 @@
-"""Runtime tools — runtime_correlate, verify, where, inventory, skill_trust implementations."""
+"""Runtime tools — runtime correlation, verification, inventory, and skill scanning."""
 
 from __future__ import annotations
 
@@ -258,9 +258,7 @@ def skill_trust_impl(
 ) -> str:
     """Implementation of the skill_trust tool."""
     try:
-        from agent_bom.parsers.skill_audit import audit_skill_result
-        from agent_bom.parsers.skills import parse_skill_file
-        from agent_bom.parsers.trust_assessment import assess_trust
+        from agent_bom.skills_service import scan_skill_targets
 
         try:
             p = _safe_path(skill_path)
@@ -272,39 +270,65 @@ def skill_trust_impl(
         if p.stat().st_size > _MAX_FILE_SIZE:
             return json.dumps({"error": f"File too large ({p.stat().st_size} bytes, max {_MAX_FILE_SIZE})"})
 
-        scan = parse_skill_file(p)
-        audit = audit_skill_result(scan)
-        trust = assess_trust(scan, audit)
-
-        result = trust.to_dict()
-
-        # Instruction file provenance check (Sigstore)
-        try:
-            from agent_bom.integrity import verify_instruction_file
-
-            provenance = verify_instruction_file(p)
-            if provenance.verified:
-                result["provenance"] = {
-                    "status": "verified",
-                    "signer": provenance.signer_identity,
-                    "rekor_index": provenance.rekor_log_index,
-                    "sha256": provenance.sha256,
-                }
-            elif provenance.has_sigstore_bundle:
-                result["provenance"] = {
-                    "status": "bundle_found_but_invalid",
-                    "reason": provenance.reason,
-                    "sha256": provenance.sha256,
-                }
-            else:
-                result["provenance"] = {
-                    "status": "unsigned",
-                    "sha256": provenance.sha256,
-                }
-        except Exception:
-            result["provenance"] = {"status": "check_failed"}
+        file_report = scan_skill_targets([p]).files[0]
+        result = file_report.trust.to_dict()
+        result["provenance"] = file_report.provenance
+        result["audit"] = {
+            "passed": file_report.audit.passed,
+            "findings": len(file_report.audit.findings),
+        }
 
         return _truncate_response(json.dumps(result, indent=2))
+    except Exception as exc:
+        logger.exception("MCP tool error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+def skill_scan_impl(
+    *,
+    path: str,
+    _safe_path,
+    _truncate_response,
+) -> str:
+    """Implementation of the skill_scan tool."""
+    try:
+        from agent_bom.skills_service import scan_skill_targets
+
+        try:
+            target = _safe_path(path)
+        except ValueError as exc:
+            logger.exception("MCP tool error")
+            return json.dumps({"error": sanitize_error(exc)})
+
+        report = scan_skill_targets([target]).to_dict()
+        if report["summary"]["files_scanned"] == 0:
+            return json.dumps({"status": "no_skill_files_found", "path": str(target)})
+        return _truncate_response(json.dumps(report, indent=2))
+    except Exception as exc:
+        logger.exception("MCP tool error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+def skill_verify_impl(
+    *,
+    path: str,
+    _safe_path,
+    _truncate_response,
+) -> str:
+    """Implementation of the skill_verify tool."""
+    try:
+        from agent_bom.skills_service import verify_skill_targets
+
+        try:
+            target = _safe_path(path)
+        except ValueError as exc:
+            logger.exception("MCP tool error")
+            return json.dumps({"error": sanitize_error(exc)})
+
+        results = verify_skill_targets([target])
+        if not results:
+            return json.dumps({"status": "no_skill_files_found", "path": str(target)})
+        return _truncate_response(json.dumps({"files": results}, indent=2))
     except Exception as exc:
         logger.exception("MCP tool error")
         return json.dumps({"error": sanitize_error(exc)})

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -1,0 +1,181 @@
+"""Shared skill scanning and provenance services for CLI and MCP surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from agent_bom.integrity import verify_instruction_file
+from agent_bom.parsers.skill_audit import SkillAuditResult, audit_skill_result
+from agent_bom.parsers.skills import SkillScanResult, discover_skill_files, parse_skill_file
+from agent_bom.parsers.trust_assessment import TrustAssessmentResult, assess_trust
+
+
+@dataclass
+class SkillFileReport:
+    """End-to-end scan, audit, trust, and provenance report for one file."""
+
+    path: Path
+    scan: SkillScanResult
+    audit: SkillAuditResult
+    trust: TrustAssessmentResult
+    provenance: dict[str, object]
+
+    def to_dict(self) -> dict:
+        """Serialize the file report to JSON-compatible data."""
+        return {
+            "path": str(self.path),
+            "packages": [
+                {
+                    "name": pkg.name,
+                    "version": pkg.version,
+                    "ecosystem": pkg.ecosystem,
+                }
+                for pkg in self.scan.packages
+            ],
+            "servers": [
+                {
+                    "name": server.name,
+                    "command": server.command,
+                    "args": list(server.args),
+                    "transport": server.transport.value,
+                }
+                for server in self.scan.servers
+            ],
+            "credential_env_vars": list(self.scan.credential_env_vars),
+            "audit": {
+                "passed": self.audit.passed,
+                "packages_checked": self.audit.packages_checked,
+                "servers_checked": self.audit.servers_checked,
+                "credentials_checked": self.audit.credentials_checked,
+                "findings": [
+                    {
+                        "severity": finding.severity,
+                        "category": finding.category,
+                        "title": finding.title,
+                        "detail": finding.detail,
+                        "source_file": finding.source_file,
+                        "package": finding.package,
+                        "server": finding.server,
+                        "recommendation": finding.recommendation,
+                        "context": finding.context,
+                    }
+                    for finding in self.audit.findings
+                ],
+            },
+            "trust": self.trust.to_dict(),
+            "provenance": self.provenance,
+        }
+
+
+@dataclass
+class SkillsScanReport:
+    """Aggregated report across one or more skill/instruction files."""
+
+    files: list[SkillFileReport] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize the aggregated scan report."""
+        package_keys = {(pkg["name"].lower(), pkg["ecosystem"]) for report in self.files for pkg in report.to_dict()["packages"]}
+        server_names = {server["name"] for report in self.files for server in report.to_dict()["servers"]}
+        credential_names = {cred for report in self.files for cred in report.scan.credential_env_vars}
+
+        suspicious = sum(1 for report in self.files if report.trust.verdict.value == "suspicious")
+        malicious = sum(1 for report in self.files if report.trust.verdict.value == "malicious")
+        verified = sum(1 for report in self.files if report.provenance.get("status") == "verified")
+
+        return {
+            "summary": {
+                "files_scanned": len(self.files),
+                "packages_found": len(package_keys),
+                "servers_found": len(server_names),
+                "credential_env_vars": len(credential_names),
+                "findings": sum(len(report.audit.findings) for report in self.files),
+                "verified_files": verified,
+                "suspicious_files": suspicious,
+                "malicious_files": malicious,
+            },
+            "files": [report.to_dict() for report in self.files],
+        }
+
+
+def resolve_skill_targets(paths: Iterable[str | Path] | None = None, *, cwd: Path | None = None) -> list[Path]:
+    """Resolve files/directories to concrete skill/instruction files."""
+    base_dir = cwd or Path.cwd()
+    requested = list(paths or [base_dir])
+    resolved: list[Path] = []
+    seen: set[Path] = set()
+
+    for raw_path in requested:
+        path = raw_path if isinstance(raw_path, Path) else Path(raw_path)
+        candidate = path if path.is_absolute() else (base_dir / path)
+        candidate = candidate.resolve()
+
+        discovered: list[Path]
+        if candidate.is_dir():
+            discovered = discover_skill_files(candidate)
+        elif candidate.is_file():
+            discovered = [candidate]
+        else:
+            continue
+
+        for file_path in discovered:
+            normalized = file_path.resolve()
+            if normalized not in seen:
+                seen.add(normalized)
+                resolved.append(normalized)
+
+    return sorted(resolved)
+
+
+def _provenance_to_dict(path: Path) -> dict[str, object]:
+    """Convert instruction-file verification to stable JSON output."""
+    verification = verify_instruction_file(path)
+    if verification.verified:
+        status = "verified"
+    elif verification.has_sigstore_bundle:
+        status = "bundle_found_but_invalid"
+    elif verification.reason == "file_not_found":
+        status = "missing"
+    else:
+        status = "unsigned"
+
+    return {
+        "status": status,
+        "reason": verification.reason,
+        "sha256": verification.sha256,
+        "signer": verification.signer_identity,
+        "rekor_log_index": verification.rekor_log_index,
+        "has_sigstore_bundle": verification.has_sigstore_bundle,
+    }
+
+
+def scan_skill_targets(paths: Iterable[str | Path] | None = None, *, cwd: Path | None = None) -> SkillsScanReport:
+    """Scan one or more skill targets and return aggregate results."""
+    reports: list[SkillFileReport] = []
+    for path in resolve_skill_targets(paths, cwd=cwd):
+        scan = parse_skill_file(path)
+        audit = audit_skill_result(scan)
+        trust = assess_trust(scan, audit)
+        reports.append(
+            SkillFileReport(
+                path=path,
+                scan=scan,
+                audit=audit,
+                trust=trust,
+                provenance=_provenance_to_dict(path),
+            )
+        )
+    return SkillsScanReport(files=reports)
+
+
+def verify_skill_targets(paths: Iterable[str | Path] | None = None, *, cwd: Path | None = None) -> list[dict[str, object]]:
+    """Verify provenance for one or more skill targets."""
+    return [
+        {
+            "path": str(path),
+            **_provenance_to_dict(path),
+        }
+        for path in resolve_skill_targets(paths, cwd=cwd)
+    ]

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -211,15 +211,17 @@ def test_health_endpoint_fields():
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_server_help_shows_14_tools():
-    """MCP server help should mention 14 tools."""
+def test_mcp_server_help_shows_skill_tools():
+    """MCP server help should mention the expanded skill tool surface."""
     from click.testing import CliRunner
 
     from agent_bom.cli import main
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp", "server", "--help"])
-    assert "32 security tools" in result.output
+    assert "35 security tools" in result.output
+    assert "skill_scan" in result.output
+    assert "skill_verify" in result.output
     assert "compliance" in result.output
     assert "remediate" in result.output
 

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -1006,7 +1006,7 @@ async def test_license_compliance_scan_with_policy():
 
 
 # ---------------------------------------------------------------------------
-# mcp_tools/runtime.py — verify_impl, skill_trust_impl
+# mcp_tools/runtime.py — verify_impl, skill_scan_impl, skill_verify_impl, skill_trust_impl
 # ---------------------------------------------------------------------------
 
 
@@ -1044,6 +1044,37 @@ def test_skill_trust_impl_file_not_found():
     )
     data = json.loads(result)
     assert "error" in data
+
+
+def test_skill_scan_impl_success(tmp_path):
+    from agent_bom.mcp_tools.runtime import skill_scan_impl
+
+    skill_file = tmp_path / "CLAUDE.md"
+    skill_file.write_text("# System\nUse npx @modelcontextprotocol/server-filesystem\n")
+
+    result = skill_scan_impl(
+        path=str(tmp_path),
+        _safe_path=lambda p: tmp_path,
+        _truncate_response=_trunc,
+    )
+    data = json.loads(result)
+    assert data["summary"]["files_scanned"] == 1
+
+
+def test_skill_verify_impl_success(tmp_path):
+    from agent_bom.mcp_tools.runtime import skill_verify_impl
+
+    skill_file = tmp_path / "CLAUDE.md"
+    skill_file.write_text("# System\nStay safe.\n")
+
+    result = skill_verify_impl(
+        path=str(tmp_path),
+        _safe_path=lambda p: tmp_path,
+        _truncate_response=_trunc,
+    )
+    data = json.loads(result)
+    assert len(data["files"]) == 1
+    assert data["files"][0]["status"] == "unsigned"
 
 
 def test_skill_trust_impl_safe_path_error():
@@ -1151,28 +1182,14 @@ def test_skill_trust_impl_success(tmp_path):
     skill_file = tmp_path / "CLAUDE.md"
     skill_file.write_text("# System\nYou are a helpful assistant.")
 
-    mock_scan = MagicMock()
-    mock_audit = MagicMock()
-    mock_trust = MagicMock()
-    mock_trust.to_dict.return_value = {"trust_level": "high", "risk_score": 0.1}
-    mock_provenance = MagicMock()
-    mock_provenance.verified = False
-    mock_provenance.has_sigstore_bundle = False
-    mock_provenance.sha256 = "abc123"
-
-    with (
-        patch("agent_bom.parsers.skill_audit.audit_skill_result", return_value=mock_audit),
-        patch("agent_bom.parsers.skills.parse_skill_file", return_value=mock_scan),
-        patch("agent_bom.parsers.trust_assessment.assess_trust", return_value=mock_trust),
-        patch("agent_bom.integrity.verify_instruction_file", return_value=mock_provenance),
-    ):
-        result = skill_trust_impl(
-            skill_path=str(skill_file),
-            _safe_path=lambda p: skill_file,
-            _truncate_response=_trunc,
-        )
+    result = skill_trust_impl(
+        skill_path=str(skill_file),
+        _safe_path=lambda p: skill_file,
+        _truncate_response=_trunc,
+    )
     data = json.loads(result)
-    assert "trust_level" in data
+    assert "verdict" in data
+    assert "categories" in data
     assert data["provenance"]["status"] == "unsigned"
 
 

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -1,0 +1,59 @@
+"""CLI tests for the first-class skills command surface."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+def test_skills_scan_json(tmp_path):
+    """`agent-bom skills scan` returns structured aggregate results."""
+    skill_file = tmp_path / "CLAUDE.md"
+    skill_file.write_text(
+        """# Project instructions
+
+Use the filesystem server:
+
+```bash
+npx @modelcontextprotocol/server-filesystem
+```
+
+Environment:
+- ANTHROPIC_API_KEY
+"""
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skills", "scan", str(tmp_path), "--format", "json"])
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(result.output)
+    assert data["summary"]["files_scanned"] == 1
+    assert data["summary"]["packages_found"] >= 1
+    assert data["summary"]["credential_env_vars"] >= 1
+    assert data["files"][0]["path"].endswith("CLAUDE.md")
+
+
+def test_skills_verify_json_unsigned(tmp_path):
+    """`agent-bom skills verify` reports unsigned files and exits non-zero."""
+    skill_file = tmp_path / "CLAUDE.md"
+    skill_file.write_text("# Instructions\nStay read-only.\n")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skills", "verify", str(tmp_path), "--format", "json"])
+    assert result.exit_code == 1, result.output
+
+    data = json.loads(result.output)
+    assert len(data["files"]) == 1
+    assert data["files"][0]["status"] == "unsigned"
+
+
+def test_main_help_lists_skills_command():
+    """Top-level help should surface the new skills command group."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "skills" in result.output

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -601,11 +601,13 @@ def test_trust_assessment_absent_when_no_skill():
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def test_mcp_skill_trust_tool_exists():
-    """skill_trust tool is registered on the MCP server."""
+def test_mcp_skill_tools_exist():
+    """Skill scan, verify, and trust tools are registered on the MCP server."""
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
     tool_names = [t["name"] for t in _SERVER_CARD_TOOLS]
+    assert "skill_scan" in tool_names
+    assert "skill_verify" in tool_names
     assert "skill_trust" in tool_names
 
 


### PR DESCRIPTION
## Summary
- add a first-class `agent-bom skills` command group with dedicated `scan` and `verify` workflows
- expose matching MCP tools and route existing `skill_trust` through shared scan/audit/provenance logic
- align help text, server metadata, and public docs/listings with the expanded 35-tool MCP surface

## Validation
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_skills_cli.py tests/test_mcp_tool_impls.py tests/test_trust_assessment.py tests/test_deployment.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_regression_quality.py tests/test_stats_alignment.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_release_consistency.py`
- live CLI sanity:
  - `uv run agent-bom skills scan integrations/openclaw/SKILL.md --format json`
  - `uv run agent-bom skills verify integrations/openclaw/SKILL.md --format json`
