### PR TITLE
Fix filesystem scan output credibility

### DIFF
--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -118,11 +118,23 @@ class ClickHouseAnalyticsStore:
     def record_scan(self, scan_id: str, agent_name: str, vulns: list[dict]) -> None:
         if not vulns:
             return
+
+        def _split_package(v: dict) -> tuple[str, str]:
+            pkg_name = v.get("package_name", "")
+            pkg_version = v.get("package_version", "") or v.get("version", "")
+            if pkg_name:
+                return pkg_name, pkg_version
+            pkg = v.get("package", "")
+            if isinstance(pkg, str) and "@" in pkg:
+                name, version = pkg.rsplit("@", 1)
+                return name, version
+            return str(pkg or ""), pkg_version
+
         rows = [
             {
                 "scan_id": scan_id,
-                "package_name": v.get("package", ""),
-                "package_version": v.get("version", ""),
+                "package_name": _split_package(v)[0],
+                "package_version": _split_package(v)[1],
                 "ecosystem": v.get("ecosystem", ""),
                 "cve_id": v.get("cve_id", v.get("id", "")),
                 "cvss_score": float(v.get("cvss_score", 0.0)),

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -571,7 +571,7 @@ def run_local_discovery(
 
     # Step 1d4: Project package scan
     if not skill_only and project and not images and not code_paths and not sbom_file:
-        from agent_bom.models import Agent, AgentType, MCPServer, TransportType
+        from agent_bom.models import Agent, AgentType, MCPServer, ServerSurface, TransportType
         from agent_bom.parsers import scan_project_directory
 
         proj_root = Path(project)
@@ -594,6 +594,7 @@ def run_local_discovery(
                     command="project",
                     args=[str(manifest_dir_resolved)],
                     transport=TransportType.STDIO,
+                    surface=ServerSurface.OTHER,
                     packages=pkgs,
                 )
                 proj_servers.append(proj_server)

--- a/src/agent_bom/compliance_utils.py
+++ b/src/agent_bom/compliance_utils.py
@@ -1,0 +1,63 @@
+"""Helpers for consistent compliance tag handling across scan outputs.
+
+Blast radius findings can carry two layers of framework tags:
+
+- vulnerability-intrinsic tags derived from CVE/package properties
+- context-aware tags derived from agent/server/credential/tool exposure
+
+These helpers merge both sources so JSON, posture scoring, and reports stay
+truthful even when a caller only populated one layer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from agent_bom.models import BlastRadius
+
+_FIELD_TO_VULN_KEY: dict[str, str] = {
+    "owasp_tags": "owasp_llm",
+    "atlas_tags": "atlas",
+    "nist_ai_rmf_tags": "nist_ai_rmf",
+    "owasp_mcp_tags": "owasp_mcp",
+    "owasp_agentic_tags": "owasp_agentic",
+    "eu_ai_act_tags": "eu_ai_act",
+    "nist_csf_tags": "nist_csf",
+    "iso_27001_tags": "iso_27001",
+    "soc2_tags": "soc2",
+    "cis_tags": "cis",
+    "cmmc_tags": "cmmc",
+    "nist_800_53_tags": "nist_800_53",
+    "fedramp_tags": "fedramp",
+}
+
+
+def _merged_tags(*groups: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for group in groups:
+        for tag in group:
+            if tag and tag not in seen:
+                seen.add(tag)
+                result.append(tag)
+    return sorted(result)
+
+
+def effective_blast_radius_tags(br: BlastRadius) -> dict[str, list[str]]:
+    """Return merged framework tags for a blast radius entry."""
+    vuln_tags = getattr(br.vulnerability, "compliance_tags", {}) or {}
+    result: dict[str, list[str]] = {}
+    for field, vuln_key in _FIELD_TO_VULN_KEY.items():
+        result[field] = _merged_tags(
+            getattr(br, field, []) or [],
+            vuln_tags.get(vuln_key, []) or [],
+        )
+    result["attack_tags"] = _merged_tags(getattr(br, "attack_tags", []) or [])
+    return result
+
+
+def apply_effective_blast_radius_tags(br: BlastRadius) -> BlastRadius:
+    """Mutate ``br`` so all framework fields reflect merged effective tags."""
+    for field, tags in effective_blast_radius_tags(br).items():
+        setattr(br, field, tags)
+    return br

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from agent_bom.compliance_utils import effective_blast_radius_tags
 from agent_bom.models import AIBOMReport, BlastRadius
 
 
@@ -103,25 +104,26 @@ def _build_framework_summary(blast_radii: list[BlastRadius]) -> dict:
     soc2_counts: Counter[str] = Counter()
     cis_counts: Counter[str] = Counter()
     for br in blast_radii:
-        for tag in br.owasp_tags:
+        tags = effective_blast_radius_tags(br)
+        for tag in tags["owasp_tags"]:
             owasp_counts[tag] += 1
-        for tag in br.atlas_tags:
+        for tag in tags["atlas_tags"]:
             atlas_counts[tag] += 1
-        for tag in br.nist_ai_rmf_tags:
+        for tag in tags["nist_ai_rmf_tags"]:
             nist_counts[tag] += 1
-        for tag in br.owasp_mcp_tags:
+        for tag in tags["owasp_mcp_tags"]:
             owasp_mcp_counts[tag] += 1
-        for tag in br.owasp_agentic_tags:
+        for tag in tags["owasp_agentic_tags"]:
             owasp_agentic_counts[tag] += 1
-        for tag in br.eu_ai_act_tags:
+        for tag in tags["eu_ai_act_tags"]:
             eu_ai_act_counts[tag] += 1
-        for tag in br.nist_csf_tags:
+        for tag in tags["nist_csf_tags"]:
             nist_csf_counts[tag] += 1
-        for tag in br.iso_27001_tags:
+        for tag in tags["iso_27001_tags"]:
             iso_27001_counts[tag] += 1
-        for tag in br.soc2_tags:
+        for tag in tags["soc2_tags"]:
             soc2_counts[tag] += 1
-        for tag in br.cis_tags:
+        for tag in tags["cis_tags"]:
             cis_counts[tag] += 1
 
     return {
@@ -564,6 +566,8 @@ def to_json(report: AIBOMReport) -> dict:
         ],
         "blast_radius": [
             {
+                **({"package_name": br.package.name, "package_version": br.package.version, "package_stable_id": br.package.stable_id}),
+                **effective_blast_radius_tags(br),
                 "risk_score": br.risk_score,
                 "reachability": br.reachability,
                 "actionable": br.is_actionable,
@@ -593,20 +597,6 @@ def to_json(report: AIBOMReport) -> dict:
                 "cvss_severity": getattr(br.vulnerability, "cvss_severity", None),
                 "ai_risk_context": br.ai_risk_context,
                 "ai_summary": br.ai_summary,
-                "owasp_tags": br.owasp_tags,
-                "atlas_tags": br.atlas_tags,
-                "attack_tags": getattr(br, "attack_tags", []),
-                "nist_ai_rmf_tags": br.nist_ai_rmf_tags,
-                "owasp_mcp_tags": br.owasp_mcp_tags,
-                "owasp_agentic_tags": br.owasp_agentic_tags,
-                "eu_ai_act_tags": br.eu_ai_act_tags,
-                "nist_csf_tags": br.nist_csf_tags,
-                "iso_27001_tags": br.iso_27001_tags,
-                "soc2_tags": br.soc2_tags,
-                "cis_tags": br.cis_tags,
-                "cmmc_tags": br.cmmc_tags,
-                "nist_800_53_tags": br.nist_800_53_tags,
-                "fedramp_tags": br.fedramp_tags,
                 "hop_depth": getattr(br, "hop_depth", 1),
                 "delegation_chain": getattr(br, "delegation_chain", []),
                 "transitive_agents": getattr(br, "transitive_agents", []),

--- a/src/agent_bom/posture.py
+++ b/src/agent_bom/posture.py
@@ -19,6 +19,8 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from agent_bom.compliance_utils import effective_blast_radius_tags
+
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport
 
@@ -178,18 +180,19 @@ def compute_posture_scorecard(report: "AIBOMReport") -> PostureScorecard:
     total_tags = 0
     tagged_findings = 0
     for br in report.blast_radii:
+        tags = effective_blast_radius_tags(br)
         total_tags += 1
         has_tag = bool(
-            br.owasp_tags
-            or br.atlas_tags
-            or br.nist_ai_rmf_tags
-            or br.owasp_mcp_tags
-            or br.owasp_agentic_tags
-            or br.eu_ai_act_tags
-            or br.nist_csf_tags
-            or br.iso_27001_tags
-            or br.soc2_tags
-            or br.cis_tags
+            tags["owasp_tags"]
+            or tags["atlas_tags"]
+            or tags["nist_ai_rmf_tags"]
+            or tags["owasp_mcp_tags"]
+            or tags["owasp_agentic_tags"]
+            or tags["eu_ai_act_tags"]
+            or tags["nist_csf_tags"]
+            or tags["iso_27001_tags"]
+            or tags["soc2_tags"]
+            or tags["cis_tags"]
         )
         if has_tag:
             tagged_findings += 1
@@ -255,6 +258,9 @@ def compute_posture_scorecard(report: "AIBOMReport") -> PostureScorecard:
     if total_servers == 0:
         config_score = 50.0
         config_detail = "No servers to evaluate"
+    elif not report.has_mcp_context:
+        config_score = 100.0
+        config_detail = "N/A for scans without MCP server configuration context"
     else:
         verified_pct = verified_servers / total_servers
         tools_pct = servers_with_tools / total_servers

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -15,6 +15,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from agent_bom.atlas import tag_blast_radius as tag_atlas_techniques
 from agent_bom.cis_controls import tag_blast_radius as tag_cis_controls
 from agent_bom.cmmc import tag_blast_radius as tag_cmmc
+from agent_bom.compliance_utils import apply_effective_blast_radius_tags
 from agent_bom.config import (
     SCANNER_BATCH_DELAY as BATCH_DELAY_SECONDS,
 )
@@ -67,7 +68,9 @@ def set_offline_mode(value: bool) -> None:
 # packages not found in the DB. Set automatically when DB is <24h old.
 prefer_local_db: bool = False
 
-# When False, skip compliance framework tagging on findings (faster for individual scans)
+# CVE-level framework tags are always computed so structured outputs stay
+# truthful by default. The CLI --compliance flag still controls whether
+# context-heavy compliance views are rendered explicitly.
 compliance_mode: bool = False
 
 OSV_API_URL = "https://api.osv.dev/v1"
@@ -1171,8 +1174,7 @@ def _scan_packages_local_db(packages: list[Package]) -> tuple[int, set[str]]:
                     pkg.vulnerabilities.extend(new_vulns)
                     total += len(new_vulns)
                     for v in new_vulns:
-                        if compliance_mode:
-                            v.compliance_tags = _tag_vuln(v, pkg)
+                        v.compliance_tags = _tag_vuln(v, pkg)
                     flag_malicious_from_vulns(pkg)
     finally:
         conn.close()
@@ -1236,8 +1238,7 @@ def _scan_packages_local_db_batch(
             pkg.vulnerabilities.extend(new_vulns)
             total += len(new_vulns)
             for v in new_vulns:
-                if compliance_mode:
-                    v.compliance_tags = _tag_vuln(v, pkg)
+                v.compliance_tags = _tag_vuln(v, pkg)
             flag_malicious_from_vulns(pkg)
 
     return total
@@ -1437,8 +1438,7 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
             total_vulns += len(merged)
             # Tag each CVE with compliance framework codes (pre-enrichment)
             for v in merged:
-                if compliance_mode:
-                    v.compliance_tags = _tag_vuln(v, pkg)
+                v.compliance_tags = _tag_vuln(v, pkg)
             # Flag packages with MAL- prefixed vulnerability IDs as malicious
             flag_malicious_from_vulns(pkg)
 
@@ -1448,8 +1448,7 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
             continue  # already processed above
         for v in pkg.vulnerabilities:
             if not v.compliance_tags:
-                if compliance_mode:
-                    v.compliance_tags = _tag_vuln(v, pkg)
+                v.compliance_tags = _tag_vuln(v, pkg)
 
     # Supplemental: check NVIDIA advisories for all AI framework packages.
     # nvidia_advisory.py maps NVIDIA CSAF products to bundling frameworks (torch,
@@ -1643,6 +1642,9 @@ async def scan_agents(agents: list[Agent], *, compliance_enabled: bool = False, 
             ai_risk_context = None
 
         for vuln in pkg.vulnerabilities:
+            if not vuln.compliance_tags:
+                vuln.compliance_tags = _tag_vuln(vuln, pkg)
+
             # CWE-aware filtering: only expose credentials/tools the vuln
             # type can realistically reach. A DoS (CWE-400) doesn't steal
             # DATABASE_URL. An RCE (CWE-94) does.
@@ -1685,7 +1687,8 @@ async def scan_agents(agents: list[Agent], *, compliance_enabled: bool = False, 
                 attack_vector_summary=attack_summary,
             )
             br.calculate_risk_score()
-            # Compliance tagging — opt-in via --compliance flag
+            # Context-aware tagging remains opt-in for explicit compliance
+            # views, but effective framework tags are always materialized.
             if compliance_enabled:
                 br.owasp_tags = tag_blast_radius(br)
                 br.atlas_tags = tag_atlas_techniques(br)
@@ -1701,6 +1704,7 @@ async def scan_agents(agents: list[Agent], *, compliance_enabled: bool = False, 
                 br.cmmc_tags = tag_cmmc(br)
                 br.nist_800_53_tags = tag_nist_800_53(br)
                 br.fedramp_tags = tag_fedramp(br)
+            apply_effective_blast_radius_tags(br)
             blast_radii.append(br)
 
     # Sort by risk score descending
@@ -1726,10 +1730,11 @@ async def scan_agents_with_enrichment(
     agents: list[Agent],
     nvd_api_key: Optional[str] = None,
     enable_enrichment: bool = True,
+    compliance_enabled: bool = False,
 ) -> list[BlastRadius]:
     """Scan agents and enrich vulnerabilities with NVD/EPSS/KEV data."""
     # First, do normal OSV scan
-    blast_radii = await scan_agents(agents)
+    blast_radii = await scan_agents(agents, compliance_enabled=compliance_enabled)
 
     # Then enrich with external data
     if enable_enrichment and blast_radii:
@@ -1756,8 +1761,7 @@ async def scan_agents_with_enrichment(
                 for server in agent.mcp_servers:
                     for pkg in server.packages:
                         for v in pkg.vulnerabilities:
-                            if compliance_mode:
-                                v.compliance_tags = _tag_vuln(v, pkg)
+                            v.compliance_tags = _tag_vuln(v, pkg)
 
         # Scorecard enrichment — adds supply-chain quality signal
         try:
@@ -1781,6 +1785,7 @@ async def scan_agents_with_enrichment(
         # Recalculate blast radius with all enriched data
         for br in blast_radii:
             br.calculate_risk_score()
+            apply_effective_blast_radius_tags(br)
 
         # Re-sort by updated risk scores
         blast_radii.sort(key=lambda br: br.risk_score, reverse=True)
@@ -1912,7 +1917,14 @@ def scan_agents_sync(
 ) -> list[BlastRadius]:
     """Synchronous wrapper for scan_agents."""
     if enable_enrichment:
-        blast_radii = asyncio.run(scan_agents_with_enrichment(agents, nvd_api_key, enable_enrichment))
+        blast_radii = asyncio.run(
+            scan_agents_with_enrichment(
+                agents,
+                nvd_api_key,
+                enable_enrichment,
+                compliance_enabled=compliance_enabled,
+            )
+        )
     else:
         blast_radii = asyncio.run(scan_agents(agents, compliance_enabled=compliance_enabled, resolve_transitive=resolve_transitive))
     if blast_radius_depth > 1:

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -214,3 +214,37 @@ class TestNullAnalyticsStore:
             store.record_scan("id", "agent", [])
             store.record_event({})
         assert store.query_vuln_trends() == []
+
+
+class TestClickHouseAnalyticsStore:
+    def test_record_scan_splits_package_name_and_version(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        inserted = {}
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                inserted["table"] = table
+                inserted["rows"] = rows
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_scan(
+                "scan-1",
+                "agent-1",
+                [
+                    {
+                        "package": "requests@2.33.0",
+                        "ecosystem": "pypi",
+                        "vulnerability_id": "CVE-2026-0001",
+                        "severity": "high",
+                    }
+                ],
+            )
+
+        assert inserted["table"] == "vulnerability_scans"
+        assert inserted["rows"][0]["package_name"] == "requests"
+        assert inserted["rows"][0]["package_version"] == "2.33.0"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3038,6 +3038,59 @@ def test_json_framework_empty_when_no_findings():
     assert all(e["triggered"] is False for e in summary["mitre_atlas"])
 
 
+def test_json_blast_radius_includes_explicit_package_fields(sample_report):
+    """Blast radius JSON should expose package fields directly for downstream consumers."""
+    data = to_json(sample_report)
+    item = data["blast_radius"][0]
+    assert item["package_name"] == sample_report.blast_radii[0].package.name
+    assert item["package_version"] == sample_report.blast_radii[0].package.version
+    assert item["package_stable_id"] == sample_report.blast_radii[0].package.stable_id
+
+
+def test_json_framework_summary_uses_vuln_level_tags_when_blast_tags_empty():
+    """Structured outputs should stay truthful even if only vuln-level tags are populated."""
+    from agent_bom.models import Package, Severity, Vulnerability
+    from agent_bom.vuln_compliance import tag_vulnerability
+
+    pkg = Package(name="langchain", version="0.1.0", ecosystem="pypi")
+    vuln = Vulnerability(id="CVE-2026-0001", summary="demo", severity=Severity.HIGH)
+    vuln.compliance_tags = tag_vulnerability(vuln, pkg)
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    report = AIBOMReport(agents=[], blast_radii=[br])
+    data = to_json(report)
+    summary = data["threat_framework_summary"]
+    assert summary["total_owasp_triggered"] > 0
+    assert summary["total_atlas_triggered"] > 0
+
+
+def test_scan_agents_populates_intrinsic_framework_tags_without_compliance_flag(monkeypatch):
+    """Default scan output should still carry intrinsic framework tags."""
+    from agent_bom.models import Agent, AgentType, MCPServer, Package, Severity, Vulnerability
+    from agent_bom.scanners import scan_agents_sync
+
+    async def _seeded_scan(packages, resolve_transitive=False):
+        return sum(len(pkg.vulnerabilities) for pkg in packages)
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _seeded_scan)
+
+    vuln = Vulnerability(id="CVE-2026-0002", summary="demo", severity=Severity.HIGH)
+    pkg = Package(name="langchain", version="0.1.0", ecosystem="pypi", vulnerabilities=[vuln])
+    server = MCPServer(name="srv", command="python", packages=[pkg])
+    agent = Agent(name="agt", agent_type=AgentType.CUSTOM, config_path="/tmp", mcp_servers=[server])
+
+    blast_radii = scan_agents_sync([agent], compliance_enabled=False)
+    assert blast_radii
+    assert blast_radii[0].owasp_tags
+    assert blast_radii[0].nist_csf_tags
+
+
 def test_print_threat_frameworks_no_crash(sample_report):
     """print_threat_frameworks() runs without crashing on a real report."""
     from agent_bom.atlas import tag_blast_radius as tag_atlas

--- a/tests/test_enterprise_scenarios.py
+++ b/tests/test_enterprise_scenarios.py
@@ -217,6 +217,26 @@ class TestPostureScorecard:
         sc_nofix = compute_posture_scorecard(unfixable_report)
         assert sc_fix.dimensions["vulnerability_posture"].score >= sc_nofix.dimensions["vulnerability_posture"].score
 
+    def test_filesystem_only_scans_do_not_fail_configuration_quality(self):
+        """Filesystem-only scans should treat MCP config quality as not applicable."""
+        from agent_bom.models import Agent, AgentType, MCPServer, Package, ServerSurface, Severity, Vulnerability
+        from agent_bom.posture import compute_posture_scorecard
+        from agent_bom.vuln_compliance import tag_vulnerability
+
+        pkg = Package(name="langchain", version="0.1.0", ecosystem="pypi")
+        vuln = Vulnerability(id="CVE-2026-1000", summary="demo", severity=Severity.HIGH)
+        vuln.compliance_tags = tag_vulnerability(vuln, pkg)
+        br = _make_blast_radius(pkg=pkg, vuln=vuln)
+
+        fs_server = MCPServer(name="filesystem:repo", command="", packages=[pkg], surface=ServerSurface.FILESYSTEM)
+        fs_agent = Agent(name="filesystem:repo", agent_type=AgentType.CUSTOM, config_path=".", mcp_servers=[fs_server])
+        report = _make_report(agents=[fs_agent], blast_radii=[br])
+
+        sc = compute_posture_scorecard(report)
+        assert sc.dimensions["configuration_quality"].score == 100.0
+        assert "N/A" in sc.dimensions["configuration_quality"].details
+        assert sc.dimensions["compliance_coverage"].score > 0
+
 
 # ── Credential Risk Ranking ──────────────────────────────────────────────────
 

--- a/tests/test_synthetic_surfaces.py
+++ b/tests/test_synthetic_surfaces.py
@@ -49,6 +49,31 @@ def test_image_surface_does_not_claim_mcp_context():
     assert report.has_mcp_context is False
 
 
+def test_other_surface_does_not_claim_mcp_context():
+    project_server = MCPServer(
+        name="project:repo",
+        command="project",
+        args=["/workspace"],
+        transport=TransportType.STDIO,
+        surface=ServerSurface.OTHER,
+        packages=[Package(name="requests", version="2.33.0", ecosystem="pypi")],
+    )
+    report = AIBOMReport(
+        agents=[
+            Agent(
+                name="project:repo",
+                agent_type=AgentType.CUSTOM,
+                config_path="/workspace",
+                source="project",
+                mcp_servers=[project_server],
+            )
+        ],
+        generated_at=datetime(2026, 3, 25, 12, 0, 0),
+    )
+
+    assert report.has_mcp_context is False
+
+
 def test_json_inventory_snapshot_preserves_server_surface():
     image_server = MCPServer(
         name="agentbom/agent-bom:latest",


### PR DESCRIPTION
## Summary
- make intrinsic compliance tags and blast-radius framework fields truthful by default
- stop synthetic project/filesystem surfaces from being scored as real MCP configuration context
- add explicit package name/version fields to blast-radius JSON and align ClickHouse ingestion

## Validation
- uv run pytest -q tests/test_core.py tests/test_enterprise_scenarios.py tests/test_synthetic_surfaces.py tests/test_clickhouse.py
- uv run agent-bom fs . --offline --format json -o /tmp/abom-fs-fixed.json
- uv run agent-bom agents -p . --offline --format json -o /tmp/abom-agents-fixed2.json
- uv run python -m compileall src/agent_bom
