### PR TITLE
Improve advisory labeling and resolver continuity

### DIFF
--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -21,6 +21,7 @@ SEVERITY_BADGES: dict[Severity, str] = {
     Severity.HIGH: "white on #e67e22",
     Severity.MEDIUM: "black on yellow",
     Severity.LOW: "white on #555555",
+    Severity.UNKNOWN: "black on white",
 }
 
 SEVERITY_TEXT: dict[Severity, str] = {
@@ -39,6 +40,7 @@ def _sev_badge(severity: Severity) -> str:
         Severity.HIGH: " HIGH ",
         Severity.MEDIUM: " MED  ",
         Severity.LOW: " LOW  ",
+        Severity.UNKNOWN: " ADV  ",
     }
     label = labels.get(severity, f" {severity.value.upper()} ")
     return f"[{style}]{label}[/{style}]"
@@ -1313,11 +1315,12 @@ def print_compact_summary(report: AIBOMReport) -> None:
         for sev_name, sev_enum in sev_map:
             if sev_counts.get(sev_name):
                 badge_parts.append(f"{_sev_badge(sev_enum)} {sev_counts[sev_name]}")
-        # Show UNKNOWN/NONE count — these need --enrich to classify
+        # UNKNOWN findings are still real advisories; they just lack finalized
+        # severity scoring data and should not read like parser breakage.
         unknown_count = sev_counts.get("UNKNOWN", 0) + sev_counts.get("NONE", 0)
         if unknown_count:
-            badge_parts.append(f"[dim]{unknown_count} unscored[/dim]")
-        posture = "  ".join(badge_parts) if badge_parts else "[dim]unscored[/dim]"
+            badge_parts.append(f"[dim]{unknown_count} advisory[/dim]")
+        posture = "  ".join(badge_parts) if badge_parts else "[dim]advisory findings pending severity[/dim]"
         border_style = "red" if sev_counts.get("CRITICAL", 0) > 0 else "yellow"
 
     # Credential count

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -6,7 +6,17 @@ import json
 from pathlib import Path
 
 from agent_bom.compliance_utils import effective_blast_radius_tags
-from agent_bom.models import AIBOMReport, BlastRadius
+from agent_bom.models import AIBOMReport, BlastRadius, Severity
+
+
+def _severity_state(severity: Severity) -> str:
+    """Stable severity-state label for structured consumers."""
+    return "pending" if severity == Severity.UNKNOWN else "scored"
+
+
+def _severity_label(severity: Severity) -> str:
+    """Human-friendly label that distinguishes advisory-only findings."""
+    return "advisory" if severity == Severity.UNKNOWN else severity.value
 
 
 def _risk_narrative(item: dict) -> str:
@@ -517,6 +527,8 @@ def to_json(report: AIBOMReport) -> dict:
                                         "id": v.id,
                                         "summary": v.summary,
                                         "severity": v.severity.value,
+                                        "severity_label": _severity_label(v.severity),
+                                        "severity_state": _severity_state(v.severity),
                                         "severity_source": v.severity_source,
                                         "confidence": v.confidence,
                                         "cvss_score": v.cvss_score,
@@ -573,6 +585,8 @@ def to_json(report: AIBOMReport) -> dict:
                 "actionable": br.is_actionable,
                 "vulnerability_id": br.vulnerability.id,
                 "severity": br.vulnerability.severity.value,
+                "severity_label": _severity_label(br.vulnerability.severity),
+                "severity_state": _severity_state(br.vulnerability.severity),
                 "cvss_score": br.vulnerability.cvss_score,
                 "epss_score": br.vulnerability.epss_score,
                 "is_kev": br.vulnerability.is_kev,

--- a/src/agent_bom/resolver.py
+++ b/src/agent_bom/resolver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import defaultdict
 from typing import Optional
 
 import httpx
@@ -19,6 +20,8 @@ NPM_REGISTRY = "https://registry.npmjs.org"
 PYPI_API = "https://pypi.org/pypi"
 _INVALID_VERSIONS = {"latest", "unknown", "", "{{VERSION}}"}
 _RESOLVE_CONCURRENCY = 8
+_NPM_LATEST_CACHE: dict[str, dict | None] = {}
+_PYPI_INFO_CACHE: dict[str, dict | None] = {}
 
 
 def _apply_registry_version_fallback(pkg: Package) -> bool:
@@ -36,28 +39,85 @@ def _apply_registry_version_fallback(pkg: Package) -> bool:
     return True
 
 
-async def resolve_npm_metadata(
-    package_name: str,
-    client: httpx.AsyncClient,
-) -> tuple[Optional[str], Optional[str]]:
-    """Return (version, license) from npm registry."""
+def _resolution_key(pkg: Package) -> tuple[str, str]:
+    """Stable key for deduping identical registry lookups within one run."""
+    return (pkg.ecosystem.lower(), pkg.name.lower())
+
+
+def _copy_resolution_fields(source: Package, target: Package) -> bool:
+    """Copy resolved version metadata from *source* to *target*."""
+    if source.version in _INVALID_VERSIONS:
+        return False
+    target.version = source.version
+    target.purl = source.purl
+    if source.license and not target.license:
+        target.license = source.license
+    if source.version_source == "registry_fallback":
+        target.version_source = "registry_fallback"
+    return True
+
+
+async def _get_npm_latest_doc(package_name: str, client: httpx.AsyncClient) -> dict | None:
+    """Return cached npm `/latest` JSON for a package."""
+    cache_key = package_name.lower()
+    if cache_key in _NPM_LATEST_CACHE:
+        return _NPM_LATEST_CACHE[cache_key]
+
     encoded_name = package_name.replace("/", "%2F")
     response = await request_with_retry(
         client,
         "GET",
         f"{NPM_REGISTRY}/{encoded_name}/latest",
     )
+    data: dict | None = None
     if response and response.status_code == 200:
         try:
-            data = response.json()
-            version = data.get("version")
-            lic = data.get("license")
-            # license can be a string or {"type": "MIT"} object
-            if isinstance(lic, dict):
-                lic = lic.get("type")
-            return version, lic if isinstance(lic, str) else None
-        except (ValueError, KeyError) as exc:
+            parsed = response.json()
+            if isinstance(parsed, dict):
+                data = parsed
+        except ValueError as exc:
             _logger.debug("Failed to parse npm metadata for %s: %s", package_name, exc)
+    _NPM_LATEST_CACHE[cache_key] = data
+    return data
+
+
+async def _get_pypi_info_doc(package_name: str, client: httpx.AsyncClient) -> dict | None:
+    """Return cached PyPI `info` JSON for a package."""
+    cache_key = package_name.lower()
+    if cache_key in _PYPI_INFO_CACHE:
+        return _PYPI_INFO_CACHE[cache_key]
+
+    response = await request_with_retry(
+        client,
+        "GET",
+        f"{PYPI_API}/{package_name}/json",
+    )
+    info: dict | None = None
+    if response and response.status_code == 200:
+        try:
+            parsed = response.json()
+            maybe_info = parsed.get("info", {}) if isinstance(parsed, dict) else {}
+            if isinstance(maybe_info, dict):
+                info = maybe_info
+        except ValueError as exc:
+            _logger.debug("Failed to parse PyPI metadata for %s: %s", package_name, exc)
+    _PYPI_INFO_CACHE[cache_key] = info
+    return info
+
+
+async def resolve_npm_metadata(
+    package_name: str,
+    client: httpx.AsyncClient,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return (version, license) from npm registry."""
+    data = await _get_npm_latest_doc(package_name, client)
+    if data:
+        version = data.get("version")
+        lic = data.get("license")
+        # license can be a string or {"type": "MIT"} object
+        if isinstance(lic, dict):
+            lic = lic.get("type")
+        return version, lic if isinstance(lic, str) else None
     return None, None
 
 
@@ -66,12 +126,10 @@ async def resolve_npm_supply_chain(
     client: httpx.AsyncClient,
 ) -> None:
     """Enrich a Package with npm registry supply chain metadata."""
-    encoded_name = pkg.name.replace("/", "%2F")
-    response = await request_with_retry(client, "GET", f"{NPM_REGISTRY}/{encoded_name}/latest")
-    if not response or response.status_code != 200:
+    data = await _get_npm_latest_doc(pkg.name, client)
+    if not data:
         return
     try:
-        data = response.json()
         if not pkg.description:
             pkg.description = (data.get("description") or "")[:300] or None
         if not pkg.homepage:
@@ -97,33 +155,25 @@ async def resolve_pypi_metadata(
     client: httpx.AsyncClient,
 ) -> tuple[Optional[str], Optional[str]]:
     """Return (version, license) from PyPI."""
-    response = await request_with_retry(
-        client,
-        "GET",
-        f"{PYPI_API}/{package_name}/json",
-    )
-    if response and response.status_code == 200:
-        try:
-            info = response.json().get("info", {})
-            version = info.get("version")
-            lic = info.get("license")
-            # PyPI license can be empty string, "UNKNOWN", or full license text.
-            # Prefer the SPDX classifier; fall back to first line of license field.
-            if lic and lic.upper() not in ("UNKNOWN", ""):
-                # If license field is multi-line (full text), extract SPDX from classifiers
-                if "\n" in lic or len(lic) > 120:
-                    classifiers = info.get("classifiers") or []
-                    for c in classifiers:
-                        if c.startswith("License :: OSI Approved :: "):
-                            lic = c.split(" :: ")[-1]
-                            break
-                    else:
-                        # No classifier — take first line, capped
-                        lic = lic.split("\n", 1)[0][:80]
-                return version, lic
-            return version, None
-        except (ValueError, KeyError) as exc:
-            _logger.debug("Failed to parse PyPI metadata for %s: %s", package_name, exc)
+    info = await _get_pypi_info_doc(package_name, client)
+    if info:
+        version = info.get("version")
+        lic = info.get("license")
+        # PyPI license can be empty string, "UNKNOWN", or full license text.
+        # Prefer the SPDX classifier; fall back to first line of license field.
+        if lic and lic.upper() not in ("UNKNOWN", ""):
+            # If license field is multi-line (full text), extract SPDX from classifiers
+            if "\n" in lic or len(lic) > 120:
+                classifiers = info.get("classifiers") or []
+                for c in classifiers:
+                    if c.startswith("License :: OSI Approved :: "):
+                        lic = c.split(" :: ")[-1]
+                        break
+                else:
+                    # No classifier — take first line, capped
+                    lic = lic.split("\n", 1)[0][:80]
+            return version, lic
+        return version, None
     return None, None
 
 
@@ -132,11 +182,10 @@ async def resolve_pypi_supply_chain(
     client: httpx.AsyncClient,
 ) -> None:
     """Enrich a Package with PyPI supply chain metadata."""
-    response = await request_with_retry(client, "GET", f"{PYPI_API}/{pkg.name}/json")
-    if not response or response.status_code != 200:
+    info = await _get_pypi_info_doc(pkg.name, client)
+    if not info:
         return
     try:
-        info = response.json().get("info", {})
         if not pkg.description:
             pkg.description = (info.get("summary") or "")[:300] or None
         if not pkg.homepage:
@@ -283,6 +332,10 @@ async def resolve_all_versions(
     if not unresolved:
         return 0
     resolved_count = 0
+    groups: dict[tuple[str, str], list[Package]] = defaultdict(list)
+    for pkg in unresolved:
+        groups[_resolution_key(pkg)].append(pkg)
+    representatives = [members[0] for members in groups.values()]
     try:
         async with create_client(timeout=10.0) as client:
             semaphore = asyncio.Semaphore(_RESOLVE_CONCURRENCY)
@@ -291,45 +344,66 @@ async def resolve_all_versions(
                 async with semaphore:
                     return await resolve_package_version(pkg, client)
 
-            tasks = {asyncio.create_task(_resolve_with_limit(pkg)): i for i, pkg in enumerate(unresolved)}
+            tasks = {asyncio.create_task(_resolve_with_limit(pkg)): pkg for pkg in representatives}
             done, pending = await asyncio.wait(tasks.keys(), timeout=global_timeout)
 
             for task in done:
-                i = tasks[task]
+                pkg = tasks[task]
+                peers = groups[_resolution_key(pkg)]
                 result: bool | Exception
                 try:
                     result = task.result()
                 except Exception as exc:  # noqa: BLE001
                     result = exc
                 if result is True:
-                    resolved_count += 1
+                    peer_resolved = 0
+                    for peer in peers:
+                        if peer is pkg:
+                            peer_resolved += 1
+                            continue
+                        if _copy_resolution_fields(pkg, peer):
+                            peer_resolved += 1
+                    resolved_count += peer_resolved
                     if not quiet:
                         lic_tag = ""
-                        if unresolved[i].license:
-                            short_lic = (unresolved[i].license or "").split("\n", 1)[0][:60]
+                        if pkg.license:
+                            short_lic = (pkg.license or "").split("\n", 1)[0][:60]
                             lic_tag = f" ({short_lic})"
                         icon = "[green]✓[/green]"
                         note = ""
-                        if unresolved[i].version_source == "registry_fallback":
+                        if pkg.version_source == "registry_fallback":
                             icon = "[yellow]↺[/yellow]"
                             note = " [dim](bundled registry fallback)[/dim]"
-                        console.print(f"  {icon} Resolved {unresolved[i].name} → {unresolved[i].version}{lic_tag}{note}")
+                        peer_note = f" [dim](applied to {len(peers)} package entries)[/dim]" if len(peers) > 1 else ""
+                        console.print(f"  {icon} Resolved {pkg.name} → {pkg.version}{lic_tag}{note}{peer_note}")
                 elif isinstance(result, Exception):
                     if not quiet:
-                        console.print(f"  [yellow]⚠[/yellow] Failed to resolve {unresolved[i].name}: {result}")
+                        console.print(f"  [yellow]⚠[/yellow] Failed to resolve {pkg.name}: {result}")
                 elif not quiet:
-                    console.print(f"  [yellow]⚠[/yellow] Could not resolve {unresolved[i].name} from live registries")
+                    console.print(f"  [yellow]⚠[/yellow] Could not resolve {pkg.name} from live registries")
 
             for task in pending:
-                i = tasks[task]
-                pkg = unresolved[i]
+                pkg = tasks[task]
+                peers = groups[_resolution_key(pkg)]
                 task.cancel()
-                _apply_registry_version_fallback(pkg)
-                if pkg.version_source == "registry_fallback":
-                    resolved_count += 1
+                group_fallbacks = 0
+                if _apply_registry_version_fallback(pkg):
+                    group_fallbacks += 1
+                for peer in peers:
+                    if peer is pkg:
+                        continue
+                    if not _copy_resolution_fields(pkg, peer):
+                        if _apply_registry_version_fallback(peer):
+                            group_fallbacks += 1
+                    else:
+                        group_fallbacks += 1
+                if group_fallbacks:
+                    resolved_count += group_fallbacks
                     if not quiet:
                         console.print(
-                            f"  [yellow]↺[/yellow] Resolved {pkg.name} → {pkg.version} [dim](bundled registry fallback after timeout)[/dim]"
+                            f"  [yellow]↺[/yellow] Resolved {pkg.name} → {pkg.version} "
+                            f"[dim](bundled registry fallback after timeout"
+                            f"{'; applied to ' + str(len(peers)) + ' package entries' if len(peers) > 1 else ''})[/dim]"
                         )
             if pending:
                 await asyncio.gather(*pending, return_exceptions=True)

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -126,6 +126,19 @@ def test_compact_summary_credentials():
     assert "GITHUB_TOKEN" in output
 
 
+def test_compact_summary_unknown_severity_is_labeled_advisory():
+    """UNKNOWN severity should read as advisory, not vague unscored noise."""
+    vuln = Vulnerability(id="GHSA-test", summary="Advisory without CVSS", severity=Severity.UNKNOWN)
+    pkg = Package(name="mystery", version="1.0.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = _make_server(packages=[pkg])
+    agent = _make_agent(servers=[server])
+    br = _blast(vuln, pkg, [agent], [server])
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    output = _capture(print_compact_summary, report)
+    assert "advisory" in output.lower()
+    assert "unscored" not in output.lower()
+
+
 # ── print_compact_agents ─────────────────────────────────────────────────────
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3840,6 +3840,31 @@ def test_json_output_includes_license():
     assert pkgs[0]["license"] == "MIT"
 
 
+def test_json_output_labels_unknown_severity_as_advisory_state():
+    """Structured JSON should distinguish advisory-only findings from scored severities."""
+    vuln = Vulnerability(id="GHSA-123", summary="Pending severity", severity=Severity.UNKNOWN)
+    pkg = Package(name="mystery", version="1.0.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = MCPServer(name="s", command="npx", args=["-y", "mystery"], packages=[pkg])
+    agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_agents=[agent],
+        affected_servers=[server],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    data = to_json(report)
+    vuln_json = data["agents"][0]["mcp_servers"][0]["packages"][0]["vulnerabilities"][0]
+    blast_json = data["blast_radius"][0]
+    assert vuln_json["severity"] == "unknown"
+    assert vuln_json["severity_label"] == "advisory"
+    assert vuln_json["severity_state"] == "pending"
+    assert blast_json["severity_label"] == "advisory"
+    assert blast_json["severity_state"] == "pending"
+
+
 def test_api_posture_counts_empty():
     """GET /v1/posture/counts returns zero counts with no scans."""
     pytest.importorskip("fastapi", reason="fastapi not installed")

--- a/tests/test_resolver_cov.py
+++ b/tests/test_resolver_cov.py
@@ -9,6 +9,8 @@ import pytest
 
 from agent_bom.models import Package
 from agent_bom.resolver import (
+    _NPM_LATEST_CACHE,
+    _PYPI_INFO_CACHE,
     enrich_licenses,
     enrich_supply_chain_metadata,
     resolve_all_versions,
@@ -18,6 +20,15 @@ from agent_bom.resolver import (
     resolve_pypi_metadata,
     resolve_pypi_supply_chain,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_registry_metadata_caches():
+    _NPM_LATEST_CACHE.clear()
+    _PYPI_INFO_CACHE.clear()
+    yield
+    _NPM_LATEST_CACHE.clear()
+    _PYPI_INFO_CACHE.clear()
 
 
 class TestResolveNpmMetadata:
@@ -51,6 +62,25 @@ class TestResolveNpmMetadata:
             version, lic = await resolve_npm_metadata("nonexistent", client)
             assert version is None
             assert lic is None
+
+    @pytest.mark.asyncio
+    async def test_caches_latest_doc_across_version_and_supply_chain(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "version": "1.2.3",
+            "license": "MIT",
+            "description": "Cached package",
+        }
+        pkg = Package(name="cached", version="1.2.3", ecosystem="npm")
+        with patch("agent_bom.resolver.request_with_retry", return_value=mock_response) as mock_request:
+            client = AsyncMock()
+            version, lic = await resolve_npm_metadata("cached", client)
+            await resolve_npm_supply_chain(pkg, client)
+        assert version == "1.2.3"
+        assert lic == "MIT"
+        assert pkg.description == "Cached package"
+        assert mock_request.call_count == 1
 
 
 class TestResolvePypiMetadata:
@@ -221,6 +251,34 @@ class TestResolvePackageVersion:
 
 
 class TestResolveAllVersions:
+    @pytest.mark.asyncio
+    async def test_duplicate_package_resolution_is_deduped_and_propagated(self):
+        packages = [
+            Package(name="dup", version="unknown", ecosystem="npm"),
+            Package(name="dup", version="unknown", ecosystem="npm"),
+        ]
+
+        async def fake_resolve(pkg, client):
+            pkg.version = "9.9.9"
+            pkg.purl = "pkg:npm/dup@9.9.9"
+            return True
+
+        client_cm = AsyncMock()
+        client_cm.__aenter__.return_value = AsyncMock()
+        client_cm.__aexit__.return_value = None
+
+        with (
+            patch("agent_bom.resolver.create_client", return_value=client_cm),
+            patch("agent_bom.resolver.resolve_package_version", side_effect=fake_resolve) as mock_resolve,
+            patch("agent_bom.resolver.enrich_licenses", return_value=0),
+        ):
+            resolved = await resolve_all_versions(packages, quiet=True, global_timeout=0.5)
+
+        assert resolved == 2
+        assert packages[0].version == "9.9.9"
+        assert packages[1].version == "9.9.9"
+        assert mock_resolve.call_count == 1
+
     @pytest.mark.asyncio
     async def test_timeout_preserves_completed_and_fallback_versions(self):
         packages = [


### PR DESCRIPTION
## Summary
- label unknown-severity findings as advisory/pending severity in compact and JSON output
- cache and dedupe npm/PyPI metadata lookups so duplicate package entries resolve once per run
- propagate fallback/live resolution results across duplicate unresolved package entries

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_resolver_cov.py tests/test_compact_output.py tests/test_core.py
- python3 -m compileall src/agent_bom
