### PR TITLE
Align CLI first-run and quickstart surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ pip install agent-bom
 
 agent-bom agents                              # Discover + scan local AI agents and MCP servers
 agent-bom agents -p .                         # Scan project manifests plus agent/MCP context
+agent-bom skills scan .                       # Scan CLAUDE.md, AGENTS.md, .cursorrules, skills/*
 agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
 agent-bom image nginx:latest                  # Container image scan
-agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC misconfigurations
+agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC scan across one or more paths
 ```
 
 <details>
@@ -55,6 +56,7 @@ agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC misconfigurations
 ```bash
 agent-bom cloud aws                     # Cloud AI posture + CIS benchmarks
 agent-bom agents -f cyclonedx -o bom.json  # AI BOM / SBOM export
+agent-bom graph report.json                # Blast radius graph / graph HTML inputs
 agent-bom proxy "npx @mcp/server-fs /ws"   # MCP security proxy
 agent-bom secrets src/                  # Hardcoded secrets + PII
 agent-bom verify requests@2.33.0        # Package integrity verification
@@ -175,10 +177,10 @@ docker run --rm agentbom/agent-bom agents    # Docker
 
 | Mode | Command | Best for |
 |------|---------|----------|
-| CLI | `agent-bom agents` | Local audit |
+| CLI | `agent-bom agents` | Local audit + project scan |
 | GitHub Action | `uses: msaad00/agent-bom@v0.75.11` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom` | Isolated scans |
-| MCP Server | `agent-bom mcp server` | Inside AI assistants |
+| MCP Server | `agent-bom mcp server` | Claude, Cursor, Codex, Windsurf, Cortex |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
 | Shield SDK | `from agent_bom.shield import Shield` | In-process protection |
 | Dashboard | `agent-bom serve` | API + Next.js UI (20 pages) |

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 33 security tools as an MCP server. Any MCP-compatible client
+agent-bom exposes 36 security tools as an MCP server. Any MCP-compatible client
 can connect and get vulnerability scanning, blast radius analysis, compliance
 checks, and supply chain verification through natural conversation.
 
@@ -44,7 +44,8 @@ Add to your MCP settings (`.cursor/mcp.json` or equivalent):
 agent-bom mcp server --sse --host 0.0.0.0 --port 8000
 ```
 
-Connect any SSE-capable MCP client to `http://your-server:8000/sse`.
+Connect any SSE-capable MCP client to `https://your-server/sse`.
+For remote deployments, put SSE behind TLS and authentication at your proxy or ingress.
 
 ### Docker
 
@@ -54,7 +55,7 @@ docker run -it --rm \
   agentbom/agent-bom:latest mcp server
 ```
 
-## Tool Categories (33 tools)
+## Tool Categories (36 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
@@ -66,8 +67,9 @@ docker run -it --rm \
 | **Policy** | `evaluate_policy` | Apply custom or built-in security policies |
 | **Inventory** | `inventory` | List agents/servers without CVE scanning |
 | **Trust** | `trust_assessment` | Multi-category trust scoring for packages |
+| **Skills** | `skill_scan`, `skill_verify`, `skill_trust` | Instruction-file trust, provenance, and tool-poisoning detection |
 | **IaC** | `scan_terraform`, `scan_dockerfile`, `scan_helm` | Infrastructure-as-code security scanning |
-| **Runtime** | `shield_status` | Runtime protection engine status |
+| **Runtime** | `shield_status`, `tool_risk_assessment` | Runtime protection engine status and live MCP capability risk |
 
 ## Example Conversations
 

--- a/site-docs/getting-started/quickstart.md
+++ b/site-docs/getting-started/quickstart.md
@@ -1,57 +1,94 @@
 # Quick Start
 
-## Scan your environment
+## Install
 
 ```bash
-agent-bom scan
+pip install agent-bom
 ```
 
-This auto-discovers MCP clients on your machine (Claude Desktop, Cursor, VS Code, Windsurf, etc.), extracts configured servers and packages, and scans for CVEs.
-
-## Check a specific package
+## Scan your local AI environment
 
 ```bash
-agent-bom check langchain
+agent-bom agents
+```
+
+This auto-discovers local MCP clients and AI agent configs, extracts configured
+servers and packages, and scans for CVEs.
+
+## Scan a project plus local agent context
+
+```bash
+agent-bom agents -p .
+```
+
+Use this when you want one scan to cover both:
+- project manifests and lockfiles in the current repo
+- local MCP / agent context on your machine
+
+## Scan instruction and skill files
+
+```bash
+agent-bom skills scan .
+agent-bom skills verify .
+```
+
+This covers `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, and supported `skills/*`
+instruction surfaces.
+
+## Check a specific package before installing
+
+```bash
+agent-bom check langchain --ecosystem pypi
 agent-bom check express --ecosystem npm
 agent-bom check tensorflow --ecosystem pypi
 ```
 
-## See what was discovered
+## Export machine-readable output
 
 ```bash
-agent-bom where    # show all discovery paths
-agent-bom scan -f json -o report.json   # full JSON report
+agent-bom agents -f json -o report.json
+agent-bom agents -f sarif -o findings.sarif
+agent-bom agents -f cyclonedx -o bom.json
 ```
 
-## Generate an SBOM
+## Run compliance mapping
 
 ```bash
-agent-bom scan --sbom cyclonedx -o sbom.json
-agent-bom scan --sbom spdx -o sbom.spdx.json
-```
-
-## Run compliance checks
-
-```bash
-agent-bom scan --compliance owasp-llm
-agent-bom scan --compliance eu-ai-act
-agent-bom scan --compliance all
+agent-bom agents --compliance owasp-llm
+agent-bom agents --compliance eu-ai-act
+agent-bom agents --compliance all
 ```
 
 ## Scan a container image
 
 ```bash
-agent-bom scan --image python:3.12-slim
+agent-bom image python:3.12-slim
 ```
 
-Uses agent-bom's native container scanning path for image analysis.
+## Scan infrastructure as code
+
+```bash
+agent-bom iac Dockerfile k8s/ infra/main.tf
+```
+
+`iac` accepts one or more paths in a single run, so the example above scans:
+- a Dockerfile
+- a Kubernetes directory
+- a Terraform file
+
+## Inspect discovery paths
+
+```bash
+agent-bom mcp where
+agent-bom mcp inventory
+```
 
 ## Output formats
 
 ```bash
-agent-bom scan -f table    # terminal table (default)
-agent-bom scan -f json     # JSON report
-agent-bom scan -f html     # HTML dashboard
-agent-bom scan -f sarif    # SARIF for GitHub Code Scanning
-agent-bom scan -f csv      # CSV export
+agent-bom agents -f table    # terminal table (default)
+agent-bom agents -f json     # JSON report
+agent-bom agents -f html     # HTML dashboard
+agent-bom agents -f sarif    # SARIF for GitHub Code Scanning
+agent-bom agents -f csv      # CSV export
 ```

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -24,6 +24,7 @@ Traditional scanners often stop at CVE -> package. agent-bom shows which MCP ser
 ```bash
 pip install agent-bom
 agent-bom agents                         # auto-discover local AI agents + MCP servers
+agent-bom skills scan .                 # scan skills / instruction files
 agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 ```
 
@@ -49,7 +50,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|
 | CLI | `pip install agent-bom` |
 | MCP server | `agent-bom mcp server` |
-| Docker | `docker run ghcr.io/msaad00/agent-bom scan` |
+| Docker | `docker run ghcr.io/msaad00/agent-bom agents` |
 | GitHub Action | `uses: msaad00/agent-bom@v0.75.11` |
 | Kubernetes | Helm chart + CronJob + DaemonSet |
 | Remote SSE | Self-host or use hosted endpoint |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -51,13 +51,16 @@ def main():
 
     \b
     Quick start:
-      agent-bom agents                      AI agent discovery + scan
-      agent-bom skills scan                skill / instruction trust scan
-      agent-bom image nginx:latest          container image scan
-      agent-bom iac Dockerfile k8s/         IaC misconfigurations
-      agent-bom cloud aws                   cloud posture + CIS
-      agent-bom proxy "npx server"          MCP security proxy
-      agent-bom check flask@2.0.0           pre-install CVE gate
+      agent-bom agents                               discover + scan local agents and MCP servers
+      agent-bom agents -p .                          scan project manifests plus agent/MCP context
+      agent-bom skills scan .                        scan skills and instruction files
+      agent-bom check flask@2.0.0 --ecosystem pypi  pre-install CVE gate
+      agent-bom image nginx:latest                   container image scan
+      agent-bom iac Dockerfile k8s/ infra/main.tf    IaC scan across one or more paths
+      agent-bom proxy "npx @mcp/server-fs /workspace"  MCP security proxy
+
+    \b
+    Tip: `agent-bom -h` groups commands by scanning, runtime, MCP, reporting, and governance.
 
     \b
     Docs:  https://github.com/msaad00/agent-bom


### PR DESCRIPTION
## Summary
- align top-level CLI quick start with canonical commands and grouped help
- update README and site quickstart to use `agents`, `skills`, `image`, and `iac` consistently
- refresh MCP server docs for current tool count and remote SSE guidance

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_release_consistency.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom -h
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom skills scan --help
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom mcp where --help