### PR TITLE
fix: close final 0.75.12 carry-forwards

### DIFF
--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -64,7 +64,10 @@ def _jobs_put(job_id: str, job: ScanJob) -> None:
         _jobs[job_id] = job
         if len(_jobs) > _MAX_IN_MEMORY_JOBS:
             completed = [(jid, j) for jid, j in _jobs.items() if j.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)]
-            completed.sort(key=lambda x: x[1].completed_at or "")
+            # Evict the oldest completed jobs first. Jobs missing a completion
+            # timestamp are treated as newest/unknown so they are not discarded
+            # ahead of jobs with a concrete older completed_at value.
+            completed.sort(key=lambda x: (x[1].completed_at is None, x[1].completed_at or ""))
             for jid, _ in completed[: len(_jobs) - _MAX_IN_MEMORY_JOBS]:
                 _jobs.pop(jid, None)
 
@@ -153,7 +156,8 @@ _schedule_store: ScheduleStore | None = None
 
 def _get_schedule_store() -> ScheduleStore:
     """Get the active schedule store. Must be initialized during lifespan."""
-    assert _schedule_store is not None, "Schedule store not initialized"
+    if _schedule_store is None:
+        raise RuntimeError("Schedule store not initialized")
     return _schedule_store
 
 

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -950,17 +950,15 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
         g["package"] = br.package.name
         g["ecosystem"] = br.package.ecosystem
         g["current"] = br.package.version
-        # Only accept fixed_version that is a forward upgrade; pick the minimum valid fix
+        # Only accept fixed_version values that are real forward upgrades for
+        # the package ecosystem; this avoids downgrade/canary suggestions from
+        # multi-branch or pre-release advisories.
         fv = br.vulnerability.fixed_version
         if fv:
-            try:
-                from packaging.version import Version as _PkgV
+            from agent_bom.version_utils import compare_versions
 
-                if _PkgV(fv) > _PkgV(br.package.version):
-                    if g["fix"] is None or _PkgV(fv) < _PkgV(g["fix"]):
-                        g["fix"] = fv
-            except Exception:
-                if g["fix"] is None:
+            if compare_versions(br.package.version, fv, br.package.ecosystem):
+                if g["fix"] is None or compare_versions(fv, g["fix"], br.package.ecosystem):
                     g["fix"] = fv
         g["vulns"].append(br.vulnerability.id)
         for a in br.affected_agents:

--- a/src/agent_bom/posture.py
+++ b/src/agent_bom/posture.py
@@ -165,6 +165,12 @@ def compute_posture_scorecard(report: "AIBOMReport") -> PostureScorecard:
                     scorecard_scores.append(pkg.scorecard_score)
 
     scorecard_stats = summarize_scorecard_coverage(all_packages)
+    transient_scorecard_failures = {
+        pkg.scorecard_lookup_reason
+        for pkg in all_packages
+        if pkg.scorecard_lookup_state == "failed"
+        and pkg.scorecard_lookup_reason in {"scorecard_rate_limited", "scorecard_service_unavailable"}
+    }
     if scorecard_scores:
         avg_scorecard = sum(scorecard_scores) / len(scorecard_scores)
         sc_score = min(100.0, avg_scorecard * 10)  # 0-10 → 0-100
@@ -175,6 +181,13 @@ def compute_posture_scorecard(report: "AIBOMReport") -> PostureScorecard:
     elif scorecard_stats.eligible_packages == 0:
         sc_score = 50.0
         sc_detail = "No GitHub-backed packages eligible for OpenSSF Scorecard"
+    elif scorecard_stats.failed_packages > 0 and transient_scorecard_failures:
+        sc_score = 100.0
+        sc_detail = (
+            "OpenSSF Scorecard temporarily unavailable upstream; "
+            f"not penalizing posture ({scorecard_stats.enriched_packages}/{scorecard_stats.eligible_packages} eligible packages enriched, "
+            f"{scorecard_stats.failed_packages} transient lookup failures)"
+        )
     elif scorecard_stats.failed_packages > 0:
         sc_score = 50.0
         sc_detail = (
@@ -307,10 +320,7 @@ def compute_posture_scorecard(report: "AIBOMReport") -> PostureScorecard:
     else:
         drivers: list[str] = []
         if total_cred_servers > 0:
-            drivers.append(
-                f"real credential exposure across {total_cred_servers} "
-                f"server{'s' if total_cred_servers != 1 else ''}"
-            )
+            drivers.append(f"real credential exposure across {total_cred_servers} server{'s' if total_cred_servers != 1 else ''}")
         if report.has_mcp_context and total_servers > 0 and verified_servers < total_servers:
             drivers.append(
                 "unverified or underspecified MCP configuration on "
@@ -318,10 +328,7 @@ def compute_posture_scorecard(report: "AIBOMReport") -> PostureScorecard:
                 f"server{'s' if total_servers != 1 else ''}"
             )
         if drivers:
-            summary = (
-                f"Weak security posture ({grade}, {total_score}%) — this grade is driven by "
-                + " and ".join(drivers)
-            )
+            summary = f"Weak security posture ({grade}, {total_score}%) — this grade is driven by " + " and ".join(drivers)
         else:
             summary = f"Weak security posture ({grade}, {total_score}%) — immediate attention required"
 

--- a/src/agent_bom/scorecard.py
+++ b/src/agent_bom/scorecard.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -26,6 +27,8 @@ SCORECARD_API_URL = "https://api.securityscorecards.dev/projects"
 
 # Cache: repo_url -> scorecard data (or None for miss)
 _scorecard_cache: dict[str, Optional[dict]] = {}
+_scorecard_reason_cache: dict[str, Optional[str]] = {}
+_scorecard_cooldown_until: float = 0.0
 
 # Pattern to extract GitHub owner/repo from various URL formats
 _GITHUB_REPO_PATTERN = re.compile(r"(?:https?://)?github\.com/([^/]+/[^/#?]+?)(?:\.git)?(?:[/#?]|$)")
@@ -109,11 +112,20 @@ async def fetch_scorecard(repo: str) -> Optional[dict]:
         Scorecard data dict with 'score' and 'checks', or None.
     """
     # Validate repo format to prevent SSRF via path manipulation
+    global _scorecard_cooldown_until
+
     if not _SAFE_REPO_PATTERN.match(repo):
+        _scorecard_reason_cache[repo] = "invalid_repo"
         return None
 
     if repo in _scorecard_cache:
         return _scorecard_cache[repo]
+
+    if time.monotonic() < _scorecard_cooldown_until:
+        reason = "scorecard_service_unavailable"
+        _scorecard_cache[repo] = None
+        _scorecard_reason_cache[repo] = reason
+        return None
 
     async with create_client(timeout=15.0) as client:
         url = f"{SCORECARD_API_URL}/github.com/{repo}"
@@ -129,13 +141,37 @@ async def fetch_scorecard(repo: str) -> Optional[dict]:
                     "checks": {check["name"]: check.get("score", -1) for check in data.get("checks", [])},
                 }
                 _scorecard_cache[repo] = result
+                _scorecard_reason_cache[repo] = None
                 return result
             except (ValueError, KeyError) as exc:
                 safe_repo = repo.replace("\n", "").replace("\r", "")
                 safe_exc = str(exc).replace("\n", "\\n").replace("\r", "\\r")
                 logger.debug("Scorecard parse error for %s: %s", safe_repo, safe_exc)
+                reason = "scorecard_parse_error"
+                _scorecard_cache[repo] = None
+                _scorecard_reason_cache[repo] = reason
+                return None
+
+        if response is None:
+            reason = "scorecard_service_unavailable"
+        elif response.status_code == 404:
+            reason = "scorecard_not_found"
+        elif response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            try:
+                cooldown = min(float(retry_after), 300.0) if retry_after else 120.0
+            except ValueError:
+                cooldown = 120.0
+            _scorecard_cooldown_until = max(_scorecard_cooldown_until, time.monotonic() + cooldown)
+            reason = "scorecard_rate_limited"
+        elif response.status_code >= 500:
+            _scorecard_cooldown_until = max(_scorecard_cooldown_until, time.monotonic() + 60.0)
+            reason = "scorecard_service_unavailable"
+        else:
+            reason = "scorecard_lookup_failed"
 
         _scorecard_cache[repo] = None
+        _scorecard_reason_cache[repo] = reason
         return None
 
 
@@ -210,7 +246,7 @@ async def enrich_packages_with_scorecard_stats(packages: list[Package]) -> Score
             for pkg in group:
                 pkg.scorecard_repo = repo
                 pkg.scorecard_lookup_state = "failed"
-                pkg.scorecard_lookup_reason = "scorecard_lookup_failed"
+                pkg.scorecard_lookup_reason = _scorecard_reason_cache.get(repo) or "scorecard_lookup_failed"
 
     return stats
 

--- a/tests/test_enterprise_scenarios.py
+++ b/tests/test_enterprise_scenarios.py
@@ -750,6 +750,22 @@ class TestJSONOutputIntegration:
         sc = compute_posture_scorecard(report)
         assert "coverage pending" in sc.dimensions["supply_chain_quality"].details.lower()
 
+    def test_posture_supply_chain_does_not_penalize_transient_scorecard_outage(self):
+        """Temporary upstream Scorecard failures should not drag posture down as if package quality were bad."""
+        from agent_bom.posture import compute_posture_scorecard
+
+        pkg = _make_package()
+        pkg.homepage = "https://github.com/example/repo"
+        pkg.scorecard_lookup_state = "failed"
+        pkg.scorecard_lookup_reason = "scorecard_service_unavailable"
+        server = _make_server(packages=[pkg])
+        agent = _make_agent(servers=[server])
+        report = _make_report(agents=[agent])
+        sc = compute_posture_scorecard(report)
+        dim = sc.dimensions["supply_chain_quality"]
+        assert dim.score == 100.0
+        assert "temporarily unavailable upstream" in dim.details.lower()
+
     def test_to_json_incident_with_agents(self):
         """to_json incidents should list agents with vulns."""
         from agent_bom.output import to_json

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -76,6 +76,45 @@ def test_jobs_bounded_eviction():
                     del _jobs[k]
 
 
+def test_jobs_bounded_eviction_keeps_none_completed_at_until_real_oldest_removed():
+    """Jobs missing completed_at should not evict ahead of genuinely older completed jobs."""
+    from agent_bom.api import stores as _stores
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest, _jobs, _jobs_lock, _jobs_put
+
+    original_max = _stores._MAX_IN_MEMORY_JOBS
+    try:
+        _stores._MAX_IN_MEMORY_JOBS = 2
+        with _jobs_lock:
+            _jobs.clear()
+
+        old = ScanJob(job_id="evict-old", created_at="2025-01-01T00:00:00Z", request=ScanRequest())
+        old.status = JobStatus.DONE
+        old.completed_at = "2025-01-01T00:01:00Z"
+
+        missing = ScanJob(job_id="evict-missing", created_at="2025-01-01T00:00:00Z", request=ScanRequest())
+        missing.status = JobStatus.DONE
+        missing.completed_at = None
+
+        newest = ScanJob(job_id="evict-new", created_at="2025-01-01T00:00:00Z", request=ScanRequest())
+        newest.status = JobStatus.DONE
+        newest.completed_at = "2025-01-01T00:02:00Z"
+
+        _jobs_put("evict-old", old)
+        _jobs_put("evict-missing", missing)
+        _jobs_put("evict-new", newest)
+
+        with _jobs_lock:
+            assert "evict-old" not in _jobs
+            assert "evict-missing" in _jobs
+            assert "evict-new" in _jobs
+    finally:
+        _stores._MAX_IN_MEMORY_JOBS = original_max
+        with _jobs_lock:
+            for k in list(_jobs.keys()):
+                if k.startswith("evict-"):
+                    del _jobs[k]
+
+
 def test_jobs_concurrent_access():
     """Concurrent _jobs_put/_jobs_get don't raise."""
     from agent_bom.api.server import ScanJob, ScanRequest, _jobs_get, _jobs_pop, _jobs_put
@@ -109,6 +148,21 @@ def test_store_lock_exists():
     from agent_bom.api.stores import _store_lock
 
     assert isinstance(_store_lock, type(threading.Lock()))
+
+
+def test_get_schedule_store_raises_runtime_error_when_uninitialized():
+    from agent_bom.api import stores as _stores
+
+    old = _stores._schedule_store
+    try:
+        _stores._schedule_store = None
+        try:
+            _stores._get_schedule_store()
+            assert False, "expected RuntimeError"
+        except RuntimeError as exc:
+            assert "not initialized" in str(exc)
+    finally:
+        _stores._schedule_store = old
 
 
 # ── Pagination ──────────────────────────────────────────────────────────────

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -581,6 +581,32 @@ def test_build_remediation_plan_no_downgrade():
     assert plan[0]["fix"] == "3.2.14"
 
 
+def test_build_remediation_plan_skips_prerelease_downgrade_for_npm():
+    """npm canary/pre-release branches should not be emitted as a downgrade fix."""
+    pkg = Package(name="next", version="16.2.1", ecosystem="npm", vulnerabilities=[])
+    vuln_canary = Vulnerability(
+        id="CVE-2026-1111",
+        severity=Severity.HIGH,
+        summary="Next issue",
+        fixed_version="13.4.20-canary.13",
+    )
+    vuln_valid = Vulnerability(
+        id="CVE-2026-1111",
+        severity=Severity.HIGH,
+        summary="Next issue",
+        fixed_version="16.2.2",
+    )
+    br1 = BlastRadius(
+        vulnerability=vuln_canary, package=pkg, affected_agents=[], affected_servers=[], exposed_credentials=[], exposed_tools=[]
+    )
+    br2 = BlastRadius(
+        vulnerability=vuln_valid, package=pkg, affected_agents=[], affected_servers=[], exposed_credentials=[], exposed_tools=[]
+    )
+    plan = build_remediation_plan([br1, br2])
+    assert len(plan) == 1
+    assert plan[0]["fix"] == "16.2.2"
+
+
 # ── to_json (from cov2) ─────────────────────────────────────────────────────
 
 

--- a/tests/test_scorecard_cov.py
+++ b/tests/test_scorecard_cov.py
@@ -180,3 +180,28 @@ class TestEnrichPackagesWithScorecard:
             assert stats.eligible_packages == 1
             assert stats.failed_packages == 1
             assert pkg.scorecard_lookup_state == "failed"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_sets_reason_and_cooldown(self):
+        from agent_bom.models import Package
+
+        pkg1 = Package(name="express", version="4.18.2", ecosystem="npm", homepage="https://github.com/expressjs/express")
+        pkg2 = Package(name="next", version="16.2.1", ecosystem="npm", homepage="https://github.com/vercel/next.js")
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {"Retry-After": "7"}
+
+        with (
+            patch("agent_bom.scorecard.create_client"),
+            patch("agent_bom.scorecard.request_with_retry", return_value=mock_response) as mock_request,
+            patch("agent_bom.scorecard._scorecard_cache", {}),
+            patch("agent_bom.scorecard._scorecard_reason_cache", {}),
+            patch("agent_bom.scorecard._scorecard_cooldown_until", 0.0),
+            patch("agent_bom.scorecard.time.monotonic", return_value=100.0),
+        ):
+            stats = await enrich_packages_with_scorecard_stats([pkg1, pkg2])
+
+        assert stats.failed_packages == 2
+        assert mock_request.call_count == 1
+        assert pkg1.scorecard_lookup_reason == "scorecard_rate_limited"
+        assert pkg2.scorecard_lookup_reason == "scorecard_service_unavailable"


### PR DESCRIPTION
## Summary
- fix in-memory job eviction ordering and replace production assert in schedule store access
- classify and back off transient OpenSSF Scorecard failures so posture is not penalized for upstream outages
- prevent remediation from suggesting downgrade or canary fixes that are not real forward upgrades
- add regression coverage for the release carry-forwards

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_hardening.py tests/test_scorecard_cov.py tests/test_enterprise_scenarios.py tests/test_output_cov.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python -m compileall src/agent_bom
- pre-commit hooks via signed commit (ruff, mypy, bandit)
