### PR TITLE
docs: polish release audit cosmetics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **30 MCP clients** — added Pieces, mcp-cli, Trae, Aide, Void, Replit Agent, Aider, Sourcegraph Cody, Tabnine, Copilot CLI, Junie, JetBrains AI
-- **AI BOM tools** — 32 MCP tools for scanning, compliance, runtime, cloud
+- **AI BOM tools** — 32 MCP tools for scanning, compliance, runtime, cloud in the `0.72.0` release
 - **Version accuracy** — all surfaces updated with correct version and client counts
 - **Compliance noise reduction** — actionable findings only in default output
 

--- a/docs/images/scan-output-light.svg
+++ b/docs/images/scan-output-light.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
+  <defs>
+    <style>
+      .bg    { fill: #ffffff; }
+      .bar   { fill: #f3f4f6; }
+      .dot-r { fill: #ff5f57; }
+      .dot-y { fill: #ffbd2e; }
+      .dot-g { fill: #28c840; }
+      text   { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; }
+      .dim   { fill: #9ca3af; }
+      .norm  { fill: #111827; }
+      .grn   { fill: #15803d; }
+      .yel   { fill: #b45309; }
+      .red   { fill: #dc2626; }
+      .blu   { fill: #2563eb; }
+      .cyn   { fill: #0284c7; }
+      .pur   { fill: #7c3aed; }
+      .hdr   { fill: #6b7280; }
+      .stroke { stroke: #e5e7eb; }
+    </style>
+  </defs>
+
+  <rect width="900" height="600" rx="10" class="bg"/>
+  <rect width="900" height="36" rx="10" class="bar"/>
+  <rect y="26" width="900" height="10" class="bar"/>
+  <circle cx="18" cy="18" r="6" class="dot-r"/>
+  <circle cx="38" cy="18" r="6" class="dot-y"/>
+  <circle cx="58" cy="18" r="6" class="dot-g"/>
+  <text x="440" y="23" text-anchor="middle" class="hdr">agent-bom v0.71.2</text>
+
+  <text x="20" y="62" class="dim">$</text>
+  <text x="32" y="62" class="grn">agent-bom scan --gpu-scan --delta --aws --aws-include-eks</text>
+
+  <text x="20" y="88" class="blu">Discovering MCP configurations...</text>
+  <text x="20" y="108" class="grn">  ✓</text>
+  <text x="38" y="108" class="norm">Found claude-desktop with 3 MCP server(s)</text>
+  <text x="20" y="124" class="grn">  ✓</text>
+  <text x="38" y="124" class="norm">Found cursor with 5 MCP server(s)</text>
+  <text x="20" y="140" class="grn">  ✓</text>
+  <text x="38" y="140" class="norm">Found docker-mcp with 1 enabled server(s), 22 tool(s)</text>
+  <text x="20" y="156" class="grn">  ✓</text>
+  <text x="38" y="156" class="norm">Discovered 2 MCP servers on EKS (pod labels: mcp.io/server=true)</text>
+  <text x="20" y="172" class="hdr">  Found 4 configured agent(s) with 11 MCP server(s) total</text>
+
+  <text x="20" y="192" class="blu">Resolving packages (Go · Gradle · Bun · conda · pip)...</text>
+  <text x="20" y="208" class="grn">  ✓</text>
+  <text x="38" y="208" class="norm">Resolved @modelcontextprotocol/server-filesystem → 2026.1.14 (MIT)</text>
+  <text x="20" y="224" class="grn">  ✓</text>
+  <text x="38" y="224" class="norm">Resolved torch → 2.3.0 (BSD-3-Clause)</text>
+  <text x="20" y="240" class="grn">  ✓</text>
+  <text x="38" y="240" class="norm">Resolved agent-bom → 0.70.9 (Apache-2.0)</text>
+  <text x="20" y="256" class="hdr">  14 packages resolved  |  2 unresolved (latest — warnings logged)</text>
+
+  <line x1="20" y1="268" x2="880" y2="268" class="stroke" stroke-width="1"/>
+
+  <text x="20" y="288" class="blu">Scanning GPU/AI compute infrastructure (EKS + local)...</text>
+  <text x="20" y="308" class="grn">  ✓</text>
+  <text x="38" y="308" class="norm">3 GPU container(s), 2 K8s GPU node(s)  |  CUDA: 12.4.0, 12.3.0</text>
+  <text x="20" y="324" class="grn">  ✓</text>
+  <text x="38" y="324" class="norm">2 NIM containers (nvcr.io/nim/meta/llama-3.1-8b-instruct:latest)</text>
+  <text x="20" y="340" class="red">  ⚠</text>
+  <text x="36" y="340" class="red">1 unauthenticated DCGM exporter — GPU metrics exposed on :9400</text>
+
+  <line x1="20" y1="352" x2="880" y2="352" class="stroke" stroke-width="1"/>
+
+  <text x="20" y="372" class="blu">Scanning 14 packages (local DB + OSV + GHSA)  |  delta mode: new findings only...</text>
+  <text x="20" y="392" class="yel">  ⚠ HIGH</text>
+  <text x="82" y="392" class="norm">  torch 2.3.0 — CVE-2024-5480  CVSS 8.1  EPSS 0.42  [KEV]</text>
+  <text x="20" y="408" class="yel">  ⚠ HIGH</text>
+  <text x="82" y="408" class="norm">  nvidia-cuda-runtime-cu12 — CVE-2024-0085  CVSS 7.8</text>
+  <text x="20" y="424" class="hdr">  2 new finding(s) since last scan  |  compliance: OWASP LLM05, NIST AI RMF MAP-1.5</text>
+
+  <line x1="20" y1="436" x2="880" y2="436" class="stroke" stroke-width="1"/>
+
+  <rect x="20" y="448" width="860" height="132" rx="6" fill="#f9fafb" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="36" y="468" class="grn">AI-BOM Report  v0.71.2</text>
+  <text x="36" y="484" class="hdr">────────────────────────────────────────────────────────────────────</text>
+  <text x="36" y="500" class="norm">Agents: </text><text x="90" y="500" class="cyn">4</text>
+  <text x="120" y="500" class="norm">Servers: </text><text x="178" y="500" class="cyn">11</text>
+  <text x="208" y="500" class="norm">Packages: </text><text x="276" y="500" class="cyn">14</text>
+  <text x="306" y="500" class="norm">CVEs: </text><text x="346" y="500" class="yel">2</text>
+  <text x="376" y="500" class="norm">GPU containers: </text><text x="490" y="500" class="yel">3</text>
+  <text x="520" y="500" class="norm">DCGM exposed: </text><text x="626" y="500" class="red">1</text>
+  <text x="36" y="516" class="norm">Compliance: </text><text x="110" y="516" class="pur">OWASP LLM · OWASP MCP · OWASP Agentic · OWASP AISVS · MITRE ATLAS · NIST AI RMF</text>
+  <text x="36" y="532" class="norm">           </text><text x="110" y="532" class="pur">EU AI Act · NIST CSF · ISO 27001 · SOC 2 · CIS Controls  (11 frameworks)</text>
+  <text x="36" y="548" class="norm">Cloud: </text><text x="82" y="548" class="cyn">AWS (EC2 · EKS · Bedrock)  |  12 providers supported</text>
+  <text x="36" y="564" class="yel">Exit 2 — 2 new HIGH finding(s)  [--warn-on HIGH]</text>
+</svg>


### PR DESCRIPTION
## Summary
- clarify the historical 0.72.0 changelog tool-count line so it is not mistaken for current MCP surface drift
- add a light-theme companion for scan-output-dark.svg to complete the docs image set

## Validation
- signed commit hooks passed
- asset added and changelog wording updated
