### PR TITLE
feat(cli): add operator summary and mesh view

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -30,6 +30,7 @@ pip install agent-bom
 
 agent-bom agents                              # Discover + scan local AI agents and MCP servers
 agent-bom agents -p .                         # Scan project manifests plus agent/MCP context
+agent-bom mesh --project .                    # Show the live agent / MCP topology
 agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
 agent-bom image nginx:latest                  # Container image scan
 agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC misconfigurations

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ pip install agent-bom
 
 agent-bom agents                              # Discover + scan local AI agents and MCP servers
 agent-bom agents -p .                         # Scan project manifests plus agent/MCP context
+agent-bom mesh --project .                    # Show the live agent / MCP topology
 agent-bom skills scan .                       # Scan CLAUDE.md, AGENTS.md, .cursorrules, skills/*
 agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
 agent-bom image nginx:latest                  # Container image scan

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -53,6 +53,7 @@ def main():
     Quick start:
       agent-bom agents                               discover + scan local agents and MCP servers
       agent-bom agents -p .                          scan project manifests plus agent/MCP context
+      agent-bom mesh --project .                     show the live agent/MCP topology
       agent-bom skills scan .                        scan skills and instruction files
       agent-bom check flask@2.0.0 --ecosystem pypi  pre-install CVE gate
       agent-bom image nginx:latest                   container image scan
@@ -166,9 +167,11 @@ from agent_bom.cli._analysis import (  # noqa: E402
     dashboard_cmd,
     graph_cmd,
     introspect_cmd,
+    mesh_cmd,
 )
 
 main.add_command(graph_cmd, "graph")
+main.add_command(mesh_cmd, "mesh")
 # introspect is under `mcp introspect` — no top-level duplicate
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -1,14 +1,74 @@
-"""Analysis commands — analytics, graph, dashboard, introspect."""
+"""Analysis commands — analytics, graph, dashboard, introspect, mesh."""
 
 from __future__ import annotations
 
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Optional
 
 import click
 from rich.console import Console
+
+
+def _load_mesh_source(scan_file: Optional[str], project_dir: Optional[str]) -> tuple[list[dict], list[dict] | None]:
+    """Load agent topology from either a saved report or live discovery."""
+    if scan_file:
+        data = json.loads(Path(scan_file).read_text())
+        agents_data = data.get("agents", [])
+        blast_radius = data.get("blast_radius")
+        if not isinstance(agents_data, list):
+            raise ValueError("scan file did not contain a valid 'agents' list")
+        if blast_radius is not None and not isinstance(blast_radius, list):
+            blast_radius = None
+        return agents_data, blast_radius
+
+    from dataclasses import asdict
+
+    from agent_bom.discovery import discover_all
+    from agent_bom.parsers import extract_packages
+
+    agents = discover_all(project_dir=project_dir)
+    for agent in agents:
+        for server in agent.mcp_servers:
+            if not server.packages:
+                server.packages = extract_packages(server)
+
+    return [asdict(agent) for agent in agents], None
+
+
+def _render_mesh_summary(con: Console, agents_data: list[dict], mesh: dict) -> None:
+    """Print a compact human-readable topology summary."""
+    stats = mesh.get("stats", {})
+    shared_counts: Counter[str] = Counter()
+    for agent in agents_data:
+        for server in agent.get("mcp_servers", []):
+            shared_counts[server.get("name", "unknown")] += 1
+
+    con.print()
+    con.print(
+        f"[bold]Mesh[/bold]  "
+        f"[dim]{stats.get('total_agents', 0)} agents · {stats.get('total_servers', 0)} servers · "
+        f"{stats.get('total_tools', 0)} tools · {stats.get('total_vulnerabilities', 0)} vulns[/dim]"
+    )
+
+    for agent in agents_data:
+        servers = agent.get("mcp_servers", [])
+        con.print(f"  [bold]{agent.get('name', 'unknown')}[/bold] [dim]({len(servers)} server(s))[/dim]")
+        for server in servers:
+            packages = server.get("packages", [])
+            tools = server.get("tools", [])
+            env = server.get("env", {}) or {}
+            creds = [k for k in env if any(p in k.lower() for p in ("key", "token", "secret", "password", "credential", "auth"))]
+            vuln_count = sum(len(pkg.get("vulnerabilities", [])) for pkg in packages)
+            shared = " [dim](shared)[/dim]" if shared_counts[server.get("name", "unknown")] > 1 else ""
+            con.print(
+                "    "
+                f"• [cyan]{server.get('name', 'unknown')}[/cyan]{shared} "
+                f"[dim]{len(packages)} pkg · {len(tools)} tool · {len(creds)} cred · {vuln_count} vuln[/dim]"
+            )
+    con.print()
 
 
 @click.command("analytics")
@@ -152,6 +212,66 @@ def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str]) -> None:
         _con.print(f"[green]Graph exported[/green] ({graph.node_count()} nodes, {graph.edge_count()} edges) → {output_path}")
     else:
         click.echo(output)
+
+
+@click.command("mesh")
+@click.argument("scan_file", required=False, type=click.Path(exists=True))
+@click.option(
+    "--project",
+    "project_dir",
+    type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="Discover agents relative to a project directory.",
+)
+@click.option(
+    "--format",
+    "-f",
+    "fmt",
+    type=click.Choice(["summary", "json"]),
+    default="summary",
+    show_default=True,
+    help="Output format.",
+)
+@click.option("--output", "-o", "output_path", default=None, help="Write to file instead of stdout.")
+def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, output_path: Optional[str]) -> None:
+    """Show lightweight agent/MCP topology without the dashboard.
+
+    \b
+    Examples:
+      agent-bom mesh
+      agent-bom mesh --project .
+      agent-bom mesh report.json --format json --output mesh.json
+    """
+    from agent_bom.output.agent_mesh import build_agent_mesh
+
+    con = Console()
+
+    try:
+        agents_data, blast_radius = _load_mesh_source(scan_file, project_dir)
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        con.print(f"[red]Error loading mesh source:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    if not agents_data:
+        con.print("[yellow]No agents discovered.[/yellow]")
+        return
+
+    mesh = build_agent_mesh(agents_data, blast_radius)
+
+    if fmt == "json":
+        output = json.dumps(mesh, indent=2)
+        if output_path:
+            Path(output_path).write_text(output)
+            con.print(f"[green]Mesh exported[/green] → {output_path}")
+        else:
+            click.echo(output)
+        return
+
+    if output_path:
+        con.print("[red]--output is only supported with --format json for mesh.[/red]")
+        raise SystemExit(2)
+
+    _render_mesh_summary(con, agents_data, mesh)
 
 
 @click.command("dashboard")

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -24,7 +24,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "Reporting",
-            ["graph", "report"],
+            ["graph", "mesh", "report"],
         ),
         (
             "Governance",

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1317,13 +1317,63 @@ def _pct(part: int, total: int) -> str:
 # ─── Compact Output (default mode) ───────────────────────────────────────────
 
 
+def _posture_grade_badge(grade: str) -> str:
+    """Render a compact color badge for posture grade output."""
+    grade = (grade or "?").upper()
+    if grade == "A":
+        style = "white on green"
+    elif grade == "B":
+        style = "black on bright_green"
+    elif grade == "C":
+        style = "black on yellow"
+    elif grade == "D":
+        style = "white on dark_orange3"
+    else:
+        style = "white on red"
+    return f"[bold {style}] {grade} [/bold {style}]"
+
+
+def _compact_detail(text: str, limit: int = 88) -> str:
+    """Trim long explanatory detail so the default output stays one-screen friendly."""
+    clean = " ".join(text.split())
+    if len(clean) <= limit:
+        return clean
+    return clean[: limit - 1].rstrip() + "…"
+
+
 def print_compact_summary(report: AIBOMReport) -> None:
     """Compact summary — posture + key metrics in ~8 lines."""
     from collections import Counter
 
+    from agent_bom.posture import compute_posture_scorecard
+
     sev_counts: Counter[str] = Counter()
     for br in report.blast_radii:
         sev_counts[br.vulnerability.severity.value.upper()] += 1
+
+    scorecard = compute_posture_scorecard(report)
+    preferred_driver_order = [
+        "credential_hygiene",
+        "vulnerability_posture",
+        "active_exploitation",
+        "configuration_quality",
+        "supply_chain_quality",
+        "compliance_coverage",
+    ]
+    weak_dimensions = [
+        scorecard.dimensions[name]
+        for name in preferred_driver_order
+        if name in scorecard.dimensions and scorecard.dimensions[name].score < 90
+    ][:2]
+    if len(weak_dimensions) < 2:
+        seen_names = {dim.name for dim in weak_dimensions}
+        for dim in sorted(scorecard.dimensions.values(), key=lambda d: d.score):
+            if dim.score >= 80 or dim.name in seen_names:
+                continue
+            weak_dimensions.append(dim)
+            seen_names.add(dim.name)
+            if len(weak_dimensions) >= 2:
+                break
 
     if report.total_vulnerabilities == 0:
         posture = "[bold white on green] CLEAN [/bold white on green]"
@@ -1364,6 +1414,8 @@ def print_compact_summary(report: AIBOMReport) -> None:
     pkg_detail = f" ({n_direct}D/{n_transitive}T)" if n_transitive else ""
 
     lines = [
+        f"  [bold]POSTURE GRADE:[/bold]  {_posture_grade_badge(scorecard.grade)} "
+        f"[bold]{scorecard.score:.1f}/100[/bold]  [dim]{scorecard.summary}[/dim]",
         f"  [bold]SECURITY POSTURE:[/bold]  {posture}",
         "",
         f"  Agents  [bold]{report.total_agents}[/bold]    "
@@ -1371,6 +1423,9 @@ def print_compact_summary(report: AIBOMReport) -> None:
         f"Packages  [bold]{report.total_packages}[/bold][dim]{pkg_detail}[/dim]    "
         f"Vulns  [bold]{report.total_vulnerabilities}[/bold]",
     ]
+    if weak_dimensions:
+        driver_parts = [f"[yellow]{dim.name}[/yellow]: {_compact_detail(dim.details, limit=54)}" for dim in weak_dimensions]
+        lines.append(f"  [bold]Top Drivers:[/bold]  {' [dim]·[/dim] '.join(driver_parts)}")
     if cred_names:
         names = ", ".join(cred_names[:3])
         more = f" +{len(cred_names) - 3}" if len(cred_names) > 3 else ""
@@ -1601,7 +1656,7 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
 
     console.print()
     total = len(fixable)
-    title = f"Remediation (top {min(limit, total)} of {total})" if total > limit else f"Remediation ({total})"
+    title = f"Fix First (top {min(limit, total)} of {total})" if total > limit else f"Fix First ({total})"
     console.print(f"  [bold]{title}[/bold]")
 
     sev_style = {
@@ -1615,11 +1670,18 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
     for i, item in enumerate(fixable[:limit], 1):
         style = sev_style.get(item["max_severity"], "white")
         kev = " [red]KEV[/red]" if item["has_kev"] else ""
+        reach_parts = [f"{len(item['vulns'])} vuln(s)", f"{len(item['agents'])} agent(s)"]
+        if item["creds"]:
+            reach_parts.append(f"{len(item['creds'])} credential(s)")
+        if item["tools"]:
+            reach_parts.append(f"{len(item['tools'])} tool(s)")
+        reach = ", ".join(reach_parts)
         console.print(
             f"  [{style}]{i}.[/{style}] [bold]{item['package']}[/bold] "
             f"[dim]{item['current']}[/dim] → [green]{item['fix']}[/green]{kev}  "
-            f"[dim]clears {len(item['vulns'])} vuln(s), {len(item['agents'])} agent(s)[/dim]"
+            f"[dim]{item['priority']} · clears {reach}[/dim]"
         )
+        console.print(f"     [dim]{_compact_detail(item['action'], limit=110)}[/dim]")
 
     if total > limit:
         console.print(f"  [dim]... {total - limit} more (use --verbose for full plan)[/dim]")

--- a/tests/test_cli_analysis.py
+++ b/tests/test_cli_analysis.py
@@ -12,6 +12,7 @@ from agent_bom.cli._analysis import (
     dashboard_cmd,
     graph_cmd,
     introspect_cmd,
+    mesh_cmd,
 )
 
 # ---------------------------------------------------------------------------
@@ -149,6 +150,85 @@ def test_graph_cmd_load_error(tmp_path):
     with patch("agent_bom.output.graph_export.load_graph_from_scan", side_effect=ValueError("bad scan")):
         result = runner.invoke(graph_cmd, [str(scan_file)])
         assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# mesh_cmd
+# ---------------------------------------------------------------------------
+
+
+def test_mesh_cmd_from_scan_file_json(tmp_path):
+    runner = CliRunner()
+    scan_file = tmp_path / "scan.json"
+    scan_file.write_text(
+        json.dumps(
+            {
+                "agents": [
+                    {
+                        "name": "claude",
+                        "mcp_servers": [
+                            {
+                                "name": "filesystem",
+                                "packages": [{"name": "pkg", "version": "1.0.0", "vulnerabilities": []}],
+                                "tools": [{"name": "read_file"}],
+                                "env": {"OPENAI_API_KEY": "x"},
+                            }
+                        ],
+                    }
+                ],
+                "blast_radius": [],
+            }
+        )
+    )
+
+    result = runner.invoke(mesh_cmd, [str(scan_file), "--format", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["stats"]["total_agents"] == 1
+    assert data["stats"]["total_tools"] == 1
+
+
+def test_mesh_cmd_live_summary():
+    runner = CliRunner()
+    server = MagicMock()
+    server.name = "filesystem"
+    server.packages = []
+    server.tools = [{"name": "read_file"}, {"name": "write_file"}]
+    server.env = {"GITHUB_TOKEN": "x"}
+    agent = MagicMock()
+    agent.mcp_servers = [server]
+
+    with (
+        patch("agent_bom.discovery.discover_all", return_value=[agent]),
+        patch("agent_bom.parsers.extract_packages", return_value=[{"name": "pkg", "version": "1.0.0", "vulnerabilities": []}]),
+        patch(
+            "dataclasses.asdict",
+            return_value={
+                "name": "claude",
+                "mcp_servers": [
+                    {
+                        "name": "filesystem",
+                        "packages": [{"name": "pkg", "version": "1.0.0", "vulnerabilities": []}],
+                        "tools": [{"name": "read_file"}, {"name": "write_file"}],
+                        "env": {"GITHUB_TOKEN": "x"},
+                    }
+                ],
+            },
+        ),
+    ):
+        result = runner.invoke(mesh_cmd, [])
+        assert result.exit_code == 0
+        assert "Mesh" in result.output
+        assert "claude" in result.output
+        assert "filesystem" in result.output
+
+
+def test_mesh_cmd_summary_rejects_output_path(tmp_path):
+    runner = CliRunner()
+    scan_file = tmp_path / "scan.json"
+    scan_file.write_text(json.dumps({"agents": [{"name": "a", "mcp_servers": []}], "blast_radius": []}))
+    result = runner.invoke(mesh_cmd, [str(scan_file), "--output", str(tmp_path / "mesh.txt")])
+    assert result.exit_code == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -100,6 +100,7 @@ def test_compact_summary_clean():
     report = AIBOMReport(agents=[agent])
     output = _capture(print_compact_summary, report)
     assert "CLEAN" in output
+    assert "POSTURE GRADE" in output
     assert "Agents" in output
     assert "1" in output
 
@@ -113,6 +114,7 @@ def test_compact_summary_with_vulns():
     br = _blast(vuln, pkg, [agent], [server])
     report = AIBOMReport(agents=[agent], blast_radii=[br])
     output = _capture(print_compact_summary, report)
+    assert "POSTURE GRADE" in output
     assert "CRIT" in output  # Badge shows " CRIT " not "CRITICAL"
     assert "Vulns" in output
 
@@ -137,6 +139,19 @@ def test_compact_summary_unknown_severity_is_labeled_advisory():
     output = _capture(print_compact_summary, report)
     assert "advisory" in output.lower()
     assert "unscored" not in output.lower()
+
+
+def test_compact_summary_shows_top_drivers_for_weak_posture():
+    """Weak posture should surface the key drivers inline."""
+    vuln = _vuln(severity=Severity.HIGH, fixed="9.9.9")
+    pkg = Package(name="pkg", version="1.0.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = _make_server(packages=[pkg], env={"AWS_SECRET_ACCESS_KEY": "x"})
+    agent = _make_agent(servers=[server])
+    br = _blast(vuln, pkg, [agent], [server], creds=["AWS_SECRET_ACCESS_KEY"])
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    output = _capture(print_compact_summary, report)
+    assert "Top Drivers" in output
+    assert "Credential Hygiene" in output
 
 
 # ── print_compact_agents ─────────────────────────────────────────────────────
@@ -241,6 +256,20 @@ def test_compact_remediation_limit():
     output = _capture(print_compact_remediation, report, limit=2)
     assert "more" in output
     assert "--verbose" in output
+
+
+def test_compact_remediation_shows_priority_and_action():
+    """Default remediation output should explain why an item is first."""
+    server = _make_server(env={"GITHUB_TOKEN": "x"}, tools=[{"name": "read_file"}])
+    agent = _make_agent(servers=[server])
+    vuln = _vuln(vid="CVE-2024-0001", severity=Severity.CRITICAL, fixed="2.0.0", kev=True)
+    pkg = Package(name="openssl", version="1.0.0", ecosystem="pypi", vulnerabilities=[vuln])
+    br = _blast(vuln, pkg, [agent], [server], creds=["GITHUB_TOKEN"])
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    output = _capture(print_compact_remediation, report)
+    assert "Fix First" in output
+    assert "P1" in output
+    assert "rotate exposed credentials" in output
 
 
 def test_compact_remediation_empty():


### PR DESCRIPTION
## Summary
- add a stronger default operator summary with posture grade, top drivers, and fix-first guidance in compact agents output
- add agent-bom mesh for lightweight live or report-based agent/MCP topology without the dashboard
- surface the new mesh workflow in grouped help and quickstart docs

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_entry_points.py tests/test_compact_output.py tests/test_cli_analysis.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/cli/_analysis.py src/agent_bom/output/__init__.py src/agent_bom/cli/__init__.py src/agent_bom/cli/_grouped_help.py tests/test_cli_analysis.py tests/test_compact_output.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_release_consistency.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom -h
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom mesh --help
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run agent-bom agents --demo --offline
