### PR TITLE
feat(skills): add deterministic bundle identity

### DIFF
--- a/src/agent_bom/skill_bundles.py
+++ b/src/agent_bom/skill_bundles.py
@@ -1,0 +1,121 @@
+"""Deterministic bundle identity for skill and instruction files."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from agent_bom.finding import stable_id
+
+_MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+_LOCAL_PATH_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:\./|\.\./)?(?:[\w.-]+/)*[\w.-]+\.(?:py|sh|js|ts|tsx|jsx|json|ya?ml|toml|ini|cfg|txt|md|sql|csv|svg|png|jpg|jpeg)"
+)
+_URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+
+
+@dataclass(frozen=True)
+class SkillBundleFile:
+    """One file included in a deterministic skill bundle."""
+
+    path: str
+    sha256: str
+    size: int
+    role: str = "referenced"
+
+
+@dataclass(frozen=True)
+class SkillBundle:
+    """Stable bundle identity for a skill file and its local references."""
+
+    stable_id: str
+    sha256: str
+    root: str
+    file_count: int
+    referenced_file_count: int
+    files: list[SkillBundleFile] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize bundle metadata to JSON-compatible data."""
+        return {
+            "stable_id": self.stable_id,
+            "sha256": self.sha256,
+            "root": self.root,
+            "file_count": self.file_count,
+            "referenced_file_count": self.referenced_file_count,
+            "files": [
+                {
+                    "path": entry.path,
+                    "sha256": entry.sha256,
+                    "size": entry.size,
+                    "role": entry.role,
+                }
+                for entry in self.files
+            ],
+        }
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _candidate_local_refs(content: str) -> set[str]:
+    refs: set[str] = set()
+    for match in _MARKDOWN_LINK_RE.finditer(content):
+        candidate = match.group(1).strip()
+        if candidate and not _URL_SCHEME_RE.match(candidate) and not candidate.startswith(("#", "mailto:", "data:")):
+            refs.add(candidate)
+    for match in _LOCAL_PATH_TOKEN_RE.finditer(content):
+        candidate = match.group(0).strip()
+        if candidate and not candidate.startswith(("/", "~")):
+            refs.add(candidate)
+    return refs
+
+
+def _resolve_local_refs(primary_path: Path, content: str) -> list[Path]:
+    base = primary_path.parent
+    refs: list[Path] = []
+    seen: set[Path] = set()
+    for ref in sorted(_candidate_local_refs(content)):
+        candidate = (base / ref).resolve()
+        if candidate.is_file() and candidate != primary_path.resolve() and candidate not in seen:
+            seen.add(candidate)
+            refs.append(candidate)
+    return refs
+
+
+def build_skill_bundle(path: Path, content: str | None = None) -> SkillBundle:
+    """Build a deterministic bundle identity for one skill file."""
+    primary = path.resolve()
+    if content is None:
+        content = primary.read_text(encoding="utf-8", errors="replace")
+    included = [primary, *_resolve_local_refs(primary, content)]
+    root = primary.parent
+
+    files: list[SkillBundleFile] = []
+    manifest_rows: list[dict[str, object]] = []
+    for included_path in sorted(included, key=lambda p: p.relative_to(root).as_posix()):
+        role = "primary" if included_path == primary else "referenced"
+        rel_path = included_path.relative_to(root).as_posix()
+        file_hash = _sha256_file(included_path)
+        size = included_path.stat().st_size
+        files.append(SkillBundleFile(path=rel_path, sha256=file_hash, size=size, role=role))
+        manifest_rows.append({"path": rel_path, "sha256": file_hash, "size": size, "role": role})
+
+    manifest = json.dumps(manifest_rows, sort_keys=True, separators=(",", ":"))
+    bundle_hash = hashlib.sha256(manifest.encode("utf-8")).hexdigest()
+    return SkillBundle(
+        stable_id=stable_id("skill-bundle", bundle_hash),
+        sha256=bundle_hash,
+        root=str(root),
+        file_count=len(files),
+        referenced_file_count=max(0, len(files) - 1),
+        files=files,
+    )

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -10,6 +10,7 @@ from agent_bom.integrity import verify_instruction_file
 from agent_bom.parsers.skill_audit import SkillAuditResult, audit_skill_result
 from agent_bom.parsers.skills import SkillScanResult, discover_skill_files, parse_skill_file
 from agent_bom.parsers.trust_assessment import TrustAssessmentResult, assess_trust
+from agent_bom.skill_bundles import SkillBundle, build_skill_bundle
 
 
 @dataclass
@@ -21,11 +22,13 @@ class SkillFileReport:
     audit: SkillAuditResult
     trust: TrustAssessmentResult
     provenance: dict[str, object]
+    bundle: SkillBundle
 
     def to_dict(self) -> dict:
         """Serialize the file report to JSON-compatible data."""
         return {
             "path": str(self.path),
+            "bundle": self.bundle.to_dict(),
             "packages": [
                 {
                     "name": pkg.name,
@@ -77,9 +80,12 @@ class SkillsScanReport:
 
     def to_dict(self) -> dict:
         """Serialize the aggregated scan report."""
-        package_keys = {(pkg["name"].lower(), pkg["ecosystem"]) for report in self.files for pkg in report.to_dict()["packages"]}
-        server_names = {server["name"] for report in self.files for server in report.to_dict()["servers"]}
+        serialized_files = [report.to_dict() for report in self.files]
+        package_keys = {(pkg["name"].lower(), pkg["ecosystem"]) for report in serialized_files for pkg in report["packages"]}
+        server_names = {server["name"] for report in serialized_files for server in report["servers"]}
         credential_names = {cred for report in self.files for cred in report.scan.credential_env_vars}
+        bundle_ids = {report.bundle.stable_id for report in self.files}
+        bundled_paths = {entry["path"] for report in serialized_files for entry in report["bundle"]["files"]}
 
         suspicious = sum(1 for report in self.files if report.trust.verdict.value == "suspicious")
         malicious = sum(1 for report in self.files if report.trust.verdict.value == "malicious")
@@ -88,6 +94,8 @@ class SkillsScanReport:
         return {
             "summary": {
                 "files_scanned": len(self.files),
+                "bundles": len(bundle_ids),
+                "bundled_files": len(bundled_paths),
                 "packages_found": len(package_keys),
                 "servers_found": len(server_names),
                 "credential_env_vars": len(credential_names),
@@ -96,14 +104,30 @@ class SkillsScanReport:
                 "suspicious_files": suspicious,
                 "malicious_files": malicious,
             },
-            "files": [report.to_dict() for report in self.files],
+            "files": serialized_files,
         }
+
+
+def _discover_explicit_skill_files(directory: Path) -> list[Path]:
+    """Discover skill-like files inside a directory explicitly requested by the user."""
+    found: list[Path] = []
+    seen: set[Path] = set()
+    for path in sorted(directory.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name in {".cursorrules", ".windsurfrules"} or path.suffix.lower() == ".md":
+            resolved = path.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                found.append(resolved)
+    return found
 
 
 def resolve_skill_targets(paths: Iterable[str | Path] | None = None, *, cwd: Path | None = None) -> list[Path]:
     """Resolve files/directories to concrete skill/instruction files."""
     base_dir = cwd or Path.cwd()
-    requested = list(paths or [base_dir])
+    requested = list(paths) if paths is not None else [base_dir]
+    explicit_paths = bool(requested)
     resolved: list[Path] = []
     seen: set[Path] = set()
 
@@ -114,7 +138,7 @@ def resolve_skill_targets(paths: Iterable[str | Path] | None = None, *, cwd: Pat
 
         discovered: list[Path]
         if candidate.is_dir():
-            discovered = discover_skill_files(candidate)
+            discovered = _discover_explicit_skill_files(candidate) if explicit_paths else discover_skill_files(candidate)
         elif candidate.is_file():
             discovered = [candidate]
         else:
@@ -165,6 +189,7 @@ def scan_skill_targets(paths: Iterable[str | Path] | None = None, *, cwd: Path |
                 audit=audit,
                 trust=trust,
                 provenance=_provenance_to_dict(path),
+                bundle=build_skill_bundle(path),
             )
         )
     return SkillsScanReport(files=reports)

--- a/tests/test_skill_bundles.py
+++ b/tests/test_skill_bundles.py
@@ -1,0 +1,30 @@
+"""Tests for deterministic skill bundle identity."""
+
+from __future__ import annotations
+
+from agent_bom.skill_bundles import build_skill_bundle
+
+
+def test_build_skill_bundle_includes_referenced_local_files(tmp_path):
+    skill = tmp_path / "SKILL.md"
+    script = tmp_path / "scripts" / "run.sh"
+    script.parent.mkdir()
+    script.write_text("#!/usr/bin/env bash\necho hi\n")
+    skill.write_text("[runner](scripts/run.sh)\n")
+
+    bundle = build_skill_bundle(skill, skill.read_text())
+    assert bundle.file_count == 2
+    assert bundle.referenced_file_count == 1
+    assert [entry.path for entry in bundle.files] == ["SKILL.md", "scripts/run.sh"]
+
+
+def test_build_skill_bundle_is_deterministic(tmp_path):
+    skill = tmp_path / "SKILL.md"
+    helper = tmp_path / "helper.py"
+    helper.write_text("print('ok')\n")
+    skill.write_text("Use `helper.py`\n")
+
+    first = build_skill_bundle(skill, skill.read_text())
+    second = build_skill_bundle(skill, skill.read_text())
+    assert first.sha256 == second.sha256
+    assert first.stable_id == second.stable_id

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -32,9 +32,28 @@ Environment:
 
     data = json.loads(result.output)
     assert data["summary"]["files_scanned"] == 1
+    assert data["summary"]["bundles"] == 1
     assert data["summary"]["packages_found"] >= 1
     assert data["summary"]["credential_env_vars"] >= 1
     assert data["files"][0]["path"].endswith("CLAUDE.md")
+    assert data["files"][0]["bundle"]["file_count"] == 1
+    assert data["files"][0]["bundle"]["sha256"]
+
+
+def test_skills_scan_explicit_directory_globs_markdown(tmp_path):
+    """Explicit directory targets should scan markdown files inside that directory."""
+    docs_skills = tmp_path / "docs" / "skills"
+    docs_skills.mkdir(parents=True)
+    skill_file = docs_skills / "mcp-server-review.md"
+    skill_file.write_text("# Review\n\n```bash\nnpx @modelcontextprotocol/server-filesystem\n```\n")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skills", "scan", str(docs_skills), "--format", "json"])
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(result.output)
+    assert data["summary"]["files_scanned"] == 1
+    assert data["files"][0]["path"].endswith("mcp-server-review.md")
 
 
 def test_skills_verify_json_unsigned(tmp_path):


### PR DESCRIPTION
## Summary
- add deterministic bundle identity metadata for skill and instruction files
- include bundle hashes and stable bundle ids in skills scan JSON output
- make explicit directory targets scan markdown skill files recursively instead of only well-known filenames

## Testing
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_skills_cli.py tests/test_skills_parser.py tests/test_skill_bundles.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/skill_bundles.py src/agent_bom/skills_service.py tests/test_skills_cli.py tests/test_skill_bundles.py

Closes #1163