### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ agent-bom serve                         # API + Next.js dashboard
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/msaad00-agent-bom).
+
 ## Use it by environment
 
 | Environment | Recommendation |


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/msaad00-agent-bom).