### PR TITLE
docs(mcp): deepen Claude and Cortex integration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 <p align="center"><b>Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.</b></p>
 
+<p align="center">Security and visibility for agentic infrastructure should be open, transparent, and accessible — not reserved for teams with enterprise budgets.</p>
+
 <p align="center"><b>Your AI agent's dependencies have a CVE. Which credentials leak?</b></p>
 
 ```text
@@ -117,7 +119,14 @@ Wrap a third-party MCP server with the proxy when you want runtime inspection in
 agent-bom proxy "npx @modelcontextprotocol/server-filesystem /workspace"
 ```
 
-The proxy inspects MCP JSON-RPC traffic with drift, credential, injection, sequence, and capability-aware detectors before forwarding to the real server.
+The proxy inspects MCP JSON-RPC traffic with drift, credential, argument, response, vector, rate, and sequence detectors before forwarding to the real server.
+
+Guides:
+
+- [Claude Desktop / Claude Code](docs/CLAUDE_INTEGRATION.md)
+- [Cortex CoCo / Cortex Code](docs/CORTEX_CODE.md)
+- [MCP server mode](docs/MCP_SERVER.md)
+- [Runtime proxy and monitoring](docs/RUNTIME_MONITORING.md)
 
 </details>
 
@@ -197,7 +206,7 @@ Blast radius is **CWE-aware**: an RCE (CWE-94) shows full credential exposure, a
 <details>
 <summary><b>Runtime, policy, and trust</b></summary>
 
-- MCP proxy enforcement with 8 behavioral detectors and 112 detection patterns
+- Runtime protection engine with 8 detectors; MCP proxy with 7 inline detectors and 112 detection patterns
 - Capability-aware risk, drift detection, credential redaction, and kill-switch controls
 - 14 compliance frameworks mapped onto findings, including OWASP, MITRE, NIST, ISO, SOC 2, CIS, CMMC, and the EU AI Act
 
@@ -209,7 +218,7 @@ Blast radius is **CWE-aware**: an RCE (CWE-94) shows full credential exposure, a
 
 ## Runtime protection
 
-MCP security proxy with 112 detection patterns, 8 detectors, PII redaction, and kill switch:
+MCP security proxy with 112 detection patterns, 7 inline detectors, PII redaction, and kill switch:
 
 ```bash
 agent-bom proxy "npx @mcp/server-filesystem /workspace"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ graph TB
         Console["Console\nTable / verbose"]
         Formats["Formats\nJSON / SARIF / HTML / CycloneDX"]
         API["REST API + MCP\n36 tools"]
-        Proxy["Runtime Proxy\n8 detectors"]
+        Proxy["Runtime Proxy\n7 inline detectors"]
     end
 
     Scan & MCP_Cmd --> Discovery

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -1,0 +1,103 @@
+# Claude Desktop / Claude Code Integration
+
+This guide covers the full `agent-bom` flow for Anthropic clients:
+
+1. add `agent-bom` as an MCP server so Claude can call the scanner directly
+2. scan Claude MCP configurations and project context
+3. wrap third-party MCP servers with the runtime proxy when you want live enforcement
+
+## Use agent-bom as an MCP server
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "agent-bom",
+      "args": ["mcp", "server"]
+    }
+  }
+}
+```
+
+If you prefer not to install globally, use `uvx` instead:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "uvx",
+      "args": ["agent-bom", "mcp", "server"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+The quickest path is:
+
+```bash
+claude mcp add agent-bom -- uvx agent-bom mcp server
+```
+
+`agent-bom` also discovers Claude Code project MCP servers from `~/.claude.json`.
+
+## What users get inside Claude
+
+`agent-bom mcp server` exposes 36 read-only tools for:
+
+- agent and MCP discovery
+- package and registry checks
+- blast radius analysis
+- compliance evidence
+- skills scanning and trust
+- SBOM generation
+- runtime and tool-risk queries
+
+## Scan Claude environments directly
+
+Use the CLI when you want a local audit instead of an MCP tool call:
+
+```bash
+agent-bom agents
+agent-bom agents -p .
+agent-bom skills scan .
+```
+
+This discovers Claude Desktop and Claude Code MCP configs, project-level instruction files, and the packages behind those MCP servers.
+
+## Runtime proxy for Claude-connected MCP servers
+
+When you want live inspection of third-party MCP traffic, wrap the real server:
+
+```bash
+agent-bom proxy "npx @modelcontextprotocol/server-filesystem /workspace"
+```
+
+For JSON-based configs, auto-wrap all eligible stdio servers:
+
+```bash
+agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials --apply
+```
+
+The proxy adds runtime inspection for:
+
+- tool drift
+- argument injection
+- credential leakage
+- rate spikes
+- suspicious sequences
+- response cloaking
+- vector/RAG injection
+
+For cross-agent correlation across sessions, use the broader runtime protection engine with `agent-bom runtime protect --shield`.
+
+## Notes
+
+- `agent-bom` is read-only in MCP server mode.
+- Proxy mode is opt-in and wraps the target server command; it does not modify the server itself.
+- Use [MCP_SERVER.md](MCP_SERVER.md) for the full MCP tool catalog and [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) for deployment and policy details.

--- a/docs/CORTEX_CODE.md
+++ b/docs/CORTEX_CODE.md
@@ -1,0 +1,103 @@
+# Cortex CoCo / Cortex Code Integration
+
+This guide covers the full `agent-bom` flow for Snowflake Cortex CoCo:
+
+1. add `agent-bom` as an MCP server inside CoCo
+2. scan CoCo MCP servers plus Cortex-specific config state
+3. wrap third-party MCP servers with the runtime proxy when you want live inspection
+
+## Use agent-bom as an MCP server
+
+Add to `~/.snowflake/cortex/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "uvx",
+      "args": ["agent-bom", "mcp", "server"]
+    }
+  }
+}
+```
+
+Or, if `agent-bom` is already installed:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "agent-bom",
+      "args": ["mcp", "server"]
+    }
+  }
+}
+```
+
+This makes the same 36 `agent-bom` MCP tools available in CoCo conversations.
+
+## What agent-bom discovers for Cortex
+
+`agent-bom` does more than read `mcp.json`. It also inspects:
+
+- `~/.snowflake/cortex/settings.json`
+- `~/.snowflake/cortex/permissions.json`
+- `~/.snowflake/cortex/hooks.json`
+
+That gives you Cortex-specific audit visibility that normal MCP discovery does not provide.
+
+## Cortex-specific security checks
+
+`agent-bom` audits:
+
+- cached approvals in `permissions.json`
+- high-risk tools approved persistently
+- approvals without integrity hashes
+- dangerous shell hook commands in `hooks.json`
+- hooks that fire on all events
+- hooks that exfiltrate to external URLs
+
+## Scan Cortex environments directly
+
+Use the CLI when you want an audit of the local CoCo setup:
+
+```bash
+agent-bom agents
+agent-bom agents -p .
+agent-bom skills scan .
+```
+
+This discovers CoCo MCP servers, package dependencies, exposed credential names, and auxiliary Cortex config findings.
+
+## Runtime proxy for CoCo-connected MCP servers
+
+When you want live inspection of third-party MCP traffic, wrap the real server:
+
+```bash
+agent-bom proxy "npx @modelcontextprotocol/server-filesystem /workspace"
+```
+
+Or auto-wrap eligible JSON MCP configs:
+
+```bash
+agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials --apply
+```
+
+That adds runtime monitoring for:
+
+- tool drift
+- credential leakage
+- argument injection
+- rate spikes
+- suspicious sequences
+- response cloaking
+- vector/RAG injection
+
+For cross-agent correlation across sessions, use the broader runtime protection engine with `agent-bom runtime protect --shield`.
+
+## Notes
+
+- `agent-bom` does not need write access to the target MCP server to scan it.
+- MCP server mode is read-only.
+- Proxy mode is opt-in and is the path for runtime enforcement.
+- See [MCP_SERVER.md](MCP_SERVER.md) for the MCP tool catalog and [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) for deployment details.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -138,7 +138,7 @@ An agent operating autonomously can be steered into a multi-step exfiltration se
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 35 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 36 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -166,7 +166,7 @@ agent-bom proxy "uvx mcp-server-filesystem /" --policy policy.yml
 agent-bom proxy --url http://localhost:3000 --policy policy.yml
 ```
 
-**8 behavioral detectors running on every message:**
+**7 inline proxy detectors on every message:**
 
 | Detector | What it catches | Framework reference |
 |----------|----------------|---------------------|
@@ -177,7 +177,6 @@ agent-bom proxy --url http://localhost:3000 --policy policy.yml
 | `SequenceAnalyzer` | Read → send → delete exfiltration sequences | MITRE ATLAS AML.T0025 |
 | `ResponseInspector` | Cloaking (invisible unicode), SVG injection, metadata poisoning | OWASP LLM05 |
 | `VectorDBInjectionDetector` | Prompt injection from retrieved vector DB chunks | OWASP LLM RAG-03 |
-| `CrossAgentCorrelator` | Cross-agent tool convergence and lateral movement patterns | OWASP Agentic AI ASI07, runtime lateral movement detection |
 
 Policy conditions (17 declarative + expression engine):
 
@@ -191,6 +190,8 @@ rate_limit:
 max_response_size_kb: 512
 ```
 
+For cross-agent correlation, use the broader runtime protection engine (`agent-bom runtime protect --shield`), which adds `CrossAgentCorrelator` on top of the inline proxy detector set.
+
 ### 4.3 MCP server mode
 
 ```bash
@@ -200,10 +201,10 @@ agent-bom mcp server
 Exposes 36 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query the registry, and generate compliance reports without leaving the chat:
 
 ```
-scan_agents         — full scan, returns JSON report
-check_package       — CVE check for a single package
-registry_search     — search 427+ MCP servers by name/tag
-compliance_report   — generate framework-mapped compliance report
+scan                — full discovery + scan, returns JSON report
+check               — CVE check for a single package
+registry_lookup     — search 427+ MCP servers by name/tag
+compliance          — generate framework-mapped compliance report
 blast_radius        — blast radius for a specific CVE
 ...
 ```
@@ -214,7 +215,7 @@ blast_radius        — blast radius for a specific CVE
 
 - **Does not run MCP servers.** Read-only. Never starts or restarts a server.
 - **Does not store credentials.** Only env var *names* (not values) appear in reports.
-- **Does not modify MCP configs** unless you explicitly run `agent-bom runtime configure --apply`.
+- **Does not modify MCP configs** unless you explicitly run `agent-bom proxy-configure --apply`.
 - **Does not send telemetry.** Only package name + version leaves your machine for CVE lookups (OSV, NVD, EPSS). See [PERMISSIONS.md](../PERMISSIONS.md).
 - **Does not replace IAM or network controls.** It is a detection and enforcement layer, not a perimeter.
 
@@ -252,12 +253,12 @@ echo "ignores:\n  - id: CVE-2024-1234\n    reason: 'Not reachable'\n    expires:
 
 ```bash
 # Wrap every MCP server in your Claude Desktop config
-agent-bom runtime configure --apply
+agent-bom proxy-configure --apply
 
 # Or wrap a single server manually
 agent-bom proxy "uvx mcp-server-filesystem /" \
   --policy policy.yml \
-  --audit-log /var/log/mcp-audit.jsonl
+  --log /var/log/mcp-audit.jsonl
 ```
 
 ---
@@ -266,5 +267,7 @@ agent-bom proxy "uvx mcp-server-filesystem /" \
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — component diagram, data flow, module boundaries
 - [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) — proxy internals, detector configuration
+- [CLAUDE_INTEGRATION.md](CLAUDE_INTEGRATION.md) — Claude Desktop / Claude Code setup and proxy flow
+- [CORTEX_CODE.md](CORTEX_CODE.md) — Cortex CoCo / Cortex Code setup, discovery, permissions, and hooks
 - [AI_INFRASTRUCTURE_SCANNING.md](AI_INFRASTRUCTURE_SCANNING.md) — GPU, CUDA, ML framework scanning
 - [PERMISSIONS.md](PERMISSIONS.md) — full trust contract, what data leaves your machine

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -4,9 +4,15 @@ agent-bom exposes 36 security tools as an MCP server. Any MCP-compatible client
 can connect and get vulnerability scanning, blast radius analysis, compliance
 checks, and supply chain verification through natural conversation.
 
+See also:
+
+- [Claude Desktop / Claude Code guide](CLAUDE_INTEGRATION.md)
+- [Cortex CoCo / Cortex Code guide](CORTEX_CODE.md)
+- [Runtime Monitoring](RUNTIME_MONITORING.md)
+
 ## Quick Start
 
-### Claude Desktop / Claude Code
+### Claude Desktop
 
 Add to your `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/`):
 
@@ -23,11 +29,15 @@ Add to your `claude_desktop_config.json` (macOS: `~/Library/Application Support/
 
 Restart Claude Desktop. You can now ask: *"Scan my AI agents for vulnerabilities"*
 
-For Claude Code, the equivalent one-liner is:
+### Claude Code
+
+If you already use the Claude CLI, add agent-bom directly:
 
 ```bash
 claude mcp add agent-bom -- uvx agent-bom mcp server
 ```
+
+Claude Code project-level MCP servers are also discovered from `~/.claude.json`.
 
 ### Cortex CoCo
 
@@ -45,6 +55,12 @@ Add to `~/.snowflake/cortex/mcp.json`:
 ```
 
 CoCo can then call the same 36 `agent-bom` tools over MCP.
+
+agent-bom also discovers Cortex auxiliary security files alongside `mcp.json`:
+
+- `settings.json`
+- `permissions.json`
+- `hooks.json`
 
 ### Cursor / Windsurf / VS Code
 
@@ -88,21 +104,29 @@ agent-bom proxy "npx @modelcontextprotocol/server-filesystem /workspace"
 
 This keeps the real server behind `agent-bom` and enables runtime detectors for tool drift, credential leakage, injection patterns, sequence risk, and related policy decisions.
 
+For JSON-configured clients like Claude Desktop or Cortex CoCo, use:
+
+```bash
+agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials
+```
+
+Add `--apply` to write the wrapped config back to compatible JSON MCP config files.
+
 ## Tool Categories (36 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
-| **Scan** | `scan_agents`, `scan_image`, `scan_filesystem`, `scan_sbom` | Discover agents, scan containers, filesystems, and existing SBOMs for CVEs |
-| **Check** | `check_package`, `verify_package` | Pre-install CVE gate + supply chain provenance verification |
+| **Scan** | `scan`, `code_scan`, `vector_db_scan`, `gpu_infra_scan`, `ai_inventory_scan` | Discover agents, scan packages, code, vector stores, GPU infra, and AI usage |
+| **Check** | `check`, `verify`, `marketplace_check`, `license_compliance_scan` | Pre-install CVE gate, integrity verification, marketplace trust, and license policy |
 | **Blast Radius** | `blast_radius` | Map CVE → package → MCP server → agent → credentials → tools |
-| **Registry** | `registry_lookup`, `batch_registry_scan` | Query 427+ MCP server security metadata |
-| **Compliance** | `compliance_check`, `cis_benchmark` | Run OWASP, NIST, MITRE ATLAS, CIS checks |
-| **Policy** | `evaluate_policy` | Apply custom or built-in security policies |
+| **Registry** | `registry_lookup`, `inventory`, `where`, `fleet_scan` | Query the MCP registry, inspect discovery paths, and summarize fleet inventories |
+| **Compliance** | `compliance`, `cis_benchmark`, `aisvs_benchmark` | Run OWASP, NIST, MITRE ATLAS, CIS, and AISVS-aligned posture checks |
+| **Policy** | `policy_check`, `remediate` | Evaluate policies and generate guided remediation plans |
 | **Inventory** | `inventory` | List agents/servers without CVE scanning |
-| **Trust** | `trust_assessment` | Multi-category trust scoring for packages |
+| **Trust** | `marketplace_check`, `runtime_correlate`, `tool_risk_assessment` | Score package trust, correlate runtime usage, and assess live tool capability risk |
 | **Skills** | `skill_scan`, `skill_verify`, `skill_trust` | Instruction-file trust, provenance, and tool-poisoning detection |
-| **IaC** | `scan_terraform`, `scan_dockerfile`, `scan_helm` | Infrastructure-as-code security scanning |
-| **Runtime** | `shield_status`, `tool_risk_assessment` | Runtime protection engine status and live MCP capability risk |
+| **Graph / Runtime** | `context_graph`, `graph_export`, `runtime_correlate`, `tool_risk_assessment` | Visualize lateral movement, export graph data, and connect runtime logs to findings |
+| **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan` | Scan AI artifacts, prompts, model files, browser extensions, and external scanner results |
 
 ## Example Conversations
 
@@ -128,9 +152,10 @@ This keeps the real server behind `agent-bom` and enables runtime detectors for 
 
 ## Resources
 
-The server exposes one MCP resource:
+The server exposes two MCP resources:
 
 - `registry://servers` — Browse the full 427+ server security metadata registry
+- `policy://template` — Default security policy template
 
 ## Prompts
 

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -7,12 +7,12 @@ agent-bom includes a runtime security proxy (`agent-bom proxy`) that sits betwee
 The proxy interposes on the stdio channel between an MCP client (Claude Desktop, Cursor, VS Code, etc.) and an MCP server. Every JSON-RPC message passes through the proxy, which:
 
 1. **Logs** every `tools/call` invocation to a JSONL audit trail
-2. **Detects** anomalous or dangerous tool usage via five built-in detectors
+2. **Detects** anomalous or dangerous tool usage via seven inline detectors
 3. **Enforces** policy rules — optionally blocking tool calls that violate policy
 4. **Tracks** declared vs. actual tool usage (drift detection)
 5. **Measures** latency, call counts, and blocked-call metrics
 
-### Five Detectors
+### Seven Inline Detectors
 
 | Detector | What it catches | Default mode |
 |---|---|---|
@@ -21,6 +21,8 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 | **Credential leak** | Arguments containing patterns that look like API keys, tokens, passwords, or connection strings being passed to tools. | Log |
 | **Rate limiting** | Abnormal call frequency for a single tool within a time window — detects runaway loops or abuse. | Log |
 | **Sequence analysis** | Suspicious sequences of tool calls (e.g., `list_files` followed by `read_file` on every file, or `exec` after `write_file`). | Log |
+| **Response inspection** | Cloaking, invisible Unicode, SVG/script payloads, and poisoned response content. | Log |
+| **Vector DB injection** | Retrieved prompt chunks or vector-backed content attempting to coerce downstream tools or agents. | Log |
 
 ---
 
@@ -145,6 +147,16 @@ All tool calls are allowed through. Every invocation is recorded in the JSONL au
 agent-bom proxy --log audit.jsonl -- npx @mcp/server-filesystem /workspace
 ```
 
+For Claude Desktop, Claude Code, and Cortex JSON configs, you can auto-wrap eligible stdio servers:
+
+```bash
+agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials
+```
+
+Add `--apply` to persist the wrapped config entries.
+
+If you need cross-agent correlation and the broader 8-detector runtime engine, use `agent-bom runtime protect --shield` alongside or upstream of the proxy pipeline.
+
 ### Enforce mode
 
 Add `--block-undeclared` and/or `--policy policy.json` to actively block tool calls:
@@ -215,7 +227,13 @@ Tracks call frequency per tool within a sliding time window. Detects runaway loo
 
 Analyzes the order of tool calls to detect suspicious multi-step patterns. For example: `list_directory` followed by `read_file` on every discovered file (bulk exfiltration), or `write_file` followed by `exec` (code injection + execution).
 
----
+### Response Inspection
+
+Scans tool responses for cloaking tricks, invisible Unicode, SVG/script payloads, and other content that tries to smuggle instructions back into the agent.
+
+### Vector DB Injection
+
+Detects prompt-coercion or poisoning patterns from retrieval-backed tools and escalates them when the response clearly comes from vector or RAG-like sources.
 
 ## Configuration Examples
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -58,9 +58,11 @@ The proxy sits between the MCP client and server on the **stdio transport layer*
 1. Reads JSON-RPC messages from the client
 2. Inspects message content (tool calls, tool responses)
 3. Applies policy rules (allow/deny/log)
-4. Runs 8 detectors (tool drift, prompt injection, credential/PII leak, rate-limit abuse, exfiltration sequences, response cloaking, vector DB injection, cross-agent correlation)
+4. Runs 7 inline proxy detectors (tool drift, prompt injection, credential/PII leak, rate-limit abuse, exfiltration sequences, response cloaking, vector DB injection)
 5. Forwards allowed messages to the server
 6. Logs all activity to JSONL audit file
+
+For cross-agent correlation and the broader 8-detector protection engine, run `agent-bom runtime protect --shield` alongside the proxy workflow.
 
 ### Security Controls
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -39,7 +39,7 @@ agent-bom operates in four modes:
 | Local filesystem | Trusted | User's own config files; validated with `validate_path(restrict_to_home=True)` |
 | Public vuln APIs (OSV, NVD, EPSS, KEV) | Untrusted input | Responses are parsed defensively; no code execution from API data |
 | Cloud provider APIs (AWS, Azure, GCP, Snowflake) | Authenticated, semi-trusted | Read-only API calls; credentials from environment; responses parsed defensively |
-| Upstream MCP servers (via proxy) | Untrusted | All traffic inspected by 8 detectors; policy enforcement before relay |
+| Upstream MCP servers (via proxy) | Untrusted | All traffic inspected by 7 inline proxy detectors; policy enforcement before relay |
 | AI clients (via MCP server) | Semi-trusted | Tool inputs validated; no shell execution from AI-provided arguments |
 | Docker daemon socket | Privileged | Only accessed with explicit `--image` flag; user must opt in |
 | Kubernetes API | Privileged | Only accessed with explicit `--k8s-mcp` flag; uses kubeconfig auth |

--- a/docs/decisions/004-proxy-runtime-enforcement.md
+++ b/docs/decisions/004-proxy-runtime-enforcement.md
@@ -24,7 +24,7 @@ and server, intercepting all JSON-RPC messages. The proxy:
 3. **Enforces** policies (block/allow/audit per tool, per argument pattern)
 4. **Logs** all traffic to JSONL audit files for forensic replay
 
-**Detector pipeline (8 detectors):**
+**Detector pipeline (7 inline proxy detectors):**
 
 | Detector | Threat |
 |----------|--------|
@@ -35,6 +35,8 @@ and server, intercepting all JSON-RPC messages. The proxy:
 | SequenceAnalyzer | Multi-step exfiltration patterns (read→encode→send) |
 | ResponseInspector | Cloaking attacks, SVG injection, invisible Unicode |
 | VectorDBInjection | Injection in vector DB query/retrieval payloads |
+
+For broader runtime correlation, the protection engine adds `CrossAgentCorrelator` on top of the inline proxy detector set via `agent-bom runtime protect --shield`.
 
 **Deployment model:** Users configure their MCP client to run
 `agent-bom proxy <original-command>` instead of the direct server command.

--- a/integrations/cortex-code/README.md
+++ b/integrations/cortex-code/README.md
@@ -1,4 +1,4 @@
-# agent-bom + Cortex Code CLI Integration
+# agent-bom + Cortex CoCo / Cortex Code Integration
 
 ## Add agent-bom as an MCP Server
 
@@ -28,7 +28,7 @@ Or if installed via pip/pipx:
 }
 ```
 
-This gives Cortex Code access to agent-bom's MCP security and analysis tools via natural language.
+This gives Cortex CoCo access to agent-bom's MCP security and analysis tools via natural language.
 
 ## Install as a Cortex Code Skill
 
@@ -78,9 +78,9 @@ Cortex Code can use agent-bom CLI commands directly:
 - "Generate an SBOM for compliance"
 - "What's the blast radius of CVE-2024-21538?"
 
-## Cortex Code Security Coverage
+## Cortex CoCo Security Coverage
 
-agent-bom fills these security gaps in Cortex Code:
+agent-bom fills these security gaps in Cortex CoCo:
 
 | Cortex Code guidance | agent-bom automation |
 |---------------------|---------------------|
@@ -89,10 +89,31 @@ agent-bom fills these security gaps in Cortex Code:
 | Manual permission review | Blast radius analysis showing credential exposure |
 | No CVE scanning | Full enrichment: OSV + NVD + EPSS + CISA KEV |
 | No compliance mapping | Framework-aware evidence across OWASP, NIST, EU AI Act, ISO 27001, SOC 2, CIS, and more |
-| No runtime enforcement | Runtime proxy with behavioral detectors and policy enforcement |
+| No runtime enforcement | Runtime proxy with 7 inline detectors, plus the broader 8-detector protection engine |
+
+## Runtime proxy and config audit
+
+Wrap third-party MCP servers when you want live traffic inspection:
+
+```bash
+agent-bom proxy "npx @modelcontextprotocol/server-filesystem /workspace"
+```
+
+Or auto-wrap eligible JSON MCP configs:
+
+```bash
+agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials --apply
+```
+
+For Cortex, agent-bom also audits:
+
+- `~/.snowflake/cortex/permissions.json` for overly broad cached approvals
+- `~/.snowflake/cortex/hooks.json` for risky shell hooks or unrestricted triggers
+- `~/.snowflake/cortex/settings.json` for auxiliary config context
 
 ## Auto-Discovery
 
-agent-bom already discovers Cortex Code's MCP configuration at
-`~/.snowflake/cortex/mcp.json`. Running `agent-bom scan` will
-automatically find and scan your Cortex Code MCP servers.
+agent-bom already discovers Cortex CoCo's MCP configuration at
+`~/.snowflake/cortex/mcp.json`. Running `agent-bom agents` will
+automatically find and scan your Cortex Code MCP servers plus the associated
+settings, permissions, and hooks files.

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -161,8 +161,8 @@ def proxy_configure_cmd(policy, log_dir, detect_credentials, block_undeclared, a
 
     \b
     Example:
-      agent-bom runtime configure --log-dir ~/.agent-bom/logs --detect-credentials
-      agent-bom runtime configure --policy policy.json --block-undeclared --apply
+      agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials
+      agent-bom proxy-configure --policy policy.json --block-undeclared --apply
     """
     from agent_bom.discovery import discover_all
     from agent_bom.proxy_configure import apply_proxy_configs, auto_configure_proxies
@@ -229,12 +229,15 @@ def protect_cmd(mode, port, host, detectors, alert_file, alert_webhook, log_leve
     """Run the runtime protection engine as a standalone monitor.
 
     \b
-    Analyzes tool calls through 5 security detectors:
+    Analyzes tool calls and responses through 8 security detectors:
     - Tool drift detection (rug pull / capability changes)
     - Argument analysis (shell injection, path traversal)
     - Credential leak detection (API keys, tokens in responses)
     - Rate limiting (abnormal call frequency)
     - Sequence analysis (suspicious multi-step patterns)
+    - Response inspection (cloaking, SVG, invisible characters)
+    - Vector DB injection detection (RAG/cache poisoning)
+    - Cross-agent correlation (lateral movement patterns)
 
     \b
     stdin mode (default) — pipe line-delimited JSON:

--- a/src/agent_bom/cli/shield.py
+++ b/src/agent_bom/cli/shield.py
@@ -1,8 +1,8 @@
 """agent-shield — Runtime protection for AI agents.
 
-Monitors MCP traffic in real-time with 8 behavioral detectors,
-enforces security policies, and provides deep defense mode with
-correlated threat scoring and automatic kill-switch.
+Monitors MCP traffic in real-time with 7 inline proxy detectors,
+enforces security policies, and provides audit replay for
+runtime investigations.
 
 Entry point: ``agent-shield`` (registered in pyproject.toml).
 """
@@ -45,10 +45,10 @@ def shield():
     """agent-shield — Runtime protection for AI agents.
 
     \b
-    MCP security proxy with 112 detection patterns across 8 detectors:
+    MCP security proxy with 112 detection patterns across 7 inline detectors:
     · Tool drift (rug pull)    · Shell injection     · Credential leaks
     · Rate limiting            · Attack sequences    · Response cloaking
-    · Vector DB injection      · PII redaction
+    · Vector DB injection
 
     \b
     Quick start:


### PR DESCRIPTION
## Summary
- add first-class Claude Desktop / Claude Code and Cortex CoCo / Cortex Code integration guides
- tighten MCP server, proxy, and runtime docs so proxy claims match the actual 7 inline detector path and the broader 8-detector protection engine
- align README, shield help, and architecture/security docs around the scan -> MCP server -> proxy -> runtime story

## Validation
- python -m py_compile src/agent_bom/cli/_runtime.py src/agent_bom/cli/shield.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_mcp_tool_impls.py tests/test_runtime_detectors.py tests/test_proxy.py tests/test_proxy_configure.py tests/test_discovery_enhanced.py tests/test_discovery_new_clients.py
- focused grep pass so only historical audit/registry-submission docs still mention the old 35-tool / 8-detector wording
