### PR TITLE
release: prepare v0.75.13

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.75.12","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.75.12"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.75.13","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.75.13"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.75.12  # pinned — bump on each release
+        run: uv tool install agent-bom==0.75.13  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -63,7 +63,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.title=agent-bom
-            org.opencontainers.image.description=Open security platform for agentic infrastructure — MCP server (stdio)
+            org.opencontainers.image.description=Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime. MCP server (stdio).
             org.opencontainers.image.created=${{ github.event.workflow_run.created_at || github.event.repository.updated_at }}
             org.opencontainers.image.revision=${{ github.sha }}
 
@@ -128,7 +128,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.title=agent-bom-sse
-            org.opencontainers.image.description=Open security platform for agentic infrastructure — MCP server (streamable HTTP)
+            org.opencontainers.image.description=Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime. MCP server (streamable HTTP).
             org.opencontainers.image.created=${{ github.event.workflow_run.created_at || github.event.repository.updated_at }}
             org.opencontainers.image.revision=${{ github.sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.title=agent-bom
-            org.opencontainers.image.description=Open security scanner for agentic infrastructure: agents, MCP, containers, cloud, and runtime.
+            org.opencontainers.image.description=Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
             org.opencontainers.image.revision=${{ github.sha }}
 
@@ -158,7 +158,7 @@ jobs:
             "https://hub.docker.com/v2/repositories/agentbom/agent-bom/" \
             -H "Authorization: Bearer ${TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"full_description\": ${DESCRIPTION}, \"description\": \"Open security scanner for agentic infrastructure: agents, MCP, containers, cloud, and runtime.\"}"
+            -d "{\"full_description\": ${DESCRIPTION}, \"description\": \"Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.\"}"
 
       - name: Clean up old Docker Hub tags (keep last 10)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.75.13] – 2026-04-01
+
+### Added
+- **Focused MCP server review** — `agent-bom mcp scan <server>` adds a narrower audit path for a single MCP server or command before adoption
+- **Compliance narrative CLI** — compliance narrative export is now reachable from the CLI for release and audit workflows
+
+### Changed
+- **Release surfaces aligned** — README, PyPI, Docker Hub, site docs, Helm, OCI metadata, and publishing surfaces now share the same product description and release references
+- **Canonical product story** — product positioning, Claude/Cortex integration references, and repo-derived metrics now point back to the canonical brief and generated metrics appendix
+- **First-run guidance** — empty-state discovery help now shows concrete Claude, Cursor, Codex CLI, and Cortex CoCo config paths instead of circular retry suggestions
+- **SARIF defaults** — SARIF export now auto-enables enrichment when online so severity context lands in GitHub and downstream scanners by default
+
+### Fixed
+- **Offline safety boundary** — offline scans now fail closed when the local vulnerability database is missing or incomplete instead of producing a false clean result
+- **Incomplete result visibility** — critical scanner and enrichment failures now surface warning summaries instead of silently degrading to partial output
+- **Skills scanning** — `agent-bom skills scan .` no longer crashes on repo-local path validation, and the command now supports `-v` / `--verbose`
+- **Package checks** — `agent-bom check` now resolves ambiguous package names more safely and avoids cross-ecosystem false positives
+- **Output format handling** — unknown output extensions now fail loudly instead of silently falling back to JSON
+- **ClickHouse query hardening** — analytics escaping was tightened and the associated tests expanded
+- **Release quality gates** — follow-up CodeQL, lint, mypy, FastAPI response-model, and regression issues from the stabilization lane were fixed before release
+
+### Security
+- The `0.75.13` release closes the remaining pre-release P0/P1 safety issues from the final audit lane, including offline false-clean behavior, incomplete scan signaling, and ClickHouse query hardening
+
+---
+
 ## [0.75.12] – 2026-03-29
 
 ### Added

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -113,7 +113,7 @@ It covers:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `v0.75.12` | Current stable version (pinned) |
+| `v0.75.13` | Current stable version (pinned) |
 
 ## Links
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.75.12
+ARG VERSION=0.75.13
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — CVEs, blast radius, credential exposure, runtime enforcement"

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ docker run --rm agentbom/agent-bom agents    # Docker
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom agents` | Local audit + project scan |
-| GitHub Action | `uses: msaad00/agent-bom@v0.75.12` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.75.13` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom` | Isolated scans |
 | MCP Server | `agent-bom mcp server` | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
@@ -284,7 +284,7 @@ Use the GitHub Action when you want Trivy-style adoption: one step, one gate, SA
 **Repo + MCP + instruction files**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: scan
     severity-threshold: high
@@ -296,7 +296,7 @@ Use the GitHub Action when you want Trivy-style adoption: one step, one gate, SA
 **Container image gate**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
@@ -306,7 +306,7 @@ Use the GitHub Action when you want Trivy-style adoption: one step, one gate, SA
 **IaC gate**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
@@ -316,7 +316,7 @@ Use the GitHub Action when you want Trivy-style adoption: one step, one gate, SA
 **Air-gapped / pre-synced CI**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     auto-update-db: false
     enrich: false
@@ -326,7 +326,7 @@ Use the GitHub Action when you want Trivy-style adoption: one step, one gate, SA
 <summary><b>GitHub Action</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.75.12
+ARG VERSION=0.75.13
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="Security scanner for AI infrastructure — MCP server mode"

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -16,14 +16,14 @@ FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb
 WORKDIR /app
 COPY LICENSE ./
 
-ARG VERSION=0.75.12
+ARG VERSION=0.75.13
 
 RUN pip install --no-cache-dir --prefix=/install agent-bom==${VERSION}
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.75.12
+ARG VERSION=0.75.13
 
 LABEL org.opencontainers.image.title="agent-bom runtime proxy"
 LABEL org.opencontainers.image.description="MCP runtime security proxy — intercepts JSON-RPC for audit logging and policy enforcement"

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.75.12
+ARG VERSION=0.75.13
 
 LABEL maintainer="W S <34316639+msaad00@users.noreply.github.com>"
 LABEL description="agent-bom API for Snowpark Container Services"

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.75.12
+ARG VERSION=0.75.13
 
 LABEL org.opencontainers.image.title="agent-bom MCP Server"
 LABEL org.opencontainers.image.description="Security scanner for AI infrastructure — MCP server with streamable HTTP transport"

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
-description: Open security platform for agentic infrastructure — broad scanning plus MCP, blast radius, runtime, and trust
+description: Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.
 version: 0.1.0
-appVersion: "0.75.12"
+appVersion: "0.75.13"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.75.12"
+  tag: "0.75.13"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.75.12"
+  tag: "0.75.13"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ sequenceDiagram
 
     CLI->>BlastRadius: Vulns + topology
     BlastRadius->>BlastRadius: CVE → package → server → agent → creds → tools
-    BlastRadius->>BlastRadius: Tag 14 compliance frameworks
+    BlastRadius->>BlastRadius: Tag 15 compliance frameworks
     BlastRadius-->>CLI: Scored + tagged findings
 
     CLI->>Reporter: Full results
@@ -147,7 +147,7 @@ graph LR
 
 ## 4. Compliance Tagging
 
-Every finding is tagged against 14 frameworks, grouped into four families.
+Every finding is tagged against 15 frameworks, grouped into four families.
 
 ```mermaid
 graph LR

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -21,7 +21,7 @@ Start with the same adoption pattern teams expect from Trivy or Grype: a single 
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -38,21 +38,21 @@ Start with the same adoption pattern teams expect from Trivy or Grype: a single 
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     auto-update-db: false
     enrich: false
@@ -142,7 +142,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/root/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.75.12 agents --format json
+  agentbom/agent-bom:0.75.13 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -152,7 +152,7 @@ agent-bom agents --enforce    # + static tool poisoning analysis
 agent-bom agents --gpu-scan   # + GPU containers, CUDA versions, DCGM exposure
 ```
 
-Outputs: blast radius tree, compliance mapping (14 frameworks), posture score, SARIF/CycloneDX/SPDX/HTML.
+Outputs: blast radius tree, compliance mapping (15 frameworks), posture score, SARIF/CycloneDX/SPDX/HTML.
 
 ### 4.2 Proxy mode
 
@@ -226,7 +226,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.75.12
+- uses: msaad00/agent-bom@v0.75.13
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-04-01",
-  "version": "0.75.12",
+  "version": "0.75.13",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-04-01`
-- Version: `0.75.12`
+- Version: `0.75.13`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -72,7 +72,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.75.12"
+  --version "0.75.13"
 ```
 
 ### Verification
@@ -108,8 +108,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.75.12
-git push origin v0.75.12
+git tag v0.75.13
+git push origin v0.75.13
 ```
 
 This triggers:

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -125,7 +125,7 @@ If engaging a third-party auditor, the recommended scope:
 
 ### Compliance Framework Mapping
 
-agent-bom **maps findings TO compliance controls** across 14 frameworks:
+agent-bom **maps findings TO compliance controls** across 15 frameworks:
 
 OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10,
 EU AI Act, NIST AI RMF, NIST CSF, ISO 27001, SOC 2, CIS Controls,

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -110,4 +110,4 @@ agent-bom operates in four modes:
 ## Review cadence
 
 This threat model is reviewed with each major release (x.0) and after any
-security advisory. Last reviewed: v0.75.12 (March 2026).
+security advisory. Last reviewed: v0.75.13 (April 2026).

--- a/docs/WINDOWS_CONTAINERS.md
+++ b/docs/WINDOWS_CONTAINERS.md
@@ -111,7 +111,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.75.12`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.75.13`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.75.12 hero demo
+# agent-bom v0.75.13 hero demo
 # Shows: scan with blast radius → pre-install check → integrity verify
 
 Output docs/images/demo-latest.gif

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="138" class="item-label" fill="#fb7185">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">15 frameworks</text>
   <rect x="422" y="144" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="162" class="item-label" fill="#fb7185">Policy engine</text>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="138" class="item-label" fill="#e11d48">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">15 frameworks</text>
   <rect x="422" y="144" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="162" class="item-label" fill="#e11d48">Policy engine</text>

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.",
-  "version": "0.75.12",
+  "version": "0.75.13",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.",
   "title": "agent-bom",
-  "version": "0.75.12",
+  "version": "0.75.13",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.75.12",
+      "version": "0.75.13",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []
@@ -402,6 +402,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.75.12`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.75.13`
 - **6,533+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []
@@ -216,6 +216,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.75.12`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.75.13`
 - **6,533+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.75.12
+version: 0.75.13
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.75.12
+    docker: ghcr.io/msaad00/agent-bom:0.75.13
   openclaw:
     requires:
       bins: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.75.12"
-description = "Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust."
+version = "0.75.13"
+description = "Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -5,7 +5,7 @@
 | **CLI** | Local scanning, CI/CD | `pip install agent-bom` |
 | **MCP Server** | AI agent integration | `agent-bom mcp server` |
 | **Docker** | Isolated scanning | `docker run ghcr.io/msaad00/agent-bom scan` |
-| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.75.12` |
+| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.75.13` |
 | **Kubernetes** | Fleet monitoring | Helm chart |
 | **REST API** | Platform integration | `agent-bom serve` |
 | **Runtime Proxy** | Real-time enforcement | `agent-bom runtime proxy` |

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.75.12
+  uses: msaad00/agent-bom@v0.75.13
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,8 +1,8 @@
 # agent-bom
 
-**Open security platform for agentic infrastructure. Broad scanning, blast radius, runtime, and trust.**
+**Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.**
 
-Find CVEs, map blast radius, detect credential exposure across MCP agents, containers, Kubernetes, cloud, and GPU workloads.
+Scan agents, MCP, packages, containers, Kubernetes, cloud, and GPU workloads with blast-radius context.
 
 ## What it does
 
@@ -17,7 +17,7 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Traditional scanners often stop at CVE -> package. agent-bom shows which MCP servers, AI agents, credentials, and tools are actually at risk.
+Package risk is only the start. agent-bom maps what it can reach across MCP servers, agents, credentials, tools, and runtime context.
 
 ## Quick start
 
@@ -51,6 +51,6 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | CLI | `pip install agent-bom` |
 | MCP server | `agent-bom mcp server` |
 | Docker | `docker run ghcr.io/msaad00/agent-bom agents` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.75.12` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.75.13` |
 | Kubernetes | Helm chart + CronJob + DaemonSet |
 | Remote SSE | Self-host or use hosted endpoint |

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.75.12"
+    __version__ = "0.75.13"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -78,9 +79,7 @@ def lookup_package(
     ).fetchall()
 
     results: list[LocalVuln] = []
-    for row in rows:
-        if version and not _version_affected(version, row["introduced"], row["fixed"], row["last_affected"], row["ecosystem"]):
-            continue
+    for row in _select_vulnerability_rows(rows, version):
         # Parse comma-separated CWE IDs from DB column
         raw_cwes = row["cwe_ids"] or ""
         cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
@@ -122,6 +121,92 @@ def _version_affected(
     from agent_bom.version_utils import version_in_range
 
     return version_in_range(version, introduced, fixed, last_affected, ecosystem)
+
+
+def _version_match_state(
+    version: str,
+    introduced: Optional[str],
+    fixed: Optional[str],
+    last_affected: Optional[str],
+    ecosystem: str = "",
+) -> str:
+    """Return ``affected``, ``unaffected``, or ``unknown`` for one affected-range row."""
+    from agent_bom.version_utils import _looks_like_commit_sha, compare_version_order
+
+    intro = introduced or None
+    fix = fixed or None
+    last = last_affected or None
+    unknown = False
+
+    if intro:
+        intro_cmp = compare_version_order(version, intro, ecosystem)
+        if intro_cmp is not None and intro_cmp < 0:
+            return "unaffected"
+        if intro_cmp is None:
+            unknown = True
+
+    if fix:
+        if _looks_like_commit_sha(fix):
+            unknown = True
+        else:
+            fix_cmp = compare_version_order(version, fix, ecosystem)
+            if fix_cmp is not None and fix_cmp >= 0:
+                return "unaffected"
+            if fix_cmp is None:
+                unknown = True
+
+    if last:
+        last_cmp = compare_version_order(version, last, ecosystem)
+        if last_cmp is not None and last_cmp > 0:
+            return "unaffected"
+        if last_cmp is None:
+            unknown = True
+
+    return "unknown" if unknown else "affected"
+
+
+def _select_vulnerability_rows(rows: list[sqlite3.Row], version: Optional[str]) -> list[sqlite3.Row]:
+    """Choose at most one authoritative affected row per vulnerability.
+
+    If any row for a vulnerability definitively matches the requested version,
+    include the vulnerability. If no rows match but at least one row
+    definitively excludes the version, suppress the vulnerability even if
+    sibling rows are ambiguous (for example, duplicate PYSEC rows with git-SHA
+    fix bounds). If all rows are ambiguous, include the first one
+    conservatively.
+    """
+    if not version:
+        grouped_rows: dict[str, list[sqlite3.Row]] = defaultdict(list)
+        for row in rows:
+            grouped_rows[row["id"]].append(row)
+        return [group[0] for group in grouped_rows.values()]
+
+    grouped: dict[str, list[sqlite3.Row]] = defaultdict(list)
+    for row in rows:
+        grouped[row["id"]].append(row)
+
+    selected: list[sqlite3.Row] = []
+    for vuln_rows in grouped.values():
+        affected_row: sqlite3.Row | None = None
+        unknown_row: sqlite3.Row | None = None
+        saw_unaffected = False
+
+        for row in vuln_rows:
+            state = _version_match_state(version, row["introduced"], row["fixed"], row["last_affected"], row["ecosystem"])
+            if state == "affected":
+                affected_row = row
+                break
+            if state == "unknown" and unknown_row is None:
+                unknown_row = row
+            if state == "unaffected":
+                saw_unaffected = True
+
+        if affected_row is not None:
+            selected.append(affected_row)
+        elif not saw_unaffected and unknown_row is not None:
+            selected.append(unknown_row)
+
+    return selected
 
 
 def lookup_packages_batch(
@@ -180,8 +265,6 @@ def lookup_packages_batch(
         all_rows.extend(conn.execute(query, params).fetchall())
 
     # Group rows by (lower_ecosystem, package_name)
-    from collections import defaultdict
-
     grouped: dict[tuple[str, str], list[sqlite3.Row]] = defaultdict(list)
     for row in all_rows:
         grouped[(row["ecosystem"].lower(), row["package_name"])].append(row)
@@ -194,9 +277,7 @@ def lookup_packages_batch(
         rows = grouped.get((eco_lower, name), [])
 
         vulns: list[LocalVuln] = []
-        for row in rows:
-            if version and not _version_affected(version, row["introduced"], row["fixed"], row["last_affected"], row["ecosystem"]):
-                continue
+        for row in _select_vulnerability_rows(rows, version):
             raw_cwes = row["cwe_ids"] or ""
             cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
             raw_aliases = row["aliases"] or ""

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -311,7 +311,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             f"agent-bom v{__version__} — AI infrastructure security scanner with MCP security tools. "
             "Scans packages and images for CVEs (OSV, NVD, EPSS, CISA KEV), maps blast radius "
             "from vulnerabilities to credentials and tools, generates SBOMs (CycloneDX, SPDX), "
-            "enforces security policies, and maps to 14 compliance frameworks "
+            "enforces security policies, and maps to 15 compliance frameworks "
             "(OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST AI RMF/CSF/800-53, FedRAMP, EU AI Act, ISO 27001, SOC 2). "
             "Discovers 30 MCP clients. Read-only, agentless, no credentials required."
         ),

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -12,6 +12,8 @@ from agent_bom.parsers.skills import SkillScanResult, discover_skill_files, pars
 from agent_bom.parsers.trust_assessment import TrustAssessmentResult, assess_trust
 from agent_bom.skill_bundles import SkillBundle, build_skill_bundle
 
+_SKILL_DISCOVERY_SKIP_DIRS = {".git", ".venv", "venv", "node_modules", "__pycache__"}
+
 
 @dataclass
 class SkillFileReport:
@@ -108,18 +110,47 @@ class SkillsScanReport:
         }
 
 
+def _looks_like_instruction_surface(path: Path, *, allow_docs_skills: bool = False) -> bool:
+    """Return True when a file path looks like a real skill/instruction surface."""
+    if any(part in _SKILL_DISCOVERY_SKIP_DIRS for part in path.parts):
+        return False
+    if not allow_docs_skills and "docs" in path.parts and "skills" in path.parts:
+        return False
+
+    name = path.name
+
+    if name in {"CLAUDE.md", "AGENTS.md", "SKILL.md", "skill.md", ".cursorrules", ".windsurfrules"}:
+        return True
+
+    if name == "copilot-instructions.md" and any(parent.name == ".github" for parent in path.parents):
+        return True
+
+    if path.suffix.lower() != ".md":
+        return False
+
+    if any(parent.name == "skills" for parent in path.parents):
+        return True
+
+    if any(parent.name == "rules" and parent.parent.name == ".cursor" for parent in path.parents if parent.parent != parent):
+        return True
+
+    return False
+
+
 def _discover_explicit_skill_files(directory: Path) -> list[Path]:
     """Discover skill-like files inside a directory explicitly requested by the user."""
     found: list[Path] = []
     seen: set[Path] = set()
+    allow_docs_skills = "docs" in directory.parts and "skills" in directory.parts
     for path in sorted(directory.rglob("*")):
         if not path.is_file():
             continue
-        if path.name in {".cursorrules", ".windsurfrules"} or path.suffix.lower() == ".md":
-            resolved = path.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                found.append(resolved)
+        if not _looks_like_instruction_surface(path, allow_docs_skills=allow_docs_skills):
+            continue
+        resolved = path.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            found.append(resolved)
     return found
 
 

--- a/tests/test_batch_db_lookup.py
+++ b/tests/test_batch_db_lookup.py
@@ -203,8 +203,7 @@ def test_unparseable_fixed_version_reports_affected(tmp_db):
     _insert_vuln(tmp_db, vuln_id="CVE-2024-HASH")
     # Insert with a git commit hash as the fixed version — non-parseable by packaging.version
     tmp_db.execute(
-        "INSERT OR REPLACE INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected)"
-        " VALUES (?,?,?,?,?,'')",
+        "INSERT OR REPLACE INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,'')",
         ("CVE-2024-HASH", "pypi", "some-lib", "1.0.0", "abc123def456git"),
     )
     tmp_db.commit()
@@ -214,6 +213,25 @@ def test_unparseable_fixed_version_reports_affected(tmp_db):
     # Must be reported as affected (not silently dropped)
     cve_ids = {v.id for v in vulns}
     assert "CVE-2024-HASH" in cve_ids, (
-        "CVE with unparseable fixed version (git hash) was silently dropped; "
-        "should be conservatively reported as affected"
+        "CVE with unparseable fixed version (git hash) was silently dropped; should be conservatively reported as affected"
     )
+
+
+def test_duplicate_sha_row_does_not_override_semver_unaffected(tmp_db):
+    """A duplicate SHA-based row must not resurrect a vuln once a semver row excludes it."""
+    _insert_vuln(tmp_db, vuln_id="CVE-2024-DUPE")
+    tmp_db.execute(
+        "INSERT OR REPLACE INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,'')",
+        ("CVE-2024-DUPE", "pypi", "requests", "0", "3bd8afbff29e50b38f889b2f688785a669b9aafc"),
+    )
+    tmp_db.execute(
+        "INSERT OR REPLACE INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,'')",
+        ("CVE-2024-DUPE", "pypi", "requests", "2.1.0", "2.6.0"),
+    )
+    tmp_db.commit()
+
+    vulns = lookup_package(tmp_db, "pypi", "requests", "2.33.0")
+    assert "CVE-2024-DUPE" not in {v.id for v in vulns}
+
+    batch = lookup_packages_batch(tmp_db, [("pypi", "requests", "2.33.0")])
+    assert "CVE-2024-DUPE" not in {v.id for v in batch[("pypi", "requests", "2.33.0")]}

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -87,7 +87,7 @@ def test_skills_scan_handles_referenced_files_outside_primary_directory(tmp_path
     docs_skill.write_text("# Guide\n\n[rules](../../security/image-exceptions.yaml)\n")
 
     runner = CliRunner()
-    result = runner.invoke(main, ["skills", "scan", str(tmp_path), "--format", "json"])
+    result = runner.invoke(main, ["skills", "scan", str(docs_skill.parent), "--format", "json"])
 
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)

--- a/tests/test_skills_parser.py
+++ b/tests/test_skills_parser.py
@@ -139,6 +139,60 @@ def test_scan_deduplicates(tmp_path):
     assert names.count("@modelcontextprotocol/server-filesystem") == 1
 
 
+def test_explicit_directory_discovery_ignores_generic_markdown(tmp_path):
+    """Explicit directory scans should not treat arbitrary repo docs as skill files."""
+    (tmp_path / "README.md").write_text("# Generic doc\n")
+    github_dir = tmp_path / ".github"
+    github_dir.mkdir()
+    (github_dir / "PULL_REQUEST_TEMPLATE.md").write_text("# PR template\n")
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "review.md").write_text("# Skill review\n")
+    (tmp_path / "CLAUDE.md").write_text("# Project instructions\n")
+
+    from agent_bom.skills_service import resolve_skill_targets
+
+    resolved = resolve_skill_targets([tmp_path], cwd=tmp_path)
+    names = sorted(path.name for path in resolved)
+
+    assert "CLAUDE.md" in names
+    assert "review.md" in names
+    assert "README.md" not in names
+    assert "PULL_REQUEST_TEMPLATE.md" not in names
+
+
+def test_explicit_directory_discovery_skips_docs_skills_examples(tmp_path):
+    docs_skill = tmp_path / "docs" / "skills" / "review.md"
+    docs_skill.parent.mkdir(parents=True)
+    docs_skill.write_text("# Example skill doc\n")
+
+    from agent_bom.skills_service import resolve_skill_targets
+
+    resolved = resolve_skill_targets([tmp_path], cwd=tmp_path)
+
+    assert docs_skill.resolve() not in resolved
+
+
+def test_explicit_directory_discovery_skips_virtualenv_and_node_modules(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text("# Project instructions\n")
+    venv_skill = tmp_path / ".venv" / "lib" / "python3.13" / "site-packages" / "pkg" / "skills" / "tool.md"
+    node_skill = tmp_path / "ui" / "node_modules" / "pkg" / "AGENTS.md"
+    venv_skill.parent.mkdir(parents=True)
+    node_skill.parent.mkdir(parents=True)
+    venv_skill.write_text("# Third-party skill\n")
+    node_skill.write_text("# Third-party agent\n")
+
+    from agent_bom.skills_service import resolve_skill_targets
+
+    resolved = resolve_skill_targets([tmp_path], cwd=tmp_path)
+    names = sorted(path.name for path in resolved)
+
+    assert "CLAUDE.md" in names
+    assert "tool.md" not in names
+    assert "AGENTS.md" not in names
+
+
 def test_parse_preserves_raw_content(tmp_path):
     """parse_skill_file stores raw text in raw_content dict."""
     md = tmp_path / "CLAUDE.md"

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -214,3 +214,10 @@ def test_version_in_range_apk():
 def test_version_in_range_rpm():
     assert version_in_range("3.0.7-24.el9", "0", "3.0.7-25.el9", None, "rpm") is True
     assert version_in_range("3.0.7-25.el9", "0", "3.0.7-25.el9", None, "rpm") is False
+
+
+def test_version_in_range_pypi_fixed_requests_regression():
+    """PyPI ranges fixed before 2.33.0 must not report that version as affected."""
+    assert version_in_range("2.33.0", None, "2.6.0", None, "pypi") is False
+    assert version_in_range("2.33.0", "2.3.0", "2.31.0", None, "pypi") is False
+    assert version_in_range("2.25.0", "2.3.0", "2.31.0", None, "pypi") is True

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.75.12' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.75.13' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.75.12"
+version = "0.75.13"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- prepare the `v0.75.13` release branch and align release-facing copy around the current product positioning
- land the remaining release-blocker fixes from the audit: narrower repo-level skills scan scope and safer local DB vulnerability row selection for duplicate SHA-based advisory ranges
- refresh release metadata, metrics, docs, diagrams, and changelog content for `0.75.13`

## Why
The release audit cleared the earlier safety and CLI blockers, but two final issues still needed to be addressed before cutting `v0.75.13`:
- repo-level `skills scan .` was sweeping generic docs and third-party artifacts, which made the output noisy and misleading
- duplicate advisory rows with git-SHA fix bounds could keep a package marked vulnerable even when a sibling semver row already proved the installed version was unaffected

This branch tightens those behaviors and brings the release surfaces into sync with the current product story.

## User Impact
- `skills scan .` behaves sanely on large repos and focuses on real instruction/skill surfaces
- local DB lookups stay conservative for ambiguous advisory rows, but no longer let duplicate SHA-only rows override a semver-unaffected package version
- the release surfaces consistently describe agent-bom as:
  - `Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.`
- docs, diagrams, metrics, and changelog are aligned for `v0.75.13`

## Validation
- `UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_skills_parser.py tests/test_skills_cli.py tests/test_batch_db_lookup.py tests/test_version_utils.py tests/test_cli_check.py`
- `UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_check.py tests/test_skills_cli.py tests/test_skill_bundles.py tests/test_cli_history.py tests/test_mcp_tool_impls.py tests/test_runtime_detectors.py tests/test_proxy.py tests/test_proxy_configure.py`
- `UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped`
- `UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python scripts/check_release_consistency.py`
- release commit hooks: `ruff`, `ruff-format`, `mypy`, and `bandit` all passed on `bd68bf9c`

## Notes
- historical snapshot docs keep historical counts by design; current-state docs and diagrams were updated to reflect the current 15-framework surface
- the remaining untracked local files (`node_modules/`, demo outputs, and local artifacts) are not part of this PR