### PR TITLE
fix(mcp): shorten registry description for schema validation

### DIFF
--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msaad00/agent-bom",
-  "description": "Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.",
+  "description": "Open security scanner for agents, MCP, packages, cloud, and runtime.",
   "title": "agent-bom",
   "version": "0.75.13",
   "repository": {


### PR DESCRIPTION
## Summary
- shorten the MCP registry `server.json` description so it satisfies the registry validator's `description` length limit

## Why
`Publish to MCP Registry` is failing on `main` with HTTP `422` during `server.json` validation. The live validator response is:

- `body.description`: `expected length <= 100`

The previous description matched the broader release copy, but it exceeds the MCP registry schema limit.

## Validation
- confirmed current failure with the live validator returning HTTP `422`
- updated `integrations/mcp-registry/server.json` to a schema-safe description (`68` chars)
- revalidated against `https://registry.modelcontextprotocol.io/v0.1/validate`
- result: HTTP `200`

## Impact
- clears the post-release mainline regression tracked in #1180
- keeps the broader release copy unchanged on GitHub, Docker, and docs while using a registry-safe short description for the MCP registry surface