### PR TITLE
docs(mcp): expand first-class client integration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ The proxy inspects MCP JSON-RPC traffic with drift, credential, argument, respon
 
 Guides:
 
+- [Major MCP client guides](docs/MCP_CLIENT_GUIDES.md)
 - [Claude Desktop / Claude Code](docs/CLAUDE_INTEGRATION.md)
 - [Cortex CoCo / Cortex Code](docs/CORTEX_CODE.md)
+- [Codex CLI](docs/CODEX_CLI.md)
 - [MCP server mode](docs/MCP_SERVER.md)
 - [Runtime proxy and monitoring](docs/RUNTIME_MONITORING.md)
 

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -10,6 +10,12 @@ This guide covers the full `agent-bom` flow for Anthropic clients:
 
 ### Claude Desktop
 
+Config paths:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+- Windows: `~/AppData/Roaming/Claude/claude_desktop_config.json`
+
 Add to your `claude_desktop_config.json`:
 
 ```json
@@ -37,6 +43,11 @@ If you prefer not to install globally, use `uvx` instead:
 ```
 
 ### Claude Code
+
+Config paths discovered by `agent-bom`:
+
+- `~/.claude/settings.json`
+- `~/.claude.json`
 
 The quickest path is:
 
@@ -96,8 +107,14 @@ The proxy adds runtime inspection for:
 
 For cross-agent correlation across sessions, use the broader runtime protection engine with `agent-bom runtime protect --shield`.
 
+## When to use MCP server vs proxy
+
+- Use `agent-bom mcp server` when you want Claude to call the scanner directly.
+- Use `agent-bom proxy` when Claude should keep talking to a third-party MCP server, but you want inline runtime inspection and policy enforcement around that traffic.
+- Use `agent-bom proxy-configure --apply` when you want to auto-wrap JSON-configured stdio servers in supported Claude config files.
+
 ## Notes
 
 - `agent-bom` is read-only in MCP server mode.
 - Proxy mode is opt-in and wraps the target server command; it does not modify the server itself.
-- Use [MCP_SERVER.md](MCP_SERVER.md) for the full MCP tool catalog and [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) for deployment and policy details.
+- Use [MCP_CLIENT_GUIDES.md](MCP_CLIENT_GUIDES.md) for the broader MCP client matrix, [MCP_SERVER.md](MCP_SERVER.md) for the full MCP tool catalog, and [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) for deployment and policy details.

--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -1,0 +1,76 @@
+# Codex CLI Integration
+
+This guide covers `agent-bom` with OpenAI Codex CLI and other Codex-oriented local setups that use `~/.codex/config.toml`.
+
+## Use agent-bom as an MCP server
+
+Add this to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.agent-bom]
+command = "uvx"
+args = ["agent-bom", "mcp", "server"]
+```
+
+If `agent-bom` is already installed locally:
+
+```toml
+[mcp_servers.agent-bom]
+command = "agent-bom"
+args = ["mcp", "server"]
+```
+
+That makes the same 36 read-only `agent-bom` MCP tools available to Codex.
+
+## What agent-bom discovers for Codex
+
+`agent-bom agents` already discovers Codex MCP servers from:
+
+- macOS: `~/.codex/config.toml`
+- Linux: `~/.codex/config.toml`
+- Windows: `~/.codex/config.toml`
+
+Codex TOML configs can include:
+
+- stdio MCP servers with `command` and `args`
+- remote MCP endpoints with `url`
+- bearer token env var references
+
+`agent-bom` parses those and redacts credential-bearing env values in output.
+
+## Scan Codex environments directly
+
+Use the CLI when you want a local audit instead of an MCP tool call:
+
+```bash
+agent-bom agents
+agent-bom agents -p .
+agent-bom mcp inventory
+```
+
+## Runtime proxy for Codex-connected MCP servers
+
+Codex uses TOML, so `agent-bom proxy-configure` does not auto-rewrite the config today. Wrap the target server manually:
+
+```toml
+[mcp_servers.filesystem]
+command = "agent-bom"
+args = ["proxy", "--log", "~/.agent-bom/logs/filesystem.jsonl", "--", "npx", "@modelcontextprotocol/server-filesystem", "/workspace"]
+```
+
+That gives you:
+
+- tool drift detection
+- argument and injection checks
+- credential leak detection
+- response inspection
+- sequence and rate analysis
+
+For deeper protection workflows beyond the lighter proxy path, use the broader runtime engine documented in [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md).
+
+## Notes
+
+- `agent-bom mcp server` is read-only.
+- `agent-bom proxy` is the runtime enforcement path.
+- Codex TOML configs support both local stdio and remote URL-based MCP servers, but only stdio targets can be wrapped with the local proxy command pattern.
+- See [MCP_CLIENT_GUIDES.md](MCP_CLIENT_GUIDES.md) for the broader client matrix.

--- a/docs/CORTEX_CODE.md
+++ b/docs/CORTEX_CODE.md
@@ -8,6 +8,13 @@ This guide covers the full `agent-bom` flow for Snowflake Cortex CoCo:
 
 ## Use agent-bom as an MCP server
 
+Config files discovered by `agent-bom`:
+
+- `~/.snowflake/cortex/mcp.json`
+- `~/.snowflake/cortex/settings.json`
+- `~/.snowflake/cortex/permissions.json`
+- `~/.snowflake/cortex/hooks.json`
+
 Add to `~/.snowflake/cortex/mcp.json`:
 
 ```json
@@ -95,9 +102,15 @@ That adds runtime monitoring for:
 
 For cross-agent correlation across sessions, use the broader runtime protection engine with `agent-bom runtime protect --shield`.
 
+## When to use MCP server vs proxy
+
+- Use `agent-bom mcp server` when you want CoCo to call `agent-bom` tools directly.
+- Use `agent-bom proxy` when CoCo should keep talking to a third-party MCP server, but you want live runtime inspection around that server.
+- Use `agent-bom proxy-configure --apply` when you want to auto-wrap eligible JSON-configured stdio servers in Cortex MCP configs.
+
 ## Notes
 
 - `agent-bom` does not need write access to the target MCP server to scan it.
 - MCP server mode is read-only.
 - Proxy mode is opt-in and is the path for runtime enforcement.
-- See [MCP_SERVER.md](MCP_SERVER.md) for the MCP tool catalog and [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) for deployment details.
+- See [MCP_CLIENT_GUIDES.md](MCP_CLIENT_GUIDES.md) for the broader client matrix, [MCP_SERVER.md](MCP_SERVER.md) for the MCP tool catalog, and [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) for deployment details.

--- a/docs/MCP_CLIENT_GUIDES.md
+++ b/docs/MCP_CLIENT_GUIDES.md
@@ -1,0 +1,91 @@
+# MCP Client Guides
+
+Use this page when you want the shortest path to wiring `agent-bom` into a specific MCP-capable client.
+
+Two modes matter:
+
+- `agent-bom mcp server`: expose `agent-bom` itself as a read-only MCP tool surface
+- `agent-bom proxy`: wrap a third-party MCP server when you want runtime inspection and enforcement
+
+## Which mode to use
+
+| Goal | Use | Why |
+|------|-----|-----|
+| Ask an assistant to run `agent-bom` tools directly | `agent-bom mcp server` | Makes discovery, scan, blast-radius, compliance, and trust tools available in-chat |
+| Inspect or block live MCP traffic to another server | `agent-bom proxy` | Adds inline JSON-RPC inspection, audit logs, and policy enforcement |
+| Auto-wrap JSON-based stdio MCP configs | `agent-bom proxy-configure` | Rewrites eligible client configs so they point at the proxy wrapper |
+
+## Major clients
+
+| Client | Primary config path(s) | Recommended setup | Notes |
+|--------|-------------------------|-------------------|-------|
+| Claude Desktop | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json` Linux: `~/.config/Claude/claude_desktop_config.json` Windows: `~/AppData/Roaming/Claude/claude_desktop_config.json` | `agent-bom mcp server` or `uvx agent-bom mcp server` | Good fit for MCP server mode. Proxy wrapping works for JSON-configured stdio servers. |
+| Claude Code | `~/.claude/settings.json`, `~/.claude.json` | `claude mcp add agent-bom -- uvx agent-bom mcp server` | `agent-bom` also discovers project-level MCP servers from `~/.claude.json`. |
+| Cortex CoCo / Cortex Code | `~/.snowflake/cortex/mcp.json` plus `settings.json`, `permissions.json`, `hooks.json` in the same directory | `uvx agent-bom mcp server` in `mcp.json` | Best fit when you want both MCP discovery and Cortex-specific permission/hook audits. |
+| Cursor | macOS: `~/Library/Application Support/Cursor/User/globalStorage/cursor.mcp/mcp.json`, `~/.cursor/mcp.json` Linux: `~/.config/Cursor/User/globalStorage/cursor.mcp/mcp.json`, `~/.cursor/mcp.json` Windows: `~/AppData/Roaming/Cursor/User/globalStorage/cursor.mcp/mcp.json`, `~/.cursor/mcp.json` | `agent-bom mcp server` | Cursor uses standard JSON MCP config, so `proxy-configure` can wrap eligible stdio servers. |
+| Windsurf | macOS: `~/.windsurf/mcp.json`, `~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/mcp.json` Linux: `~/.windsurf/mcp.json` Windows: `~/.windsurf/mcp.json` | `agent-bom mcp server` | Same `mcpServers` JSON shape as Claude/Cursor. |
+| Codex CLI | `~/.codex/config.toml` on macOS, Linux, and Windows | `agent-bom mcp server` via `[mcp_servers.agent-bom]` | Codex uses TOML, not JSON. `proxy-configure` does not rewrite TOML configs; wrap manually when needed. |
+| Gemini CLI | `~/.gemini/settings.json` on macOS, Linux, and Windows | `agent-bom mcp server` | Uses standard JSON MCP config. |
+
+## Config snippets
+
+### JSON clients
+
+Claude Desktop, Cortex CoCo, Cursor, Windsurf, and Gemini CLI all use JSON MCP config shapes that look like:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "uvx",
+      "args": ["agent-bom", "mcp", "server"]
+    }
+  }
+}
+```
+
+If `agent-bom` is already installed locally, you can replace `uvx` with:
+
+```json
+{
+  "mcpServers": {
+    "agent-bom": {
+      "command": "agent-bom",
+      "args": ["mcp", "server"]
+    }
+  }
+}
+```
+
+### Codex CLI
+
+Codex CLI uses TOML:
+
+```toml
+[mcp_servers.agent-bom]
+command = "uvx"
+args = ["agent-bom", "mcp", "server"]
+```
+
+For a manual proxy-wrapped third-party server in Codex:
+
+```toml
+[mcp_servers.filesystem]
+command = "agent-bom"
+args = ["proxy", "--log", "~/.agent-bom/logs/filesystem.jsonl", "--", "npx", "@modelcontextprotocol/server-filesystem", "/workspace"]
+```
+
+## Runtime proxy notes
+
+- `agent-bom proxy` is best when the client talks to a third-party stdio server and you want runtime inspection.
+- `agent-bom proxy-configure --apply` currently targets JSON MCP configs. It is a good fit for Claude Desktop, Cursor, Windsurf, and Cortex CoCo.
+- TOML clients like Codex CLI need manual proxy wrapping today.
+- SSE / HTTP clients can still use `agent-bom mcp server --sse`, but transport auth and TLS should live at your ingress or reverse proxy.
+
+## Next steps
+
+- [Claude Desktop / Claude Code](CLAUDE_INTEGRATION.md)
+- [Cortex CoCo / Cortex Code](CORTEX_CODE.md)
+- [Codex CLI](CODEX_CLI.md)
+- [MCP server mode](MCP_SERVER.md)
+- [Runtime monitoring and proxy](RUNTIME_MONITORING.md)

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -6,8 +6,10 @@ checks, and supply chain verification through natural conversation.
 
 See also:
 
+- [MCP client guides](MCP_CLIENT_GUIDES.md)
 - [Claude Desktop / Claude Code guide](CLAUDE_INTEGRATION.md)
 - [Cortex CoCo / Cortex Code guide](CORTEX_CODE.md)
+- [Codex CLI guide](CODEX_CLI.md)
 - [Runtime Monitoring](RUNTIME_MONITORING.md)
 
 ## Quick Start
@@ -77,6 +79,24 @@ Add to your MCP settings (`.cursor/mcp.json` or equivalent):
 }
 ```
 
+agent-bom discovers these MCP client config paths directly:
+
+- Cursor: `~/Library/Application Support/Cursor/User/globalStorage/cursor.mcp/mcp.json`, `~/.cursor/mcp.json`
+- Windsurf: `~/.windsurf/mcp.json`, `~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/mcp.json`
+- VS Code: `~/Library/Application Support/Code/User/mcp.json`, plus workspace `.vscode/mcp.json`
+
+### Codex CLI
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.agent-bom]
+command = "uvx"
+args = ["agent-bom", "mcp", "server"]
+```
+
+Codex uses TOML, so manual proxy wrapping is the right path when you want runtime inspection around a third-party server.
+
 ### SSE Transport (Remote / Multi-Client)
 
 ```bash
@@ -111,6 +131,8 @@ agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials
 ```
 
 Add `--apply` to write the wrapped config back to compatible JSON MCP config files.
+
+`proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
 ## Tool Categories (36 tools)
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -76,8 +76,10 @@ When comparing the product, prefer language like:
 
 - [README](../README.md)
 - [Product metrics](PRODUCT_METRICS.md)
+- [Major MCP client guides](MCP_CLIENT_GUIDES.md)
 - [Claude Desktop / Claude Code integration](CLAUDE_INTEGRATION.md)
 - [Cortex CoCo / Cortex Code integration](CORTEX_CODE.md)
+- [Codex CLI integration](CODEX_CLI.md)
 - [MCP server mode](MCP_SERVER.md)
 - [Runtime monitoring and proxy](RUNTIME_MONITORING.md)
 - [MCP security model](MCP_SECURITY_MODEL.md)


### PR DESCRIPTION
## Summary
- add a major-client MCP guide that explains when to use `agent-bom mcp server`, `agent-bom proxy`, and `agent-bom proxy-configure`
- add a dedicated Codex CLI integration guide covering TOML config and manual proxy wrapping
- tighten the existing Claude, Cortex, README, MCP server, and product brief references so the MCP integration story is coherent across current docs

## Why
The MCP surface is already wired in code, but the adoption gap is still documentation friction. The discovery engine already knows the real config paths for Claude, Cursor, Windsurf, Cortex, Codex, and Gemini. This patch turns that into first-class setup guidance instead of scattering the story across a few partial docs.

## What changed
- new [docs/MCP_CLIENT_GUIDES.md](docs/MCP_CLIENT_GUIDES.md)
- new [docs/CODEX_CLI.md](docs/CODEX_CLI.md)
- updated [docs/CLAUDE_INTEGRATION.md](docs/CLAUDE_INTEGRATION.md)
- updated [docs/CORTEX_CODE.md](docs/CORTEX_CODE.md)
- updated [docs/MCP_SERVER.md](docs/MCP_SERVER.md)
- updated [README.md](README.md)
- updated [docs/PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md)

## Impact
- clearer per-client config paths across macOS, Linux, and Windows
- explicit guidance on MCP server mode vs runtime proxy mode
- Codex CLI is now a first-class documented path instead of an implied discovery surface
- current docs now point to one major-client matrix instead of making users stitch the path together themselves

## Validation
- docs-only patch
- content grounded in the current discovery paths from `src/agent_bom/discovery/__init__.py` and `src/agent_bom/discovery/config_parsers.py`