### PR TITLE
chore: tighten audit-driven docs and config hygiene

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,7 +352,7 @@ jobs:
           done
 
       - name: Upload provenance artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: slsa-provenance
           path: provenance/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Next.js Insights page** (`/insights`) — SupplyChainTreemap, BlastRadiusRadial, PipelineFlow, EpssVsCvssChart, VulnTrendChart wired to real scan data; treemap cells are clickable and drill down to `/vulns`
+- **Gateway enforcement chart** — audit tab shows stacked bar of blocked/alerted/allowed actions per tool
+- **Governance findings chart** — stacked bar of finding severity by governance category
+- **Activity query chart** — bar chart of agent query pattern frequency
+- **Fleet lifecycle chart** — bar chart of agents by lifecycle state
+- **Jobs status donut** — pie chart summarising job queue by status
+- **`ui/components/empty-state.tsx`** — reusable `EmptyState` + `ErrorBanner` components used across pages
+- **Retry buttons** — Activity and Governance error states now include a Retry button
+- **SECURITY.md** expanded — response SLA, known limitations, API security model, disclosure timeline
+- **PR template** — added Related Issues, TypeScript check, breaking changes, checklist sections
+- **pre-commit hooks** — added `check-yaml`, `check-json`, `check-toml`, `end-of-file-fixer`, `trailing-whitespace`, `detect-private-key`, `check-merge-conflict`, `mixed-line-ending`
+- **`agent-bom mcp scan`** — focused MCP server package audit path for pre-install checks
+- **Compliance narrative CLI** — auditor-facing narrative export from saved scan reports via `agent-bom report compliance-narrative`
+
+### Fixed
+- **JSON report import** — file upload now validates size (10 MB), schema, prototype-pollution keys, and finite numeric values before use (`ui/lib/validators.ts`)
+- **`generated_at` TypeScript error** — `ScanResult` does not have `generated_at`; use `scan_timestamp` instead
+- **JetBrains claim** — removed from active integrations; filed as issue #412 for proper implementation
+- **`skills scan` path handling** — bundle identity now supports referenced files outside the primary file directory, fixing repo-local scans against shared security assets
+- **`check` ecosystem ambiguity** — pre-install checks now fail closed on genuinely ambiguous package names and use version-aware registry detection to avoid cross-registry false positives
+- **`skills scan --verbose`** — added parity with other CLI surfaces for easier debugging
+- **Runtime CLI warning noise** — async proxy tests now use async-aware mocks, removing unawaited coroutine warnings from that path
+
+### Security
+- **JSON file upload** — `ui/lib/validators.ts` guards against DoS via oversized files, prototype pollution, and schema-invalid payloads (no new npm dependencies)
+
+---
+
 ## [0.75.13] – 2026-04-01
 
 ### Added
@@ -251,43 +282,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **CI self-scan gap**: added `agent-bom scan --os-packages` inside built Docker image to catch base-image CVEs (glibc, sqlite3, dpkg) that Docker Hub found but CI missed (#931)
 - **Alpine CI image**: pinned `python:3.12-alpine` by SHA256 digest (#929)
 - **Glama Dockerfile**: added missing HEALTHCHECK (#929)
-- **Container rescan**: weekly Trivy scan escalated from informational to exit-code 1 with warning annotation (#931)
+- **Container rescan**: weekly container image rescan escalated from informational to exit-code 1 with warning annotation (#931)
 - **action.yml**: shortened description to 91 chars (was 141, GitHub Marketplace truncates at 125) (#933)
 
 ### Added
 - **CMMC 2.0 in REST API**: wired 17 CMMC practices into `/v1/compliance` endpoint — 14 frameworks now accessible via API (#933)
 - **Sync HTTP client**: `create_sync_client()`, `sync_request_with_retry()`, `fetch_bytes()`, `fetch_json()` in `http_client.py` (#932)
-
-## [Unreleased]
-
-### Added
-- **Next.js Insights page** (`/insights`) — SupplyChainTreemap, BlastRadiusRadial, PipelineFlow, EpssVsCvssChart, VulnTrendChart wired to real scan data; treemap cells are clickable and drill down to `/vulns`
-- **Gateway enforcement chart** — audit tab shows stacked bar of blocked/alerted/allowed actions per tool
-- **Governance findings chart** — stacked bar of finding severity by governance category
-- **Activity query chart** — bar chart of agent query pattern frequency
-- **Fleet lifecycle chart** — bar chart of agents by lifecycle state
-- **Jobs status donut** — pie chart summarising job queue by status
-- **`ui/components/empty-state.tsx`** — reusable `EmptyState` + `ErrorBanner` components used across pages
-- **Retry buttons** — Activity and Governance error states now include a Retry button
-- **SECURITY.md** expanded — response SLA, known limitations, API security model, disclosure timeline
-- **PR template** — added Related Issues, TypeScript check, breaking changes, checklist sections
-- **pre-commit hooks** — added `check-yaml`, `check-json`, `check-toml`, `end-of-file-fixer`, `trailing-whitespace`, `detect-private-key`, `check-merge-conflict`, `mixed-line-ending`
-- **`agent-bom mcp scan`** — focused MCP server package audit path for pre-install checks
-- **Compliance narrative CLI** — auditor-facing narrative export from saved scan reports via `agent-bom report compliance-narrative`
-
-### Fixed
-- **JSON report import** — file upload now validates size (10 MB), schema, prototype-pollution keys, and finite numeric values before use (`ui/lib/validators.ts`)
-- **`generated_at` TypeScript error** — `ScanResult` does not have `generated_at`; use `scan_timestamp` instead
-- **JetBrains claim** — removed from active integrations; filed as issue #412 for proper implementation
-- **`skills scan` path handling** — bundle identity now supports referenced files outside the primary file directory, fixing repo-local scans against shared security assets
-- **`check` ecosystem ambiguity** — pre-install checks now fail closed on genuinely ambiguous package names and use version-aware registry detection to avoid cross-registry false positives
-- **`skills scan --verbose`** — added parity with other CLI surfaces for easier debugging
-- **Runtime CLI warning noise** — async proxy tests now use async-aware mocks, removing unawaited coroutine warnings from that path
-
-### Security
-- **JSON file upload** — `ui/lib/validators.ts` guards against DoS via oversized files, prototype pollution, and schema-invalid payloads (no new npm dependencies)
-
----
 
 ## [0.71.2] – 2026-03-16
 
@@ -320,7 +320,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Nebius pagination** — cursor-based pagination with `nextPageToken`/`next_page_token` wired into all 3 discovery functions
 - **Post-merge self-scan** — GitHub Actions workflow scans agent-bom with agent-bom on every merge; blocks release on critical CVE (#648)
 - **Two-tier severity gate** — `--warn-on` for CI warning gates, `--fail-on-severity` for hard failures (#625)
-- **Trivy/Grype/Syft ingestion** — import external scanner JSON output with blast radius enrichment (#624)
+- **External scanner JSON ingestion** — import supported scanner JSON output with blast radius enrichment (#624)
 - **Delta scanning** — `--delta` flag reports only new findings since last scan; exit code based on new-only (#630)
 - **Local embedded vulnerability database** — SQLite schema, OSV/EPSS/KEV sync, fast lookup (#631)
 - **Bun, NuGet (.NET), pip-compile parsers** (#660)
@@ -366,7 +366,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 - **Update notifications** — background daemon thread checks PyPI on startup, 24-hour file cache at `~/.cache/agent-bom/`, non-blocking notice shown on clean exit.
-- **Improved `--version` output** — shows Python version, platform, Syft/Grype install status.
+- **Improved `--version` output** — shows Python version, platform, and external scanner install status.
 - **Better first-run UX** — zero-config scan shows actionable quick-start commands.
 
 ### Changed
@@ -447,6 +447,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.75.13...HEAD
+[0.75.13]: https://github.com/msaad00/agent-bom/compare/v0.75.12...v0.75.13
+[0.75.12]: https://github.com/msaad00/agent-bom/compare/v0.75.0...v0.75.12
+[0.75.0]: https://github.com/msaad00/agent-bom/compare/v0.72.0...v0.75.0
+[0.72.0]: https://github.com/msaad00/agent-bom/compare/v0.71.4...v0.72.0
+[0.71.4]: https://github.com/msaad00/agent-bom/compare/v0.71.3...v0.71.4
+[0.71.3]: https://github.com/msaad00/agent-bom/compare/v0.71.2...v0.71.3
+[0.71.2]: https://github.com/msaad00/agent-bom/compare/v0.71.1...v0.71.2
+[0.71.1]: https://github.com/msaad00/agent-bom/compare/v0.70.4...v0.71.1
+[0.70.4]: https://github.com/msaad00/agent-bom/compare/v0.60.1...v0.70.4
 [0.60.1]: https://github.com/msaad00/agent-bom/compare/v0.60.0...v0.60.1
 [0.60.0]: https://github.com/msaad00/agent-bom/compare/v0.59.3...v0.60.0
 [0.59.3]: https://github.com/msaad00/agent-bom/compare/v0.59.2...v0.59.3

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Every finding is tagged with mapped control coverage across 14 surfaced complian
 | OWASP LLM Top 10 | 10 mapped categories |
 | OWASP MCP Top 10 | 10 mapped categories |
 | OWASP Agentic Top 10 | 10 mapped categories |
+| OWASP AISVS v1.0 | 9 mapped checks |
 | MITRE ATLAS | 65 mapped techniques |
 | NIST AI RMF 1.0 | 14 mapped subcategories |
 | NIST CSF 2.0 | 14 mapped categories |
@@ -281,7 +282,7 @@ docker run --rm agentbom/agent-bom agents    # Docker
 
 ### CI/CD in 60 seconds
 
-Use the GitHub Action when you want Trivy-style adoption: one step, one gate, SARIF in the Security tab, and a clean exit code for CI.
+Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in the Security tab, and a clean exit code for CI.
 
 **Repo + MCP + instruction files**
 

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -40,7 +40,7 @@ metadata:
       https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/security.py#L159
     optional_env:
       - name: SNYK_TOKEN
-        purpose: "Snyk vulnerability enrichment for code_scan (optional)"
+        purpose: "Optional third-party vulnerability enrichment for code_scan (requires SNYK_TOKEN)"
         required: false
       - name: AWS_PROFILE
         purpose: "AWS CIS benchmark checks — uses boto3 with local AWS profile"
@@ -174,7 +174,7 @@ metadata:
         purpose: "GitHub Security Advisories — supplemental CVE lookup"
         auth: false
       - url: "https://api.snyk.io"
-        purpose: "Snyk vulnerability enrichment for code_scan (requires SNYK_TOKEN)"
+        purpose: "Optional third-party vulnerability enrichment for code_scan (requires SNYK_TOKEN)"
         auth: true
       - url: "https://*.amazonaws.com"
         purpose: "AWS CIS benchmark checks — read-only API calls (optional, user-initiated)"
@@ -226,7 +226,7 @@ agent-bom where             # show all discovery paths
   "mcpServers": {
     "agent-bom": {
       "command": "uvx",
-      "args": ["agent-bom", "mcp"]
+      "args": ["agent-bom", "mcp", "server"]
     }
   }
 }
@@ -245,7 +245,7 @@ agent-bom where             # show all discovery paths
 | [analyze](analyze/SKILL.md) | Blast radius, attack paths, context graph | "blast radius", "threat intel", "attack path" |
 | [troubleshoot](troubleshoot/SKILL.md) | Diagnostics, doctor, config validation | "doctor", "debug", "why failing", "validate config" |
 
-## Tools (33)
+## Tools
 
 ### Vulnerability Scanning
 | Tool | Description |

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6040
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -29,7 +29,7 @@ metadata:
     credential_policy: "Zero credentials required. Registry data is bundled locally. No network calls needed."
     optional_env:
       - name: SNYK_TOKEN
-        purpose: "Snyk vulnerability enrichment for code_scan (optional)"
+        purpose: "Optional third-party vulnerability enrichment for code_scan (requires SNYK_TOKEN)"
         required: false
     optional_bins:
       - semgrep
@@ -47,7 +47,7 @@ metadata:
     file_writes: []
     network_endpoints:
       - url: "https://api.snyk.io"
-        purpose: "Snyk vulnerability enrichment for code_scan (requires SNYK_TOKEN)"
+        purpose: "Optional third-party vulnerability enrichment for code_scan (requires SNYK_TOKEN)"
         auth: true
     telemetry: false
     persistence: false

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6040
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom
@@ -142,7 +142,7 @@ agent-bom where              # show all discovery paths
   "mcpServers": {
     "agent-bom": {
       "command": "uvx",
-      "args": ["agent-bom", "mcp"]
+      "args": ["agent-bom", "mcp", "server"]
     }
   }
 }

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   source: https://github.com/msaad00/agent-bom
   pypi: https://pypi.org/project/agent-bom/
   scorecard: https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom
-  tests: 6533
+  tests: 7108
   install:
     pipx: agent-bom
     pip: agent-bom

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -77,23 +77,3 @@ reason = "Flask session cookie disclosure — fixed in 2.3.8, our locked version
 [[IgnoredVulns]]
 id = "PYSEC-2023-62"
 reason = "Flask alias (GHSA-m2qf-hxjv-5gpq) — fixed in 3.1.3"
-
-# ── pyopenssl — blocked by snowflake-connector-python <26.0.0 cap ────────────
-
-[[IgnoredVulns]]
-id = "GHSA-5pwr-322w-8jr4"
-reason = """
-pyopenssl vulnerability (fixed in pyopenssl>=26.0.0).
-BLOCKER: snowflake-connector-python requires pyopenssl<26.0.0.
-NOT DIRECTLY EXPLOITABLE: agent-bom does not use the affected code paths.
-Tracked: https://github.com/msaad00/agent-bom/issues/930
-"""
-
-[[IgnoredVulns]]
-id = "GHSA-vp96-hxj8-p424"
-reason = """
-pyopenssl vulnerability (fixed in pyopenssl>=26.0.0).
-BLOCKER: snowflake-connector-python requires pyopenssl<26.0.0.
-NOT DIRECTLY EXPLOITABLE: agent-bom does not use the affected code paths.
-Tracked: https://github.com/msaad00/agent-bom/issues/930
-"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,7 @@ dependencies = [
     # nltk is not imported by agent-bom. Keeping it added 3 CVEs to Docker images.
     "pyjwt>=2.12.0",  # CVE-2026-32597 (crit header bypass) — transitive via auth
     "tornado>=6.5.5",  # CVE-2026-31958 (multipart DoS), GHSA-78cv-mqj4-43f7 (cookie injection) — transitive via streamlit
-    # NOTE: pyopenssl (transitive via snowflake[cloud] extra) — GHSA-68rp-wp8r-4726, GHSA-5pwr-322w-8jr4,
-    # GHSA-vp96-hxj8-p424 — all fixed in pyopenssl>=26.0.0, but snowflake-connector-python requires pyopenssl<26.0.0.
-    # Cannot upgrade until upstream drops that cap. Not exploitable: agent-bom does not use affected pyopenssl paths.
+    # NOTE: stale pyopenssl suppressions were retired after snowflake-connector-python moved to a compatible range.
     # Tracked: https://github.com/msaad00/agent-bom/issues/930
 ]
 


### PR DESCRIPTION
## Summary
- fix current docs and integration drift surfaced in the v0.75.13 audit
- correct OpenClaw MCP server args and stale metadata counts
- clean changelog/release metadata and remove stale pyopenssl suppressions

## Testing
- python3 - <<'PY'
import tomllib
for path in ['pyproject.toml','osv-scanner.toml']:
    with open(path,'rb') as f:
        tomllib.load(f)
    print(path)
PY
- UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest --collect-only -q | tail -1
- targeted grep for the stale audit strings after patching
