### PR TITLE
fix: resolve remaining v0.75.13 audit findings

### DIFF
--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -211,7 +211,7 @@ Modules with no test file (functionality tested indirectly via integration tests
 | `atlas.py` | LOW | Compliance tagger; simple mapping logic |
 | `github_actions.py` | LOW | GHA discovery; tested in integration test |
 | `terraform.py` | LOW | Terraform IaC parsing |
-| `image.py` | MEDIUM | Container image scanning via Grype/Syft |
+| `image.py` | MEDIUM | Container image scanning via external scanners |
 | `integrity.py` | MEDIUM | Package integrity + SLSA |
 | `transitive.py` | LOW | Transitive dep resolution |
 | `config.py` | LOW | Config constants with env var overrides |
@@ -243,14 +243,14 @@ Input Sources
 ├── Local MCP configs (30 client types)
 ├── Cloud providers (12: AWS, Azure, GCP, Snowflake, Databricks, CoreWeave,
 │   Nebius, HuggingFace, W&B, MLflow, OpenAI, Ollama)
-├── Container images (--image, via Syft/Grype)
-├── Filesystem/VM snapshots (--scan-dir, via Syft)
+├── Container images (--image, via external scanners)
+├── Filesystem/VM snapshots (--scan-dir, via SBOM extraction)
 ├── SBOM files (--sbom, CycloneDX/SPDX)
 ├── IaC (--tf-dir Terraform, --gha GitHub Actions)
 └── SAST (--code Semgrep, 52 CWEs)
         |
         v
-Package Extraction (agent-bom owns this for MCP/cloud; Syft for images/fs)
+Package Extraction (agent-bom owns this for MCP/cloud; external scanners for images/fs)
         |
         v
 Vulnerability Scanning
@@ -410,7 +410,7 @@ ScanRequest → _run_scan_sync() [ThreadPoolExecutor]
     ├── discovery/     MCP client config → list of servers + packages
     ├── cloud/         Cloud provider APIs → list of agents + packages
     ├── sbom.py        SBOM ingest (CycloneDX/SPDX) → packages
-    ├── image.py       Syft/Grype → packages + CVEs
+    ├── image.py       Container scanners → packages + CVEs
     ├── sast.py        Semgrep → CWE findings
     ├── integrity.py   SLSA + package integrity
     └── transitive.py  Transitive dependency resolution

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,30 +2,11 @@
 
 ## 🎯 Overview
 
-agent-bom is designed to scale from local CLI usage to enterprise-wide AI infrastructure scanning, similar to how Syft/Grype work for SBOM generation and vulnerability scanning. This document explains deployment patterns, containerization, CI/CD integration, and cloud-native architectures.
+agent-bom is designed to scale from local CLI usage to enterprise-wide AI infrastructure scanning. This document explains deployment patterns, containerization, CI/CD integration, and cloud-native architectures.
 
 ---
 
-## 🏗️ Architecture Comparison: agent-bom vs Syft/Grype
-
-### How Syft/Grype Work
-
-```
-┌─────────────────────────────────────────┐
-│  Syft (SBOM Generator)                  │
-│  ├─ Scans container images              │
-│  ├─ Scans filesystems                   │
-│  ├─ Scans directories                   │
-│  └─ Outputs SBOM (CycloneDX/SPDX)      │
-└─────────────────────────────────────────┘
-              ↓
-┌─────────────────────────────────────────┐
-│  Grype (Vulnerability Scanner)          │
-│  ├─ Consumes SBOM                       │
-│  ├─ Matches packages to CVEs            │
-│  └─ Outputs vulnerability report        │
-└─────────────────────────────────────────┘
-```
+## 🏗️ Architecture Overview
 
 ### How agent-bom Works
 
@@ -64,7 +45,7 @@ agent-bom agents --enrich --output report.json
 
 ---
 
-### 2. Docker Container (Similar to Syft)
+### 2. Docker Container
 
 **Use case**: CI/CD pipelines, reproducible scans, air-gapped environments
 
@@ -717,19 +698,19 @@ def scan_with_audit(user, target):
 
 ---
 
-## 📋 Comparison: agent-bom vs Other Tools
+## 📋 Key Capabilities
 
-| Feature | agent-bom | Syft | Grype | Snyk | Wiz |
-|---------|-----------|------|-------|------|-----|
-| AI agent config discovery | ✅ (30 MCP clients) | ❌ | ❌ | ❌ | ❌ |
-| MCP server support | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Transitive deps | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Blast radius (AI-specific) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| EPSS/KEV enrichment | ✅ | ❌ | ❌ | ✅ | ✅ |
-| Container scanning | ✅ (via Grype/Syft) | ✅ | ✅ | ✅ | ✅ |
-| Cloud API scanning | ✅ (AWS, Azure, GCP, Snowflake, Databricks) | ❌ | ❌ | ✅ | ✅ |
-| Open source | ✅ | ✅ | ✅ | ❌ | ❌ |
-| CycloneDX output | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Feature | agent-bom |
+|---------|-----------|
+| AI agent config discovery | ✅ (30 MCP clients) |
+| MCP server support | ✅ |
+| Transitive deps | ✅ |
+| Blast radius (AI-specific) | ✅ |
+| EPSS/KEV enrichment | ✅ |
+| Container scanning | ✅ |
+| Cloud API scanning | ✅ (AWS, Azure, GCP, Snowflake, Databricks) |
+| Open source | ✅ |
+| CycloneDX output | ✅ |
 
 ---
 

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -17,7 +17,7 @@ agent-bom is built on four security principles:
 
 ### 1. CI/CD Pipeline — scan on every PR
 
-Start with the same adoption pattern teams expect from Trivy or Grype: a single CI step that fails on policy, uploads SARIF, and produces artifacts security teams can review.
+Start with a familiar adoption pattern: a single CI step that fails on policy, uploads SARIF, and produces artifacts security teams can review.
 
 ```yaml
 # GitHub Actions

--- a/docs/GOLDEN_IMAGE_PROGRAM.md
+++ b/docs/GOLDEN_IMAGE_PROGRAM.md
@@ -40,7 +40,7 @@ We separate image roles so the most visible public image stays the cleanest:
 Each promoted base and each public product image should pass:
 
 - native `agent-bom image`
-- Trivy
+- Container vulnerability scanner
 - Docker Scout
 - architecture-specific smoke tests
 - package extraction sanity checks

--- a/docs/IMAGE_SECURITY.md
+++ b/docs/IMAGE_SECURITY.md
@@ -19,7 +19,7 @@ Every public runtime image must:
 The release pipeline currently enforces:
 
 - `agent-bom` self-scan gate
-- Trivy image scan gate
+- Container image scan gate
 - Docker image smoke test
 - SBOM generation
 - Sigstore signing for Python distributions

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -14,7 +14,7 @@ agent-bom reads only what you explicitly ask it to scan:
 | Agent configs | auto-discovery or `--project` | Config JSON/YAML files (e.g. `claude_desktop_config.json`) |
 | Inventory | `--inventory` | Your inventory JSON file |
 | Lock files | inferred from project | `package-lock.json`, `requirements.txt`, `Cargo.lock`, etc. |
-| Docker images | `--image` | Image filesystem layers (via Grype/Syft subprocess) |
+| Docker images | `--image` | Image filesystem layers (via container inspection subprocess) |
 | Kubernetes | `--k8s` | Pod specs via `kubectl get pods -o json` (read-only) |
 | Terraform | `--tf-dir` | `.tf` source files (no state files, no `.tfvars`) |
 | GitHub Actions | `--gha` | `.github/workflows/*.yml` files |

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -84,10 +84,10 @@ For cross-agent correlation and the broader 8-detector protection engine, run `a
 | **pip-audit** | Python dependency vulnerabilities | Every PR |
 | **npm audit** | npm dependency vulnerabilities (ui/) | Every PR |
 | **OSV Scanner** | Lockfile vulnerability scanning | Every PR |
-| **Trivy** | Filesystem vulnerability scanning (HIGH/CRITICAL) | Every PR |
+| **Container scanner** | Filesystem vulnerability scanning (HIGH/CRITICAL) | Every PR |
 | **ClusterFuzzLite** | Fuzz testing (crash/OOM/timeout detection) | Every PR |
 | **Self-scan** | agent-bom scanning its own dependencies | Every release |
-| **Container rescan** | Weekly Trivy scan of Docker images (amd64 + arm64) | Weekly cron |
+| **Container rescan** | Weekly container scan of Docker images (amd64 + arm64) | Weekly cron |
 | **Dependency review** | License + vulnerability check on new deps | Every PR |
 
 ### What a Formal Pentest Should Cover

--- a/docs/WINDOWS_CONTAINERS.md
+++ b/docs/WINDOWS_CONTAINERS.md
@@ -106,7 +106,7 @@ docker run --rm --gpus all agentbom/agent-bom agents --gpu-scan
 ## Windows containers (not supported)
 
 agent-bom does not publish Windows container (nanoserver / servercore) images.
-The scanner engine relies on Unix tooling (Syft, Grype) and Linux-native
+The scanner engine relies on Unix tooling and Linux-native
 container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively

--- a/docs/images/engine-internals-dark.svg
+++ b/docs/images/engine-internals-dark.svg
@@ -45,7 +45,7 @@
 
   <rect x="38" y="198" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="216" class="mod-name">Container Scanner</text>
-  <text x="210" y="216" text-anchor="end" class="mod-sub" fill="#60a5fa">Grype/Syft</text>
+  <text x="210" y="216" text-anchor="end" class="mod-sub" fill="#60a5fa">image layers</text>
 
   <rect x="38" y="232" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="250" class="mod-name">Package Parsers</text>

--- a/docs/images/engine-internals-light.svg
+++ b/docs/images/engine-internals-light.svg
@@ -45,7 +45,7 @@
 
   <rect x="38" y="198" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="216" class="mod-name">Container Scanner</text>
-  <text x="210" y="216" text-anchor="end" class="mod-sub" fill="#2563eb">Grype/Syft</text>
+  <text x="210" y="216" text-anchor="end" class="mod-sub" fill="#2563eb">image layers</text>
 
   <rect x="38" y="232" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="250" class="mod-name">Package Parsers</text>

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -245,9 +245,9 @@
   },
   {
     "name": "ingest_external_scan",
-    "description": "Ingest Trivy, Grype, or Syft JSON scan output and return packages with blast radius analysis.",
+    "description": "Ingest external scanner JSON output and return packages with blast radius analysis.",
     "arguments": [
-      {"name": "scan_file", "type": "string", "desc": "Path to Trivy/Grype/Syft JSON output file"},
+      {"name": "scan_file", "type": "string", "desc": "Path to external scanner JSON output file"},
       {"name": "format", "type": "string", "desc": "Scanner format: trivy, grype, syft (auto-detected if omitted)"}
     ]
   }

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -403,5 +403,5 @@ provider's own APIs.
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.75.13`
-- **6,533+ tests** with CodeQL + OpenSSF Scorecard
+- **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -188,5 +188,5 @@ and confirm before any cloud API calls are made.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **6,533+ tests** with CodeQL + OpenSSF Scorecard
+- **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -113,5 +113,5 @@ as a string argument (no file system access needed).
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **6,040+ tests** with CodeQL + OpenSSF Scorecard
+- **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -90,5 +90,5 @@ ClickHouse endpoint for persistent analytics.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **6,040+ tests** with CodeQL + OpenSSF Scorecard
+- **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -217,5 +217,5 @@ agent-bom agents
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
 - **Sigstore signed**: `agent-bom verify agent-bom@0.75.13`
-- **6,533+ tests** with CodeQL + OpenSSF Scorecard
+- **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -311,7 +311,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
             f"agent-bom v{__version__} — AI infrastructure security scanner with MCP security tools. "
             "Scans packages and images for CVEs (OSV, NVD, EPSS, CISA KEV), maps blast radius "
             "from vulnerabilities to credentials and tools, generates SBOMs (CycloneDX, SPDX), "
-            "enforces security policies, and maps to 15 compliance frameworks "
+            "enforces security policies, and maps to 14 compliance frameworks"
             "(OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST AI RMF/CSF/800-53, FedRAMP, EU AI Act, ISO 27001, SOC 2). "
             "Discovers 30 MCP clients. Read-only, agentless, no credentials required."
         ),


### PR DESCRIPTION
## Summary
- Fix MCP server compliance framework count from 15 → 14 (matches README and SKILL tables)
- Update stale test counts in 5 OpenClaw SKILL verification sections (6,533/6,040 → 7,100+)
- Remove all competitor names (Trivy/Grype/Syft/Snyk) from docs, integrations, and SVG diagrams
- Replace competitive comparison table in DEPLOYMENT.md with capabilities-only table

## Files changed (17)
- `src/agent_bom/mcp_server.py` — compliance count fix
- `integrations/openclaw/{root,scan,compliance,registry,runtime}/SKILL.md` — test count updates
- `integrations/docker-mcp-registry/tools.json` — neutralize ingest tool description
- `docs/DEPLOYMENT.md` — remove comparison table, competitor references
- `docs/ENTERPRISE_DEPLOYMENT.md`, `PERMISSIONS.md`, `WINDOWS_CONTAINERS.md`, `IMAGE_SECURITY.md`, `GOLDEN_IMAGE_PROGRAM.md`, `SECURITY_ARCHITECTURE.md`, `AUDIT.md` — competitor name cleanup
- `docs/images/engine-internals-{light,dark}.svg` — replace label text

## Test plan
- [ ] All 7,100+ tests pass (pre-commit hooks passed including ruff, mypy, bandit)
- [ ] Verify `grep -rn 'Trivy\|Grype\|Syft\|Snyk' docs/ integrations/ README.md CHANGELOG.md` returns zero outside ADRs/decisions/strategic audit
- [ ] Verify MCP server instructions string says "14 compliance frameworks"