### PR TITLE
docs: clarify local UI traffic vs third-party network calls

### DIFF
--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -169,7 +169,8 @@ Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base i
 - Never cache credentials to disk
 - Never log credential values (`sanitize_error()` strips them)
 - Never require admin or write permissions
-- Never make network calls beyond explicitly listed data sources
+- Never make third-party network calls beyond explicitly listed data sources.
+  Local UI-to-API traffic is expected when using the dashboard or browser client.
 - Never install agents on target systems
 - Never store PII or secret values in scan results
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -202,8 +202,10 @@ X-Agent-Bom-Read-Only: true
 X-Agent-Bom-No-Credential-Storage: true
 ```
 
-The API server itself runs entirely in-process. No outbound connections are made
-unless a scan job explicitly requests enrichment (`"enrich": true` in the request body).
+The API server itself runs entirely in-process. It does not make third-party outbound
+connections unless a scan job explicitly requests enrichment (`"enrich": true` in the
+request body). Browser clients and local dashboards may still connect to the local
+agent-bom API over HTTP/WebSocket for normal UI operation.
 
 ---
 
@@ -260,7 +262,8 @@ agent-bom agents --snowflake --snowflake-authenticator oauth
 - Never cache credentials to disk
 - Never log credential values (sanitize_error removes them)
 - Never require admin/write permissions
-- Never make network calls beyond the explicitly listed data sources
+- Never make third-party network calls beyond the explicitly listed data sources.
+  Local UI-to-API traffic is expected when using the dashboard or browser client.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that the API server does not make third-party outbound calls unless enrichment is requested
- explicitly distinguish local dashboard/browser traffic from third-party outbound traffic
- tighten the same wording in enterprise deployment docs

## Why
Third-party heuristic scanners misread the older wording as claiming there is no local browser-to-API traffic at all. This patch makes the trust model precise without changing behavior.

Closes #1181