### PR TITLE
docs: clean low-visibility hygiene stragglers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,6 +451,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 [0.75.13]: https://github.com/msaad00/agent-bom/compare/v0.75.12...v0.75.13
 [0.75.12]: https://github.com/msaad00/agent-bom/compare/v0.75.0...v0.75.12
 [0.75.0]: https://github.com/msaad00/agent-bom/compare/v0.72.0...v0.75.0
+[0.74.1]: https://github.com/msaad00/agent-bom/compare/v0.74.0...v0.74.1
+[0.74.0]: https://github.com/msaad00/agent-bom/compare/v0.73.0...v0.74.0
+[0.73.0]: https://github.com/msaad00/agent-bom/compare/v0.72.0...v0.73.0
 [0.72.0]: https://github.com/msaad00/agent-bom/compare/v0.71.4...v0.72.0
 [0.71.4]: https://github.com/msaad00/agent-bom/compare/v0.71.3...v0.71.4
 [0.71.3]: https://github.com/msaad00/agent-bom/compare/v0.71.2...v0.71.3

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
           RESULT_FILE="agent-bom-results.sarif"
         fi
 
-        # Map scan-type to focused command (Trivy-style)
+        # Map scan-type to focused command
         #   scan  → agent-bom agents (full auto-detect, default)
         #   image → agent-bom image <ref>
         #   fs    → agent-bom fs <path>

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -154,7 +154,7 @@ AI_PACKAGES constant covers 40+ GPU/ML packages including torch, tensorflow, vll
 |-------|-----------|---------|--------|
 | `databricks` | `databricks-sdk>=0.20` | `cloud/databricks.py`, `cloud/databricks_security.py` | ✓ |
 | `coreweave` | `[]` (empty) | `kubectl` subprocess only | ✓ |
-| `snyk` | `[]` (empty) | `httpx` (already in core) | ✓ |
+| empty optional API extra | `[]` (empty) | `httpx` (already in core) | ✓ |
 | `ai-enrich` | `litellm>=1.30` | `ai_enrich.py` | ✓ |
 | `graph` | `networkx>=3.0` | `output/graph.py`, `context_graph.py` | ✓ |
 | `cloud` | meta-extra | bundles aws+azure+gcp+databricks+snowflake+nebius+huggingface+wandb+openai | ✓ |

--- a/docs/IMAGE_SECURITY.md
+++ b/docs/IMAGE_SECURITY.md
@@ -41,7 +41,7 @@ Temporary exceptions are allowed only when all of the following are true:
 
 Active image exceptions are tracked in [`security/image-exceptions.yaml`](../security/image-exceptions.yaml).
 
-`.trivyignore` remains the scanner input today, but the YAML registry is the human-reviewed source of truth for why an exception exists.
+The generated image ignore file remains the scanner input today, but the YAML registry is the human-reviewed source of truth for why an exception exists.
 
 ## Stable release bar
 
@@ -70,7 +70,7 @@ For each architecture we want:
 
 ## Near-term follow-ups
 
-- add a generated sync step from `security/image-exceptions.yaml` into `.trivyignore`
+- add a generated sync step from `security/image-exceptions.yaml` into the image scanner ignore file
 - sign and attest Docker images directly, not just Python artifacts and BuildKit attestations
 - add Docker Scout as an explicit release gate
 - add promoted golden base images per architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 authors = [
     {name = "Wagdy Saad", email = "andwgdysaad@gmail.com"}
 ]
-keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "grype", "syft", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment", "credential-exposure", "config-security", "ai-supply-chain", "ai-infrastructure", "gpu-security", "cuda", "pytorch", "openssf-scorecard", "malicious-package-detection", "runtime-monitoring", "model-provenance"]
+keywords = ["ai-bom", "sbom", "mcp", "mcp-server", "security", "ai-agents", "vulnerability", "supply-chain", "owasp", "mitre-atlas", "nist-ai-rmf", "blast-radius", "cve", "llm-security", "remediation", "mcp-introspection", "openclaw", "ai-enrichment", "credential-exposure", "config-security", "ai-supply-chain", "ai-infrastructure", "gpu-security", "cuda", "pytorch", "openssf-scorecard", "malicious-package-detection", "runtime-monitoring", "model-provenance"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary
- clean the remaining low-visibility wording and metadata stragglers from the latest audit
- neutralize scanner-specific phrasing in the action and image security docs
- add the missing changelog compare refs for `v0.73.0`, `v0.74.0`, and `v0.74.1`
- trim `grype`/`syft` from PyPI keywords

## Notes
- kept the existing `snyk` optional extra in `pyproject.toml` intact because renaming or removing it would be a behavior/API change, not a docs-only hygiene cleanup
- no runtime or product behavior changes in this PR

## Validation
- `python - <<'PY' ... tomllib.load(...)` on `pyproject.toml`
- targeted grep confirmed the flagged low-visibility strings are removed from the intended files
