### PR TITLE
perf: improve scan latency and cache hit rate across enrichment

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -64,8 +64,9 @@ from agent_bom.output import (
     to_spdx,
 )
 from agent_bom.parsers import extract_packages
+from agent_bom.resolver import consume_performance_stats as consume_resolution_performance
 from agent_bom.resolver import resolve_all_versions_sync
-from agent_bom.scanners import IncompleteScanError, consume_scan_warnings, scan_agents_sync
+from agent_bom.scanners import IncompleteScanError, consume_scan_performance, consume_scan_warnings, scan_agents_sync
 
 
 def _build_self_scan_inventory() -> dict[str, list[dict[str, object]]]:
@@ -710,6 +711,14 @@ def scan(
 
     # Create shared context object
     ctx = ScanContext(con=con)
+    try:
+        from agent_bom.resolver import reset_performance_stats as _reset_resolver_performance
+        from agent_bom.scanners import reset_scan_performance as _reset_scan_performance
+
+        _reset_resolver_performance()
+        _reset_scan_performance()
+    except Exception:
+        pass
 
     # Compute any_cloud for early no-agent check in _discovery
     any_cloud = (
@@ -1429,6 +1438,35 @@ def scan(
         scan_sources=_scan_sources,
         scan_id=_scan_id,
     )
+    _resolver_perf = consume_resolution_performance()
+    _scan_perf = consume_scan_performance()
+    _scan_perf_data = {
+        "osv": {
+            "packages_seen": _scan_perf.get("packages_seen", 0),
+            "packages_deduplicated": _scan_perf.get("packages_deduplicated", 0),
+            "cache_hits": _scan_perf.get("osv_cache_hits", 0),
+            "cache_hits_with_vulns": _scan_perf.get("osv_cache_hits_with_vulns", 0),
+            "cache_hits_clean": _scan_perf.get("osv_cache_hits_clean", 0),
+            "cache_misses": _scan_perf.get("osv_cache_misses", 0),
+            "packages_queried": _scan_perf.get("osv_packages_queried", 0),
+            "queries_sent": _scan_perf.get("osv_queries_sent", 0),
+            "batches": _scan_perf.get("osv_batches", 0),
+            "lookup_errors": _scan_perf.get("osv_lookup_errors", 0),
+            "offline_skips": _scan_perf.get("offline_skips", 0),
+            "skipped_unresolvable_versions": _scan_perf.get("skipped_unresolvable_versions", 0),
+            "skipped_non_osv_ecosystems": _scan_perf.get("skipped_non_osv_ecosystems", 0),
+            "cache_hit_rate_pct": _scan_perf.get("osv_cache_hit_rate_pct", 0),
+        },
+        "registry": _resolver_perf.get("registry_metadata", {}),
+        "version_resolution": _resolver_perf.get("version_resolution", {}),
+        "license_enrichment": _resolver_perf.get("license_enrichment", {}),
+        "supply_chain_enrichment": _resolver_perf.get("supply_chain_enrichment", {}),
+    }
+    if any(
+        isinstance(section, dict) and any(int(v) > 0 for v in section.values() if isinstance(v, int))
+        for section in _scan_perf_data.values()
+    ):
+        report.scan_performance_data = _scan_perf_data
 
     # Attach skill/trust/prompt/enforcement data from context
     if ctx.skill_audit_data:

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -33,6 +33,7 @@ from agent_bom.output import (
     print_export_hint,
     print_posture_summary,
     print_remediation_plan,
+    print_scan_performance_summary,
     print_severity_chart,
     print_summary,
     print_threat_frameworks,
@@ -128,6 +129,7 @@ def render_output(
         if verbose:
             # Full output (--verbose)
             print_summary(report)
+            print_scan_performance_summary(report)
             print_posture_summary(report)
             if not no_tree:
                 print_agent_tree(report)
@@ -139,6 +141,7 @@ def render_output(
         else:
             # Compact output (default)
             print_compact_summary(report)
+            print_scan_performance_summary(report)
             print_compact_agents(report)
             print_compact_blast_radius(report, fixable_only=fixable_only)
 

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -749,6 +749,7 @@ class AIBOMReport:
     gpu_infra_data: Optional[dict] = None  # Serialized GPU/AI compute infra scan results
     iac_findings_data: Optional[dict] = None  # Serialized IaC misconfiguration findings (set by CLI)
     runtime_correlation: Optional[dict] = None  # Runtime ↔ scan correlation (proxy audit vs CVE findings)
+    scan_performance_data: Optional[dict] = None  # Cache coverage / scan latency metadata
     training_pipelines: Optional[dict] = None  # Serialized TrainingPipelineScanResult
     dataset_cards: Optional[dict] = None  # Serialized DatasetScanResult
     serving_configs: Optional[list] = None  # Serialized ServingConfig list

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -85,7 +85,59 @@ def print_summary(report: AIBOMReport) -> None:
         if keys:
             table.add_row("Hardcoded API keys", f"[red]{keys}[/red]")
 
+    perf = report.scan_performance_data or {}
+    osv = perf.get("osv") or {}
+    registry = perf.get("registry") or {}
+    if osv:
+        hit_rate = osv.get("cache_hit_rate_pct")
+        osv_label = f"{osv.get('cache_hits', 0)} hit / {osv.get('cache_misses', 0)} miss"
+        if hit_rate is not None:
+            osv_label += f" ({hit_rate}% hit rate)"
+        table.add_row("OSV cache", osv_label)
+    if registry:
+        reg_label = f"{registry.get('cache_hits', 0)} hit / {registry.get('cache_misses', 0)} miss"
+        reg_rate = registry.get("cache_hit_rate_pct")
+        if reg_rate is not None:
+            reg_label += f" ({reg_rate}% hit rate)"
+        table.add_row("Registry cache", reg_label)
+
     console.print(table)
+
+
+def print_scan_performance_summary(report: AIBOMReport) -> None:
+    """Print a compact cache/performance summary when available."""
+    perf = report.scan_performance_data or {}
+    osv = perf.get("osv") or {}
+    registry = perf.get("registry") or {}
+    if not osv and not registry:
+        return
+
+    lines: list[str] = []
+    if osv:
+        osv_line = (
+            f"OSV cache {osv.get('cache_hits', 0)} hit / {osv.get('cache_misses', 0)} miss"
+            f" · {osv.get('packages_queried', 0)} package lookup(s)"
+        )
+        hit_rate = osv.get("cache_hit_rate_pct")
+        if hit_rate is not None:
+            osv_line += f" · {hit_rate}% hit rate"
+        if osv.get("lookup_errors", 0):
+            osv_line += f" · {osv.get('lookup_errors', 0)} lookup error(s)"
+        lines.append(osv_line)
+    if registry:
+        reg_line = (
+            f"Registry cache {registry.get('cache_hits', 0)} hit / {registry.get('cache_misses', 0)} miss"
+            f" · {registry.get('network_requests', 0)} network request(s)"
+        )
+        reg_rate = registry.get("cache_hit_rate_pct")
+        if reg_rate is not None:
+            reg_line += f" · {reg_rate}% hit rate"
+        if registry.get("npm_rate_limit_short_circuits", 0):
+            reg_line += f" · {registry.get('npm_rate_limit_short_circuits', 0)} npm cooldown skip(s)"
+        lines.append(reg_line)
+    console.print("\n[dim]Cache & lookup reuse[/dim]")
+    for line in lines:
+        console.print(f"  [dim]{line}[/dim]")
 
 
 def print_posture_summary(report: AIBOMReport) -> None:

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -716,6 +716,8 @@ def to_json(report: AIBOMReport) -> dict:
 
     if report.runtime_correlation:
         result["runtime_correlation"] = report.runtime_correlation
+    if report.scan_performance_data:
+        result["scan_performance"] = report.scan_performance_data
     if report.runtime_session_graph:
         result["runtime_session_graph"] = report.runtime_session_graph
     if mcp_runtime_diff:

--- a/src/agent_bom/resolver.py
+++ b/src/agent_bom/resolver.py
@@ -27,6 +27,94 @@ _PYPI_INFO_CACHE: dict[str, dict | None] = {}
 _NPM_RATE_LIMIT_UNTIL = 0.0
 _NPM_RATE_LIMIT_HITS = 0
 _NPM_RATE_LIMIT_MAX_COOLDOWN = 20.0
+_PERF_TEMPLATE = {
+    "registry_cache_hits": 0,
+    "registry_cache_misses": 0,
+    "registry_network_requests": 0,
+    "npm_rate_limit_events": 0,
+    "npm_rate_limit_short_circuits": 0,
+    "version_candidates": 0,
+    "version_unique_lookups": 0,
+    "version_reused_entries": 0,
+    "version_resolved_live": 0,
+    "version_resolved_fallback": 0,
+    "version_unresolved": 0,
+    "license_candidates": 0,
+    "license_unique_lookups": 0,
+    "license_reused_entries": 0,
+    "license_enriched": 0,
+    "license_deps_dev_lookups": 0,
+    "supply_chain_candidates": 0,
+    "supply_chain_unique_lookups": 0,
+    "supply_chain_reused_entries": 0,
+    "supply_chain_enriched": 0,
+    "supply_chain_deps_dev_fallbacks": 0,
+}
+_PERF_STATS = dict(_PERF_TEMPLATE)
+
+
+def reset_performance_stats() -> None:
+    """Reset per-scan resolver performance counters."""
+    _PERF_STATS.clear()
+    _PERF_STATS.update(_PERF_TEMPLATE)
+
+
+def _bump_perf(key: str, delta: int = 1) -> None:
+    _PERF_STATS[key] = int(_PERF_STATS.get(key, 0)) + delta
+
+
+def consume_performance_stats() -> dict[str, dict[str, int]]:
+    """Return and reset resolver performance counters."""
+    registry_hits = int(_PERF_STATS["registry_cache_hits"])
+    registry_misses = int(_PERF_STATS["registry_cache_misses"])
+    version_candidates = int(_PERF_STATS["version_candidates"])
+    version_reused = int(_PERF_STATS["version_reused_entries"])
+    license_candidates = int(_PERF_STATS["license_candidates"])
+    license_reused = int(_PERF_STATS["license_reused_entries"])
+    supply_candidates = int(_PERF_STATS["supply_chain_candidates"])
+    supply_reused = int(_PERF_STATS["supply_chain_reused_entries"])
+    snapshot = {
+        "registry_metadata": {
+            "cache_hits": registry_hits,
+            "cache_misses": registry_misses,
+            "network_requests": int(_PERF_STATS["registry_network_requests"]),
+            "npm_rate_limit_events": int(_PERF_STATS["npm_rate_limit_events"]),
+            "npm_rate_limit_short_circuits": int(_PERF_STATS["npm_rate_limit_short_circuits"]),
+        },
+        "version_resolution": {
+            "candidates": version_candidates,
+            "unique_lookups": int(_PERF_STATS["version_unique_lookups"]),
+            "reused_entries": version_reused,
+            "resolved_live": int(_PERF_STATS["version_resolved_live"]),
+            "resolved_fallback": int(_PERF_STATS["version_resolved_fallback"]),
+            "unresolved": int(_PERF_STATS["version_unresolved"]),
+        },
+        "license_enrichment": {
+            "candidates": license_candidates,
+            "unique_lookups": int(_PERF_STATS["license_unique_lookups"]),
+            "reused_entries": license_reused,
+            "enriched": int(_PERF_STATS["license_enriched"]),
+            "deps_dev_lookups": int(_PERF_STATS["license_deps_dev_lookups"]),
+        },
+        "supply_chain_enrichment": {
+            "candidates": supply_candidates,
+            "unique_lookups": int(_PERF_STATS["supply_chain_unique_lookups"]),
+            "reused_entries": supply_reused,
+            "enriched": int(_PERF_STATS["supply_chain_enriched"]),
+            "deps_dev_fallbacks": int(_PERF_STATS["supply_chain_deps_dev_fallbacks"]),
+        },
+    }
+    total_registry_lookups = registry_hits + registry_misses
+    if total_registry_lookups:
+        snapshot["registry_metadata"]["cache_hit_rate_pct"] = int(round((registry_hits / total_registry_lookups) * 100))
+    if version_candidates:
+        snapshot["version_resolution"]["reuse_rate_pct"] = int(round((version_reused / version_candidates) * 100))
+    if license_candidates:
+        snapshot["license_enrichment"]["reuse_rate_pct"] = int(round((license_reused / license_candidates) * 100))
+    if supply_candidates:
+        snapshot["supply_chain_enrichment"]["reuse_rate_pct"] = int(round((supply_reused / supply_candidates) * 100))
+    reset_performance_stats()
+    return snapshot
 
 
 def _apply_registry_version_fallback(pkg: Package) -> bool:
@@ -84,6 +172,7 @@ def _record_npm_rate_limit(response: httpx.Response | None) -> None:
             except ValueError:
                 wait = 5.0
     _NPM_RATE_LIMIT_HITS += 1
+    _bump_perf("npm_rate_limit_events")
     _NPM_RATE_LIMIT_UNTIL = max(_NPM_RATE_LIMIT_UNTIL, time.monotonic() + wait)
 
 
@@ -91,9 +180,13 @@ async def _get_npm_latest_doc(package_name: str, client: httpx.AsyncClient) -> d
     """Return cached npm `/latest` JSON for a package."""
     cache_key = package_name.lower()
     if cache_key in _NPM_LATEST_CACHE:
+        _bump_perf("registry_cache_hits")
         return _NPM_LATEST_CACHE[cache_key]
     if _npm_rate_limit_active():
+        _bump_perf("npm_rate_limit_short_circuits")
         return None
+    _bump_perf("registry_cache_misses")
+    _bump_perf("registry_network_requests")
 
     encoded_name = package_name.replace("/", "%2F")
     response = await request_with_retry(
@@ -120,7 +213,10 @@ async def _get_pypi_info_doc(package_name: str, client: httpx.AsyncClient) -> di
     """Return cached PyPI `info` JSON for a package."""
     cache_key = package_name.lower()
     if cache_key in _PYPI_INFO_CACHE:
+        _bump_perf("registry_cache_hits")
         return _PYPI_INFO_CACHE[cache_key]
+    _bump_perf("registry_cache_misses")
+    _bump_perf("registry_network_requests")
 
     response = await request_with_retry(
         client,
@@ -281,39 +377,59 @@ async def enrich_licenses(packages: list[Package], client: httpx.AsyncClient) ->
     need_license = [p for p in packages if not p.license and p.version not in ("latest", "unknown", "")]
     if not need_license:
         return 0
+    _bump_perf("license_candidates", len(need_license))
     count = 0
-    deps_dev_batch = []
+    registry_groups: dict[tuple[str, str], list[Package]] = defaultdict(list)
+    deps_dev_groups: dict[tuple[str, str, str], list[Package]] = defaultdict(list)
     for pkg in need_license:
-        _, lic = None, None
-        if pkg.ecosystem == "npm":
-            _, lic = await resolve_npm_metadata(pkg.name, client)
-        elif pkg.ecosystem == "pypi":
-            _, lic = await resolve_pypi_metadata(pkg.name, client)
+        eco = pkg.ecosystem.lower()
+        if eco in ("npm", "pypi"):
+            registry_groups[(eco, pkg.name.lower())].append(pkg)
         else:
-            # Queue for deps.dev fallback (go, cargo, maven, nuget)
-            deps_dev_batch.append(pkg)
-            continue
-        if lic:
-            pkg.license = lic
-            count += 1
+            deps_dev_groups[(eco, pkg.name, pkg.version)].append(pkg)
+    _bump_perf("license_unique_lookups", len(registry_groups) + len(deps_dev_groups))
+    _bump_perf("license_reused_entries", len(need_license) - len(registry_groups) - len(deps_dev_groups))
+
+    async def _resolve_registry_license(key: tuple[str, str], grouped: list[Package]) -> tuple[list[Package], str | None]:
+        eco, _name = key
+        representative = grouped[0]
+        if eco == "npm":
+            _, lic = await resolve_npm_metadata(representative.name, client)
+        else:
+            _, lic = await resolve_pypi_metadata(representative.name, client)
+        return grouped, lic
+
+    if registry_groups:
+        tasks = [_resolve_registry_license(key, grouped) for key, grouped in registry_groups.items()]
+        for grouped, lic in await asyncio.gather(*tasks):
+            if not lic:
+                continue
+            for pkg in grouped:
+                if not pkg.license:
+                    pkg.license = lic
+                    count += 1
+                    _bump_perf("license_enriched")
 
     # deps.dev fallback for non-npm/non-pypi ecosystems
-    if deps_dev_batch:
+    if deps_dev_groups:
         try:
             from agent_bom.deps_dev import get_package_info
 
-            for pkg in deps_dev_batch:
+            _bump_perf("license_deps_dev_lookups", len(deps_dev_groups))
+            for (_eco, _name, _version), grouped in deps_dev_groups.items():
+                pkg = grouped[0]
                 info = await get_package_info(pkg.ecosystem, pkg.name, pkg.version, client)
                 if info:
                     licenses = info.get("licenses", [])
                     spdx_ids = [lic for lic in licenses if isinstance(lic, str) and lic]
                     if spdx_ids:
-                        pkg.license = spdx_ids[0]
-                        if len(spdx_ids) > 1:
-                            pkg.license_expression = " AND ".join(spdx_ids)
-                        else:
-                            pkg.license_expression = spdx_ids[0]
-                        count += 1
+                        license_value = spdx_ids[0]
+                        license_expression = " AND ".join(spdx_ids) if len(spdx_ids) > 1 else spdx_ids[0]
+                        for member in grouped:
+                            member.license = license_value
+                            member.license_expression = license_expression
+                            count += 1
+                            _bump_perf("license_enriched")
         except ImportError:
             pass  # deps_dev module not available — skip gracefully
 
@@ -334,9 +450,15 @@ async def enrich_supply_chain_metadata(
     need_meta = [p for p in packages if not p.description and p.version not in ("latest", "unknown", "") and p.ecosystem in ("npm", "pypi")]
     if not need_meta:
         return 0
-
-    count = 0
+    _bump_perf("supply_chain_candidates", len(need_meta))
+    groups: dict[tuple[str, str], list[Package]] = defaultdict(list)
     for pkg in need_meta:
+        groups[(pkg.ecosystem.lower(), pkg.name.lower())].append(pkg)
+    _bump_perf("supply_chain_unique_lookups", len(groups))
+    _bump_perf("supply_chain_reused_entries", len(need_meta) - len(groups))
+    count = 0
+    for (_eco, _name), grouped in groups.items():
+        pkg = grouped[0]
         try:
             if pkg.ecosystem == "npm":
                 await resolve_npm_supply_chain(pkg, client)
@@ -349,6 +471,7 @@ async def enrich_supply_chain_metadata(
                 try:
                     from agent_bom.deps_dev import get_package_info
 
+                    _bump_perf("supply_chain_deps_dev_fallbacks")
                     info = await get_package_info(pkg.ecosystem, pkg.name, pkg.version, client)
                     if info:
                         links = info.get("links", [])
@@ -368,8 +491,22 @@ async def enrich_supply_chain_metadata(
                 except Exception:  # noqa: BLE001
                     pass
 
-            if pkg.description or pkg.homepage or pkg.repository_url:
-                count += 1
+            for peer in grouped[1:]:
+                if pkg.description and not peer.description:
+                    peer.description = pkg.description
+                if pkg.homepage and not peer.homepage:
+                    peer.homepage = pkg.homepage
+                if pkg.repository_url and not peer.repository_url:
+                    peer.repository_url = pkg.repository_url
+                if pkg.author and not peer.author:
+                    peer.author = pkg.author
+                if pkg.supplier and not peer.supplier:
+                    peer.supplier = pkg.supplier
+
+            for member in grouped:
+                if member.description or member.homepage or member.repository_url:
+                    count += 1
+                    _bump_perf("supply_chain_enriched")
         except Exception as exc:  # noqa: BLE001
             _logger.warning("Failed to enrich supply chain metadata for %s@%s: %s", pkg.name, pkg.version, exc)
             continue
@@ -392,12 +529,15 @@ async def resolve_all_versions(
     unresolved = [p for p in packages if p.version in ("latest", "unknown", "")]
     if not unresolved:
         return 0
+    _bump_perf("version_candidates", len(unresolved))
     npm_rate_limit_hits_before = _NPM_RATE_LIMIT_HITS
     resolved_count = 0
     groups: dict[tuple[str, str], list[Package]] = defaultdict(list)
     for pkg in unresolved:
         groups[_resolution_key(pkg)].append(pkg)
     representatives = [members[0] for members in groups.values()]
+    _bump_perf("version_unique_lookups", len(representatives))
+    _bump_perf("version_reused_entries", len(unresolved) - len(representatives))
     try:
         async with create_client(timeout=10.0) as client:
             npm_semaphore = asyncio.Semaphore(_NPM_RESOLVE_CONCURRENCY)
@@ -428,6 +568,10 @@ async def resolve_all_versions(
                         if _copy_resolution_fields(pkg, peer):
                             peer_resolved += 1
                     resolved_count += peer_resolved
+                    if pkg.version_source == "registry_fallback":
+                        _bump_perf("version_resolved_fallback", peer_resolved)
+                    else:
+                        _bump_perf("version_resolved_live", peer_resolved)
                     if not quiet:
                         lic_tag = ""
                         if pkg.license:
@@ -463,6 +607,7 @@ async def resolve_all_versions(
                         group_fallbacks += 1
                 if group_fallbacks:
                     resolved_count += group_fallbacks
+                    _bump_perf("version_resolved_fallback", group_fallbacks)
                     if not quiet:
                         console.print(
                             f"  [yellow]↺[/yellow] Resolved {pkg.name} → {pkg.version} "
@@ -478,6 +623,8 @@ async def resolve_all_versions(
                 console.print(f"  [green]✓[/green] Enriched {lic_count} package license(s)")
 
             unresolved_after = [p for p in unresolved if p.version in ("latest", "unknown", "")]
+            if unresolved_after:
+                _bump_perf("version_unresolved", len(unresolved_after))
             if unresolved_after and not quiet:
                 fallback_count = sum(1 for p in unresolved if p.version_source == "registry_fallback")
                 console.print(

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -54,6 +54,22 @@ _logger = logging.getLogger(__name__)
 # Also synced from http_client._OFFLINE for transport-layer enforcement.
 offline_mode: bool = False
 _scan_warnings: list[str] = []
+_SCAN_PERF_TEMPLATE = {
+    "packages_seen": 0,
+    "packages_deduplicated": 0,
+    "osv_cache_hits": 0,
+    "osv_cache_hits_with_vulns": 0,
+    "osv_cache_hits_clean": 0,
+    "osv_cache_misses": 0,
+    "osv_packages_queried": 0,
+    "osv_queries_sent": 0,
+    "osv_batches": 0,
+    "osv_lookup_errors": 0,
+    "offline_skips": 0,
+    "skipped_unresolvable_versions": 0,
+    "skipped_non_osv_ecosystems": 0,
+}
+_scan_performance: dict[str, int] = dict(_SCAN_PERF_TEMPLATE)
 
 
 class IncompleteScanError(RuntimeError):
@@ -76,6 +92,26 @@ def consume_scan_warnings() -> list[str]:
     warnings = list(_scan_warnings)
     _scan_warnings.clear()
     return warnings
+
+
+def reset_scan_performance() -> None:
+    """Clear accumulated performance counters for the next scan."""
+    _scan_performance.clear()
+    _scan_performance.update(_SCAN_PERF_TEMPLATE)
+
+
+def _bump_scan_perf(key: str, delta: int = 1) -> None:
+    _scan_performance[key] = int(_scan_performance.get(key, 0)) + delta
+
+
+def consume_scan_performance() -> dict[str, int]:
+    """Return and clear accumulated scan performance counters."""
+    snapshot = dict(_scan_performance)
+    reset_scan_performance()
+    total_cache = snapshot["osv_cache_hits"] + snapshot["osv_cache_misses"]
+    if total_cache:
+        snapshot["osv_cache_hit_rate_pct"] = int(round((snapshot["osv_cache_hits"] / total_cache) * 100))
+    return snapshot
 
 
 def set_offline_mode(value: bool) -> None:
@@ -655,6 +691,7 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
                     pkg.ecosystem,
                 )
             skipped_ecosystems[eco_key] = skipped_ecosystems.get(eco_key, 0) + 1
+            _bump_scan_perf("skipped_non_osv_ecosystems")
             continue
         if not pkg.version or pkg.version in ("unknown", "latest"):
             _logger.warning(
@@ -664,16 +701,22 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
                 pkg.version,
             )
             skipped_versions += 1
+            _bump_scan_perf("skipped_unresolvable_versions")
             continue
         norm_name = normalize_package_name(pkg.name, eco_key)
         cache_key_eco = eco_key if len(osv_ecosystems) == 1 else f"{eco_key}|{'|'.join(osv_ecosystems)}"
         if cache:
             cached = cache.get(cache_key_eco, norm_name, pkg.version)
             if cached is not None:
+                _bump_scan_perf("osv_cache_hits")
                 if cached:  # non-empty vuln list
                     key = f"{eco_key}:{norm_name}@{pkg.version}"
                     results[key] = cached
+                    _bump_scan_perf("osv_cache_hits_with_vulns")
+                else:
+                    _bump_scan_perf("osv_cache_hits_clean")
                 continue  # skip API call (cached hit or cached "clean")
+        _bump_scan_perf("osv_cache_misses")
         packages_to_query.append(pkg)
 
     if not packages_to_query:
@@ -719,6 +762,8 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
 
     if not queries:
         return await _enrich_results_if_needed(results)
+    _bump_scan_perf("osv_packages_queried", len(packages_to_query))
+    _bump_scan_perf("osv_queries_sent", len(queries))
 
     # Track which queried packages got vulns (to cache "clean" results too)
     queried_keys_with_vulns: set[str] = set()
@@ -734,11 +779,13 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         _logger.info("Offline mode: skipping OSV batch query for %d packages", len(queries))
         console.print("  [yellow]⚠[/yellow] Offline mode — CVE scanning skipped. Use local DB or remove --offline.")
         record_scan_warning("offline mode skipped remote CVE lookups")
+        _bump_scan_perf("offline_skips", len(packages_to_query))
         return results
 
     async with _client_ctx as client:
         for batch_start in range(0, len(queries), batch_size):
             batch = queries[batch_start : batch_start + batch_size]
+            _bump_scan_perf("osv_batches")
 
             async with semaphore:
                 response = await request_with_retry(
@@ -851,6 +898,7 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
         parts = ", ".join(f"{eco}: {cnt}" for eco, cnt in sorted(skipped_ecosystems.items()))
         console.print(f"  [dim]Skipped {total_skipped_eco} packages not in OSV database ({parts})[/dim]")
     if _lookup_errors:
+        _bump_scan_perf("osv_lookup_errors", len(_lookup_errors))
         _logger.warning(
             "%d packages had CVE lookup errors — vulnerability detection may be incomplete",
             len(_lookup_errors),
@@ -1282,6 +1330,10 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
     original_count = len(packages)
     packages = deduplicate_packages(packages)
     deduped = original_count - len(packages)
+    reset_scan_performance()
+    _bump_scan_perf("packages_seen", original_count)
+    if deduped > 0:
+        _bump_scan_perf("packages_deduplicated", deduped)
     if deduped > 0:
         _logger.info("Deduplicated %d duplicate packages (kept %d unique)", deduped, len(packages))
 
@@ -1294,6 +1346,12 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
             pkg.name = normalize_package_name(pkg.name, pkg.ecosystem)
 
     reset_scan_warnings()
+    try:
+        from agent_bom.resolver import reset_performance_stats as _reset_resolver_performance
+
+        _reset_resolver_performance()
+    except Exception:  # noqa: BLE001
+        pass
 
     # ── Local version resolution (installed packages) ──────────────────────
     # Try resolving versions from locally installed packages FIRST.

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -28,6 +28,7 @@ from agent_bom.output import (
     print_export_hint,
     print_policy_results,
     print_posture_summary,
+    print_scan_performance_summary,
     print_severity_chart,
     print_summary,
     print_threat_frameworks,
@@ -134,6 +135,24 @@ class TestPrintSummary:
         agent = _make_agent(servers=[_make_server()])
         report = _make_report(agents=[agent])
         print_summary(report)
+
+    def test_with_scan_performance_data(self, capsys):
+        report = _make_report()
+        report.scan_performance_data = {
+            "osv": {"cache_hits": 3, "cache_misses": 1, "cache_hit_rate_pct": 75},
+            "registry": {"cache_hits": 4, "cache_misses": 2, "cache_hit_rate_pct": 67},
+        }
+        print_summary(report)
+
+
+class TestPrintScanPerformanceSummary:
+    def test_prints_cache_summary(self, capsys):
+        report = _make_report()
+        report.scan_performance_data = {
+            "osv": {"cache_hits": 3, "cache_misses": 1, "packages_queried": 2, "cache_hit_rate_pct": 75, "lookup_errors": 0},
+            "registry": {"cache_hits": 4, "cache_misses": 2, "network_requests": 2, "cache_hit_rate_pct": 67},
+        }
+        print_scan_performance_summary(report)
 
 
 # ── print_posture_summary ────────────────────────────────────────────────────

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -280,6 +280,18 @@ class TestJSON:
         assert nested_pkg["vulnerability_count"] == 2
         assert len(nested_pkg["vulnerabilities"]) == 2
 
+    def test_scan_performance_passthrough_present(self):
+        report = _make_report()
+        report.scan_performance_data = {
+            "osv": {"cache_hits": 5, "cache_misses": 2, "cache_hit_rate_pct": 71},
+            "registry": {"cache_hits": 4, "cache_misses": 1, "cache_hit_rate_pct": 80},
+        }
+
+        result = to_json(report)
+
+        assert result["scan_performance"]["osv"]["cache_hits"] == 5
+        assert result["scan_performance"]["registry"]["cache_hit_rate_pct"] == 80
+
 
 def test_json_runtime_session_graph_passthrough():
     report = _make_report()

--- a/tests/test_resolver_cov.py
+++ b/tests/test_resolver_cov.py
@@ -13,8 +13,10 @@ from agent_bom.resolver import (
     _NPM_LATEST_CACHE,
     _PYPI_INFO_CACHE,
     _get_npm_latest_doc,
+    consume_performance_stats,
     enrich_licenses,
     enrich_supply_chain_metadata,
+    reset_performance_stats,
     resolve_all_versions,
     resolve_npm_metadata,
     resolve_npm_supply_chain,
@@ -28,12 +30,14 @@ from agent_bom.resolver import (
 def clear_registry_metadata_caches():
     _NPM_LATEST_CACHE.clear()
     _PYPI_INFO_CACHE.clear()
+    reset_performance_stats()
 
     resolver._NPM_RATE_LIMIT_UNTIL = 0.0
     resolver._NPM_RATE_LIMIT_HITS = 0
     yield
     _NPM_LATEST_CACHE.clear()
     _PYPI_INFO_CACHE.clear()
+    reset_performance_stats()
     resolver._NPM_RATE_LIMIT_UNTIL = 0.0
     resolver._NPM_RATE_LIMIT_HITS = 0
 
@@ -106,6 +110,21 @@ class TestResolveNpmMetadata:
         assert lic == "MIT"
         assert pkg.description == "Cached package"
         assert mock_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_registry_perf_tracks_cache_hits_and_misses(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"version": "1.2.3", "license": "MIT"}
+        with patch("agent_bom.resolver.request_with_retry", return_value=mock_response):
+            client = AsyncMock()
+            await _get_npm_latest_doc("cached", client)
+            await _get_npm_latest_doc("cached", client)
+
+        perf = consume_performance_stats()
+        assert perf["registry_metadata"]["cache_misses"] == 1
+        assert perf["registry_metadata"]["cache_hits"] == 1
+        assert perf["registry_metadata"]["network_requests"] == 1
 
 
 class TestResolvePypiMetadata:
@@ -392,6 +411,24 @@ class TestEnrichLicenses:
         count = await enrich_licenses([pkg], client)
         assert count == 0
 
+    @pytest.mark.asyncio
+    async def test_dedupes_duplicate_registry_license_lookups(self):
+        pkgs = [
+            Package(name="express", version="4.18.2", ecosystem="npm"),
+            Package(name="express", version="4.18.2", ecosystem="npm"),
+        ]
+        with patch("agent_bom.resolver.resolve_npm_metadata", return_value=(None, "MIT")) as mock_resolve:
+            client = AsyncMock()
+            count = await enrich_licenses(pkgs, client)
+
+        perf = consume_performance_stats()
+        assert count == 2
+        assert all(pkg.license == "MIT" for pkg in pkgs)
+        assert mock_resolve.call_count == 1
+        assert perf["license_enrichment"]["unique_lookups"] == 1
+        assert perf["license_enrichment"]["reused_entries"] == 1
+        assert perf["license_enrichment"]["enriched"] == 2
+
 
 class TestEnrichSupplyChainMetadata:
     @pytest.mark.asyncio
@@ -435,3 +472,28 @@ class TestEnrichSupplyChainMetadata:
         client = AsyncMock()
         count = await enrich_supply_chain_metadata([pkg], client)
         assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_reuses_supply_chain_metadata_for_duplicate_packages(self):
+        pkgs = [
+            Package(name="requests", version="2.31.0", ecosystem="pypi"),
+            Package(name="requests", version="2.31.0", ecosystem="pypi"),
+        ]
+
+        async def fake_supply_chain(pkg, client):  # noqa: ARG001
+            pkg.description = "Python HTTP library"
+            pkg.homepage = "https://requests.readthedocs.io"
+            pkg.repository_url = "https://github.com/psf/requests"
+
+        with patch("agent_bom.resolver.resolve_pypi_supply_chain", side_effect=fake_supply_chain) as mock_supply:
+            client = AsyncMock()
+            count = await enrich_supply_chain_metadata(pkgs, client)
+
+        perf = consume_performance_stats()
+        assert count == 2
+        assert mock_supply.call_count == 1
+        assert all(pkg.description == "Python HTTP library" for pkg in pkgs)
+        assert all(pkg.repository_url == "https://github.com/psf/requests" for pkg in pkgs)
+        assert perf["supply_chain_enrichment"]["unique_lookups"] == 1
+        assert perf["supply_chain_enrichment"]["reused_entries"] == 1
+        assert perf["supply_chain_enrichment"]["enriched"] == 2

--- a/tests/test_scanner_robustness.py
+++ b/tests/test_scanner_robustness.py
@@ -190,6 +190,32 @@ class TestBatchSizeConfig:
         importlib.reload(agent_bom.config)
 
 
+class TestScanPerformance:
+    @pytest.mark.asyncio
+    async def test_query_osv_batch_tracks_cache_hit_stats(self, tmp_path):
+        from unittest.mock import AsyncMock, patch
+
+        from agent_bom.models import Package
+        from agent_bom.scan_cache import ScanCache
+        from agent_bom.scanners import consume_scan_performance, query_osv_batch, reset_scan_performance
+
+        cache = ScanCache(db_path=tmp_path / "scan-cache.db", ttl_seconds=3600)
+        cache.put("npm", "lodash", "4.17.20", [{"id": "GHSA-123"}])
+        reset_scan_performance()
+
+        with (
+            patch("agent_bom.scanners._get_scan_cache", return_value=cache),
+            patch("agent_bom.scanners._enrich_results_if_needed", new_callable=AsyncMock, side_effect=lambda data: data),
+        ):
+            results = await query_osv_batch([Package(name="lodash", version="4.17.20", ecosystem="npm")])
+
+        perf = consume_scan_performance()
+        assert results["npm:lodash@4.17.20"][0]["id"] == "GHSA-123"
+        assert perf["osv_cache_hits"] == 1
+        assert perf["osv_cache_hits_with_vulns"] == 1
+        assert perf["osv_cache_misses"] == 0
+
+
 # ── Name Normalization in Scanner Pipeline ────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- dedupe repeated registry, license, and supply-chain lookups within a scan
- capture resolver and OSV cache performance stats and attach them to scan reports
- surface cache hit/miss visibility in console and JSON output with focused regression tests

Closes #1156

## Validation
- UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_resolver_cov.py tests/test_scanner_robustness.py tests/test_output_cov.py tests/test_output_formats.py
- UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_scan.py -k 'empty_state or unknown_output_extension or no_scan_flag'
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python -m compileall src/agent_bom
- UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/resolver.py src/agent_bom/scanners/__init__.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_output.py src/agent_bom/output/__init__.py src/agent_bom/output/json_fmt.py --ignore-missing-imports --disable-error-code import-untyped