### PR TITLE
fix(action): harden execution contract and summaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -137,8 +137,11 @@ outputs:
     description: 'Path to generated SARIF file (if format=sarif).'
     value: ${{ steps.scan.outputs.sarif_file }}
   exit-code:
-    description: 'Scan exit code (0=clean, 1=violations found).'
+    description: 'Scan process exit code.'
     value: ${{ steps.scan.outputs.exit_code }}
+  scan-status:
+    description: 'High-level scan status (clean, violations, or error).'
+    value: ${{ steps.scan.outputs.scan_status }}
   vulnerability-count:
     description: 'Number of vulnerabilities found, or skill findings when scan-type=skills.'
     value: ${{ steps.scan.outputs.vuln_count }}
@@ -230,7 +233,6 @@ runs:
         trim_arg() {
           printf '%s' "$1" | xargs
         }
-
         # Map scan-type to focused command
         #   scan  → agent-bom agents (full auto-detect, default)
         #   image → agent-bom image <ref>
@@ -451,6 +453,13 @@ runs:
 
         # Run scan, capture exit code
         set +e
+        echo "::group::agent-bom command"
+        printf 'Running:'
+        for arg in "${ARGS[@]}"; do
+          printf ' %q' "$arg"
+        done
+        printf '\n'
+        echo "::endgroup::"
         agent-bom "${ARGS[@]}"
         EXIT_CODE=$?
         set -e
@@ -462,6 +471,13 @@ runs:
           VULN_COUNT=$(python3 -c "import json; d=json.load(open('$RESULT_FILE')); print(len(d.get('runs',[{}])[0].get('results',[])))" 2>/dev/null || echo 0)
         elif [ "$INPUT_SCAN_TYPE" = "skills" ] && [ -f "$RESULT_FILE" ]; then
           VULN_COUNT=$(python3 -c "import json; d=json.load(open('$RESULT_FILE')); print(d.get('summary',{}).get('findings',0))" 2>/dev/null || echo 0)
+        fi
+
+        SCAN_STATUS="error"
+        if [ "$EXIT_CODE" = "0" ]; then
+          SCAN_STATUS="clean"
+        elif [ "$VULN_COUNT" -gt 0 ]; then
+          SCAN_STATUS="violations"
         fi
 
         # Generate badge from SARIF results (no second scan)
@@ -501,21 +517,29 @@ runs:
 
         echo "sarif_file=$SARIF_FILE" >> "$GITHUB_OUTPUT"
         echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+        echo "scan_status=$SCAN_STATUS" >> "$GITHUB_OUTPUT"
         echo "vuln_count=$VULN_COUNT" >> "$GITHUB_OUTPUT"
         echo "badge_file=$BADGE_FILE" >> "$GITHUB_OUTPUT"
 
         if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
           {
             echo "## agent-bom scan summary"
-            echo
-            echo "- Scan type: ${INPUT_SCAN_TYPE:-scan}"
-            echo "- Exit code: ${EXIT_CODE}"
-            echo "- Findings: ${VULN_COUNT}"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Scan type | \`${INPUT_SCAN_TYPE:-scan}\` |"
+            echo "| Format | \`${INPUT_FORMAT:-sarif}\` |"
+            echo "| Status | \`${SCAN_STATUS}\` |"
+            echo "| Exit code | \`${EXIT_CODE}\` |"
+            echo "| Finding count | \`${VULN_COUNT}\` |"
             if [ -n "$RESULT_FILE" ] && [ -f "$RESULT_FILE" ]; then
-              echo "- Output: ${RESULT_FILE}"
+              echo "| Result file | \`${RESULT_FILE}\` |"
+            fi
+            if [ -n "$SARIF_FILE" ]; then
+              echo "| SARIF file | \`${SARIF_FILE}\` |"
             fi
             if [ -n "$BADGE_FILE" ]; then
-              echo "- Badge: ${BADGE_FILE}"
+              echo "| Badge file | \`${BADGE_FILE}\` |"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
         fi

--- a/tests/test_ai_enrich.py
+++ b/tests/test_ai_enrich.py
@@ -667,6 +667,7 @@ def test_action_yml_has_outputs():
     outputs = data.get("outputs", {})
     assert "sarif-file" in outputs
     assert "exit-code" in outputs
+    assert "scan-status" in outputs
     assert "vulnerability-count" in outputs
 
 
@@ -702,27 +703,32 @@ def test_action_yml_skills_mode_skips_vulnerability_scan_flags():
     guard = 'if [ "$INPUT_SCAN_TYPE" != "skills" ]; then'
     assert guard in action_text
     guarded_block = action_text.split(guard, 1)[1].split("# Skill-only mode", 1)[0]
-    assert "--auto-update-db" in guarded_block
     assert 'ARGS+=(--policy "$INPUT_POLICY")' in guarded_block
+    assert "auto-update-db" in guarded_block
 
 
-def test_action_yml_uses_safe_argv_execution():
-    """The action should build argv arrays instead of shell-expanded command strings."""
+def test_action_yml_uses_safe_argv_execution_and_step_summary():
+    """The action should avoid shell-built argv execution and emit a step summary."""
     from pathlib import Path
 
     action_text = (Path(__file__).parent.parent / "action.yml").read_text()
     assert "ARGS=(" in action_text
     assert 'agent-bom "${ARGS[@]}"' in action_text
     assert "agent-bom $ARGS" not in action_text
+    assert "GITHUB_STEP_SUMMARY" in action_text
+    assert "scan_status=$SCAN_STATUS" in action_text
 
 
-def test_action_yml_writes_step_summary():
-    """The action should publish a concise GitHub step summary."""
+def test_action_yml_enables_pip_cache_in_setup_python():
+    """The composite action should enable pip caching in setup-python."""
     from pathlib import Path
 
-    action_text = (Path(__file__).parent.parent / "action.yml").read_text()
-    assert "GITHUB_STEP_SUMMARY" in action_text
-    assert "## agent-bom scan summary" in action_text
+    import yaml
+
+    action_path = Path(__file__).parent.parent / "action.yml"
+    data = yaml.safe_load(action_path.read_text())
+    setup_step = next(step for step in data["runs"]["steps"] if step.get("name") == "Set up Python")
+    assert setup_step["with"]["cache"] == "pip"
 
 
 # ── Skill file AI analysis tests ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- replace shell-built action args with safe argv execution
- add pip caching and step summary output to the composite action
- expose explicit scan-status output and lock the contract with tests

## Testing
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_ai_enrich.py -k action_yml