### PR TITLE
feat(mcp): require auth on remote transports

### DIFF
--- a/docs/MCP_CLIENT_GUIDES.md
+++ b/docs/MCP_CLIENT_GUIDES.md
@@ -80,7 +80,9 @@ args = ["proxy", "--log", "~/.agent-bom/logs/filesystem.jsonl", "--", "npx", "@m
 - `agent-bom proxy` is best when the client talks to a third-party stdio server and you want runtime inspection.
 - `agent-bom proxy-configure --apply` currently targets JSON MCP configs. It is a good fit for Claude Desktop, Cursor, Windsurf, and Cortex CoCo.
 - TOML clients like Codex CLI need manual proxy wrapping today.
-- SSE / HTTP clients can still use `agent-bom mcp server --sse`, but transport auth and TLS should live at your ingress or reverse proxy.
+- SSE / HTTP clients can use `agent-bom mcp server --transport sse --bearer-token "$AGENT_BOM_MCP_BEARER_TOKEN"` or `--transport streamable-http`.
+- Non-loopback remote transports fail closed unless you configure `--bearer-token` / `AGENT_BOM_MCP_BEARER_TOKEN` or explicitly pass `--allow-insecure-no-auth`.
+- Keep TLS at your ingress or reverse proxy for remote deployments.
 
 ## Next steps
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -100,11 +100,13 @@ Codex uses TOML, so manual proxy wrapping is the right path when you want runtim
 ### SSE Transport (Remote / Multi-Client)
 
 ```bash
-agent-bom mcp server --sse --host 0.0.0.0 --port 8000
+agent-bom mcp server --transport sse --host 0.0.0.0 --port 8000 --bearer-token "$AGENT_BOM_MCP_BEARER_TOKEN"
 ```
 
 Connect any SSE-capable MCP client to `https://your-server/sse`.
-For remote deployments, put SSE behind TLS and authentication at your proxy or ingress.
+For non-loopback SSE or Streamable HTTP binds, `agent-bom` now fails closed unless you set
+`--bearer-token` / `AGENT_BOM_MCP_BEARER_TOKEN` or explicitly pass
+`--allow-insecure-no-auth`. Keep TLS at your proxy or ingress for remote deployments.
 
 ### Docker
 

--- a/docs/WINDOWS_CONTAINERS.md
+++ b/docs/WINDOWS_CONTAINERS.md
@@ -18,7 +18,9 @@ docker run --rm agentbom/agent-bom agents
 docker run --rm -v "${env:APPDATA}:/root/.config:ro" agentbom/agent-bom agents
 
 # MCP server mode
-docker run --rm -p 8423:8423 agentbom/agent-bom mcp server --transport streamable-http --host 0.0.0.0 --port 8423
+docker run --rm -p 8423:8423 `
+  -e AGENT_BOM_MCP_BEARER_TOKEN=change-me `
+  agentbom/agent-bom mcp server --transport streamable-http --host 0.0.0.0 --port 8423
 ```
 
 ### Volume mount paths

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -40,6 +40,18 @@ def _enforce_auth_defaults(command: str, host: str, api_key: str | None, allow_i
     )
 
 
+def _enforce_remote_mcp_auth_defaults(host: str, bearer_token: str | None, allow_insecure_no_auth: bool) -> None:
+    """Refuse unauthenticated remote MCP transports on non-loopback binds."""
+    if bearer_token or _is_loopback_host(host):
+        return
+    if allow_insecure_no_auth:
+        return
+    raise click.ClickException(
+        f"Refusing to expose `mcp server` on non-loopback host {host!r} without transport authentication. "
+        "Set --bearer-token / AGENT_BOM_MCP_BEARER_TOKEN or pass --allow-insecure-no-auth to override."
+    )
+
+
 @click.command("serve")
 @click.option("--host", default="127.0.0.1", show_default=True, help="Host to bind to (use 0.0.0.0 for LAN access)")
 @click.option("--port", default=8422, show_default=True, help="API server port")
@@ -292,9 +304,30 @@ def api_cmd(
 )
 @click.option("--port", default=8423, show_default=True, help="Port for HTTP/SSE transport.")
 @click.option("--host", default="127.0.0.1", show_default=True, help="Host for HTTP/SSE transport.")
+@click.option(
+    "--bearer-token",
+    default=None,
+    envvar="AGENT_BOM_MCP_BEARER_TOKEN",
+    metavar="TOKEN",
+    help="Require Bearer token auth for SSE / Streamable HTTP transports.",
+)
+@click.option(
+    "--allow-insecure-no-auth",
+    is_flag=True,
+    default=False,
+    help="Allow unauthenticated non-loopback SSE / HTTP exposure. Unsafe outside local development.",
+)
 @click.option("--log-level", "log_level", type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False), default="INFO")
 @click.option("--log-json", "log_json", is_flag=True, help="Structured JSON logs")
-def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_json: bool):
+def mcp_server_cmd(
+    transport: str,
+    port: int,
+    host: str,
+    bearer_token: str | None,
+    allow_insecure_no_auth: bool,
+    log_level: str,
+    log_json: bool,
+):
     """Start agent-bom as an MCP server.
 
     \b
@@ -360,14 +393,23 @@ def mcp_server_cmd(transport: str, port: int, host: str, log_level: str, log_jso
         )
         sys.exit(1)
 
-    server = create_mcp_server(host=host, port=port)
+    if transport in ("sse", "streamable-http"):
+        _enforce_remote_mcp_auth_defaults(host, bearer_token, allow_insecure_no_auth)
+
+    server = create_mcp_server(host=host, port=port, bearer_token=bearer_token)
 
     if transport in ("sse", "streamable-http"):
         from agent_bom import __version__ as _ver
 
         click.echo(f"  agent-bom MCP Server v{_ver}", err=True)
         click.echo(f"  Transport: {transport} on http://{host}:{port}", err=True)
+        if bearer_token:
+            click.echo("  Auth:      Bearer token required", err=True)
+        elif allow_insecure_no_auth and not _is_loopback_host(host):
+            click.echo("  Auth:      disabled by explicit override (--allow-insecure-no-auth)", err=True)
         click.echo("  Press Ctrl+C to stop.\n", err=True)
         server.run(transport=transport)
     else:
+        if bearer_token:
+            click.echo("  Warning:   --bearer-token applies only to SSE / Streamable HTTP transports", err=True)
         server.run(transport="stdio")

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -52,6 +52,7 @@ Security: Read-only. Never executes MCP servers or reads credential values.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import re
@@ -83,6 +84,20 @@ _VALID_ECOSYSTEMS = SUPPORTED_PACKAGE_ECOSYSTEM_SET
 
 _CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
 _GHSA_RE = re.compile(r"^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$", re.IGNORECASE)
+
+
+class _StaticBearerTokenVerifier:
+    """FastMCP token verifier backed by a single configured bearer token."""
+
+    def __init__(self, token: str):
+        self._token = token
+
+    async def verify_token(self, token: str):
+        from mcp.server.auth.provider import AccessToken
+
+        if token and hmac.compare_digest(token, self._token):
+            return AccessToken(token=token, client_id="agent-bom-static-token", scopes=[], resource=None)
+        return None
 
 
 def _validate_ecosystem(ecosystem: str) -> str:
@@ -496,7 +511,7 @@ async def _run_scan_pipeline(
 # ---------------------------------------------------------------------------
 
 
-def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
+def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token: str | None = None):
     """Create and configure the agent-bom MCP server with all tools.
 
     When the smithery SDK is installed, the server is automatically enhanced
@@ -506,14 +521,28 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
 
     setup_logging(level="INFO")
     _check_mcp_sdk()
+    from mcp.server.auth.settings import AuthSettings
     from mcp.server.fastmcp import FastMCP
 
     from agent_bom import __version__
+
+    auth_settings = None
+    token_verifier = None
+    if bearer_token:
+        resource_url = f"http://{host}:{port}"
+        auth_settings = AuthSettings(
+            issuer_url=resource_url,
+            resource_server_url=resource_url,
+            required_scopes=[],
+        )
+        token_verifier = _StaticBearerTokenVerifier(bearer_token)
 
     mcp = FastMCP(
         name="agent-bom",
         host=host,
         port=port,
+        auth=auth_settings,
+        token_verifier=token_verifier,
         instructions=(
             f"agent-bom v{__version__} — AI infrastructure security scanner with MCP security tools. "
             "Scans packages and images for CVEs (OSV, NVD, EPSS, CISA KEV), maps blast radius "
@@ -1873,6 +1902,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                 "pypi": "https://pypi.org/project/agent-bom/",
                 "documentation": "https://github.com/msaad00/agent-bom#readme",
                 "server_card": "/.well-known/mcp/server-card.json",
+                "auth_required": bool(bearer_token),
             }
         )
 
@@ -1888,6 +1918,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000):
                 "status": "healthy",
                 "name": "agent-bom",
                 "version": __version__,
+                "auth_required": bool(bearer_token),
                 "mcp_metrics": _tool_metrics_snapshot()["summary"],
             }
         )

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -137,6 +137,48 @@ def test_mcp_server_cmd_sse():
         mock_server.run.assert_called_once_with(transport="sse")
 
 
+def test_mcp_server_cmd_rejects_unauthenticated_non_loopback_remote_bind():
+    """Remote MCP transports should fail closed on non-loopback binds without auth."""
+    runner = CliRunner()
+
+    with patch("agent_bom.mcp_server.create_mcp_server") as mock_create:
+        result = runner.invoke(mcp_server_cmd, ["--transport", "sse", "--host", "0.0.0.0"])
+
+    assert result.exit_code == 1
+    assert "without transport authentication" in result.output
+    mock_create.assert_not_called()
+
+
+def test_mcp_server_cmd_allows_remote_bind_with_bearer_token():
+    """Remote MCP transports should allow non-loopback binds when bearer auth is configured."""
+    runner = CliRunner()
+    mock_server = MagicMock()
+
+    with patch("agent_bom.mcp_server.create_mcp_server", return_value=mock_server) as mock_create:
+        result = runner.invoke(
+            mcp_server_cmd,
+            ["--transport", "sse", "--host", "0.0.0.0", "--bearer-token", "test-token"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    mock_create.assert_called_once_with(host="0.0.0.0", port=8423, bearer_token="test-token")
+    mock_server.run.assert_called_once_with(transport="sse")
+    assert "Bearer token required" in result.output
+
+
+def test_mcp_server_cmd_stdio_warns_when_bearer_token_is_unused():
+    """Bearer auth config should warn when used with stdio transport."""
+    runner = CliRunner()
+    mock_server = MagicMock()
+
+    with patch("agent_bom.mcp_server.create_mcp_server", return_value=mock_server):
+        result = runner.invoke(mcp_server_cmd, ["--bearer-token", "test-token"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "applies only to SSE / Streamable HTTP" in result.output
+
+
 def test_mcp_server_cmd_missing_sdk():
     """Test mcp-server command when MCP SDK is not installed."""
     runner = CliRunner()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -77,6 +77,17 @@ def test_mcp_server_tool_names():
     assert names == {t["name"] for t in _SERVER_CARD_TOOLS}
 
 
+def test_create_mcp_server_enables_static_bearer_auth():
+    """create_mcp_server should wire FastMCP auth when a bearer token is configured."""
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier, create_mcp_server
+
+    server = create_mcp_server(host="0.0.0.0", port=8423, bearer_token="test-token")
+    assert isinstance(server._token_verifier, _StaticBearerTokenVerifier)
+    assert server.settings.auth is not None
+    assert str(server.settings.auth.resource_server_url) == "http://0.0.0.0:8423/"
+    assert server.settings.auth.required_scopes == []
+
+
 # ---------------------------------------------------------------------------
 # Tool: registry_lookup (no mocking needed — reads local JSON)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- require auth for non-loopback SSE and Streamable HTTP MCP transports by default
- add static bearer-token auth wiring for FastMCP remote transports
- align MCP remote transport docs and Windows container examples with the new contract

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_server.py tests/test_mcp_server.py
- python3 -m py_compile src/agent_bom/cli/_server.py src/agent_bom/mcp_server.py