### PR TITLE
fix(deploy): require railway bearer token for mcp startup

### DIFF
--- a/deploy/Procfile
+++ b/deploy/Procfile
@@ -1,1 +1,1 @@
-web: agent-bom mcp server --transport streamable-http --host 0.0.0.0 --port ${PORT:-8423}
+web: test -n "$AGENT_BOM_MCP_BEARER_TOKEN" || { echo "AGENT_BOM_MCP_BEARER_TOKEN is required for remote MCP deployment"; exit 1; }; agent-bom mcp server --transport streamable-http --host 0.0.0.0 --port ${PORT:-8423}

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -10,6 +10,7 @@
 # Environment variables (optional):
 #   NVD_API_KEY  — Higher rate limits for CVSS enrichment
 #   PORT         — Override default port (Railway/Render inject this)
+#   AGENT_BOM_MCP_BEARER_TOKEN — Required for secure non-loopback deployments
 
 ## ── Builder stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9 AS builder
@@ -87,4 +88,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT:-8423}/health')" || exit 1
 
 # Use shell form so $PORT is expanded at runtime (Railway/Render inject PORT)
-CMD agent-bom mcp server --transport streamable-http --host 0.0.0.0 --port ${PORT}
+CMD test -n "$AGENT_BOM_MCP_BEARER_TOKEN" || { echo "AGENT_BOM_MCP_BEARER_TOKEN is required for remote MCP deployment"; exit 1; }; \
+    agent-bom mcp server --transport streamable-http --host 0.0.0.0 --port ${PORT}

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -17,6 +17,12 @@ Smithery requires a publicly accessible HTTP URL for the MCP server.
 ### Step 1: Deploy SSE server
 
 The SSE server is deployed on Railway at `https://agent-bom-mcp.up.railway.app` (automated via `deploy-mcp-sse.yml`).
+Secure remote deployments should set `AGENT_BOM_MCP_BEARER_TOKEN` in Railway service
+variables so the MCP transport can start with built-in Bearer auth. Keep TLS at your
+ingress or platform edge.
+
+If you need a public unauthenticated registry/demo endpoint, treat that as a separate,
+explicitly less-trusted deployment surface rather than weakening the primary service.
 
 ### Step 2: Publish to Smithery
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -68,6 +68,14 @@ def test_procfile_exists():
     assert content.startswith("web:")
     assert "mcp" in content and "server" in content
     assert "streamable-http" in content
+    assert "AGENT_BOM_MCP_BEARER_TOKEN" in content
+
+
+def test_dockerfile_sse_does_not_opt_into_insecure_public_mode():
+    """The maintained SSE/HTTP image should not disable remote auth by default."""
+    content = (ROOT / "deploy" / "docker" / "Dockerfile.sse").read_text()
+    assert "--allow-insecure-no-auth" not in content
+    assert "AGENT_BOM_MCP_BEARER_TOKEN" in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- require AGENT_BOM_MCP_BEARER_TOKEN for the Railway streamable-http MCP deployment path
- make the Procfile and SSE image fail loudly with a clear token-required message instead of crashing ambiguously
- enforce the secure deploy contract in deployment tests

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_deployment.py