### PR TITLE
feat(ci): add daily preventive security automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "github-actions"
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "python"
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
       - "javascript"

--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -6,7 +6,7 @@ name: Container Re-Scan
 
 on:
   schedule:
-    - cron: "0 8 * * 3"   # Wednesday 08:00 UTC
+    - cron: "0 8 * * *"   # daily at 08:00 UTC
   workflow_dispatch:
 
 permissions: {}  # deny all by default; jobs declare only what they need
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       security-events: write  # required: SARIF upload to GitHub Security tab
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -88,3 +89,37 @@ jobs:
         if: steps.trivy-table.outcome == 'failure'
         run: |
           echo "::warning::Trivy found HIGH/CRITICAL CVEs in agentbom/agent-bom:latest (${{ matrix.platform }}). Check SARIF in Security tab."
+
+      - name: Open or close base image vulnerability issue
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="base-image-vulnerability: agentbom/agent-bom:latest has HIGH/CRITICAL findings on ${{ matrix.platform }}"
+          gh label create base-image-vulnerability --color B60205 --description "Automated base image vulnerability findings" >/dev/null 2>&1 || true
+          gh label create security-preventive --color 0E8A16 --description "Preventive daily security automation findings" >/dev/null 2>&1 || true
+          gh label create automated --color 5319E7 --description "Opened or updated automatically by CI" >/dev/null 2>&1 || true
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+
+          if [ "${{ steps.trivy-table.outcome }}" = "failure" ]; then
+            BODY=$(cat <<EOF
+          ## Automated Base Image Vulnerability Alert
+
+          Daily image rescan found HIGH/CRITICAL findings in \`agentbom/agent-bom:latest\`.
+
+          - Platform: \`${{ matrix.platform }}\`
+          - SARIF category: \`${{ matrix.sarif_category }}\`
+          - Source workflow: \`.github/workflows/container-rescan.yml\`
+
+          Review the GitHub Security tab and the workflow logs for the current image findings.
+          EOF
+          )
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "$BODY"
+            else
+              gh issue create --title "$TITLE" --label "base-image-vulnerability,security-preventive,automated" --body "$BODY"
+            fi
+          elif [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Daily image rescan is clean again; closing the automated base image vulnerability alert."
+          fi

--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -81,19 +81,36 @@ jobs:
           EXPECTED="${{ steps.expected.outputs.version }}"
           RAILWAY="${{ steps.railway.outputs.railway_version }}"
           TOOLS="${{ steps.smithery.outputs.tool_count }}"
+          TITLE="supply-chain-drift: Railway serving $RAILWAY, expected $EXPECTED"
+
+          gh label create supply-chain-drift --color FBCA04 --description "Automated supply-chain or deployment drift detection" >/dev/null 2>&1 || true
+          gh label create security-preventive --color 0E8A16 --description "Preventive daily security automation findings" >/dev/null 2>&1 || true
+          gh label create automated --color 5319E7 --description "Opened or updated automatically by CI" >/dev/null 2>&1 || true
 
           # Check if an issue already exists
-          EXISTING=$(gh issue list --label "deployment-stale" --state open --json number --jq 'length')
-          if [ "$EXISTING" -gt "0" ]; then
-            echo "Stale deployment issue already open — skipping"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$(cat <<EOF
+          ## Supply-Chain Drift Check Failed
+
+          | Surface | Deployed | Expected |
+          |---------|----------|----------|
+          | Railway | $RAILWAY | $EXPECTED |
+          | Tool count | $TOOLS | (check mcp_server.py) |
+
+          **Action**: Re-run the Deploy MCP SSE workflow or trigger a new release.
+
+          This issue was auto-updated by the deployment-freshness workflow.
+          EOF
+          )"
             exit 0
           fi
 
           gh issue create \
-            --title "Deployment stale: Railway serving $RAILWAY, expected $EXPECTED" \
-            --label "deployment-stale,bug" \
+            --title "$TITLE" \
+            --label "supply-chain-drift,security-preventive,automated" \
             --body "$(cat <<EOF
-          ## Deployment Freshness Check Failed
+          ## Supply-Chain Drift Check Failed
 
           | Surface | Deployed | Expected |
           |---------|----------|----------|
@@ -105,3 +122,14 @@ jobs:
           This issue was auto-created by the deployment-freshness workflow.
           EOF
           )"
+
+      - name: Close supply-chain drift issue when deployment is fresh
+        if: steps.railway.outputs.stale != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh issue list --label "supply-chain-drift" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Deployment freshness check is clean again; closing the automated supply-chain drift alert."
+          fi

--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       security-events: write  # required: SARIF upload to GitHub Security tab
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -44,6 +45,48 @@ jobs:
           uv run agent-bom scan --self-scan --format sarif -o sarif/self-dep.sarif \
             --fail-on-severity high --exclude-unfixable --quiet
           echo "dep_exit=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Build self-scan summary
+        if: always()
+        id: dep_summary
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("sarif/self-dep.sarif")
+          total = critical = high = medium = low = 0
+          if path.exists():
+              data = json.loads(path.read_text())
+              for run in data.get("runs", []):
+                  for result in run.get("results", []):
+                      total += 1
+                      level = str(result.get("level", "")).lower()
+                      props = result.get("properties", {}) or {}
+                      sev = str(props.get("security-severity", "")).lower()
+                      if level == "error" or sev.startswith("9"):
+                          critical += 1
+                      elif level == "warning" or sev.startswith(("7", "8")):
+                          high += 1
+                      elif level == "note" or sev.startswith(("4", "5", "6")):
+                          medium += 1
+                      else:
+                          low += 1
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"total={total}\n")
+              fh.write(f"critical={critical}\n")
+              fh.write(f"high={high}\n")
+              fh.write(f"medium={medium}\n")
+              fh.write(f"low={low}\n")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write("## Dependency Self-Scan Summary\n")
+              fh.write(f"- Total findings: {total}\n")
+              fh.write(f"- Critical: {critical}\n")
+              fh.write(f"- High: {high}\n")
+              fh.write(f"- Medium: {medium}\n")
+              fh.write(f"- Low: {low}\n")
+          PY
 
       - name: Print full dep scan summary (all severities, for logs)
         if: always()
@@ -81,6 +124,55 @@ jobs:
           if [ "${{ steps.dep_scan.outputs.dep_exit }}" != "0" ]; then
             echo "::error::Critical vulnerability found in self dep scan — check Security tab"
             exit 1
+          fi
+
+      - name: Open or close dependency vulnerability issue
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEP_EXIT: ${{ steps.dep_scan.outputs.dep_exit }}
+          TOTAL: ${{ steps.dep_summary.outputs.total }}
+          CRITICAL: ${{ steps.dep_summary.outputs.critical }}
+          HIGH: ${{ steps.dep_summary.outputs.high }}
+          MEDIUM: ${{ steps.dep_summary.outputs.medium }}
+          LOW: ${{ steps.dep_summary.outputs.low }}
+        run: |
+          set -euo pipefail
+          TITLE="dependency-vulnerability: self-scan found HIGH/CRITICAL findings on main"
+          gh label create dependency-vulnerability --color D73A4A --description "Automated dependency vulnerability findings" >/dev/null 2>&1 || true
+          gh label create security-preventive --color 0E8A16 --description "Preventive daily security automation findings" >/dev/null 2>&1 || true
+          gh label create automated --color 5319E7 --description "Opened or updated automatically by CI" >/dev/null 2>&1 || true
+
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+
+          if [ "$DEP_EXIT" != "0" ]; then
+            BODY=$(cat <<EOF
+          ## Automated Dependency Vulnerability Alert
+
+          Daily self-scan found fixable HIGH/CRITICAL findings in agent-bom dependencies.
+
+          | Severity | Count |
+          |---|---:|
+          | Critical | $CRITICAL |
+          | High | $HIGH |
+          | Medium | $MEDIUM |
+          | Low | $LOW |
+          | Total | $TOTAL |
+
+          Source: \`.github/workflows/post-merge-self-scan.yml\`
+          Trigger: \`${{ github.event_name }}\`
+
+          This issue is auto-managed. It should be updated or closed by the next clean preventive run.
+          EOF
+          )
+
+            if [ -n "$EXISTING" ]; then
+              gh issue comment "$EXISTING" --body "$BODY"
+            else
+              gh issue create --title "$TITLE" --label "dependency-vulnerability,security-preventive,automated" --body "$BODY"
+            fi
+          elif [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Daily self-scan is clean again; closing the automated dependency vulnerability alert."
           fi
 
   generate-sbom:


### PR DESCRIPTION
## Summary
- make Dependabot run daily for pip, npm, and GitHub Actions
- strengthen scheduled self-scan/container/deployment freshness workflows with issue automation
- separate dependency, base-image, and supply-chain drift findings into explicit issue taxonomies

## Testing
- python - <<'PY'
import yaml
for path in [
    '.github/workflows/post-merge-self-scan.yml',
    '.github/workflows/container-rescan.yml',
    '.github/workflows/deployment-freshness.yml',
    '.github/dependabot.yml',
]:
    with open(path, 'r', encoding='utf-8') as f:
        yaml.safe_load(f)
    print('ok', path)
PY