### PR TITLE
fix(ci): verify authenticated Railway freshness

### DIFF
--- a/.github/workflows/deploy-mcp-sse.yml
+++ b/.github/workflows/deploy-mcp-sse.yml
@@ -85,13 +85,18 @@ jobs:
       - name: Post-deploy version check
         env:
           RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
+          RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
         run: |
           echo "Waiting 60s for Railway to rebuild and start..."
           sleep 60
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
+          CURL_ARGS=()
+          if [ -n "${RAILWAY_MCP_BEARER_TOKEN:-}" ]; then
+            CURL_ARGS=(-H "Authorization: Bearer $RAILWAY_MCP_BEARER_TOKEN")
+          fi
           echo "Checking $DEPLOY_URL/health"
           for attempt in 1 2 3 4 5; do
-            RESPONSE=$(curl -sf "$DEPLOY_URL/health" 2>/dev/null || true)
+            RESPONSE=$(curl -sf "${CURL_ARGS[@]}" "$DEPLOY_URL/health" 2>/dev/null || true)
             if [ -n "$RESPONSE" ]; then
               echo "Health response: $RESPONSE"
               DEPLOYED_VERSION=$(echo "$RESPONSE" | python3 -c "
@@ -108,7 +113,7 @@ jobs:
                 echo "✅ Version match confirmed"
                 exit 0
               elif [ "$DEPLOYED_VERSION" = "unknown" ]; then
-                echo "⚠️ Could not extract version from health endpoint — deploy may still be starting"
+                echo "⚠️ Could not extract version from health endpoint — auth or startup may still be incomplete"
               else
                 echo "::warning::Version mismatch — deployed=$DEPLOYED_VERSION expected=$repo_version"
               fi

--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -35,10 +35,15 @@ jobs:
         continue-on-error: true
         env:
           RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
+          RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
         run: |
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
+          CURL_ARGS=(--max-time 15)
+          if [ -n "${RAILWAY_MCP_BEARER_TOKEN:-}" ]; then
+            CURL_ARGS+=(-H "Authorization: Bearer $RAILWAY_MCP_BEARER_TOKEN")
+          fi
           echo "Checking $DEPLOY_URL/health ..."
-          RESPONSE=$(curl -sf --max-time 15 "$DEPLOY_URL/health" 2>/dev/null || echo '{}')
+          RESPONSE=$(curl -sf "${CURL_ARGS[@]}" "$DEPLOY_URL/health" 2>/dev/null || echo '{}')
           DEPLOYED=$(echo "$RESPONSE" | python3 -c "
           import sys, json
           try:
@@ -58,15 +63,19 @@ jobs:
         continue-on-error: true
         env:
           RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
+          RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
         run: |
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
-          # Connect to MCP endpoint and check capabilities
-          RESPONSE=$(curl -sf --max-time 15 "$DEPLOY_URL/health" 2>/dev/null || echo '{}')
+          CURL_ARGS=(--max-time 15)
+          if [ -n "${RAILWAY_MCP_BEARER_TOKEN:-}" ]; then
+            CURL_ARGS+=(-H "Authorization: Bearer $RAILWAY_MCP_BEARER_TOKEN")
+          fi
+          RESPONSE=$(curl -sf "${CURL_ARGS[@]}" "$DEPLOY_URL/health" 2>/dev/null || echo '{}')
           TOOL_COUNT=$(echo "$RESPONSE" | python3 -c "
           import sys, json
           try:
               data = json.load(sys.stdin)
-              print(data.get('tools', 'unknown'))
+              print(data.get('tool_count', data.get('mcp_metrics', {}).get('tool_count', 'unknown')))
           except Exception:
               print('unknown')
           ")

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -2125,13 +2125,16 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
 
         from agent_bom import __version__
 
+        metrics = _tool_metrics_snapshot()["summary"]
+
         return JSONResponse(
             {
                 "status": "healthy",
                 "name": "agent-bom",
                 "version": __version__,
                 "auth_required": bool(bearer_token),
-                "mcp_metrics": _tool_metrics_snapshot()["summary"],
+                "tool_count": metrics["tool_count"],
+                "mcp_metrics": metrics,
             }
         )
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -200,10 +200,10 @@ def test_root_metadata_fields():
 
 
 def test_health_endpoint_fields():
-    """Health check should return name, version, and healthy status."""
+    """Health check contract should expose version and tool-count metadata."""
 
     from agent_bom import __version__
-    from agent_bom.mcp_server import create_mcp_server
+    from agent_bom.mcp_server import _tool_metrics_snapshot, create_mcp_server
 
     create_mcp_server()
     # The routes are registered; verify the build_server_card still works
@@ -212,6 +212,23 @@ def test_health_endpoint_fields():
     card = build_server_card()
     assert card["version"] == __version__
     assert card["name"] == "agent-bom"
+    summary = _tool_metrics_snapshot()["summary"]
+    assert "tool_count" in summary
+
+
+def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count():
+    """Deployment freshness should probe authenticated MCP health endpoints safely."""
+    workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
+    assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
+    assert "Authorization: Bearer" in workflow
+    assert "tool_count" in workflow
+
+
+def test_deploy_mcp_sse_workflow_uses_bearer_token_for_health_check():
+    """Post-deploy health verification should use the same auth contract as Railway."""
+    workflow = (ROOT / ".github" / "workflows" / "deploy-mcp-sse.yml").read_text()
+    assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
+    assert "Authorization: Bearer" in workflow
 
 
 def test_dockerfiles_support_proxy_and_ca_contract():


### PR DESCRIPTION
## Summary
- probe Railway MCP health with the configured bearer token in freshness and post-deploy checks
- expose top-level tool_count in the MCP health contract for deployment drift validation
- add regression coverage for the authenticated freshness workflow contract

## Testing
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_deployment.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_mcp_server.py -k tool_count
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python -m compileall src/agent_bom

Closes #1225