### PR TITLE
feat(postgres): add first tenant RLS slice

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -110,12 +110,24 @@ CREATE TABLE IF NOT EXISTS scan_schedules (
     schedule_id TEXT PRIMARY KEY,
     enabled     INTEGER DEFAULT 1,
     next_run    TEXT,
+    tenant_id   TEXT NOT NULL DEFAULT 'default',
     data        JSONB NOT NULL
 );
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_schedules' AND column_name = 'tenant_id'
+    ) THEN
+        ALTER TABLE scan_schedules ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default';
+    END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_schedules_due
     ON scan_schedules(next_run)
     WHERE enabled = 1 AND next_run IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_schedules_tenant_due
+    ON scan_schedules(tenant_id, enabled, next_run);
 
 -- ── Tables: OSV Scan Cache ────────────────────────────────────────────────────
 
@@ -290,6 +302,65 @@ CREATE INDEX IF NOT EXISTS idx_jobq_status_due ON job_queue(status, scheduled_fo
     WHERE status IN ('pending', 'running');
 CREATE INDEX IF NOT EXISTS idx_jobq_team       ON job_queue(team_id);
 CREATE INDEX IF NOT EXISTS idx_jobq_type       ON job_queue(job_type);
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- TENANT RLS HELPERS + POLICIES
+-- ══════════════════════════════════════════════════════════════════════════════
+--
+-- Request handlers set app.tenant_id on the Postgres session. Internal trusted
+-- scheduler tasks can set app.bypass_rls=1 for cross-tenant maintenance work.
+
+CREATE OR REPLACE FUNCTION public.abom_current_tenant()
+RETURNS TEXT
+LANGUAGE SQL
+STABLE
+AS $$
+    SELECT COALESCE(NULLIF(current_setting('app.tenant_id', true), ''), 'default')
+$$;
+
+CREATE OR REPLACE FUNCTION public.abom_rls_bypass()
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+AS $$
+    SELECT COALESCE(NULLIF(current_setting('app.bypass_rls', true), ''), '0') = '1'
+$$;
+
+ALTER TABLE fleet_agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fleet_agents FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'fleet_agents'
+          AND policyname = 'fleet_agents_tenant_isolation'
+    ) THEN
+        CREATE POLICY fleet_agents_tenant_isolation ON fleet_agents
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE scan_schedules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scan_schedules FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'scan_schedules'
+          AND policyname = 'scan_schedules_tenant_isolation'
+    ) THEN
+        CREATE POLICY scan_schedules_tenant_isolation ON scan_schedules
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
 
 -- ══════════════════════════════════════════════════════════════════════════════
 -- LEAST PRIVILEGE: App user — DML only, no DDL (cannot CREATE/DROP/ALTER)

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -115,6 +115,9 @@ export AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1        # fail closed if the claim i
 ```
 
 That keeps API roles and tenant boundaries aligned with the upstream identity provider instead of silently falling back to a shared tenant when you expect strict isolation.
+
+For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated tenant into the database session (`app.tenant_id`) so Postgres row-level security can enforce the same tenant boundary for fleet and schedule data. Internal scheduler work uses an explicit trusted bypass rather than silently reading across tenants.
+
 **Storage:** SQLite (single node), PostgreSQL (team), Snowflake/ClickHouse (enterprise).
 
 ### 4. Cloud Infrastructure — agentless discovery

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,8 +51,9 @@ Goal: make the product secure and explainable by default in real deployments.
 
 | Item | Issue | Status |
 |------|-------|--------|
-| Helm security defaults: security context, probes, NetworkPolicy wiring | [#1214](https://github.com/msaad00/agent-bom/pull/1214) | In progress |
-| Tenant isolation enforcement on fleet and schedule routes | [#1222](https://github.com/msaad00/agent-bom/pull/1222) | In progress |
+| Helm security defaults: security context, probes, NetworkPolicy wiring | [#1214](https://github.com/msaad00/agent-bom/pull/1214) | Landed |
+| Tenant isolation enforcement on fleet and schedule routes | [#1222](https://github.com/msaad00/agent-bom/pull/1222) | Landed |
+| Postgres tenant session plumbing + first DB-level RLS slice | New lane | In progress |
 
 ### Next
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -32,7 +32,18 @@ class TrustHeadersMiddleware(BaseHTTPMiddleware):
         request.state.request_id = request_id
         if not hasattr(request.state, "tenant_id"):
             request.state.tenant_id = "default"
-        response = await call_next(request)
+        tenant_token = None
+        try:
+            if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+                from agent_bom.api.postgres_store import set_current_tenant
+
+                tenant_token = set_current_tenant(getattr(request.state, "tenant_id", "default"))
+            response = await call_next(request)
+        finally:
+            if tenant_token is not None:
+                from agent_bom.api.postgres_store import reset_current_tenant
+
+                reset_current_tenant(tenant_token)
         response.headers["X-Request-ID"] = request_id
         response.headers["X-Agent-Bom-Read-Only"] = "true"
         response.headers["X-Agent-Bom-No-Credential-Storage"] = "true"
@@ -132,7 +143,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             request.state.api_key_name = "static-key"
             request.state.api_key_role = "admin"
             request.state.tenant_id = "default"
-            return await call_next(request)
+            return await self._call_with_tenant_context(request, call_next)
 
         # OIDC mode: try JWT verification when AGENT_BOM_OIDC_ISSUER is set
         if not self._oidc_checked:
@@ -154,7 +165,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                     request.state.api_key_name = _claims.get("email") or _claims.get("sub", "oidc-user")
                     request.state.api_key_role = oidc_role
                     request.state.tenant_id = oidc_cfg.resolve_tenant(_claims)
-                    return await call_next(request)
+                    return await self._call_with_tenant_context(request, call_next)
                 return JSONResponse(
                     status_code=403,
                     content={"detail": f"Forbidden — requires {required} role, OIDC token has {oidc_role}"},
@@ -180,12 +191,26 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 request.state.api_key_name = api_key.name
                 request.state.api_key_role = api_key.role.value
                 request.state.tenant_id = api_key.tenant_id
-                return await call_next(request)
+                return await self._call_with_tenant_context(request, call_next)
 
         return JSONResponse(
             status_code=401,
             content={"detail": "Unauthorized — invalid API key"},
         )
+
+    async def _call_with_tenant_context(self, request: StarletteRequest, call_next):
+        tenant_token = None
+        try:
+            if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+                from agent_bom.api.postgres_store import set_current_tenant
+
+                tenant_token = set_current_tenant(getattr(request.state, "tenant_id", "default"))
+            return await call_next(request)
+        finally:
+            if tenant_token is not None:
+                from agent_bom.api.postgres_store import reset_current_tenant
+
+                reset_current_tenant(tenant_token)
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -19,6 +19,8 @@ import json
 import logging
 import os
 import time
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
@@ -27,6 +29,28 @@ _JOB_TTL_SECONDS = 3600
 
 # Module-level pool singleton
 _pool = None
+_current_tenant: ContextVar[str] = ContextVar("agent_bom_postgres_tenant", default="default")
+_bypass_tenant_rls: ContextVar[bool] = ContextVar("agent_bom_postgres_bypass_rls", default=False)
+
+
+def set_current_tenant(tenant_id: str) -> Token[str]:
+    """Bind the current Postgres tenant context for the active request/task."""
+    return _current_tenant.set((tenant_id or "default").strip() or "default")
+
+
+def reset_current_tenant(token: Token[str]) -> None:
+    """Restore the previous Postgres tenant context."""
+    _current_tenant.reset(token)
+
+
+@contextmanager
+def bypass_tenant_rls():
+    """Temporarily disable Postgres tenant RLS for trusted internal tasks."""
+    token = _bypass_tenant_rls.set(True)
+    try:
+        yield
+    finally:
+        _bypass_tenant_rls.reset(token)
 
 
 def _get_pool():
@@ -49,6 +73,68 @@ def reset_pool():
     """Reset the connection pool (for testing)."""
     global _pool
     _pool = None
+
+
+def _apply_tenant_session(conn) -> None:
+    """Attach tenant session settings used by Postgres RLS policies."""
+    conn.execute("SELECT set_config('app.tenant_id', %s, true)", (_current_tenant.get(),))
+    conn.execute("SELECT set_config('app.bypass_rls', %s, true)", ("1" if _bypass_tenant_rls.get() else "0",))
+
+
+def _ensure_rls_helpers(conn) -> None:
+    """Create shared SQL helpers used by tenant RLS policies."""
+    conn.execute("""
+        CREATE OR REPLACE FUNCTION public.abom_current_tenant()
+        RETURNS TEXT
+        LANGUAGE SQL
+        STABLE
+        AS $$
+            SELECT COALESCE(NULLIF(current_setting('app.tenant_id', true), ''), 'default')
+        $$;
+    """)
+    conn.execute("""
+        CREATE OR REPLACE FUNCTION public.abom_rls_bypass()
+        RETURNS BOOLEAN
+        LANGUAGE SQL
+        STABLE
+        AS $$
+            SELECT COALESCE(NULLIF(current_setting('app.bypass_rls', true), ''), '0') = '1'
+        $$;
+    """)
+
+
+def _ensure_tenant_rls(conn, table: str, column: str) -> None:
+    """Enable tenant RLS for a table using the shared tenant session helpers."""
+    _ensure_rls_helpers(conn)
+    conn.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")  # nosec B608
+    conn.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")  # nosec B608
+    conn.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_policies
+                WHERE schemaname = 'public'
+                  AND tablename = '{table}'
+                  AND policyname = '{table}_tenant_isolation'
+            ) THEN
+                EXECUTE 'CREATE POLICY {table}_tenant_isolation ON {table}
+                    USING (public.abom_rls_bypass() OR {column} = public.abom_current_tenant())
+                    WITH CHECK (public.abom_rls_bypass() OR {column} = public.abom_current_tenant())';
+            END IF;
+        END
+        $$;
+        """  # nosec B608
+    )
+
+
+@contextmanager
+def _tenant_connection(pool):
+    """Open a connection with the current tenant/bypass settings attached."""
+    with pool.connection() as conn:
+        _apply_tenant_session(conn)
+        yield conn
 
 
 # ── PostgresJobStore ───────────────────────────────────────────────────────
@@ -76,7 +162,7 @@ class PostgresJobStore:
 
     def put(self, job) -> None:
         data = job.model_dump_json()
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             conn.execute(
                 """INSERT INTO scan_jobs (job_id, status, created_at, completed_at, data)
                    VALUES (%s, %s, %s, %s, %s)
@@ -91,7 +177,7 @@ class PostgresJobStore:
     def get(self, job_id: str):
         from .server import ScanJob
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             row = conn.execute("SELECT data FROM scan_jobs WHERE job_id = %s", (job_id,)).fetchone()
             if row is None:
                 return None
@@ -99,7 +185,7 @@ class PostgresJobStore:
             return ScanJob.model_validate_json(raw)
 
     def delete(self, job_id: str) -> bool:
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             cursor = conn.execute("DELETE FROM scan_jobs WHERE job_id = %s", (job_id,))
             conn.commit()
             return cursor.rowcount > 0
@@ -107,18 +193,18 @@ class PostgresJobStore:
     def list_all(self) -> list:
         from .server import ScanJob
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC").fetchall()
             return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_summary(self) -> list[dict]:
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT job_id, status, created_at, completed_at FROM scan_jobs ORDER BY created_at DESC").fetchall()
             return [{"job_id": r[0], "status": r[1], "created_at": r[2], "completed_at": r[3]} for r in rows]
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         now = datetime.now(timezone.utc).isoformat()
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
                 """DELETE FROM scan_jobs
                    WHERE status IN ('done', 'failed', 'cancelled')
@@ -156,11 +242,12 @@ class PostgresFleetStore:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_name ON fleet_agents(name)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state ON fleet_agents(lifecycle_state)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_tenant ON fleet_agents(tenant_id)")
+            _ensure_tenant_rls(conn, "fleet_agents", "tenant_id")
             conn.commit()
 
     def put(self, agent) -> None:
         data = agent.model_dump_json()
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             conn.execute(
                 """INSERT INTO fleet_agents (agent_id, name, lifecycle_state, trust_score, tenant_id, updated_at, data)
                    VALUES (%s, %s, %s, %s, %s, %s, %s)
@@ -178,7 +265,7 @@ class PostgresFleetStore:
     def get(self, agent_id: str):
         from .fleet_store import FleetAgent
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             row = conn.execute("SELECT data FROM fleet_agents WHERE agent_id = %s", (agent_id,)).fetchone()
             if row is None:
                 return None
@@ -188,7 +275,7 @@ class PostgresFleetStore:
     def get_by_name(self, name: str):
         from .fleet_store import FleetAgent
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             row = conn.execute("SELECT data FROM fleet_agents WHERE name = %s", (name,)).fetchone()
             if row is None:
                 return None
@@ -196,7 +283,7 @@ class PostgresFleetStore:
             return FleetAgent.model_validate_json(raw)
 
     def delete(self, agent_id: str) -> bool:
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             cursor = conn.execute("DELETE FROM fleet_agents WHERE agent_id = %s", (agent_id,))
             conn.commit()
             return cursor.rowcount > 0
@@ -204,29 +291,29 @@ class PostgresFleetStore:
     def list_all(self) -> list:
         from .fleet_store import FleetAgent
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT data FROM fleet_agents ORDER BY name").fetchall()
             return [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_summary(self) -> list[dict]:
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT agent_id, name, lifecycle_state, trust_score FROM fleet_agents ORDER BY name").fetchall()
             return [{"agent_id": r[0], "name": r[1], "lifecycle_state": r[2], "trust_score": r[3]} for r in rows]
 
     def list_by_tenant(self, tenant_id: str) -> list:
         from .fleet_store import FleetAgent
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT data FROM fleet_agents WHERE tenant_id = %s ORDER BY name", (tenant_id,)).fetchall()
             return [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_tenants(self) -> list[dict]:
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT tenant_id, COUNT(*) as cnt FROM fleet_agents GROUP BY tenant_id ORDER BY tenant_id").fetchall()
             return [{"tenant_id": r[0], "agent_count": r[1]} for r in rows]
 
     def update_state(self, agent_id: str, state) -> bool:
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
                 "UPDATE fleet_agents SET lifecycle_state = %s WHERE agent_id = %s",
                 (state.value, agent_id),
@@ -362,29 +449,45 @@ class PostgresScheduleStore:
                     schedule_id TEXT PRIMARY KEY,
                     enabled INTEGER DEFAULT 1,
                     next_run TEXT,
+                    tenant_id TEXT NOT NULL DEFAULT 'default',
                     data JSONB NOT NULL
                 )
             """)
+            conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_schedules' AND column_name = 'tenant_id'
+                    ) THEN
+                        ALTER TABLE scan_schedules ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                END
+                $$;
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_sched_tenant_due ON scan_schedules(tenant_id, enabled, next_run)")
+            _ensure_tenant_rls(conn, "scan_schedules", "tenant_id")
             conn.commit()
 
     def put(self, schedule) -> None:
         data = schedule.model_dump_json()
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             conn.execute(
-                """INSERT INTO scan_schedules (schedule_id, enabled, next_run, data)
-                   VALUES (%s, %s, %s, %s)
+                """INSERT INTO scan_schedules (schedule_id, enabled, next_run, tenant_id, data)
+                   VALUES (%s, %s, %s, %s, %s)
                    ON CONFLICT (schedule_id) DO UPDATE SET
                      enabled = EXCLUDED.enabled,
                      next_run = EXCLUDED.next_run,
+                     tenant_id = EXCLUDED.tenant_id,
                      data = EXCLUDED.data""",
-                (schedule.schedule_id, int(schedule.enabled), schedule.next_run, data),
+                (schedule.schedule_id, int(schedule.enabled), schedule.next_run, schedule.tenant_id, data),
             )
             conn.commit()
 
     def get(self, schedule_id: str):
         from .schedule_store import ScanSchedule
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             row = conn.execute("SELECT data FROM scan_schedules WHERE schedule_id = %s", (schedule_id,)).fetchone()
             if row is None:
                 return None
@@ -392,7 +495,7 @@ class PostgresScheduleStore:
             return ScanSchedule.model_validate_json(raw)
 
     def delete(self, schedule_id: str) -> bool:
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             cursor = conn.execute("DELETE FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
             conn.commit()
             return cursor.rowcount > 0
@@ -400,14 +503,14 @@ class PostgresScheduleStore:
     def list_all(self) -> list:
         from .schedule_store import ScanSchedule
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT data FROM scan_schedules ORDER BY schedule_id").fetchall()
             return [ScanSchedule.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_due(self, now_iso: str) -> list:
         from .schedule_store import ScanSchedule
 
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT data FROM scan_schedules WHERE enabled = 1 AND next_run IS NOT NULL AND next_run <= %s",
                 (now_iso,),

--- a/src/agent_bom/api/scheduler.py
+++ b/src/agent_bom/api/scheduler.py
@@ -100,7 +100,13 @@ async def scheduler_loop(
         try:
             now = datetime.now(timezone.utc)
             now_iso = now.isoformat()
-            due = schedule_store.list_due(now_iso)
+            try:
+                from agent_bom.api.postgres_store import bypass_tenant_rls
+            except Exception:  # pragma: no cover - optional postgres backend
+                due = schedule_store.list_due(now_iso)
+            else:
+                with bypass_tenant_rls():
+                    due = schedule_store.list_due(now_iso)
 
             for schedule in due:
                 if not schedule.enabled:
@@ -115,7 +121,13 @@ async def scheduler_loop(
                     next_run = parse_cron_next(schedule.cron_expression, now)
                     schedule.next_run = next_run.isoformat() if next_run else None
                     schedule.updated_at = now_iso
-                    schedule_store.put(schedule)
+                    try:
+                        from agent_bom.api.postgres_store import bypass_tenant_rls
+                    except Exception:  # pragma: no cover - optional postgres backend
+                        schedule_store.put(schedule)
+                    else:
+                        with bypass_tenant_rls():
+                            schedule_store.put(schedule)
                 except Exception:
                     logger.exception("Failed to trigger scheduled scan: %s", schedule.name)
 

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -256,6 +256,33 @@ def test_job_queue_payload_jsonb():
     assert "JSONB" in SQL.split("payload")[1][:20].upper()
 
 
+# ── scan_schedules RLS / tenant contract ────────────────────────────────────
+
+
+def test_scan_schedules_has_tenant_id_column():
+    cols = _columns_for("scan_schedules")
+    assert "tenant_id" in cols
+
+
+def test_scan_schedules_tenant_index_exists():
+    assert "idx_schedules_tenant_due" in _indexes()
+
+
+def test_rls_helpers_exist():
+    assert "CREATE OR REPLACE FUNCTION public.abom_current_tenant()" in SQL
+    assert "CREATE OR REPLACE FUNCTION public.abom_rls_bypass()" in SQL
+
+
+def test_fleet_agents_rls_policy_exists():
+    assert "ALTER TABLE fleet_agents ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY fleet_agents_tenant_isolation ON fleet_agents" in SQL
+
+
+def test_scan_schedules_rls_policy_exists():
+    assert "ALTER TABLE scan_schedules ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY scan_schedules_tenant_isolation ON scan_schedules" in SQL
+
+
 # ── FK consistency ────────────────────────────────────────────────────────────
 
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -31,12 +31,20 @@ class MockConnection:
     def __init__(self):
         self._store: dict[str, dict] = {}  # table -> {pk: data}
         self._cursors: list[MockCursor] = []
+        self.executed: list[tuple[str, object]] = []
 
     def execute(self, sql, params=None):
         cursor = MockCursor()
         sql_lower = sql.strip().lower()
+        self.executed.append((sql, params))
 
-        if sql_lower.startswith("create table") or sql_lower.startswith("create index"):
+        if (
+            sql_lower.startswith("create table")
+            or sql_lower.startswith("create index")
+            or sql_lower.startswith("create or replace function")
+            or sql_lower.startswith("alter table")
+            or sql_lower.startswith("do $$")
+        ):
             pass  # DDL — no-op
         elif sql_lower.startswith("insert"):
             cursor.rowcount = 1
@@ -559,6 +567,31 @@ def test_schedule_store_list_due(mock_pool):
     store = PostgresScheduleStore(pool=mock_pool)
     result = store.list_due("2025-06-15T12:00:00+00:00")
     assert isinstance(result, list)
+
+
+def test_tenant_context_is_applied_to_postgres_session(mock_pool):
+    from agent_bom.api.postgres_store import PostgresFleetStore, reset_current_tenant, set_current_tenant
+
+    token = set_current_tenant("tenant-zeta")
+    try:
+        store = PostgresFleetStore(pool=mock_pool)
+        store.list_by_tenant("tenant-zeta")
+    finally:
+        reset_current_tenant(token)
+
+    assert any("set_config('app.tenant_id'" in sql for sql, _ in mock_pool._conn.executed)
+    assert any(params == ("tenant-zeta",) for sql, params in mock_pool._conn.executed if "set_config('app.tenant_id'" in sql)
+
+
+def test_scheduler_bypass_sets_rls_flag(mock_pool):
+    from agent_bom.api.postgres_store import PostgresScheduleStore, bypass_tenant_rls
+
+    store = PostgresScheduleStore(pool=mock_pool)
+    with bypass_tenant_rls():
+        store.list_due("2025-06-15T12:00:00+00:00")
+
+    assert any("set_config('app.bypass_rls'" in sql for sql, _ in mock_pool._conn.executed)
+    assert any(params == ("1",) for sql, params in mock_pool._conn.executed if "set_config('app.bypass_rls'" in sql)
 
 
 # ─── PostgresScanCache ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add Postgres tenant session plumbing so request tenant flows into the DB session
- enforce a first DB-level RLS slice for fleet agents and scan schedules
- add an explicit trusted scheduler bypass instead of silent cross-tenant reads
- align Supabase/Postgres schema, enterprise docs, roadmap, and tests with the new contract

## Validation
- uv run pytest -q tests/test_postgres_schema.py tests/test_postgres_store.py tests/test_api_oidc.py tests/test_api_hardening.py
- uv run pytest -q tests/test_schedule_store.py tests/test_api_tenant_isolation.py tests/test_api_enterprise_tenant.py
- uv run python -m compileall src/agent_bom/api