### PR TITLE
feat(api): persist enterprise stores in postgres

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -275,6 +275,30 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_team   ON api_keys(team_id);
 CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(key_prefix);   -- fast lookup during auth
 CREATE INDEX IF NOT EXISTS idx_api_keys_active ON api_keys(team_id, revoked) WHERE revoked = FALSE;
 
+-- ── Table: exceptions ────────────────────────────────────────────────────────
+-- Persistent vulnerability exceptions and false positives. team_id keeps
+-- exception workflows tenant-scoped in hosted deployments.
+
+CREATE TABLE IF NOT EXISTS exceptions (
+    exception_id TEXT PRIMARY KEY,
+    vuln_id      TEXT NOT NULL,
+    package_name TEXT NOT NULL,
+    server_name  TEXT NOT NULL DEFAULT '',
+    reason       TEXT NOT NULL DEFAULT '',
+    requested_by TEXT NOT NULL DEFAULT '',
+    approved_by  TEXT NOT NULL DEFAULT '',
+    status       TEXT NOT NULL DEFAULT 'pending',
+    created_at   TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+    expires_at   TEXT NOT NULL DEFAULT '',
+    approved_at  TEXT NOT NULL DEFAULT '',
+    revoked_at   TEXT NOT NULL DEFAULT '',
+    team_id      TEXT NOT NULL DEFAULT 'default' REFERENCES teams(team_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_exc_status ON exceptions(status);
+CREATE INDEX IF NOT EXISTS idx_exc_team   ON exceptions(team_id);
+CREATE INDEX IF NOT EXISTS idx_exc_vuln   ON exceptions(vuln_id);
+
 -- ── Table: job_queue ──────────────────────────────────────────────────────────
 -- Background task queue for async operations: CVE enrichment, report
 -- generation, policy batch evaluation. Separate from scan_jobs so each
@@ -376,6 +400,42 @@ BEGIN
         CREATE POLICY scan_schedules_tenant_isolation ON scan_schedules
             USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
             WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY;
+ALTER TABLE api_keys FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'api_keys'
+          AND policyname = 'api_keys_tenant_isolation'
+    ) THEN
+        CREATE POLICY api_keys_tenant_isolation ON api_keys
+            USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE exceptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE exceptions FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'exceptions'
+          AND policyname = 'exceptions_tenant_isolation'
+    ) THEN
+        CREATE POLICY exceptions_tenant_isolation ON exceptions
+            USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
     END IF;
 END
 $$;

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -14,6 +14,7 @@ import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
+from typing import Protocol
 
 
 class Role(str, Enum):
@@ -175,11 +176,22 @@ class KeyStore:
             return len(self._keys) > 0
 
 
-_key_store: KeyStore | None = None
+class KeyStoreProtocol(Protocol):
+    """Interface shared by in-memory and persistent API key stores."""
+
+    def add(self, key: ApiKey) -> None: ...
+    def remove(self, key_id: str) -> bool: ...
+    def get(self, key_id: str) -> ApiKey | None: ...
+    def list_keys(self, tenant_id: str | None = None) -> list[ApiKey]: ...
+    def verify(self, raw_key: str) -> ApiKey | None: ...
+    def has_keys(self) -> bool: ...
+
+
+_key_store: KeyStoreProtocol | None = None
 _store_lock = threading.Lock()
 
 
-def get_key_store() -> KeyStore:
+def get_key_store() -> KeyStoreProtocol:
     global _key_store
     if _key_store is None:
         with _store_lock:
@@ -188,7 +200,7 @@ def get_key_store() -> KeyStore:
     return _key_store
 
 
-def set_key_store(store: KeyStore) -> None:
+def set_key_store(store: KeyStoreProtocol) -> None:
     global _key_store
     with _store_lock:
         _key_store = store

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -3,6 +3,8 @@
 Provides pluggable PostgreSQL persistence for all store protocols:
 - ``PostgresJobStore``       — scan job persistence
 - ``PostgresFleetStore``     — fleet agent lifecycle
+- ``PostgresKeyStore``       — persistent API key storage
+- ``PostgresExceptionStore`` — exception and false-positive storage
 - ``PostgresPolicyStore``    — gateway policies + audit log
 - ``PostgresScheduleStore``  — recurring scan schedules
 - ``PostgresScanCache``      — OSV vulnerability scan cache
@@ -22,6 +24,9 @@ import time
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from datetime import datetime, timezone
+
+from agent_bom.api.auth import ApiKey, Role, verify_api_key
+from agent_bom.api.exception_store import ExceptionStatus, VulnException
 
 logger = logging.getLogger(__name__)
 
@@ -356,6 +361,297 @@ class PostgresFleetStore:
             self.put(agent)
             count += 1
         return count
+
+
+# ── PostgresKeyStore ───────────────────────────────────────────────────────
+
+
+class PostgresKeyStore:
+    """PostgreSQL-backed API key storage with tenant RLS."""
+
+    def __init__(self, pool=None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS api_keys (
+                    key_id TEXT PRIMARY KEY,
+                    key_hash TEXT NOT NULL,
+                    key_salt TEXT NOT NULL,
+                    key_prefix TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    team_id TEXT NOT NULL DEFAULT 'default',
+                    scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    created_by TEXT,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT,
+                    last_used TEXT,
+                    revoked BOOLEAN NOT NULL DEFAULT FALSE
+                )
+            """)
+            conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'api_keys' AND column_name = 'team_id'
+                    ) THEN
+                        ALTER TABLE api_keys ADD COLUMN team_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                END
+                $$;
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_team ON api_keys(team_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(key_prefix)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_active ON api_keys(team_id, revoked)")
+            _ensure_tenant_rls(conn, "api_keys", "team_id")
+            conn.commit()
+
+    @staticmethod
+    def _row_to_key(row) -> ApiKey:
+        scopes = row[7] if isinstance(row[7], list) else json.loads(row[7] or "[]")
+        return ApiKey(
+            key_id=row[0],
+            key_hash=row[1],
+            key_salt=row[2],
+            key_prefix=row[3],
+            name=row[4],
+            role=Role(row[5]),
+            tenant_id=row[6],
+            scopes=scopes,
+            created_at=row[8],
+            expires_at=row[9],
+        )
+
+    def add(self, key: ApiKey) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """INSERT INTO api_keys
+                   (key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at, revoked)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+                   ON CONFLICT (key_id) DO UPDATE SET
+                     key_hash = EXCLUDED.key_hash,
+                     key_salt = EXCLUDED.key_salt,
+                     key_prefix = EXCLUDED.key_prefix,
+                     name = EXCLUDED.name,
+                     role = EXCLUDED.role,
+                     team_id = EXCLUDED.team_id,
+                     scopes = EXCLUDED.scopes,
+                     created_at = EXCLUDED.created_at,
+                     expires_at = EXCLUDED.expires_at,
+                     revoked = FALSE""",
+                (
+                    key.key_id,
+                    key.key_hash,
+                    key.key_salt,
+                    key.key_prefix,
+                    key.name,
+                    key.role.value,
+                    key.tenant_id,
+                    json.dumps(key.scopes),
+                    key.created_at,
+                    key.expires_at,
+                ),
+            )
+            conn.commit()
+
+    def remove(self, key_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "UPDATE api_keys SET revoked = TRUE WHERE key_id = %s AND revoked = FALSE",
+                (key_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def get(self, key_id: str) -> ApiKey | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                """SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
+                   FROM api_keys
+                   WHERE key_id = %s AND revoked = FALSE""",
+                (key_id,),
+            ).fetchone()
+            return self._row_to_key(row) if row else None
+
+    def list_keys(self, tenant_id: str | None = None) -> list[ApiKey]:
+        query = """
+            SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
+            FROM api_keys
+            WHERE revoked = FALSE
+        """
+        params: tuple[object, ...] = ()
+        if tenant_id is not None:
+            query += " AND team_id = %s"
+            params = (tenant_id,)
+        query += " ORDER BY created_at DESC"
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(query, params).fetchall()
+            return [self._row_to_key(row) for row in rows]
+
+    def verify(self, raw_key: str) -> ApiKey | None:
+        prefix = raw_key[:12]
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                """SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
+                   FROM api_keys
+                   WHERE key_prefix = %s AND revoked = FALSE""",
+                (prefix,),
+            ).fetchall()
+        return verify_api_key(raw_key, [self._row_to_key(row) for row in rows])
+
+    def has_keys(self) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute("SELECT COUNT(*) FROM api_keys WHERE revoked = FALSE").fetchone()
+            return bool(row and row[0] > 0)
+
+
+# ── PostgresExceptionStore ─────────────────────────────────────────────────
+
+
+class PostgresExceptionStore:
+    """PostgreSQL-backed vulnerability exception storage with tenant RLS."""
+
+    def __init__(self, pool=None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS exceptions (
+                    exception_id TEXT PRIMARY KEY,
+                    vuln_id TEXT NOT NULL,
+                    package_name TEXT NOT NULL,
+                    server_name TEXT NOT NULL DEFAULT '',
+                    reason TEXT NOT NULL DEFAULT '',
+                    requested_by TEXT NOT NULL DEFAULT '',
+                    approved_by TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL DEFAULT '',
+                    approved_at TEXT NOT NULL DEFAULT '',
+                    revoked_at TEXT NOT NULL DEFAULT '',
+                    team_id TEXT NOT NULL DEFAULT 'default'
+                )
+            """)
+            conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'exceptions' AND column_name = 'team_id'
+                    ) THEN
+                        ALTER TABLE exceptions ADD COLUMN team_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                END
+                $$;
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_exc_status ON exceptions(status)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_exc_team ON exceptions(team_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_exc_vuln ON exceptions(vuln_id)")
+            _ensure_tenant_rls(conn, "exceptions", "team_id")
+            conn.commit()
+
+    @staticmethod
+    def _row_to_exception(row) -> VulnException:
+        return VulnException(
+            exception_id=row[0],
+            vuln_id=row[1],
+            package_name=row[2],
+            server_name=row[3],
+            reason=row[4],
+            requested_by=row[5],
+            approved_by=row[6],
+            status=ExceptionStatus(row[7]),
+            created_at=row[8],
+            expires_at=row[9],
+            approved_at=row[10],
+            revoked_at=row[11],
+            tenant_id=row[12],
+        )
+
+    def put(self, exc: VulnException) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """INSERT INTO exceptions
+                   (exception_id, vuln_id, package_name, server_name, reason, requested_by, approved_by, status,
+                    created_at, expires_at, approved_at, revoked_at, team_id)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                   ON CONFLICT (exception_id) DO UPDATE SET
+                     vuln_id = EXCLUDED.vuln_id,
+                     package_name = EXCLUDED.package_name,
+                     server_name = EXCLUDED.server_name,
+                     reason = EXCLUDED.reason,
+                     requested_by = EXCLUDED.requested_by,
+                     approved_by = EXCLUDED.approved_by,
+                     status = EXCLUDED.status,
+                     created_at = EXCLUDED.created_at,
+                     expires_at = EXCLUDED.expires_at,
+                     approved_at = EXCLUDED.approved_at,
+                     revoked_at = EXCLUDED.revoked_at,
+                     team_id = EXCLUDED.team_id""",
+                (
+                    exc.exception_id,
+                    exc.vuln_id,
+                    exc.package_name,
+                    exc.server_name,
+                    exc.reason,
+                    exc.requested_by,
+                    exc.approved_by,
+                    exc.status.value,
+                    exc.created_at,
+                    exc.expires_at,
+                    exc.approved_at,
+                    exc.revoked_at,
+                    exc.tenant_id,
+                ),
+            )
+            conn.commit()
+
+    def get(self, exception_id: str) -> VulnException | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                """SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, approved_by,
+                          status, created_at, expires_at, approved_at, revoked_at, team_id
+                   FROM exceptions
+                   WHERE exception_id = %s""",
+                (exception_id,),
+            ).fetchone()
+            return self._row_to_exception(row) if row else None
+
+    def delete(self, exception_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute("DELETE FROM exceptions WHERE exception_id = %s", (exception_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def list_all(self, status: str | None = None, tenant_id: str = "default") -> list[VulnException]:
+        query = """
+            SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, approved_by,
+                   status, created_at, expires_at, approved_at, revoked_at, team_id
+            FROM exceptions
+            WHERE team_id = %s
+        """
+        params: list[object] = [tenant_id]
+        if status:
+            query += " AND status = %s"
+            params.append(status)
+        query += " ORDER BY created_at DESC"
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(query, tuple(params)).fetchall()
+            return [self._row_to_exception(row) for row in rows]
+
+    def find_matching(self, vuln_id: str, package_name: str, server_name: str = "", tenant_id: str = "default") -> VulnException | None:
+        active = self.list_all(status="active", tenant_id=tenant_id)
+        approved = self.list_all(status="approved", tenant_id=tenant_id)
+        for exc in active + approved:
+            if exc.matches(vuln_id, package_name, server_name):
+                return exc
+        return None
 
 
 # ── PostgresPolicyStore ────────────────────────────────────────────────────

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -41,6 +41,7 @@ from agent_bom.api.stores import (
     _jobs_pop,  # noqa: F401 — re-exported for tests
     _jobs_put,  # noqa: F401 — re-exported for tests
     set_analytics_store,
+    set_exception_store,
     set_fleet_store,
     set_job_store,
     set_policy_store,
@@ -86,9 +87,13 @@ async def _lifespan(app_instance: FastAPI):
         if _stores._policy_store is None:
             set_policy_store(SnowflakePolicyStore(sf))
     elif os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        from agent_bom.api import auth as _auth
+        from agent_bom.api.auth import set_key_store
         from agent_bom.api.postgres_store import (
+            PostgresExceptionStore,
             PostgresFleetStore,
             PostgresJobStore,
+            PostgresKeyStore,
             PostgresPolicyStore,
         )
 
@@ -98,6 +103,10 @@ async def _lifespan(app_instance: FastAPI):
             set_fleet_store(PostgresFleetStore())
         if _stores._policy_store is None:
             set_policy_store(PostgresPolicyStore())
+        if _stores._exception_store is None:
+            set_exception_store(PostgresExceptionStore())
+        if _auth._key_store is None:
+            set_key_store(PostgresKeyStore())
     elif os.environ.get("AGENT_BOM_DB"):
         db_path = os.environ["AGENT_BOM_DB"]
         if _stores._store is None:

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -183,6 +183,12 @@ def _get_exception_store():
     return _exception_store
 
 
+def set_exception_store(store: Any) -> None:
+    """Switch the exception store backend. Call before server startup."""
+    global _exception_store
+    _exception_store = store
+
+
 # ─── Trend store (enterprise baseline comparison) ───────────────────────────
 _trend_store: Any = None
 _last_scan_report: dict | None = None

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -241,6 +241,46 @@ def test_api_keys_prefix_index():
     assert "idx_api_keys_prefix" in _indexes()
 
 
+def test_api_keys_rls_policy_exists():
+    assert "ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY api_keys_tenant_isolation ON api_keys" in SQL
+
+
+# ── exceptions ────────────────────────────────────────────────────────────────
+
+
+def test_exceptions_required_columns():
+    cols = _columns_for("exceptions")
+    for col in (
+        "exception_id",
+        "vuln_id",
+        "package_name",
+        "server_name",
+        "reason",
+        "requested_by",
+        "approved_by",
+        "status",
+        "created_at",
+        "expires_at",
+        "approved_at",
+        "revoked_at",
+        "team_id",
+    ):
+        assert col in cols, f"exceptions missing column: {col}"
+
+
+def test_exceptions_indexes_exist():
+    indexes = _indexes()
+    assert "idx_exc_status" in indexes
+    assert "idx_exc_team" in indexes
+    assert "idx_exc_vuln" in indexes
+
+
+def test_exceptions_rls_policy_exists():
+    assert "ALTER TABLE exceptions ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY exceptions_tenant_isolation ON exceptions" in SQL
+
+
 # ── job_queue ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -55,6 +55,10 @@ class MockConnection:
                     table = "scan_jobs"
                 elif "fleet_agents" in sql:
                     table = "fleet_agents"
+                elif "api_keys" in sql:
+                    table = "api_keys"
+                elif "exceptions" in sql:
+                    table = "exceptions"
                 elif "gateway_policies" in sql:
                     table = "gateway_policies"
                 elif "policy_audit_log" in sql:
@@ -74,6 +78,34 @@ class MockConnection:
                 # COUNT query
                 total = sum(len(td) for td in self._store.values())
                 cursor.rows = [(total,)]
+            elif (
+                "from api_keys" in sql_lower
+                and "key_id, key_hash, key_salt, key_prefix" in sql_lower
+                and "name, role, team_id, scopes, created_at, expires_at" in sql_lower
+            ):
+                rows = list(self._store.get("api_keys", {}).values())
+                if params:
+                    if "key_prefix = %s" in sql_lower:
+                        rows = [r for r in rows if r[3] == params[0]]
+                    elif "key_id = %s" in sql_lower:
+                        rows = [r for r in rows if r[0] == params[0]]
+                    elif "team_id = %s" in sql_lower:
+                        rows = [r for r in rows if r[6] == params[0]]
+                cursor.rows = [(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]) for r in rows]
+            elif (
+                "from exceptions" in sql_lower
+                and "exception_id, vuln_id, package_name" in sql_lower
+                and "server_name, reason, requested_by, approved_by" in sql_lower
+            ):
+                rows = list(self._store.get("exceptions", {}).values())
+                if params:
+                    if "exception_id = %s" in sql_lower:
+                        rows = [r for r in rows if r[0] == params[0]]
+                    elif "team_id = %s" in sql_lower:
+                        rows = [r for r in rows if r[12] == params[0]]
+                        if len(params) > 1:
+                            rows = [r for r in rows if r[7] == params[1]]
+                cursor.rows = [tuple(r[:13]) for r in rows]
             elif "from scan_jobs" in sql_lower and "job_id, team_id, status, created_at, completed_at" in sql_lower:
                 rows = list(self._store.get("scan_jobs", {}).values())
                 cursor.rows = [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
@@ -382,6 +414,93 @@ def test_fleet_store_batch_put(mock_pool):
     ]
     count = store.batch_put(agents)
     assert count == 3
+
+
+# ─── PostgresKeyStore ────────────────────────────────────────────────────────
+
+
+def test_key_store_add_get_list_verify_remove(mock_pool):
+    from agent_bom.api.auth import Role, create_api_key
+    from agent_bom.api.postgres_store import PostgresKeyStore
+
+    store = PostgresKeyStore(pool=mock_pool)
+    raw_key, api_key = create_api_key("alpha-admin", Role.ADMIN, tenant_id="tenant-alpha")
+    store.add(api_key)
+
+    mock_pool._conn._store.setdefault("api_keys", {})[api_key.key_id] = (
+        api_key.key_id,
+        api_key.key_hash,
+        api_key.key_salt,
+        api_key.key_prefix,
+        api_key.name,
+        api_key.role.value,
+        api_key.tenant_id,
+        json.dumps(api_key.scopes),
+        api_key.created_at,
+        api_key.expires_at,
+    )
+
+    loaded = store.get(api_key.key_id)
+    assert loaded is not None
+    assert loaded.tenant_id == "tenant-alpha"
+
+    listed = store.list_keys("tenant-alpha")
+    assert len(listed) == 1
+    assert listed[0].key_id == api_key.key_id
+
+    verified = store.verify(raw_key)
+    assert verified is not None
+    assert verified.key_id == api_key.key_id
+
+    assert store.remove(api_key.key_id) is True
+
+
+# ─── PostgresExceptionStore ──────────────────────────────────────────────────
+
+
+def test_exception_store_put_get_list_delete(mock_pool):
+    from agent_bom.api.exception_store import ExceptionStatus, VulnException
+    from agent_bom.api.postgres_store import PostgresExceptionStore
+
+    store = PostgresExceptionStore(pool=mock_pool)
+    exc = VulnException(
+        exception_id="exc-1",
+        vuln_id="CVE-1",
+        package_name="requests",
+        status=ExceptionStatus.ACTIVE,
+        tenant_id="tenant-alpha",
+    )
+    store.put(exc)
+
+    mock_pool._conn._store.setdefault("exceptions", {})[exc.exception_id] = (
+        exc.exception_id,
+        exc.vuln_id,
+        exc.package_name,
+        exc.server_name,
+        exc.reason,
+        exc.requested_by,
+        exc.approved_by,
+        exc.status.value,
+        exc.created_at,
+        exc.expires_at,
+        exc.approved_at,
+        exc.revoked_at,
+        exc.tenant_id,
+    )
+
+    loaded = store.get(exc.exception_id)
+    assert loaded is not None
+    assert loaded.tenant_id == "tenant-alpha"
+
+    listed = store.list_all(tenant_id="tenant-alpha")
+    assert len(listed) == 1
+    assert listed[0].exception_id == exc.exception_id
+
+    match = store.find_matching("CVE-1", "requests", tenant_id="tenant-alpha")
+    assert match is not None
+    assert match.exception_id == exc.exception_id
+
+    assert store.delete(exc.exception_id) is True
 
 
 # ─── PostgresPolicyStore ──────────────────────────────────────────────────────
@@ -713,3 +832,14 @@ def test_server_lifespan_postgres_schedule_store():
 
     source = inspect.getsource(server._lifespan)
     assert "PostgresScheduleStore" in source
+
+
+def test_server_lifespan_postgres_enterprise_stores():
+    """Postgres-backed enterprise stores are referenced in server lifespan."""
+    import inspect
+
+    from agent_bom.api import server
+
+    source = inspect.getsource(server._lifespan)
+    assert "PostgresKeyStore" in source
+    assert "PostgresExceptionStore" in source


### PR DESCRIPTION
## Summary
- persist enterprise API keys in Postgres and enforce tenant RLS on `api_keys`
- persist exceptions and false positives in Postgres and enforce tenant RLS on `exceptions`
- wire Postgres-backed key and exception stores into API startup when `AGENT_BOM_POSTGRES_URL` is set

## Testing
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_postgres_store.py tests/test_postgres_schema.py tests/test_api_enterprise_tenant.py tests/test_auth.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python -m compileall src/agent_bom/api`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/api/auth.py src/agent_bom/api/postgres_store.py src/agent_bom/api/server.py src/agent_bom/api/stores.py --ignore-missing-imports --disable-error-code import-untyped`
