### PR TITLE
feat(api): scope gateway policies by tenant

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -93,16 +93,20 @@ CREATE INDEX IF NOT EXISTS idx_fleet_tenant ON fleet_agents(tenant_id);
 
 CREATE TABLE IF NOT EXISTS gateway_policies (
     policy_id TEXT PRIMARY KEY,
+    team_id   TEXT NOT NULL DEFAULT 'default',
     data      JSONB NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS policy_audit_log (
-    id   SERIAL PRIMARY KEY,
-    ts   TEXT NOT NULL,
-    data JSONB NOT NULL
+    id      SERIAL PRIMARY KEY,
+    ts      TEXT NOT NULL,
+    team_id TEXT NOT NULL DEFAULT 'default',
+    data    JSONB NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_audit_ts ON policy_audit_log(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_gateway_policies_team ON gateway_policies(team_id);
+CREATE INDEX IF NOT EXISTS idx_policy_audit_log_team_ts ON policy_audit_log(team_id, ts DESC);
 
 -- ── Tables: Scan Schedules ────────────────────────────────────────────────────
 
@@ -350,6 +354,12 @@ AS $$
     SELECT COALESCE(NULLIF(current_setting('app.bypass_rls', true), ''), '0') = '1'
 $$;
 
+ALTER TABLE gateway_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gateway_policies FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE policy_audit_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE policy_audit_log FORCE ROW LEVEL SECURITY;
+
 ALTER TABLE fleet_agents ENABLE ROW LEVEL SECURITY;
 ALTER TABLE fleet_agents FORCE ROW LEVEL SECURITY;
 
@@ -365,6 +375,36 @@ BEGIN
           AND policyname = 'scan_jobs_tenant_isolation'
     ) THEN
         CREATE POLICY scan_jobs_tenant_isolation ON scan_jobs
+            USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'gateway_policies'
+          AND policyname = 'gateway_policies_tenant_isolation'
+    ) THEN
+        CREATE POLICY gateway_policies_tenant_isolation ON gateway_policies
+            USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'policy_audit_log'
+          AND policyname = 'policy_audit_log_tenant_isolation'
+    ) THEN
+        CREATE POLICY policy_audit_log_tenant_isolation ON policy_audit_log
             USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
             WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
     END IF;

--- a/src/agent_bom/api/policy_store.py
+++ b/src/agent_bom/api/policy_store.py
@@ -50,6 +50,7 @@ class GatewayPolicy(BaseModel):
     created_at: str = ""
     updated_at: str = ""
     enabled: bool = True
+    tenant_id: str = "default"
 
 
 class PolicyAuditEntry(BaseModel):
@@ -63,6 +64,7 @@ class PolicyAuditEntry(BaseModel):
     action_taken: str  # "blocked" | "alerted" | "allowed"
     reason: str
     timestamp: str = ""
+    tenant_id: str = "default"
 
 
 # ── Protocol ──────────────────────────────────────────────────────────────────
@@ -70,14 +72,15 @@ class PolicyAuditEntry(BaseModel):
 
 class PolicyStore(Protocol):
     def put_policy(self, policy: GatewayPolicy) -> None: ...
-    def get_policy(self, policy_id: str) -> GatewayPolicy | None: ...
-    def delete_policy(self, policy_id: str) -> bool: ...
-    def list_policies(self) -> list[GatewayPolicy]: ...
+    def get_policy(self, policy_id: str, tenant_id: str | None = None) -> GatewayPolicy | None: ...
+    def delete_policy(self, policy_id: str, tenant_id: str | None = None) -> bool: ...
+    def list_policies(self, tenant_id: str | None = None) -> list[GatewayPolicy]: ...
     def get_policies_for_agent(
         self,
         agent_name: str | None = None,
         agent_type: str | None = None,
         environment: str | None = None,
+        tenant_id: str | None = None,
     ) -> list[GatewayPolicy]: ...
     def put_audit_entry(self, entry: PolicyAuditEntry) -> None: ...
     def list_audit_entries(
@@ -85,6 +88,7 @@ class PolicyStore(Protocol):
         policy_id: str | None = None,
         agent_name: str | None = None,
         limit: int = 100,
+        tenant_id: str | None = None,
     ) -> list[PolicyAuditEntry]: ...
 
 
@@ -99,26 +103,35 @@ class InMemoryPolicyStore:
     def put_policy(self, policy: GatewayPolicy) -> None:
         self._policies[policy.policy_id] = policy
 
-    def get_policy(self, policy_id: str) -> GatewayPolicy | None:
-        return self._policies.get(policy_id)
+    def get_policy(self, policy_id: str, tenant_id: str | None = None) -> GatewayPolicy | None:
+        policy = self._policies.get(policy_id)
+        if policy is None:
+            return None
+        if tenant_id is not None and policy.tenant_id != tenant_id:
+            return None
+        return policy
 
-    def delete_policy(self, policy_id: str) -> bool:
-        if policy_id in self._policies:
+    def delete_policy(self, policy_id: str, tenant_id: str | None = None) -> bool:
+        if self.get_policy(policy_id, tenant_id=tenant_id) is not None:
             del self._policies[policy_id]
             return True
         return False
 
-    def list_policies(self) -> list[GatewayPolicy]:
-        return list(self._policies.values())
+    def list_policies(self, tenant_id: str | None = None) -> list[GatewayPolicy]:
+        policies = list(self._policies.values())
+        if tenant_id is not None:
+            policies = [p for p in policies if p.tenant_id == tenant_id]
+        return policies
 
     def get_policies_for_agent(
         self,
         agent_name: str | None = None,
         agent_type: str | None = None,
         environment: str | None = None,
+        tenant_id: str | None = None,
     ) -> list[GatewayPolicy]:
         results = []
-        for p in self._policies.values():
+        for p in self.list_policies(tenant_id=tenant_id):
             if not p.enabled:
                 continue
             if p.bound_agents and agent_name and agent_name not in p.bound_agents:
@@ -138,12 +151,15 @@ class InMemoryPolicyStore:
         policy_id: str | None = None,
         agent_name: str | None = None,
         limit: int = 100,
+        tenant_id: str | None = None,
     ) -> list[PolicyAuditEntry]:
         entries = self._audit
         if policy_id:
             entries = [e for e in entries if e.policy_id == policy_id]
         if agent_name:
             entries = [e for e in entries if e.agent_name == agent_name]
+        if tenant_id is not None:
+            entries = [e for e in entries if e.tenant_id == tenant_id]
         return entries[-limit:][::-1]
 
 
@@ -172,10 +188,15 @@ class SQLitePolicyStore:
                 mode TEXT NOT NULL,
                 enabled INTEGER NOT NULL DEFAULT 1,
                 updated_at TEXT,
+                tenant_id TEXT NOT NULL DEFAULT 'default',
                 data TEXT NOT NULL
             )"""
         )
+        cols = {r[1] for r in c.execute("PRAGMA table_info(gateway_policies)").fetchall()}
+        if "tenant_id" not in cols:
+            c.execute("ALTER TABLE gateway_policies ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
         c.execute("CREATE INDEX IF NOT EXISTS idx_gp_name ON gateway_policies(name)")
+        c.execute("CREATE INDEX IF NOT EXISTS idx_gp_tenant_name ON gateway_policies(tenant_id, name)")
         c.execute(
             """CREATE TABLE IF NOT EXISTS policy_audit_log (
                 entry_id TEXT PRIMARY KEY,
@@ -183,12 +204,17 @@ class SQLitePolicyStore:
                 agent_name TEXT,
                 action_taken TEXT,
                 timestamp TEXT,
+                tenant_id TEXT NOT NULL DEFAULT 'default',
                 data TEXT NOT NULL
             )"""
         )
+        audit_cols = {r[1] for r in c.execute("PRAGMA table_info(policy_audit_log)").fetchall()}
+        if "tenant_id" not in audit_cols:
+            c.execute("ALTER TABLE policy_audit_log ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
         c.execute("CREATE INDEX IF NOT EXISTS idx_pal_policy ON policy_audit_log(policy_id)")
         c.execute("CREATE INDEX IF NOT EXISTS idx_pal_agent ON policy_audit_log(agent_name)")
         c.execute("CREATE INDEX IF NOT EXISTS idx_pal_ts ON policy_audit_log(timestamp)")
+        c.execute("CREATE INDEX IF NOT EXISTS idx_pal_tenant_ts ON policy_audit_log(tenant_id, timestamp)")
         c.commit()
 
     # ── policies ──
@@ -196,38 +222,49 @@ class SQLitePolicyStore:
     def put_policy(self, policy: GatewayPolicy) -> None:
         self._conn.execute(
             """INSERT OR REPLACE INTO gateway_policies
-               (policy_id, name, mode, enabled, updated_at, data)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+               (policy_id, name, mode, enabled, updated_at, tenant_id, data)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (
                 policy.policy_id,
                 policy.name,
                 policy.mode.value,
                 int(policy.enabled),
                 policy.updated_at,
+                policy.tenant_id,
                 policy.model_dump_json(),
             ),
         )
         self._conn.commit()
 
-    def get_policy(self, policy_id: str) -> GatewayPolicy | None:
-        row = self._conn.execute(
-            "SELECT data FROM gateway_policies WHERE policy_id = ?",
-            (policy_id,),
-        ).fetchone()
+    def get_policy(self, policy_id: str, tenant_id: str | None = None) -> GatewayPolicy | None:
+        sql = "SELECT data FROM gateway_policies WHERE policy_id = ?"
+        params: list[object] = [policy_id]
+        if tenant_id is not None:
+            sql += " AND tenant_id = ?"
+            params.append(tenant_id)
+        row = self._conn.execute(sql, params).fetchone()
         if row is None:
             return None
         return GatewayPolicy.model_validate_json(row[0])
 
-    def delete_policy(self, policy_id: str) -> bool:
-        cur = self._conn.execute(
-            "DELETE FROM gateway_policies WHERE policy_id = ?",
-            (policy_id,),
-        )
+    def delete_policy(self, policy_id: str, tenant_id: str | None = None) -> bool:
+        sql = "DELETE FROM gateway_policies WHERE policy_id = ?"
+        params: list[object] = [policy_id]
+        if tenant_id is not None:
+            sql += " AND tenant_id = ?"
+            params.append(tenant_id)
+        cur = self._conn.execute(sql, params)
         self._conn.commit()
         return cur.rowcount > 0
 
-    def list_policies(self) -> list[GatewayPolicy]:
-        rows = self._conn.execute("SELECT data FROM gateway_policies ORDER BY name").fetchall()
+    def list_policies(self, tenant_id: str | None = None) -> list[GatewayPolicy]:
+        sql = "SELECT data FROM gateway_policies"
+        params: list[object] = []
+        if tenant_id is not None:
+            sql += " WHERE tenant_id = ?"
+            params.append(tenant_id)
+        sql += " ORDER BY name"
+        rows = self._conn.execute(sql, params).fetchall()
         return [GatewayPolicy.model_validate_json(r[0]) for r in rows]
 
     def get_policies_for_agent(
@@ -235,8 +272,9 @@ class SQLitePolicyStore:
         agent_name: str | None = None,
         agent_type: str | None = None,
         environment: str | None = None,
+        tenant_id: str | None = None,
     ) -> list[GatewayPolicy]:
-        policies = [p for p in self.list_policies() if p.enabled]
+        policies = [p for p in self.list_policies(tenant_id=tenant_id) if p.enabled]
         results = []
         for p in policies:
             if p.bound_agents and agent_name and agent_name not in p.bound_agents:
@@ -253,14 +291,15 @@ class SQLitePolicyStore:
     def put_audit_entry(self, entry: PolicyAuditEntry) -> None:
         self._conn.execute(
             """INSERT INTO policy_audit_log
-               (entry_id, policy_id, agent_name, action_taken, timestamp, data)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+               (entry_id, policy_id, agent_name, action_taken, timestamp, tenant_id, data)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (
                 entry.entry_id,
                 entry.policy_id,
                 entry.agent_name,
                 entry.action_taken,
                 entry.timestamp,
+                entry.tenant_id,
                 entry.model_dump_json(),
             ),
         )
@@ -271,6 +310,7 @@ class SQLitePolicyStore:
         policy_id: str | None = None,
         agent_name: str | None = None,
         limit: int = 100,
+        tenant_id: str | None = None,
     ) -> list[PolicyAuditEntry]:
         sql = "SELECT data FROM policy_audit_log WHERE 1=1"
         params: list[str] = []
@@ -280,6 +320,9 @@ class SQLitePolicyStore:
         if agent_name:
             sql += " AND agent_name = ?"
             params.append(agent_name)
+        if tenant_id is not None:
+            sql += " AND tenant_id = ?"
+            params.append(tenant_id)
         sql += " ORDER BY timestamp DESC LIMIT ?"
         params.append(str(limit))
         rows = self._conn.execute(sql, params).fetchall()

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -669,6 +669,7 @@ class PostgresPolicyStore:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS gateway_policies (
                     policy_id TEXT PRIMARY KEY,
+                    team_id TEXT NOT NULL DEFAULT 'default',
                     data JSONB NOT NULL
                 )
             """)
@@ -676,73 +677,155 @@ class PostgresPolicyStore:
                 CREATE TABLE IF NOT EXISTS policy_audit_log (
                     id SERIAL PRIMARY KEY,
                     ts TEXT NOT NULL,
+                    team_id TEXT NOT NULL DEFAULT 'default',
                     data JSONB NOT NULL
                 )
             """)
+            conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'gateway_policies' AND column_name = 'team_id'
+                    ) THEN
+                        ALTER TABLE gateway_policies ADD COLUMN team_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'policy_audit_log' AND column_name = 'team_id'
+                    ) THEN
+                        ALTER TABLE policy_audit_log ADD COLUMN team_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                END
+                $$;
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_gateway_policies_team ON gateway_policies(team_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_audit_log_team_ts ON policy_audit_log(team_id, ts DESC)")
+            _ensure_tenant_rls(conn, "gateway_policies", "team_id")
+            _ensure_tenant_rls(conn, "policy_audit_log", "team_id")
             conn.commit()
 
     def put_policy(self, policy) -> None:
         data = policy.model_dump_json()
-        with self._pool.connection() as conn:
+        with _tenant_connection(self._pool) as conn:
             conn.execute(
-                """INSERT INTO gateway_policies (policy_id, data) VALUES (%s, %s)
-                   ON CONFLICT (policy_id) DO UPDATE SET data = EXCLUDED.data""",
-                (policy.policy_id, data),
+                """INSERT INTO gateway_policies (policy_id, team_id, data) VALUES (%s, %s, %s)
+                   ON CONFLICT (policy_id) DO UPDATE SET team_id = EXCLUDED.team_id, data = EXCLUDED.data""",
+                (policy.policy_id, policy.tenant_id, data),
             )
             conn.commit()
 
-    def get_policy(self, policy_id: str):
+    def get_policy(self, policy_id: str, tenant_id: str | None = None):
         from .policy_store import GatewayPolicy
 
-        with self._pool.connection() as conn:
-            row = conn.execute("SELECT data FROM gateway_policies WHERE policy_id = %s", (policy_id,)).fetchone()
+        sql = "SELECT data FROM gateway_policies WHERE policy_id = %s"
+        params: list[object] = [policy_id]
+        if tenant_id is not None:
+            sql += " AND team_id = %s"
+            params.append(tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(sql, params).fetchone()
             if row is None:
                 return None
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return GatewayPolicy.model_validate_json(raw)
 
-    def delete_policy(self, policy_id: str) -> bool:
-        with self._pool.connection() as conn:
-            cursor = conn.execute("DELETE FROM gateway_policies WHERE policy_id = %s", (policy_id,))
+    def delete_policy(self, policy_id: str, tenant_id: str | None = None) -> bool:
+        sql = "DELETE FROM gateway_policies WHERE policy_id = %s"
+        params: list[object] = [policy_id]
+        if tenant_id is not None:
+            sql += " AND team_id = %s"
+            params.append(tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(sql, params)
             conn.commit()
             return cursor.rowcount > 0
 
-    def list_policies(self, enabled: bool | None = None, mode: str | None = None) -> list:
+    def list_policies(self, tenant_id: str | None = None, enabled: bool | None = None, mode: str | None = None) -> list:
         from .policy_store import GatewayPolicy
 
-        with self._pool.connection() as conn:
-            rows = conn.execute("SELECT data FROM gateway_policies").fetchall()
+        sql = "SELECT data FROM gateway_policies"
+        params: list[object] = []
+        if tenant_id is not None:
+            sql += " WHERE team_id = %s"
+            params.append(tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(sql, params).fetchall()
             policies = [GatewayPolicy.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
             if enabled is not None:
                 policies = [p for p in policies if p.enabled == enabled]
             if mode is not None:
-                policies = [p for p in policies if p.mode == mode]
+                policies = [p for p in policies if getattr(p.mode, "value", p.mode) == mode]
             return policies
 
-    def get_policies_for_agent(self, agent_type: str) -> list:
-        return [p for p in self.list_policies(enabled=True) if not p.agent_types or agent_type in p.agent_types]
+    def get_policies_for_agent(
+        self,
+        agent_name: str | None = None,
+        agent_type: str | None = None,
+        environment: str | None = None,
+        tenant_id: str | None = None,
+    ) -> list:
+        policies = self.list_policies(tenant_id=tenant_id, enabled=True)
+        results = []
+        for p in policies:
+            if p.bound_agents and agent_name and agent_name not in p.bound_agents:
+                continue
+            if p.bound_agent_types and agent_type and agent_type not in p.bound_agent_types:
+                continue
+            if p.bound_environments and environment and environment not in p.bound_environments:
+                continue
+            results.append(p)
+        return results
 
     def put_audit_entry(self, entry) -> None:
         data = entry.model_dump_json() if hasattr(entry, "model_dump_json") else json.dumps(entry)
-        with self._pool.connection() as conn:
+        team_id = getattr(entry, "tenant_id", "default")
+        with _tenant_connection(self._pool) as conn:
             conn.execute(
-                "INSERT INTO policy_audit_log (ts, data) VALUES (%s, %s)",
-                (datetime.now(timezone.utc).isoformat(), data),
+                "INSERT INTO policy_audit_log (ts, team_id, data) VALUES (%s, %s, %s)",
+                (datetime.now(timezone.utc).isoformat(), team_id, data),
             )
             conn.commit()
 
-    def list_audit_entries(self, limit: int = 100) -> list:
+    def list_audit_entries(
+        self,
+        policy_id: str | None = None,
+        agent_name: str | None = None,
+        limit: int = 100,
+        tenant_id: str | None = None,
+    ) -> list:
         from .policy_store import PolicyAuditEntry
 
-        with self._pool.connection() as conn:
-            rows = conn.execute("SELECT data FROM policy_audit_log ORDER BY ts DESC LIMIT %s", (limit,)).fetchall()
+        sql = "SELECT data FROM policy_audit_log"
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("team_id = %s")
+            params.append(tenant_id)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY ts DESC LIMIT %s"
+        params.append(limit)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(sql, params).fetchall()
             results = []
             for r in rows:
                 raw = r[0] if isinstance(r[0], str) else json.dumps(r[0])
                 try:
-                    results.append(PolicyAuditEntry.model_validate_json(raw))
+                    entry = PolicyAuditEntry.model_validate_json(raw)
                 except Exception:
-                    results.append(json.loads(raw))
+                    entry = json.loads(raw)
+                if isinstance(entry, dict):
+                    entry_policy_id = entry.get("policy_id")
+                    entry_agent_name = entry.get("agent_name")
+                else:
+                    entry_policy_id = entry.policy_id
+                    entry_agent_name = entry.agent_name
+                if policy_id and entry_policy_id != policy_id:
+                    continue
+                if agent_name and entry_agent_name != agent_name:
+                    continue
+                results.append(entry)
             return results
 
 

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from agent_bom.api.models import EvaluateRequest, PolicyCreate, PolicyUpdate
 from agent_bom.api.stores import _get_policy_store
@@ -25,9 +25,10 @@ router = APIRouter()
 
 
 @router.get("/v1/gateway/policies", tags=["gateway"])
-async def list_gateway_policies(enabled: bool | None = None, mode: str | None = None):
+async def list_gateway_policies(request: Request, enabled: bool | None = None, mode: str | None = None):
     """List all gateway policies."""
-    policies = _get_policy_store().list_policies()
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    policies = _get_policy_store().list_policies(tenant_id=tenant_id)
     if enabled is not None:
         policies = [p for p in policies if p.enabled == enabled]
     if mode:
@@ -36,7 +37,7 @@ async def list_gateway_policies(enabled: bool | None = None, mode: str | None = 
 
 
 @router.post("/v1/gateway/policies", tags=["gateway"], status_code=201)
-async def create_gateway_policy(body: PolicyCreate):
+async def create_gateway_policy(body: PolicyCreate, request: Request):
     """Create a new gateway policy."""
     from agent_bom.api.policy_store import GatewayPolicy, GatewayRule, PolicyMode
 
@@ -61,27 +62,30 @@ async def create_gateway_policy(body: PolicyCreate):
         enabled=body.enabled,
         created_at=now,
         updated_at=now,
+        tenant_id=getattr(request.state, "tenant_id", "default"),
     )
     _get_policy_store().put_policy(policy)
     return policy.model_dump()
 
 
 @router.get("/v1/gateway/policies/{policy_id}", tags=["gateway"])
-async def get_gateway_policy(policy_id: str):
+async def get_gateway_policy(policy_id: str, request: Request):
     """Get a gateway policy by ID."""
-    policy = _get_policy_store().get_policy(policy_id)
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    policy = _get_policy_store().get_policy(policy_id, tenant_id=tenant_id)
     if policy is None:
         raise HTTPException(status_code=404, detail="Policy not found")
     return policy.model_dump()
 
 
 @router.put("/v1/gateway/policies/{policy_id}", tags=["gateway"])
-async def update_gateway_policy(policy_id: str, body: PolicyUpdate):
+async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Request):
     """Update an existing gateway policy."""
     from agent_bom.api.policy_store import GatewayRule, PolicyMode
 
     store = _get_policy_store()
-    policy = store.get_policy(policy_id)
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    policy = store.get_policy(policy_id, tenant_id=tenant_id)
     if policy is None:
         raise HTTPException(status_code=404, detail="Policy not found")
     if body.name is not None:
@@ -109,19 +113,21 @@ async def update_gateway_policy(policy_id: str, body: PolicyUpdate):
 
 
 @router.delete("/v1/gateway/policies/{policy_id}", tags=["gateway"])
-async def delete_gateway_policy(policy_id: str):
+async def delete_gateway_policy(policy_id: str, request: Request):
     """Delete a gateway policy."""
-    if not _get_policy_store().delete_policy(policy_id):
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    if not _get_policy_store().delete_policy(policy_id, tenant_id=tenant_id):
         raise HTTPException(status_code=404, detail="Policy not found")
     return {"deleted": True, "policy_id": policy_id}
 
 
 @router.post("/v1/gateway/evaluate", tags=["gateway"])
-async def evaluate_gateway(body: EvaluateRequest):
+async def evaluate_gateway(body: EvaluateRequest, request: Request):
     """Dry-run evaluation of gateway policies against a tool call."""
     from agent_bom.gateway import evaluate_gateway_policies
 
-    policies = _get_policy_store().list_policies()
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    policies = _get_policy_store().list_policies(tenant_id=tenant_id)
     active = [p for p in policies if p.enabled]
     allowed, reason, policy_id = evaluate_gateway_policies(
         active,
@@ -138,24 +144,28 @@ async def evaluate_gateway(body: EvaluateRequest):
 
 @router.get("/v1/gateway/audit", tags=["gateway"])
 async def list_gateway_audit(
+    request: Request,
     policy_id: str | None = None,
     agent_name: str | None = None,
     limit: int = 100,
 ):
     """Query the gateway policy audit log."""
+    tenant_id = getattr(request.state, "tenant_id", "default")
     entries = _get_policy_store().list_audit_entries(
         policy_id=policy_id,
         agent_name=agent_name,
         limit=limit,
+        tenant_id=tenant_id,
     )
     return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
 
 
 @router.get("/v1/gateway/stats", tags=["gateway"])
-async def gateway_stats():
+async def gateway_stats(request: Request):
     """Gateway-wide statistics."""
-    policies = _get_policy_store().list_policies()
-    audit = _get_policy_store().list_audit_entries(limit=10000)
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    policies = _get_policy_store().list_policies(tenant_id=tenant_id)
+    audit = _get_policy_store().list_audit_entries(limit=10000, tenant_id=tenant_id)
     enforce_count = sum(1 for p in policies if p.mode.value == "enforce" and p.enabled)
     audit_count = sum(1 for p in policies if p.mode.value == "audit" and p.enabled)
     blocked = sum(1 for e in audit if e.action_taken == "blocked")

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -384,7 +384,7 @@ class SnowflakePolicyStore:
                 ),
             )
 
-    def get_policy(self, policy_id: str) -> GatewayPolicy | None:
+    def get_policy(self, policy_id: str, tenant_id: str | None = None) -> GatewayPolicy | None:
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute(
@@ -394,9 +394,14 @@ class SnowflakePolicyStore:
             row = cur.fetchone()
             if row is None:
                 return None
-            return GatewayPolicy.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
+            policy = GatewayPolicy.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
+            if tenant_id is not None and policy.tenant_id != tenant_id:
+                return None
+            return policy
 
-    def delete_policy(self, policy_id: str) -> bool:
+    def delete_policy(self, policy_id: str, tenant_id: str | None = None) -> bool:
+        if tenant_id is not None and self.get_policy(policy_id, tenant_id=tenant_id) is None:
+            return False
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute(
@@ -405,19 +410,23 @@ class SnowflakePolicyStore:
             )
             return (cur.rowcount or 0) > 0
 
-    def list_policies(self) -> list[GatewayPolicy]:
+    def list_policies(self, tenant_id: str | None = None) -> list[GatewayPolicy]:
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute("SELECT data FROM gateway_policies ORDER BY name")
-            return [GatewayPolicy.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+            policies = [GatewayPolicy.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+            if tenant_id is not None:
+                policies = [p for p in policies if p.tenant_id == tenant_id]
+            return policies
 
     def get_policies_for_agent(
         self,
         agent_name: str | None = None,
         agent_type: str | None = None,
         environment: str | None = None,
+        tenant_id: str | None = None,
     ) -> list[GatewayPolicy]:
-        policies = [p for p in self.list_policies() if p.enabled]
+        policies = [p for p in self.list_policies(tenant_id=tenant_id) if p.enabled]
         results = []
         for p in policies:
             if p.bound_agents and agent_name and agent_name not in p.bound_agents:
@@ -452,6 +461,7 @@ class SnowflakePolicyStore:
         policy_id: str | None = None,
         agent_name: str | None = None,
         limit: int = 100,
+        tenant_id: str | None = None,
     ) -> list[PolicyAuditEntry]:
         with self._connect() as conn:
             sql = "SELECT data FROM policy_audit_log WHERE 1=1"
@@ -466,4 +476,7 @@ class SnowflakePolicyStore:
             params.append(limit)
             cur = conn.cursor()
             cur.execute(sql, params)
-            return [PolicyAuditEntry.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+            entries = [PolicyAuditEntry.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+            if tenant_id is not None:
+                entries = [e for e in entries if e.tenant_id == tenant_id]
+            return entries

--- a/tests/test_api_gateway.py
+++ b/tests/test_api_gateway.py
@@ -85,6 +85,7 @@ def test_create_policy():
     data = resp.json()
     assert data["name"] == "block-exec"
     assert data["mode"] == "enforce"
+    assert data["tenant_id"] == "default"
     assert len(store.list_policies()) == 1
 
 
@@ -108,6 +109,13 @@ def test_get_policy():
 def test_get_not_found():
     client, _ = _fresh_client()
     resp = client.get("/v1/gateway/policies/missing")
+    assert resp.status_code == 404
+
+
+def test_get_cross_tenant_hidden():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy(policy_id="p-1", tenant_id="tenant-b"))
+    resp = client.get("/v1/gateway/policies/p-1")
     assert resp.status_code == 404
 
 
@@ -145,6 +153,15 @@ def test_delete_not_found():
     client, _ = _fresh_client()
     resp = client.delete("/v1/gateway/policies/missing")
     assert resp.status_code == 404
+
+
+def test_list_hides_other_tenants():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy(policy_id="p-1", tenant_id="default"))
+    store.put_policy(_make_policy(policy_id="p-2", tenant_id="tenant-b"))
+    resp = client.get("/v1/gateway/policies")
+    assert resp.status_code == 200
+    assert [p["policy_id"] for p in resp.json()["policies"]] == ["p-1"]
 
 
 # ── Evaluate ──────────────────────────────────────────────────────────────────

--- a/tests/test_policy_store.py
+++ b/tests/test_policy_store.py
@@ -42,6 +42,7 @@ def _make_audit(
     policy_id: str = "p-1",
     agent_name: str = "agent-a",
     action_taken: str = "blocked",
+    **kw,
 ) -> PolicyAuditEntry:
     return PolicyAuditEntry(
         entry_id=entry_id,
@@ -53,6 +54,7 @@ def _make_audit(
         action_taken=action_taken,
         reason="blocked by rule",
         timestamp=_now(),
+        **kw,
     )
 
 
@@ -84,6 +86,14 @@ def test_list_policies():
     store.put_policy(_make_policy(policy_id="p-1", name="alpha"))
     store.put_policy(_make_policy(policy_id="p-2", name="beta"))
     assert len(store.list_policies()) == 2
+
+
+def test_list_policies_by_tenant():
+    store = InMemoryPolicyStore()
+    store.put_policy(_make_policy(policy_id="p-1", tenant_id="tenant-a"))
+    store.put_policy(_make_policy(policy_id="p-2", tenant_id="tenant-b"))
+    result = store.list_policies(tenant_id="tenant-a")
+    assert [p.policy_id for p in result] == ["p-1"]
 
 
 def test_get_policies_for_agent_unbound():
@@ -130,6 +140,14 @@ def test_audit_entries_by_policy():
     assert len(result) == 1
 
 
+def test_audit_entries_by_tenant():
+    store = InMemoryPolicyStore()
+    store.put_audit_entry(_make_audit(entry_id="e-1", tenant_id="tenant-a"))
+    store.put_audit_entry(_make_audit(entry_id="e-2", tenant_id="tenant-b"))
+    result = store.list_audit_entries(tenant_id="tenant-a")
+    assert [e.entry_id for e in result] == ["e-1"]
+
+
 # ── SQLitePolicyStore ────────────────────────────────────────────────────────
 
 
@@ -165,6 +183,19 @@ def test_sqlite_list():
         store.put_policy(_make_policy(policy_id="p-1", name="alpha"))
         store.put_policy(_make_policy(policy_id="p-2", name="beta"))
         assert len(store.list_policies()) == 2
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_sqlite_tenant_scoping():
+    store, path = _sqlite_store()
+    try:
+        store.put_policy(_make_policy(policy_id="p-1", tenant_id="tenant-a"))
+        store.put_policy(_make_policy(policy_id="p-2", tenant_id="tenant-b"))
+        store.put_audit_entry(_make_audit(entry_id="e-1", tenant_id="tenant-a"))
+        store.put_audit_entry(_make_audit(entry_id="e-2", tenant_id="tenant-b"))
+        assert [p.policy_id for p in store.list_policies(tenant_id="tenant-a")] == ["p-1"]
+        assert [e.entry_id for e in store.list_audit_entries(tenant_id="tenant-a")] == ["e-1"]
     finally:
         path.unlink(missing_ok=True)
 

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -96,6 +96,18 @@ def test_total_table_count():
     assert len(_tables()) >= 12
 
 
+def test_gateway_policy_tables_have_tenant_columns():
+    assert "team_id" in _columns_for("gateway_policies")
+    assert "team_id" in _columns_for("policy_audit_log")
+
+
+def test_gateway_policy_rls_policies_exist():
+    assert "ALTER TABLE gateway_policies ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY gateway_policies_tenant_isolation ON gateway_policies" in SQL
+    assert "ALTER TABLE policy_audit_log ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY policy_audit_log_tenant_isolation ON policy_audit_log" in SQL
+
+
 # ── teams table ───────────────────────────────────────────────────────────────
 
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -62,7 +62,7 @@ class MockConnection:
                 elif "gateway_policies" in sql:
                     table = "gateway_policies"
                 elif "policy_audit_log" in sql:
-                    table = "audit"
+                    table = "policy_audit_log"
                 elif "scan_schedules" in sql:
                     table = "scan_schedules"
                 elif "osv_cache" in sql:
@@ -106,6 +106,20 @@ class MockConnection:
                         if len(params) > 1:
                             rows = [r for r in rows if r[7] == params[1]]
                 cursor.rows = [tuple(r[:13]) for r in rows]
+            elif "from gateway_policies" in sql_lower:
+                rows = list(self._store.get("gateway_policies", {}).values())
+                if "where policy_id" in sql_lower and params:
+                    rows = [r for r in rows if r[0] == params[0]]
+                    if len(params) > 1:
+                        rows = [r for r in rows if r[1] == params[1]]
+                elif "where team_id" in sql_lower and params:
+                    rows = [r for r in rows if r[1] == params[0]]
+                cursor.rows = [(r[-1],) for r in rows]
+            elif "from policy_audit_log" in sql_lower:
+                rows = list(self._store.get("policy_audit_log", {}).values())
+                if "where team_id" in sql_lower and params:
+                    rows = [r for r in rows if r[1] == params[0]]
+                cursor.rows = [(r[-1],) for r in rows]
             elif "from scan_jobs" in sql_lower and "job_id, team_id, status, created_at, completed_at" in sql_lower:
                 rows = list(self._store.get("scan_jobs", {}).values())
                 cursor.rows = [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
@@ -119,6 +133,10 @@ class MockConnection:
                             if "osv_cache" in sql and "vulns_json" in sql:
                                 # Cache query returns (vulns_json, cached_at)
                                 cursor.rows = [(row[1], row[2])]
+                            elif "from gateway_policies" in sql:
+                                cursor.rows = [(row[-1],)]
+                            elif "from policy_audit_log" in sql:
+                                cursor.rows = [(row[-1],)]
                             else:
                                 # Return the last element (data column)
                                 cursor.rows = [(row[-1],)]
@@ -528,6 +546,7 @@ def test_policy_store_put_get(mock_pool):
 
     mock_pool._conn._store.setdefault("gateway_policies", {})["p-1"] = (
         "p-1",
+        "default",
         policy.model_dump_json(),
     )
 
@@ -540,7 +559,7 @@ def test_policy_store_delete(mock_pool):
     from agent_bom.api.postgres_store import PostgresPolicyStore
 
     store = PostgresPolicyStore(pool=mock_pool)
-    mock_pool._conn._store.setdefault("gateway_policies", {})["p-1"] = ("p-1", "{}")
+    mock_pool._conn._store.setdefault("gateway_policies", {})["p-1"] = ("p-1", "default", "{}")
     assert store.delete_policy("p-1") is True
 
 
@@ -567,6 +586,33 @@ def test_policy_store_list_audit_entries(mock_pool):
     store = PostgresPolicyStore(pool=mock_pool)
     result = store.list_audit_entries()
     assert isinstance(result, list)
+
+
+def test_policy_store_tenant_filters(mock_pool):
+    from agent_bom.api.policy_store import GatewayPolicy, PolicyAuditEntry
+    from agent_bom.api.postgres_store import PostgresPolicyStore
+
+    store = PostgresPolicyStore(pool=mock_pool)
+    policy = GatewayPolicy(policy_id="p-1", name="tenant-a-policy", rules=[], tenant_id="tenant-a")
+    store.put_policy(policy)
+    mock_pool._conn._store.setdefault("gateway_policies", {})["p-1"] = ("p-1", "tenant-a", policy.model_dump_json())
+    assert store.get_policy("p-1", tenant_id="tenant-a") is not None
+    assert store.get_policy("p-1", tenant_id="tenant-b") is None
+
+    entry = PolicyAuditEntry(
+        entry_id="e-1",
+        policy_id="p-1",
+        policy_name="tenant-a-policy",
+        rule_id="r1",
+        agent_name="agent-a",
+        tool_name="read_file",
+        action_taken="allowed",
+        reason="ok",
+        tenant_id="tenant-a",
+    )
+    store.put_audit_entry(entry)
+    mock_pool._conn._store.setdefault("policy_audit_log", {})["e-1"] = ("2026-01-01T00:00:00Z", "tenant-a", entry.model_dump_json())
+    assert store.list_audit_entries(tenant_id="tenant-a")
 
 
 # ─── Pool / Config ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- scope gateway policies and policy audit entries by tenant across in-memory, SQLite, Postgres, and Snowflake stores
- enforce tenant-aware gateway route behavior for list/get/update/delete/evaluate/audit/stats
- add Postgres RLS and schema coverage for `gateway_policies` and `policy_audit_log`

## Testing
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_policy_store.py tests/test_api_gateway.py tests/test_postgres_store.py tests/test_postgres_schema.py tests/test_snowflake_stores.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/api/policy_store.py src/agent_bom/api/routes/gateway.py src/agent_bom/api/postgres_store.py src/agent_bom/api/snowflake_store.py --ignore-missing-imports --disable-error-code import-untyped`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python -m compileall src/agent_bom/api`
