### PR TITLE
feat(scan): expose model supply-chain coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ agent-bom serve                         # API + Next.js dashboard
 - MCP-aware blast radius instead of flat package CVE lists
 - AI-focused scanning across agents, instruction files, skills, runtime proxy traffic, and cloud AI surfaces
 - Project lockfile and manifest inventory with direct/transitive dependency visibility in CLI and JSON output
+- Model and weight supply-chain checks with signed-artifact detection, HuggingFace provenance, and hash-verification visibility in CLI and JSON output
 - Real operator outputs: SARIF, CycloneDX, HTML, graphs, badges, JSON, API, dashboard, and MCP tools
 - Works as local CLI, CI gate, authenticated remote service, and enterprise deployment base
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -24,7 +24,7 @@ Current repo-derived counts live in [PRODUCT_METRICS.md](PRODUCT_METRICS.md). Th
 
 ### Scanning
 
-The scanner covers package risk, malicious or suspicious package indicators, container layers, IaC, cloud AI surfaces, secrets, and instruction or skill files. Project scans surface lockfile-backed inventory, declaration-only manifests, and direct-versus-transitive package depth so users can tell how much dependency truth they are getting from a scan.
+The scanner covers package risk, malicious or suspicious package indicators, container layers, IaC, cloud AI surfaces, secrets, instruction or skill files, and model or weight supply chain integrity. Project scans surface lockfile-backed inventory, declaration-only manifests, and direct-versus-transitive package depth so users can tell how much dependency truth they are getting from a scan. Model and weight scans surface risky formats, signature presence, provenance checks, and Hub-backed hash verification where available.
 
 ### Blast radius
 
@@ -35,6 +35,8 @@ Blast radius is the product center of gravity. `agent-bom` connects vulnerabilit
 `agent-bom` scores trust with evidence, not a black-box label. It combines package and registry posture, capability risk, drift, exposed credentials, and related supply-chain signals. Policy and compliance layers can then act on those findings with clearer context.
 
 The product also protects its own shipped surfaces with the same discipline: signed releases, provenance, daily dependency monitoring, drift checks, and CI guards for the JavaScript surfaces so accidental source-map leaks or stale npm dependencies do not silently ship.
+
+Model and weight security should be described the same way: not just as file detection, but as a supply-chain contract that surfaces risky formats, signature presence, provenance checks, and Hub-backed hash verification where available.
 
 ### Runtime protection
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -98,6 +98,13 @@ For cross-agent correlation and the broader 8-detector protection engine, run `a
 - The TypeScript SDK build is checked to ensure it does not emit `.map` files into `dist/`
 - The UI explicitly disables production browser source maps
 
+### Model / weight supply-chain posture
+
+- `agent-bom` treats model artifacts as supply-chain inputs, not opaque blobs
+- Local model scans surface risky formats, signature presence, and per-file security flags
+- HuggingFace provenance checks surface author, card presence, digest availability, and gated/private posture
+- Hash verification can compare local weights against HuggingFace Hub metadata and report verified, unverified, offline, or tampered states
+
 ### What a Formal Pentest Should Cover
 
 If engaging a third-party auditor, the recommended scope:

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1491,6 +1491,8 @@ def scan(
         report.ai_inventory_data = ctx.ai_inventory_data
     if ctx.project_inventory_data:
         report.project_inventory_data = ctx.project_inventory_data
+    if ctx.model_hash_verification_data:
+        report.model_hash_verification_data = ctx.model_hash_verification_data
 
     # Attach benchmark reports
     if ctx.cis_benchmark_report is not None:
@@ -1818,6 +1820,15 @@ def scan(
                 _scan_sources.append("secret_scan")
         except Exception:
             pass  # Secret scanning not available
+
+    if report.model_files or report.model_provenance or report.model_hash_verification_data:
+        from agent_bom.model_files import summarize_model_supply_chain
+
+        report.model_supply_chain_data = summarize_model_supply_chain(
+            report.model_files,
+            report.model_provenance,
+            report.model_hash_verification_data,
+        )
 
     # Persist browser extension results to report
     if ctx._browser_ext_results is not None:

--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -232,9 +232,28 @@ def run_benchmarks(
         from agent_bom.model_hash import verify_model_hashes as _verify_hashes
 
         _scan_roots = [Path(project)] if project else [Path.home()]
+        _combined_hash_report: dict[str, Any] = {
+            "scanned": 0,
+            "verified": 0,
+            "tampered": 0,
+            "unverified": 0,
+            "offline": 0,
+            "has_tampering": False,
+            "results": [],
+            "roots": [],
+        }
         for _root in _scan_roots:
             with con.status(f"[bold]Verifying model weight hashes under {_root.name}...[/bold]", spinner="dots"):
                 _hash_report = _verify_hashes(str(_root), token=hf_token)
+            _hash_data = _hash_report.to_dict()
+            _combined_hash_report["scanned"] += _hash_data["scanned"]
+            _combined_hash_report["verified"] += _hash_data["verified"]
+            _combined_hash_report["tampered"] += _hash_data["tampered"]
+            _combined_hash_report["unverified"] += _hash_data["unverified"]
+            _combined_hash_report["offline"] += _hash_data["offline"]
+            _combined_hash_report["has_tampering"] = _combined_hash_report["has_tampering"] or _hash_data["has_tampering"]
+            _combined_hash_report["results"].extend(_hash_data["results"])
+            _combined_hash_report["roots"].append(str(_root))
             if _hash_report.scanned == 0:
                 con.print(f"  [dim]No model weight files found under {_root}[/dim]")
             elif _hash_report.has_tampering:
@@ -254,6 +273,7 @@ def run_benchmarks(
                 con.print(
                     f"  [green]✓[/green] {_hash_report.verified} model file(s) verified, {_hash_report.unverified} unverified (not in Hub)"
                 )
+        ctx.model_hash_verification_data = _combined_hash_report
 
     # Step 1y: CIS AWS Foundations Benchmark
     if aws_cis_benchmark:

--- a/src/agent_bom/cli/agents/_context.py
+++ b/src/agent_bom/cli/agents/_context.py
@@ -31,6 +31,8 @@ class ScanContext:
     sast_data: Any = None
     ai_inventory_data: Any = None
     project_inventory_data: Any = None
+    model_hash_verification_data: Any = None
+    model_supply_chain_data: Any = None
     iac_findings_data: Any = None
     delta_result: Any = None
     policy_passed: bool = True

--- a/src/agent_bom/model_files.py
+++ b/src/agent_bom/model_files.py
@@ -47,6 +47,8 @@ _SECURITY_FLAGS: dict[str, dict] = {
     },
 }
 
+_UNSAFE_MODEL_EXTENSIONS = frozenset({".pt", ".pth", ".pkl", ".joblib", ".bin"})
+
 
 def _human_size(size_bytes: int | float) -> str:
     """Convert bytes to human-readable size string."""
@@ -308,3 +310,72 @@ def check_huggingface_provenance(
         )
 
     return result
+
+
+def summarize_model_supply_chain(
+    model_files: list[dict],
+    model_provenance: list[dict] | None = None,
+    model_hash_verification: dict | None = None,
+) -> dict:
+    """Build a stable summary of model/weight supply-chain coverage.
+
+    This consolidates local model artifact scanning, HuggingFace provenance
+    checks, and optional hash verification into one operator-facing contract
+    that can be surfaced consistently in CLI, JSON, and docs.
+    """
+    provenance = model_provenance or []
+    hash_verification = model_hash_verification or {}
+
+    files_with_flags = 0
+    signed_files = 0
+    unsigned_files = 0
+    unsafe_files = 0
+    total_size_bytes = 0
+    ecosystems: set[str] = set()
+    formats: set[str] = set()
+
+    for model_file in model_files:
+        total_size_bytes += int(model_file.get("size_bytes", 0) or 0)
+        if model_file.get("security_flags"):
+            files_with_flags += 1
+        if model_file.get("signed") is True:
+            signed_files += 1
+        else:
+            unsigned_files += 1
+        if str(model_file.get("extension", "")).lower() in _UNSAFE_MODEL_EXTENSIONS:
+            unsafe_files += 1
+        ecosystem = model_file.get("ecosystem")
+        if ecosystem:
+            ecosystems.add(str(ecosystem))
+        fmt = model_file.get("format")
+        if fmt:
+            formats.add(str(fmt))
+
+    provenance_with_flags = sum(1 for item in provenance if item.get("security_flags"))
+    provenance_with_digest = sum(1 for item in provenance if item.get("has_digest") is True or item.get("sha256_available") is True)
+    gated_models = sum(1 for item in provenance if item.get("is_gated") is True or item.get("gated") is True)
+    sources = sorted({str(item.get("source", "huggingface")) for item in provenance})
+
+    return {
+        "model_files": len(model_files),
+        "total_size_bytes": total_size_bytes,
+        "signed_files": signed_files,
+        "unsigned_files": unsigned_files,
+        "unsafe_format_files": unsafe_files,
+        "files_with_security_flags": files_with_flags,
+        "formats": sorted(formats),
+        "ecosystems": sorted(ecosystems),
+        "provenance_checks": len(provenance),
+        "provenance_with_digest": provenance_with_digest,
+        "gated_models": gated_models,
+        "provenance_with_security_flags": provenance_with_flags,
+        "provenance_sources": sources,
+        "hash_verification": {
+            "scanned": int(hash_verification.get("scanned", 0) or 0),
+            "verified": int(hash_verification.get("verified", 0) or 0),
+            "tampered": int(hash_verification.get("tampered", 0) or 0),
+            "unverified": int(hash_verification.get("unverified", 0) or 0),
+            "offline": int(hash_verification.get("offline", 0) or 0),
+            "has_tampering": bool(hash_verification.get("has_tampering", False)),
+        },
+    }

--- a/src/agent_bom/model_hash.py
+++ b/src/agent_bom/model_hash.py
@@ -50,6 +50,19 @@ class ModelHashResult:
     def is_verified(self) -> bool:
         return self.status == "ok"
 
+    def to_dict(self) -> dict:
+        return {
+            "file_path": self.file_path,
+            "repo_id": self.repo_id,
+            "filename": self.filename,
+            "expected_sha256": self.expected_sha256,
+            "actual_sha256": self.actual_sha256,
+            "status": self.status,
+            "error": self.error,
+            "is_tampered": self.is_tampered,
+            "is_verified": self.is_verified,
+        }
+
 
 @dataclass
 class ModelHashReport:
@@ -74,6 +87,12 @@ class ModelHashReport:
             "unverified": self.unverified,
             "offline": self.offline,
         }
+
+    def to_dict(self) -> dict:
+        data = self.summary()
+        data["has_tampering"] = self.has_tampering
+        data["results"] = [result.to_dict() for result in self.results]
+        return data
 
 
 # ─── Hash computation ─────────────────────────────────────────────────────────

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -732,6 +732,8 @@ class AIBOMReport:
     prompt_scan_data: Optional[dict] = None  # Serialized PromptScanResult (set by CLI)
     model_files: list[dict] = field(default_factory=list)
     model_provenance: list[dict] = field(default_factory=list)  # HuggingFace provenance results
+    model_hash_verification_data: Optional[dict] = None  # Serialized model hash verification report
+    model_supply_chain_data: Optional[dict] = None  # Consolidated model file/provenance/hash summary
     enforcement_data: Optional[dict] = None  # Serialized EnforcementReport (set by CLI)
     context_graph_data: Optional[dict] = None  # Serialized context graph (set by CLI)
     license_report: Optional[dict] = None  # Serialized license compliance report

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -97,6 +97,24 @@ def print_summary(report: AIBOMReport) -> None:
             ),
         )
 
+    model_sc = getattr(report, "model_supply_chain_data", None)
+    if model_sc:
+        table.add_row(
+            "Model artifacts",
+            f"{model_sc.get('model_files', 0)} file(s), {model_sc.get('provenance_checks', 0)} provenance check(s)",
+        )
+        table.add_row(
+            "Model integrity",
+            (
+                f"{model_sc.get('signed_files', 0)} signed, "
+                f"{model_sc.get('hash_verification', {}).get('verified', 0)} hash-verified, "
+                f"{model_sc.get('hash_verification', {}).get('tampered', 0)} tampered"
+            ),
+        )
+        model_flags = model_sc.get("files_with_security_flags", 0) + model_sc.get("provenance_with_security_flags", 0)
+        if model_flags:
+            table.add_row("Model risk flags", f"[yellow]{model_flags}[/yellow]")
+
     perf = report.scan_performance_data or {}
     osv = perf.get("osv") or {}
     registry = perf.get("registry") or {}

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -673,6 +673,12 @@ def to_json(report: AIBOMReport) -> dict:
     if report.model_provenance:
         result["model_provenance"] = report.model_provenance
 
+    if report.model_hash_verification_data:
+        result["model_hash_verification"] = report.model_hash_verification_data
+
+    if report.model_supply_chain_data:
+        result["model_supply_chain"] = report.model_supply_chain_data
+
     if report.enforcement_data:
         result["enforcement"] = report.enforcement_data
 

--- a/tests/test_model_provenance.py
+++ b/tests/test_model_provenance.py
@@ -10,6 +10,7 @@ import httpx
 from agent_bom.model_files import (
     check_huggingface_provenance,
     check_sigstore_signature,
+    summarize_model_supply_chain,
     verify_model_hash,
 )
 
@@ -110,6 +111,47 @@ class TestCheckSigstoreSignature:
         result = check_sigstore_signature(tmp_path / "nope.bin")
         assert result["signed"] is False
         assert result["security_flags"] == []  # silently skip, no model found
+
+
+class TestSummarizeModelSupplyChain:
+    def test_builds_operator_summary(self):
+        summary = summarize_model_supply_chain(
+            model_files=[
+                {
+                    "filename": "model.safetensors",
+                    "extension": ".safetensors",
+                    "format": "SafeTensors",
+                    "ecosystem": "HuggingFace",
+                    "size_bytes": 1024,
+                    "signed": True,
+                    "security_flags": [],
+                },
+                {
+                    "filename": "adapter.pkl",
+                    "extension": ".pkl",
+                    "format": "Pickle",
+                    "ecosystem": "Python",
+                    "size_bytes": 512,
+                    "signed": False,
+                    "security_flags": [{"type": "PICKLE_DESERIALIZATION"}],
+                },
+            ],
+            model_provenance=[
+                {"model": "org/model-a", "sha256_available": True, "gated": True, "security_flags": []},
+                {"model": "org/model-b", "sha256_available": False, "gated": False, "security_flags": [{"type": "NO_AUTHOR"}]},
+            ],
+            model_hash_verification={"scanned": 2, "verified": 1, "tampered": 1, "unverified": 0, "offline": 0, "has_tampering": True},
+        )
+        assert summary["model_files"] == 2
+        assert summary["signed_files"] == 1
+        assert summary["unsigned_files"] == 1
+        assert summary["unsafe_format_files"] == 1
+        assert summary["files_with_security_flags"] == 1
+        assert summary["provenance_checks"] == 2
+        assert summary["provenance_with_digest"] == 1
+        assert summary["gated_models"] == 1
+        assert summary["provenance_with_security_flags"] == 1
+        assert summary["hash_verification"]["tampered"] == 1
 
 
 # ── check_huggingface_provenance ─────────────────────────────────

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -155,6 +155,18 @@ class TestPrintSummary:
         }
         print_summary(report)
 
+    def test_with_model_supply_chain_data(self, capsys):
+        report = _make_report()
+        report.model_supply_chain_data = {
+            "model_files": 2,
+            "provenance_checks": 1,
+            "signed_files": 1,
+            "files_with_security_flags": 1,
+            "provenance_with_security_flags": 0,
+            "hash_verification": {"verified": 1, "tampered": 0},
+        }
+        print_summary(report)
+
 
 class TestPrintScanPerformanceSummary:
     def test_prints_cache_summary(self, capsys):
@@ -730,6 +742,37 @@ def test_to_json_with_optional_fields():
     assert result.get("executive_summary") == "Test summary"
     assert "skill_audit" in result
     assert "trust_assessment" in result
+
+
+def test_to_json_with_model_supply_chain_fields():
+    report = _make_report_cov2()
+    report.model_hash_verification_data = {
+        "scanned": 2,
+        "verified": 1,
+        "tampered": 0,
+        "unverified": 1,
+        "offline": 0,
+        "has_tampering": False,
+        "results": [],
+    }
+    report.model_supply_chain_data = {
+        "model_files": 2,
+        "signed_files": 1,
+        "unsigned_files": 1,
+        "unsafe_format_files": 1,
+        "files_with_security_flags": 1,
+        "formats": ["Pickle", "SafeTensors"],
+        "ecosystems": ["HuggingFace", "Python"],
+        "provenance_checks": 1,
+        "provenance_with_digest": 1,
+        "gated_models": 0,
+        "provenance_with_security_flags": 0,
+        "provenance_sources": ["huggingface"],
+        "hash_verification": {"scanned": 2, "verified": 1, "tampered": 0, "unverified": 1, "offline": 0, "has_tampering": False},
+    }
+    result = to_json(report)
+    assert result["model_hash_verification"]["verified"] == 1
+    assert result["model_supply_chain"]["model_files"] == 2
 
 
 # ── print_threat_frameworks (from cov2) ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- add first-class model and weight supply-chain metadata to scan reports
- surface signed/unsigned files, risky formats, provenance coverage, and hash verification in CLI and JSON output
- align README, product brief, and security architecture docs with the real model-supply-chain contract

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache-model-supply uv run pytest -q tests/test_model_provenance.py tests/test_model_hash.py tests/test_output_cov.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache-model-supply uv run mypy src/agent_bom/model_files.py src/agent_bom/model_hash.py src/agent_bom/models.py src/agent_bom/cli/agents/_context.py src/agent_bom/cli/agents/_cloud.py src/agent_bom/cli/agents/__init__.py src/agent_bom/output/__init__.py src/agent_bom/output/json_fmt.py
- python -m compileall src/agent_bom/model_files.py src/agent_bom/model_hash.py src/agent_bom/models.py src/agent_bom/cli/agents/_context.py src/agent_bom/cli/agents/_cloud.py src/agent_bom/cli/agents/__init__.py src/agent_bom/output/__init__.py src/agent_bom/output/json_fmt.py
