### PR TITLE
feat(api): make ClickHouse analytics a first-class backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ agent-bom serve                         # API + Next.js dashboard
 - Remote package, API, and MCP deployment surfaces should all report the same version and health state after release.
 - Automated freshness checks watch for deployment drift so stale Railway or registry surfaces do not go unnoticed.
 - The repo monitors both JavaScript surfaces (`ui/` and `sdks/typescript/`) with daily Dependabot, `npm audit`, and CI guards that fail if tracked or published source maps appear unexpectedly.
+- `agent-bom api` and `agent-bom serve` make the analytics backend explicit too: ClickHouse can be enabled as a first-class buffered backend, and `/health` reports the active analytics/tracing contract for operators.
 
 <details>
 <summary><b>Claude, Cortex, and MCP integration</b></summary>

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -123,6 +123,17 @@ For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated
 
 **Storage:** SQLite (single node), PostgreSQL (team), Snowflake/ClickHouse (enterprise).
 
+For ClickHouse-backed analytics, make the backend explicit instead of relying on ambient environment alone:
+
+```bash
+agent-bom api \
+  --api-key "$AGENT_BOM_API_KEY" \
+  --analytics-backend clickhouse \
+  --clickhouse-url "http://clickhouse.internal:8123"
+```
+
+Server mode enables buffered ClickHouse writes by default so scan and runtime paths do not block on OLAP round-trips. `GET /health` now reports the active analytics contract (`backend`, `enabled`, `buffered`, `flush_interval_seconds`, `max_batch`) alongside tracing so operators can confirm both observability and analytics posture from one probe.
+
 ### 4. Cloud Infrastructure — agentless discovery
 
 ```bash

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -18,7 +18,9 @@ Security note — SQL injection mitigation:
 from __future__ import annotations
 
 import logging
+import queue
 import re
+import threading
 import uuid
 from typing import Any, Protocol, runtime_checkable
 
@@ -67,6 +69,10 @@ class AnalyticsStore(Protocol):
         """Record scan-level metadata (agent count, vuln count, grade)."""
         ...
 
+    def close(self) -> None:
+        """Flush and release any buffered resources."""
+        ...
+
 
 # ------------------------------------------------------------------
 # Null implementation (default — zero overhead)
@@ -100,6 +106,9 @@ class NullAnalyticsStore:
     def record_scan_metadata(self, metadata: dict) -> None:
         pass
 
+    def close(self) -> None:
+        pass
+
 
 # ------------------------------------------------------------------
 # ClickHouse implementation
@@ -118,8 +127,13 @@ class ClickHouseAnalyticsStore:
     # -- writes --------------------------------------------------------
 
     def record_scan(self, scan_id: str, agent_name: str, vulns: list[dict]) -> None:
+        rows = self._scan_rows(scan_id, agent_name, vulns)
+        if rows:
+            self._client.insert_json("vulnerability_scans", rows)
+
+    def _scan_rows(self, scan_id: str, agent_name: str, vulns: list[dict]) -> list[dict[str, Any]]:
         if not vulns:
-            return
+            return []
 
         def _split_package(v: dict) -> tuple[str, str]:
             pkg_name = v.get("package_name", "")
@@ -132,7 +146,7 @@ class ClickHouseAnalyticsStore:
                 return name, version
             return str(pkg or ""), pkg_version
 
-        rows = [
+        return [
             {
                 "scan_id": scan_id,
                 "package_name": _split_package(v)[0],
@@ -149,10 +163,12 @@ class ClickHouseAnalyticsStore:
             }
             for v in vulns
         ]
-        self._client.insert_json("vulnerability_scans", rows)
 
     def record_event(self, event: dict) -> None:
-        row = {
+        self._client.insert_json("runtime_events", [self._event_row(event)])
+
+    def _event_row(self, event: dict) -> dict[str, Any]:
+        return {
             "event_id": event.get("event_id", str(uuid.uuid4())),
             "event_type": event.get("event_type", event.get("type", "")),
             "detector": event.get("detector", ""),
@@ -161,10 +177,12 @@ class ClickHouseAnalyticsStore:
             "message": event.get("message", ""),
             "agent_name": event.get("agent_name", ""),
         }
-        self._client.insert_json("runtime_events", [row])
 
     def record_posture(self, agent_name: str, snapshot: dict) -> None:
-        row = {
+        self._client.insert_json("posture_scores", [self._posture_row(agent_name, snapshot)])
+
+    def _posture_row(self, agent_name: str, snapshot: dict) -> dict[str, Any]:
+        return {
             "agent_name": agent_name,
             "total_packages": int(snapshot.get("total_packages", 0)),
             "critical_vulns": int(snapshot.get("critical", 0)),
@@ -174,7 +192,6 @@ class ClickHouseAnalyticsStore:
             "risk_score": float(snapshot.get("risk_score", 0.0)),
             "compliance_score": float(snapshot.get("compliance_score", 0.0)),
         }
-        self._client.insert_json("posture_scores", [row])
 
     # -- reads ---------------------------------------------------------
 
@@ -223,7 +240,10 @@ class ClickHouseAnalyticsStore:
         return self._client.query_json(query)
 
     def record_scan_metadata(self, metadata: dict) -> None:
-        row = {
+        self._client.insert_json("scan_metadata", [self._metadata_row(metadata)])
+
+    def _metadata_row(self, metadata: dict) -> dict[str, Any]:
+        return {
             "scan_id": metadata.get("scan_id", str(uuid.uuid4())),
             "agent_count": int(metadata.get("agent_count", 0)),
             "package_count": int(metadata.get("package_count", 0)),
@@ -236,7 +256,118 @@ class ClickHouseAnalyticsStore:
             "aisvs_score": float(metadata.get("aisvs_score", 0.0)),
             "has_runtime_correlation": int(bool(metadata.get("has_runtime_correlation", False))),
         }
-        self._client.insert_json("scan_metadata", [row])
+
+    def close(self) -> None:
+        """Synchronous store has nothing buffered to flush."""
+
+
+class BufferedAnalyticsStore:
+    """Buffered wrapper for ClickHouse analytics writes.
+
+    Writes are queued and flushed from a background thread so scan and runtime
+    paths do not block on ClickHouse round-trips.
+    """
+
+    def __init__(self, store: ClickHouseAnalyticsStore, *, max_batch: int = 200, flush_interval: float = 1.0) -> None:
+        self._store = store
+        self._max_batch = max(1, int(max_batch))
+        self._flush_interval = max(0.1, float(flush_interval))
+        self._queue: queue.Queue[tuple[str, tuple[Any, ...]]] = queue.Queue()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="agent-bom-clickhouse-buffer", daemon=True)
+        self._thread.start()
+
+    def record_scan(self, scan_id: str, agent_name: str, vulns: list[dict]) -> None:
+        self._queue.put(("scan", (scan_id, agent_name, vulns)))
+
+    def record_event(self, event: dict) -> None:
+        self._queue.put(("event", (event,)))
+
+    def record_posture(self, agent_name: str, snapshot: dict) -> None:
+        self._queue.put(("posture", (agent_name, snapshot)))
+
+    def record_scan_metadata(self, metadata: dict) -> None:
+        self._queue.put(("metadata", (metadata,)))
+
+    def query_vuln_trends(self, days: int = 30, agent: str | None = None) -> list[dict]:
+        self._flush_pending()
+        return self._store.query_vuln_trends(days=days, agent=agent)
+
+    def query_top_cves(self, limit: int = 20) -> list[dict]:
+        self._flush_pending()
+        return self._store.query_top_cves(limit=limit)
+
+    def query_posture_history(self, agent: str | None = None, days: int = 90) -> list[dict]:
+        self._flush_pending()
+        return self._store.query_posture_history(agent=agent, days=days)
+
+    def query_event_summary(self, hours: int = 24) -> list[dict]:
+        self._flush_pending()
+        return self._store.query_event_summary(hours=hours)
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=max(1.0, self._flush_interval * 4))
+        self._flush_pending()
+        self._store.close()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._flush_pending()
+            self._stop.wait(self._flush_interval)
+
+    def _drain(self) -> list[tuple[str, tuple[Any, ...]]]:
+        drained: list[tuple[str, tuple[Any, ...]]] = []
+        while len(drained) < self._max_batch:
+            try:
+                drained.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return drained
+
+    def _flush_pending(self) -> None:
+        drained = self._drain()
+        if not drained:
+            return
+
+        scan_rows: list[dict[str, Any]] = []
+        event_rows: list[dict[str, Any]] = []
+        posture_rows: list[dict[str, Any]] = []
+        metadata_rows: list[dict[str, Any]] = []
+
+        for kind, payload in drained:
+            if kind == "scan":
+                scan_id, agent_name, vulns = payload
+                scan_rows.extend(self._store._scan_rows(str(scan_id), str(agent_name), list(vulns)))
+            elif kind == "event":
+                (event,) = payload
+                event_rows.append(self._store._event_row(dict(event)))
+            elif kind == "posture":
+                agent_name, snapshot = payload
+                posture_rows.append(self._store._posture_row(str(agent_name), dict(snapshot)))
+            elif kind == "metadata":
+                (metadata,) = payload
+                metadata_rows.append(self._store._metadata_row(dict(metadata)))
+
+        try:
+            if scan_rows:
+                self._store._client.insert_json("vulnerability_scans", scan_rows)
+            if event_rows:
+                self._store._client.insert_json("runtime_events", event_rows)
+            if posture_rows:
+                self._store._client.insert_json("posture_scores", posture_rows)
+            if metadata_rows:
+                self._store._client.insert_json("scan_metadata", metadata_rows)
+        except Exception:
+            logger.warning("Buffered ClickHouse flush failed", exc_info=True)
+
+    @property
+    def flush_interval(self) -> float:
+        return self._flush_interval
+
+    @property
+    def max_batch(self) -> int:
+        return self._max_batch
 
 
 def _escape(value: str) -> str:

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -128,10 +128,20 @@ class TracingHealth(BaseModel):
     otlp_headers_configured: bool = False
 
 
+class AnalyticsHealth(BaseModel):
+    backend: str = "disabled"
+    enabled: bool = False
+    buffered: bool = False
+    clickhouse_url_configured: bool = False
+    flush_interval_seconds: float | None = None
+    max_batch: int | None = None
+
+
 class HealthResponse(BaseModel):
     status: str = "ok"
     version: str
     tracing: TracingHealth
+    analytics: AnalyticsHealth
 
 
 # ─── Fleet Models ──────────────────────────────────────────────────────────

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import uuid
 
 from agent_bom import __version__
@@ -25,6 +26,7 @@ from agent_bom.api.middleware import (
 
 # ─── Extracted modules ────────────────────────────────────────────────────────
 from agent_bom.api.models import (
+    AnalyticsHealth,
     HealthResponse,
     JobStatus,
     ScanJob,
@@ -68,6 +70,39 @@ except ImportError as exc:  # pragma: no cover
 # ─── App ──────────────────────────────────────────────────────────────────────
 
 from contextlib import asynccontextmanager  # noqa: E402
+
+
+def _analytics_backend_config() -> tuple[str, str | None]:
+    """Resolve the requested analytics backend and configured ClickHouse URL."""
+    backend = os.environ.get("AGENT_BOM_ANALYTICS_BACKEND", "").strip().lower()
+    clickhouse_url = os.environ.get("AGENT_BOM_CLICKHOUSE_URL", "").strip() or None
+    if backend in {"", "auto"}:
+        backend = "clickhouse" if clickhouse_url else "disabled"
+    return backend, clickhouse_url
+
+
+def _analytics_health() -> AnalyticsHealth:
+    """Return the active analytics backend contract for operators."""
+    backend, clickhouse_url = _analytics_backend_config()
+    active_store = _stores._analytics_store
+    if active_store is None:
+        return AnalyticsHealth(
+            backend=backend if backend != "disabled" else "disabled",
+            enabled=False,
+            buffered=False,
+            clickhouse_url_configured=bool(clickhouse_url),
+        )
+
+    store_name = type(active_store).__name__
+    buffered = hasattr(active_store, "flush_interval") and hasattr(active_store, "max_batch")
+    return AnalyticsHealth(
+        backend="clickhouse" if "ClickHouse" in store_name or buffered else backend,
+        enabled=store_name != "NullAnalyticsStore",
+        buffered=buffered,
+        clickhouse_url_configured=bool(clickhouse_url),
+        flush_interval_seconds=float(getattr(active_store, "flush_interval", 0.0)) if buffered else None,
+        max_batch=int(getattr(active_store, "max_batch", 0)) if buffered else None,
+    )
 
 
 @asynccontextmanager
@@ -159,12 +194,26 @@ async def _lifespan(app_instance: FastAPI):
             set_schedule_store(InMemoryScheduleStore())
 
     # ── Analytics store (ClickHouse OLAP — optional) ──
-    if os.environ.get("AGENT_BOM_CLICKHOUSE_URL") and _stores._analytics_store is None:
+    analytics_backend, clickhouse_url = _analytics_backend_config()
+    if analytics_backend == "clickhouse" and _stores._analytics_store is None:
         try:
-            from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+            from agent_bom.api.clickhouse_store import BufferedAnalyticsStore, ClickHouseAnalyticsStore
 
-            set_analytics_store(ClickHouseAnalyticsStore(url=os.environ["AGENT_BOM_CLICKHOUSE_URL"]))
-            _logger.info("ClickHouse analytics store enabled")
+            if not clickhouse_url:
+                raise ValueError("ClickHouse analytics backend requires AGENT_BOM_CLICKHOUSE_URL")
+            base_store = ClickHouseAnalyticsStore(url=clickhouse_url)
+            if os.environ.get("AGENT_BOM_CLICKHOUSE_BUFFERED", "1").strip().lower() not in {"0", "false", "no"}:
+                flush_interval = float(os.environ.get("AGENT_BOM_CLICKHOUSE_FLUSH_INTERVAL", "1.0"))
+                max_batch = int(os.environ.get("AGENT_BOM_CLICKHOUSE_MAX_BATCH", "200"))
+                set_analytics_store(BufferedAnalyticsStore(base_store, flush_interval=flush_interval, max_batch=max_batch))
+                _logger.info(
+                    "ClickHouse analytics store enabled with buffered writes (batch=%s, flush_interval=%.2fs)",
+                    max_batch,
+                    flush_interval,
+                )
+            else:
+                set_analytics_store(base_store)
+                _logger.info("ClickHouse analytics store enabled without buffering")
         except Exception:
             _logger.warning("ClickHouse analytics unavailable, using NullAnalyticsStore", exc_info=True)
 
@@ -214,6 +263,11 @@ async def _lifespan(app_instance: FastAPI):
                 _pg_pool.close()
     except Exception:
         _logger.debug("Postgres pool close skipped")
+    try:
+        if _stores._analytics_store is not None and hasattr(_stores._analytics_store, "close"):
+            _stores._analytics_store.close()
+    except Exception:
+        _logger.debug("Analytics store close skipped", exc_info=True)
 
 
 app = FastAPI(
@@ -224,9 +278,6 @@ app = FastAPI(
     redoc_url="/redoc",
     lifespan=_lifespan,
 )
-
-# ── API hardening config ─────────────────────────────────────────────────
-import os  # noqa: E402
 
 _default_origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
 _cors_env = os.environ.get("CORS_ORIGINS")
@@ -372,7 +423,12 @@ async def root() -> RedirectResponse:
 @app.get("/health", response_model=HealthResponse, tags=["meta"])
 async def health() -> HealthResponse:
     """Liveness probe."""
-    return HealthResponse(status="ok", version=__version__, tracing=TracingHealth(**get_tracing_health()))
+    return HealthResponse(
+        status="ok",
+        version=__version__,
+        tracing=TracingHealth(**get_tracing_health()),
+        analytics=_analytics_health(),
+    )
 
 
 @app.get("/version", response_model=VersionInfo, tags=["meta"])

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -52,13 +52,46 @@ def _enforce_remote_mcp_auth_defaults(host: str, bearer_token: str | None, allow
     )
 
 
+def _configure_analytics_backend(
+    *,
+    analytics_backend: str | None,
+    clickhouse_url: str | None,
+    analytics_buffered: bool,
+    analytics_flush_interval: float,
+    analytics_max_batch: int,
+) -> tuple[str, str | None]:
+    """Resolve and export the requested analytics backend contract."""
+    resolved_backend = (analytics_backend or "").strip().lower()
+    env_clickhouse_url = os.environ.get("AGENT_BOM_CLICKHOUSE_URL") or ""
+    resolved_url = (clickhouse_url or env_clickhouse_url).strip() or None
+    if resolved_backend in {"", "auto"}:
+        resolved_backend = "clickhouse" if resolved_url else "disabled"
+    if resolved_backend == "clickhouse" and not resolved_url:
+        raise click.ClickException("ClickHouse analytics requires --clickhouse-url or AGENT_BOM_CLICKHOUSE_URL.")
+
+    os.environ["AGENT_BOM_ANALYTICS_BACKEND"] = resolved_backend
+    if resolved_url:
+        os.environ["AGENT_BOM_CLICKHOUSE_URL"] = resolved_url
+    elif resolved_backend == "disabled":
+        os.environ.pop("AGENT_BOM_CLICKHOUSE_URL", None)
+
+    os.environ["AGENT_BOM_CLICKHOUSE_BUFFERED"] = "1" if analytics_buffered else "0"
+    os.environ["AGENT_BOM_CLICKHOUSE_FLUSH_INTERVAL"] = f"{analytics_flush_interval:.3f}"
+    os.environ["AGENT_BOM_CLICKHOUSE_MAX_BATCH"] = str(max(1, analytics_max_batch))
+    return resolved_backend, resolved_url
+
+
 @click.command("serve")
 @click.option("--host", default="127.0.0.1", show_default=True, help="Host to bind to (use 0.0.0.0 for LAN access)")
 @click.option("--port", default=8422, show_default=True, help="API server port")
 @click.option("--persist", default=None, metavar="DB_PATH", help="Enable persistent job storage via SQLite (e.g. --persist jobs.db).")
 @click.option("--cors-allow-all", is_flag=True, default=False, help="Allow all CORS origins (dev mode).")
 @click.option(
-    "--api-key", default=None, envvar="AGENT_BOM_API_KEY", metavar="KEY", help="Require API key auth (Bearer token or X-API-Key header)."
+    "--api-key",
+    default=None,
+    envvar="AGENT_BOM_API_KEY",
+    metavar="KEY",
+    help="Require API key auth (Bearer token or X-API-Key header).",
 )
 @click.option(
     "--allow-insecure-no-auth",
@@ -67,8 +100,49 @@ def _enforce_remote_mcp_auth_defaults(host: str, bearer_token: str | None, allow
     help="Allow unauthenticated non-loopback API exposure. Unsafe outside local development.",
 )
 @click.option("--reload", is_flag=True, help="Auto-reload on code changes (development mode)")
-@click.option("--log-level", "log_level", type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False), default="INFO")
+@click.option(
+    "--log-level",
+    "log_level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    default="INFO",
+)
 @click.option("--log-json", "log_json", is_flag=True, help="Structured JSON logs")
+@click.option(
+    "--analytics-backend",
+    type=click.Choice(["auto", "disabled", "clickhouse"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Analytics backend for trend/event persistence.",
+)
+@click.option(
+    "--clickhouse-url",
+    default=None,
+    envvar="AGENT_BOM_CLICKHOUSE_URL",
+    metavar="URL",
+    help="ClickHouse HTTP URL for analytics.",
+)
+@click.option(
+    "--analytics-buffered/--no-analytics-buffered",
+    default=True,
+    show_default=True,
+    help="Buffer ClickHouse analytics writes in a background thread.",
+)
+@click.option(
+    "--analytics-flush-interval",
+    default=1.0,
+    show_default=True,
+    type=float,
+    metavar="SECONDS",
+    help="Buffered ClickHouse flush interval.",
+)
+@click.option(
+    "--analytics-max-batch",
+    default=200,
+    show_default=True,
+    type=int,
+    metavar="ROWS",
+    help="Maximum rows to flush per ClickHouse batch.",
+)
 def serve_cmd(
     host: str,
     port: int,
@@ -79,6 +153,11 @@ def serve_cmd(
     reload: bool,
     log_level: str,
     log_json: bool,
+    analytics_backend: str,
+    clickhouse_url: str | None,
+    analytics_buffered: bool,
+    analytics_flush_interval: float,
+    analytics_max_batch: int,
 ):
     """Start the API server + Next.js dashboard.
 
@@ -109,6 +188,13 @@ def serve_cmd(
         _os.environ["AGENT_BOM_DB"] = str(Path(persist).resolve())
     if cors_allow_all:
         _os.environ["AGENT_BOM_CORS_ALL"] = "1"
+    resolved_backend, resolved_url = _configure_analytics_backend(
+        analytics_backend=analytics_backend,
+        clickhouse_url=clickhouse_url,
+        analytics_buffered=analytics_buffered,
+        analytics_flush_interval=analytics_flush_interval,
+        analytics_max_batch=analytics_max_batch,
+    )
 
     _enforce_auth_defaults("serve", host, api_key, allow_insecure_no_auth)
 
@@ -132,6 +218,12 @@ def serve_cmd(
         click.echo("  Auth:       OIDC bearer token required")
     elif allow_insecure_no_auth and not _is_loopback_host(host):
         click.echo("  Auth:       disabled by explicit override (--allow-insecure-no-auth)")
+    if resolved_backend == "clickhouse":
+        mode = "buffered" if analytics_buffered else "direct"
+        click.echo(f"  Analytics:  ClickHouse ({mode}, batch={max(1, analytics_max_batch)}, flush={analytics_flush_interval:.2f}s)")
+        click.echo(f"              {resolved_url}")
+    else:
+        click.echo("  Analytics:  disabled")
     click.echo("  Press Ctrl+C to stop.\n")
 
     import uvicorn as _uvicorn
@@ -154,7 +246,11 @@ def serve_cmd(
 @click.option("--cors-origins", default=None, metavar="ORIGINS", help="Comma-separated CORS origins (default: localhost:3000).")
 @click.option("--cors-allow-all", is_flag=True, default=False, help="Allow all CORS origins (dev mode).")
 @click.option(
-    "--api-key", default=None, envvar="AGENT_BOM_API_KEY", metavar="KEY", help="Require API key auth (Bearer token or X-API-Key header)."
+    "--api-key",
+    default=None,
+    envvar="AGENT_BOM_API_KEY",
+    metavar="KEY",
+    help="Require API key auth (Bearer token or X-API-Key header).",
 )
 @click.option(
     "--allow-insecure-no-auth",
@@ -186,6 +282,42 @@ def serve_cmd(
     help="Log verbosity level.",
 )
 @click.option("--log-json", "log_json", is_flag=True, help="Emit structured JSON logs (for log aggregation pipelines).")
+@click.option(
+    "--analytics-backend",
+    type=click.Choice(["auto", "disabled", "clickhouse"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Analytics backend for trend/event persistence.",
+)
+@click.option(
+    "--clickhouse-url",
+    default=None,
+    envvar="AGENT_BOM_CLICKHOUSE_URL",
+    metavar="URL",
+    help="ClickHouse HTTP URL for analytics.",
+)
+@click.option(
+    "--analytics-buffered/--no-analytics-buffered",
+    default=True,
+    show_default=True,
+    help="Buffer ClickHouse analytics writes in a background thread.",
+)
+@click.option(
+    "--analytics-flush-interval",
+    default=1.0,
+    show_default=True,
+    type=float,
+    metavar="SECONDS",
+    help="Buffered ClickHouse flush interval.",
+)
+@click.option(
+    "--analytics-max-batch",
+    default=200,
+    show_default=True,
+    type=int,
+    metavar="ROWS",
+    help="Maximum rows to flush per ClickHouse batch.",
+)
 def api_cmd(
     host: str,
     port: int,
@@ -199,6 +331,11 @@ def api_cmd(
     persist: str | None,
     log_level: str,
     log_json: bool,
+    analytics_backend: str,
+    clickhouse_url: str | None,
+    analytics_buffered: bool,
+    analytics_flush_interval: float,
+    analytics_max_batch: int,
 ):
     """Start the agent-bom REST API server.
 
@@ -238,6 +375,14 @@ def api_cmd(
 
     import os as _os
 
+    resolved_backend, resolved_url = _configure_analytics_backend(
+        analytics_backend=analytics_backend,
+        clickhouse_url=clickhouse_url,
+        analytics_buffered=analytics_buffered,
+        analytics_flush_interval=analytics_flush_interval,
+        analytics_max_batch=analytics_max_batch,
+    )
+
     from agent_bom import __version__ as _ver
     from agent_bom.api.server import configure_api, set_job_store
 
@@ -275,6 +420,12 @@ def api_cmd(
         click.echo("  Storage:      PostgreSQL")
     elif persist:
         click.echo(f"  Storage:      SQLite ({persist})")
+    if resolved_backend == "clickhouse":
+        mode = "buffered" if analytics_buffered else "direct"
+        click.echo(f"  Analytics:    ClickHouse ({mode}, batch={max(1, analytics_max_batch)}, flush={analytics_flush_interval:.2f}s)")
+        click.echo(f"                {resolved_url}")
+    else:
+        click.echo("  Analytics:    disabled")
     click.echo("  Press Ctrl+C to stop.\n")
 
     uvicorn.run(

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -53,6 +53,9 @@ def test_health_endpoint():
     assert body["tracing"]["w3c_tracestate"] is True
     assert body["tracing"]["w3c_baggage"] is True
     assert body["tracing"]["otlp_export"] in {"configured", "disabled", "missing_deps"}
+    assert body["analytics"]["backend"] in {"disabled", "clickhouse"}
+    assert isinstance(body["analytics"]["enabled"], bool)
+    assert isinstance(body["analytics"]["buffered"], bool)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -87,6 +88,45 @@ def test_api_cmd_allows_non_loopback_bind_with_api_key():
     assert "API key required" in result.output
 
 
+def test_api_cmd_enables_clickhouse_analytics():
+    runner = CliRunner()
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("agent_bom.api.server.configure_api") as mock_configure,
+        patch("uvicorn.run") as mock_run,
+    ):
+        result = runner.invoke(
+            api_cmd,
+            [
+                "--host",
+                "0.0.0.0",
+                "--api-key",
+                "test-key",
+                "--analytics-backend",
+                "clickhouse",
+                "--clickhouse-url",
+                "http://clickhouse:8123",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_configure.assert_called_once()
+    mock_run.assert_called_once()
+    assert "Analytics:    ClickHouse" in result.output
+
+
+def test_api_cmd_requires_clickhouse_url_for_backend():
+    runner = CliRunner()
+
+    with patch.dict(os.environ, {"AGENT_BOM_CLICKHOUSE_URL": ""}, clear=False), patch("uvicorn.run") as mock_run:
+        result = runner.invoke(api_cmd, ["--api-key", "test-key", "--analytics-backend", "clickhouse"])
+
+    assert result.exit_code == 1
+    assert "ClickHouse analytics requires" in result.output
+    mock_run.assert_not_called()
+
+
 def test_serve_cmd_rejects_unauthenticated_non_loopback_bind():
     """Serve should use the same auth-default guard as the raw API command."""
     runner = CliRunner()
@@ -110,6 +150,36 @@ def test_serve_cmd_configures_api_auth():
     mock_configure.assert_called_once()
     mock_run.assert_called_once()
     assert "API key required" in result.output
+
+
+def test_serve_cmd_enables_clickhouse_analytics():
+    runner = CliRunner()
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("agent_bom.api.server.configure_api") as mock_configure,
+        patch("uvicorn.run") as mock_run,
+    ):
+        result = runner.invoke(
+            serve_cmd,
+            ["--api-key", "test-key", "--analytics-backend", "clickhouse", "--clickhouse-url", "http://clickhouse:8123"],
+        )
+
+    assert result.exit_code == 0
+    mock_configure.assert_called_once()
+    mock_run.assert_called_once()
+    assert "Analytics:  ClickHouse" in result.output
+
+
+def test_serve_cmd_requires_clickhouse_url_for_backend():
+    runner = CliRunner()
+
+    with patch.dict(os.environ, {"AGENT_BOM_CLICKHOUSE_URL": ""}, clear=False), patch("uvicorn.run") as mock_run:
+        result = runner.invoke(serve_cmd, ["--api-key", "test-key", "--analytics-backend", "clickhouse"])
+
+    assert result.exit_code == 1
+    assert "ClickHouse analytics requires" in result.output
+    mock_run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -249,6 +249,53 @@ class TestClickHouseAnalyticsStore:
         assert inserted["rows"][0]["package_name"] == "requests"
         assert inserted["rows"][0]["package_version"] == "2.33.0"
 
+    def test_buffered_store_flushes_on_close(self):
+        from agent_bom.api.clickhouse_store import BufferedAnalyticsStore, ClickHouseAnalyticsStore
+
+        inserted: list[tuple[str, list[dict]]] = []
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                inserted.append((table, rows))
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            buffered = BufferedAnalyticsStore(store, max_batch=10, flush_interval=60.0)
+            buffered.record_event({"event_type": "tool_blocked", "severity": "high"})
+            buffered.record_scan_metadata({"scan_id": "scan-1", "vuln_count": 4})
+            buffered.close()
+
+        assert any(table == "runtime_events" for table, _rows in inserted)
+        assert any(table == "scan_metadata" for table, _rows in inserted)
+
+    def test_buffered_store_flushes_before_query(self):
+        from agent_bom.api.clickhouse_store import BufferedAnalyticsStore, ClickHouseAnalyticsStore
+
+        inserted: list[tuple[str, list[dict]]] = []
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                inserted.append((table, rows))
+
+            def query_json(self, _query):
+                return [{"day": "2026-04-05", "severity": "high", "cnt": 1}]
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            buffered = BufferedAnalyticsStore(store, max_batch=10, flush_interval=60.0)
+            buffered.record_scan("scan-1", "agent-1", [{"package": "requests@2.33.0", "severity": "high"}])
+            result = buffered.query_vuln_trends()
+            buffered.close()
+
+        assert result == [{"day": "2026-04-05", "severity": "high", "cnt": 1}]
+        assert any(table == "vulnerability_scans" for table, _rows in inserted)
+
 
 def test_clickhouse_escape_strips_control_chars_and_quotes():
     from agent_bom.api.clickhouse_store import _escape


### PR DESCRIPTION
## Summary
- make ClickHouse an explicit `agent-bom api` / `agent-bom serve` analytics backend via CLI flags and env contract
- add buffered ClickHouse writes for server mode and expose analytics backend health on `/health`
- align README, enterprise deployment docs, and focused ClickHouse/API/CLI tests with the new operator contract

## Validation
- `UV_CACHE_DIR=/tmp/agent-bom-clickhouse-uv-cache uv run pytest -q tests/test_clickhouse.py tests/test_cli_server.py tests/test_api_endpoints.py`
- `UV_CACHE_DIR=/tmp/agent-bom-clickhouse-uv-cache uv run mypy src/agent_bom/api/clickhouse_store.py src/agent_bom/api/server.py src/agent_bom/cli/_server.py src/agent_bom/api/models.py`
- `python -m compileall src/agent_bom/api src/agent_bom/cli`
