### PR TITLE
feat(scan): surface advisory depth for project inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ agent-bom serve                         # API + Next.js dashboard
 
 - MCP-aware blast radius instead of flat package CVE lists
 - AI-focused scanning across agents, instruction files, skills, runtime proxy traffic, and cloud AI surfaces
-- Project lockfile and manifest inventory with direct/transitive dependency visibility in CLI and JSON output
+- Project lockfile and manifest inventory with direct/transitive dependency visibility plus lockfile-backed versus declaration-only advisory depth in CLI and JSON output
 - Model and weight supply-chain checks with signed-artifact detection, bundle manifest and lineage visibility, HuggingFace provenance, and hash-verification visibility in CLI and JSON output
 - Real operator outputs: SARIF, CycloneDX, HTML, graphs, badges, JSON, API, dashboard, and MCP tools
 - Works as local CLI, CI gate, authenticated remote service, and enterprise deployment base

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -24,7 +24,7 @@ Current repo-derived counts live in [PRODUCT_METRICS.md](PRODUCT_METRICS.md). Th
 
 ### Scanning
 
-The scanner covers package risk, malicious or suspicious package indicators, container layers, IaC, cloud AI surfaces, secrets, instruction or skill files, and model or weight supply chain integrity. Project scans surface lockfile-backed inventory, declaration-only manifests, and direct-versus-transitive package depth so users can tell how much dependency truth they are getting from a scan. Model and weight scans surface risky formats, signature presence, bundle manifests, adapter lineage, provenance checks, and Hub-backed hash verification where available.
+The scanner covers package risk, malicious or suspicious package indicators, container layers, IaC, cloud AI surfaces, secrets, instruction or skill files, and model or weight supply chain integrity. Project scans surface lockfile-backed inventory, declaration-only manifests, direct-versus-transitive package depth, and explicit advisory-depth coverage so users can tell how much of the scan came from resolved lockfiles versus manifest-only declarations. Model and weight scans surface risky formats, signature presence, bundle manifests, adapter lineage, provenance checks, and Hub-backed hash verification where available.
 
 ### Blast radius
 

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -622,7 +622,9 @@ def run_local_discovery(
                 f"{'ies' if project_inventory['manifest_directories'] != 1 else 'y'} "
                 f"({project_inventory['manifest_files']} files, {project_inventory['lockfiles']} lockfile"
                 f"{'s' if project_inventory['lockfiles'] != 1 else ''}, "
-                f"{project_inventory['direct_packages']} direct / {project_inventory['transitive_packages']} transitive)"
+                f"{project_inventory['direct_packages']} direct / {project_inventory['transitive_packages']} transitive, "
+                f"{project_inventory['lockfile_backed_packages']} lockfile-backed / "
+                f"{project_inventory['declaration_only_packages']} declaration-only)"
             )
 
             proj_servers: list[MCPServer] = []

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -96,6 +96,13 @@ def print_summary(report: AIBOMReport) -> None:
                 f"({project_inv.get('direct_packages', 0)} direct / {project_inv.get('transitive_packages', 0)} transitive)"
             ),
         )
+        lockfile_backed_packages = project_inv.get("lockfile_backed_packages", project_inv.get("package_count", 0))
+        declaration_only_packages = project_inv.get("declaration_only_packages", 0)
+        advisory_depth_pct = project_inv.get("advisory_depth_pct")
+        advisory_depth = f"{lockfile_backed_packages} lockfile-backed / {declaration_only_packages} declaration-only"
+        if advisory_depth_pct is not None:
+            advisory_depth += f" ({advisory_depth_pct}% lockfile-backed)"
+        table.add_row("Advisory depth", advisory_depth)
 
     model_sc = getattr(report, "model_supply_chain_data", None)
     if model_sc:

--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -457,6 +457,14 @@ def summarize_project_inventory(
     total_transitive = 0
     manifest_file_total = 0
     lockfile_total = 0
+    lockfile_directories = 0
+    declaration_only_directories = 0
+    lockfile_backed_packages = 0
+    declaration_only_packages = 0
+    lockfile_backed_direct_packages = 0
+    lockfile_backed_transitive_packages = 0
+    declaration_only_direct_packages = 0
+    declaration_only_transitive_packages = 0
 
     for directory, packages in sorted(dir_map.items(), key=lambda item: str(item[0])):
         manifest_files = _manifest_file_names(directory)
@@ -464,6 +472,7 @@ def summarize_project_inventory(
         manifests = [name for name in manifest_files if name not in _LOCKFILE_FILES]
         direct_count = sum(1 for pkg in packages if pkg.is_direct)
         transitive_count = len(packages) - direct_count
+        advisory_evidence = "lockfile_backed" if lockfiles else "declaration_only"
 
         rel_path = "." if directory == root else str(directory.relative_to(root))
         eco_breakdown: dict[str, int] = {}
@@ -480,6 +489,7 @@ def summarize_project_inventory(
                 "manifest_files": manifest_files,
                 "lockfile_files": lockfiles,
                 "declaration_files": manifests,
+                "advisory_evidence": advisory_evidence,
                 "ecosystems": eco_breakdown,
             }
         )
@@ -488,16 +498,37 @@ def summarize_project_inventory(
         total_transitive += transitive_count
         manifest_file_total += len(manifest_files)
         lockfile_total += len(lockfiles)
+        if lockfiles:
+            lockfile_directories += 1
+            lockfile_backed_packages += len(packages)
+            lockfile_backed_direct_packages += direct_count
+            lockfile_backed_transitive_packages += transitive_count
+        else:
+            declaration_only_directories += 1
+            declaration_only_packages += len(packages)
+            declaration_only_direct_packages += direct_count
+            declaration_only_transitive_packages += transitive_count
+
+    advisory_depth_pct = round(lockfile_backed_packages / total_packages * 100) if total_packages else 0
 
     return {
         "root": str(root),
         "manifest_directories": len(dir_map),
+        "lockfile_directories": lockfile_directories,
+        "declaration_only_directories": declaration_only_directories,
         "manifest_files": manifest_file_total,
         "lockfiles": lockfile_total,
         "declaration_only_files": manifest_file_total - lockfile_total,
         "package_count": total_packages,
         "direct_packages": total_direct,
         "transitive_packages": total_transitive,
+        "lockfile_backed_packages": lockfile_backed_packages,
+        "declaration_only_packages": declaration_only_packages,
+        "lockfile_backed_direct_packages": lockfile_backed_direct_packages,
+        "lockfile_backed_transitive_packages": lockfile_backed_transitive_packages,
+        "declaration_only_direct_packages": declaration_only_direct_packages,
+        "declaration_only_transitive_packages": declaration_only_transitive_packages,
+        "advisory_depth_pct": advisory_depth_pct,
         "ecosystems": ecosystems,
         "directories": directories,
     }

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -152,6 +152,9 @@ class TestPrintSummary:
             "package_count": 12,
             "direct_packages": 5,
             "transitive_packages": 7,
+            "lockfile_backed_packages": 9,
+            "declaration_only_packages": 3,
+            "advisory_depth_pct": 75,
         }
         print_summary(report)
 
@@ -411,12 +414,21 @@ class TestToJson:
         report.project_inventory_data = {
             "root": "/tmp/project",
             "manifest_directories": 2,
+            "lockfile_directories": 1,
+            "declaration_only_directories": 1,
             "manifest_files": 4,
             "lockfiles": 2,
             "declaration_only_files": 2,
             "package_count": 8,
             "direct_packages": 3,
             "transitive_packages": 5,
+            "lockfile_backed_packages": 6,
+            "declaration_only_packages": 2,
+            "lockfile_backed_direct_packages": 2,
+            "lockfile_backed_transitive_packages": 4,
+            "declaration_only_direct_packages": 1,
+            "declaration_only_transitive_packages": 1,
+            "advisory_depth_pct": 75,
             "ecosystems": {"pypi": 3, "npm": 5},
             "directories": [
                 {
@@ -427,12 +439,14 @@ class TestToJson:
                     "manifest_files": ["package.json", "package-lock.json"],
                     "lockfile_files": ["package-lock.json"],
                     "declaration_files": ["package.json"],
+                    "advisory_evidence": "lockfile_backed",
                     "ecosystems": {"npm": 5},
                 }
             ],
         }
         data = to_json(report)
         assert data["project_inventory"]["lockfiles"] == 2
+        assert data["project_inventory"]["advisory_depth_pct"] == 75
         assert data["project_inventory"]["directories"][0]["path"] == "."
 
 

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -148,8 +148,26 @@ class TestScanProjectDirectory:
         assert summary["package_count"] == 2
         assert summary["direct_packages"] == 1
         assert summary["transitive_packages"] == 1
+        assert summary["lockfile_directories"] == 1
+        assert summary["declaration_only_directories"] == 0
+        assert summary["lockfile_backed_packages"] == 2
+        assert summary["declaration_only_packages"] == 0
+        assert summary["advisory_depth_pct"] == 100
         assert summary["ecosystems"] == {"npm": 2}
         assert summary["directories"][0]["lockfile_files"] == ["package-lock.json"]
+        assert summary["directories"][0]["advisory_evidence"] == "lockfile_backed"
+
+    def test_summarize_project_inventory_marks_manifest_only_depth(self, tmp_path):
+        (tmp_path / "requirements.txt").write_text("requests==2.31.0\nflask==3.0.0\n")
+        result = scan_project_directory(tmp_path)
+        summary = summarize_project_inventory(tmp_path, result)
+        assert summary["manifest_directories"] == 1
+        assert summary["lockfile_directories"] == 0
+        assert summary["declaration_only_directories"] == 1
+        assert summary["lockfile_backed_packages"] == 0
+        assert summary["declaration_only_packages"] == 2
+        assert summary["advisory_depth_pct"] == 0
+        assert summary["directories"][0]["advisory_evidence"] == "declaration_only"
 
 
 # ── detect_sbom_resource_name ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- surface lockfile-backed versus declaration-only advisory depth in project inventory summaries
- carry the new advisory-depth contract through CLI text, JSON output, and report summaries
- align the README and product brief with the real project-scan coverage semantics

## Validation
- UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_project_mode.py tests/test_output_cov.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/parsers/__init__.py src/agent_bom/output/__init__.py src/agent_bom/cli/agents/_discovery.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run python -m compileall src/agent_bom