### PR TITLE
feat(report): diff external sboms against scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ That work is tracked in [docs/ROADMAP.md](docs/ROADMAP.md).
 - OSV, NVD, GHSA, EPSS, and CISA KEV enrichment
 - Blast radius mapping: CVE → package → MCP server → agent → credentials → tools
 - CycloneDX 1.6 with ML BOM extensions, SPDX 3.0, VEX, SARIF, HTML, graph, JSON, and more
+- External SBOM ingest and diff workflows so teams can compare vendor or baseline BOMs against current scans
 
 </details>
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -76,6 +76,7 @@ The next phase should stay disciplined:
 
 - enterprise hardening: auth defaults, tenant isolation, Helm and deployment defaults, stable operator contracts
 - scanner depth: stronger lockfile and package coverage so buyers do not need a second tool for basic SCA depth
+- supply chain operations: tighter SBOM import/diff workflows so external vendor BOMs and current scans stay comparable
 - MCP and runtime depth: keep improving governance, observability, and remote operation without weakening the low-friction local story
 - skills depth: move from strong regex-first analysis toward more semantic analysis while preserving stable output contracts
 - contributor scalability: make extension and contribution paths clearer without destabilizing the core product

--- a/src/agent_bom/cli/_history.py
+++ b/src/agent_bom/cli/_history.py
@@ -190,26 +190,28 @@ def diff_cmd(baseline: str, current: Optional[str]):
     Usage:
       agent-bom report diff baseline.json                # diff against latest saved scan
       agent-bom report diff baseline.json current.json   # diff two specific files
+      agent-bom report diff baseline.cdx.json current.spdx.json   # diff two external SBOMs
+      agent-bom report diff baseline.cdx.json latest-scan.json    # diff external SBOM vs agent-bom report
 
     \b
     Exit codes:
       0  No new findings
       1  New vulnerability findings detected
     """
-    from agent_bom.history import diff_reports, latest_report, load_report
+    from agent_bom.history import diff_reports, latest_report, load_report_or_sbom
 
     console = Console()
 
-    baseline_data = load_report(Path(baseline))
+    baseline_data = load_report_or_sbom(Path(baseline))
 
     if current:
-        current_data = load_report(Path(current))
+        current_data = load_report_or_sbom(Path(current))
     else:
         latest = latest_report()
         if not latest:
             console.print("[red]No saved scans in history. Run: agent-bom scan --save[/red]")
             sys.exit(1)
-        current_data = load_report(latest)
+        current_data = load_report_or_sbom(latest)
 
     diff = diff_reports(baseline_data, current_data)
     print_diff(diff)

--- a/src/agent_bom/cli/_report_group.py
+++ b/src/agent_bom/cli/_report_group.py
@@ -3,7 +3,7 @@
 Usage::
 
     agent-bom report history             # list saved scan reports
-    agent-bom report diff <a> <b>        # diff two scan reports
+    agent-bom report diff <a> <b>        # diff two scan reports or SBOMs
     agent-bom report rescan              # re-scan to verify remediation
     agent-bom report compliance-narrative report.json
     agent-bom report analytics           # query vulnerability trends
@@ -23,7 +23,7 @@ def report_group(ctx: click.Context) -> None:
     \b
     Subcommands:
       history     List saved scan reports
-      diff        Diff two scan reports
+      diff        Diff two scan reports or CycloneDX/SPDX SBOMs
       rescan      Re-scan vulnerable packages to verify remediation
       compliance-narrative  Generate auditor-facing compliance narrative from a saved scan report
       analytics   Query vulnerability trends (ClickHouse)

--- a/src/agent_bom/history.py
+++ b/src/agent_bom/history.py
@@ -7,6 +7,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from agent_bom.models import Package
+from agent_bom.sbom import parse_sbom_document
+
 HISTORY_DIR = Path.home() / ".agent-bom" / "history"
 
 
@@ -36,6 +39,81 @@ def list_reports() -> list[Path]:
 def load_report(path: Path) -> dict:
     """Load a saved report JSON file."""
     return json.loads(path.read_text())
+
+
+def _synthetic_report_from_packages(
+    packages: list[Package],
+    *,
+    generated_at: str,
+    source_path: Path,
+    source_name: str,
+    format_name: str,
+) -> dict:
+    """Build a minimal report-shaped dict for non-agent package inventories."""
+    package_dicts = [
+        {
+            "name": pkg.name,
+            "version": pkg.version,
+            "ecosystem": pkg.ecosystem,
+            "purl": getattr(pkg, "purl", None),
+            "is_direct": getattr(pkg, "is_direct", True),
+            "stable_id": getattr(pkg, "stable_id", None),
+        }
+        for pkg in packages
+    ]
+    server_name = f"sbom:{source_name}"
+    return {
+        "generated_at": generated_at,
+        "summary": {
+            "total_agents": 1,
+            "total_packages": len(package_dicts),
+            "total_vulnerabilities": 0,
+            "critical_findings": 0,
+        },
+        "scan_sources": ["sbom"],
+        "sbom_baseline": {
+            "source_path": str(source_path),
+            "source_name": source_name,
+            "format": format_name,
+            "package_count": len(package_dicts),
+        },
+        "agents": [
+            {
+                "name": server_name,
+                "stable_id": server_name,
+                "mcp_servers": [
+                    {
+                        "name": server_name,
+                        "stable_id": server_name,
+                        "surface": "sbom",
+                        "fingerprint": "",
+                        "packages": package_dicts,
+                        "tools": [],
+                        "resources": [],
+                    }
+                ],
+            }
+        ],
+        "blast_radius": [],
+    }
+
+
+def load_report_or_sbom(path: Path) -> dict:
+    """Load either an agent-bom report or an external CycloneDX/SPDX SBOM."""
+    data = load_report(path)
+    if "blast_radius" in data or "ai_bom_version" in data:
+        return data
+
+    packages, format_name, detected_name = parse_sbom_document(data, source_name=str(path))
+    generated_at = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+    source_name = detected_name or path.stem
+    return _synthetic_report_from_packages(
+        packages,
+        generated_at=generated_at,
+        source_path=path,
+        source_name=source_name,
+        format_name=format_name,
+    )
 
 
 def latest_report() -> Optional[Path]:

--- a/src/agent_bom/sbom.py
+++ b/src/agent_bom/sbom.py
@@ -430,6 +430,29 @@ def detect_sbom_resource_name(data: dict) -> str | None:
     return None
 
 
+def parse_sbom_document(data: dict, source_name: str = "<memory>") -> tuple[list[Package], str, str | None]:
+    """Parse an in-memory SBOM document.
+
+    Returns ``(packages, format_name, resource_name)`` where ``resource_name``
+    is auto-detected from SBOM metadata when available.
+    """
+    resource_name = detect_sbom_resource_name(data)
+
+    if "bomFormat" in data and data["bomFormat"] == "CycloneDX":
+        return parse_cyclonedx(data), "cyclonedx", resource_name
+
+    if data.get("spdxVersion", "").startswith("SPDX-3"):
+        return parse_spdx(data), "spdx-3", resource_name
+
+    if data.get("spdxVersion", "").startswith("SPDX-2"):
+        return parse_spdx(data), "spdx-2", resource_name
+
+    if "ai_bom_version" in data or "blast_radius" in data:
+        raise ValueError("That looks like an agent-bom report, not an SBOM. Use 'agent-bom diff' for report comparison.")
+
+    raise ValueError(f"Unrecognised SBOM format in {source_name}. Expected CycloneDX JSON (bomFormat=CycloneDX) or SPDX 2.x/3.0 JSON.")
+
+
 def load_sbom(path: str) -> tuple[list[Package], str, str | None]:
     """Load an SBOM file and return ``(packages, format_name, resource_name)``.
 
@@ -446,22 +469,4 @@ def load_sbom(path: str) -> tuple[list[Package], str, str | None]:
 
     data = json.loads(p.read_text())
 
-    resource_name = detect_sbom_resource_name(data)
-
-    # CycloneDX: has "bomFormat" key
-    if "bomFormat" in data and data["bomFormat"] == "CycloneDX":
-        return parse_cyclonedx(data), "cyclonedx", resource_name
-
-    # SPDX 3.0: has "spdxVersion" starting with "SPDX-3"
-    if data.get("spdxVersion", "").startswith("SPDX-3"):
-        return parse_spdx(data), "spdx-3", resource_name
-
-    # SPDX 2.x: has "spdxVersion" starting with "SPDX-2"
-    if data.get("spdxVersion", "").startswith("SPDX-2"):
-        return parse_spdx(data), "spdx-2", resource_name
-
-    # agent-bom JSON report: has "ai_bom_version"
-    if "ai_bom_version" in data or "blast_radius" in data:
-        raise ValueError("That looks like an agent-bom report, not an SBOM. Use 'agent-bom diff' for report comparison.")
-
-    raise ValueError(f"Unrecognised SBOM format in {path}. Expected CycloneDX JSON (bomFormat=CycloneDX) or SPDX 2.x/3.0 JSON.")
+    return parse_sbom_document(data, source_name=path)

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -125,6 +125,97 @@ def test_diff_baseline_with_latest(tmp_path):
         assert result.exit_code == 0
 
 
+def test_diff_accepts_sbom_baseline_and_latest_report(tmp_path):
+    runner = CliRunner()
+    baseline = tmp_path / "baseline.cdx.json"
+    latest = tmp_path / "latest.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "bomFormat": "CycloneDX",
+                "metadata": {"component": {"name": "vendor-api"}},
+                "components": [{"type": "library", "name": "requests", "version": "2.31.0", "purl": "pkg:pypi/requests@2.31.0"}],
+            }
+        )
+    )
+    latest.write_text(
+        json.dumps(
+            {
+                "generated_at": "2025-01-02T00:00:00Z",
+                "summary": {"total_agents": 1, "total_packages": 1},
+                "agents": [
+                    {
+                        "name": "scan",
+                        "mcp_servers": [
+                            {
+                                "name": "scan",
+                                "packages": [{"name": "requests", "version": "2.31.0", "ecosystem": "pypi"}],
+                            }
+                        ],
+                    }
+                ],
+                "blast_radius": [],
+            }
+        )
+    )
+
+    with patch("agent_bom.history.latest_report", return_value=latest), patch("agent_bom.cli._history.print_diff") as mock_print:
+        result = runner.invoke(diff_cmd, [str(baseline)])
+        assert result.exit_code == 0
+        mock_print.assert_called_once()
+
+
+def test_diff_accepts_two_sboms(tmp_path):
+    runner = CliRunner()
+    baseline = tmp_path / "baseline.cdx.json"
+    current = tmp_path / "current.spdx.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "bomFormat": "CycloneDX",
+                "components": [{"type": "library", "name": "requests", "version": "2.31.0", "purl": "pkg:pypi/requests@2.31.0"}],
+            }
+        )
+    )
+    current.write_text(
+        json.dumps(
+            {
+                "spdxVersion": "SPDX-2.3",
+                "packages": [
+                    {
+                        "name": "requests",
+                        "versionInfo": "2.31.0",
+                        "externalRefs": [
+                            {
+                                "referenceCategory": "PACKAGE-MANAGER",
+                                "referenceType": "purl",
+                                "referenceLocator": "pkg:pypi/requests@2.31.0",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "urllib3",
+                        "versionInfo": "2.2.0",
+                        "externalRefs": [
+                            {
+                                "referenceCategory": "PACKAGE-MANAGER",
+                                "referenceType": "purl",
+                                "referenceLocator": "pkg:pypi/urllib3@2.2.0",
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+
+    with patch("agent_bom.cli._history.print_diff") as mock_print:
+        result = runner.invoke(diff_cmd, [str(baseline), str(current)])
+        assert result.exit_code == 0
+        diff_payload = mock_print.call_args.args[0]
+        assert diff_payload["summary"]["new_packages"] == 1
+
+
 # ---------------------------------------------------------------------------
 # rescan_command
 # ---------------------------------------------------------------------------

--- a/tests/test_sbom_ingestion.py
+++ b/tests/test_sbom_ingestion.py
@@ -9,6 +9,7 @@ from agent_bom.sbom import (
     _ecosystem_from_type,
     load_sbom,
     parse_cyclonedx,
+    parse_sbom_document,
     parse_spdx,
 )
 
@@ -227,6 +228,11 @@ def test_load_sbom_rejects_agent_bom_report(tmp_path):
         load_sbom(str(path))
 
 
+def test_parse_sbom_document_rejects_agent_bom_report():
+    with pytest.raises(ValueError, match="agent-bom report"):
+        parse_sbom_document({"ai_bom_version": "0.75.15", "blast_radius": []})
+
+
 def test_load_sbom_unknown_format(tmp_path):
     data = {"random_key": "random_value"}
     path = tmp_path / "mystery.json"
@@ -234,6 +240,31 @@ def test_load_sbom_unknown_format(tmp_path):
 
     with pytest.raises(ValueError, match="Unrecognised SBOM format"):
         load_sbom(str(path))
+
+
+def test_parse_sbom_document_autodetects_spdx_2():
+    data = {
+        "spdxVersion": "SPDX-2.3",
+        "name": "DOCUMENT-prod-api-01",
+        "packages": [
+            {
+                "name": "flask",
+                "versionInfo": "3.0.0",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": "pkg:pypi/flask@3.0.0",
+                    }
+                ],
+            }
+        ],
+    }
+    packages, fmt, resource_name = parse_sbom_document(data, source_name="memory.json")
+    assert fmt == "spdx-2"
+    assert resource_name == "prod-api-01"
+    assert len(packages) == 1
+    assert packages[0].name == "flask"
 
 
 def test_load_sbom_file_not_found():


### PR DESCRIPTION
Summary:
- let agent-bom report diff accept external CycloneDX/SPDX SBOMs as either side of the comparison
- reuse the existing report diff engine by normalizing SBOMs into a minimal report-shaped inventory snapshot
- align README and product brief with the real SBOM drift workflow

Validation:
- UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_cli_history.py tests/test_sbom_ingestion.py
- UV_NO_SYNC=1 UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/history.py src/agent_bom/sbom.py src/agent_bom/cli/_history.py src/agent_bom/cli/_report_group.py
- python -m compileall src/agent_bom/history.py src/agent_bom/sbom.py src/agent_bom/cli/_history.py src/agent_bom/cli/_report_group.py