### PR TITLE
docs(enterprise): map claims to controls and community paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Package risk is only the start. agent-bom maps what it can reach across MCP serv
 
 `agent-bom` is now a real released product surface, not just a research repo: installable from PyPI, publishable through Docker, usable in GitHub Actions, deployable as an authenticated API and remote MCP service, and validated end to end through CLI, reports, API, dashboard, and policy gates.
 
-For the canonical product brief and verified repo-derived metrics, see [docs/PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) and [docs/PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md).
+For the canonical product brief and verified repo-derived metrics, see [docs/PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) and [docs/PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md). For enterprise-control traceability, see [docs/ENTERPRISE.md](docs/ENTERPRISE.md).
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom demo" width="900" />
@@ -98,6 +98,15 @@ agent-bom serve                         # API + Next.js dashboard
 | **CI/CD** | Use the GitHub Action or `docker run --rm agentbom/agent-bom`. It is isolated by default and easy to gate on exit code or SARIF. |
 | **Enterprise fleet** | Deploy `agent-bom serve` in its own container or namespace with API keys or OIDC-backed role checks and a real backend. Use the CLI or Action on endpoints and repos; use the API for fleet visibility. |
 | **Air-gapped / isolated** | Pre-sync the local DB, copy the cache, and run with `--offline` or `auto-update-db: false`. |
+
+## Enterprise and community
+
+- Enterprise controls map: [docs/ENTERPRISE.md](docs/ENTERPRISE.md)
+- Enterprise deployment guide: [docs/ENTERPRISE_DEPLOYMENT.md](docs/ENTERPRISE_DEPLOYMENT.md)
+- Runtime monitoring and proxy deployment: [docs/RUNTIME_MONITORING.md](docs/RUNTIME_MONITORING.md)
+- Community bootstrap plan: [docs/COMMUNITY.md](docs/COMMUNITY.md)
+
+When the Discord server is live, add the invite link in this section and in release notes so support and contributor traffic has a single obvious entry point.
 
 ## Update and release hygiene
 

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -1,0 +1,63 @@
+# Community
+
+`agent-bom` is strong enough that adoption is now limited more by discoverability and response loops than by missing core product features.
+
+This page defines the minimum community surface we should keep live and honest.
+
+## Recommended Discord Server Shape
+
+Start small and keep it active:
+
+- `#general`
+- `#feedback`
+- `#support`
+- `#contributors`
+- `#good-first-issues`
+- `#release-notes`
+
+## What To Pin On Day One
+
+In `#general`:
+
+- what `agent-bom` is
+- where to install it
+- where to file bugs
+- where releases are announced
+
+In `#contributors`:
+
+- contribution path
+- review expectation target
+- where parser / scanner / API extension points live
+
+In `#support`:
+
+- how to ask for help
+- what logs / commands to include
+- reminder not to paste live secrets
+
+## Repo Wiring
+
+Once the Discord invite exists, add it to:
+
+- `README.md`
+- release notes
+- Reddit launch post
+- Slack / forum launch post
+
+## Contribution Expectations
+
+The fastest way to turn interest into contributors is to keep the entry path concrete:
+
+- publish `good first issue` tickets with exact file pointers
+- keep issue labels tidy
+- answer PRs quickly
+- keep docs truthful to the code
+
+## Current Goal
+
+Community should make `agent-bom` easier to adopt, not noisier:
+
+- easy to ask questions
+- easy to see what is real
+- easy to find small contribution slices

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -1,0 +1,128 @@
+# Enterprise Controls Map
+
+This page maps enterprise-facing `agent-bom` claims to the code that implements them.
+
+It exists for a simple reason: the controls are real, but they should not require a repo archeology session to verify.
+
+## What Is True Today
+
+`agent-bom` is production-ready OSS and enterprise-adaptable. The current enterprise control plane is built around:
+
+- API key auth with ordered RBAC route rules
+- optional OIDC bearer auth with fail-closed tenant claims
+- PostgreSQL-backed multi-tenant stores with row-level security
+- HMAC-chained audit logging
+- request tracing and `/health` observability contracts
+- explicit storage/backend behavior for Postgres, Supabase, Snowflake, and ClickHouse
+
+## Claim To Code Map
+
+| Claim | What it means | Code |
+|---|---|---|
+| API key auth + RBAC | API keys carry `admin` / `analyst` / `viewer` roles and are checked per route prefix | `src/agent_bom/api/auth.py`, `src/agent_bom/api/middleware.py` |
+| OIDC / SSO | Any standard OIDC provider can issue bearer tokens for API access | `src/agent_bom/api/oidc.py`, `src/agent_bom/api/middleware.py` |
+| Fail-closed tenant claims | If `AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1`, the token must carry the configured tenant claim | `src/agent_bom/api/oidc.py` |
+| Postgres tenant isolation | The authenticated tenant is pushed into the DB session as `app.tenant_id` before request handling | `src/agent_bom/api/middleware.py`, `src/agent_bom/api/postgres_store.py` |
+| PostgreSQL row-level security | Tenant-bearing tables have RLS policies keyed off the current tenant | `deploy/supabase/postgres/init.sql`, `src/agent_bom/api/postgres_store.py` |
+| API keys persisted in Postgres | Keys move from in-memory to transactional storage when `AGENT_BOM_POSTGRES_URL` is set | `src/agent_bom/api/server.py`, `src/agent_bom/api/postgres_store.py`, `src/agent_bom/api/auth.py` |
+| Exceptions and false positives persisted in Postgres | Exception workflow uses a tenant-aware Postgres store when configured | `src/agent_bom/api/server.py`, `src/agent_bom/api/postgres_store.py`, `src/agent_bom/api/routes/enterprise.py` |
+| Audit log integrity | Audit entries are chain-signed with HMAC and can be verified via API | `src/agent_bom/api/audit_log.py`, `src/agent_bom/api/routes/enterprise.py` |
+| Rate limiting | Read and scan endpoints have separate request budgets with shared Postgres-backed storage when configured | `src/agent_bom/api/middleware.py`, `src/agent_bom/api/postgres_store.py` |
+| Request tracing | API preserves W3C trace context and exposes tracing state on `/health` | `src/agent_bom/api/tracing.py`, `src/agent_bom/api/middleware.py`, `src/agent_bom/api/server.py` |
+| ClickHouse analytics backend | Server mode can buffer analytics writes and report backend state on `/health` | `src/agent_bom/api/server.py`, `src/agent_bom/api/clickhouse_store.py` |
+| Snowflake backend | Snowflake has native stores for selected enterprise data paths, not full transactional parity | `src/agent_bom/api/server.py`, `src/agent_bom/api/snowflake_store.py` |
+
+## RBAC Matrix
+
+The API middleware uses ordered route rules. Narrower enterprise routes win over broad prefixes.
+
+| Method | Route prefix | Minimum role |
+|---|---|---|
+| `GET` | `/v1/auth/keys` | `admin` |
+| `POST` | `/v1/auth/keys` | `admin` |
+| `DELETE` | `/v1/auth/keys/` | `admin` |
+| `POST` | `/v1/gateway/policies` | `admin` |
+| `PUT` | `/v1/gateway/policies/` | `admin` |
+| `DELETE` | `/v1/gateway/policies/` | `admin` |
+| `POST` | `/v1/fleet/sync` | `admin` |
+| `PUT` | `/v1/fleet/` | `admin` |
+| `PUT` | `/v1/exceptions/` | `admin` |
+| `DELETE` | `/v1/exceptions/` | `admin` |
+| `POST` | `/v1/siem/test` | `admin` |
+| `POST` | `/v1/shield/start` | `admin` |
+| `POST` | `/v1/shield/unblock` | `admin` |
+| `POST` | `/v1/shield/break-glass` | `admin` |
+| `DELETE` | `/v1/scan/` | `admin` |
+| `POST` | `/v1/exceptions` | `analyst` |
+| `POST` | `/v1/findings/jira` | `analyst` |
+| `POST` | `/v1/findings/false-positive` | `analyst` |
+| `DELETE` | `/v1/findings/false-positive/` | `analyst` |
+| `POST` | `/v1/scan` | `analyst` |
+| `POST` | `/v1/gateway/evaluate` | `analyst` |
+| `POST` | `/v1/traces` | `analyst` |
+| `POST` | `/v1/results/push` | `analyst` |
+| `POST` | `/v1/schedules` | `analyst` |
+| `DELETE` | `/v1/schedules/` | `analyst` |
+| `PUT` | `/v1/schedules/` | `analyst` |
+| any unmatched route | everything else | `viewer` |
+
+Implementation source: `src/agent_bom/api/middleware.py`
+
+## Authentication Contract
+
+`agent-bom api` and `agent-bom serve` support three runtime postures:
+
+1. Loopback development
+   - localhost binds are allowed without remote auth
+2. API key enforcement
+   - non-loopback binds require `AGENT_BOM_API_KEY` or stored API keys
+3. OIDC bearer enforcement
+   - set `AGENT_BOM_OIDC_ISSUER`
+   - optionally set `AGENT_BOM_OIDC_AUDIENCE`
+   - map roles with `AGENT_BOM_OIDC_ROLE_CLAIM`
+   - map tenants with `AGENT_BOM_OIDC_TENANT_CLAIM`
+   - fail closed with `AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1`
+
+Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`
+
+## Storage Compatibility
+
+`agent-bom` uses different backends for different jobs. The current documented default should be read this way:
+
+| Backend | Status | Best fit |
+|---|---|---|
+| PostgreSQL | Full transactional control-plane backend | team and enterprise API deployments |
+| Supabase | Full transactional control-plane backend because it is PostgreSQL | managed Postgres deployments |
+| SQLite | single-node / local persistence | local or small deployments |
+| ClickHouse | analytics backend | high-volume scan and posture analytics |
+| Snowflake | selected enterprise stores, not full transactional parity | governance / analytics / Snowflake-native environments |
+
+Today, if you want the broadest transactional feature coverage, use PostgreSQL or Supabase.
+
+## Multi-Tenant Reference Architecture
+
+```mermaid
+flowchart LR
+    EP[Endpoints / CI / Repos] --> CLI[CLI / Action / Docker]
+    EP --> API[agent-bom API / serve]
+    CLI --> API
+    API --> AUTH[API key auth / OIDC]
+    AUTH --> MW[Middleware\nRBAC + rate limit + trace context]
+    MW --> PG[(PostgreSQL / Supabase\ntransactional control plane)]
+    MW --> CH[(ClickHouse\nanalytics)]
+    MW --> SF[(Snowflake\npartial parity)]
+    MW --> AUDIT[HMAC audit log]
+    MW --> OBS[/health + /metrics + OTLP]
+
+    PG --> RLS[RLS via app.tenant_id]
+    API --> UI[Dashboard / JSON / MCP / reports]
+```
+
+## Related Docs
+
+- `docs/ENTERPRISE_DEPLOYMENT.md`
+- `docs/RUNTIME_MONITORING.md`
+- `docs/PERMISSIONS.md`
+- `docs/SECURITY_ARCHITECTURE.md`
+- `docs/THREAT_MODEL.md`
+- `docs/adr/005-no-rbac-custom-auth.md`

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 Deploy agent-bom across your organization — from developer endpoints to cloud infrastructure.
 
+If you want a code-mapped explanation of the enterprise claims in this guide, start with [ENTERPRISE.md](ENTERPRISE.md).
+
 ## Architecture Principles
 
 agent-bom is built on four security principles:
@@ -121,7 +123,7 @@ That keeps API roles and tenant boundaries aligned with the upstream identity pr
 
 For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated tenant into the database session (`app.tenant_id`) so Postgres row-level security can enforce the same tenant boundary for fleet and schedule data. Internal scheduler work uses an explicit trusted bypass rather than silently reading across tenants.
 
-**Storage:** SQLite (single node), PostgreSQL-compatible backends such as Postgres or Supabase (transactional team control plane), Snowflake/ClickHouse (analytics and selected enterprise backends). Snowflake does not yet have full parity for every transactional API store, so Postgres-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, audit, and trend state.
+**Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, audit, and trend state.
 
 For ClickHouse-backed analytics, make the backend explicit instead of relying on ambient environment alone:
 


### PR DESCRIPTION
## Summary
- add ENTERPRISE.md with a code-mapped enterprise controls matrix
- add COMMUNITY.md with the Discord/community bootstrap plan
- align README and enterprise deployment docs with the actual storage and control-plane contract

## Validation
- git diff --check
- verified README and deployment links to ENTERPRISE.md and COMMUNITY.md