### PR TITLE
feat(clickhouse): persist API scan analytics

### DIFF
--- a/src/agent_bom/analytics_contract.py
+++ b/src/agent_bom/analytics_contract.py
@@ -1,0 +1,156 @@
+"""Shared analytics payload builders for ClickHouse persistence.
+
+These helpers keep CLI and API scan paths aligned so both emit the same
+finding, scan-metadata, and posture snapshot contract when analytics are
+enabled.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+from agent_bom.models import AIBOMReport
+from agent_bom.output import to_json
+
+
+@dataclass
+class ScanAnalyticsPayload:
+    """Normalized analytics rows derived from an AI-BOM report."""
+
+    scan_id: str
+    agent_findings: dict[str, list[dict[str, Any]]]
+    scan_metadata: dict[str, Any]
+    posture_snapshots: dict[str, dict[str, Any]]
+
+
+def build_scan_analytics_payload(
+    report: AIBOMReport,
+    *,
+    report_json: dict[str, Any] | None = None,
+    scan_id: str | None = None,
+    source: str = "cli",
+) -> ScanAnalyticsPayload:
+    """Build shared ClickHouse analytics rows from a report.
+
+    The API and CLI use the same contract so dashboards and operators do not
+    get subtly different records depending on how a scan was launched.
+    """
+    data = report_json or to_json(report)
+    final_scan_id = scan_id or data.get("scan_id") or report.scan_id
+    if not final_scan_id:
+        raise ValueError("scan_id required for analytics payload")
+
+    agent_findings = _build_agent_findings(data.get("blast_radius", []), report.agents)
+    posture_snapshots = _build_posture_snapshots(report, data.get("blast_radius", []))
+    summary = data.get("summary", {})
+    posture = data.get("posture_scorecard", {})
+
+    scan_metadata = {
+        "scan_id": final_scan_id,
+        "agent_count": int(summary.get("total_agents", report.total_agents)),
+        "package_count": int(summary.get("total_packages", report.total_packages)),
+        "vuln_count": int(summary.get("total_vulnerabilities", report.total_vulnerabilities)),
+        "critical_count": int(summary.get("critical_findings", len(report.critical_vulns))),
+        "high_count": sum(1 for item in data.get("blast_radius", []) if item.get("severity") == "high"),
+        "posture_grade": posture.get("grade", ""),
+        "scan_duration_ms": int(data.get("scan_duration_ms", 0) or 0),
+        "source": source,
+        "aisvs_score": float((report.aisvs_benchmark_data or {}).get("overall_score", 0.0) or 0.0),
+        "has_runtime_correlation": bool(report.runtime_correlation),
+    }
+    return ScanAnalyticsPayload(
+        scan_id=final_scan_id,
+        agent_findings=agent_findings,
+        scan_metadata=scan_metadata,
+        posture_snapshots=posture_snapshots,
+    )
+
+
+def _build_agent_findings(blast_radius: list[dict[str, Any]], agents: list[Any]) -> dict[str, list[dict[str, Any]]]:
+    findings_by_agent: dict[str, list[dict[str, Any]]] = {agent.name: [] for agent in agents}
+    for item in blast_radius:
+        finding = {
+            "package_name": item.get("package_name", ""),
+            "package_version": item.get("package_version", ""),
+            "package": item.get("package", ""),
+            "ecosystem": item.get("ecosystem", ""),
+            "cve_id": item.get("vulnerability_id", ""),
+            "cvss_score": float(item.get("cvss_score") or 0.0),
+            "epss_score": float(item.get("epss_score") or 0.0),
+            "severity": item.get("severity", "unknown"),
+            "source": item.get("primary_advisory_source") or "osv",
+            "environment": item.get("environment", ""),
+            "cmmc_tags": list(item.get("cmmc_tags", [])),
+        }
+        for agent_name in item.get("affected_agents", []):
+            findings_by_agent.setdefault(agent_name, []).append(dict(finding))
+    return findings_by_agent
+
+
+def _build_posture_snapshots(report: AIBOMReport, blast_radius: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    findings_by_agent: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in blast_radius:
+        for agent_name in item.get("affected_agents", []):
+            findings_by_agent[agent_name].append(item)
+
+    snapshots: dict[str, dict[str, Any]] = {}
+    for agent in report.agents:
+        findings = findings_by_agent.get(agent.name, [])
+        severity_counts = Counter(str(item.get("severity", "")).lower() for item in findings)
+        total_findings = len(findings)
+        total_packages = sum(len(server.packages) for server in agent.mcp_servers)
+        max_risk_score = max((float(item.get("risk_score") or 0.0) for item in findings), default=0.0)
+        compliance_hits = sum(
+            1
+            for item in findings
+            if any(
+                item.get(key)
+                for key in (
+                    "owasp_tags",
+                    "atlas_tags",
+                    "nist_ai_rmf_tags",
+                    "owasp_mcp_tags",
+                    "owasp_agentic_tags",
+                    "eu_ai_act_tags",
+                    "nist_csf_tags",
+                    "iso_27001_tags",
+                    "soc2_tags",
+                    "cis_tags",
+                    "cmmc_tags",
+                )
+            )
+            or bool(item.get("compliance_tags"))
+        )
+        compliance_score = (compliance_hits / total_findings * 100.0) if total_findings else 100.0
+        posture_score = max(
+            0.0,
+            100.0
+            - severity_counts.get("critical", 0) * 25.0
+            - severity_counts.get("high", 0) * 10.0
+            - severity_counts.get("medium", 0) * 4.0
+            - severity_counts.get("low", 0) * 1.0,
+        )
+        snapshots[agent.name] = {
+            "total_packages": total_packages,
+            "critical": severity_counts.get("critical", 0),
+            "high": severity_counts.get("high", 0),
+            "medium": severity_counts.get("medium", 0),
+            "grade": _score_to_grade(posture_score),
+            "risk_score": round(max_risk_score, 2),
+            "compliance_score": round(compliance_score, 2),
+        }
+    return snapshots
+
+
+def _score_to_grade(score: float) -> str:
+    if score >= 90:
+        return "A"
+    if score >= 80:
+        return "B"
+    if score >= 70:
+        return "C"
+    if score >= 60:
+        return "D"
+    return "F"

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -20,7 +20,7 @@ from enum import Enum
 from typing import Any
 
 from agent_bom.api.models import JobStatus, ScanJob, StepStatus
-from agent_bom.api.stores import _get_fleet_store, _get_store, _job_lock
+from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_store, _job_lock
 from agent_bom.security import sanitize_error
 
 _logger = logging.getLogger(__name__)
@@ -499,13 +499,28 @@ def _run_scan_sync(job: ScanJob) -> None:
         pipeline.start_step("output", "Building report...")
         from agent_bom.models import AIBOMReport
 
-        report = AIBOMReport(agents=agents, blast_radii=blast_radii)
+        report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_id=job.job_id)
         report_json = to_json(report)
         report_json["warnings"] = warnings_all
         with lock:
             job.result = report_json
             job.status = JobStatus.DONE
         pipeline.complete_step("output", "Report ready")
+
+        try:
+            from agent_bom.analytics_contract import build_scan_analytics_payload
+
+            analytics_store = _get_analytics_store()
+            analytics = build_scan_analytics_payload(report, report_json=report_json, scan_id=job.job_id, source="api")
+            for agent_name, findings in analytics.agent_findings.items():
+                analytics_store.record_scan(analytics.scan_id, agent_name, findings)
+            analytics_store.record_scan_metadata(analytics.scan_metadata)
+            for agent_name, snapshot in analytics.posture_snapshots.items():
+                analytics_store.record_posture(agent_name, snapshot)
+        except Exception as analytics_exc:  # noqa: BLE001
+            _logger.warning("API ClickHouse analytics persistence failed: %s", analytics_exc)
+            with lock:
+                job.progress.append(f"Analytics sync skipped: {sanitize_error(analytics_exc)}")
 
         # Auto-sync discovered agents to fleet registry
         try:

--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from agent_bom.advisory_sources import primary_advisory_source
 from agent_bom.cli._common import SEVERITY_ORDER
 from agent_bom.cli.agents._context import ScanContext
 from agent_bom.output import to_json
@@ -82,45 +81,21 @@ def run_integrations(
         try:
             import uuid as _uuid_ch
 
+            from agent_bom.analytics_contract import build_scan_analytics_payload
             from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
 
             _ch_store = ClickHouseAnalyticsStore(url=clickhouse_url)
             _scan_id = str(_uuid_ch.uuid4())
-            vuln_dicts = [
-                {
-                    "package": br.package.name,
-                    "version": br.package.version,
-                    "ecosystem": br.package.ecosystem,
-                    "cve_id": br.vulnerability.id,
-                    "cvss_score": getattr(br.vulnerability, "cvss_score", 0.0) or 0.0,
-                    "epss_score": getattr(br.vulnerability, "epss_score", 0.0) or 0.0,
-                    "severity": br.vulnerability.severity.value.lower(),
-                    "source": primary_advisory_source(br.vulnerability),
-                    "cmmc_tags": list(br.cmmc_tags) if br.cmmc_tags else [],
-                }
-                for br in blast_radii
-            ]
-            for agent in ctx.agents:
-                _ch_store.record_scan(_scan_id, agent.name, vuln_dicts)
             if ctx.report:
-                _rpt = ctx.report
-                _ch_store.record_scan_metadata(
-                    {
-                        "scan_id": _scan_id,
-                        "agent_count": _rpt.total_agents,
-                        "package_count": _rpt.total_packages,
-                        "vuln_count": _rpt.total_vulnerabilities,
-                        "critical_count": len(_rpt.critical_vulns),
-                        "high_count": sum(1 for br in _rpt.blast_radii if br.vulnerability.severity.value.lower() == "high"),
-                        "posture_grade": "",
-                        "scan_duration_ms": 0,
-                        "source": "cli",
-                        "aisvs_score": float((_rpt.aisvs_benchmark_data or {}).get("overall_score", 0.0)),
-                        "has_runtime_correlation": bool(_rpt.runtime_correlation),
-                    }
-                )
+                analytics = build_scan_analytics_payload(ctx.report, scan_id=_scan_id, source="cli")
+                for agent_name, findings in analytics.agent_findings.items():
+                    _ch_store.record_scan(analytics.scan_id, agent_name, findings)
+                _ch_store.record_scan_metadata(analytics.scan_metadata)
+                for agent_name, snapshot in analytics.posture_snapshots.items():
+                    _ch_store.record_posture(agent_name, snapshot)
             if not quiet:
-                con.print(f"  [green]✓[/green] Analytics: {len(vuln_dicts)} finding(s) recorded to ClickHouse")
+                _finding_count = sum(len(findings) for findings in analytics.agent_findings.values()) if ctx.report else 0
+                con.print(f"  [green]✓[/green] Analytics: {_finding_count} finding(s) recorded to ClickHouse")
         except Exception as _ch_exc:
             if not quiet:
                 con.print(f"  [yellow]⚠[/yellow] ClickHouse analytics: {_ch_exc}")

--- a/tests/test_api_pipeline_image_contract.py
+++ b/tests/test_api_pipeline_image_contract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _run_scan_sync
-from agent_bom.models import Package
+from agent_bom.models import BlastRadius, Package, Severity, Vulnerability
 
 
 class _DummyStore:
@@ -38,3 +38,89 @@ def test_api_pipeline_image_scan_uses_container_surface(monkeypatch):
     assert job.result["summary"]["total_agents"] == 1
     assert job.result["agents"][0]["source"] == "image"
     assert job.result["agents"][0]["mcp_servers"][0]["surface"] == "container-image"
+
+
+def test_api_pipeline_persists_clickhouse_analytics(monkeypatch):
+    store = _DummyStore()
+    job = ScanJob(
+        job_id="clickhouse-123",
+        created_at="2026-03-25T12:00:00Z",
+        request=ScanRequest(images=["agentbom/agent-bom:latest"], enrich=False),
+    )
+
+    class _AnalyticsStore:
+        def __init__(self) -> None:
+            self.scan_calls: list[tuple[str, str, list[dict]]] = []
+            self.metadata_calls: list[dict] = []
+            self.posture_calls: list[tuple[str, dict]] = []
+
+        def record_scan(self, scan_id: str, agent_name: str, findings: list[dict]) -> None:
+            self.scan_calls.append((scan_id, agent_name, findings))
+
+        def record_scan_metadata(self, metadata: dict) -> None:
+            self.metadata_calls.append(metadata)
+
+        def record_posture(self, agent_name: str, snapshot: dict) -> None:
+            self.posture_calls.append((agent_name, snapshot))
+
+    analytics = _AnalyticsStore()
+
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+    monkeypatch.setattr("agent_bom.api.pipeline._get_analytics_store", lambda: analytics)
+    monkeypatch.setattr("agent_bom.api.pipeline._sync_scan_agents_to_fleet", lambda _agents: None)
+    monkeypatch.setattr("agent_bom.discovery.discover_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        "agent_bom.image.scan_image",
+        lambda image_ref: ([Package(name="openssl", version="3.0.16", ecosystem="deb")], "native"),
+    )
+
+    def _fake_scan(agents, enable_enrichment=False):
+        agent = agents[0]
+        server = agent.mcp_servers[0]
+        pkg = server.packages[0]
+        vuln = Vulnerability(
+            id="CVE-2026-0001",
+            summary="test vuln",
+            severity=Severity.HIGH,
+            cvss_score=8.1,
+            epss_score=0.42,
+            advisory_sources=["osv", "nvd"],
+        )
+        pkg.vulnerabilities = [vuln]
+        br = BlastRadius(
+            vulnerability=vuln,
+            package=pkg,
+            affected_servers=[server],
+            affected_agents=[agent],
+            exposed_credentials=[],
+            exposed_tools=[],
+            cmmc_tags=["RA.L2-3.11.2"],
+        )
+        br.calculate_risk_score()
+        return [br]
+
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", _fake_scan)
+
+    _run_scan_sync(job)
+
+    assert job.status == JobStatus.DONE
+    assert analytics.scan_calls
+    assert analytics.metadata_calls
+    assert analytics.posture_calls
+
+    scan_id, agent_name, findings = analytics.scan_calls[0]
+    assert scan_id == "clickhouse-123"
+    assert agent_name == "image:agentbom/agent-bom:latest"
+    assert findings[0]["package_name"] == "openssl"
+    assert findings[0]["source"] == "osv"
+
+    metadata = analytics.metadata_calls[0]
+    assert metadata["scan_id"] == "clickhouse-123"
+    assert metadata["source"] == "api"
+    assert metadata["agent_count"] == 1
+    assert metadata["vuln_count"] == 1
+
+    posture_agent, snapshot = analytics.posture_calls[0]
+    assert posture_agent == "image:agentbom/agent-bom:latest"
+    assert snapshot["high"] == 1
+    assert snapshot["total_packages"] == 1

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -306,3 +306,41 @@ def test_clickhouse_escape_strips_control_chars_and_quotes():
     assert "\u2028" not in escaped
     assert "\\'" in escaped
     assert "\\\\" in escaped
+
+
+def test_build_scan_analytics_payload_splits_findings_by_agent():
+    from agent_bom.analytics_contract import build_scan_analytics_payload
+    from agent_bom.models import Agent, AgentType, AIBOMReport, BlastRadius, MCPServer, Package, Severity, Vulnerability
+
+    shared_pkg = Package(name="requests", version="2.33.0", ecosystem="pypi")
+    vuln = Vulnerability(
+        id="CVE-2026-9999",
+        summary="shared vuln",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        advisory_sources=["osv", "ghsa", "nvd"],
+    )
+    shared_pkg.vulnerabilities = [vuln]
+    server = MCPServer(name="filesystem", packages=[shared_pkg])
+    agent_a = Agent(name="alpha", agent_type=AgentType.CUSTOM, config_path="alpha.json", mcp_servers=[server])
+    agent_b = Agent(name="beta", agent_type=AgentType.CUSTOM, config_path="beta.json", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=shared_pkg,
+        affected_servers=[server],
+        affected_agents=[agent_a, agent_b],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    br.calculate_risk_score()
+    report = AIBOMReport(agents=[agent_a, agent_b], blast_radii=[br], scan_id="scan-xyz")
+
+    payload = build_scan_analytics_payload(report, source="api")
+
+    assert payload.scan_id == "scan-xyz"
+    assert payload.scan_metadata["source"] == "api"
+    assert payload.scan_metadata["vuln_count"] == 2
+    assert payload.agent_findings["alpha"][0]["source"] == "osv"
+    assert payload.agent_findings["beta"][0]["cve_id"] == "CVE-2026-9999"
+    assert payload.posture_snapshots["alpha"]["critical"] == 1
+    assert payload.posture_snapshots["beta"]["critical"] == 1


### PR DESCRIPTION
## Summary
- persist ClickHouse analytics from the API scan pipeline instead of only the CLI path
- use one shared analytics payload builder so CLI and API emit the same finding/metadata/posture contract
- add focused tests proving API scans now record findings, scan metadata, and posture snapshots

## Why
The real mismatch was that `agent-bom agents` wrote ClickHouse analytics, but `POST /v1/scan` built the report and returned success without emitting the same analytics rows. This PR closes that gap directly instead of masking it in docs.

## Validation
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_api_pipeline_image_contract.py tests/test_clickhouse.py`
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/analytics_contract.py src/agent_bom/api/pipeline.py src/agent_bom/cli/agents/_post.py`
- `python3 -m compileall src/agent_bom/analytics_contract.py src/agent_bom/api/pipeline.py src/agent_bom/cli/agents/_post.py`
