### PR TITLE
fix(docs): remove stray readme conflict marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Use Discord for support, implementation questions, and release discussion. Use G
 - Remote package, API, and MCP deployment surfaces should all report the same version and health state after release.
 - Automated freshness checks watch for deployment drift so stale Railway or registry surfaces do not go unnoticed.
 - The repo monitors both JavaScript surfaces (`ui/` and `sdks/typescript/`) with daily Dependabot, `npm audit`, and CI guards that fail if tracked or published source maps appear unexpectedly.
-<<<<<<< HEAD
 - `agent-bom api` and `agent-bom serve` make analytics backend selection explicit.
 - ClickHouse can run as a first-class buffered analytics backend.
 - `/health` reports the active analytics backend and tracing state for operators.


### PR DESCRIPTION
## Summary
- remove the stray unresolved conflict marker from the shipped README
- keep the existing analytics backend bullets intact
- prevent a release-surface credibility bug from surviving into the  audit

## Validation
- 
- 
