### PR TITLE
fix CI Railway health probes for deployment drift checks

### DIFF
--- a/.github/workflows/deploy-mcp-sse.yml
+++ b/.github/workflows/deploy-mcp-sse.yml
@@ -90,16 +90,17 @@ jobs:
           echo "Waiting 60s for Railway to rebuild and start..."
           sleep 60
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
-          CURL_ARGS=()
-          if [ -n "${RAILWAY_MCP_BEARER_TOKEN:-}" ]; then
-            CURL_ARGS=(-H "Authorization: Bearer $RAILWAY_MCP_BEARER_TOKEN")
-          fi
-          echo "Checking $DEPLOY_URL/health"
-          for attempt in 1 2 3 4 5; do
-            RESPONSE=$(curl -sf "${CURL_ARGS[@]}" "$DEPLOY_URL/health" 2>/dev/null || true)
-            if [ -n "$RESPONSE" ]; then
-              echo "Health response: $RESPONSE"
-              DEPLOYED_VERSION=$(echo "$RESPONSE" | python3 -c "
+          HEALTH_URL=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe --base-url "$DEPLOY_URL" --resolve-only)
+          echo "Checking $HEALTH_URL"
+          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
+            --base-url "$DEPLOY_URL" \
+            --bearer-token "${RAILWAY_MCP_BEARER_TOKEN:-}" \
+            --attempts 5 \
+            --backoff-seconds 30 \
+            --timeout 15 2>/dev/null || true)
+          if [ -n "$RESPONSE" ]; then
+            echo "Health response: $RESPONSE"
+            DEPLOYED_VERSION=$(echo "$RESPONSE" | python3 -c "
           import sys, json
           try:
               data = json.load(sys.stdin)
@@ -107,19 +108,17 @@ jobs:
           except Exception:
               print('unknown')
           " 2>/dev/null || echo "unknown")
-              echo "Deployed version: $DEPLOYED_VERSION"
-              echo "Expected version: $repo_version"
-              if [ "$DEPLOYED_VERSION" = "$repo_version" ]; then
-                echo "✅ Version match confirmed"
-                exit 0
-              elif [ "$DEPLOYED_VERSION" = "unknown" ]; then
-                echo "⚠️ Could not extract version from health endpoint — auth or startup may still be incomplete"
-              else
-                echo "::warning::Version mismatch — deployed=$DEPLOYED_VERSION expected=$repo_version"
-              fi
-              break
+            echo "Deployed version: $DEPLOYED_VERSION"
+            echo "Expected version: $repo_version"
+            if [ "$DEPLOYED_VERSION" = "$repo_version" ]; then
+              echo "✅ Version match confirmed"
+              exit 0
+            elif [ "$DEPLOYED_VERSION" = "unknown" ]; then
+              echo "⚠️ Could not extract version from health endpoint — auth or startup may still be incomplete"
+            else
+              echo "::warning::Version mismatch — deployed=$DEPLOYED_VERSION expected=$repo_version"
             fi
-            echo "Attempt $attempt: health endpoint not ready, waiting 30s..."
-            sleep 30
-          done
+          else
+            echo "::warning::Health endpoint not ready after retries"
+          fi
           echo "::warning::Could not verify deployed version — check Railway manually"

--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -38,12 +38,14 @@ jobs:
           RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
         run: |
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
-          CURL_ARGS=(--max-time 15)
-          if [ -n "${RAILWAY_MCP_BEARER_TOKEN:-}" ]; then
-            CURL_ARGS+=(-H "Authorization: Bearer $RAILWAY_MCP_BEARER_TOKEN")
-          fi
-          echo "Checking $DEPLOY_URL/health ..."
-          RESPONSE=$(curl -sf "${CURL_ARGS[@]}" "$DEPLOY_URL/health" 2>/dev/null || echo '{}')
+          HEALTH_URL=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe --base-url "$DEPLOY_URL" --resolve-only)
+          echo "Checking $HEALTH_URL ..."
+          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
+            --base-url "$DEPLOY_URL" \
+            --bearer-token "${RAILWAY_MCP_BEARER_TOKEN:-}" \
+            --attempts 3 \
+            --backoff-seconds 5 \
+            --timeout 15 2>/dev/null || echo '{}')
           DEPLOYED=$(echo "$RESPONSE" | python3 -c "
           import sys, json
           try:
@@ -54,7 +56,10 @@ jobs:
           ")
           echo "railway_version=$DEPLOYED" >> "$GITHUB_OUTPUT"
           echo "Railway version: $DEPLOYED (expected: ${{ steps.expected.outputs.version }})"
-          if [ "$DEPLOYED" != "${{ steps.expected.outputs.version }}" ]; then
+          if [ "$DEPLOYED" = "unknown" ] || [ "$DEPLOYED" = "unreachable" ]; then
+            echo "probe_failed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not verify Railway version from $HEALTH_URL"
+          elif [ "$DEPLOYED" != "${{ steps.expected.outputs.version }}" ]; then
             echo "stale=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -66,11 +71,12 @@ jobs:
           RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
         run: |
           DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
-          CURL_ARGS=(--max-time 15)
-          if [ -n "${RAILWAY_MCP_BEARER_TOKEN:-}" ]; then
-            CURL_ARGS+=(-H "Authorization: Bearer $RAILWAY_MCP_BEARER_TOKEN")
-          fi
-          RESPONSE=$(curl -sf "${CURL_ARGS[@]}" "$DEPLOY_URL/health" 2>/dev/null || echo '{}')
+          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
+            --base-url "$DEPLOY_URL" \
+            --bearer-token "${RAILWAY_MCP_BEARER_TOKEN:-}" \
+            --attempts 3 \
+            --backoff-seconds 5 \
+            --timeout 15 2>/dev/null || echo '{}')
           TOOL_COUNT=$(echo "$RESPONSE" | python3 -c "
           import sys, json
           try:
@@ -133,7 +139,7 @@ jobs:
           )"
 
       - name: Close supply-chain drift issue when deployment is fresh
-        if: steps.railway.outputs.stale != 'true'
+        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/src/agent_bom/deployment_probe.py
+++ b/src/agent_bom/deployment_probe.py
@@ -1,0 +1,133 @@
+"""Helpers for Railway/MCP deployment health probes used in CI workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+DEFAULT_BASE_URL = "https://agent-bom-mcp.up.railway.app"
+_USER_AGENT = "agent-bom-deployment-probe"
+
+
+def resolve_health_url(base_url: str | None) -> str:
+    """Return the canonical MCP health URL for a base Railway endpoint.
+
+    ``RAILWAY_MCP_URL`` is used in two different shapes across the repo:
+    the bare Railway host for health probes and the ``/mcp`` endpoint for
+    registry publishing. CI should accept either form and normalize both to
+    the real health route exposed by the MCP server.
+    """
+
+    raw = (base_url or DEFAULT_BASE_URL).strip()
+    if not raw:
+        raw = DEFAULT_BASE_URL
+
+    parts = urlsplit(raw)
+    if not parts.scheme or not parts.netloc:
+        raise ValueError(f"invalid base URL: {base_url!r}")
+    if parts.scheme not in {"http", "https"}:
+        raise ValueError(f"unsupported URL scheme for deployment probe: {parts.scheme!r}")
+
+    path = parts.path.rstrip("/")
+    if path.endswith("/mcp"):
+        path = path[: -len("/mcp")]
+
+    path = f"{path}/health" if path else "/health"
+    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+
+
+def fetch_health(
+    base_url: str | None,
+    *,
+    bearer_token: str | None = None,
+    attempts: int = 1,
+    backoff_seconds: float = 0.0,
+    timeout: float = 15.0,
+) -> tuple[str, dict[str, Any]]:
+    """Fetch and parse the MCP health payload with retry support."""
+
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    health_url = resolve_health_url(base_url)
+    headers = {"User-Agent": _USER_AGENT}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(health_url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310 - resolve_health_url enforces http/https only
+                payload = json.loads(response.read())
+            if not isinstance(payload, dict):
+                raise ValueError("health response must be a JSON object")
+            return health_url, payload
+        except (ValueError, json.JSONDecodeError, OSError, urllib.error.URLError) as exc:
+            last_error = exc
+            if attempt == attempts:
+                break
+            sleep_seconds = max(backoff_seconds, 0.0) * attempt
+            if sleep_seconds:
+                print(
+                    f"Attempt {attempt}/{attempts} failed for {health_url}: {exc}. Retrying in {sleep_seconds:.0f}s...",
+                    file=sys.stderr,
+                )
+                time.sleep(sleep_seconds)
+
+    raise RuntimeError(f"unable to fetch MCP health from {health_url}: {last_error}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Probe the MCP health endpoint used by CI workflows.")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="Railway base URL or MCP endpoint URL.")
+    parser.add_argument("--bearer-token", default=None, help="Optional bearer token for authenticated probes.")
+    parser.add_argument("--attempts", type=int, default=1, help="Number of probe attempts before failing.")
+    parser.add_argument(
+        "--backoff-seconds",
+        type=float,
+        default=0.0,
+        help="Linear backoff between attempts. Attempt N sleeps N * backoff seconds.",
+    )
+    parser.add_argument("--timeout", type=float, default=15.0, help="Per-request timeout in seconds.")
+    parser.add_argument(
+        "--resolve-only",
+        action="store_true",
+        help="Print the normalized health URL without making a network request.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.resolve_only:
+            print(resolve_health_url(args.base_url))
+            return 0
+
+        _, payload = fetch_health(
+            args.base_url,
+            bearer_token=args.bearer_token,
+            attempts=args.attempts,
+            backoff_seconds=args.backoff_seconds,
+            timeout=args.timeout,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    json.dump(payload, sys.stdout, separators=(",", ":"))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -220,15 +220,19 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     """Deployment freshness should probe authenticated MCP health endpoints safely."""
     workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
     assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
-    assert "Authorization: Bearer" in workflow
+    assert "python3 -m agent_bom.deployment_probe" in workflow
     assert "tool_count" in workflow
+    assert "probe_failed=true" in workflow
+    assert "steps.railway.outputs.probe_failed != 'true'" in workflow
+    assert "--resolve-only" in workflow
 
 
 def test_deploy_mcp_sse_workflow_uses_bearer_token_for_health_check():
     """Post-deploy health verification should use the same auth contract as Railway."""
     workflow = (ROOT / ".github" / "workflows" / "deploy-mcp-sse.yml").read_text()
     assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
-    assert "Authorization: Bearer" in workflow
+    assert "python3 -m agent_bom.deployment_probe" in workflow
+    assert "--attempts 5" in workflow
 
 
 def test_dockerfiles_support_proxy_and_ca_contract():

--- a/tests/test_deployment_probe.py
+++ b/tests/test_deployment_probe.py
@@ -1,0 +1,60 @@
+"""Tests for CI deployment health probe helpers."""
+
+from __future__ import annotations
+
+import urllib.error
+
+from agent_bom.deployment_probe import fetch_health, resolve_health_url
+
+
+class _Response:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+def test_resolve_health_url_accepts_root_base_url():
+    assert resolve_health_url("https://agent-bom-mcp.up.railway.app") == "https://agent-bom-mcp.up.railway.app/health"
+    assert resolve_health_url("https://agent-bom-mcp.up.railway.app/") == "https://agent-bom-mcp.up.railway.app/health"
+
+
+def test_resolve_health_url_strips_mcp_suffix():
+    assert resolve_health_url("https://agent-bom-mcp.up.railway.app/mcp") == "https://agent-bom-mcp.up.railway.app/health"
+    assert resolve_health_url("https://agent-bom-mcp.up.railway.app/nested/mcp") == "https://agent-bom-mcp.up.railway.app/nested/health"
+
+
+def test_fetch_health_retries_normalized_url(monkeypatch):
+    calls: list[str] = []
+
+    def fake_urlopen(request, timeout):
+        calls.append(request.full_url)
+        if len(calls) == 1:
+            raise urllib.error.URLError("temporary failure")
+        assert timeout == 12
+        return _Response(b'{"version":"0.75.15","tool_count":0}')
+
+    monkeypatch.setattr("agent_bom.deployment_probe.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("agent_bom.deployment_probe.time.sleep", lambda *_args: None)
+
+    url, payload = fetch_health(
+        "https://agent-bom-mcp.up.railway.app/mcp",
+        bearer_token="secret",
+        attempts=2,
+        backoff_seconds=5,
+        timeout=12,
+    )
+
+    assert url == "https://agent-bom-mcp.up.railway.app/health"
+    assert payload["version"] == "0.75.15"
+    assert calls == [
+        "https://agent-bom-mcp.up.railway.app/health",
+        "https://agent-bom-mcp.up.railway.app/health",
+    ]


### PR DESCRIPTION
## Summary
- normalize Railway MCP URLs so CI health checks work whether `RAILWAY_MCP_URL` is configured as the bare host or the `/mcp` endpoint
- reuse one deployment probe helper across the deployment-freshness and deploy-mcp-sse workflows
- avoid opening or auto-closing supply-chain drift issues when the probe itself is temporarily unavailable
- add regression tests for workflow wiring and health URL normalization/retry behavior

## Root Cause
The deployment drift workflow and the post-deploy verification step assumed `RAILWAY_MCP_URL` always pointed at the health base URL. Elsewhere in the repo, Railway MCP URLs are also represented as the `/mcp` endpoint for registry publishing. That mismatch could make CI probe the wrong path and fall back to `unknown`, creating false-positive drift alerts like `#1281` even when Railway was serving the expected version.

## Validation
- `pytest -q tests/test_deployment.py tests/test_deployment_probe.py`
- `ruff check src/agent_bom/deployment_probe.py tests/test_deployment.py tests/test_deployment_probe.py`
- `PYTHONPATH=src python3 -m agent_bom.deployment_probe --base-url https://agent-bom-mcp.up.railway.app/mcp --attempts 2 --backoff-seconds 1 --timeout 15`

## Impact
CI now resolves the canonical `/health` endpoint consistently, retries transient failures, and only flags actual deployment drift instead of URL-shape mismatches.