### PR TITLE
align CLI output contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ pip install agent-bom                  # Standard CLI install
 
 agent-bom agents                              # Discover + scan local AI agents and MCP servers
 agent-bom agents -p .                         # Scan project lockfiles/manifests plus agent/MCP context
+agent-bom where                               # Show MCP discovery paths checked on this machine
 agent-bom mesh --project .                    # Show the live agent / MCP topology
 agent-bom skills scan .                       # Scan CLAUDE.md, AGENTS.md, .cursorrules, skills/*
 agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
@@ -93,9 +94,12 @@ agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC scan across one or more path
 ```bash
 agent-bom cloud aws                     # Cloud AI posture + CIS benchmarks
 agent-bom agents -f cyclonedx -o bom.json  # AI BOM / SBOM export
+agent-bom check requests@2.33.0 -e pypi -f json  # Machine-readable pre-install verdict
+agent-bom report diff before.json after.json -f json  # CI-friendly diff output
 agent-bom graph report.json                # Blast radius graph / graph HTML inputs
 agent-bom proxy "npx @mcp/server-fs /ws"   # MCP security proxy
 agent-bom secrets src/                  # Hardcoded secrets + PII
+agent-bom verify agent-bom              # Verify this installation
 agent-bom verify requests@2.33.0        # Package integrity verification
 agent-bom verify --model-dir ./models   # Model weight hash verification
 agent-bom serve                         # API + Next.js dashboard
@@ -273,11 +277,11 @@ No source code, config contents, or credential values are sent. No telemetry or 
 
 ```bash
 git clone https://github.com/msaad00/agent-bom.git && cd agent-bom
-pip install -e ".[dev]"
+pip install -e ".[dev-all]"
 pytest && ruff check src/
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) | [SECURITY.md](SECURITY.md) | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+See [CONTRIBUTING.md](CONTRIBUTING.md) | [docs/CLI_DEBUG_GUIDE.md](docs/CLI_DEBUG_GUIDE.md) | [SECURITY.md](SECURITY.md) | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 ---
 

--- a/docs/CLI_DEBUG_GUIDE.md
+++ b/docs/CLI_DEBUG_GUIDE.md
@@ -1,0 +1,67 @@
+# CLI Debug Guide
+
+## First triage
+
+```bash
+agent-bom doctor
+agent-bom where
+agent-bom agents --dry-run
+agent-bom agents -p . --no-scan
+```
+
+- `doctor` checks local prerequisites.
+- `where` shows the MCP config paths scanned on the current machine.
+- `agents --dry-run` shows what would be accessed without performing the scan.
+- `agents -p . --no-scan` verifies discovery and package extraction before any CVE lookups.
+
+## Logging and quiet mode
+
+```bash
+agent-bom agents --verbose
+agent-bom agents --log-level debug --log-file /tmp/agent-bom.log
+agent-bom agents --quiet --no-scan
+```
+
+- `--quiet` suppresses scan chatter and retry noise. Use it for scripting.
+- `--verbose` expands the console view.
+- `--log-level debug` and `--log-file` are the fastest way to capture a reproducible failure.
+
+## Output contracts
+
+- `check` supports `--format json` for machine-readable pre-install verdicts.
+- `report history` and `report diff` support `--format json` for CI consumption.
+- Use `agents` for JSON, SARIF, HTML, PDF, CycloneDX, SPDX, and other report formats.
+- Use `agent-bom check requests@2.33.0 -e pypi -f json` for a single-package JSON verdict.
+- Use `agent-bom report diff before.json after.json -f json -o diff.json` for machine-readable diff output.
+- Use `agent-bom agents -f sarif -o results.sarif` for file output.
+- Use `agent-bom agents -f sarif -o -` when you need SARIF JSON on stdout.
+
+## Verification flows
+
+```bash
+agent-bom verify
+agent-bom verify agent-bom
+agent-bom verify requests@2.33.0 -e pypi
+agent-bom verify @modelcontextprotocol/server-filesystem@2025.1.14 -e npm
+```
+
+- `verify` with no arguments self-verifies the installed `agent-bom`.
+- `verify agent-bom` is the same shortcut.
+- Other packages require an explicit `name@version`.
+
+## Discovery and command routing
+
+- `agent-bom where` is the top-level shortcut for discovery paths.
+- `agent-bom mcp where` remains available when you want the grouped MCP command.
+- `agent-bom check` is for one package.
+- `agent-bom agents` is for environment, project, SBOM, and export workflows.
+
+## Contributor setup
+
+```bash
+pip install -e ".[dev-all]"
+pytest tests/ -x -q
+```
+
+- `.[dev-all]` is the supported full-suite contributor environment.
+- The `graph` extra includes the numeric dependencies required for PageRank and centrality tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
   - Reference:
       - MCP Tools: reference/mcp-tools.md
       - CLI Commands: reference/cli.md
+      - CLI Debug Guide: reference/cli-debug.md
       - Configuration: reference/configuration.md
   - API Reference:
       - Models: api/models.md

--- a/site-docs/getting-started/quickstart.md
+++ b/site-docs/getting-started/quickstart.md
@@ -38,9 +38,9 @@ instruction surfaces.
 ## Check a specific package before installing
 
 ```bash
-agent-bom check langchain --ecosystem pypi
-agent-bom check express --ecosystem npm
-agent-bom check tensorflow --ecosystem pypi
+agent-bom check langchain@0.2.17 --ecosystem pypi
+agent-bom check express@4.18.2 --ecosystem npm
+agent-bom check tensorflow@2.17.0 --ecosystem pypi
 ```
 
 ## Export machine-readable output
@@ -79,9 +79,11 @@ agent-bom iac Dockerfile k8s/ infra/main.tf
 ## Inspect discovery paths
 
 ```bash
-agent-bom mcp where
+agent-bom where
 agent-bom mcp inventory
 ```
+
+`agent-bom mcp where` still works when you want the grouped MCP subcommand form.
 
 ## Output formats
 
@@ -91,4 +93,6 @@ agent-bom agents -f json     # JSON report
 agent-bom agents -f html     # HTML dashboard
 agent-bom agents -f sarif    # SARIF for GitHub Code Scanning
 agent-bom agents -f csv      # CSV export
+agent-bom check requests@2.33.0 -e pypi -f json   # single-package JSON verdict
+agent-bom report history -f json                  # saved scan metadata for CI
 ```

--- a/site-docs/reference/cli-debug.md
+++ b/site-docs/reference/cli-debug.md
@@ -1,0 +1,43 @@
+# CLI Debug Guide
+
+## Fast triage
+
+```bash
+agent-bom doctor
+agent-bom where
+agent-bom agents --dry-run
+agent-bom agents -p . --no-scan
+```
+
+Use these commands to separate discovery problems from vulnerability-scanning problems before turning on enrichment or exports.
+
+## Quiet, logs, and output
+
+```bash
+agent-bom agents --quiet --no-scan
+agent-bom agents --log-level debug --log-file /tmp/agent-bom.log
+agent-bom agents -f sarif -o results.sarif
+agent-bom agents -f sarif -o -
+```
+
+- `--quiet` suppresses scan chatter and retry noise for scripting.
+- `--log-level debug` with `--log-file` is the quickest way to capture a reproducible issue.
+- `-o -` is the stdout form for machine-readable exports.
+
+## Command contracts
+
+- `check` supports `--format json` for machine-readable single-package verdicts.
+- `report history` and `report diff` support `--format json` for automation.
+- `verify` with no arguments, or `verify agent-bom`, self-verifies the installed package.
+- `where` is available both as `agent-bom where` and `agent-bom mcp where`.
+- Use `agents` for environment scans, exports, and report generation.
+
+## Package verification
+
+```bash
+agent-bom verify
+agent-bom verify requests@2.33.0 -e pypi
+agent-bom verify @modelcontextprotocol/server-filesystem@2025.1.14 -e npm
+```
+
+Explicit `name@version` is required for packages other than the installed `agent-bom`.

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -4,8 +4,10 @@
 
 | Command | Description |
 |---------|-------------|
-| `scan` | Discover MCP clients + scan for vulnerabilities |
+| `agents` | Discover MCP clients + scan for vulnerabilities |
 | `check` | Check a specific package for CVEs |
+| `verify` | Verify package integrity / provenance or self-verify `agent-bom` |
+| `where` | Show MCP discovery paths checked on this machine |
 | `image` | Container image scan |
 | `fs` | Filesystem / VM scan |
 | `iac` | Infrastructure-as-code misconfigurations |
@@ -21,40 +23,56 @@
 | `guard` | Pre-install CVE check |
 | `registry` | Registry management (list, search, update) |
 
+## Command contracts
+
+- `check` supports terminal output by default plus `--format json` for machine-readable pre-install verdicts.
+- `report history` and `report diff` support `--format json` for CI and automation.
+- Use `agent-bom agents -f <format> -o <path>` for SARIF, HTML, SBOM, and richer environment exports.
+- Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.
+- `where` is available both as `agent-bom where` and `agent-bom mcp where`.
+- `agent-bom verify` and `agent-bom verify agent-bom` both self-verify the installed package.
+
 ## Common flags
 
 ```bash
 # Output format
-agent-bom scan -f json|table|html|sarif|csv
+agent-bom agents -f json|html|sarif|csv|cyclonedx|spdx
 
 # Output file
-agent-bom scan -o report.json
+agent-bom agents -o report.json
+agent-bom check requests@2.33.0 -e pypi -f json -o check.json
+agent-bom report diff before.json after.json -f json -o diff.json
 
 # Compliance
-agent-bom scan --compliance owasp-llm,eu-ai-act,all
+agent-bom agents --compliance owasp-llm,eu-ai-act,all
 
 # SBOM
-agent-bom scan --sbom cyclonedx|spdx
+agent-bom agents -f cyclonedx -o bom.json
+agent-bom agents -f spdx -o bom.spdx.json
 
 # Image scanning
-agent-bom scan --image python:3.12-slim
+agent-bom agents --image python:3.12-slim
 
 # Policy
-agent-bom scan --policy policy.json
+agent-bom agents --policy policy.json
 
 # Enrichment
-agent-bom scan --enrich    # NVD CVSS v4 + EPSS
+agent-bom agents --enrich    # NVD CVSS v4 + EPSS
 
 # Prometheus
-agent-bom scan --push-gateway http://pushgateway:9091
+agent-bom agents --push-gateway http://pushgateway:9091
 
 # VEX
-agent-bom scan --vex vex.json
-agent-bom scan --generate-vex --vex-output vex.json
+agent-bom agents --vex vex.json
+agent-bom agents --generate-vex --vex-output vex.json
 
 # Config directory
-agent-bom scan --config-dir /path/to/configs
+agent-bom agents --config-dir /path/to/configs
 ```
+
+## Troubleshooting
+
+See [CLI Debug Guide](cli-debug.md) for quiet/logging behavior, stdout vs file output, discovery triage, and package verification workflows.
 
 ## Environment variables
 

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -53,6 +53,7 @@ def main():
     Quick start:
       agent-bom agents                               discover + scan local agents and MCP servers
       agent-bom agents -p .                          scan project manifests plus agent/MCP context
+      agent-bom where                                show MCP discovery paths checked on this machine
       agent-bom mesh --project .                     show the live agent/MCP topology
       agent-bom skills scan .                        scan skills and instruction files
       agent-bom skills rescan                        revisit previously cataloged skills
@@ -90,12 +91,13 @@ main.commands["scan"] = _scan_hidden
 
 from agent_bom.cli._inventory import completions_cmd, inventory, validate, where  # noqa: E402
 
-# inventory + where are under `mcp` group — no top-level duplicate
+# inventory remains under `mcp`; `where` is also exposed top-level for discovery.
 _validate_hidden = _copy.copy(validate)
 _validate_hidden.hidden = True  # Use `mcp validate` or `iac validate`
 _validate_hidden.name = "validate"
 main.commands["validate"] = _validate_hidden
 main.add_command(completions_cmd, "completions")
+main.add_command(where)
 
 from agent_bom.cli._check import check, guard_cmd, verify  # noqa: E402
 

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Optional
 
@@ -11,6 +12,7 @@ import click
 from rich.console import Console
 
 from agent_bom import __version__
+from agent_bom.cli._common import _sync_runtime_consoles
 from agent_bom.ecosystems import SUPPORTED_PACKAGE_ECOSYSTEMS
 
 
@@ -85,6 +87,57 @@ def _parse_package_spec(
             ecosystem = _detect_ecosystem(name, version) or "pypi"
 
     return name, version, ecosystem
+
+
+def _write_json_output(payload: dict, output_path: str | None) -> None:
+    """Write JSON to stdout or a file."""
+    text = json.dumps(payload, indent=2)
+    if output_path and output_path != "-":
+        Path(output_path).write_text(text, encoding="utf-8")
+        return
+    click.echo(text)
+
+
+def _check_result_payload(
+    *,
+    name: str,
+    version: str,
+    ecosystems: list[str],
+    verdict: str,
+    message: str,
+    exit_code: int,
+    vulnerabilities: list | None = None,
+    warnings: list[str] | None = None,
+    exit_zero: bool = False,
+) -> dict:
+    """Build machine-readable check output."""
+    serialized_vulns = []
+    for vuln in vulnerabilities or []:
+        serialized_vulns.append(
+            {
+                "id": vuln.id,
+                "summary": vuln.summary,
+                "severity": vuln.severity.value,
+                "fixed_version": vuln.fixed_version,
+                "is_kev": vuln.is_kev,
+                "cwe_ids": list(vuln.cwe_ids),
+                "aliases": list(vuln.aliases),
+                "references": list(vuln.references),
+            }
+        )
+
+    return {
+        "package": name,
+        "version": version,
+        "ecosystems": ecosystems,
+        "verdict": verdict,
+        "message": message,
+        "exit_code": exit_code,
+        "exit_zero": exit_zero,
+        "vulnerability_count": len(serialized_vulns),
+        "scan_warnings": warnings or [],
+        "vulnerabilities": serialized_vulns,
+    }
 
 
 def _resolve_check_ecosystems(name: str, version: str, ecosystem: Optional[str], detected_eco: str) -> list[str]:
@@ -204,14 +257,32 @@ def _exit_model_verification(
     type=click.Choice(SUPPORTED_PACKAGE_ECOSYSTEMS),
     help="Package ecosystem (inferred from name/command if omitted)",
 )
-@click.option("--quiet", "-q", is_flag=True, help="Only print vuln count, no details")
+@click.option("--quiet", "-q", is_flag=True, help="Only print the final verdict, no details")
 @click.option("--no-color", is_flag=True, help="Disable colored output")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["console", "json"], case_sensitive=False),
+    default="console",
+    show_default=True,
+    help="Output format.",
+)
+@click.option("--output", "-o", "output_path", type=str, default=None, help="Write JSON output to a file (use '-' for stdout).")
 @click.option(
     "--exit-zero",
     is_flag=True,
     help="Exit 0 even when vulnerabilities are found (useful for exploratory or parallel checks)",
 )
-def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bool, exit_zero: bool):
+def check(
+    package_spec: str,
+    ecosystem: Optional[str],
+    quiet: bool,
+    no_color: bool,
+    output_format: str,
+    output_path: str | None,
+    exit_zero: bool,
+):
     """Check a package for known vulnerabilities before installing.
 
     \b
@@ -229,10 +300,20 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
 
     \b
     Notes:
+      `check` supports terminal output by default and `--format json`
+      for machine-readable pre-install verdicts.
+      For SARIF, HTML, PDF, or SBOM output, use `agent-bom agents`
+      (or `agent-bom scan`) with `--format/--output`.
       Use --exit-zero for exploratory or parallel workflows where findings
       should be reported without failing the command.
     """
-    console = Console(no_color=no_color)
+    if output_path and output_format != "json":
+        raise click.ClickException("`check --output` requires `--format json`.")
+
+    structured_output = output_format == "json"
+    console = Console(no_color=no_color, stderr=structured_output or output_path is not None)
+    runtime_console = Console(stderr=True, quiet=quiet or structured_output or output_path is not None, no_color=no_color)
+    _sync_runtime_consoles(runtime_console)
 
     name, version, detected_eco = _parse_package_spec(package_spec, ecosystem)
 
@@ -240,8 +321,22 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
     from agent_bom.parsers.os_parsers import enrich_os_package_context
 
     if version == "unknown":
-        console.print(f"[yellow]⚠ No version specified for {name} — skipping OSV lookup.[/yellow]")
-        console.print("  Provide a version: agent-bom check name@version --ecosystem ecosystem")
+        message = f"No version specified for {name}; skipping OSV lookup."
+        if structured_output:
+            _write_json_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=[detected_eco],
+                    verdict="skipped",
+                    message=message,
+                    exit_code=0,
+                ),
+                output_path,
+            )
+        else:
+            console.print(f"[yellow]⚠ No version specified for {name} — skipping OSV lookup.[/yellow]")
+            console.print("  Provide a version: agent-bom check name@version --ecosystem ecosystem")
         sys.exit(0)
 
     ecosystems = _resolve_check_ecosystems(name, version, ecosystem, detected_eco)
@@ -263,52 +358,124 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
                         return True
                 return False
 
-        with console.status("[bold]Resolving version from registry...[/bold]", spinner="dots"):
-            import asyncio
+        import asyncio
 
+        if quiet:
             resolved = asyncio.run(_resolve())
+        else:
+            with console.status("[bold]Resolving version from registry...[/bold]", spinner="dots"):
+                resolved = asyncio.run(_resolve())
         if resolved:
             version = next((p.version for p in pkgs if p.version not in ("unknown", "latest", "")), version)
             for p in pkgs:
                 p.version = version
-            console.print(f"  [green]✓ Resolved @latest → {version}[/green]")
+            if not quiet:
+                console.print(f"  [green]✓ Resolved @latest → {version}[/green]")
         else:
             eco_str = "/".join(ecosystems)
-            console.print(f"[yellow]⚠ Could not resolve latest version for {name} ({eco_str})[/yellow]")
-            console.print("  Provide an explicit version: agent-bom check name@1.2.3 -e ecosystem")
+            message = f"Could not resolve latest version for {name} ({eco_str})."
+            if structured_output:
+                _write_json_output(
+                    _check_result_payload(
+                        name=name,
+                        version=version,
+                        ecosystems=ecosystems,
+                        verdict="skipped",
+                        message=message,
+                        exit_code=0,
+                    ),
+                    output_path,
+                )
+            else:
+                console.print(f"[yellow]⚠ Could not resolve latest version for {name} ({eco_str})[/yellow]")
+                console.print("  Provide an explicit version: agent-bom check name@1.2.3 -e ecosystem")
             sys.exit(0)
 
     eco_display = "/".join(ecosystems)
-    console.print(f"\n[bold blue]🔍 Checking {name}@{version} ({eco_display})[/bold blue]\n")
+    if not quiet:
+        console.print(f"\n[bold blue]🔍 Checking {name}@{version} ({eco_display})[/bold blue]\n")
 
-    with console.status("[bold]Scanning package risk...[/bold]", spinner="dots"):
-        import asyncio
+    import asyncio
 
+    status_context = console.status("[bold]Scanning package risk...[/bold]", spinner="dots") if not quiet else nullcontext()
+
+    with status_context:
         from agent_bom.scanners import IncompleteScanError, consume_scan_warnings, scan_packages
 
         try:
             asyncio.run(scan_packages(pkgs))
         except IncompleteScanError as exc:
-            console.print(f"  [yellow]⚠[/yellow] {exc}")
+            if structured_output:
+                _write_json_output(
+                    _check_result_payload(
+                        name=name,
+                        version=version,
+                        ecosystems=ecosystems,
+                        verdict="incomplete",
+                        message=str(exc),
+                        exit_code=2,
+                    ),
+                    output_path,
+                )
+            else:
+                console.print(f"  [yellow]⚠[/yellow] {exc}")
             sys.exit(2)
 
     scan_warnings = consume_scan_warnings()
-    if scan_warnings:
+    if scan_warnings and not quiet:
         console.print(f"  [yellow]⚠[/yellow] Scan completed with {len(scan_warnings)} warning(s); results may be incomplete.")
 
     matched_pkg = next((p for p in pkgs if p.vulnerabilities), pkgs[0])
     vulns = matched_pkg.vulnerabilities
 
     if not vulns and matched_pkg.ecosystem in {"deb", "apk", "rpm"} and not os_context_complete:
-        console.print(f"  [yellow]⚠ Incomplete OS package context for {name}@{version}[/yellow]")
-        console.print(
-            "  Best-effort matching found no vulnerabilities, but source/distro metadata was "
-            "insufficient for a trustworthy clean verdict.\n"
+        message = (
+            f"Incomplete OS package context for {name}@{version}. "
+            "Best-effort matching found no vulnerabilities, but distro metadata was insufficient for a trustworthy clean verdict."
         )
+        if structured_output:
+            _write_json_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="incomplete",
+                    message=message,
+                    exit_code=2,
+                    warnings=scan_warnings,
+                ),
+                output_path,
+            )
+            sys.exit(2)
+        if quiet:
+            click.echo(f"{name}@{version}: incomplete OS package context")
+        else:
+            console.print(f"  [yellow]⚠ Incomplete OS package context for {name}@{version}[/yellow]")
+            console.print(
+                "  Best-effort matching found no vulnerabilities, but source/distro metadata was "
+                "insufficient for a trustworthy clean verdict.\n"
+            )
         sys.exit(2)
 
     if not vulns:
-        console.print(f"  [green]✓ No known vulnerabilities in {name}@{version}[/green]\n")
+        if structured_output:
+            _write_json_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="clean",
+                    message=f"No known vulnerabilities in {name}@{version}.",
+                    exit_code=0,
+                    warnings=scan_warnings,
+                ),
+                output_path,
+            )
+            sys.exit(0)
+        if quiet:
+            click.echo(f"{name}@{version}: CLEAN")
+        else:
+            console.print(f"  [green]✓ No known vulnerabilities in {name}@{version}[/green]\n")
         sys.exit(0)
 
     if not quiet:
@@ -367,10 +534,48 @@ def check(package_spec: str, ecosystem: Optional[str], quiet: bool, no_color: bo
         console.print()
 
     if exit_zero:
-        console.print(f"  [yellow]⚠ {len(vulns)} vulnerability/ies found — reported without failing due to --exit-zero.[/yellow]\n")
+        if structured_output:
+            _write_json_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="unsafe",
+                    message=f"{len(vulns)} vulnerability/ies found in {name}@{version}; reported without failing due to --exit-zero.",
+                    exit_code=0,
+                    vulnerabilities=vulns,
+                    warnings=scan_warnings,
+                    exit_zero=True,
+                ),
+                output_path,
+            )
+            sys.exit(0)
+        if quiet:
+            click.echo(f"{name}@{version}: {len(vulns)} vulnerability/ies found (exit-zero)")
+        else:
+            console.print(f"  [yellow]⚠ {len(vulns)} vulnerability/ies found — reported without failing due to --exit-zero.[/yellow]\n")
         sys.exit(0)
 
-    console.print(f"  [red]✗ {len(vulns)} vulnerability/ies found — do not install without review.[/red]\n")
+    if structured_output:
+        _write_json_output(
+            _check_result_payload(
+                name=name,
+                version=version,
+                ecosystems=ecosystems,
+                verdict="unsafe",
+                message=f"{len(vulns)} vulnerability/ies found in {name}@{version}.",
+                exit_code=1,
+                vulnerabilities=vulns,
+                warnings=scan_warnings,
+            ),
+            output_path,
+        )
+        sys.exit(1)
+
+    if quiet:
+        click.echo(f"{name}@{version}: {len(vulns)} vulnerability/ies found")
+    else:
+        console.print(f"  [red]✗ {len(vulns)} vulnerability/ies found — do not install without review.[/red]\n")
     sys.exit(1)
 
 
@@ -410,8 +615,9 @@ def verify(
     """Verify package integrity and provenance against registries.
 
     \b
-    Self-verify (no arguments):
+    Self-verify (no arguments or explicit package name):
       agent-bom verify              check THIS installation of agent-bom
+      agent-bom verify agent-bom    same as above
 
     \b
     Verify any package:
@@ -446,22 +652,33 @@ def verify(
     console = Console()
 
     # Determine target
-    if package_spec is None:
+    self_verify = package_spec is None or (
+        package_spec is not None and package_spec.strip() in {"agent-bom", "agent_bom"} and ecosystem in (None, "pypi")
+    )
+
+    if self_verify:
         name, version, eco = "agent-bom", __version__, "pypi"
         if not quiet:
             console.print(f"\n[bold blue]Verifying agent-bom {version} installation...[/bold blue]\n")
         record_result = verify_installed_record("agent-bom")
     else:
+        assert package_spec is not None
         name, version, eco = _parse_package_spec(package_spec, ecosystem)
         record_result = None
         if not quiet:
             console.print(f"\n[bold blue]Verifying {name}@{version} ({eco})...[/bold blue]\n")
 
     if version in ("unknown", ""):
-        console.print(
-            "[red]Error: version required. Use name@version format, "
-            "for example requests@2.33.0 or @modelcontextprotocol/server-filesystem@2025.1.14.[/red]"
-        )
+        if name in {"agent-bom", "agent_bom"}:
+            console.print(
+                f"[red]Error: use `agent-bom verify` to self-verify this installation, or pass a version like "
+                f"`agent-bom verify agent-bom@{__version__} -e pypi`.[/red]"
+            )
+        else:
+            console.print(
+                "[red]Error: version required. Use name@version format, "
+                "for example requests@2.33.0 or @modelcontextprotocol/server-filesystem@2025.1.14.[/red]"
+            )
         sys.exit(2)
 
     checks: dict[str, dict] = {}

--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import threading
 from pathlib import Path
@@ -38,6 +39,24 @@ def _make_console(quiet: bool = False, output_format: str = "console", no_color:
     if output_format != "console":
         return Console(stderr=True, no_color=no_color)
     return Console(no_color=no_color)
+
+
+def _sync_runtime_consoles(console: Console) -> None:
+    """Point shared module-level consoles at the active CLI console."""
+    for module_name in (
+        "agent_bom.scanners",
+        "agent_bom.enrichment",
+        "agent_bom.resolver",
+        "agent_bom.transitive",
+        "agent_bom.parsers",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not sync console for %s: %s", module_name, exc)
+            continue
+        if hasattr(module, "console"):
+            setattr(module, "console", console)
 
 
 def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list:

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -20,7 +20,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "MCP",
-            ["mcp"],
+            ["mcp", "where"],
         ),
         (
             "Reporting",

--- a/src/agent_bom/cli/_history.py
+++ b/src/agent_bom/cli/_history.py
@@ -136,17 +136,88 @@ def _report_from_json(data: dict) -> "_NarrativeReport":
     )
 
 
+def _write_cli_output(payload: dict, output_path: str | None) -> None:
+    """Write JSON payload to stdout or a file."""
+    text = _json.dumps(payload, indent=2)
+    if output_path and output_path != "-":
+        Path(output_path).write_text(text, encoding="utf-8")
+        return
+    click.echo(text)
+
+
 @click.command("history")
 @click.option("--limit", "-n", type=int, default=10, help="Number of recent scans to show")
-def history_cmd(limit: int):
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["console", "json"], case_sensitive=False),
+    default="console",
+    show_default=True,
+    help="Output format.",
+)
+@click.option("--output", "-o", type=str, default=None, help="Write JSON output to a file (use '-' for stdout).")
+def history_cmd(limit: int, output_format: str, output: str | None):
     """List saved scan reports from ~/.agent-bom/history/."""
     from agent_bom.history import list_reports, load_report
+
+    if output and output_format != "json":
+        raise click.ClickException("`report history --output` requires `--format json`.")
 
     console = Console()
 
     reports = list_reports()
     if not reports:
+        if output_format == "json":
+            _write_cli_output(
+                {
+                    "history_dir": str(Path.home() / ".agent-bom" / "history"),
+                    "total_reports": 0,
+                    "reports": [],
+                },
+                output,
+            )
+            return
         console.print("\n  [dim]No saved scans yet. Run with --save to start tracking history.[/dim]\n")
+        return
+
+    rows: list[dict[str, object]] = []
+    for path in reports[:limit]:
+        row: dict[str, object] = {
+            "path": str(path),
+            "file": path.name,
+            "generated_at": None,
+            "total_agents": None,
+            "total_packages": None,
+            "total_vulnerabilities": None,
+            "critical_findings": None,
+        }
+        try:
+            data = load_report(path)
+            summary = data.get("summary", {})
+            row.update(
+                {
+                    "generated_at": data.get("generated_at", "unknown"),
+                    "total_agents": summary.get("total_agents"),
+                    "total_packages": summary.get("total_packages"),
+                    "total_vulnerabilities": summary.get("total_vulnerabilities"),
+                    "critical_findings": summary.get("critical_findings"),
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            row["error"] = str(exc)
+        rows.append(row)
+
+    if output_format == "json":
+        _write_cli_output(
+            {
+                "history_dir": str(reports[0].parent),
+                "total_reports": len(reports),
+                "returned_reports": len(rows),
+                "reports": rows,
+            },
+            output,
+        )
         return
 
     console.print(f"\n[bold blue]📂 Scan History[/bold blue]  ({len(reports)} total, showing {min(limit, len(reports))})\n")
@@ -161,20 +232,20 @@ def history_cmd(limit: int):
     table.add_column("Vulns", width=6, justify="center")
     table.add_column("Critical", width=9, justify="center")
 
-    for path in reports[:limit]:
-        try:
-            data = load_report(path)
-            summary = data.get("summary", {})
-            table.add_row(
-                path.name,
-                data.get("generated_at", "unknown")[:19].replace("T", " "),
-                str(summary.get("total_agents", "?")),
-                str(summary.get("total_packages", "?")),
-                str(summary.get("total_vulnerabilities", "?")),
-                str(summary.get("critical_findings", "?")),
-            )
-        except Exception:
-            table.add_row(path.name, "—", "—", "—", "—", "—")
+    for row in rows:
+        generated_at = row.get("generated_at")
+        if isinstance(generated_at, str) and generated_at not in {"", "unknown"}:
+            generated = generated_at[:19].replace("T", " ")
+        else:
+            generated = "—"
+        table.add_row(
+            str(row["file"]),
+            generated,
+            str(row.get("total_agents", "?") if row.get("total_agents") is not None else "—"),
+            str(row.get("total_packages", "?") if row.get("total_packages") is not None else "—"),
+            str(row.get("total_vulnerabilities", "?") if row.get("total_vulnerabilities") is not None else "—"),
+            str(row.get("critical_findings", "?") if row.get("critical_findings") is not None else "—"),
+        )
 
     console.print(table)
     console.print(f"\n  [dim]History directory: {reports[0].parent}[/dim]\n")
@@ -183,7 +254,17 @@ def history_cmd(limit: int):
 @click.command("diff")
 @click.argument("baseline", type=click.Path(exists=True))
 @click.argument("current", type=click.Path(exists=True), required=False)
-def diff_cmd(baseline: str, current: Optional[str]):
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["console", "json"], case_sensitive=False),
+    default="console",
+    show_default=True,
+    help="Output format.",
+)
+@click.option("--output", "-o", type=str, default=None, help="Write JSON output to a file (use '-' for stdout).")
+def diff_cmd(baseline: str, current: Optional[str], output_format: str, output: str | None):
     """Diff two scan reports to see what changed.
 
     \b
@@ -200,21 +281,36 @@ def diff_cmd(baseline: str, current: Optional[str]):
     """
     from agent_bom.history import diff_reports, latest_report, load_report_or_sbom
 
+    if output and output_format != "json":
+        raise click.ClickException("`report diff --output` requires `--format json`.")
+
     console = Console()
 
     baseline_data = load_report_or_sbom(Path(baseline))
 
     if current:
-        current_data = load_report_or_sbom(Path(current))
+        current_path = Path(current)
+        current_data = load_report_or_sbom(current_path)
     else:
         latest = latest_report()
         if not latest:
             console.print("[red]No saved scans in history. Run: agent-bom scan --save[/red]")
             sys.exit(1)
-        current_data = load_report_or_sbom(latest)
+        current_path = latest
+        current_data = load_report_or_sbom(current_path)
 
     diff = diff_reports(baseline_data, current_data)
-    print_diff(diff)
+    if output_format == "json":
+        _write_cli_output(
+            {
+                "baseline_path": str(Path(baseline).resolve()),
+                "current_path": str(current_path.resolve()),
+                **diff,
+            },
+            output,
+        )
+    else:
+        print_diff(diff)
 
     if diff["summary"]["new_findings"] > 0:
         sys.exit(1)

--- a/src/agent_bom/cli/_mcp_group.py
+++ b/src/agent_bom/cli/_mcp_group.py
@@ -55,4 +55,12 @@ def mcp_scan_cmd(server_spec: str, ecosystem: str | None, quiet: bool, no_color:
     callback = check.callback
     if callback is None:
         raise click.ClickException("check command is unavailable")
-    callback(package_spec=server_spec, ecosystem=ecosystem, quiet=quiet, no_color=no_color, exit_zero=exit_zero)
+    callback(
+        package_spec=server_spec,
+        ecosystem=ecosystem,
+        quiet=quiet,
+        no_color=no_color,
+        output_format="console",
+        output_path=None,
+        exit_zero=exit_zero,
+    )

--- a/src/agent_bom/cli/_remediate.py
+++ b/src/agent_bom/cli/_remediate.py
@@ -14,7 +14,7 @@ from typing import Optional
 import click
 
 from agent_bom import __version__
-from agent_bom.cli._common import _make_console, logger
+from agent_bom.cli._common import _make_console, _sync_runtime_consoles, logger
 from agent_bom.cli._scan_runner import ScanConfig, run_default_scan
 
 # ---------------------------------------------------------------------------
@@ -188,6 +188,7 @@ def _plan_to_json(plan_items: list[dict]) -> dict:
     help="Filter to show only items at this priority or higher.",
 )
 @click.option("--fixable-only", is_flag=True, default=False, help="Hide items without a fix version.")
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress scan chatter and file-write status messages.")
 def remediate_cmd(
     demo: bool,
     offline: bool,
@@ -197,6 +198,7 @@ def remediate_cmd(
     output_path: Optional[str],
     min_priority: Optional[str],
     fixable_only: bool,
+    quiet: bool,
 ) -> None:
     """Generate a prioritized remediation plan for discovered vulnerabilities.
 
@@ -211,15 +213,18 @@ def remediate_cmd(
       agent-bom remediate --fixable-only --priority P2 show P1+P2 fixable items only
       agent-bom remediate --server-group               group by MCP server
     """
-    from agent_bom.output import build_remediation_plan, print_remediation_plan
+    import agent_bom.output as output_mod
 
-    con = _make_console(quiet=(output_format != "console"), output_format=output_format)
+    runtime_console = _make_console(quiet=quiet or (output_format != "console"), output_format=output_format)
+    output_console = _make_console()
+    _sync_runtime_consoles(runtime_console)
+    output_mod.console = output_console
 
     # Run the scan pipeline
     try:
         result = run_default_scan(
             ScanConfig(project=project, demo=demo, offline=offline),
-            con=con,
+            con=runtime_console,
         )
         blast_radii, report = result.blast_radii, result.report
     except SystemExit:
@@ -237,11 +242,11 @@ def remediate_cmd(
             else:
                 click.echo(_out_str)
             return
-        con.print("\n[green]No vulnerabilities found — no remediation needed.[/green]\n")
+        output_console.print("\n[green]No vulnerabilities found — no remediation needed.[/green]\n")
         return
 
     # Build the plan
-    plan = build_remediation_plan(blast_radii)
+    plan = output_mod.build_remediation_plan(blast_radii)
 
     # Enrich with blast_radius_score
     for item in plan:
@@ -264,7 +269,7 @@ def remediate_cmd(
             else:
                 click.echo(_out_str)
             return
-        con.print("\n[dim]No remediation items match the current filters.[/dim]\n")
+        output_console.print("\n[dim]No remediation items match the current filters.[/dim]\n")
         return
 
     # Render output
@@ -273,24 +278,24 @@ def remediate_cmd(
             groups = _group_by_server(plan, blast_radii)
             from rich.rule import Rule
 
-            con.print()
-            con.print(Rule("Remediation Plan (grouped by MCP server)", style="green"))
-            con.print()
+            output_console.print()
+            output_console.print(Rule("Remediation Plan (grouped by MCP server)", style="green"))
+            output_console.print()
             for srv_name, items in groups.items():
-                con.print(f"\n  [bold cyan]{srv_name}[/bold cyan]")
+                output_console.print(f"\n  [bold cyan]{srv_name}[/bold cyan]")
                 for item in items:
                     fix_str = f"[green]{item['fix']}[/green]" if item.get("fix") else "[dim]no fix[/dim]"
                     kev = " [red][KEV][/red]" if item.get("has_kev") else ""
-                    con.print(
+                    output_console.print(
                         f"    [{item['priority']}] {item['package']} "
                         f"[dim]{item['current']}[/dim] -> {fix_str}{kev}"
                         f"  ({len(item.get('vulns', []))} vuln(s))"
                     )
-            con.print()
+            output_console.print()
         else:
             # Use the existing print_remediation_plan for default console view
             assert report is not None  # guaranteed after successful scan
-            print_remediation_plan(report)
+            output_mod.print_remediation_plan(report)
 
     elif output_format == "json":
         if server_group:
@@ -302,8 +307,8 @@ def remediate_cmd(
         _out_str = json.dumps(json_out, indent=2)
         if output_path:
             Path(output_path).write_text(_out_str)
-            con_file = _make_console(quiet=False)
-            con_file.print(f"[green]Remediation plan written[/green] -> {output_path}")
+            if not quiet:
+                output_console.print(f"[green]Remediation plan written[/green] -> {output_path}")
         else:
             click.echo(_out_str)
 
@@ -311,7 +316,7 @@ def remediate_cmd(
         md = _render_markdown(plan, blast_radii)
         if output_path:
             Path(output_path).write_text(md)
-            con_file = _make_console(quiet=False)
-            con_file.print(f"[green]Remediation report written[/green] -> {output_path}")
+            if not quiet:
+                output_console.print(f"[green]Remediation report written[/green] -> {output_path}")
         else:
             click.echo(md)

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -16,11 +16,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 import click
+from rich.console import Console
 
 from agent_bom.cli._common import (
     SEVERITY_ORDER,
     _build_agents_from_inventory,
     _make_console,
+    _sync_runtime_consoles,
     logger,
 )
 from agent_bom.cli.agents._cloud import run_benchmarks, run_cloud_discovery
@@ -323,7 +325,10 @@ def scan(
     _scan_start = _time.monotonic()
 
     # Configure logging — explicit --log-level overrides --verbose
-    _log_level = log_level or ("DEBUG" if verbose else "WARNING")
+    if quiet and log_level is None and not verbose and not log_json and not log_file:
+        _log_level = "ERROR"
+    else:
+        _log_level = log_level or ("DEBUG" if verbose else "WARNING")
     setup_logging(level=_log_level, json_output=log_json, log_file=log_file)
 
     # Load .agent-bom.yaml project config — CLI flags always win
@@ -417,6 +422,8 @@ def scan(
     # Route console output based on flags
     is_stdout = output == "-"
     con = _make_console(quiet=quiet or is_stdout, output_format=output_format, no_color=no_color)
+    runtime_console = Console(stderr=True, quiet=quiet or is_stdout, no_color=no_color)
+    _sync_runtime_consoles(runtime_console)
 
     # Also set the output module's console so print_summary etc. route correctly
     import agent_bom.output as _out

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from urllib.parse import urlparse
 
 from click.testing import CliRunner
@@ -137,3 +138,68 @@ def test_mcp_scan_delegates_to_package_check(monkeypatch):
 
     assert result.exit_code == 0
     assert "No known vulnerabilities" in result.output
+
+
+def test_check_quiet_suppresses_scan_chatter(monkeypatch):
+    async def _scan_packages(pkgs):
+        import agent_bom.scanners as scanners
+
+        scanners.console.print("scanner noise that should stay hidden")
+        for pkg in pkgs:
+            pkg.vulnerabilities = [
+                Vulnerability(
+                    id="CVE-2023-30861",
+                    summary="Session cookie disclosure",
+                    severity=Severity.HIGH,
+                    fixed_version="2.3.2",
+                )
+            ]
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _scan_packages)
+    monkeypatch.setattr("agent_bom.parsers.os_parsers.enrich_os_package_context", lambda pkg: True)
+
+    result = CliRunner().invoke(main, ["check", "flask@2.2.0", "--ecosystem", "pypi", "--quiet"])
+
+    assert result.exit_code == 1
+    assert "scanner noise" not in result.output
+    assert "Checking flask@2.2.0" not in result.output
+    assert "1 vulnerability/ies found" in result.output
+
+
+def test_check_json_output_is_machine_readable(monkeypatch):
+    _patch_check_scan(
+        monkeypatch,
+        [
+            Vulnerability(
+                id="CVE-2023-30861",
+                summary="Session cookie disclosure",
+                severity=Severity.HIGH,
+                fixed_version="2.3.2",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "flask@2.2.0", "--ecosystem", "pypi", "--format", "json", "--quiet"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["package"] == "flask"
+    assert payload["version"] == "2.2.0"
+    assert payload["verdict"] == "unsafe"
+    assert payload["vulnerability_count"] == 1
+    assert payload["vulnerabilities"][0]["id"] == "CVE-2023-30861"
+
+
+def test_check_output_requires_json_format(monkeypatch):
+    _patch_check_scan(monkeypatch, [])
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "django@4.1.0", "--ecosystem", "pypi", "--output", "report.json"],
+    )
+
+    assert result.exit_code == 1
+    assert "--format json" in result.output

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -58,6 +58,32 @@ def test_history_with_corrupt_report(tmp_path):
         assert result.exit_code == 0
 
 
+def test_history_json_output(tmp_path):
+    runner = CliRunner()
+    report_path = tmp_path / "scan_20250101.json"
+    report_data = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "summary": {
+            "total_agents": 2,
+            "total_packages": 10,
+            "total_vulnerabilities": 3,
+            "critical_findings": 1,
+        },
+    }
+    report_path.write_text(json.dumps(report_data))
+
+    with (
+        patch("agent_bom.history.list_reports", return_value=[report_path]),
+        patch("agent_bom.history.load_report", return_value=report_data),
+    ):
+        result = runner.invoke(history_cmd, ["--format", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["total_reports"] == 1
+        assert payload["reports"][0]["file"] == "scan_20250101.json"
+        assert payload["reports"][0]["total_vulnerabilities"] == 3
+
+
 # ---------------------------------------------------------------------------
 # diff_cmd
 # ---------------------------------------------------------------------------
@@ -214,6 +240,33 @@ def test_diff_accepts_two_sboms(tmp_path):
         assert result.exit_code == 0
         diff_payload = mock_print.call_args.args[0]
         assert diff_payload["summary"]["new_packages"] == 1
+
+
+def test_diff_json_output(tmp_path):
+    runner = CliRunner()
+    base = tmp_path / "base.json"
+    curr = tmp_path / "curr.json"
+    base.write_text(json.dumps(_make_report_data()))
+    curr.write_text(json.dumps(_make_report_data()))
+
+    diff_result = {
+        "baseline_generated_at": "2025-01-01T00:00:00Z",
+        "current_generated_at": "2025-01-02T00:00:00Z",
+        "new": [],
+        "resolved": [],
+        "unchanged": [],
+        "new_packages": [],
+        "removed_packages": [],
+        "inventory_diff": {},
+        "summary": {"new_findings": 0, "resolved_findings": 0, "unchanged_findings": 0, "new_packages": 0, "removed_packages": 0},
+    }
+    with patch("agent_bom.history.diff_reports", return_value=diff_result):
+        result = runner.invoke(diff_cmd, [str(base), str(curr), "--format", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["baseline_path"].endswith("base.json")
+        assert payload["current_path"].endswith("curr.json")
+        assert payload["summary"]["new_findings"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_remediate.py
+++ b/tests/test_cli_remediate.py
@@ -208,3 +208,23 @@ def test_remediate_output_file(tmp_path):
     assert out_file.exists()
     data = json.loads(out_file.read_text())
     assert "remediation_plan" in data
+
+
+def test_remediate_quiet_suppresses_scan_chatter():
+    from agent_bom.cli._scan_runner import ScanResult
+    from agent_bom.models import AIBOMReport
+
+    blast_radii = [_make_mock_blast_radius()]
+    report = AIBOMReport(agents=[MagicMock()], blast_radii=blast_radii, findings=[])
+
+    def _fake_run_default_scan(config, con):  # noqa: ARG001
+        con.print("scan chatter that should stay hidden")
+        return ScanResult(agents=[MagicMock()], blast_radii=blast_radii, report=report, total_packages=1)
+
+    runner = CliRunner()
+    with patch("agent_bom.cli._remediate.run_default_scan", side_effect=_fake_run_default_scan):
+        result = runner.invoke(remediate_cmd, ["--demo", "--offline", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert "scan chatter" not in result.output
+    assert "flask" in result.output

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -44,6 +44,7 @@ def test_main_help():
     result = _run(["--help"])
     assert result.exit_code == 0
     assert "scan" in result.output
+    assert "where" in result.output
 
 
 def test_main_version():
@@ -130,6 +131,29 @@ def test_scan_quiet_flag():
     with patch("agent_bom.cli.agents.discover_all", return_value=[]):
         result = _run(["scan", "--quiet", "--no-scan"])
     assert result.exit_code == 0
+
+
+def test_scan_quiet_uses_error_log_level(monkeypatch):
+    captured = {}
+
+    def _fake_setup_logging(*, level, json_output=None, log_file=None):
+        captured["level"] = level
+        captured["json_output"] = json_output
+        captured["log_file"] = log_file
+
+    monkeypatch.setattr("agent_bom.logging_config.setup_logging", _fake_setup_logging)
+    monkeypatch.setattr("agent_bom.cli.agents.discover_all", lambda *args, **kwargs: [])
+
+    result = _run(["scan", "--quiet", "--no-scan"])
+
+    assert result.exit_code == 0
+    assert captured["level"] == "ERROR"
+
+
+def test_where_help():
+    result = _run(["where", "--help"])
+    assert result.exit_code == 0
+    assert "MCP configurations" in result.output
 
 
 def test_scan_output_to_file(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -294,6 +294,12 @@ def test_verify_self_no_args():
     assert result.exit_code == 0 or "VERIFIED" in result.output
 
 
+def test_verify_agent_bom_shortcut_uses_self_verify():
+    record, integrity, provenance, pypi_meta = _mock_verify_all_pass()
+    result = _run_verify_with_mocks(["verify", "agent-bom"], record, integrity, provenance, pypi_meta)
+    assert result.exit_code == 0 or "VERIFIED" in result.output
+
+
 def test_verify_self_json_output():
     record, integrity, provenance, pypi_meta = _mock_verify_all_pass()
     result = _run_verify_with_mocks(["verify", "--json"], record, integrity, provenance, pypi_meta)


### PR DESCRIPTION
## What changed
- tightened CLI quiet-mode behavior so scan chatter and retry noise stay out of scripted runs
- added the top-level `where` command and made `agent-bom verify agent-bom` follow the documented self-verify path
- added machine-readable JSON output to `agent-bom check`, `agent-bom report history`, and `agent-bom report diff`
- added `--quiet` to `agent-bom remediate`
- updated CLI docs and added a dedicated CLI debug guide

## Why
A v0.76.0 CLI audit found a few concrete UX and automation gaps: `--quiet` was leaky, `verify agent-bom` was confusing, `where` was easy to miss, and several commands needed a stable JSON contract for CI and scripting.

## Impact
- safer piping and quieter scripted runs
- clearer self-verification and discovery flows
- JSON output for pre-install checks and report history/diff workflows
- more consistent CLI behavior across related commands

## Validation
- `pytest tests/test_cli_check.py tests/test_cli_history.py tests/test_cli_remediate.py tests/test_cli_scan.py tests/test_verify.py -q`
- `ruff check src/agent_bom/cli/_check.py src/agent_bom/cli/_history.py src/agent_bom/cli/_remediate.py src/agent_bom/cli/_mcp_group.py tests/test_cli_check.py tests/test_cli_history.py tests/test_cli_remediate.py`