### PR TITLE
align graph and contributor extras

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,13 @@ agent-bom has 7,000+ monthly installs. Every contribution directly improves secu
 git clone https://github.com/msaad00/agent-bom.git
 cd agent-bom
 python3 -m venv venv && source venv/bin/activate   # Windows: venv\Scripts\activate
-pip install -e ".[dev]"
+pip install -e ".[dev-all]"
 pre-commit install                                  # wires ruff + ruff-format hooks
 pytest tests/ -x -q                                # must be green before you start
 ```
 
 That's it. `agent-bom scan` now runs from your local checkout.
+Use `.[dev]` only for a lighter core workflow; `.[dev-all]` is the supported full-suite contributor setup.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ help:  ## Show this help message
 	@echo 'Available targets:'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-install:  ## Install agent-bom in development mode
-	pip install -e ".[dev]"
+install:  ## Install agent-bom with the full contributor test extras
+	pip install -e ".[dev-all]"
 
 install-all:  ## Install agent-bom with all development extras
 	pip install -e ".[dev-all]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,11 @@ wandb = ["wandb>=0.16"]
 # MLflow discovery still works if users install `mlflow` separately.
 openai = ["openai>=1.12"]
 ai-enrich = ["litellm>=1.30"]
-graph = ["networkx>=3.0"]
+graph = [
+    "networkx>=3.0",
+    "numpy>=1.26",
+    "scipy>=1.13",
+]
 pdf = []
 postgres = ["psycopg[binary]>=3.1", "psycopg-pool>=3.1"]
 watch = ["watchdog>=4.0"]
@@ -140,6 +144,8 @@ dev-all = [
     "agent-bom[dev]",
     "agent-bom[ui]",
     "agent-bom[mcp-server]",
+    "agent-bom[graph]",
+    "agent-bom[postgres]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What changed
- added `numpy` and `scipy` to the `graph` extra so PageRank and centrality features have their numeric runtime dependencies
- expanded `dev-all` to include the graph and postgres extras
- updated contributor install docs and the `Makefile` install target to use the full contributor environment

## Why
The v0.76.0 release audit found that the documented contributor path was not enough to run the full graph-related behavior and tests reliably. The graph feature depended on numeric libraries that were not pulled in by the declared extras.

## Impact
- `agent-bom[graph]` now matches the graph runtime it exposes
- the default contributor install path is closer to the full test contract
- fewer clean-environment failures when exercising graph analysis and related tests

## Validation
- `pytest tests/test_graph_backend.py -q`
- `python -m mypy src/agent_bom/cli/_check.py src/agent_bom/cli/_history.py src/agent_bom/cli/_remediate.py src/agent_bom/cli/_mcp_group.py`