### PR TITLE
harden Docker Hub release workflow

### DIFF
--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -45,16 +45,16 @@ jobs:
             exit 1
           fi
 
-          # Fetch all tags sorted by last_updated (newest first)
+          # Fetch all tags sorted by last_updated, then keep the highest semver tags.
           ALL_TAGS=$(curl -sf "https://hub.docker.com/v2/repositories/${REPO}/tags/?page_size=100&ordering=-last_updated" \
             -H "Authorization: Bearer $TOKEN" | jq -r '.results[].name')
 
           # Tags to always keep
           KEEP_PATTERNS="^(latest|0)$"
 
-          # Build keep list: floating tags + last N semver tags
-          SEMVER_TAGS=$(echo "$ALL_TAGS" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)
-          KEEP_SEMVER=$(echo "$SEMVER_TAGS" | head -n "${KEEP_COUNT}")
+          # Build keep list: floating tags + highest N semver tags
+          SEMVER_TAGS=$(printf '%s\n' "$ALL_TAGS" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr || true)
+          KEEP_SEMVER=$(printf '%s\n' "$SEMVER_TAGS" | head -n "${KEEP_COUNT}")
 
           echo "=== Tags to KEEP ==="
           echo "  latest, 0 (floating)"
@@ -64,7 +64,8 @@ jobs:
           echo ""
           echo "=== Tags to DELETE ==="
 
-          for tag in $ALL_TAGS; do
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
             # Skip floating tags
             if echo "$tag" | grep -qE "$KEEP_PATTERNS"; then
               continue
@@ -89,7 +90,7 @@ jobs:
                 echo "    ✗ failed (HTTP $HTTP_CODE)"
               fi
             fi
-          done
+          done <<< "$ALL_TAGS"
 
           echo ""
           if [ "$DRY_RUN" = "true" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,8 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          SHORT_DESCRIPTION="Open security scanner for agentic infrastructure: agents, MCP, containers, cloud, and runtime."
           TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
             -H "Content-Type: application/json" \
             -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
@@ -153,19 +155,29 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$TOKEN"
-          DESCRIPTION=$(cat DOCKER_HUB_README.md | jq -Rs .)
-          curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+          DESCRIPTION=$(jq -Rs . < DOCKER_HUB_README.md)
+          SHORT_DESCRIPTION_JSON=$(printf '%s' "$SHORT_DESCRIPTION" | jq -Rs .)
+          RESPONSE_FILE=$(mktemp)
+          HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" -X PATCH \
             "https://hub.docker.com/v2/repositories/agentbom/agent-bom/" \
             -H "Authorization: Bearer ${TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"full_description\": ${DESCRIPTION}, \"description\": \"Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.\"}"
+            -d "{\"full_description\": ${DESCRIPTION}, \"description\": ${SHORT_DESCRIPTION_JSON}}")
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Docker Hub README sync failed (HTTP $HTTP_CODE)"
+            cat "$RESPONSE_FILE"
+            exit 1
+          fi
+          rm -f "$RESPONSE_FILE"
 
       - name: Clean up old Docker Hub tags (keep last 10)
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
+          set -euo pipefail
           REPO="agentbom/agent-bom"
+          CURRENT_VERSION="${{ steps.meta.outputs.version }}"
           TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
             -H "Content-Type: application/json" \
             -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
@@ -175,17 +187,23 @@ jobs:
 
           ALL_TAGS=$(curl -sf "https://hub.docker.com/v2/repositories/${REPO}/tags/?page_size=100&ordering=-last_updated" \
             -H "Authorization: Bearer $TOKEN" | jq -r '.results[].name')
-          SEMVER_TAGS=$(echo "$ALL_TAGS" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)
-          KEEP=$(echo "$SEMVER_TAGS" | head -n 10)
+          SEMVER_TAGS=$(printf '%s\n' "$ALL_TAGS" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr || true)
+          KEEP=$(printf '%s\n%s\n' "$CURRENT_VERSION" "$SEMVER_TAGS" | awk 'NF && !seen[$0]++' | head -n 10)
 
-          for tag in $ALL_TAGS; do
+          echo "Keeping Docker Hub tags:"
+          printf '  %s\n' latest 0
+          printf '%s\n' "$KEEP" | sed '/^$/d;s/^/  /'
+
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
             echo "$tag" | grep -qE '^(latest|0)$' && continue
+            [ "$tag" = "$CURRENT_VERSION" ] && continue
             echo "$KEEP" | grep -qxF "$tag" && continue
             echo "Deleting $tag"
             curl -sf -o /dev/null -X DELETE \
               "https://hub.docker.com/v2/repositories/${REPO}/tags/${tag}" \
               -H "Authorization: Bearer $TOKEN" || true
-          done
+          done <<< "$ALL_TAGS"
 
   container-gate:
     name: Container release gate

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -113,7 +113,7 @@ It covers:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `v0.76.0` | Current stable version (pinned) |
+| `0.76.0` | Current stable version (pinned) |
 
 ## Links
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -94,8 +94,10 @@ clawhub install agent-bom
 Automated via `.github/workflows/release.yml` on each tag push.
 
 Images published:
-- `agentbom/agent-bom:v{version}`
+- `agentbom/agent-bom:{version}`
 - `agentbom/agent-bom:latest`
+
+The Git tag remains `v{version}`. Docker Hub image tags are published without the `v` prefix.
 
 ---
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -55,7 +55,7 @@ DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("site-docs/features/policy.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("site-docs/deployment/overview.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("docs/ENTERPRISE_DEPLOYMENT.md", re.compile(r"(agentbom/agent-bom:)(?:v)?\d+\.\d+\.\d+"), r"\g<1>{v}"),
-    ("DOCKER_HUB_README.md", re.compile(r"(\| `v)\d+\.\d+\.\d+(` \| Current stable version \(pinned\) \|)"), r"\g<1>{v}\g<2>"),
+    ("DOCKER_HUB_README.md", re.compile(r"(\| `)\d+\.\d+\.\d+(` \| Current stable version \(pinned\) \|)"), r"\g<1>{v}\g<2>"),
     # PUBLISHING.md — version examples
     ("docs/PUBLISHING.md", re.compile(r'(--version\s+")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
     ("docs/PUBLISHING.md", re.compile(r"(git tag v)\S+", re.M), r"\g<1>{v}"),

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -149,8 +149,8 @@ def main() -> int:
     glama_text = GLAMA_SERVER.read_text()
     if f'"version": "{version}"' not in glama_text:
         _fail(f"integrations/glama/server.json must be aligned to {version}")
-    if f"`v{version}` | Current stable version (pinned)" not in DOCKER_README.read_text():
-        _fail(f"DOCKER_HUB_README.md must mark v{version} as the current stable version")
+    if f"`{version}` | Current stable version (pinned)" not in DOCKER_README.read_text():
+        _fail(f"DOCKER_HUB_README.md must mark {version} as the current stable version")
     if f"ARG VERSION={version}" not in TOP_DOCKERFILE.read_text():
         _fail(f"Dockerfile ARG VERSION must be {version}")
 


### PR DESCRIPTION
## Summary
- harden the Docker Hub README sync step so non-2xx responses fail the release and surface the response body
- keep Docker Hub semver tags by version order and explicitly preserve the current release tag during cleanup
- align Docker Hub docs with the actual published tag format (`0.x.y`, not `v0.x.y`)

## Root Cause
The `v0.76.0` release path pushed `agentbom/agent-bom:0.76.0`, but the cleanup step could still delete that fresh tag because retention relied on Docker Hub's `last_updated` ordering instead of semver ordering. The README sync step also printed an HTTP status without failing the job, so a Docker Hub `400` left the repository metadata stale while the overall job still looked successful.

## Impact
- versioned Docker tags are preserved instead of being deleted immediately after release
- Docker Hub README sync failures become visible and actionable
- docs now match the actual image tags users can pull

## Validation
- `git diff --check`
- parsed `.github/workflows/release.yml` with `yaml.safe_load_all`
- parsed `.github/workflows/dockerhub-cleanup.yml` with `yaml.safe_load_all`
- repo pre-commit hooks passed during `git commit`
