### PR TITLE
prepare 0.76.1 release

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.76.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.76.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.76.1","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.76.1"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.76.0  # pinned — bump on each release
+        run: uv tool install agent-bom==0.76.1  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.76.1] – 2026-04-09
+
+### Added
+- **CLI output parity for reporting commands** — `check`, `report diff`, and `report history` now have clearer machine-readable behavior, and reporting surfaces that were still missing `--quiet` now support quiet scripting flows
+- **CLI troubleshooting coverage** — the shipped docs now include a dedicated debug guide for quiet mode, stdout vs file output, discovery triage, and verification workflows
+
+### Changed
+- **Patch release alignment** — release-managed files, Docker/Helm metadata, OpenClaw skills metadata, docs, registry surfaces, and action examples are now aligned on `0.76.1`
+- **Verification status wording** — package provenance verification now distinguishes missing attestations from service unavailability instead of collapsing both into a generic unknown state
+
+### Fixed
+- **Quiet mode consistency** — reporting and analysis commands now suppress headings/export chatter when `--quiet` is requested
+- **Verify JSON output** — `agent-bom verify --json` no longer prepends human console banners before the JSON payload
+- **Graph contributor install contract** — graph centrality dependencies and contributor install paths were aligned so graph analysis works in a clean optional-extra install
+- **Live MITRE/STIX parsing** — ATT&CK/CAPEC runtime parsing now handles the current upstream payload shape and restores live CWE→ATT&CK mapping
+- **Docker Hub release hardening** — release sync, cleanup retention, and version-alignment checks now match the real Docker tag contract and fail loudly on drift
+- **Release bump automation** — stale version-bump patterns were removed so dry-run and check mode only flag real managed release surfaces
+
+### Security
+- **Supply-chain verification clarity** — provenance verification now reports whether attestations are absent or temporarily unavailable, reducing ambiguous release-audit results for package verification
+
+---
+
 ## [0.76.0] – 2026-04-09
 
 ### Added
@@ -511,7 +534,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.76.0...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.76.1...HEAD
+[0.76.1]: https://github.com/msaad00/agent-bom/compare/v0.76.0...v0.76.1
 [0.76.0]: https://github.com/msaad00/agent-bom/compare/v0.75.15...v0.76.0
 [0.75.15]: https://github.com/msaad00/agent-bom/compare/v0.75.14...v0.75.15
 [0.75.14]: https://github.com/msaad00/agent-bom/compare/v0.75.13...v0.75.14

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -113,7 +113,7 @@ It covers:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.76.0` | Current stable version (pinned) |
+| `0.76.1` | Current stable version (pinned) |
 
 ## Links
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.76.0
+ARG VERSION=0.76.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ docker run --rm agentbom/agent-bom agents    # Docker
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom agents` | Local audit + project scan |
-| GitHub Action | `uses: msaad00/agent-bom@v0.76.0` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.76.1` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom` | Isolated scans |
 | MCP Server | `agent-bom mcp server` | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
@@ -171,7 +171,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **Repo + MCP + instruction files**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     scan-type: scan
     severity-threshold: high
@@ -183,7 +183,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **Container image gate**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
@@ -193,7 +193,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **IaC gate**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
@@ -203,7 +203,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **Air-gapped / pre-synced CI**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     auto-update-db: false
     enrich: false

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.76.0
+ARG VERSION=0.76.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.76.0
+ARG VERSION=0.76.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.76.0
+ARG VERSION=0.76.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.76.0
+ARG VERSION=0.76.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.76.0
+ARG VERSION=0.76.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for agentic infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
 version: 0.1.0
-appVersion: "0.76.0"
+appVersion: "0.76.1"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.76.0"
+  tag: "0.76.1"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.76.0"
+  tag: "0.76.1"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -23,7 +23,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -41,21 +41,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     auto-update-db: false
     enrich: false
@@ -173,7 +173,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/root/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.76.0 agents --format json
+  agentbom/agent-bom:0.76.1 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -226,7 +226,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.0
+- uses: msaad00/agent-bom@v0.76.1
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -78,7 +78,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.76.0"
+  --version "0.76.1"
 ```
 
 ### Verification
@@ -116,8 +116,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.76.0
-git push origin v0.76.0
+git tag v0.76.1
+git push origin v0.76.1
 ```
 
 This triggers:

--- a/docs/WINDOWS_CONTAINERS.md
+++ b/docs/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.76.0`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.76.1`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.76.0 blast-radius demo
+# agent-bom v0.76.1 blast-radius demo
 # Shows: blast radius → fix-first remediation → integrity verify
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.76.0",
+  "version": "0.76.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.76.0",
+  "version": "0.76.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.76.0",
+      "version": "0.76.1",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []
@@ -402,6 +402,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.76.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.76.1`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []
@@ -216,6 +216,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.76.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.76.1`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.76.0
+version: 0.76.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.0
+    docker: ghcr.io/msaad00/agent-bom:0.76.1
   openclaw:
     requires:
       bins: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.76.0"
+version = "0.76.1"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -61,18 +61,12 @@ DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("docs/PUBLISHING.md", re.compile(r"(git tag v)\S+", re.M), r"\g<1>{v}"),
     ("docs/PUBLISHING.md", re.compile(r"(git push origin v)\S+", re.M), r"\g<1>{v}"),
     ("ui/tests/nav.test.tsx", re.compile(r"(version:\s*')\d+\.\d+\.\d+(')"), r"\g<1>{v}\g<2>"),
-    # tests/test_core.py — version assertions
-    ("tests/test_core.py", re.compile(r'(assert\s+__version__\s*==\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
-    # Only match version assertions that currently contain a semver pattern (avoids clobbering SARIF "2.1.0")
-    ("tests/test_core.py", re.compile(r'(assert\s+data\["version"\]\s*==\s*")0\.\d+\.\d+(")', re.M), r"\g<1>{v}\g<2>"),
     # cve-freshness.yml — SARIF fallback template version
     (".github/workflows/cve-freshness.yml", re.compile(r'("version":")\d+\.\d+\.\d+(")'), r"\g<1>{v}\g<2>"),
     # mcp-change-scan.yml — pinned agent-bom install version
     (".github/workflows/mcp-change-scan.yml", re.compile(r"(agent-bom==)\d+\.\d+\.\d+"), r"\g<1>{v}"),
-    # README.md — Sigstore verify line
-    ("README.md", re.compile(r"(agent-bom verify agent-bom@)\S+"), r"\g<1>{v}"),
     # docs/demo.tape — version header
-    ("docs/demo.tape", re.compile(r"^(# agent-bom v)\d+\.\d+\.\d+(\s+demo.*)$", re.M), r"\g<1>{v}\g<2>"),
+    ("docs/demo.tape", re.compile(r"^(# agent-bom v)\d+\.\d+\.\d+(\s+.*demo.*)$", re.M), r"\g<1>{v}\g<2>"),
 ]
 
 
@@ -85,7 +79,9 @@ def bump(new_version: str, *, dry_run: bool = False, check: bool = False) -> int
     all_locations = VERSION_LOCATIONS + DOC_TEST_LOCATIONS
     for glob_pattern, pattern, template in OPENCLAW_SKILL_PATTERNS:
         for path in sorted(ROOT.glob(glob_pattern)):
-            all_locations.append((str(path.relative_to(ROOT)), pattern, template))
+            text = path.read_text()
+            if pattern.search(text):
+                all_locations.append((str(path.relative_to(ROOT)), pattern, template))
     changed = 0
 
     for rel_path, pattern, template in all_locations:

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -5,7 +5,7 @@
 | **CLI** | Local scanning, CI/CD | `pip install agent-bom` |
 | **MCP Server** | AI agent integration | `agent-bom mcp server` |
 | **Docker** | Isolated scanning | `docker run ghcr.io/msaad00/agent-bom scan` |
-| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.76.0` |
+| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.76.1` |
 | **Kubernetes** | Fleet monitoring | Helm chart |
 | **REST API** | Platform integration | `agent-bom serve` |
 | **Runtime Proxy** | Real-time enforcement | `agent-bom runtime proxy` |

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.76.0
+  uses: msaad00/agent-bom@v0.76.1
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -51,6 +51,6 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | CLI | `pip install agent-bom` |
 | MCP server | `agent-bom mcp server` |
 | Docker | `docker run ghcr.io/msaad00/agent-bom agents` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.76.0` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.76.1` |
 | Kubernetes | Helm chart + CronJob + DaemonSet |
 | Remote SSE | Self-host or use hosted endpoint |

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.76.0"
+    __version__ = "0.76.1"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -38,7 +38,7 @@ def _load_mesh_source(scan_file: Optional[str], project_dir: Optional[str]) -> t
     return [asdict(agent) for agent in agents], None
 
 
-def _render_mesh_summary(con: Console, agents_data: list[dict], mesh: dict) -> None:
+def _render_mesh_summary(con: Console, agents_data: list[dict], mesh: dict, *, quiet: bool = False) -> None:
     """Print a compact human-readable topology summary."""
     stats = mesh.get("stats", {})
     shared_counts: Counter[str] = Counter()
@@ -46,12 +46,13 @@ def _render_mesh_summary(con: Console, agents_data: list[dict], mesh: dict) -> N
         for server in agent.get("mcp_servers", []):
             shared_counts[server.get("name", "unknown")] += 1
 
-    con.print()
-    con.print(
-        f"[bold]Mesh[/bold]  "
-        f"[dim]{stats.get('total_agents', 0)} agents · {stats.get('total_servers', 0)} servers · "
-        f"{stats.get('total_tools', 0)} tools · {stats.get('total_vulnerabilities', 0)} vulns[/dim]"
-    )
+    if not quiet:
+        con.print()
+        con.print(
+            f"[bold]Mesh[/bold]  "
+            f"[dim]{stats.get('total_agents', 0)} agents · {stats.get('total_servers', 0)} servers · "
+            f"{stats.get('total_tools', 0)} tools · {stats.get('total_vulnerabilities', 0)} vulns[/dim]"
+        )
 
     for agent in agents_data:
         servers = agent.get("mcp_servers", [])
@@ -68,7 +69,8 @@ def _render_mesh_summary(con: Console, agents_data: list[dict], mesh: dict) -> N
                 f"• [cyan]{server.get('name', 'unknown')}[/cyan]{shared} "
                 f"[dim]{len(packages)} pkg · {len(tools)} tool · {len(creds)} cred · {vuln_count} vuln[/dim]"
             )
-    con.print()
+    if not quiet:
+        con.print()
 
 
 @click.command("analytics")
@@ -206,7 +208,8 @@ def analytics_cmd(query_type, days, hours, agent, top_limit, clickhouse_url):
     help="Output format.",
 )
 @click.option("--output", "-o", "output_path", default=None, help="Write to file instead of stdout.")
-def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str]) -> None:
+@click.option("--quiet", "-q", is_flag=True, help="Suppress success messages when writing files.")
+def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool) -> None:
     """Export the transitive dependency graph from a saved JSON scan report.
 
     \b
@@ -247,7 +250,8 @@ def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str]) -> None:
 
     if output_path:
         Path(output_path).write_text(output)
-        _con.print(f"[green]Graph exported[/green] ({graph.node_count()} nodes, {graph.edge_count()} edges) → {output_path}")
+        if not quiet:
+            _con.print(f"[green]Graph exported[/green] ({graph.node_count()} nodes, {graph.edge_count()} edges) → {output_path}")
     else:
         click.echo(output)
 
@@ -271,7 +275,8 @@ def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str]) -> None:
     help="Output format.",
 )
 @click.option("--output", "-o", "output_path", default=None, help="Write to file instead of stdout.")
-def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, output_path: Optional[str]) -> None:
+@click.option("--quiet", "-q", is_flag=True, help="Suppress summary headers and export notices.")
+def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, output_path: Optional[str], quiet: bool) -> None:
     """Show lightweight agent/MCP topology without the dashboard.
 
     \b
@@ -300,7 +305,8 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
         output = json.dumps(mesh, indent=2)
         if output_path:
             Path(output_path).write_text(output)
-            con.print(f"[green]Mesh exported[/green] → {output_path}")
+            if not quiet:
+                con.print(f"[green]Mesh exported[/green] → {output_path}")
         else:
             click.echo(output)
         return
@@ -309,7 +315,7 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
         con.print("[red]--output is only supported with --format json for mesh.[/red]")
         raise SystemExit(2)
 
-    _render_mesh_summary(con, agents_data, mesh)
+    _render_mesh_summary(con, agents_data, mesh, quiet=quiet)
 
 
 @click.command("dashboard")

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -98,6 +98,37 @@ def _write_json_output(payload: dict, output_path: str | None) -> None:
     click.echo(text)
 
 
+def _render_provenance_check(provenance: dict | None) -> dict[str, str]:
+    """Normalize provenance verification into a stable CLI-facing status."""
+    if provenance and provenance.get("has_provenance"):
+        att_count = provenance.get("attestation_count", 0)
+        return {
+            "status": "pass",
+            "detail": f"Attestation found ({att_count} attestation(s))",
+        }
+
+    status = str((provenance or {}).get("status") or "")
+    if status == "not_published":
+        return {
+            "status": "missing",
+            "detail": "No provenance attestation published",
+        }
+    if status == "not_provenance":
+        return {
+            "status": "missing",
+            "detail": "Attestations found, but none were SLSA/provenance attestations",
+        }
+    if status == "unavailable":
+        return {
+            "status": "unavailable",
+            "detail": "Provenance service unavailable",
+        }
+    return {
+        "status": "unknown",
+        "detail": "Could not determine provenance status",
+    }
+
+
 def _check_result_payload(
     *,
     name: str,
@@ -658,14 +689,14 @@ def verify(
 
     if self_verify:
         name, version, eco = "agent-bom", __version__, "pypi"
-        if not quiet:
+        if not quiet and not as_json:
             console.print(f"\n[bold blue]Verifying agent-bom {version} installation...[/bold blue]\n")
         record_result = verify_installed_record("agent-bom")
     else:
         assert package_spec is not None
         name, version, eco = _parse_package_spec(package_spec, ecosystem)
         record_result = None
-        if not quiet:
+        if not quiet and not as_json:
             console.print(f"\n[bold blue]Verifying {name}@{version} ({eco})...[/bold blue]\n")
 
     if version in ("unknown", ""):
@@ -738,16 +769,7 @@ def verify(
         checks["registry_hash"] = {"status": "unknown", "detail": "Could not reach registry"}
 
     # Provenance check
-    if provenance and provenance.get("has_provenance"):
-        att_count = provenance.get("attestation_count", 0)
-        checks["provenance"] = {
-            "status": "pass",
-            "detail": f"Attestation found ({att_count} attestation(s))",
-        }
-    elif provenance:
-        checks["provenance"] = {"status": "unknown", "detail": "No provenance attestation"}
-    else:
-        checks["provenance"] = {"status": "unknown", "detail": "Could not check provenance"}
+    checks["provenance"] = _render_provenance_check(provenance)
 
     # Metadata consistency (self-verify with pypi_meta only)
     if pypi_meta and record_result:
@@ -792,7 +814,13 @@ def verify(
     # Rich table output
     from rich.table import Table
 
-    status_icons = {"pass": "[green]PASS[/green]", "fail": "[red]FAIL[/red]", "unknown": "[yellow]UNKNOWN[/yellow]"}
+    status_icons = {
+        "pass": "[green]PASS[/green]",
+        "fail": "[red]FAIL[/red]",
+        "missing": "[dim]MISSING[/dim]",
+        "unavailable": "[yellow]UNAVAILABLE[/yellow]",
+        "unknown": "[yellow]UNKNOWN[/yellow]",
+    }
     check_labels = {
         "record_integrity": "RECORD integrity",
         "registry_hash": "Registry SHA-256",

--- a/src/agent_bom/cli/_history.py
+++ b/src/agent_bom/cli/_history.py
@@ -157,7 +157,8 @@ def _write_cli_output(payload: dict, output_path: str | None) -> None:
     help="Output format.",
 )
 @click.option("--output", "-o", type=str, default=None, help="Write JSON output to a file (use '-' for stdout).")
-def history_cmd(limit: int, output_format: str, output: str | None):
+@click.option("--quiet", "-q", is_flag=True, help="Suppress headings and footer metadata in console output.")
+def history_cmd(limit: int, output_format: str, output: str | None, quiet: bool):
     """List saved scan reports from ~/.agent-bom/history/."""
     from agent_bom.history import list_reports, load_report
 
@@ -220,7 +221,8 @@ def history_cmd(limit: int, output_format: str, output: str | None):
         )
         return
 
-    console.print(f"\n[bold blue]📂 Scan History[/bold blue]  ({len(reports)} total, showing {min(limit, len(reports))})\n")
+    if not quiet:
+        console.print(f"\n[bold blue]📂 Scan History[/bold blue]  ({len(reports)} total, showing {min(limit, len(reports))})\n")
 
     from rich.table import Table
 
@@ -248,7 +250,8 @@ def history_cmd(limit: int, output_format: str, output: str | None):
         )
 
     console.print(table)
-    console.print(f"\n  [dim]History directory: {reports[0].parent}[/dim]\n")
+    if not quiet:
+        console.print(f"\n  [dim]History directory: {reports[0].parent}[/dim]\n")
 
 
 @click.command("diff")
@@ -264,7 +267,8 @@ def history_cmd(limit: int, output_format: str, output: str | None):
     help="Output format.",
 )
 @click.option("--output", "-o", type=str, default=None, help="Write JSON output to a file (use '-' for stdout).")
-def diff_cmd(baseline: str, current: Optional[str], output_format: str, output: str | None):
+@click.option("--quiet", "-q", is_flag=True, help="Only print a compact summary in console output.")
+def diff_cmd(baseline: str, current: Optional[str], output_format: str, output: str | None, quiet: bool):
     """Diff two scan reports to see what changed.
 
     \b
@@ -310,7 +314,7 @@ def diff_cmd(baseline: str, current: Optional[str], output_format: str, output: 
             output,
         )
     else:
-        print_diff(diff)
+        print_diff(diff, quiet=quiet)
 
     if diff["summary"]["new_findings"] > 0:
         sys.exit(1)

--- a/src/agent_bom/cli/_skills_group.py
+++ b/src/agent_bom/cli/_skills_group.py
@@ -54,6 +54,7 @@ def skills_group(ctx: click.Context) -> None:
     help="Path to the local skills catalog (defaults to ~/.agent-bom/skills/catalog.json)",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Show all findings instead of only the default top findings summary")
+@click.option("--quiet", "-q", is_flag=True, help="Suppress headings, summaries, and recommendations in console output")
 def skills_scan_cmd(
     paths: tuple[Path, ...],
     output_format: str,
@@ -62,6 +63,7 @@ def skills_scan_cmd(
     intel_source: str | None,
     catalog_path: Path | None,
     verbose: bool,
+    quiet: bool,
 ) -> None:
     """Scan skill and instruction files for trust, risk, and provenance.
 
@@ -84,22 +86,25 @@ def skills_scan_cmd(
         console = Console()
         summary = payload["summary"]
 
-        console.print("\n[bold]agent-bom skills scan[/bold]\n")
         if not report.files:
+            if not quiet:
+                console.print("\n[bold]agent-bom skills scan[/bold]\n")
             console.print("  [yellow]⚠ No supported skill or instruction files found.[/yellow]\n")
             if output_path:
                 output_path.write_text("")
             sys.exit(2)
 
-        console.print(
-            "  "
-            f"[green]{summary['files_scanned']}[/green] file(s) · "
-            f"[green]{summary['packages_found']}[/green] package ref(s) · "
-            f"[green]{summary['servers_found']}[/green] server ref(s) · "
-            f"[yellow]{summary['credential_env_vars']}[/yellow] credential var(s)\n"
-        )
-        if report.catalog_path:
-            console.print(f"  [dim]Catalog updated:[/dim] {report.catalog_path}\n")
+        if not quiet:
+            console.print("\n[bold]agent-bom skills scan[/bold]\n")
+            console.print(
+                "  "
+                f"[green]{summary['files_scanned']}[/green] file(s) · "
+                f"[green]{summary['packages_found']}[/green] package ref(s) · "
+                f"[green]{summary['servers_found']}[/green] server ref(s) · "
+                f"[yellow]{summary['credential_env_vars']}[/yellow] credential var(s)\n"
+            )
+            if report.catalog_path:
+                console.print(f"  [dim]Catalog updated:[/dim] {report.catalog_path}\n")
 
         files_table = Table(title="Instruction Surface", expand=True)
         files_table.add_column("File")
@@ -151,7 +156,8 @@ def skills_scan_cmd(
                     finding.category,
                     finding.title,
                 )
-            console.print()
+            if not quiet:
+                console.print()
             console.print(finding_table)
 
         family_totals: dict[str, int] = {}
@@ -161,7 +167,7 @@ def skills_scan_cmd(
             for family, count in families.items():
                 family_totals[family] = family_totals.get(family, 0) + int(count)
 
-        if family_totals:
+        if family_totals and not quiet:
             behavior_table = Table(title="Behavior Profile", expand=True)
             behavior_table.add_column("Family")
             behavior_table.add_column("Signals", justify="right", no_wrap=True)
@@ -178,11 +184,12 @@ def skills_scan_cmd(
                     seen_recommendations.add(recommendation)
                     recommendations.append(recommendation)
 
-        if recommendations:
+        if recommendations and not quiet:
             console.print("\n[bold]Recommended next steps[/bold]")
             for recommendation in recommendations[:5]:
                 console.print(f"  • {recommendation}")
-        console.print()
+        if not quiet:
+            console.print()
 
         if output_path:
             output_path.write_text(json.dumps(payload, indent=2))

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1337,7 +1337,13 @@ def scan(
                             con.print(f"  [green]✓[/green] {pkg.name}@{pkg.version} — SLSA provenance attested")
                         elif provenance:
                             pkg.provenance_attested = False
-                            con.print(f"  [dim]  {pkg.name}@{pkg.version} — no SLSA provenance[/dim]")
+                            prov_status = str(provenance.get("status") or "")
+                            if prov_status == "unavailable":
+                                con.print(f"  [yellow]⚠[/yellow] {pkg.name}@{pkg.version} — provenance service unavailable")
+                            elif prov_status == "not_provenance":
+                                con.print(f"  [dim]  {pkg.name}@{pkg.version} — attestations present, but none were SLSA provenance[/dim]")
+                            else:
+                                con.print(f"  [dim]  {pkg.name}@{pkg.version} — no SLSA provenance[/dim]")
 
             if unique_pkgs:
                 con.print(f"\n[bold blue]🔐 Verifying integrity for {len(unique_pkgs)} package(s)...[/bold blue]\n")

--- a/src/agent_bom/integrity.py
+++ b/src/agent_bom/integrity.py
@@ -149,7 +149,13 @@ async def check_npm_provenance(
         f"https://registry.npmjs.org/-/npm/v1/attestations/{encoded_name}@{version}",
     )
 
-    if response and response.status_code == 200:
+    if response is None:
+        return {"has_provenance": False, "status": "unavailable"}
+
+    if response.status_code == 404:
+        return {"has_provenance": False, "status": "not_published", "attestation_count": 0}
+
+    if response.status_code == 200:
         try:
             data = response.json()
             attestations = data.get("attestations", [])
@@ -158,6 +164,7 @@ async def check_npm_provenance(
                 if "slsa" in predicate_type.lower() or "provenance" in predicate_type.lower():
                     return {
                         "has_provenance": True,
+                        "status": "verified",
                         "predicate_type": predicate_type,
                         "attestation_count": len(attestations),
                     }
@@ -165,13 +172,20 @@ async def check_npm_provenance(
             if attestations:
                 return {
                     "has_provenance": False,
+                    "status": "not_provenance",
                     "attestation_count": len(attestations),
                     "predicate_types": [a.get("predicateType", "") for a in attestations],
                 }
+            return {
+                "has_provenance": False,
+                "status": "not_published",
+                "attestation_count": 0,
+            }
         except (ValueError, KeyError):
-            pass
+            logger.warning("npm provenance parse failed for %s@%s", package_name, version)
+            return {"has_provenance": False, "status": "unavailable"}
 
-    return None
+    return {"has_provenance": False, "status": "unavailable", "http_status": response.status_code}
 
 
 async def check_pypi_provenance(
@@ -193,18 +207,31 @@ async def check_pypi_provenance(
         f"https://pypi.org/integrity/{package_name}/{version}/",
     )
 
-    if response and response.status_code == 200:
+    if response is None:
+        return {"has_provenance": False, "status": "unavailable"}
+
+    if response.status_code == 404:
+        return {"has_provenance": False, "status": "not_published", "attestation_count": 0}
+
+    if response.status_code == 200:
         try:
             data = response.json()
             if data.get("attestations"):
                 return {
                     "has_provenance": True,
+                    "status": "verified",
                     "attestation_count": len(data["attestations"]),
                 }
+            return {
+                "has_provenance": False,
+                "status": "not_published",
+                "attestation_count": 0,
+            }
         except (ValueError, KeyError):
-            pass
+            logger.warning("PyPI provenance parse failed for %s@%s", package_name, version)
+            return {"has_provenance": False, "status": "unavailable"}
 
-    return None
+    return {"has_provenance": False, "status": "unavailable", "http_status": response.status_code}
 
 
 async def check_package_provenance(
@@ -254,18 +281,25 @@ async def check_go_provenance(
         f"https://sum.golang.org/lookup/{module_path}@{version}",
     )
 
-    if response and response.status_code == 200:
+    if response is None:
+        return {"has_provenance": False, "status": "unavailable"}
+
+    if response.status_code == 404:
+        return {"has_provenance": False, "status": "not_published"}
+
+    if response.status_code == 200:
         body = response.text.strip()
         # Response format: line 1 = id, line 2 = module@version hash, line 3 = go.sum hash
         lines = body.split("\n")
         if len(lines) >= 2:
             return {
                 "has_provenance": True,
+                "status": "verified",
                 "source": "sum.golang.org",
                 "checksum_db_entry": lines[0].strip() if lines else "",
             }
 
-    return None
+    return {"has_provenance": False, "status": "unavailable", "http_status": response.status_code}
 
 
 def verify_installed_record(package_name: str) -> dict:

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1841,13 +1841,11 @@ def print_compact_export_hint(report: AIBOMReport) -> None:
 # ─── Diff Output ─────────────────────────────────────────────────────────────
 
 
-def print_diff(diff: dict) -> None:
+def print_diff(diff: dict, *, quiet: bool = False) -> None:
     """Print a human-readable diff between two scan reports."""
     summary = diff["summary"]
     baseline_ts = diff["baseline_generated_at"]
     current_ts = diff["current_generated_at"]
-
-    console.print(f"\n[bold blue]📊 Scan Diff[/bold blue]  [dim]{baseline_ts}[/dim] → [dim]{current_ts}[/dim]\n")
 
     parts = []
     if summary["new_findings"]:
@@ -1880,6 +1878,15 @@ def print_diff(diff: dict) -> None:
         parts.append(f"[cyan]{inv_summary['new_relationships']} new relationship(s)[/cyan]")
     if inv_summary.get("removed_relationships"):
         parts.append(f"[dim]{inv_summary['removed_relationships']} removed relationship(s)[/dim]")
+
+    if quiet:
+        if parts:
+            console.print("  •  ".join(parts))
+        else:
+            console.print("No changes since baseline.")
+        return
+
+    console.print(f"\n[bold blue]📊 Scan Diff[/bold blue]  [dim]{baseline_ts}[/dim] → [dim]{current_ts}[/dim]\n")
 
     if parts:
         console.print("  " + "  •  ".join(parts) + "\n")

--- a/tests/test_cli_analysis.py
+++ b/tests/test_cli_analysis.py
@@ -155,6 +155,26 @@ def test_graph_cmd_dot_with_output(tmp_path):
         assert out_file.exists()
 
 
+def test_graph_cmd_quiet_suppresses_export_message(tmp_path):
+    runner = CliRunner()
+    scan_file = tmp_path / "scan.json"
+    scan_file.write_text("{}")
+    out_file = tmp_path / "graph.dot"
+
+    mock_graph = MagicMock()
+    mock_graph.node_count.return_value = 2
+    mock_graph.edge_count.return_value = 1
+
+    with (
+        patch("agent_bom.output.graph_export.load_graph_from_scan", return_value=mock_graph),
+        patch("agent_bom.output.graph_export.to_dot", return_value="digraph {}"),
+    ):
+        result = runner.invoke(graph_cmd, [str(scan_file), "-f", "dot", "-o", str(out_file), "--quiet"])
+        assert result.exit_code == 0
+        assert out_file.exists()
+        assert "Graph exported" not in result.output
+
+
 def test_graph_cmd_mermaid(tmp_path):
     runner = CliRunner()
     scan_file = tmp_path / "scan.json"
@@ -256,6 +276,40 @@ def test_mesh_cmd_summary_rejects_output_path(tmp_path):
     scan_file.write_text(json.dumps({"agents": [{"name": "a", "mcp_servers": []}], "blast_radius": []}))
     result = runner.invoke(mesh_cmd, [str(scan_file), "--output", str(tmp_path / "mesh.txt")])
     assert result.exit_code == 2
+
+
+def test_mesh_cmd_quiet_suppresses_summary_heading():
+    runner = CliRunner()
+    server = MagicMock()
+    server.name = "filesystem"
+    server.packages = []
+    server.tools = [{"name": "read_file"}]
+    server.env = {}
+    agent = MagicMock()
+    agent.mcp_servers = [server]
+
+    with (
+        patch("agent_bom.discovery.discover_all", return_value=[agent]),
+        patch("agent_bom.parsers.extract_packages", return_value=[{"name": "pkg", "version": "1.0.0", "vulnerabilities": []}]),
+        patch(
+            "dataclasses.asdict",
+            return_value={
+                "name": "claude",
+                "mcp_servers": [
+                    {
+                        "name": "filesystem",
+                        "packages": [{"name": "pkg", "version": "1.0.0", "vulnerabilities": []}],
+                        "tools": [{"name": "read_file"}],
+                        "env": {},
+                    }
+                ],
+            },
+        ),
+    ):
+        result = runner.invoke(mesh_cmd, ["--quiet"])
+        assert result.exit_code == 0
+        assert "Mesh" not in result.output
+        assert "filesystem" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -84,6 +84,31 @@ def test_history_json_output(tmp_path):
         assert payload["reports"][0]["total_vulnerabilities"] == 3
 
 
+def test_history_quiet_suppresses_heading_and_footer(tmp_path):
+    runner = CliRunner()
+    report_path = tmp_path / "scan_20250101.json"
+    report_data = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "summary": {
+            "total_agents": 2,
+            "total_packages": 10,
+            "total_vulnerabilities": 3,
+            "critical_findings": 1,
+        },
+    }
+    report_path.write_text(json.dumps(report_data))
+
+    with (
+        patch("agent_bom.history.list_reports", return_value=[report_path]),
+        patch("agent_bom.history.load_report", return_value=report_data),
+    ):
+        result = runner.invoke(history_cmd, ["--quiet"])
+        assert result.exit_code == 0
+        assert "Scan History" not in result.output
+        assert "History directory" not in result.output
+        assert "scan_20250101.json" in result.output
+
+
 # ---------------------------------------------------------------------------
 # diff_cmd
 # ---------------------------------------------------------------------------
@@ -267,6 +292,31 @@ def test_diff_json_output(tmp_path):
         assert payload["baseline_path"].endswith("base.json")
         assert payload["current_path"].endswith("curr.json")
         assert payload["summary"]["new_findings"] == 0
+
+
+def test_diff_quiet_prints_compact_summary(tmp_path):
+    runner = CliRunner()
+    base = tmp_path / "base.json"
+    curr = tmp_path / "curr.json"
+    base.write_text(json.dumps(_make_report_data()))
+    curr.write_text(json.dumps(_make_report_data()))
+
+    diff_result = {
+        "baseline_generated_at": "2025-01-01T00:00:00Z",
+        "current_generated_at": "2025-01-02T00:00:00Z",
+        "new": [],
+        "resolved": [],
+        "unchanged": [],
+        "new_packages": [],
+        "removed_packages": [],
+        "inventory_diff": {},
+        "summary": {"new_findings": 0, "resolved_findings": 0, "unchanged_findings": 0, "new_packages": 0, "removed_packages": 0},
+    }
+    with patch("agent_bom.history.diff_reports", return_value=diff_result):
+        result = runner.invoke(diff_cmd, [str(base), str(curr), "--quiet"])
+        assert result.exit_code == 0
+        assert "Scan Diff" not in result.output
+        assert "No changes since baseline." in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -170,7 +170,7 @@ def test_check_npm_provenance_non_slsa():
 def test_check_npm_provenance_none():
     with patch("agent_bom.integrity.request_with_retry", new_callable=AsyncMock, return_value=None):
         result = asyncio.run(check_npm_provenance("pkg", "1.0.0", AsyncMock()))
-        assert result is None
+        assert result == {"has_provenance": False, "status": "unavailable"}
 
 
 # ---------------------------------------------------------------------------
@@ -198,4 +198,4 @@ def test_check_pypi_provenance_success():
 def test_check_pypi_provenance_no_attestations():
     with patch("agent_bom.integrity.request_with_retry", new_callable=AsyncMock, return_value=None):
         result = asyncio.run(check_pypi_provenance("pkg", "1.0.0", AsyncMock()))
-        assert result is None
+        assert result == {"has_provenance": False, "status": "unavailable"}

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -183,3 +183,15 @@ def test_skills_scan_verbose_flag_is_supported(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "agent-bom skills scan" in result.output
+
+
+def test_skills_scan_quiet_suppresses_heading(tmp_path):
+    skill_file = tmp_path / "CLAUDE.md"
+    skill_file.write_text("# Instructions\n\nUse API key OPENAI_API_KEY.\n")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skills", "scan", str(tmp_path), "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert "agent-bom skills scan" not in result.output
+    assert "Instruction Surface" in result.output

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -211,6 +211,32 @@ async def test_fetch_pypi_release_metadata_not_found():
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_check_pypi_provenance_not_published():
+    from agent_bom.integrity import check_pypi_provenance
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_client = AsyncMock()
+
+    with patch("agent_bom.integrity.request_with_retry", return_value=mock_response):
+        result = await check_pypi_provenance("agent-bom", "0.76.0", mock_client)
+
+    assert result == {"has_provenance": False, "status": "not_published", "attestation_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_check_pypi_provenance_unavailable():
+    from agent_bom.integrity import check_pypi_provenance
+
+    mock_client = AsyncMock()
+
+    with patch("agent_bom.integrity.request_with_retry", return_value=None):
+        result = await check_pypi_provenance("agent-bom", "0.76.0", mock_client)
+
+    assert result == {"has_provenance": False, "status": "unavailable"}
+
+
 # ─── CLI verify command ──────────────────────────────────────────────────────
 
 
@@ -357,6 +383,26 @@ def test_verify_record_not_available_still_passes():
         data = json.loads(result.output)
         record_check = data.get("checks", {}).get("record_integrity", {})
         assert record_check.get("status") == "unknown"
+
+
+def test_verify_provenance_missing_is_not_unknown():
+    record, integrity, _provenance, pypi_meta = _mock_verify_all_pass()
+    missing_provenance = {"has_provenance": False, "status": "not_published", "attestation_count": 0}
+
+    result = _run_verify_with_mocks(["verify", "--json"], record, integrity, missing_provenance, pypi_meta)
+
+    data = json.loads(result.output)
+    assert data["checks"]["provenance"]["status"] == "missing"
+
+
+def test_verify_provenance_unavailable_is_not_unknown():
+    record, integrity, _provenance, pypi_meta = _mock_verify_all_pass()
+    unavailable_provenance = {"has_provenance": False, "status": "unavailable"}
+
+    result = _run_verify_with_mocks(["verify", "--json"], record, integrity, unavailable_provenance, pypi_meta)
+
+    data = json.loads(result.output)
+    assert data["checks"]["provenance"]["status"] == "unavailable"
 
 
 def test_verify_record_tampered_fails():

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.76.0' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.76.1' }),
   },
 }))
 


### PR DESCRIPTION
## What changed

This prepares the `0.76.1` patch release on top of the post-`0.76.0` fixes already merged to `main`.

It includes:

- bumping all release-managed version surfaces to `0.76.1`
- adding the `0.76.1` changelog entry and compare links
- cleaning `scripts/bump-version.py` so dry-run/check mode only report real managed version targets
- tightening CLI quiet-mode coverage on reporting/analysis/skills surfaces
- making `verify --json` emit clean JSON without banner noise
- clarifying provenance verification results so missing attestations and temporary service unavailability are reported separately instead of as a generic `UNKNOWN`

## Why

`main` contains follow-up fixes that were not part of the shipped `v0.76.0` artifact. The correct next publish is `0.76.1`, and the release surfaces needed to be aligned before tagging.

The pre-release cleanup also closes the remaining low-severity audit items that were still worth fixing before publish:

- stale `bump-version.py` no-match warnings
- missing `--quiet` on some reporting commands
- ambiguous provenance status in verify flows

## User / developer impact

- release docs, Docker/Helm metadata, OpenClaw metadata, and registry surfaces now consistently point at `0.76.1`
- automation can rely on `bump-version.py --dry-run/--check` without dead warnings
- scripting flows for `report history`, `report diff`, `graph`, `mesh`, and `skills scan` are quieter and more consistent
- verification output is easier to interpret during release audits

## Validation

- `python scripts/check_release_consistency.py`
- `python scripts/bump-version.py 0.76.1 --check`
- `pytest tests/test_verify.py tests/test_cli_history.py tests/test_cli_analysis.py tests/test_skills_cli.py -q`
- `ruff check` on all touched files

## Root cause

The repository had moved beyond the `v0.76.0` release with merged fixes on `main`, but the release-managed version surfaces still advertised `0.76.0`. Separately, some CLI/reporting edges and provenance wording were still carrying pre-release audit debt.
