### PR TITLE
fix: ingest Alpine secdb and prepare 0.76.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,8 @@ jobs:
         with:
           image-ref: agent-bom:test
           format: table
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
+          ignore-unfixed: true
           exit-code: '1'
           trivyignores: .trivyignore
 

--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.76.1","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.76.1"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.76.2","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.76.2"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.76.1  # pinned — bump on each release
+        run: uv tool install agent-bom==0.76.2  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,8 @@ jobs:
         with:
           image-ref: agent-bom:release-test
           format: table
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
+          ignore-unfixed: true
           exit-code: "1"
           trivyignores: .trivyignore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.76.2] – 2026-04-09
+
+### Changed
+- **Patch release alignment** — managed release/version surfaces are now aligned on `0.76.2` for the next patch cut
+
+### Fixed
+- **Alpine package visibility** — local vulnerability DB sync now ingests Alpine secdb in addition to OSV, so Alpine package advisories like the recent `openssl` and `util-linux` fixes are detected without waiting on OSV lag
+- **Alpine scanner coverage** — Alpine OS-package fallback queries now include `v3.23`, matching the current container base branch
+- **Container hardening** — the Docker build now upgrades installed Alpine packages during both builder and runtime stages instead of only bumping `zlib`
+- **Release image gating** — CI and release image scans now fail on fixable `MEDIUM+` and `UNKNOWN` image vulnerabilities while ignoring upstream-unfixed image findings
+
+### Security
+- **Container CVE response** — the patch release closes the fixable Alpine `openssl` and `util-linux` image findings and adds stronger pre-release guardrails to stop similar Docker regressions from shipping unnoticed
+
+---
+
 ## [0.76.1] – 2026-04-09
 
 ### Added
@@ -534,7 +550,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.76.1...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.76.2...HEAD
+[0.76.2]: https://github.com/msaad00/agent-bom/compare/v0.76.1...v0.76.2
 [0.76.1]: https://github.com/msaad00/agent-bom/compare/v0.76.0...v0.76.1
 [0.76.0]: https://github.com/msaad00/agent-bom/compare/v0.75.15...v0.76.0
 [0.75.15]: https://github.com/msaad00/agent-bom/compare/v0.75.14...v0.75.15

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -113,7 +113,7 @@ It covers:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.76.1` | Current stable version (pinned) |
+| `0.76.2` | Current stable version (pinned) |
 
 ## Links
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ENV HTTP_PROXY=${HTTP_PROXY} \
     PIP_CERT=${PIP_CERT}
 
 # Build-time deps for wheel compilation when musllinux wheels are unavailable.
-RUN apk add --no-cache build-base ca-certificates git linux-headers && update-ca-certificates
+RUN apk add --no-cache build-base ca-certificates git linux-headers \
+    && apk upgrade --no-cache --available \
+    && update-ca-certificates
 
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
@@ -28,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.76.1
+ARG VERSION=0.76.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -47,7 +49,9 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
-RUN apk add --no-cache ca-certificates && update-ca-certificates && apk upgrade --no-cache zlib
+RUN apk add --no-cache ca-certificates \
+    && apk upgrade --no-cache --available \
+    && update-ca-certificates
 COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
 RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ docker run --rm agentbom/agent-bom agents    # Docker
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom agents` | Local audit + project scan |
-| GitHub Action | `uses: msaad00/agent-bom@v0.76.1` | CI/CD + SARIF |
+| GitHub Action | `uses: msaad00/agent-bom@v0.76.2` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom` | Isolated scans |
 | MCP Server | `agent-bom mcp server` | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
@@ -171,7 +171,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **Repo + MCP + instruction files**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     scan-type: scan
     severity-threshold: high
@@ -183,7 +183,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **Container image gate**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
@@ -193,7 +193,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **IaC gate**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
@@ -203,7 +203,7 @@ Use the GitHub Action when you want a fast CI gate: one step, one gate, SARIF in
 **Air-gapped / pre-synced CI**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     auto-update-db: false
     enrich: false

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.76.1
+ARG VERSION=0.76.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.76.1
+ARG VERSION=0.76.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.76.1
+ARG VERSION=0.76.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.76.1
+ARG VERSION=0.76.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.76.1
+ARG VERSION=0.76.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for agentic infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
 version: 0.1.0
-appVersion: "0.76.1"
+appVersion: "0.76.2"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.76.1"
+  tag: "0.76.2"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom-runtime
-  tag: "0.76.1"
+  tag: "0.76.2"
   pullPolicy: IfNotPresent
 
 scanner:

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -23,7 +23,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -41,21 +41,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     auto-update-db: false
     enrich: false
@@ -173,7 +173,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/root/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.76.1 agents --format json
+  agentbom/agent-bom:0.76.2 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -226,7 +226,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.76.1
+- uses: msaad00/agent-bom@v0.76.2
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -78,7 +78,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
 clawhub publish integrations/openclaw \
   --slug agent-bom --name "agent-bom" \
-  --version "0.76.1"
+  --version "0.76.2"
 ```
 
 ### Verification
@@ -116,8 +116,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.76.1
-git push origin v0.76.1
+git tag v0.76.2
+git push origin v0.76.2
 ```
 
 This triggers:

--- a/docs/WINDOWS_CONTAINERS.md
+++ b/docs/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.76.1`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.76.2`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.76.1 blast-radius demo
+# agent-bom v0.76.2 blast-radius demo
 # Shows: blast radius → fix-first remediation → integrity verify
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.76.1",
+  "version": "0.76.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.76.1",
+  "version": "0.76.2",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.76.1",
+      "version": "0.76.2",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []
@@ -402,6 +402,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.76.1`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.76.2`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []
@@ -216,6 +216,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.76.1`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.76.2`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.76.1
+version: 0.76.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.76.1
+    docker: ghcr.io/msaad00/agent-bom:0.76.2
   openclaw:
     requires:
       bins: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.76.1"
+version = "0.76.2"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -5,7 +5,7 @@
 | **CLI** | Local scanning, CI/CD | `pip install agent-bom` |
 | **MCP Server** | AI agent integration | `agent-bom mcp server` |
 | **Docker** | Isolated scanning | `docker run ghcr.io/msaad00/agent-bom scan` |
-| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.76.1` |
+| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.76.2` |
 | **Kubernetes** | Fleet monitoring | Helm chart |
 | **REST API** | Platform integration | `agent-bom serve` |
 | **Runtime Proxy** | Real-time enforcement | `agent-bom runtime proxy` |

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.76.1
+  uses: msaad00/agent-bom@v0.76.2
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -51,6 +51,6 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | CLI | `pip install agent-bom` |
 | MCP server | `agent-bom mcp server` |
 | Docker | `docker run ghcr.io/msaad00/agent-bom agents` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.76.1` |
+| GitHub Action | `uses: msaad00/agent-bom@v0.76.2` |
 | Kubernetes | Helm chart + CronJob + DaemonSet |
 | Remote SSE | Self-host or use hosted endpoint |

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.76.1"
+    __version__ = "0.76.2"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/src/agent_bom/cli/_db.py
+++ b/src/agent_bom/cli/_db.py
@@ -1,7 +1,7 @@
 """CLI commands for the local vulnerability database.
 
 Commands:
-    agent-bom db update   — sync from OSV / EPSS / KEV / GHSA / NVD
+    agent-bom db update   — sync from OSV / Alpine secdb / EPSS / KEV / GHSA / NVD
     agent-bom db status   — show DB stats and last-sync timestamps
     agent-bom db path     — print the DB file path
 """
@@ -21,8 +21,9 @@ def db_cmd() -> None:
     "--source",
     "sources",
     multiple=True,
-    type=click.Choice(["osv", "epss", "kev", "ghsa", "nvd"], case_sensitive=False),
-    help="Which sources to sync (default: osv, epss, kev). Repeatable. "
+    type=click.Choice(["osv", "alpine", "epss", "kev", "ghsa", "nvd"], case_sensitive=False),
+    help="Which sources to sync (default: osv, alpine, epss, kev). Repeatable. "
+    "Use --source alpine to sync Alpine package secfix data from Alpine secdb. "
     "Use --source ghsa to sync GitHub Security Advisories (all ecosystems). "
     "Use --source nvd to enrich unknown-severity CVEs from NVD (slow without NVD_API_KEY).",
 )
@@ -65,7 +66,7 @@ def db_update(
 ) -> None:
     """Download and sync the local vulnerability database.
 
-    Pulls from OSV.dev (bulk export), FIRST EPSS scores, and CISA KEV catalog by default.
+    Pulls from OSV.dev (bulk export), Alpine secdb, FIRST EPSS scores, and CISA KEV catalog by default.
     Pass --source ghsa to also fetch GitHub Security Advisories across all supported
     ecosystems (pip, npm, go, maven, nuget, rubygems, cargo).
     Pass --source nvd to enrich CVEs missing CVSS data from the NVD API (requires NVD_API_KEY
@@ -81,7 +82,7 @@ def db_update(
     from agent_bom.db.sync import sync_db
 
     con = Console()
-    selected = list(sources) or ["osv", "epss", "kev"]
+    selected = list(sources) or ["osv", "alpine", "epss", "kev"]
     con.print(f"[bold]Syncing local vuln DB[/bold] — sources: {', '.join(selected)}")
 
     try:

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -22,6 +22,7 @@ import csv
 import io
 import json
 import logging
+import re
 import sqlite3
 import zipfile
 from datetime import datetime, timezone
@@ -52,6 +53,9 @@ _EPSS_CSV_URL = "https://epss.cyentia.com/epss_scores-current.csv.gz"
 _KEV_JSON_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 _GHSA_REST_URL = "https://api.github.com/advisories"
 _NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_ALPINE_SECDB_BASE_URL = "https://secdb.alpinelinux.org"
+_ALPINE_SECDB_BRANCHES = ("v3.18", "v3.19", "v3.20", "v3.21", "v3.22", "v3.23")
+_ALPINE_SECDB_REPOS = ("main", "community")
 
 # AI/ML package names — kept for reference/priority tracking, NOT used as a filter.
 # As of v0.71.0, GHSA ingestion fetches ALL advisories across supported ecosystems.
@@ -365,6 +369,154 @@ def sync_osv(conn: sqlite3.Connection, url: Optional[str] = None, max_entries: i
     conn.commit()
     _update_sync_meta(conn, "osv", count)
     _logger.info("OSV sync complete: %d advisories ingested", count)
+    return count
+
+
+def _parse_alpine_secfix_tokens(value: object) -> list[str]:
+    """Extract vulnerability identifiers from one Alpine secdb secfix value."""
+    if not isinstance(value, str):
+        return []
+    return re.findall(r"(?:CVE-\d{4}-\d+|ALPINE-\d+|XSA-\d+)", value)
+
+
+def _iter_alpine_secfix_ids(secfixes: object) -> dict[str, list[str]]:
+    """Return {fixed_version: [vuln_ids...]} for one Alpine secdb package."""
+    if not isinstance(secfixes, dict):
+        return {}
+
+    parsed: dict[str, list[str]] = {}
+    for fixed_version, raw_ids in secfixes.items():
+        if not isinstance(fixed_version, str):
+            continue
+        vuln_ids: list[str] = []
+        if isinstance(raw_ids, list):
+            for item in raw_ids:
+                vuln_ids.extend(_parse_alpine_secfix_tokens(item))
+        if vuln_ids:
+            parsed[fixed_version] = vuln_ids
+    return parsed
+
+
+def _upsert_alpine_vuln_stub(
+    conn: sqlite3.Connection,
+    vuln_id: str,
+    package_name: str,
+    fixed_version: str,
+) -> None:
+    """Insert a minimal vulnerability row unless a richer row already exists."""
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO vulns
+            (id, summary, severity, cvss_score, cvss_vector, fixed_version, published, modified, source, cwe_ids, aliases)
+        VALUES
+            (?, ?, 'unknown', NULL, NULL, ?, '', '', 'alpine-secdb', '', '')
+        """,
+        (
+            vuln_id,
+            f"Alpine Linux secdb advisory for {package_name}",
+            fixed_version,
+        ),
+    )
+    conn.execute(
+        """
+        UPDATE vulns
+        SET fixed_version = CASE
+            WHEN fixed_version IS NULL OR fixed_version = '' THEN ?
+            ELSE fixed_version
+        END
+        WHERE id = ?
+        """,
+        (fixed_version, vuln_id),
+    )
+
+
+def _ingest_alpine_secdb_payload(
+    conn: sqlite3.Connection,
+    payload: dict,
+    *,
+    distro_version: str,
+    repository: str,
+) -> int:
+    """Ingest one Alpine secdb JSON document into the local DB.
+
+    Returns the number of affected package/version mappings processed.
+    """
+    from agent_bom.package_utils import normalize_package_name
+
+    ecosystem = f"alpine:{distro_version}".lower()
+    processed = 0
+
+    for package_entry in payload.get("packages", []):
+        if not isinstance(package_entry, dict):
+            continue
+        pkg = package_entry.get("pkg", {})
+        if not isinstance(pkg, dict):
+            continue
+        package_name = pkg.get("name", "")
+        if not isinstance(package_name, str) or not package_name:
+            continue
+
+        normalized_name = normalize_package_name(package_name, "apk")
+        secfixes = _iter_alpine_secfix_ids(pkg.get("secfixes"))
+        for fixed_version, vuln_ids in secfixes.items():
+            for vuln_id in vuln_ids:
+                _upsert_alpine_vuln_stub(conn, vuln_id, normalized_name, fixed_version)
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO affected
+                        (vuln_id, ecosystem, package_name, introduced, fixed, last_affected)
+                    VALUES
+                        (?, ?, ?, '0', ?, '')
+                    """,
+                    (vuln_id, ecosystem, normalized_name, fixed_version),
+                )
+                processed += 1
+
+    _logger.debug(
+        "Ingested %d Alpine secdb mappings for %s/%s",
+        processed,
+        distro_version,
+        repository,
+    )
+    return processed
+
+
+def sync_alpine_secdb(
+    conn: sqlite3.Connection,
+    *,
+    base_url: Optional[str] = None,
+    branches: tuple[str, ...] = _ALPINE_SECDB_BRANCHES,
+    repositories: tuple[str, ...] = _ALPINE_SECDB_REPOS,
+) -> int:
+    """Download and ingest Alpine Linux secdb feeds.
+
+    Alpine secdb carries package-level fix metadata for apk packages and is often
+    fresher than OSV for distro-specific Alpine advisories.
+    """
+    from agent_bom.http_client import fetch_json
+
+    root = (base_url or _ALPINE_SECDB_BASE_URL).rstrip("/")
+    _validate_sync_url(root, "alpine secdb base url")
+
+    count = 0
+    for branch in branches:
+        for repository in repositories:
+            url = f"{root}/{branch}/{repository}.json"
+            _validate_sync_url(url, "alpine secdb url")
+            _logger.info("Downloading Alpine secdb from %s …", url)
+            data = fetch_json(url, timeout=30)
+            if not isinstance(data, dict):
+                raise ValueError(f"Unexpected Alpine secdb payload type for {url}: {type(data)!r}")
+            count += _ingest_alpine_secdb_payload(
+                conn,
+                data,
+                distro_version=branch,
+                repository=repository,
+            )
+            conn.commit()
+
+    _update_sync_meta(conn, "alpine", count)
+    _logger.info("Alpine secdb sync complete: %d package advisory mappings ingested", count)
     return count
 
 
@@ -932,7 +1084,7 @@ def sync_db(
 
     Args:
         path: DB file path (default: DB_PATH from schema.py).
-        sources: list of source names to sync, e.g. ["osv", "kev"]. Default: ["osv","epss","kev"].
+        sources: list of source names to sync, e.g. ["osv", "kev"]. Default: ["osv","alpine","epss","kev"].
                  Note: "nvd" is NOT in the default set — it is slow without an API key.
         osv_url / epss_url / kev_url / ghsa_url / nvd_url: URL overrides (for testing).
         max_osv_entries: limit for OSV entries (0 = unlimited; for tests).
@@ -950,12 +1102,14 @@ def sync_db(
 
     db_path = path or DB_PATH
     conn = init_db(db_path)
-    enabled = set(sources or ["osv", "epss", "kev"])
+    enabled = set(sources or ["osv", "alpine", "epss", "kev"])
     results: dict[str, int] = {}
 
     try:
         if "osv" in enabled:
             results["osv"] = sync_osv(conn, url=osv_url, max_entries=max_osv_entries)
+        if "alpine" in enabled:
+            results["alpine"] = sync_alpine_secdb(conn)
         if "epss" in enabled:
             results["epss"] = sync_epss(conn, url=epss_url)
         if "kev" in enabled:

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -209,7 +209,7 @@ _NON_OSV_ECOSYSTEMS: frozenset[str] = frozenset(
 )
 
 _DEBIAN_OSV_FALLBACKS = ("Debian:11", "Debian:12", "Debian:13", "Debian:14")
-_ALPINE_OSV_FALLBACKS = ("Alpine:v3.18", "Alpine:v3.19", "Alpine:v3.20", "Alpine:v3.21", "Alpine:v3.22")
+_ALPINE_OSV_FALLBACKS = ("Alpine:v3.18", "Alpine:v3.19", "Alpine:v3.20", "Alpine:v3.21", "Alpine:v3.22", "Alpine:v3.23")
 
 
 def _osv_ecosystems_for_package(pkg: Package) -> list[str]:

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -12,9 +12,12 @@ import pytest
 from agent_bom.db.lookup import VulnDB, _version_affected, lookup_package
 from agent_bom.db.schema import DB_PATH, _validated_db_path, db_stats, init_db
 from agent_bom.db.sync import (
+    _ingest_alpine_secdb_payload,
     _ingest_osv_file,
+    _parse_alpine_secfix_tokens,
     _parse_osv_entry,
     _validate_sync_url,
+    sync_alpine_secdb,
     sync_epss,
     sync_kev,
     sync_osv,
@@ -647,6 +650,71 @@ def test_parse_osv_entry_with_cvss_severity_type():
     assert vuln_row["cvss_vector"] is not None
 
 
+def test_parse_alpine_secfix_tokens_splits_compound_entries():
+    assert _parse_alpine_secfix_tokens("CVE-2022-42333 CVE-2022-43334 XSA-428") == [
+        "CVE-2022-42333",
+        "CVE-2022-43334",
+        "XSA-428",
+    ]
+
+
+def test_ingest_alpine_secdb_payload_adds_affected_rows(tmp_db):
+    payload = {
+        "packages": [
+            {
+                "pkg": {
+                    "name": "util-linux",
+                    "secfixes": {
+                        "2.41.3-r1": ["CVE-2026-27456"],
+                    },
+                }
+            },
+            {
+                "pkg": {
+                    "name": "busybox",
+                    "secfixes": {
+                        "1.37.0-r28": ["CVE-2025-60876"],
+                    },
+                }
+            },
+        ]
+    }
+
+    count = _ingest_alpine_secdb_payload(tmp_db, payload, distro_version="v3.23", repository="main")
+    assert count == 2
+
+    util_vulns = lookup_package(tmp_db, "Alpine:v3.23", "util-linux", "2.41.3-r0")
+    busybox_vulns = lookup_package(tmp_db, "Alpine:v3.23", "busybox", "1.37.0-r0")
+
+    assert [v.id for v in util_vulns] == ["CVE-2026-27456"]
+    assert [v.fixed_version for v in util_vulns] == ["2.41.3-r1"]
+    assert [v.id for v in busybox_vulns] == ["CVE-2025-60876"]
+    assert [v.fixed_version for v in busybox_vulns] == ["1.37.0-r28"]
+
+
+def test_sync_alpine_secdb_downloads_selected_branches(tmp_db):
+    responses = {
+        "https://secdb.alpinelinux.org/v3.23/main.json": {
+            "packages": [
+                {
+                    "pkg": {
+                        "name": "util-linux",
+                        "secfixes": {"2.41.3-r1": ["CVE-2026-27456"]},
+                    }
+                }
+            ]
+        },
+        "https://secdb.alpinelinux.org/v3.23/community.json": {"packages": []},
+    }
+
+    with patch("agent_bom.http_client.fetch_json", side_effect=lambda url, timeout=30: responses[url]):
+        count = sync_alpine_secdb(tmp_db, branches=("v3.23",), repositories=("main", "community"))
+
+    assert count == 1
+    sync_row = tmp_db.execute("SELECT source, record_count FROM sync_meta WHERE source = 'alpine'").fetchone()
+    assert tuple(sync_row) == ("alpine", 1)
+
+
 # ---------------------------------------------------------------------------
 # sync_db — dispatcher with mocked sources
 # ---------------------------------------------------------------------------
@@ -670,6 +738,16 @@ def test_sync_db_single_epss_source(tmp_path):
         result = sync_db(path=tmp_path / "test.db", sources=["epss"])
     assert result == {"epss": 500}
     mock_epss.assert_called_once()
+
+
+def test_sync_db_single_alpine_source(tmp_path):
+    """sync_db with sources=['alpine'] only calls sync_alpine_secdb."""
+    from agent_bom.db.sync import sync_db
+
+    with patch("agent_bom.db.sync.sync_alpine_secdb", return_value=12) as mock_alpine:
+        result = sync_db(path=tmp_path / "test.db", sources=["alpine"])
+    assert result == {"alpine": 12}
+    mock_alpine.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scanner_ecosystems.py
+++ b/tests/test_scanner_ecosystems.py
@@ -253,6 +253,38 @@ async def test_query_osv_batch_debian_fallbacks_when_distro_unknown():
 
 
 @pytest.mark.asyncio
+async def test_query_osv_batch_alpine_fallbacks_include_v323():
+    """Direct apk checks without distro metadata should include the current Alpine branch."""
+    from agent_bom.scanners import query_osv_batch
+
+    pkg = Package(name="util-linux", version="2.41.3-r0", ecosystem="apk")
+    captured_queries: list[dict] = []
+
+    async def mock_request_with_retry(client, method, url, json=None, **kwargs):
+        if json and "queries" in json:
+            captured_queries.extend(json["queries"])
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"results": [{"vulns": []} for _ in captured_queries]}
+        return resp
+
+    with (
+        patch("agent_bom.scanners._get_scan_cache", return_value=None),
+        patch("agent_bom.scanners.request_with_retry", side_effect=mock_request_with_retry),
+        patch("agent_bom.scanners.create_client") as mock_create_client,
+    ):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_create_client.return_value = mock_client
+
+        await query_osv_batch([pkg])
+
+    ecosystems = {q["package"]["ecosystem"] for q in captured_queries}
+    assert "Alpine:v3.23" in ecosystems
+
+
+@pytest.mark.asyncio
 async def test_scan_packages_maven_vuln_attached():
     """Vulnerabilities from OSV are attached to Maven packages after scan."""
     from agent_bom.scanners import scan_packages

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.76.1' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.76.2' }),
   },
 }))
 


### PR DESCRIPTION
## What changed
- ingest Alpine secdb into the local vulnerability DB so apk package advisories are available even when OSV lags
- include Alpine v3.23 in direct apk fallback queries
- upgrade installed Alpine packages during both Docker build stages instead of only bumping `zlib`
- tighten CI and release image gates to fail on fixable `MEDIUM+` and `UNKNOWN` image findings
- bump managed release surfaces to `0.76.2` and add the patch changelog entry

## Why
Docker Scout surfaced Alpine image CVEs in the release image that Agent-BOM was not reliably catching. The immediate causes were:
- Alpine package advisories were not ingested from Alpine's own secdb feed
- Alpine fallback coverage stopped at `v3.22` while the image base is `alpine3.23`
- the Dockerfile only upgraded `zlib`, leaving other fixable base packages behind
- image gates only blocked `HIGH/CRITICAL`, which allowed fixable medium image CVEs to ship

## Impact
- closes the fixable `openssl` and `util-linux` Alpine image findings for the next patch release
- improves local/offline Alpine OS package detection in Agent-BOM itself
- blocks future patch releases when fixable medium-or-higher image CVEs are present

## Validation
- `python scripts/check_release_consistency.py`
- `python scripts/bump-version.py 0.76.2 --check`
- `pytest tests/test_local_vuln_db.py tests/test_scanner_ecosystems.py tests/test_os_package_scanning.py -q`
- pre-commit hooks via signed commit (`ruff`, `mypy`, `bandit`, yaml/json/toml checks)

## Remaining caveat
- `CVE-2025-60876` in Alpine `busybox` does not currently have a fix published in Alpine secdb for `v3.23`, so it cannot be removed from Docker Scout with a same-distro package upgrade. This PR gates on fixable image CVEs and leaves that upstream-unfixed item explicit rather than pretending it is resolved.
