### PR TITLE
Tighten README and dashboard onboarding

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -2,9 +2,9 @@
 
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-**Open security scanner and graph for agentic infrastructure — discover agents and MCP, map blast radius, and inspect runtime.**
+**Open security scanner for AI supply chain — agents, MCP servers, packages, containers, cloud, GPU, and runtime.**
 
-Package risk is only the start. What matters is what it can reach.
+Find what is installed, see what it can reach, and understand what a vulnerable package can actually touch.
 
 ```text
 CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
@@ -17,16 +17,17 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-agent-bom maps the blast radius: CVE → package → MCP server → AI agent → credentials → tools.
+agent-bom maps blast radius: `CVE -> package -> MCP server -> agent -> credentials -> tools`.
 
-Package risk is only the start. agent-bom maps what it can reach across MCP servers, agents, credentials, tools, and runtime context. CWE-aware impact classification keeps a DoS from being reported like credential compromise.
+Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud posture, GPU surfaces, and runtime evidence.
 
-Canonical references:
+Try the built-in demo first:
 
-- Product brief: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_BRIEF.md
-- Verified metrics: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_METRICS.md
-- Enterprise controls map: https://github.com/msaad00/agent-bom/blob/main/docs/ENTERPRISE.md
-- Community: https://discord.gg/3YmYPqKZh5
+```bash
+agent-bom agents --demo --offline
+```
+
+The GIF uses that same curated sample so the output stays reproducible across releases. For real scans, run `agent-bom agents`, or add `-p .` to fold project manifests and lockfiles into the same result.
 
 ![agent-bom demo](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif)
 
@@ -35,12 +36,10 @@ Canonical references:
 ```bash
 pip install agent-bom
 
-agent-bom agents                              # Discover + scan local AI agents and MCP servers
-agent-bom agents -p .                         # Scan project manifests plus agent/MCP context
-agent-bom mesh --project .                    # Show the live agent / MCP topology
-agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
-agent-bom image nginx:latest                  # Container image scan
-agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC misconfigurations
+agent-bom agents -p .                            # Discover + scan local AI agents, MCP, and project packages
+agent-bom agents -p . --remediate remediation.md # Generate a fix-first remediation plan
+pip install 'agent-bom[ui]'                      # once, if you want the dashboard
+agent-bom serve                                  # API + dashboard + unified graph explorer
 ```
 
 ## What it scans
@@ -51,28 +50,19 @@ agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC misconfigurations
 - **Container images + IaC** — native OCI parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes coverage
 - **Cloud AI** — cloud and AI infrastructure posture across major supported providers
 - **Secrets + runtime** — MCP proxy, Shield SDK, secrets, and redaction surfaces
-- **Compliance + evidence** — mapped governance and evidence-generation views
+- **Compliance + evidence** — mapped governance plus ZIP evidence bundles for auditors
 
 ## Key features
 
 - **Blast radius mapping** — CVE → package → MCP server → agent → credentials → tools
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not
-- **Portable outputs** — SARIF, CycloneDX, SPDX, HTML, graph, JSON, and more
+- **Portable outputs** — SARIF, CycloneDX, SPDX, HTML, graph, JSON, ZIP evidence bundles, and more
 - **MCP server mode** — expose `agent-bom` capabilities directly to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE-aware reachability
 
-## Proof points
-
-- `9` threat-intel sources
-- `16` lockfile formats
-- `13` model formats
-- `36` MCP tools
-- `13` PostgreSQL RLS-backed tenant tables
-- `8` runtime detector classes
-
-Read-only. Agentless. No secrets leave your machine.
+Read-only. Agentless. No secrets leave your machine unless you explicitly enable an outbound integration.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-<p align="center"><b>Open security scanner and graph for agentic infrastructure — discover agents and MCP, map blast radius, and inspect runtime.</b></p>
+<p align="center"><b>Open security scanner for AI supply chain — agents, MCP servers, packages, containers, cloud, GPU, and runtime.</b></p>
 
-<p align="center">Security and visibility for agentic infrastructure should be open, transparent, and accessible — not reserved for teams with enterprise budgets.</p>
-
-<p align="center"><b>Package risk is only the start. What matters is what it can reach.</b></p>
+<p align="center">Find what is installed, see what it can reach, and understand what a vulnerable package can actually touch.</p>
 
 ```text
 CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
@@ -31,13 +29,9 @@ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-**agent-bom maps the blast radius**: CVE → package → MCP server → AI agent → credentials → tools.
+**agent-bom maps blast radius**: `CVE -> package -> MCP server -> agent -> credentials -> tools`.
 
-Package risk is only the start. agent-bom maps what it can reach across MCP servers, agents, credentials, tools, and runtime context. CWE-aware impact classification keeps a DoS from being reported like credential compromise.
-
-`agent-bom` is now a real released product surface, not just a research repo: installable from PyPI, publishable through Docker, usable in GitHub Actions, deployable as an authenticated API and remote MCP service, and validated end to end through CLI, reports, API, dashboard, and policy gates.
-
-For the canonical product brief and verified repo-derived metrics, see [docs/PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) and [docs/PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md). For enterprise-control traceability, see [docs/ENTERPRISE.md](docs/ENTERPRISE.md).
+Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud posture, GPU surfaces, and runtime evidence. CWE-aware impact keeps a DoS from being reported like credential compromise.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom blast radius demo" width="900" />
@@ -49,26 +43,23 @@ Try the built-in demo first:
 agent-bom agents --demo --offline
 ```
 
-The GIF uses that curated sample so the output stays reproducible across releases. For real scans, run `agent-bom agents`, or add `-p .` to fold project lockfiles and manifests into the same scan.
+The GIF uses that same curated sample so the output stays reproducible across releases. For real scans, run `agent-bom agents`, or add `-p .` to fold project manifests and lockfiles into the same result.
 
-Current repo-derived counts live in [docs/PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md). The README keeps the product story stable and leaves fast-moving counts in the generated metrics appendix.
+## First steps after the demo
 
-## First commands after install
+If you only do three things after the demo, start here:
 
-If you only run three commands, make them these:
-
-```bash
-agent-bom agents -p .              # Local agent + MCP + project package scan
-agent-bom serve                    # API + dashboard + unified graph explorer
-agent-bom proxy "npx @mcp/server-fs /workspace"   # Runtime MCP inspection path
-```
+1. Scan your repo: `agent-bom agents -p .`
+2. Generate a fix-first plan: `agent-bom agents -p . --remediate remediation.md`
+3. Add the dashboard when you want a persistent graph: `pip install 'agent-bom[ui]'` once, then `agent-bom serve`
 
 Pick the one that matches your first goal:
 
 | Goal | Run | What you get |
 |---|---|---|
 | Find what is installed and reachable | `agent-bom agents -p .` | Agent discovery, MCP mapping, project dependency findings, blast radius |
-| Review findings in a persistent graph | `agent-bom serve` | API, dashboard, unified graph, current-state and diff views |
+| Turn findings into a fix plan | `agent-bom agents -p . --remediate remediation.md` | Prioritized remediation plan with fix versions and reachable impact |
+| Review findings in a persistent graph | `agent-bom serve` | API, dashboard, unified graph, current-state and diff views. Requires `pip install 'agent-bom[ui]'` once. |
 | Inspect live MCP traffic | `agent-bom proxy "<server command>"` | Inline runtime inspection, detector chaining, response/argument review |
 
 ## Quick start
@@ -88,6 +79,15 @@ agent-bom image nginx:latest                  # Container image scan
 agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC scan across one or more paths
 ```
 
+## What to do after the first scan
+
+```bash
+agent-bom agents -p . --remediate remediation.md                    # Fix-first plan with versions and reachable impact
+agent-bom agents -p . --compliance-export fedramp -o evidence.zip   # ZIP evidence bundle for auditors
+pip install 'agent-bom[ui]'                                         # once, for API + dashboard
+agent-bom serve                                                     # Review the same findings in the dashboard and graph
+```
+
 <details>
 <summary><b>More commands</b></summary>
 
@@ -96,6 +96,7 @@ agent-bom cloud aws                     # Cloud AI posture + CIS benchmarks
 agent-bom agents -f cyclonedx -o bom.json  # AI BOM / SBOM export
 agent-bom check requests@2.33.0 -e pypi -f json  # Machine-readable pre-install verdict
 agent-bom report diff before.json after.json -f json  # CI-friendly diff output
+agent-bom agents -p . --compliance-export fedramp -o fedramp-evidence.zip  # Auditor-ready evidence bundle
 agent-bom graph report.json                # Blast radius graph / graph HTML inputs
 agent-bom proxy "npx @mcp/server-fs /ws"   # MCP security proxy
 agent-bom secrets src/                  # Hardcoded secrets + PII
@@ -112,14 +113,15 @@ agent-bom serve                         # API + Next.js dashboard
 ## Why teams use it
 
 - Blast radius that maps `CVE -> package -> MCP server -> agent -> credentials -> tools`
-- AI-native coverage across agents, skills, instruction files, runtime proxy traffic, containers, cloud, and IaC
+- AI-native coverage across agents, MCP, instruction files, runtime proxy traffic, containers, cloud, IaC, and GPU surfaces
 - Unified graph explorer with snapshots, diff, search, impact, attack paths, and OCSF-ready export
 - Supply-chain depth across lockfiles, transitive dependencies, model artifacts, provenance, and hash verification
+- Compliance evidence bundles for `cmmc`, `fedramp`, and `nist-ai-rmf`
 - One operator path across CLI, CI, API, dashboard, reports, and MCP tools
 
 ## Graph explorer
 
-The graph is now a first-class product path, not a side export. The same persisted graph supports current-state review, snapshot diffs, attack-path drilldown, search, impact, compliance posture, and OCSF-ready export.
+The graph explorer is a real product surface, not concept art. The example below is aligned to the built-in demo so the structure and labels match actual `agent-bom` output.
 
 <p align="center">
   <picture>
@@ -136,9 +138,11 @@ agent-bom graph report.json        # Generate graph-facing output from an existi
 agent-bom mesh --project .         # Quick local topology view from the CLI
 ```
 
+If the dashboard says `API Offline`, install the UI extra and run `agent-bom serve`. If the UI is already running separately, start just the backend with `pip install 'agent-bom[api]'` and `agent-bom api`.
+
 ## Architecture at a glance
 
-One pipeline: discovery and runtime inspection feed the scanners, the scanners feed the unified graph, and the same graph powers CLI, API, dashboard, search, diff, impact, attack-path drilldown, and OCSF-ready export.
+One path: discover and observe -> scan and interpret -> persist one graph -> operate across CLI, CI, API, dashboard, exports, and runtime review.
 
 <p align="center">
   <picture>
@@ -162,7 +166,12 @@ docker run --rm agentbom/agent-bom agents    # Docker
 | MCP Server | `agent-bom mcp server` | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
 | Shield SDK | `from agent_bom.shield import Shield` | In-process protection |
-| API + dashboard | `agent-bom serve` | Fleet visibility, audit exports, and central review |
+| API + dashboard | `agent-bom serve` | Fleet visibility, audit exports, and central review. Requires `pip install 'agent-bom[ui]'` once. |
+
+Product references:
+- [docs/PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md)
+- [docs/PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md)
+- [docs/ENTERPRISE.md](docs/ENTERPRISE.md)
 
 ### CI/CD in 60 seconds
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -1,12 +1,12 @@
 # Product Brief
 
-`agent-bom` is an open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.
+`agent-bom` is an open security scanner for AI supply chain — agents, MCP, packages, containers, cloud, GPU, and runtime.
 
-It is built around a simple thesis: security and visibility for agentic infrastructure should be open, transparent, and accessible, not reserved for teams with enterprise budgets.
+It is built around a simple thesis: security and visibility for AI infrastructure should be open, transparent, and accessible, not reserved for teams with enterprise budgets.
 
 Package risk is only the start. `agent-bom` follows what it can reach across MCP servers, agents, credentials, tools, runtime behavior, and trust posture. That is the core product value.
 
-As of the `0.75.x` release line, `agent-bom` is no longer just a promising codebase. It is a released OSS product with a working CLI, GitHub Action, Docker images, authenticated API and MCP deployment paths, report formats, a dashboard, and a growing enterprise-hardening track.
+`agent-bom` is a released OSS product with a working CLI, GitHub Action, Docker images, authenticated API and MCP deployment paths, report formats, a dashboard, and a growing enterprise-hardening track.
 
 Current repo-derived counts live in [PRODUCT_METRICS.md](PRODUCT_METRICS.md). This brief intentionally keeps volatile metrics out of the main narrative.
 
@@ -87,7 +87,7 @@ This is the right path because it improves product trust without diluting the MC
 
 Good external phrasing:
 
-- Open security scanner and graph for agentic infrastructure — discover agents and MCP, map blast radius, and inspect runtime
+- Open security scanner and graph for AI supply chain — discover agents and MCP, map blast radius, and inspect runtime
 - Context-aware security for agents, MCP, runtime, and AI supply chain
 - Blast radius from package risk to agents, credentials, tools, and runtime
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
-  "generated_on": "2026-04-09",
-  "version": "0.76.0",
+  "generated_on": "2026-04-10",
+  "version": "0.76.2",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,8 +5,8 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-04-09`
-- Version: `0.76.0`
+- Generated on: `2026-04-10`
+- Version: `0.76.2`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/images/architecture-stack-dark.svg
+++ b/docs/images/architecture-stack-dark.svg
@@ -26,7 +26,7 @@
   <rect width="960" height="560" rx="18" fill="url(#bg)" stroke="#27272a"/>
 
   <text x="480" y="38" text-anchor="middle" class="title">Architecture at a glance</text>
-  <text x="480" y="58" text-anchor="middle" class="subtitle">Discovery and runtime inspection feed one persisted graph that powers the product surfaces.</text>
+  <text x="480" y="58" text-anchor="middle" class="subtitle">Discover, scan, persist one graph, then operate across CLI, API, dashboard, and exports.</text>
 
   <path d="M232 238H254" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
   <path d="M464 238H486" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
@@ -45,18 +45,18 @@
   <rect x="48" y="134" width="168" height="66" rx="12" fill="#18181b" stroke="#27272a"/>
   <text x="62" y="156" class="card-title">Agents and MCP</text>
   <text x="62" y="172" class="card-copy">
-    <tspan x="62" dy="0">Claude, Cursor, Windsurf,</tspan>
-    <tspan x="62" dy="11">VS Code, local configs</tspan>
+    <tspan x="62" dy="0">Claude, Cursor, Codex,</tspan>
+    <tspan x="62" dy="11">Windsurf, local configs</tspan>
   </text>
   <rect x="62" y="182" width="48" height="16" rx="8" fill="#312e81"/><text x="86" y="193" text-anchor="middle" class="chip">agents</text>
   <rect x="116" y="182" width="40" height="16" rx="8" fill="#312e81"/><text x="136" y="193" text-anchor="middle" class="chip">MCP</text>
   <rect x="162" y="182" width="38" height="16" rx="8" fill="#312e81"/><text x="181" y="193" text-anchor="middle" class="chip">tools</text>
 
   <rect x="48" y="214" width="168" height="66" rx="12" fill="#18181b" stroke="#27272a"/>
-  <text x="62" y="236" class="card-title">Supply-chain inputs</text>
+  <text x="62" y="236" class="card-title">Packages + infra</text>
   <text x="62" y="252" class="card-copy">
-    <tspan x="62" dy="0">Lockfiles, images, IaC,</tspan>
-    <tspan x="62" dy="11">model artifacts, cloud posture</tspan>
+    <tspan x="62" dy="0">Lockfiles, containers, IaC,</tspan>
+    <tspan x="62" dy="11">cloud and model artifacts</tspan>
   </text>
   <rect x="62" y="262" width="56" height="16" rx="8" fill="#312e81"/><text x="90" y="273" text-anchor="middle" class="chip">lockfiles</text>
   <rect x="124" y="262" width="42" height="16" rx="8" fill="#312e81"/><text x="145" y="273" text-anchor="middle" class="chip">images</text>
@@ -66,7 +66,7 @@
   <text x="62" y="316" class="card-title">Runtime signals</text>
   <text x="62" y="332" class="card-copy">
     <tspan x="62" dy="0">Proxy traffic, Shield hooks,</tspan>
-    <tspan x="62" dy="11">drift, credential, and sequence checks</tspan>
+    <tspan x="62" dy="11">drift and policy signals</tspan>
   </text>
   <rect x="62" y="346" width="40" height="16" rx="8" fill="#312e81"/><text x="82" y="357" text-anchor="middle" class="chip">proxy</text>
   <rect x="108" y="346" width="42" height="16" rx="8" fill="#312e81"/><text x="129" y="357" text-anchor="middle" class="chip">Shield</text>
@@ -74,13 +74,13 @@
 
   <rect x="48" y="382" width="168" height="44" rx="12" fill="#1f172a" stroke="#4c1d95"/>
   <text x="62" y="401" class="note-title">INPUTS</text>
-  <text x="62" y="417" class="note-copy">Inventory, findings, runtime evidence, config posture</text>
+  <text x="62" y="417" class="note-copy">Configs, evidence, inventory</text>
 
   <rect x="280" y="134" width="168" height="66" rx="12" fill="#18181b" stroke="#27272a"/>
   <text x="294" y="156" class="card-title">Core scanning</text>
   <text x="294" y="172" class="card-copy">
-    <tspan x="294" dy="0">Package CVEs, secrets,</tspan>
-    <tspan x="294" dy="11">containers, IaC, cloud posture</tspan>
+    <tspan x="294" dy="0">CVEs, secrets, containers,</tspan>
+    <tspan x="294" dy="11">IaC, cloud, GPU posture</tspan>
   </text>
   <rect x="294" y="182" width="34" height="16" rx="8" fill="#4c0519"/><text x="311" y="193" text-anchor="middle" class="chip">CVE</text>
   <rect x="334" y="182" width="46" height="16" rx="8" fill="#4c0519"/><text x="357" y="193" text-anchor="middle" class="chip">secrets</text>
@@ -90,7 +90,7 @@
   <text x="294" y="236" class="card-title">AST + SAST depth</text>
   <text x="294" y="252" class="card-copy">
     <tspan x="294" dy="0">Python, JS/TS, Go,</tspan>
-    <tspan x="294" dy="11">cross-file flows, taint, SARIF</tspan>
+    <tspan x="294" dy="11">AST, SAST, taint, SARIF</tspan>
   </text>
   <rect x="294" y="262" width="32" height="16" rx="8" fill="#4c0519"/><text x="310" y="273" text-anchor="middle" class="chip">AST</text>
   <rect x="332" y="262" width="38" height="16" rx="8" fill="#4c0519"/><text x="351" y="273" text-anchor="middle" class="chip">SAST</text>
@@ -100,12 +100,12 @@
   <text x="294" y="316" class="card-title">Risk interpretation</text>
   <text x="294" y="332" class="card-copy">
     <tspan x="294" dy="0">Blast radius, CWE impact,</tspan>
-    <tspan x="294" dy="11">compliance tags, trust posture</tspan>
+    <tspan x="294" dy="11">trust, compliance, fix-first</tspan>
   </text>
 
   <rect x="280" y="382" width="168" height="44" rx="12" fill="#3f1d0a" stroke="#9a3412"/>
   <text x="294" y="401" class="note-title">OUTPUT</text>
-  <text x="294" y="417" class="note-copy">Entities, findings, attack-path facts, remediation context</text>
+  <text x="294" y="417" class="note-copy">Findings, paths, remediation</text>
 
   <rect x="512" y="134" width="168" height="66" rx="12" fill="#18181b" stroke="#27272a"/>
   <text x="526" y="156" class="card-title">Canonical contract</text>
@@ -120,15 +120,15 @@
   <rect x="512" y="214" width="168" height="66" rx="12" fill="#18181b" stroke="#27272a"/>
   <text x="526" y="236" class="card-title">Persistence + tenancy</text>
   <text x="526" y="252" class="card-copy">
-    <tspan x="526" dy="0">SQLite or Postgres, tenant snapshots,</tspan>
-    <tspan x="526" dy="11">presets, latest-state resolution</tspan>
+    <tspan x="526" dy="0">SQLite or Postgres, snapshots,</tspan>
+    <tspan x="526" dy="11">latest state and tenancy</tspan>
   </text>
 
   <rect x="512" y="294" width="168" height="74" rx="12" fill="#18181b" stroke="#27272a"/>
   <text x="526" y="316" class="card-title">Views and pivots</text>
   <text x="526" y="332" class="card-copy">
-    <tspan x="526" dy="0">Current state, diff, search, impact,</tspan>
-    <tspan x="526" dy="11">attack paths, compliance, OCSF export</tspan>
+    <tspan x="526" dy="0">Search, impact, diff,</tspan>
+    <tspan x="526" dy="11">attack paths, compliance, OCSF</tspan>
   </text>
   <rect x="526" y="346" width="40" height="16" rx="8" fill="#052e16"/><text x="546" y="357" text-anchor="middle" class="chip">graph</text>
   <rect x="572" y="346" width="34" height="16" rx="8" fill="#052e16"/><text x="589" y="357" text-anchor="middle" class="chip">diff</text>
@@ -136,7 +136,7 @@
 
   <rect x="512" y="382" width="168" height="44" rx="12" fill="#052e16" stroke="#047857"/>
   <text x="526" y="401" class="note-title">ONE GRAPH</text>
-  <text x="526" y="417" class="note-copy">Same contract across CLI, API, dashboard, exports, and policy</text>
+  <text x="526" y="417" class="note-copy">Same graph across every surface</text>
 
   <rect x="744" y="134" width="168" height="66" rx="12" fill="#18181b" stroke="#27272a"/>
   <text x="758" y="156" class="card-title">CLI + CI</text>
@@ -155,8 +155,8 @@
   <rect x="744" y="294" width="168" height="74" rx="12" fill="#18181b" stroke="#27272a"/>
   <text x="758" y="316" class="card-title">Runtime + export</text>
   <text x="758" y="332" class="card-copy">
-    <tspan x="758" dy="0">Proxy enforcement, OCSF,</tspan>
-    <tspan x="758" dy="11">HTML/PDF reports, evidence bundles</tspan>
+    <tspan x="758" dy="0">Proxy enforcement, HTML/PDF,</tspan>
+    <tspan x="758" dy="11">evidence bundles, OCSF</tspan>
   </text>
   <rect x="758" y="346" width="40" height="16" rx="8" fill="#172554"/><text x="778" y="357" text-anchor="middle" class="chip">graph</text>
   <rect x="804" y="346" width="38" height="16" rx="8" fill="#172554"/><text x="823" y="357" text-anchor="middle" class="chip">delta</text>
@@ -164,9 +164,9 @@
 
   <rect x="744" y="382" width="168" height="44" rx="12" fill="#172554" stroke="#2563eb"/>
   <text x="758" y="401" class="note-title">USER PATH</text>
-  <text x="758" y="417" class="note-copy">One product surface from local scan to central review</text>
+  <text x="758" y="417" class="note-copy">Local scan -&gt; graph -&gt; team review</text>
 
   <rect x="32" y="468" width="896" height="56" rx="16" fill="#030712" stroke="#1f2937"/>
   <text x="56" y="491" class="summary-title">Why this matters</text>
-  <text x="56" y="510" class="summary-copy">The same persisted graph powers search, impact, diff, attack-path drilldown, OCSF export, and runtime-aware review.</text>
+  <text x="56" y="510" class="summary-copy">One persisted graph powers search, impact, diff, remediation, and runtime-aware review.</text>
 </svg>

--- a/docs/images/architecture-stack-light.svg
+++ b/docs/images/architecture-stack-light.svg
@@ -26,7 +26,7 @@
   <rect width="960" height="560" rx="18" fill="url(#bg)" stroke="#e5e7eb"/>
 
   <text x="480" y="38" text-anchor="middle" class="title">Architecture at a glance</text>
-  <text x="480" y="58" text-anchor="middle" class="subtitle">Discovery and runtime inspection feed one persisted graph that powers the product surfaces.</text>
+  <text x="480" y="58" text-anchor="middle" class="subtitle">Discover, scan, persist one graph, then operate across CLI, API, dashboard, and exports.</text>
 
   <path d="M232 238H254" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
   <path d="M464 238H486" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
@@ -45,18 +45,18 @@
   <rect x="48" y="134" width="168" height="66" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="62" y="156" class="card-title">Agents and MCP</text>
   <text x="62" y="172" class="card-copy">
-    <tspan x="62" dy="0">Claude, Cursor, Windsurf,</tspan>
-    <tspan x="62" dy="11">VS Code, local configs</tspan>
+    <tspan x="62" dy="0">Claude, Cursor, Codex,</tspan>
+    <tspan x="62" dy="11">Windsurf, local configs</tspan>
   </text>
   <rect x="62" y="182" width="48" height="16" rx="8" fill="#ede9fe"/><text x="86" y="193" text-anchor="middle" class="chip">agents</text>
   <rect x="116" y="182" width="40" height="16" rx="8" fill="#ede9fe"/><text x="136" y="193" text-anchor="middle" class="chip">MCP</text>
   <rect x="162" y="182" width="38" height="16" rx="8" fill="#ede9fe"/><text x="181" y="193" text-anchor="middle" class="chip">tools</text>
 
   <rect x="48" y="214" width="168" height="66" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="62" y="236" class="card-title">Supply-chain inputs</text>
+  <text x="62" y="236" class="card-title">Packages + infra</text>
   <text x="62" y="252" class="card-copy">
-    <tspan x="62" dy="0">Lockfiles, images, IaC,</tspan>
-    <tspan x="62" dy="11">model artifacts, cloud posture</tspan>
+    <tspan x="62" dy="0">Lockfiles, containers, IaC,</tspan>
+    <tspan x="62" dy="11">cloud and model artifacts</tspan>
   </text>
   <rect x="62" y="262" width="56" height="16" rx="8" fill="#ede9fe"/><text x="90" y="273" text-anchor="middle" class="chip">lockfiles</text>
   <rect x="124" y="262" width="42" height="16" rx="8" fill="#ede9fe"/><text x="145" y="273" text-anchor="middle" class="chip">images</text>
@@ -66,7 +66,7 @@
   <text x="62" y="316" class="card-title">Runtime signals</text>
   <text x="62" y="332" class="card-copy">
     <tspan x="62" dy="0">Proxy traffic, Shield hooks,</tspan>
-    <tspan x="62" dy="11">drift, credential, and sequence checks</tspan>
+    <tspan x="62" dy="11">drift and policy signals</tspan>
   </text>
   <rect x="62" y="346" width="40" height="16" rx="8" fill="#ede9fe"/><text x="82" y="357" text-anchor="middle" class="chip">proxy</text>
   <rect x="108" y="346" width="42" height="16" rx="8" fill="#ede9fe"/><text x="129" y="357" text-anchor="middle" class="chip">Shield</text>
@@ -74,13 +74,13 @@
 
   <rect x="48" y="382" width="168" height="44" rx="12" fill="#faf5ff" stroke="#ddd6fe"/>
   <text x="62" y="401" class="note-title">INPUTS</text>
-  <text x="62" y="417" class="note-copy">Inventory, findings, runtime evidence, config posture</text>
+  <text x="62" y="417" class="note-copy">Configs, evidence, inventory</text>
 
   <rect x="280" y="134" width="168" height="66" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="294" y="156" class="card-title">Core scanning</text>
   <text x="294" y="172" class="card-copy">
-    <tspan x="294" dy="0">Package CVEs, secrets,</tspan>
-    <tspan x="294" dy="11">containers, IaC, cloud posture</tspan>
+    <tspan x="294" dy="0">CVEs, secrets, containers,</tspan>
+    <tspan x="294" dy="11">IaC, cloud, GPU posture</tspan>
   </text>
   <rect x="294" y="182" width="34" height="16" rx="8" fill="#fee2e2"/><text x="311" y="193" text-anchor="middle" class="chip">CVE</text>
   <rect x="334" y="182" width="46" height="16" rx="8" fill="#fee2e2"/><text x="357" y="193" text-anchor="middle" class="chip">secrets</text>
@@ -90,7 +90,7 @@
   <text x="294" y="236" class="card-title">AST + SAST depth</text>
   <text x="294" y="252" class="card-copy">
     <tspan x="294" dy="0">Python, JS/TS, Go,</tspan>
-    <tspan x="294" dy="11">cross-file flows, taint, SARIF</tspan>
+    <tspan x="294" dy="11">AST, SAST, taint, SARIF</tspan>
   </text>
   <rect x="294" y="262" width="32" height="16" rx="8" fill="#fee2e2"/><text x="310" y="273" text-anchor="middle" class="chip">AST</text>
   <rect x="332" y="262" width="38" height="16" rx="8" fill="#fee2e2"/><text x="351" y="273" text-anchor="middle" class="chip">SAST</text>
@@ -100,12 +100,12 @@
   <text x="294" y="316" class="card-title">Risk interpretation</text>
   <text x="294" y="332" class="card-copy">
     <tspan x="294" dy="0">Blast radius, CWE impact,</tspan>
-    <tspan x="294" dy="11">compliance tags, trust posture</tspan>
+    <tspan x="294" dy="11">trust, compliance, fix-first</tspan>
   </text>
 
   <rect x="280" y="382" width="168" height="44" rx="12" fill="#fff7ed" stroke="#fdba74"/>
   <text x="294" y="401" class="note-title">OUTPUT</text>
-  <text x="294" y="417" class="note-copy">Entities, findings, attack-path facts, remediation context</text>
+  <text x="294" y="417" class="note-copy">Findings, paths, remediation</text>
 
   <rect x="512" y="134" width="168" height="66" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="526" y="156" class="card-title">Canonical contract</text>
@@ -120,15 +120,15 @@
   <rect x="512" y="214" width="168" height="66" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="526" y="236" class="card-title">Persistence + tenancy</text>
   <text x="526" y="252" class="card-copy">
-    <tspan x="526" dy="0">SQLite or Postgres, tenant snapshots,</tspan>
-    <tspan x="526" dy="11">presets, latest-state resolution</tspan>
+    <tspan x="526" dy="0">SQLite or Postgres, snapshots,</tspan>
+    <tspan x="526" dy="11">latest state and tenancy</tspan>
   </text>
 
   <rect x="512" y="294" width="168" height="74" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="526" y="316" class="card-title">Views and pivots</text>
   <text x="526" y="332" class="card-copy">
-    <tspan x="526" dy="0">Current state, diff, search, impact,</tspan>
-    <tspan x="526" dy="11">attack paths, compliance, OCSF export</tspan>
+    <tspan x="526" dy="0">Search, impact, diff,</tspan>
+    <tspan x="526" dy="11">attack paths, compliance, OCSF</tspan>
   </text>
   <rect x="526" y="346" width="40" height="16" rx="8" fill="#dcfce7"/><text x="546" y="357" text-anchor="middle" class="chip">graph</text>
   <rect x="572" y="346" width="34" height="16" rx="8" fill="#dcfce7"/><text x="589" y="357" text-anchor="middle" class="chip">diff</text>
@@ -136,7 +136,7 @@
 
   <rect x="512" y="382" width="168" height="44" rx="12" fill="#ecfdf5" stroke="#86efac"/>
   <text x="526" y="401" class="note-title">ONE GRAPH</text>
-  <text x="526" y="417" class="note-copy">Same contract across CLI, API, dashboard, exports, and policy</text>
+  <text x="526" y="417" class="note-copy">Same graph across every surface</text>
 
   <rect x="744" y="134" width="168" height="66" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="758" y="156" class="card-title">CLI + CI</text>
@@ -155,8 +155,8 @@
   <rect x="744" y="294" width="168" height="74" rx="12" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="758" y="316" class="card-title">Runtime + export</text>
   <text x="758" y="332" class="card-copy">
-    <tspan x="758" dy="0">Proxy enforcement, OCSF,</tspan>
-    <tspan x="758" dy="11">HTML/PDF reports, evidence bundles</tspan>
+    <tspan x="758" dy="0">Proxy enforcement, HTML/PDF,</tspan>
+    <tspan x="758" dy="11">evidence bundles, OCSF</tspan>
   </text>
   <rect x="758" y="346" width="40" height="16" rx="8" fill="#dbeafe"/><text x="778" y="357" text-anchor="middle" class="chip">graph</text>
   <rect x="804" y="346" width="38" height="16" rx="8" fill="#dbeafe"/><text x="823" y="357" text-anchor="middle" class="chip">delta</text>
@@ -164,9 +164,9 @@
 
   <rect x="744" y="382" width="168" height="44" rx="12" fill="#eff6ff" stroke="#93c5fd"/>
   <text x="758" y="401" class="note-title">USER PATH</text>
-  <text x="758" y="417" class="note-copy">One product surface from local scan to central review</text>
+  <text x="758" y="417" class="note-copy">Local scan -&gt; graph -&gt; team review</text>
 
   <rect x="32" y="468" width="896" height="56" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
   <text x="56" y="491" class="summary-title">Why this matters</text>
-  <text x="56" y="510" class="summary-copy">The same persisted graph powers search, impact, diff, attack-path drilldown, OCSF export, and runtime-aware review.</text>
+  <text x="56" y="510" class="summary-copy">One persisted graph powers search, impact, diff, remediation, and runtime-aware review.</text>
 </svg>

--- a/docs/images/topology-dark.svg
+++ b/docs/images/topology-dark.svg
@@ -1,239 +1,150 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" fill="none">
   <style>
     text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
-    .title { font-size: 16px; font-weight: 700; fill: #f4f4f5; }
-    .subtitle { font-size: 10.5px; font-weight: 400; fill: #52525b; }
-    .layer-label { font-size: 9px; font-weight: 700; letter-spacing: 0.1em; fill: #3f3f46; }
-    .node-type { font-size: 8px; font-weight: 700; letter-spacing: 0.1em; }
-    .node-label { font-size: 11.5px; font-weight: 700; fill: #e4e4e7; }
-    .node-detail { font-size: 9px; font-weight: 400; fill: #71717a; }
-    .tool-name { font-size: 8.5px; font-weight: 600; font-family: ui-monospace, monospace; fill: #a1a1aa; }
-    .cred-name { font-size: 8.5px; font-weight: 600; font-family: ui-monospace, monospace; fill: #fbbf24; }
-    .badge { font-size: 8px; font-weight: 700; }
-    .legend-label { font-size: 9px; font-weight: 500; fill: #71717a; }
+    .title { font-size: 18px; font-weight: 800; fill: #f8fafc; }
+    .subtitle { font-size: 11px; font-weight: 500; fill: #94a3b8; }
+    .section { font-size: 10px; font-weight: 800; letter-spacing: 0.12em; }
+    .card-title { font-size: 12px; font-weight: 760; fill: #f8fafc; }
+    .card-copy { font-size: 9.5px; font-weight: 500; fill: #94a3b8; }
+    .chip { font-size: 8px; font-weight: 700; fill: #e5e7eb; }
+    .pill { font-size: 9px; font-weight: 700; fill: #e5e7eb; }
+    .footer-title { font-size: 10px; font-weight: 800; fill: #f8fafc; }
+    .footer-copy { font-size: 9.5px; font-weight: 600; fill: #cbd5e1; }
   </style>
 
-  <!-- Background -->
-  <rect width="960" height="520" rx="12" fill="#09090b"/>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="560" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#09090b"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
 
-  <!-- Title -->
-  <text x="480" y="30" text-anchor="middle" class="title">Unified graph explorer — current environment topology</text>
-  <text x="480" y="46" text-anchor="middle" class="subtitle">Persisted graph view of agents, MCP servers, tools, and credential exposure with shared-infrastructure context</text>
+  <rect width="960" height="560" rx="18" fill="url(#bg)" stroke="#27272a"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER LABELS (left side)                                                -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <text x="16" y="100" class="layer-label" transform="rotate(-90, 16, 100)">AI AGENTS</text>
-  <text x="16" y="260" class="layer-label" transform="rotate(-90, 16, 260)">MCP SERVERS</text>
-  <text x="16" y="420" class="layer-label" transform="rotate(-90, 16, 420)">TOOLS + CREDENTIALS</text>
+  <text x="480" y="36" text-anchor="middle" class="title">Graph explorer — built-in demo topology</text>
+  <text x="480" y="56" text-anchor="middle" class="subtitle">Real README example derived from `agent-bom agents --demo --offline`.</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- EDGES: Agents → Servers (drawn first)                                   -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="252" y="74" width="72" height="22" rx="11" fill="#172554" stroke="#1d4ed8"/>
+  <text x="288" y="88" text-anchor="middle" class="pill">2 agents</text>
+  <rect x="336" y="74" width="92" height="22" rx="11" fill="#1e1b4b" stroke="#4f46e5"/>
+  <text x="382" y="88" text-anchor="middle" class="pill">4 MCP servers</text>
+  <rect x="440" y="74" width="92" height="22" rx="11" fill="#082f49" stroke="#0891b2"/>
+  <text x="486" y="88" text-anchor="middle" class="pill">12 packages</text>
+  <rect x="544" y="74" width="86" height="22" rx="11" fill="#431407" stroke="#ea580c"/>
+  <text x="587" y="88" text-anchor="middle" class="pill">55 vulns</text>
+  <rect x="642" y="74" width="92" height="22" rx="11" fill="#450a0a" stroke="#dc2626"/>
+  <text x="688" y="88" text-anchor="middle" class="pill">2 critical</text>
 
-  <!-- Claude Desktop → sqlite-mcp -->
-  <path d="M160 138 C160 170, 120 190, 120 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.25" fill="none"/>
-  <!-- Claude Desktop → filesystem-mcp (shared) -->
-  <path d="M190 138 C190 170, 360 190, 360 218" stroke="#3b82f6" stroke-width="2" opacity="0.35" fill="none"/>
-  <!-- Claude Desktop → github-mcp -->
-  <path d="M220 138 C230 170, 580 185, 580 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.25" fill="none"/>
+  <text x="52" y="124" class="section" fill="#60a5fa">AGENTS</text>
+  <text x="336" y="124" class="section" fill="#c4b5fd">MCP SERVERS</text>
+  <text x="744" y="124" class="section" fill="#34d399">REACHABLE TOOLS + CREDS</text>
 
-  <!-- Cursor → filesystem-mcp (shared) -->
-  <path d="M420 138 C420 170, 370 190, 370 218" stroke="#3b82f6" stroke-width="2" opacity="0.35" fill="none"/>
-  <!-- Cursor → sqlite-mcp -->
-  <path d="M390 138 C390 170, 130 190, 130 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.25" fill="none"/>
-  <!-- Cursor → web-search -->
-  <path d="M450 138 C450 170, 810 185, 810 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.25" fill="none"/>
+  <path d="M272 178C306 178 300 166 336 166" stroke="#334155" stroke-width="2" fill="none"/>
+  <path d="M272 178C306 178 300 270 336 270" stroke="#334155" stroke-width="2" fill="none"/>
+  <path d="M272 282C306 282 300 374 336 374" stroke="#334155" stroke-width="2" fill="none"/>
+  <path d="M272 282C306 282 300 478 336 478" stroke="#334155" stroke-width="2" fill="none"/>
 
-  <!-- Windsurf → filesystem-mcp (shared) -->
-  <path d="M650 138 C650 175, 380 190, 380 218" stroke="#3b82f6" stroke-width="2" opacity="0.35" fill="none"/>
-  <!-- Windsurf → github-mcp -->
-  <path d="M680 138 C680 170, 590 190, 590 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.25" fill="none"/>
+  <path d="M520 166C556 166 708 166 744 166" stroke="#334155" stroke-width="2" fill="none"/>
+  <path d="M728 166C700 166 640 166 640 270" stroke="#334155" stroke-width="2" fill="none" opacity="0.85"/>
+  <path d="M520 270C556 270 708 270 744 270" stroke="#334155" stroke-width="2" fill="none"/>
+  <path d="M728 270C700 270 640 270 640 374" stroke="#334155" stroke-width="2" fill="none" opacity="0.85"/>
+  <path d="M520 374C556 374 708 374 744 374" stroke="#334155" stroke-width="2" fill="none"/>
+  <path d="M520 478C556 478 708 478 744 478" stroke="#334155" stroke-width="2" fill="none"/>
 
-  <!-- VS Code → web-search -->
-  <path d="M890 138 C890 170, 820 190, 820 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.25" fill="none"/>
-  <!-- VS Code → github-mcp -->
-  <path d="M870 138 C870 170, 600 190, 600 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.25" fill="none"/>
+  <rect x="48" y="138" width="224" height="80" rx="14" fill="#18181b" stroke="#1d4ed8"/>
+  <rect x="48" y="138" width="5" height="80" rx="2.5" fill="#2563eb"/>
+  <text x="68" y="160" class="card-title">cursor</text>
+  <text x="68" y="177" class="card-copy">
+    <tspan x="68" dy="0">Uses the filesystem and database servers</tspan>
+    <tspan x="68" dy="12">and carries the highest blast-radius path in the demo.</tspan>
+  </text>
+  <rect x="68" y="190" width="84" height="16" rx="8" fill="#1d4ed8"/><text x="110" y="201" text-anchor="middle" class="chip">2 servers</text>
+  <rect x="158" y="190" width="88" height="16" rx="8" fill="#7f1d1d"/><text x="202" y="201" text-anchor="middle" class="chip">critical path</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- EDGES: Servers → Tools/Credentials                                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="48" y="242" width="224" height="80" rx="14" fill="#18181b" stroke="#1d4ed8"/>
+  <rect x="48" y="242" width="5" height="80" rx="2.5" fill="#2563eb"/>
+  <text x="68" y="264" class="card-title">claude-desktop</text>
+  <text x="68" y="281" class="card-copy">
+    <tspan x="68" dy="0">Uses the GitHub and team-chat servers</tspan>
+    <tspan x="68" dy="12">with token-backed tools and collaboration workflows.</tspan>
+  </text>
+  <rect x="68" y="294" width="84" height="16" rx="8" fill="#1d4ed8"/><text x="110" y="305" text-anchor="middle" class="chip">2 servers</text>
+  <rect x="158" y="294" width="78" height="16" rx="8" fill="#14532d"/><text x="197" y="305" text-anchor="middle" class="chip">review path</text>
 
-  <!-- sqlite-mcp → its tools -->
-  <path d="M100 290 C100 310, 60 330, 60 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <path d="M120 290 C120 310, 140 330, 140 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <path d="M140 290 C140 310, 220 330, 220 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <!-- sqlite-mcp → creds -->
-  <path d="M130 290 C130 315, 80 390, 80 408" stroke="#f59e0b" stroke-width="1" opacity="0.2" fill="none"/>
+  <rect x="336" y="126" width="184" height="80" rx="14" fill="#18181b" stroke="#3f3f46"/>
+  <rect x="336" y="126" width="5" height="80" rx="2.5" fill="#8b5cf6"/>
+  <text x="356" y="148" class="card-title">filesystem-server</text>
+  <text x="356" y="165" class="card-copy">
+    <tspan x="356" dy="0">3 npm packages powering local file operations</tspan>
+    <tspan x="356" dy="12">for `read_file`, `write_file`, and `list_directory`.</tspan>
+  </text>
+  <rect x="356" y="178" width="84" height="16" rx="8" fill="#312e81"/><text x="398" y="189" text-anchor="middle" class="chip">3 packages</text>
+  <rect x="446" y="178" width="54" height="16" rx="8" fill="#172554"/><text x="473" y="189" text-anchor="middle" class="chip">local FS</text>
 
-  <!-- filesystem-mcp → its tools -->
-  <path d="M340 290 C340 310, 310 330, 310 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <path d="M360 290 C360 310, 390 330, 390 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <path d="M380 290 C380 310, 470 330, 470 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
+  <rect x="336" y="230" width="184" height="80" rx="14" fill="#18181b" stroke="#dc2626"/>
+  <rect x="336" y="230" width="5" height="80" rx="2.5" fill="#ef4444"/>
+  <text x="356" y="252" class="card-title">database-server</text>
+  <text x="356" y="269" class="card-copy">
+    <tspan x="356" dy="0">5 Python packages including `flask`, `requests`,</tspan>
+    <tspan x="356" dy="12">`cryptography`, and `pillow` in the critical path.</tspan>
+  </text>
+  <rect x="356" y="282" width="82" height="16" rx="8" fill="#7f1d1d"/><text x="397" y="293" text-anchor="middle" class="chip">5 packages</text>
+  <rect x="444" y="282" width="56" height="16" rx="8" fill="#713f12"/><text x="472" y="293" text-anchor="middle" class="chip">2 creds</text>
 
-  <!-- github-mcp → its tools -->
-  <path d="M570 290 C570 310, 550 330, 550 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <path d="M590 290 C590 310, 630 330, 630 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <!-- github-mcp → creds -->
-  <path d="M600 290 C600 315, 370 390, 370 408" stroke="#f59e0b" stroke-width="1" opacity="0.2" fill="none"/>
+  <rect x="336" y="334" width="184" height="80" rx="14" fill="#18181b" stroke="#3f3f46"/>
+  <rect x="336" y="334" width="5" height="80" rx="2.5" fill="#8b5cf6"/>
+  <text x="356" y="356" class="card-title">github-server</text>
+  <text x="356" y="373" class="card-copy">
+    <tspan x="356" dy="0">2 npm packages with repo-writing actions like</tspan>
+    <tspan x="356" dy="12">`create_issue`, `search_repos`, and `push_files`.</tspan>
+  </text>
+  <rect x="356" y="386" width="82" height="16" rx="8" fill="#14532d"/><text x="397" y="397" text-anchor="middle" class="chip">repo ops</text>
+  <rect x="444" y="386" width="56" height="16" rx="8" fill="#713f12"/><text x="472" y="397" text-anchor="middle" class="chip">1 token</text>
 
-  <!-- web-search → its tools -->
-  <path d="M800 290 C800 310, 780 330, 780 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <path d="M820 290 C820 310, 860 330, 860 348" stroke="#a78bfa" stroke-width="1" opacity="0.2" fill="none"/>
-  <!-- web-search → creds -->
-  <path d="M810 290 C810 315, 590 390, 590 408" stroke="#f59e0b" stroke-width="1" opacity="0.2" fill="none"/>
+  <rect x="336" y="438" width="184" height="80" rx="14" fill="#18181b" stroke="#3f3f46"/>
+  <rect x="336" y="438" width="5" height="80" rx="2.5" fill="#8b5cf6"/>
+  <text x="356" y="460" class="card-title">team-chat-server</text>
+  <text x="356" y="477" class="card-copy">
+    <tspan x="356" dy="0">2 Python packages with collaboration actions like</tspan>
+    <tspan x="356" dy="12">`send_message` and `list_channels`.</tspan>
+  </text>
+  <rect x="356" y="490" width="86" height="16" rx="8" fill="#713f12"/><text x="399" y="501" text-anchor="middle" class="chip">2 secrets</text>
+  <rect x="448" y="490" width="50" height="16" rx="8" fill="#164e63"/><text x="473" y="501" text-anchor="middle" class="chip">chat ops</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 1: AI AGENTS                                                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
+  <rect x="744" y="126" width="168" height="80" rx="14" fill="#18181b" stroke="#166534"/>
+  <text x="762" y="148" class="card-title">filesystem surface</text>
+  <text x="762" y="165" class="card-copy">
+    <tspan x="762" dy="0">`read_file`, `write_file`,</tspan>
+    <tspan x="762" dy="12">`list_directory`</tspan>
+  </text>
+  <rect x="762" y="180" width="54" height="16" rx="8" fill="#14532d"/><text x="789" y="191" text-anchor="middle" class="chip">3 tools</text>
 
-  <!-- Agent: Claude Desktop -->
-  <rect x="100" y="74" width="160" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <rect x="100" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="120" y="92" class="node-type" fill="#3b82f6">AI AGENT</text>
-  <text x="120" y="108" class="node-label">Claude Desktop</text>
-  <text x="120" y="122" class="node-detail">3 servers · 8 tools</text>
+  <rect x="744" y="230" width="168" height="80" rx="14" fill="#18181b" stroke="#dc2626"/>
+  <text x="762" y="252" class="card-title">database blast radius</text>
+  <text x="762" y="269" class="card-copy">
+    <tspan x="762" dy="0">`DATABASE_URL`, `ANTHROPIC_API_KEY`,</tspan>
+    <tspan x="762" dy="12">`run_query`, `execute_sql`, `export_csv`</tspan>
+  </text>
+  <rect x="762" y="284" width="58" height="16" rx="8" fill="#7f1d1d"/><text x="791" y="295" text-anchor="middle" class="chip">2 creds</text>
+  <rect x="826" y="284" width="58" height="16" rx="8" fill="#7f1d1d"/><text x="855" y="295" text-anchor="middle" class="chip">3 tools</text>
 
-  <!-- Agent: Cursor -->
-  <rect x="330" y="74" width="160" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <rect x="330" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="350" y="92" class="node-type" fill="#3b82f6">AI AGENT</text>
-  <text x="350" y="108" class="node-label">Cursor IDE</text>
-  <text x="350" y="122" class="node-detail">3 servers · 9 tools</text>
+  <rect x="744" y="334" width="168" height="80" rx="14" fill="#18181b" stroke="#166534"/>
+  <text x="762" y="356" class="card-title">GitHub reach</text>
+  <text x="762" y="373" class="card-copy">
+    <tspan x="762" dy="0">`GITHUB_TOKEN`, `create_issue`,</tspan>
+    <tspan x="762" dy="12">`search_repos`, `push_files`</tspan>
+  </text>
+  <rect x="762" y="388" width="58" height="16" rx="8" fill="#14532d"/><text x="791" y="399" text-anchor="middle" class="chip">1 token</text>
 
-  <!-- Agent: Windsurf -->
-  <rect x="570" y="74" width="160" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <rect x="570" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="590" y="92" class="node-type" fill="#3b82f6">AI AGENT</text>
-  <text x="590" y="108" class="node-label">Windsurf</text>
-  <text x="590" y="122" class="node-detail">2 servers · 5 tools</text>
+  <rect x="744" y="438" width="168" height="80" rx="14" fill="#18181b" stroke="#a16207"/>
+  <text x="762" y="460" class="card-title">team-chat reach</text>
+  <text x="762" y="477" class="card-copy">
+    <tspan x="762" dy="0">`SLACK_BOT_TOKEN`,</tspan>
+    <tspan x="762" dy="12">`SLACK_SIGNING_SECRET`, `send_message`</tspan>
+  </text>
+  <rect x="762" y="492" width="58" height="16" rx="8" fill="#713f12"/><text x="791" y="503" text-anchor="middle" class="chip">2 secrets</text>
 
-  <!-- Agent: VS Code Copilot -->
-  <rect x="800" y="74" width="140" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <rect x="800" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="820" y="92" class="node-type" fill="#3b82f6">AI AGENT</text>
-  <text x="820" y="108" class="node-label">VS Code Copilot</text>
-  <text x="820" y="122" class="node-detail">2 servers · 4 tools</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 2: MCP SERVERS                                                    -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-
-  <!-- Server: sqlite-mcp (unverified, red border) -->
-  <rect x="52" y="218" width="170" height="72" rx="10" fill="#18181b" stroke="#ef4444" stroke-width="1.5" stroke-opacity="0.4"/>
-  <rect x="52" y="218" width="4" height="72" rx="2" fill="#a78bfa"/>
-  <text x="72" y="236" class="node-type" fill="#a78bfa">MCP SERVER</text>
-  <text x="72" y="252" class="node-label">sqlite-mcp</text>
-  <text x="72" y="266" class="node-detail">3 tools · runs as root</text>
-  <!-- Unverified badge -->
-  <rect x="160" y="222" width="56" height="16" rx="8" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="188" y="233" text-anchor="middle" class="badge" fill="#fca5a5">unverified</text>
-
-  <!-- Server: filesystem-mcp (shared by 3 agents, highlighted) -->
-  <rect x="272" y="218" width="170" height="72" rx="10" fill="#18181b" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.4"/>
-  <rect x="272" y="218" width="4" height="72" rx="2" fill="#a78bfa"/>
-  <text x="292" y="236" class="node-type" fill="#a78bfa">MCP SERVER</text>
-  <text x="292" y="252" class="node-label">filesystem-mcp</text>
-  <text x="292" y="266" class="node-detail">3 tools · read/write access</text>
-  <!-- Shared badge -->
-  <rect x="380" y="222" width="56" height="16" rx="8" fill="#f59e0b" fill-opacity="0.15" stroke="#f59e0b" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="408" y="233" text-anchor="middle" class="badge" fill="#fbbf24">3 agents</text>
-
-  <!-- Server: github-mcp -->
-  <rect x="502" y="218" width="170" height="72" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <rect x="502" y="218" width="4" height="72" rx="2" fill="#a78bfa"/>
-  <text x="522" y="236" class="node-type" fill="#a78bfa">MCP SERVER</text>
-  <text x="522" y="252" class="node-label">github-mcp</text>
-  <text x="522" y="266" class="node-detail">2 tools · verified</text>
-  <!-- Verified badge -->
-  <rect x="620" y="222" width="46" height="16" rx="8" fill="#10b981" fill-opacity="0.15" stroke="#10b981" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="643" y="233" text-anchor="middle" class="badge" fill="#34d399">verified</text>
-
-  <!-- Server: web-search -->
-  <rect x="732" y="218" width="170" height="72" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <rect x="732" y="218" width="4" height="72" rx="2" fill="#a78bfa"/>
-  <text x="752" y="236" class="node-type" fill="#a78bfa">MCP SERVER</text>
-  <text x="752" y="252" class="node-label">web-search</text>
-  <text x="752" y="266" class="node-detail">2 tools · verified</text>
-  <rect x="850" y="222" width="46" height="16" rx="8" fill="#10b981" fill-opacity="0.15" stroke="#10b981" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="873" y="233" text-anchor="middle" class="badge" fill="#34d399">verified</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 3: TOOLS                                                          -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-
-  <!-- sqlite-mcp tools -->
-  <rect x="32" y="348" width="76" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="70" y="363" text-anchor="middle" class="tool-name">query_db</text>
-
-  <rect x="116" y="348" width="76" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="154" y="363" text-anchor="middle" class="tool-name">exec_sql</text>
-
-  <rect x="200" y="348" width="76" height="22" rx="5" fill="#2d1215" stroke="#ef4444" stroke-width="1"/>
-  <text x="238" y="363" text-anchor="middle" class="tool-name" fill="#fca5a5">run_shell</text>
-
-  <!-- filesystem-mcp tools -->
-  <rect x="290" y="348" width="76" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="328" y="363" text-anchor="middle" class="tool-name">read_file</text>
-
-  <rect x="374" y="348" width="80" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="414" y="363" text-anchor="middle" class="tool-name">write_file</text>
-
-  <rect x="462" y="348" width="72" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="498" y="363" text-anchor="middle" class="tool-name">list_dir</text>
-
-  <!-- github-mcp tools -->
-  <rect x="542" y="348" width="80" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="582" y="363" text-anchor="middle" class="tool-name">create_pr</text>
-
-  <rect x="630" y="348" width="80" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="670" y="363" text-anchor="middle" class="tool-name">list_issues</text>
-
-  <!-- web-search tools -->
-  <rect x="768" y="348" width="68" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="802" y="363" text-anchor="middle" class="tool-name">search</text>
-
-  <rect x="844" y="348" width="80" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="884" y="363" text-anchor="middle" class="tool-name">fetch_url</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 3: CREDENTIALS (below tools)                                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <text x="40" y="402" class="layer-label">CREDENTIALS EXPOSED PER SERVER</text>
-
-  <!-- sqlite-mcp creds -->
-  <rect x="32" y="408" width="130" height="22" rx="5" fill="#1c1917" stroke="#78350f" stroke-width="0.5"/>
-  <circle cx="46" cy="419" r="3" fill="#f59e0b" opacity="0.5"/>
-  <text x="56" y="423" class="cred-name">DB_URL</text>
-
-  <!-- filesystem-mcp — no sensitive creds -->
-  <rect x="200" y="408" width="130" height="22" rx="5" fill="#18181b" stroke="#27272a" stroke-width="0.5"/>
-  <text x="214" y="423" class="tool-name">no credentials</text>
-
-  <!-- github-mcp creds -->
-  <rect x="370" y="408" width="130" height="22" rx="5" fill="#1c1917" stroke="#78350f" stroke-width="0.5"/>
-  <circle cx="384" cy="419" r="3" fill="#f59e0b" opacity="0.5"/>
-  <text x="394" y="423" class="cred-name">GITHUB_TOKEN</text>
-
-  <!-- web-search creds -->
-  <rect x="540" y="408" width="130" height="22" rx="5" fill="#1c1917" stroke="#78350f" stroke-width="0.5"/>
-  <circle cx="554" cy="419" r="3" fill="#f59e0b" opacity="0.5"/>
-  <text x="564" y="423" class="cred-name">SERP_API_KEY</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- INSIGHT BAR                                                             -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <rect x="24" y="452" width="912" height="52" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-
-  <text x="52" y="472" font-size="10" font-weight="600" fill="#f4f4f5">What this view tells you:</text>
-
-  <circle cx="166" cy="471" r="4" fill="#f59e0b" opacity="0.6"/>
-  <text x="178" y="475" class="legend-label">filesystem-mcp shared by 3 agents — single point of failure</text>
-
-  <circle cx="506" cy="471" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="518" y="475" class="legend-label">sqlite-mcp unverified + root + run_shell = critical risk</text>
-
-  <circle cx="806" cy="471" r="4" fill="#3b82f6" opacity="0.6"/>
-  <text x="818" y="475" class="legend-label">3 credentials exposed</text>
-  <text x="52" y="493" class="legend-label">From the same graph you can pivot into diff, attack-path drilldown, impact, search, and compliance views.</text>
+  <rect x="48" y="534" width="864" height="14" rx="7" fill="#030712"/>
+  <text x="60" y="544" class="footer-title">Why this matters</text>
+  <text x="168" y="544" class="footer-copy">The demo reaches from vulnerable packages to real tools and credentials, so the graph story in the README matches product output.</text>
 </svg>

--- a/docs/images/topology-light.svg
+++ b/docs/images/topology-light.svg
@@ -1,192 +1,150 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" fill="none">
   <style>
     text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
-    .title { font-size: 16px; font-weight: 700; fill: #18181b; }
-    .subtitle { font-size: 10.5px; font-weight: 400; fill: #a1a1aa; }
-    .layer-label { font-size: 9px; font-weight: 700; letter-spacing: 0.1em; fill: #a1a1aa; }
-    .node-type { font-size: 8px; font-weight: 700; letter-spacing: 0.1em; }
-    .node-label { font-size: 11.5px; font-weight: 700; fill: #27272a; }
-    .node-detail { font-size: 9px; font-weight: 400; fill: #71717a; }
-    .tool-name { font-size: 8.5px; font-weight: 600; font-family: ui-monospace, monospace; fill: #52525b; }
-    .cred-name { font-size: 8.5px; font-weight: 600; font-family: ui-monospace, monospace; fill: #92400e; }
-    .badge { font-size: 8px; font-weight: 700; }
-    .legend-label { font-size: 9px; font-weight: 500; fill: #71717a; }
+    .title { font-size: 18px; font-weight: 800; fill: #111827; }
+    .subtitle { font-size: 11px; font-weight: 500; fill: #64748b; }
+    .section { font-size: 10px; font-weight: 800; letter-spacing: 0.12em; }
+    .card-title { font-size: 12px; font-weight: 760; fill: #111827; }
+    .card-copy { font-size: 9.5px; font-weight: 500; fill: #475569; }
+    .chip { font-size: 8px; font-weight: 700; fill: #334155; }
+    .pill { font-size: 9px; font-weight: 700; fill: #334155; }
+    .footer-title { font-size: 10px; font-weight: 800; fill: #111827; }
+    .footer-copy { font-size: 9.5px; font-weight: 600; fill: #475569; }
   </style>
 
-  <!-- Background -->
-  <rect width="960" height="520" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="560" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+  </defs>
 
-  <!-- Title -->
-  <text x="480" y="30" text-anchor="middle" class="title">Unified graph explorer — current environment topology</text>
-  <text x="480" y="46" text-anchor="middle" class="subtitle">Persisted graph view of agents, MCP servers, tools, and credential exposure with shared-infrastructure context</text>
+  <rect width="960" height="560" rx="18" fill="url(#bg)" stroke="#e5e7eb"/>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER LABELS                                                            -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <text x="16" y="100" class="layer-label" transform="rotate(-90, 16, 100)">AI AGENTS</text>
-  <text x="16" y="260" class="layer-label" transform="rotate(-90, 16, 260)">MCP SERVERS</text>
-  <text x="16" y="420" class="layer-label" transform="rotate(-90, 16, 420)">TOOLS + CREDENTIALS</text>
+  <text x="480" y="36" text-anchor="middle" class="title">Graph explorer — built-in demo topology</text>
+  <text x="480" y="56" text-anchor="middle" class="subtitle">Real README example derived from `agent-bom agents --demo --offline`.</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- EDGES: Agents → Servers                                                 -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <path d="M160 138 C160 170, 120 190, 120 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.2" fill="none"/>
-  <path d="M190 138 C190 170, 360 190, 360 218" stroke="#3b82f6" stroke-width="2" opacity="0.3" fill="none"/>
-  <path d="M220 138 C230 170, 580 185, 580 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.2" fill="none"/>
-  <path d="M420 138 C420 170, 370 190, 370 218" stroke="#3b82f6" stroke-width="2" opacity="0.3" fill="none"/>
-  <path d="M390 138 C390 170, 130 190, 130 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.2" fill="none"/>
-  <path d="M450 138 C450 170, 810 185, 810 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.2" fill="none"/>
-  <path d="M650 138 C650 175, 380 190, 380 218" stroke="#3b82f6" stroke-width="2" opacity="0.3" fill="none"/>
-  <path d="M680 138 C680 170, 590 190, 590 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.2" fill="none"/>
-  <path d="M890 138 C890 170, 820 190, 820 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.2" fill="none"/>
-  <path d="M870 138 C870 170, 600 190, 600 218" stroke="#3b82f6" stroke-width="1.5" opacity="0.2" fill="none"/>
+  <rect x="252" y="74" width="72" height="22" rx="11" fill="#eff6ff" stroke="#bfdbfe"/>
+  <text x="288" y="88" text-anchor="middle" class="pill">2 agents</text>
+  <rect x="336" y="74" width="92" height="22" rx="11" fill="#eef2ff" stroke="#c7d2fe"/>
+  <text x="382" y="88" text-anchor="middle" class="pill">4 MCP servers</text>
+  <rect x="440" y="74" width="92" height="22" rx="11" fill="#ecfeff" stroke="#a5f3fc"/>
+  <text x="486" y="88" text-anchor="middle" class="pill">12 packages</text>
+  <rect x="544" y="74" width="86" height="22" rx="11" fill="#fff7ed" stroke="#fdba74"/>
+  <text x="587" y="88" text-anchor="middle" class="pill">55 vulns</text>
+  <rect x="642" y="74" width="92" height="22" rx="11" fill="#fef2f2" stroke="#fca5a5"/>
+  <text x="688" y="88" text-anchor="middle" class="pill">2 critical</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- EDGES: Servers → Tools/Creds                                            -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <path d="M100 290 C100 310, 60 330, 60 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M120 290 C120 310, 140 330, 140 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M140 290 C140 310, 220 330, 220 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M130 290 C130 315, 80 390, 80 408" stroke="#f59e0b" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M340 290 C340 310, 310 330, 310 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M360 290 C360 310, 390 330, 390 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M380 290 C380 310, 470 330, 470 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M570 290 C570 310, 550 330, 550 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M590 290 C590 310, 630 330, 630 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M600 290 C600 315, 370 390, 370 408" stroke="#f59e0b" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M800 290 C800 310, 780 330, 780 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M820 290 C820 310, 860 330, 860 348" stroke="#8b5cf6" stroke-width="1" opacity="0.15" fill="none"/>
-  <path d="M810 290 C810 315, 590 390, 590 408" stroke="#f59e0b" stroke-width="1" opacity="0.15" fill="none"/>
+  <text x="52" y="124" class="section" fill="#2563eb">AGENTS</text>
+  <text x="336" y="124" class="section" fill="#7c3aed">MCP SERVERS</text>
+  <text x="744" y="124" class="section" fill="#059669">REACHABLE TOOLS + CREDS</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 1: AI AGENTS                                                      -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <rect x="100" y="74" width="160" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <rect x="100" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="120" y="92" class="node-type" fill="#2563eb">AI AGENT</text>
-  <text x="120" y="108" class="node-label">Claude Desktop</text>
-  <text x="120" y="122" class="node-detail">3 servers · 8 tools</text>
+  <path d="M272 178C306 178 300 166 336 166" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M272 178C306 178 300 270 336 270" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M272 282C306 282 300 374 336 374" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M272 282C306 282 300 478 336 478" stroke="#cbd5e1" stroke-width="2" fill="none"/>
 
-  <rect x="330" y="74" width="160" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <rect x="330" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="350" y="92" class="node-type" fill="#2563eb">AI AGENT</text>
-  <text x="350" y="108" class="node-label">Cursor IDE</text>
-  <text x="350" y="122" class="node-detail">3 servers · 9 tools</text>
+  <path d="M520 166C556 166 708 166 744 166" stroke="#d1d5db" stroke-width="2" fill="none"/>
+  <path d="M728 166C700 166 640 166 640 270" stroke="#d1d5db" stroke-width="2" fill="none" opacity="0.8"/>
+  <path d="M520 270C556 270 708 270 744 270" stroke="#d1d5db" stroke-width="2" fill="none"/>
+  <path d="M728 270C700 270 640 270 640 374" stroke="#d1d5db" stroke-width="2" fill="none" opacity="0.8"/>
+  <path d="M520 374C556 374 708 374 744 374" stroke="#d1d5db" stroke-width="2" fill="none"/>
+  <path d="M520 478C556 478 708 478 744 478" stroke="#d1d5db" stroke-width="2" fill="none"/>
 
-  <rect x="570" y="74" width="160" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <rect x="570" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="590" y="92" class="node-type" fill="#2563eb">AI AGENT</text>
-  <text x="590" y="108" class="node-label">Windsurf</text>
-  <text x="590" y="122" class="node-detail">2 servers · 5 tools</text>
+  <rect x="48" y="138" width="224" height="80" rx="14" fill="#ffffff" stroke="#dbeafe"/>
+  <rect x="48" y="138" width="5" height="80" rx="2.5" fill="#2563eb"/>
+  <text x="68" y="160" class="card-title">cursor</text>
+  <text x="68" y="177" class="card-copy">
+    <tspan x="68" dy="0">Uses the filesystem and database servers</tspan>
+    <tspan x="68" dy="12">and carries the highest blast-radius path in the demo.</tspan>
+  </text>
+  <rect x="68" y="190" width="84" height="16" rx="8" fill="#dbeafe"/><text x="110" y="201" text-anchor="middle" class="chip">2 servers</text>
+  <rect x="158" y="190" width="88" height="16" rx="8" fill="#fee2e2"/><text x="202" y="201" text-anchor="middle" class="chip">critical path</text>
 
-  <rect x="800" y="74" width="140" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <rect x="800" y="74" width="4" height="64" rx="2" fill="#3b82f6"/>
-  <text x="820" y="92" class="node-type" fill="#2563eb">AI AGENT</text>
-  <text x="820" y="108" class="node-label">VS Code Copilot</text>
-  <text x="820" y="122" class="node-detail">2 servers · 4 tools</text>
+  <rect x="48" y="242" width="224" height="80" rx="14" fill="#ffffff" stroke="#dbeafe"/>
+  <rect x="48" y="242" width="5" height="80" rx="2.5" fill="#2563eb"/>
+  <text x="68" y="264" class="card-title">claude-desktop</text>
+  <text x="68" y="281" class="card-copy">
+    <tspan x="68" dy="0">Uses the GitHub and team-chat servers</tspan>
+    <tspan x="68" dy="12">with token-backed tools and collaboration workflows.</tspan>
+  </text>
+  <rect x="68" y="294" width="84" height="16" rx="8" fill="#dbeafe"/><text x="110" y="305" text-anchor="middle" class="chip">2 servers</text>
+  <rect x="158" y="294" width="78" height="16" rx="8" fill="#dcfce7"/><text x="197" y="305" text-anchor="middle" class="chip">review path</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 2: MCP SERVERS                                                    -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <rect x="52" y="218" width="170" height="72" rx="10" fill="#fafafa" stroke="#ef4444" stroke-width="1.5" stroke-opacity="0.35"/>
-  <rect x="52" y="218" width="4" height="72" rx="2" fill="#8b5cf6"/>
-  <text x="72" y="236" class="node-type" fill="#7c3aed">MCP SERVER</text>
-  <text x="72" y="252" class="node-label">sqlite-mcp</text>
-  <text x="72" y="266" class="node-detail">3 tools · runs as root</text>
-  <rect x="160" y="222" width="56" height="16" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="188" y="233" text-anchor="middle" class="badge" fill="#dc2626">unverified</text>
+  <rect x="336" y="126" width="184" height="80" rx="14" fill="#ffffff" stroke="#cbd5e1"/>
+  <rect x="336" y="126" width="5" height="80" rx="2.5" fill="#6366f1"/>
+  <text x="356" y="148" class="card-title">filesystem-server</text>
+  <text x="356" y="165" class="card-copy">
+    <tspan x="356" dy="0">3 npm packages powering local file operations</tspan>
+    <tspan x="356" dy="12">for `read_file`, `write_file`, and `list_directory`.</tspan>
+  </text>
+  <rect x="356" y="178" width="84" height="16" rx="8" fill="#e0e7ff"/><text x="398" y="189" text-anchor="middle" class="chip">3 packages</text>
+  <rect x="446" y="178" width="54" height="16" rx="8" fill="#ede9fe"/><text x="473" y="189" text-anchor="middle" class="chip">local FS</text>
 
-  <rect x="272" y="218" width="170" height="72" rx="10" fill="#fafafa" stroke="#f59e0b" stroke-width="1.5" stroke-opacity="0.35"/>
-  <rect x="272" y="218" width="4" height="72" rx="2" fill="#8b5cf6"/>
-  <text x="292" y="236" class="node-type" fill="#7c3aed">MCP SERVER</text>
-  <text x="292" y="252" class="node-label">filesystem-mcp</text>
-  <text x="292" y="266" class="node-detail">3 tools · read/write access</text>
-  <rect x="380" y="222" width="56" height="16" rx="8" fill="#fffbeb" stroke="#f59e0b" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="408" y="233" text-anchor="middle" class="badge" fill="#d97706">3 agents</text>
+  <rect x="336" y="230" width="184" height="80" rx="14" fill="#ffffff" stroke="#fca5a5"/>
+  <rect x="336" y="230" width="5" height="80" rx="2.5" fill="#ef4444"/>
+  <text x="356" y="252" class="card-title">database-server</text>
+  <text x="356" y="269" class="card-copy">
+    <tspan x="356" dy="0">5 Python packages including `flask`, `requests`,</tspan>
+    <tspan x="356" dy="12">`cryptography`, and `pillow` in the critical path.</tspan>
+  </text>
+  <rect x="356" y="282" width="82" height="16" rx="8" fill="#fee2e2"/><text x="397" y="293" text-anchor="middle" class="chip">5 packages</text>
+  <rect x="444" y="282" width="56" height="16" rx="8" fill="#fef2f2"/><text x="472" y="293" text-anchor="middle" class="chip">2 creds</text>
 
-  <rect x="502" y="218" width="170" height="72" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <rect x="502" y="218" width="4" height="72" rx="2" fill="#8b5cf6"/>
-  <text x="522" y="236" class="node-type" fill="#7c3aed">MCP SERVER</text>
-  <text x="522" y="252" class="node-label">github-mcp</text>
-  <text x="522" y="266" class="node-detail">2 tools · verified</text>
-  <rect x="620" y="222" width="46" height="16" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="643" y="233" text-anchor="middle" class="badge" fill="#059669">verified</text>
+  <rect x="336" y="334" width="184" height="80" rx="14" fill="#ffffff" stroke="#cbd5e1"/>
+  <rect x="336" y="334" width="5" height="80" rx="2.5" fill="#6366f1"/>
+  <text x="356" y="356" class="card-title">github-server</text>
+  <text x="356" y="373" class="card-copy">
+    <tspan x="356" dy="0">2 npm packages with repo-writing actions like</tspan>
+    <tspan x="356" dy="12">`create_issue`, `search_repos`, and `push_files`.</tspan>
+  </text>
+  <rect x="356" y="386" width="82" height="16" rx="8" fill="#dcfce7"/><text x="397" y="397" text-anchor="middle" class="chip">repo ops</text>
+  <rect x="444" y="386" width="56" height="16" rx="8" fill="#fef3c7"/><text x="472" y="397" text-anchor="middle" class="chip">1 token</text>
 
-  <rect x="732" y="218" width="170" height="72" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <rect x="732" y="218" width="4" height="72" rx="2" fill="#8b5cf6"/>
-  <text x="752" y="236" class="node-type" fill="#7c3aed">MCP SERVER</text>
-  <text x="752" y="252" class="node-label">web-search</text>
-  <text x="752" y="266" class="node-detail">2 tools · verified</text>
-  <rect x="850" y="222" width="46" height="16" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="0.5" stroke-opacity="0.3"/>
-  <text x="873" y="233" text-anchor="middle" class="badge" fill="#059669">verified</text>
+  <rect x="336" y="438" width="184" height="80" rx="14" fill="#ffffff" stroke="#cbd5e1"/>
+  <rect x="336" y="438" width="5" height="80" rx="2.5" fill="#6366f1"/>
+  <text x="356" y="460" class="card-title">team-chat-server</text>
+  <text x="356" y="477" class="card-copy">
+    <tspan x="356" dy="0">2 Python packages with collaboration actions like</tspan>
+    <tspan x="356" dy="12">`send_message` and `list_channels`.</tspan>
+  </text>
+  <rect x="356" y="490" width="86" height="16" rx="8" fill="#fef3c7"/><text x="399" y="501" text-anchor="middle" class="chip">2 secrets</text>
+  <rect x="448" y="490" width="50" height="16" rx="8" fill="#e0f2fe"/><text x="473" y="501" text-anchor="middle" class="chip">chat ops</text>
 
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 3: TOOLS                                                          -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <rect x="32" y="348" width="76" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="70" y="363" text-anchor="middle" class="tool-name">query_db</text>
+  <rect x="744" y="126" width="168" height="80" rx="14" fill="#ffffff" stroke="#bbf7d0"/>
+  <text x="762" y="148" class="card-title">filesystem surface</text>
+  <text x="762" y="165" class="card-copy">
+    <tspan x="762" dy="0">`read_file`, `write_file`,</tspan>
+    <tspan x="762" dy="12">`list_directory`</tspan>
+  </text>
+  <rect x="762" y="180" width="54" height="16" rx="8" fill="#dcfce7"/><text x="789" y="191" text-anchor="middle" class="chip">3 tools</text>
 
-  <rect x="116" y="348" width="76" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="154" y="363" text-anchor="middle" class="tool-name">exec_sql</text>
+  <rect x="744" y="230" width="168" height="80" rx="14" fill="#ffffff" stroke="#fecaca"/>
+  <text x="762" y="252" class="card-title">database blast radius</text>
+  <text x="762" y="269" class="card-copy">
+    <tspan x="762" dy="0">`DATABASE_URL`, `ANTHROPIC_API_KEY`,</tspan>
+    <tspan x="762" dy="12">`run_query`, `execute_sql`, `export_csv`</tspan>
+  </text>
+  <rect x="762" y="284" width="58" height="16" rx="8" fill="#fee2e2"/><text x="791" y="295" text-anchor="middle" class="chip">2 creds</text>
+  <rect x="826" y="284" width="58" height="16" rx="8" fill="#fee2e2"/><text x="855" y="295" text-anchor="middle" class="chip">3 tools</text>
 
-  <rect x="200" y="348" width="76" height="22" rx="5" fill="#fef2f2" stroke="#ef4444" stroke-width="1"/>
-  <text x="238" y="363" text-anchor="middle" class="tool-name" fill="#dc2626">run_shell</text>
+  <rect x="744" y="334" width="168" height="80" rx="14" fill="#ffffff" stroke="#bbf7d0"/>
+  <text x="762" y="356" class="card-title">GitHub reach</text>
+  <text x="762" y="373" class="card-copy">
+    <tspan x="762" dy="0">`GITHUB_TOKEN`, `create_issue`,</tspan>
+    <tspan x="762" dy="12">`search_repos`, `push_files`</tspan>
+  </text>
+  <rect x="762" y="388" width="58" height="16" rx="8" fill="#dcfce7"/><text x="791" y="399" text-anchor="middle" class="chip">1 token</text>
 
-  <rect x="290" y="348" width="76" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="328" y="363" text-anchor="middle" class="tool-name">read_file</text>
+  <rect x="744" y="438" width="168" height="80" rx="14" fill="#ffffff" stroke="#fde68a"/>
+  <text x="762" y="460" class="card-title">team-chat reach</text>
+  <text x="762" y="477" class="card-copy">
+    <tspan x="762" dy="0">`SLACK_BOT_TOKEN`,</tspan>
+    <tspan x="762" dy="12">`SLACK_SIGNING_SECRET`, `send_message`</tspan>
+  </text>
+  <rect x="762" y="492" width="58" height="16" rx="8" fill="#fef3c7"/><text x="791" y="503" text-anchor="middle" class="chip">2 secrets</text>
 
-  <rect x="374" y="348" width="80" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="414" y="363" text-anchor="middle" class="tool-name">write_file</text>
-
-  <rect x="462" y="348" width="72" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="498" y="363" text-anchor="middle" class="tool-name">list_dir</text>
-
-  <rect x="542" y="348" width="80" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="582" y="363" text-anchor="middle" class="tool-name">create_pr</text>
-
-  <rect x="630" y="348" width="80" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="670" y="363" text-anchor="middle" class="tool-name">list_issues</text>
-
-  <rect x="768" y="348" width="68" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="802" y="363" text-anchor="middle" class="tool-name">search</text>
-
-  <rect x="844" y="348" width="80" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="884" y="363" text-anchor="middle" class="tool-name">fetch_url</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- LAYER 3: CREDENTIALS                                                    -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <text x="40" y="402" class="layer-label">CREDENTIALS EXPOSED PER SERVER</text>
-
-  <rect x="32" y="408" width="130" height="22" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
-  <circle cx="46" cy="419" r="3" fill="#f59e0b" opacity="0.5"/>
-  <text x="56" y="423" class="cred-name">DB_URL</text>
-
-  <rect x="200" y="408" width="130" height="22" rx="5" fill="#fafafa" stroke="#e4e4e7" stroke-width="0.5"/>
-  <text x="214" y="423" class="tool-name">no credentials</text>
-
-  <rect x="370" y="408" width="130" height="22" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
-  <circle cx="384" cy="419" r="3" fill="#f59e0b" opacity="0.5"/>
-  <text x="394" y="423" class="cred-name">GITHUB_TOKEN</text>
-
-  <rect x="540" y="408" width="130" height="22" rx="5" fill="#fffbeb" stroke="#fde68a" stroke-width="0.5"/>
-  <circle cx="554" cy="419" r="3" fill="#f59e0b" opacity="0.5"/>
-  <text x="564" y="423" class="cred-name">SERP_API_KEY</text>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- INSIGHT BAR                                                             -->
-  <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <rect x="24" y="452" width="912" height="52" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-
-  <text x="52" y="472" font-size="10" font-weight="600" fill="#18181b">What this view tells you:</text>
-
-  <circle cx="166" cy="471" r="4" fill="#f59e0b" opacity="0.5"/>
-  <text x="178" y="475" class="legend-label">filesystem-mcp shared by 3 agents — single point of failure</text>
-
-  <circle cx="506" cy="471" r="4" fill="#ef4444" opacity="0.5"/>
-  <text x="518" y="475" class="legend-label">sqlite-mcp unverified + root + run_shell = critical risk</text>
-
-  <circle cx="806" cy="471" r="4" fill="#3b82f6" opacity="0.5"/>
-  <text x="818" y="475" class="legend-label">3 credentials exposed</text>
-  <text x="52" y="493" class="legend-label">From the same graph you can pivot into diff, attack-path drilldown, impact, search, and compliance views.</text>
+  <rect x="48" y="534" width="864" height="14" rx="7" fill="#f8fafc"/>
+  <text x="60" y="544" class="footer-title">Why this matters</text>
+  <text x="168" y="544" class="footer-copy">The demo reaches from vulnerable packages to real tools and credentials, so the graph story in the README matches product output.</text>
 </svg>

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,36 +1,41 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# agent-bom dashboard
 
-## Getting Started
+This is the Next.js dashboard for `agent-bom`.
 
-First, run the development server:
+## Recommended local run
+
+If you want the same product surface users get from the CLI, run:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pip install 'agent-bom[ui]'
+agent-bom serve
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+That starts the API on `http://localhost:8422` and serves the bundled dashboard.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## UI development
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Run the dashboard and API separately when working on frontend changes:
 
-## Learn More
+```bash
+agent-bom api
+npm run dev
+```
 
-To learn more about Next.js, take a look at the following resources:
+The UI reads `NEXT_PUBLIC_API_URL`. If it is unset, the dev server proxies `/v1/*`, `/health`, and `/ws/*` to `http://localhost:8422`.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+If you see `Failed to fetch`:
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+1. Make sure `agent-bom api` is running.
+2. Check the browser console for CORS or network errors.
+3. Confirm `NEXT_PUBLIC_API_URL` points at the backend you expect.
 
-## Deploy on Vercel
+## Offline demo path
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Use the built-in demo to exercise the dashboard without scanning a real project:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+agent-bom agents --demo --offline -f json -o report.json
+```
+
+Then import `report.json` from the dashboard home page.

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -38,6 +38,7 @@ import {
 import Link from "next/link";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
+import { ApiOfflineState } from "@/components/api-offline-state";
 
 // ─── Status helpers ──────────────────────────────────────────────────────────
 
@@ -295,14 +296,10 @@ export default function CompliancePage() {
 
   if (error) {
     return (
-      <div className="max-w-xl mx-auto mt-20 text-center space-y-4">
-        <ShieldX className="w-12 h-12 text-red-400 mx-auto" />
-        <h2 className="text-lg font-semibold text-zinc-200">Unable to load compliance data</h2>
-        <p className="text-sm text-zinc-500">
-          Make sure the API server is running: <code className="text-zinc-300">agent-bom api</code>
-        </p>
-        <p className="text-xs text-zinc-600">{error}</p>
-      </div>
+      <ApiOfflineState
+        title="Compliance view needs the agent-bom API"
+        detail={error}
+      />
     );
   }
 

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -3,13 +3,13 @@
 import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
 import { api, ScanJob, ScanResult, BlastRadius, Agent, PostureResponse, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS } from "@/lib/api";
-import { checkFileSize, validateScanReport } from "@/lib/validators";
 import { AgentTopology } from "@/components/agent-topology";
 import { TrustStack } from "@/components/trust-stack";
 import { SeverityBadge } from "@/components/severity-badge";
 import { ActivityFeed } from "@/components/activity-feed";
 import { PostureGrade } from "@/components/posture-grade";
 import { AttackPathCard } from "@/components/attack-path-card";
+import { ApiOfflineState } from "@/components/api-offline-state";
 import {
   ShieldAlert, Server, Package, Bug, Zap, ArrowRight, Clock,
   AlertTriangle, Container, Layers, FileText, ExternalLink, GitBranch,
@@ -422,16 +422,16 @@ export default function Dashboard() {
     : agentCount;
   const isLoading = loading && !importedReport;
 
-  if (apiError && !importedReport) return <ApiDown onImport={setImportedReport} />;
+  if (apiError && !importedReport) return <ApiOfflineState onImport={setImportedReport} />;
 
   return (
     <div className="space-y-8">
       <section className="relative overflow-hidden rounded-[28px] border border-zinc-800/80 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_24%),radial-gradient(circle_at_top_right,rgba(239,68,68,0.12),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.98),rgba(9,9,11,0.96))] p-6 shadow-2xl shadow-black/20">
         <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
           <div className="max-w-3xl">
-            <p className="text-[11px] uppercase tracking-[0.28em] text-emerald-400">Security command center</p>
+            <p className="text-[11px] uppercase tracking-[0.28em] text-emerald-400">Current state</p>
             <h1 className="mt-3 text-3xl font-semibold tracking-tight text-zinc-50 sm:text-4xl">
-              See the blast radius, not just the CVE list.
+              Risk across agents, MCP, packages, and runtime.
             </h1>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-300">
               Aggregated across {doneJobs.length} scan{doneJobs.length !== 1 ? "s" : ""}: {effectiveAgentCount} agent{effectiveAgentCount !== 1 ? "s" : ""}, {totalPackages} packages, and {uniqueCVEs} unique vulnerabilities with credential and tool exposure mapped into one operational view.
@@ -1038,81 +1038,5 @@ function CompoundIssueCard({ issue }: { issue: CompoundIssue }) {
         </div>
       </div>
     </Link>
-  );
-}
-
-function ApiDown({ onImport }: { onImport: (data: ScanResult) => void }) {
-  const [importError, setImportError] = useState<string | null>(null);
-
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setImportError(null);
-
-    // Reject oversized files before loading into memory
-    const sizeCheck = checkFileSize(file);
-    if (!sizeCheck.ok) {
-      setImportError(sizeCheck.error);
-      e.target.value = "";
-      return;
-    }
-
-    const reader = new FileReader();
-    reader.onerror = () => setImportError("Failed to read file.");
-    reader.onload = (ev) => {
-      const text = ev.target?.result;
-      if (typeof text !== "string") {
-        setImportError("Could not read file contents.");
-        return;
-      }
-      const result = validateScanReport(text);
-      if (!result.ok) {
-        setImportError(result.error);
-        return;
-      }
-      onImport(result.data as ScanResult);
-    };
-    reader.readAsText(file);
-  };
-
-  return (
-    <div className="text-center py-16">
-      <AlertTriangle className="w-10 h-10 text-orange-400 mx-auto mb-4" />
-      <h2 className="text-lg font-semibold mb-2">Cannot connect to agent-bom API</h2>
-      <p className="text-zinc-500 text-sm mb-6">
-        Make sure the API server is running at{" "}
-        <code className="font-mono bg-zinc-900 px-1.5 py-0.5 rounded text-zinc-300">
-          {process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8422"}
-        </code>
-      </p>
-      <code className="block bg-zinc-900 border border-zinc-800 rounded-lg px-6 py-4 text-sm font-mono text-emerald-400 mb-8 inline-block">
-        pip install &apos;agent-bom[api]&apos;<br />
-        agent-bom api
-      </code>
-      <div className="border border-dashed border-zinc-700 rounded-xl p-8 max-w-md mx-auto">
-        <FileText className="w-8 h-8 text-zinc-500 mx-auto mb-3" />
-        <p className="text-sm text-zinc-400 mb-1 font-medium">Or import a local report</p>
-        <p className="text-xs text-zinc-600 mb-4">
-          Generated with{" "}
-          <code className="font-mono">agent-bom scan -f json -o report.json</code>
-          <span className="block mt-1 text-zinc-700">Max 10 MB · schema-validated</span>
-        </p>
-        {importError && (
-          <div className="mb-4 px-3 py-2 bg-red-950/40 border border-red-800/50 rounded-lg text-left">
-            <p className="text-xs text-red-400 font-mono break-words">{importError}</p>
-          </div>
-        )}
-        <label className="cursor-pointer inline-flex items-center gap-2 px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-sm text-zinc-300 transition-colors">
-          <FileText className="w-4 h-4" />
-          Choose report.json
-          <input
-            type="file"
-            accept=".json,application/json"
-            className="hidden"
-            onChange={handleFile}
-          />
-        </label>
-      </div>
-    </div>
   );
 }

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useCallback, useEffect, useState, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { api, Vulnerability, ScanJob, ScanResult, severityColor, severityDot, OWASP_LLM_TOP10, MITRE_ATLAS } from "@/lib/api";
+import { ApiOfflineState } from "@/components/api-offline-state";
 import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff } from "lucide-react";
 
 function downloadJson(data: unknown, filename: string) {
@@ -291,9 +292,14 @@ function VulnsPage() {
           Loading vulnerabilities...
         </div>
       )}
-      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {!loading && error && (
+        <ApiOfflineState
+          title="Vulnerabilities need the agent-bom API"
+          detail={error}
+        />
+      )}
 
-      {!loading && vulns.length === 0 && (
+      {!loading && !error && vulns.length === 0 && (
         <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
           <Bug className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
           <p className="text-zinc-500 text-sm">No vulnerabilities found.</p>
@@ -303,7 +309,7 @@ function VulnsPage() {
         </div>
       )}
 
-      {vulns.length > 0 && (
+      {!error && vulns.length > 0 && (
         <>
           {/* Controls */}
           <div className="flex flex-col gap-3">

--- a/ui/components/api-offline-state.tsx
+++ b/ui/components/api-offline-state.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, type ChangeEvent } from "react";
+import Link from "next/link";
+import { AlertTriangle, FileText, PlayCircle, Server } from "lucide-react";
+
+import type { ScanResult } from "@/lib/api";
+import { checkFileSize, validateScanReport } from "@/lib/validators";
+
+interface ApiOfflineStateProps {
+  title?: string;
+  detail?: string | null;
+  onImport?: (data: ScanResult) => void;
+}
+
+const DEFAULT_API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8422";
+
+export function ApiOfflineState({
+  title = "Cannot connect to the agent-bom API",
+  detail,
+  onImport,
+}: ApiOfflineStateProps) {
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportError(null);
+
+    const sizeCheck = checkFileSize(file);
+    if (!sizeCheck.ok) {
+      setImportError(sizeCheck.error);
+      e.target.value = "";
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onerror = () => setImportError("Failed to read file.");
+    reader.onload = (ev) => {
+      const text = ev.target?.result;
+      if (typeof text !== "string") {
+        setImportError("Could not read file contents.");
+        return;
+      }
+      const result = validateScanReport(text);
+      if (!result.ok) {
+        setImportError(result.error);
+        return;
+      }
+      onImport?.(result.data as ScanResult);
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="py-10">
+      <div className="mx-auto max-w-5xl rounded-3xl border border-zinc-800 bg-zinc-950/70 p-6 shadow-2xl shadow-black/20 md:p-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <AlertTriangle className="mx-auto mb-4 h-11 w-11 text-orange-400" />
+          <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">{title}</h2>
+          <p className="mt-3 text-sm leading-6 text-zinc-400">
+            Run the local stack at{" "}
+            <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">
+              {DEFAULT_API_URL}
+            </code>{" "}
+            so the dashboard can load live scan data, graph views, and compliance surfaces.
+          </p>
+          {detail ? (
+            <p className="mt-3 text-xs text-zinc-500">
+              Current error: <span className="font-mono text-zinc-400">{detail}</span>
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-8 grid gap-4 md:grid-cols-2">
+          <div className="rounded-2xl border border-emerald-900/60 bg-emerald-950/20 p-5">
+            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-emerald-300">
+              <PlayCircle className="h-4 w-4" />
+              Recommended: start the full product surface
+            </div>
+            <p className="mb-4 text-sm text-zinc-400">
+              This starts the API and serves the bundled dashboard from one command path.
+            </p>
+            <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-emerald-400">
+              pip install &apos;agent-bom[ui]&apos;
+              <br />
+              agent-bom serve
+            </code>
+          </div>
+
+          <div className="rounded-2xl border border-blue-900/60 bg-blue-950/20 p-5">
+            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-blue-300">
+              <Server className="h-4 w-4" />
+              API only
+            </div>
+            <p className="mb-4 text-sm text-zinc-400">
+              Use this if the dashboard is already running separately and only the backend is missing.
+            </p>
+            <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-blue-300">
+              pip install &apos;agent-bom[api]&apos;
+              <br />
+              agent-bom api
+            </code>
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4 text-sm text-zinc-400">
+          If the API is already running and you still see this page, check the browser console for CORS errors and confirm{" "}
+          <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">NEXT_PUBLIC_API_URL</code>{" "}
+          points to{" "}
+          <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">{DEFAULT_API_URL}</code>.
+        </div>
+
+        {onImport ? (
+          <div className="mt-6 rounded-2xl border border-dashed border-zinc-700 bg-zinc-900/40 p-6 text-center">
+            <FileText className="mx-auto mb-3 h-8 w-8 text-zinc-500" />
+            <h3 className="text-sm font-semibold text-zinc-200">Or stay offline and import a real report</h3>
+            <p className="mt-2 text-sm text-zinc-500">
+              Use the built-in demo for a reproducible sample, or export a real project scan and load it here.
+            </p>
+            <code className="mt-4 block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-xs leading-7 text-zinc-300">
+              agent-bom agents --demo --offline -f json -o report.json
+              <br />
+              agent-bom agents -p . -f json -o report.json
+            </code>
+            {importError ? (
+              <div className="mx-auto mt-4 max-w-xl rounded-xl border border-red-800/50 bg-red-950/30 px-3 py-2 text-left">
+                <p className="break-words text-xs font-mono text-red-400">{importError}</p>
+              </div>
+            ) : null}
+            <label className="mt-5 inline-flex cursor-pointer items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-200 transition-colors hover:bg-zinc-700">
+              <FileText className="h-4 w-4" />
+              Choose report.json
+              <input
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                onChange={handleFile}
+              />
+            </label>
+            <p className="mt-3 text-xs text-zinc-600">Max 10 MB. Schema-validated before import.</p>
+          </div>
+        ) : (
+          <div className="mt-6 text-center">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-200 transition-colors hover:bg-zinc-700"
+            >
+              <FileText className="h-4 w-4" />
+              Import a local report from the home page
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Summary
- tighten the customer-facing README and PyPI copy around the demo, remediation, dashboard, and evidence-export paths
- replace the dashboard API-offline dead end with guided serve / api / report-import onboarding
- align the topology and architecture visuals with real product output and calmer UI copy

Validation
- npm --prefix ui run test:run
- npm --prefix ui run build
- git diff --check

Notes
- repo description and topics were also updated live to better match the product surface
- ui lint still has the existing eslint 10 / eslint-config-next compatibility issue and is unchanged by this PR