### PR TITLE
Tighten operator UI and trace review

### DIFF
--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections import defaultdict
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -42,26 +43,40 @@ async def ingest_traces(body: dict) -> dict:
             return {"traces": 0, "flagged": [], "message": "No tool call traces found"}
 
         # Gather vulnerable packages and servers from scan history
-        vuln_packages: list[str] = []
-        vuln_servers: list[str] = []
+        vuln_packages: dict[str, set[str]] = defaultdict(set)
+        vuln_servers: dict[str, set[str]] = defaultdict(set)
         for job in _get_store().list_all():
             if job.status == JobStatus.DONE and job.result:
                 for br in job.result.get("blast_radius", []):
+                    cve_id = br.get("vulnerability_id", "")
                     pkg = br.get("package", "")
                     if pkg:
-                        vuln_packages.append(pkg)
+                        if cve_id:
+                            vuln_packages[pkg].add(cve_id)
+                        else:
+                            vuln_packages[pkg]
                     for srv in br.get("affected_servers", []):
                         name = srv if isinstance(srv, str) else srv.get("name", "")
                         if name:
-                            vuln_servers.append(name)
+                            if cve_id:
+                                vuln_servers[name].add(cve_id)
+                            else:
+                                vuln_servers[name]
 
-        flagged = flag_vulnerable_tool_calls(traces, {p: [] for p in vuln_packages}, set(vuln_servers))
+        flagged = flag_vulnerable_tool_calls(
+            traces,
+            {pkg: sorted(cves) for pkg, cves in vuln_packages.items()},
+            {server: sorted(cves) for server, cves in vuln_servers.items()},
+        )
 
         return {
             "traces": len(traces),
             "flagged": [
                 {
                     "tool_name": f.trace.tool_name,
+                    "server": f.server or f.trace.server_name,
+                    "package_name": f.package_name or f.trace.package_name,
+                    "cve_ids": f.matched_cves,
                     "reason": f.reason,
                     "severity": f.severity,
                     "span_id": f.trace.span_id,

--- a/src/agent_bom/otel_ingest.py
+++ b/src/agent_bom/otel_ingest.py
@@ -93,6 +93,8 @@ class ToolCallTrace:
     trace_id: str
     span_id: str
     tool_name: str
+    server_name: str = ""
+    package_name: str = ""
     parameters: dict = field(default_factory=dict)
     duration_ms: float = 0.0
     status: str = "ok"
@@ -105,7 +107,10 @@ class FlaggedCall:
     trace: ToolCallTrace
     reason: str
     severity: str = "medium"  # medium or high
+    server: str = ""
+    package_name: str = ""
     matched_cve: str = ""
+    matched_cves: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -238,9 +243,17 @@ def parse_otel_traces(trace_data: dict) -> list[ToolCallTrace]:
         if not tool_name:
             continue
 
-        # Extract parameters from attributes
+        # Extract parameters and common correlation attributes from span attrs.
+        attrs = span.get("attributes", [])
         params = {}
-        for attr in span.get("attributes", []):
+        server_name = _extract_attr(attrs, "mcp.server") or _extract_attr(attrs, "server.name") or _extract_attr(attrs, "tool.server")
+        package_name = (
+            _extract_attr(attrs, "package.name")
+            or _extract_attr(attrs, "tool.package")
+            or _extract_attr(attrs, "dependency.package")
+            or _extract_attr(attrs, "package")
+        )
+        for attr in attrs:
             key = attr.get("key", "")
             if key.startswith("tool.input."):
                 param_name = key[len("tool.input.") :]
@@ -261,6 +274,8 @@ def parse_otel_traces(trace_data: dict) -> list[ToolCallTrace]:
                 trace_id=span.get("traceId", ""),
                 span_id=span.get("spanId", ""),
                 tool_name=tool_name,
+                server_name=server_name,
+                package_name=package_name,
                 parameters=params,
                 duration_ms=duration_ms,
                 status=status,
@@ -388,44 +403,70 @@ def flag_deprecated_models(calls: list[LLMAPICall]) -> list[FlaggedMLCall]:
 def flag_vulnerable_tool_calls(
     traces: list[ToolCallTrace],
     vuln_packages: dict[str, list[str]] | None = None,
-    vuln_servers: set[str] | None = None,
+    vuln_servers: dict[str, list[str]] | set[str] | None = None,
 ) -> list[FlaggedCall]:
     """Cross-reference tool calls against known-vulnerable packages/servers.
 
     Args:
         traces: Parsed tool call traces.
         vuln_packages: Map of package name → list of CVE IDs.
-        vuln_servers: Set of server/tool names with known vulnerabilities.
+        vuln_servers: Mapping of server/tool name → CVE IDs, or a simple set.
     """
     flagged: list[FlaggedCall] = []
     vuln_packages = vuln_packages or {}
-    vuln_servers = vuln_servers or set()
+    vuln_server_map: dict[str, list[str]]
+    if isinstance(vuln_servers, set):
+        vuln_server_map = {name: [] for name in vuln_servers}
+    else:
+        vuln_server_map = vuln_servers or {}
+
+    def _lookup_name(mapping: dict[str, list[str]], candidate: str) -> tuple[str, list[str]] | None:
+        lowered = candidate.lower()
+        for name, cves in mapping.items():
+            if name.lower() == lowered:
+                return name, cves
+        return None
 
     for trace in traces:
         tool_lower = trace.tool_name.lower()
+        server_match = None
+        package_match = None
+        matched_cves: list[str] = []
 
-        # Check against vulnerable server/tool names
-        if tool_lower in vuln_servers or trace.tool_name in vuln_servers:
+        for candidate in (trace.server_name, trace.tool_name):
+            if not candidate:
+                continue
+            server_match = _lookup_name(vuln_server_map, candidate)
+            if server_match:
+                matched_cves.extend(server_match[1])
+                break
+
+        # Check against vulnerable package names (prefer explicit package attr, then fuzzy tool-name match)
+        for pkg_name, cves in vuln_packages.items():
+            explicit_match = trace.package_name and trace.package_name.lower() == pkg_name.lower()
+            fuzzy_match = pkg_name.lower() in tool_lower or tool_lower in pkg_name.lower()
+            if explicit_match or fuzzy_match:
+                package_match = pkg_name
+                matched_cves.extend(cves)
+                break
+
+        if server_match or package_match:
+            deduped_cves = list(dict.fromkeys(cve for cve in matched_cves if cve))
+            reason_parts = []
+            if server_match:
+                reason_parts.append(f"server '{server_match[0]}' has known vulnerabilities")
+            if package_match:
+                reason_parts.append(f"package '{package_match}' is vulnerable")
             flagged.append(
                 FlaggedCall(
                     trace=trace,
-                    reason=f"Tool '{trace.tool_name}' belongs to a server with known vulnerabilities",
-                    severity="high",
+                    reason="; ".join(reason_parts),
+                    severity="high" if server_match else "medium",
+                    server=server_match[0] if server_match else trace.server_name,
+                    package_name=package_match or trace.package_name,
+                    matched_cve=deduped_cves[0] if deduped_cves else "",
+                    matched_cves=deduped_cves,
                 )
             )
-            continue
-
-        # Check against vulnerable package names (fuzzy: tool name contains package)
-        for pkg_name, cves in vuln_packages.items():
-            if pkg_name.lower() in tool_lower or tool_lower in pkg_name.lower():
-                flagged.append(
-                    FlaggedCall(
-                        trace=trace,
-                        reason=f"Tool '{trace.tool_name}' may be associated with vulnerable package '{pkg_name}'",
-                        severity="medium",
-                        matched_cve=cves[0] if cves else "",
-                    )
-                )
-                break
 
     return flagged

--- a/tests/test_otel_ingest.py
+++ b/tests/test_otel_ingest.py
@@ -63,6 +63,28 @@ def test_parse_generic_tool_name_attribute():
     assert traces[0].tool_name == "read_file"
 
 
+def test_parse_server_and_package_attributes():
+    data = _otlp_trace(
+        [
+            {
+                "traceId": "abc",
+                "spanId": "s2",
+                "name": "tool_call",
+                "attributes": [
+                    {"key": "tool.name", "value": {"stringValue": "query_db"}},
+                    {"key": "mcp.server", "value": {"stringValue": "sqlite-mcp"}},
+                    {"key": "package.name", "value": {"stringValue": "sqlite-utils"}},
+                ],
+                "status": {},
+            }
+        ]
+    )
+    traces = parse_otel_traces(data)
+    assert len(traces) == 1
+    assert traces[0].server_name == "sqlite-mcp"
+    assert traces[0].package_name == "sqlite-utils"
+
+
 def test_parse_skips_non_tool_spans():
     data = _otlp_trace(
         [
@@ -80,10 +102,12 @@ def test_parse_skips_non_tool_spans():
 
 
 def test_flag_vulnerable_server():
-    traces = [ToolCallTrace(trace_id="t1", span_id="s1", tool_name="evil_tool")]
-    flagged = flag_vulnerable_tool_calls(traces, vuln_servers={"evil_tool"})
+    traces = [ToolCallTrace(trace_id="t1", span_id="s1", tool_name="evil_tool", server_name="evil_tool")]
+    flagged = flag_vulnerable_tool_calls(traces, vuln_servers={"evil_tool": ["CVE-2026-1"]})
     assert len(flagged) == 1
     assert flagged[0].severity == "high"
+    assert flagged[0].server == "evil_tool"
+    assert flagged[0].matched_cves == ["CVE-2026-1"]
 
 
 def test_flag_no_match():
@@ -93,10 +117,11 @@ def test_flag_no_match():
 
 
 def test_flag_vulnerable_package():
-    traces = [ToolCallTrace(trace_id="t1", span_id="s1", tool_name="langchain_search")]
+    traces = [ToolCallTrace(trace_id="t1", span_id="s1", tool_name="langchain_search", package_name="langchain")]
     flagged = flag_vulnerable_tool_calls(traces, vuln_packages={"langchain": ["CVE-2025-1"]})
     assert len(flagged) == 1
     assert flagged[0].matched_cve == "CVE-2025-1"
+    assert flagged[0].package_name == "langchain"
 
 
 def test_parse_flat_spans_format():

--- a/ui/app/activity/page.tsx
+++ b/ui/app/activity/page.tsx
@@ -3,18 +3,16 @@
 import { useEffect, useState } from "react";
 import {
   Clock,
-  AlertTriangle,
   Bot,
   Terminal,
   Wrench,
   Zap,
   Search,
   Loader2,
-  Info,
 } from "lucide-react";
 import { api, formatDate } from "@/lib/api";
 import type { ActivityTimeline } from "@/lib/api";
-import { ErrorBanner } from "@/components/empty-state";
+import { IntegrationRequiredState } from "@/components/integration-required-state";
 import {
   ResponsiveContainer,
   BarChart,
@@ -56,17 +54,19 @@ export default function ActivityPage() {
 
   if (error) {
     return (
-      <div className="space-y-4">
-        <div className="bg-blue-950 border border-blue-800 rounded-lg p-3 mb-4 flex items-center gap-2 text-sm text-blue-300">
-          <Info className="h-4 w-4 shrink-0" />
-          This feature requires a Snowflake connection. Set <code className="bg-blue-900 px-1 rounded">SNOWFLAKE_ACCOUNT</code> to enable.
-        </div>
-        <ErrorBanner
-          message={error}
-          hint="Activity requires SNOWFLAKE_ACCOUNT env var on the API server."
-          onRetry={load}
-        />
-      </div>
+      <IntegrationRequiredState
+        title="Activity timeline integration is not configured"
+        summary="This page reconstructs agent and tool activity from query history and AI observability events. Core scanning and graph workflows work without it. The current cloud integration for this page uses Snowflake."
+        requirement="Cloud telemetry integration on the API host"
+        command={"pip install 'agent-bom[cloud]'\nexport SNOWFLAKE_ACCOUNT=...\nagent-bom api"}
+        capabilities={[
+          "Query history grouped by agent pattern and user",
+          "Tool-call and model-usage activity over time",
+          "Latency, status, and event volume from observability traces",
+        ]}
+        detail={error}
+        onRetry={load}
+      />
     );
   }
 

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -98,16 +98,11 @@ function AgentsList() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [collapsed, setCollapsed] = useState<Set<number>>(new Set());
+  const [expandedAgent, setExpandedAgent] = useState<string | null>(null);
   const [search, setSearch] = useState("");
 
-  function toggleCollapse(idx: number) {
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(idx)) next.delete(idx);
-      else next.add(idx);
-      return next;
-    });
+  function toggleCollapse(agentName: string) {
+    setExpandedAgent((current) => (current === agentName ? null : agentName));
   }
 
   useEffect(() => {
@@ -130,7 +125,7 @@ function AgentsList() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
           <p className="text-zinc-400 text-sm mt-1">
-            Auto-discovered local AI agent configurations
+            Discovered agent configurations and attached MCP servers
           </p>
         </div>
         <Link
@@ -141,6 +136,24 @@ function AgentsList() {
           Mesh View
         </Link>
       </div>
+
+      {!loading && agents.length > 0 && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="relative w-full sm:max-w-sm">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-600" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search agents or agent type"
+              className="w-full rounded-lg border border-zinc-700 bg-zinc-900 py-2 pl-9 pr-3 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+            />
+          </div>
+          <p className="text-xs text-zinc-500">
+            {filteredConfigured.length} configured · {installedOnly.length} installed only
+          </p>
+        </div>
+      )}
 
       {loading && (
         <div className="flex items-center justify-center py-20 text-zinc-400">
@@ -203,19 +216,21 @@ function AgentsList() {
       )}
 
       {/* Configured agents */}
-      <div className="space-y-4">
-        {configured?.map((agent, i) => (
-          <div key={i} className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+        <div className="space-y-4">
+        {filteredConfigured?.map((agent) => {
+          const isExpanded = expandedAgent === agent.name;
+          return (
+          <div key={agent.name} className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
             <button
               type="button"
-              onClick={() => toggleCollapse(i)}
+              onClick={() => toggleCollapse(agent.name)}
               className="w-full flex items-center justify-between"
             >
               <div className="flex items-center gap-2">
-                {collapsed.has(i) ? (
-                  <ChevronRight className="w-4 h-4 text-zinc-500" />
-                ) : (
+                {isExpanded ? (
                   <ChevronDown className="w-4 h-4 text-zinc-500" />
+                ) : (
+                  <ChevronRight className="w-4 h-4 text-zinc-500" />
                 )}
                 <h2 className="font-semibold text-zinc-100">{agent.name}</h2>
                 <span className="text-[10px] font-mono bg-emerald-950 border border-emerald-800 text-emerald-400 rounded px-1.5 py-0.5">
@@ -241,7 +256,7 @@ function AgentsList() {
               </div>
             </button>
 
-            {!collapsed.has(i) && (
+            {isExpanded ? (
               <div className="space-y-2 mt-4">
                 {agent.mcp_servers?.map((srv, j) => (
                   <div key={j} className="bg-zinc-800 border border-zinc-700 rounded-lg p-3">
@@ -285,9 +300,14 @@ function AgentsList() {
                   </div>
                 ))}
               </div>
-            )}
+            ) : null}
           </div>
-        ))}
+        )})}
+        {!loading && filteredConfigured.length === 0 && configured.length > 0 && (
+          <div className="rounded-xl border border-dashed border-zinc-800 py-12 text-center">
+            <p className="text-sm text-zinc-500">No configured agents match the current search.</p>
+          </div>
+        )}
       </div>
 
       {/* Installed but not configured */}

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   api,
   ComplianceResponse,
@@ -34,6 +34,7 @@ import {
   Scan,
   Grid3X3,
   List,
+  Search,
 } from "lucide-react";
 import Link from "next/link";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
@@ -270,6 +271,92 @@ function ControlCard({ control, catalog }: { control: ComplianceControl; catalog
   );
 }
 
+function FrameworkSection({
+  title,
+  subtitle,
+  accentClass,
+  controls,
+  catalog,
+  query,
+  statusFilter,
+  emptyMessage,
+  defaultOpen = true,
+}: {
+  title: string;
+  subtitle?: string;
+  accentClass: string;
+  controls: ComplianceControl[];
+  catalog?: Record<string, string>;
+  query: string;
+  statusFilter: "all" | "pass" | "warning" | "fail";
+  emptyMessage?: string;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleControls = useMemo(
+    () =>
+      controls.filter((control) => {
+        const matchesStatus = statusFilter === "all" || control.status === statusFilter;
+        const searchable = [
+          control.code,
+          control.name,
+          ...control.affected_packages,
+          ...control.affected_agents,
+        ]
+          .join(" ")
+          .toLowerCase();
+        const matchesQuery = !normalizedQuery || searchable.includes(normalizedQuery);
+        return matchesStatus && matchesQuery;
+      }),
+    [controls, normalizedQuery, statusFilter],
+  );
+  const failCount = controls.filter((control) => control.status === "fail").length;
+  const warningCount = controls.filter((control) => control.status === "warning").length;
+
+  return (
+    <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40">
+      <button
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left"
+      >
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className={`text-lg font-semibold ${accentClass}`}>{title}</h2>
+            {subtitle ? <span className="text-xs text-zinc-500">{subtitle}</span> : null}
+          </div>
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
+            <span>{controls.length} controls</span>
+            <span>{failCount} fail</span>
+            <span>{warningCount} warning</span>
+            {visibleControls.length !== controls.length ? <span>{visibleControls.length} shown</span> : null}
+          </div>
+        </div>
+        {open ? <ChevronDown className="h-4 w-4 text-zinc-500" /> : <ChevronRight className="h-4 w-4 text-zinc-500" />}
+      </button>
+      {open ? (
+        <div className="border-t border-zinc-800 px-5 py-5">
+          {controls.length === 0 && emptyMessage ? (
+            <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+              {emptyMessage}
+            </div>
+          ) : visibleControls.length === 0 ? (
+            <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+              No controls match the current filters.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              {visibleControls.map((control) => (
+                <ControlCard key={control.code} control={control} catalog={catalog} />
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function CompliancePage() {
@@ -277,6 +364,8 @@ export default function CompliancePage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"detail" | "heatmap" | "matrix">("detail");
+  const [controlQuery, setControlQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | "pass" | "warning" | "fail">("all");
 
   useEffect(() => {
     api
@@ -307,6 +396,106 @@ export default function CompliancePage() {
 
   const { summary: s } = data;
   const hasMcp = data.has_mcp_context ?? false;
+  const detailSections: Array<{
+    id: string;
+    title: string;
+    subtitle?: string;
+    accentClass: string;
+    controls: ComplianceControl[];
+    catalog?: Record<string, string>;
+    emptyMessage?: string;
+  }> = [
+    {
+      id: "owasp-llm",
+      title: "OWASP LLM Top 10",
+      subtitle: "2025 Edition",
+      accentClass: "text-zinc-200",
+      controls: data.owasp_llm_top10,
+      catalog: OWASP_LLM_TOP10,
+    },
+    {
+      id: "owasp-mcp",
+      title: "OWASP MCP Top 10",
+      subtitle: "MCP security risks",
+      accentClass: hasMcp ? "text-zinc-200" : "text-zinc-500",
+      controls: hasMcp ? data.owasp_mcp_top10 : [],
+      catalog: OWASP_MCP_TOP10,
+      emptyMessage: "MCP-specific controls appear after a scan with MCP server context.",
+    },
+    {
+      id: "atlas",
+      title: "MITRE ATLAS",
+      subtitle: "Adversarial ML techniques",
+      accentClass: "text-zinc-200",
+      controls: data.mitre_atlas,
+      catalog: MITRE_ATLAS,
+    },
+    {
+      id: "nist-ai-rmf",
+      title: "NIST AI RMF 1.0",
+      subtitle: "Govern / Map / Measure / Manage",
+      accentClass: "text-zinc-200",
+      controls: data.nist_ai_rmf,
+      catalog: NIST_AI_RMF,
+    },
+    {
+      id: "owasp-agentic",
+      title: "OWASP Agentic Top 10",
+      subtitle: "2026 Edition",
+      accentClass: hasMcp ? "text-zinc-200" : "text-zinc-500",
+      controls: hasMcp ? data.owasp_agentic_top10 : [],
+      catalog: OWASP_AGENTIC_TOP10,
+      emptyMessage: "Agentic controls appear after a scan with agent and MCP context.",
+    },
+    {
+      id: "eu-ai-act",
+      title: "EU AI Act",
+      subtitle: "Regulation (EU) 2024/1689",
+      accentClass: "text-zinc-200",
+      controls: data.eu_ai_act,
+      catalog: EU_AI_ACT,
+    },
+    {
+      id: "nist-csf",
+      title: "NIST CSF 2.0",
+      subtitle: "Cybersecurity Framework",
+      accentClass: "text-zinc-200",
+      controls: data.nist_csf,
+      catalog: NIST_CSF,
+    },
+    {
+      id: "iso27001",
+      title: "ISO/IEC 27001:2022",
+      subtitle: "Annex A controls",
+      accentClass: "text-zinc-200",
+      controls: data.iso_27001,
+      catalog: ISO_27001,
+    },
+    {
+      id: "soc2",
+      title: "SOC 2",
+      subtitle: "Trust Services Criteria",
+      accentClass: "text-zinc-200",
+      controls: data.soc2,
+      catalog: SOC2_TSC,
+    },
+    {
+      id: "cis",
+      title: "CIS Controls v8",
+      subtitle: "Critical security controls",
+      accentClass: "text-zinc-200",
+      controls: data.cis_controls,
+      catalog: CIS_CONTROLS,
+    },
+    {
+      id: "cmmc",
+      title: "CMMC 2.0",
+      subtitle: "Level 2 practices",
+      accentClass: "text-zinc-200",
+      controls: data.cmmc,
+      catalog: CMMC_PRACTICES,
+    },
+  ];
 
   return (
     <div className="space-y-8">
@@ -538,185 +727,57 @@ export default function CompliancePage() {
         <FrameworkBar label="CMMC 2.0" pass={s.cmmc_pass} warn={s.cmmc_warn} fail={s.cmmc_fail} total={data.cmmc.length} />
       </div>
 
-      {/* ── OWASP LLM Top 10 ──────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-emerald-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">OWASP LLM Top 10</h2>
-          <span className="text-xs text-zinc-500 ml-2">2025 Edition</span>
+      <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-zinc-200">Control explorer</h2>
+            <p className="mt-1 text-xs text-zinc-500">Filter once, then expand only the frameworks you need.</p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="relative min-w-[240px]">
+              <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-600" />
+              <input
+                type="text"
+                value={controlQuery}
+                onChange={(e) => setControlQuery(e.target.value)}
+                placeholder="Search control, package, or agent"
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+              />
+            </div>
+            <div className="flex items-center gap-1">
+              {(["all", "fail", "warning", "pass"] as const).map((value) => (
+                <button
+                  key={value}
+                  onClick={() => setStatusFilter(value)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                    statusFilter === value
+                      ? "bg-zinc-800 text-zinc-100"
+                      : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+                  }`}
+                >
+                  {value === "all" ? "All" : value === "pass" ? "Passing" : value === "warning" ? "Warnings" : "Failing"}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.owasp_llm_top10?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={OWASP_LLM_TOP10} />
-          ))}
-        </div>
-      </section>
+      </div>
 
-      {/* ── OWASP MCP Top 10 ─────────────────────────────────────────── */}
-      {hasMcp ? (
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-amber-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">OWASP MCP Top 10</h2>
-          <span className="text-xs text-zinc-500 ml-2">MCP Security Risks</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.owasp_mcp_top10?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={OWASP_MCP_TOP10} />
-          ))}
-        </div>
-      </section>
-      ) : (
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-amber-400 opacity-40" />
-          <h2 className="text-lg font-semibold text-zinc-500">OWASP MCP Top 10</h2>
-        </div>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center">
-          <p className="text-sm text-zinc-500">MCP framework analysis not applicable — no MCP servers detected</p>
-          <p className="text-xs text-zinc-600 mt-2">Run an agent discovery scan to include MCP server data</p>
-        </div>
-      </section>
-      )}
-
-      {/* ── MITRE ATLAS ───────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-blue-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">MITRE ATLAS</h2>
-          <span className="text-xs text-zinc-500 ml-2">Adversarial ML Techniques</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.mitre_atlas?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={MITRE_ATLAS} />
-          ))}
-        </div>
-      </section>
-
-      {/* ── NIST AI RMF ───────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-purple-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">NIST AI RMF 1.0</h2>
-          <span className="text-xs text-zinc-500 ml-2">Govern / Map / Measure / Manage</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.nist_ai_rmf?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={NIST_AI_RMF} />
-          ))}
-        </div>
-      </section>
-
-      {/* ── OWASP Agentic Top 10 ─────────────────────────────────────── */}
-      {hasMcp ? (
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-fuchsia-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">OWASP Agentic Top 10</h2>
-          <span className="text-xs text-zinc-500 ml-2">2026 Edition</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.owasp_agentic_top10?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={OWASP_AGENTIC_TOP10} />
-          ))}
-        </div>
-      </section>
-      ) : (
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-fuchsia-400 opacity-40" />
-          <h2 className="text-lg font-semibold text-zinc-500">OWASP Agentic Top 10</h2>
-        </div>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 text-center">
-          <p className="text-sm text-zinc-500">Agentic framework analysis not applicable — no AI agents detected</p>
-          <p className="text-xs text-zinc-600 mt-2">Run an agent discovery scan to include agent data</p>
-        </div>
-      </section>
-      )}
-
-      {/* ── EU AI Act ────────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-blue-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">EU AI Act</h2>
-          <span className="text-xs text-zinc-500 ml-2">Regulation (EU) 2024/1689</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.eu_ai_act?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={EU_AI_ACT} />
-          ))}
-        </div>
-      </section>
-
-      {/* ── NIST CSF 2.0 ─────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-teal-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">NIST CSF 2.0</h2>
-          <span className="text-xs text-zinc-500 ml-2">Cybersecurity Framework</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.nist_csf?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={NIST_CSF} />
-          ))}
-        </div>
-      </section>
-
-      {/* ── ISO 27001 ─────────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-sky-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">ISO/IEC 27001:2022</h2>
-          <span className="text-xs text-zinc-500 ml-2">Annex A Controls</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.iso_27001?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={ISO_27001} />
-          ))}
-        </div>
-      </section>
-
-      {/* ── SOC 2 ─────────────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-indigo-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">SOC 2</h2>
-          <span className="text-xs text-zinc-500 ml-2">Trust Services Criteria</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.soc2?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={SOC2_TSC} />
-          ))}
-        </div>
-      </section>
-
-      {/* ── CIS Controls v8 ──────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-lime-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">CIS Controls v8</h2>
-          <span className="text-xs text-zinc-500 ml-2">Critical Security Controls</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.cis_controls?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={CIS_CONTROLS} />
-          ))}
-        </div>
-      </section>
-
-      {/* ── CMMC 2.0 ─────────────────────────────────────────────────── */}
-      <section>
-        <div className="flex items-center gap-2 mb-4">
-          <Shield className="w-5 h-5 text-rose-400" />
-          <h2 className="text-lg font-semibold text-zinc-200">CMMC 2.0</h2>
-          <span className="text-xs text-zinc-500 ml-2">Level 2 Practices</span>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {data.cmmc?.map((c) => (
-            <ControlCard key={c.code} control={c} catalog={CMMC_PRACTICES} />
-          ))}
-        </div>
-      </section>
+      <div className="space-y-4">
+        {detailSections.map((section) => (
+          <FrameworkSection
+            key={section.id}
+            title={section.title}
+            subtitle={section.subtitle}
+            accentClass={section.accentClass}
+            controls={section.controls}
+            catalog={section.catalog}
+            query={controlQuery}
+            statusFilter={statusFilter}
+            emptyMessage={section.emptyMessage}
+          />
+        ))}
+      </div>
 
       </>
       )}

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -159,10 +159,10 @@ export default function FleetPage() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
             <Users className="w-6 h-6 text-emerald-400" />
-            Agent Fleet
+            Fleet
           </h1>
           <p className="text-zinc-400 text-sm mt-1">
-            Persistent agent inventory with lifecycle management and trust scoring
+            Persisted agent inventory, review state, and trust score from the fleet store
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -191,7 +191,7 @@ export default function FleetPage() {
       <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
         <div className="flex items-center gap-2 mb-3">
           <Settings className="w-4 h-4 text-zinc-400" />
-          <h3 className="text-sm font-semibold text-zinc-300">Trust Threshold</h3>
+          <h3 className="text-sm font-semibold text-zinc-300">Policy threshold</h3>
         </div>
         <div className="flex flex-col sm:flex-row sm:items-center gap-4">
           <div className="flex-1">

--- a/ui/app/governance/page.tsx
+++ b/ui/app/governance/page.tsx
@@ -11,7 +11,6 @@ import {
   ChevronDown,
   ChevronUp,
   Loader2,
-  Info,
 } from "lucide-react";
 import {
   api,
@@ -20,7 +19,7 @@ import {
   formatDate,
 } from "@/lib/api";
 import type { GovernanceReport, GovernanceFinding } from "@/lib/api";
-import { ErrorBanner } from "@/components/empty-state";
+import { IntegrationRequiredState } from "@/components/integration-required-state";
 import {
   ResponsiveContainer,
   BarChart,
@@ -63,17 +62,19 @@ export default function GovernancePage() {
 
   if (error) {
     return (
-      <div className="space-y-4">
-        <div className="bg-blue-950 border border-blue-800 rounded-lg p-3 mb-4 flex items-center gap-2 text-sm text-blue-300">
-          <Info className="h-4 w-4 shrink-0" />
-          This feature requires a Snowflake connection. Set <code className="bg-blue-900 px-1 rounded">SNOWFLAKE_ACCOUNT</code> to enable.
-        </div>
-        <ErrorBanner
-          message={error}
-          hint="Governance requires SNOWFLAKE_ACCOUNT env var on the API server."
-          onRetry={load}
-        />
-      </div>
+      <IntegrationRequiredState
+        title="Governance integration is not configured"
+        summary="This page mines access history, grants, data classifications, and agent usage from a cloud telemetry source. Core agent-bom scans do not depend on it. The current backend integration for this page uses Snowflake."
+        requirement="Cloud governance integration on the API host"
+        command={"pip install 'agent-bom[cloud]'\nexport SNOWFLAKE_ACCOUNT=...\nagent-bom api"}
+        capabilities={[
+          "Access-history review across users, roles, and objects",
+          "Privilege and classification findings with severity filters",
+          "Cortex agent usage and governance-focused summaries",
+        ]}
+        detail={error}
+        onRetry={load}
+      />
     );
   }
 

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -429,12 +429,12 @@ export default function Dashboard() {
       <section className="relative overflow-hidden rounded-[28px] border border-zinc-800/80 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_24%),radial-gradient(circle_at_top_right,rgba(239,68,68,0.12),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.98),rgba(9,9,11,0.96))] p-6 shadow-2xl shadow-black/20">
         <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
           <div className="max-w-3xl">
-            <p className="text-[11px] uppercase tracking-[0.28em] text-emerald-400">Current state</p>
+            <p className="text-[11px] uppercase tracking-[0.24em] text-emerald-400">Overview</p>
             <h1 className="mt-3 text-3xl font-semibold tracking-tight text-zinc-50 sm:text-4xl">
-              Risk across agents, MCP, packages, and runtime.
+              Risk overview
             </h1>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-300">
-              Aggregated across {doneJobs.length} scan{doneJobs.length !== 1 ? "s" : ""}: {effectiveAgentCount} agent{effectiveAgentCount !== 1 ? "s" : ""}, {totalPackages} packages, and {uniqueCVEs} unique vulnerabilities with credential and tool exposure mapped into one operational view.
+              {doneJobs.length} scan{doneJobs.length !== 1 ? "s" : ""} · {effectiveAgentCount} agent{effectiveAgentCount !== 1 ? "s" : ""} · {totalPackages} packages · {uniqueCVEs} CVEs
             </p>
             <div className="mt-5 flex flex-wrap gap-2">
               <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-3 py-2">
@@ -451,7 +451,7 @@ export default function Dashboard() {
               </div>
               {topRisk && (
                 <div className="rounded-2xl border border-zinc-700 bg-zinc-900/80 px-3 py-2">
-                  <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Highest path risk</div>
+                  <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Top path</div>
                   <div className="mt-1 flex items-center gap-2">
                     <span className="font-mono text-lg font-semibold text-zinc-100">{(topRisk.risk_score ?? topRisk.blast_score).toFixed(1)}</span>
                     <span className="truncate text-xs text-zinc-400">{topRisk.vulnerability_id}</span>
@@ -465,14 +465,14 @@ export default function Dashboard() {
               href="/scan"
               className="flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
             >
-              New Scan
+              Run scan
               <ArrowRight className="h-4 w-4" />
             </Link>
             <Link
               href="/graph"
               className="flex items-center gap-2 rounded-xl border border-zinc-700 bg-zinc-900/80 px-4 py-2.5 text-sm font-medium text-zinc-200 transition-colors hover:border-zinc-500 hover:bg-zinc-800"
             >
-              Explore Graph
+              Open graph
               <GitBranch className="h-4 w-4" />
             </Link>
           </div>

--- a/ui/app/registry/page.tsx
+++ b/ui/app/registry/page.tsx
@@ -177,9 +177,14 @@ function RegistryDetail({ serverId }: { serverId: string }) {
         <div className={`rounded-xl border-2 p-4 ${riskBorderColor(server.risk_level)} bg-zinc-900`}>
           <div className="flex items-center gap-2 mb-2 text-xs font-medium uppercase tracking-wider text-zinc-500">
             <Info className="w-3.5 h-3.5" />
-            Why {server.risk_level} risk?
+            Risk rationale
           </div>
           <p className="text-sm text-zinc-300 leading-relaxed">{server.risk_justification}</p>
+          {cves.length === 0 ? (
+            <p className="mt-2 text-xs text-zinc-500">
+              This classification is capability-based. No known CVEs are currently attached to this server in registry data.
+            </p>
+          ) : null}
         </div>
       )}
 

--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -127,25 +127,42 @@ function NarrativeRow({
                 item.severity
               )}`}
             />
-            <div>
+          <div>
               <span className="font-mono text-xs text-zinc-200">
                 {item.package}
               </span>
-              <span className="text-zinc-600 text-xs mx-1">
-                {item.current_version}
-              </span>
-              {item.fixed_version && (
-                <>
-                  <span className="text-zinc-600 text-xs">→</span>
-                  <span className="font-mono text-xs text-emerald-500 ml-1">
-                    {item.fixed_version}
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px]">
+                <span className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-400">
+                  current {item.current_version}
+                </span>
+                {item.fixed_version ? (
+                  <span className="rounded border border-emerald-900/70 bg-emerald-950/40 px-1.5 py-0.5 font-mono text-emerald-400">
+                    fix {item.fixed_version}
                   </span>
-                </>
-              )}
-              {!item.fixed_version && (
-                <span className="text-xs text-zinc-600 ml-1">no fix yet</span>
-              )}
+                ) : (
+                  <span className="rounded border border-zinc-800 bg-zinc-900 px-1.5 py-0.5 text-zinc-600">
+                    no published fix
+                  </span>
+                )}
+              </div>
             </div>
+          </div>
+        </td>
+
+        {/* CVEs */}
+        <td className="px-4 py-3">
+          <div className="flex max-w-[220px] flex-wrap gap-1">
+            {item.vulnerabilities.slice(0, 2).map((cve) => (
+              <span
+                key={cve}
+                className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300"
+              >
+                {cve}
+              </span>
+            ))}
+            {item.vulnerabilities.length > 2 && (
+              <span className="text-[10px] text-zinc-500">+{item.vulnerabilities.length - 2}</span>
+            )}
           </div>
         </td>
 
@@ -162,6 +179,15 @@ function NarrativeRow({
             <span className="ml-1.5 text-xs font-mono bg-red-950 border border-red-800 text-red-400 rounded px-1.5 py-0.5">
               KEV
             </span>
+          )}
+        </td>
+
+        {/* Fix target */}
+        <td className="px-4 py-3 text-xs">
+          {item.fixed_version ? (
+            <span className="font-mono text-emerald-400">{item.fixed_version}</span>
+          ) : (
+            <span className="text-zinc-600">N/A</span>
           )}
         </td>
 
@@ -188,14 +214,10 @@ function NarrativeRow({
           </div>
         </td>
 
-        {/* Agents */}
+        {/* Reach */}
         <td className="px-4 py-3 text-xs text-zinc-400">
-          {item.affected_agents?.length ?? 0}
-        </td>
-
-        {/* Credentials */}
-        <td className="px-4 py-3 text-xs text-zinc-400">
-          {item.exposed_credentials?.length ?? 0}
+          <div>{item.affected_agents?.length ?? 0} agent{(item.affected_agents?.length ?? 0) !== 1 ? "s" : ""}</div>
+          <div className="text-zinc-600">{item.exposed_credentials?.length ?? 0} credential{(item.exposed_credentials?.length ?? 0) !== 1 ? "s" : ""}</div>
         </td>
 
         {/* Compliance tags */}
@@ -217,9 +239,9 @@ function NarrativeRow({
           </div>
         </td>
 
-        {/* Risk narrative toggle */}
+        {/* Details toggle */}
         <td className="px-4 py-3">
-          {item.risk_narrative ? (
+          {item.risk_narrative || item.command || item.verify_command ? (
             <button
               onClick={() => setExpanded((v) => !v)}
               className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 transition-colors"
@@ -229,7 +251,7 @@ function NarrativeRow({
               ) : (
                 <ChevronDown className="w-3 h-3" />
               )}
-              Narrative
+              Details
             </button>
           ) : (
             <span className="text-xs text-zinc-600">—</span>
@@ -250,27 +272,61 @@ function NarrativeRow({
       </tr>
 
       {/* Expanded narrative */}
-      {expanded && item.risk_narrative && (
+      {expanded && (item.risk_narrative || item.command || item.verify_command) && (
         <tr className="bg-zinc-900/50">
-          <td colSpan={8} className="px-6 py-3">
-            <div className="text-xs text-zinc-400 leading-relaxed border-l-2 border-emerald-800 pl-3">
-              {item.risk_narrative}
-            </div>
-            {(item.reachable_tools?.length ?? 0) > 0 && (
-              <div className="mt-2 flex flex-wrap gap-1">
-                <span className="text-[10px] text-zinc-600 uppercase tracking-wide font-medium mr-1">
-                  Reachable tools:
-                </span>
-                {item.reachable_tools.map((t) => (
-                  <span
-                    key={t}
-                    className="text-[10px] font-mono bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-500"
-                  >
-                    {t}
-                  </span>
-                ))}
+          <td colSpan={9} className="px-6 py-4">
+            <div className="grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
+              <div className="space-y-3">
+                {item.risk_narrative ? (
+                  <div className="border-l-2 border-emerald-800 pl-3 text-xs leading-relaxed text-zinc-400">
+                    {item.risk_narrative}
+                  </div>
+                ) : null}
+                <div className="flex flex-wrap gap-1">
+                  {item.vulnerabilities.map((cve) => (
+                    <span
+                      key={cve}
+                      className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300"
+                    >
+                      {cve}
+                    </span>
+                  ))}
+                </div>
+                {(item.reachable_tools?.length ?? 0) > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    <span className="mr-1 text-[10px] font-medium uppercase tracking-wide text-zinc-600">
+                      Reachable tools
+                    </span>
+                    {item.reachable_tools.map((t) => (
+                      <span
+                        key={t}
+                        className="rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] text-zinc-500"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
-            )}
+              <div className="space-y-3">
+                {item.command ? (
+                  <div className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3">
+                    <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Recommended command</div>
+                    <code className="mt-2 block whitespace-pre-wrap font-mono text-xs leading-6 text-emerald-300">
+                      {item.command}
+                    </code>
+                  </div>
+                ) : null}
+                {item.verify_command ? (
+                  <div className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3">
+                    <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Verify</div>
+                    <code className="mt-2 block whitespace-pre-wrap font-mono text-xs leading-6 text-zinc-300">
+                      {item.verify_command}
+                    </code>
+                  </div>
+                ) : null}
+              </div>
+            </div>
           </td>
         </tr>
       )}
@@ -606,7 +662,7 @@ function RemediationPage() {
             Remediation
           </h1>
           <p className="text-zinc-400 text-sm mt-1">
-            {items.length} packages ranked by blast-radius impact score
+            {items.length} packages prioritized by reach, severity, and available fixes
           </p>
         </div>
         {items.length > 0 && (
@@ -743,6 +799,9 @@ function RemediationPage() {
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
                     Package
                   </th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                    CVEs
+                  </th>
                   <th className="text-left px-4 py-3">
                     <SortButton
                       label="Severity"
@@ -751,6 +810,9 @@ function RemediationPage() {
                       dir={sortDir}
                       onClick={handleSort}
                     />
+                  </th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                    Fix
                   </th>
                   <th className="text-left px-4 py-3">
                     <SortButton
@@ -761,29 +823,14 @@ function RemediationPage() {
                       onClick={handleSort}
                     />
                   </th>
-                  <th className="text-left px-4 py-3">
-                    <SortButton
-                      label="Agents"
-                      field="agents"
-                      current={sortKey}
-                      dir={sortDir}
-                      onClick={handleSort}
-                    />
-                  </th>
-                  <th className="text-left px-4 py-3">
-                    <SortButton
-                      label="Credentials"
-                      field="credentials"
-                      current={sortKey}
-                      dir={sortDir}
-                      onClick={handleSort}
-                    />
+                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                    Reach
                   </th>
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
                     Compliance
                   </th>
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
-                    Narrative
+                    Details
                   </th>
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
                     Actions

--- a/ui/app/traces/page.tsx
+++ b/ui/app/traces/page.tsx
@@ -1,51 +1,47 @@
 "use client";
 
-import { useState } from "react";
-import { Activity, AlertTriangle, CheckCircle2, Loader2, Send } from "lucide-react";
+import { useState, type ChangeEvent } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  FileUp,
+  Loader2,
+  PlayCircle,
+  Send,
+  ShieldAlert,
+} from "lucide-react";
 
-const BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
+import { api, type TraceIngestResponse } from "@/lib/api";
 
-interface FlaggedCall {
-  tool_name: string;
-  server: string;
-  package_name?: string;
-  cve_ids: string[];
-  severity: string;
-}
-
-interface TraceResult {
-  traces: number;
-  flagged: FlaggedCall[];
-  message?: string;
-}
-
-export default function TracesPage() {
-  const [payload, setPayload] = useState(
-    JSON.stringify(
+const SAMPLE_PAYLOAD = JSON.stringify(
+  {
+    resourceSpans: [
       {
-        resourceSpans: [
+        scopeSpans: [
           {
-            scopeSpans: [
+            spans: [
               {
-                spans: [
-                  {
-                    name: "adk.tool.call",
-                    attributes: [
-                      { key: "tool.name", value: { stringValue: "query_db" } },
-                      { key: "mcp.server", value: { stringValue: "sqlite-mcp" } },
-                    ],
-                  },
+                name: "adk.tool.call",
+                attributes: [
+                  { key: "tool.name", value: { stringValue: "query_db" } },
+                  { key: "mcp.server", value: { stringValue: "sqlite-mcp" } },
+                  { key: "package.name", value: { stringValue: "sqlite-utils" } },
                 ],
               },
             ],
           },
         ],
       },
-      null,
-      2,
-    ),
-  );
-  const [result, setResult] = useState<TraceResult | null>(null);
+    ],
+  },
+  null,
+  2,
+);
+
+export default function TracesPage() {
+  const [payload, setPayload] = useState(SAMPLE_PAYLOAD);
+  const [result, setResult] = useState<TraceIngestResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -54,13 +50,7 @@ export default function TracesPage() {
     setError(null);
     setResult(null);
     try {
-      const res = await fetch(`${BASE}/v1/traces`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: payload,
-      });
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-      setResult(await res.json());
+      setResult(await api.ingestTraces(JSON.parse(payload)));
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -68,111 +58,192 @@ export default function TracesPage() {
     }
   }
 
+  const handleFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onerror = () => setError("Failed to read trace export.");
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        setPayload(reader.result);
+        setError(null);
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = "";
+  };
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Traces</h1>
-        <p className="text-zinc-400 text-sm mt-1">
-          OpenTelemetry trace ingestion — flag vulnerable tool calls in real time
-        </p>
+      <div className="flex flex-col gap-4 rounded-3xl border border-zinc-800 bg-zinc-950/70 p-6 shadow-2xl shadow-black/20 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-[11px] uppercase tracking-[0.22em] text-emerald-400">Trace review</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-zinc-100">Runtime tool-call correlation</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-400">
+            Review OTLP traces against vulnerable packages and servers already known to agent-bom. This page is for inspection and replay.
+            Production collectors should send OTLP JSON to <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">POST /v1/traces</code>.
+          </p>
+        </div>
+        <div className="grid gap-3 text-xs text-zinc-400 sm:grid-cols-2 lg:w-[360px]">
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
+            <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Input</div>
+            <div className="mt-2 text-sm text-zinc-200">OTLP JSON export</div>
+            <div className="mt-1 text-zinc-500">Paste, upload, or send directly from a collector.</div>
+          </div>
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
+            <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Output</div>
+            <div className="mt-2 text-sm text-zinc-200">Flagged tool calls</div>
+            <div className="mt-1 text-zinc-500">Server, package, CVE, and severity correlation.</div>
+          </div>
+        </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Input */}
-        <div className="space-y-3">
-          <label className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
-            OTLP JSON Payload
-          </label>
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-zinc-200">Trace intake</h2>
+              <p className="mt-1 text-xs text-zinc-500">Use a real OTLP export or the sample payload for a quick validation run.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-200 transition-colors hover:bg-zinc-700">
+                <FileUp className="h-3.5 w-3.5" />
+                Upload JSON
+                <input type="file" accept=".json,application/json" className="hidden" onChange={handleFile} />
+              </label>
+              <button
+                onClick={() => setPayload(SAMPLE_PAYLOAD)}
+                className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-200 transition-colors hover:bg-zinc-700"
+              >
+                <PlayCircle className="h-3.5 w-3.5" />
+                Use sample
+              </button>
+            </div>
+          </div>
+
           <textarea
             value={payload}
             onChange={(e) => setPayload(e.target.value)}
             rows={18}
-            className="w-full bg-zinc-950 border border-zinc-800 rounded-xl px-4 py-3 font-mono text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-emerald-500 resize-none"
+            className="mt-4 w-full resize-none rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-xs leading-6 text-zinc-300 focus:outline-none focus:ring-1 focus:ring-emerald-500"
             spellCheck={false}
           />
-          <button
-            onClick={submit}
-            disabled={loading}
-            className="flex items-center gap-1.5 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
-          >
-            {loading ? (
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            ) : (
-              <Send className="w-3.5 h-3.5" />
-            )}
-            Ingest Traces
-          </button>
-        </div>
 
-        {/* Result */}
-        <div className="space-y-3">
-          <label className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
-            Response
-          </label>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              onClick={submit}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:opacity-50"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+              Run correlation
+            </button>
+            <p className="text-xs text-zinc-500">
+              Endpoint: <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-300">POST /v1/traces</code>
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-zinc-200">Correlation result</h2>
+              <p className="mt-1 text-xs text-zinc-500">Review flagged calls with mapped server, package, and CVE context.</p>
+            </div>
+          </div>
 
           {!result && !error && (
-            <div className="border border-dashed border-zinc-800 rounded-xl py-16 text-center">
-              <Activity className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-              <p className="text-zinc-500 text-sm">
-                Submit OTLP traces to flag vulnerable tool calls.
-              </p>
-              <p className="text-zinc-600 text-xs mt-1">
-                POST /v1/traces with spans containing adk.tool.* attributes.
-              </p>
+            <div className="mt-4 rounded-2xl border border-dashed border-zinc-800 py-16 text-center">
+              <Activity className="mx-auto mb-3 h-8 w-8 text-zinc-700" />
+              <p className="text-sm text-zinc-500">No trace run yet.</p>
+              <p className="mt-1 text-xs text-zinc-600">Submit a payload to validate correlation against known vulnerable assets.</p>
             </div>
           )}
 
           {error && (
-            <div className="border border-red-900/50 bg-red-950/30 rounded-xl px-4 py-3">
-              <div className="flex items-center gap-2 text-red-400 text-sm">
-                <AlertTriangle className="w-4 h-4" />
+            <div className="mt-4 rounded-2xl border border-red-900/50 bg-red-950/30 px-4 py-3">
+              <div className="flex items-center gap-2 text-sm text-red-400">
+                <AlertTriangle className="h-4 w-4" />
                 {error}
               </div>
             </div>
           )}
 
           {result && (
-            <div className="space-y-4">
+            <div className="mt-4 space-y-4">
               <div className="grid grid-cols-2 gap-3">
-                <div className="border border-zinc-800 rounded-xl px-4 py-3">
-                  <div className="text-xs text-zinc-500">Traces parsed</div>
-                  <div className="text-xl font-semibold text-zinc-100 mt-1">
-                    {result.traces}
-                  </div>
+                <div className="rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
+                  <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Traces parsed</div>
+                  <div className="mt-2 text-2xl font-semibold text-zinc-100">{result.traces}</div>
                 </div>
-                <div className="border border-zinc-800 rounded-xl px-4 py-3">
-                  <div className="text-xs text-zinc-500">Flagged calls</div>
-                  <div className={`text-xl font-semibold mt-1 ${result.flagged.length > 0 ? "text-red-400" : "text-emerald-400"}`}>
+                <div className="rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
+                  <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Flagged calls</div>
+                  <div className={`mt-2 text-2xl font-semibold ${result.flagged.length > 0 ? "text-red-400" : "text-emerald-400"}`}>
                     {result.flagged.length}
                   </div>
                 </div>
               </div>
 
-              {result.flagged.length > 0 && (
-                <div className="border border-zinc-800 rounded-xl overflow-hidden">
+              {result.message ? (
+                <div className="rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 text-xs text-zinc-500">
+                  {result.message}
+                </div>
+              ) : null}
+
+              {result.flagged.length === 0 ? (
+                <div className="rounded-2xl border border-emerald-900/40 bg-emerald-950/20 px-4 py-3">
+                  <div className="flex items-center gap-2 text-sm text-emerald-400">
+                    <CheckCircle2 className="h-4 w-4" />
+                    No vulnerable tool calls were flagged in this payload.
+                  </div>
+                </div>
+              ) : (
+                <div className="overflow-hidden rounded-2xl border border-zinc-800">
                   <table className="w-full text-sm">
                     <thead className="bg-zinc-900 border-b border-zinc-800">
                       <tr>
-                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">Tool</th>
-                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">Server</th>
-                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">CVEs</th>
-                        <th className="text-left px-4 py-2.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">Severity</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Tool</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Server</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Package</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">CVEs</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Risk</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-zinc-800 bg-zinc-950">
-                      {result.flagged?.map((f, i) => (
-                        <tr key={i} className="hover:bg-zinc-900 transition-colors">
-                          <td className="px-4 py-2.5 font-mono text-xs text-zinc-300">{f.tool_name}</td>
-                          <td className="px-4 py-2.5 text-xs text-zinc-400">{f.server}</td>
-                          <td className="px-4 py-2.5 text-xs text-zinc-400">{f.cve_ids?.join(", ") || "-"}</td>
-                          <td className="px-4 py-2.5">
-                            <span className={`text-xs font-medium ${
-                              f.severity === "critical" ? "text-red-400" :
-                              f.severity === "high" ? "text-orange-400" :
-                              f.severity === "medium" ? "text-yellow-400" :
-                              "text-zinc-400"
-                            }`}>
-                              {f.severity}
+                      {result.flagged.map((flagged) => (
+                        <tr key={`${flagged.span_id}-${flagged.tool_name}`} className="align-top hover:bg-zinc-900/70">
+                          <td className="px-4 py-3">
+                            <div className="font-mono text-xs text-zinc-200">{flagged.tool_name}</div>
+                            <div className="mt-1 text-xs text-zinc-500">{flagged.reason}</div>
+                          </td>
+                          <td className="px-4 py-3 text-xs text-zinc-400">{flagged.server || "N/A"}</td>
+                          <td className="px-4 py-3 text-xs text-zinc-400">{flagged.package_name || "N/A"}</td>
+                          <td className="px-4 py-3">
+                            {flagged.cve_ids.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {flagged.cve_ids.map((cve) => (
+                                  <span
+                                    key={cve}
+                                    className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300"
+                                  >
+                                    {cve}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : (
+                              <span className="text-xs text-zinc-600">N/A</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">
+                            <span
+                              className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs font-medium capitalize ${
+                                flagged.severity === "high"
+                                  ? "border-red-800 bg-red-950 text-red-300"
+                                  : "border-yellow-800 bg-yellow-950 text-yellow-300"
+                              }`}
+                            >
+                              <ShieldAlert className="h-3 w-3" />
+                              {flagged.severity}
                             </span>
                           </td>
                         </tr>
@@ -181,18 +252,9 @@ export default function TracesPage() {
                   </table>
                 </div>
               )}
-
-              {result.flagged.length === 0 && (
-                <div className="border border-emerald-900/30 bg-emerald-950/20 rounded-xl px-4 py-3">
-                  <div className="flex items-center gap-2 text-emerald-400 text-sm">
-                    <CheckCircle2 className="w-4 h-4" />
-                    No vulnerable tool calls detected in traces.
-                  </div>
-                </div>
-              )}
             </div>
           )}
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -271,7 +271,7 @@ function VulnsPage() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Vulnerabilities</h1>
           <p className="text-zinc-400 text-sm mt-1">
-            {vulns.length} unique CVEs aggregated across all scans
+            {vulns.length} unique CVEs aggregated across all scans. CVSS and EPSS appear only when the underlying advisory includes them.
           </p>
         </div>
         {vulns.length > 0 && (
@@ -483,10 +483,10 @@ function VulnTable({
                 </span>
               </td>
               <td className="px-4 py-3 text-xs font-mono text-zinc-400">
-                {v.cvss_score != null ? v.cvss_score.toFixed(1) : "—"}
+                {typeof v.cvss_score === "number" && Number.isFinite(v.cvss_score) ? v.cvss_score.toFixed(1) : "N/A"}
               </td>
               <td className="px-4 py-3 text-xs font-mono text-zinc-400">
-                {v.epss_score != null ? (v.epss_score * 100).toFixed(1) + "%" : "—"}
+                {typeof v.epss_score === "number" && Number.isFinite(v.epss_score) ? `${(v.epss_score * 100).toFixed(1)}%` : "N/A"}
               </td>
               <td className="px-4 py-3">
                 <div className="flex flex-wrap gap-1">
@@ -505,7 +505,7 @@ function VulnTable({
                 {v.agents.length > 2 && <span className="text-zinc-600"> +{v.agents.length - 2}</span>}
               </td>
               <td className="px-4 py-3 text-xs font-mono text-emerald-500">
-                {v.fixed_version ?? "—"}
+                {v.fixed_version ?? "N/A"}
               </td>
               <td className="px-4 py-3">
                 {suppressed.has(v.id) ? (

--- a/ui/components/integration-required-state.tsx
+++ b/ui/components/integration-required-state.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Database, RefreshCw, Settings2 } from "lucide-react";
+
+interface IntegrationRequiredStateProps {
+  title: string;
+  summary: string;
+  requirement: string;
+  command: string;
+  capabilities: string[];
+  detail?: string | null;
+  onRetry?: () => void;
+}
+
+export function IntegrationRequiredState({
+  title,
+  summary,
+  requirement,
+  command,
+  capabilities,
+  detail,
+  onRetry,
+}: IntegrationRequiredStateProps) {
+  return (
+    <div className="py-8">
+      <div className="mx-auto max-w-5xl rounded-3xl border border-zinc-800 bg-zinc-950/70 p-6 shadow-2xl shadow-black/20 md:p-8">
+        <div className="grid gap-4 lg:grid-cols-[1.3fr_0.9fr]">
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+            <div className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+              <Database className="h-4 w-4 text-emerald-400" />
+              {title}
+            </div>
+            <p className="mt-3 text-sm leading-6 text-zinc-400">{summary}</p>
+            <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">API requirement</div>
+              <div className="mt-2 font-mono text-sm text-zinc-200">{requirement}</div>
+            </div>
+            <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Enable this surface</div>
+              <code className="mt-2 block whitespace-pre-wrap font-mono text-sm leading-7 text-emerald-300">
+                {command}
+              </code>
+            </div>
+            {detail ? (
+              <p className="mt-4 text-xs text-zinc-500">
+                Current API response: <span className="font-mono text-zinc-400">{detail}</span>
+              </p>
+            ) : null}
+          </div>
+
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
+            <div className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+              <Settings2 className="h-4 w-4 text-blue-400" />
+              What this unlocks
+            </div>
+            <ul className="mt-4 space-y-2">
+              {capabilities.map((capability) => (
+                <li
+                  key={capability}
+                  className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-400"
+                >
+                  {capability}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-4 text-xs leading-5 text-zinc-500">
+              Core scan, graph, remediation, and compliance flows still work without this optional data source.
+            </p>
+            {onRetry ? (
+              <button
+                onClick={onRetry}
+                className="mt-5 inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-200 transition-colors hover:bg-zinc-700"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Retry
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -237,8 +237,10 @@ export function LineageDetailPanel({
                 {data.severity}
               </span>
             )}
-            {data.cvssScore !== undefined && <Row label="CVSS" value={data.cvssScore.toFixed(1)} />}
-            {data.epssScore !== undefined && data.epssScore > 0 && (
+            {typeof data.cvssScore === "number" && Number.isFinite(data.cvssScore) && (
+              <Row label="CVSS" value={data.cvssScore.toFixed(1)} />
+            )}
+            {typeof data.epssScore === "number" && data.epssScore > 0 && (
               <Row label="EPSS" value={`${(data.epssScore * 100).toFixed(1)}%`} />
             )}
             {data.isKev && (

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -408,9 +408,9 @@ function FindingNode({
               {data.severity}
             </span>
           )}
-          {data.cvssScore !== undefined && (
+          {typeof data.cvssScore === "number" && Number.isFinite(data.cvssScore) ? (
             <span className="text-[10px] text-zinc-400">CVSS {data.cvssScore.toFixed(1)}</span>
-          )}
+          ) : null}
           {data.isKev && (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-900 text-red-300 border border-red-700 font-mono">
               KEV

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -700,9 +700,22 @@ function withTimeout(): AbortSignal {
   return AbortSignal.timeout(FETCH_TIMEOUT_MS);
 }
 
+async function errorMessage(res: Response): Promise<string> {
+  try {
+    const data = (await res.json()) as { detail?: unknown; message?: unknown; error?: unknown };
+    const detail = data.detail ?? data.message ?? data.error;
+    if (typeof detail === "string" && detail.trim()) {
+      return detail;
+    }
+  } catch {
+    // Fall back to status text when the body is empty or not JSON.
+  }
+  return `${res.status} ${res.statusText}`;
+}
+
 async function get<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`, { signal: withTimeout() });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw new Error(await errorMessage(res));
   return res.json() as Promise<T>;
 }
 
@@ -713,7 +726,7 @@ async function post<T>(path: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
     signal: withTimeout(),
   });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw new Error(await errorMessage(res));
   return res.json() as Promise<T>;
 }
 
@@ -724,13 +737,13 @@ async function put<T>(path: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
     signal: withTimeout(),
   });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw new Error(await errorMessage(res));
   return res.json() as Promise<T>;
 }
 
 async function del(path: string): Promise<void> {
   const res = await fetch(`${BASE}${path}`, { method: "DELETE", signal: withTimeout() });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) throw new Error(await errorMessage(res));
 }
 
 // ─── API functions ────────────────────────────────────────────────────────────
@@ -931,6 +944,7 @@ export const api = {
 
   // Activity Timeline
   getActivity: (days = 30) => get<ActivityTimeline>(`/v1/activity?days=${days}`),
+  ingestTraces: (body: unknown) => post<TraceIngestResponse>("/v1/traces", body),
 
   // ── Proxy Runtime ──
   getProxyStatus: () => get<ProxyStatusResponse>("/v1/proxy/status"),
@@ -1277,6 +1291,22 @@ export interface ActivityTimeline {
     output_tokens: number;
   }>;
   warnings: string[];
+}
+
+export interface TraceFlaggedCall {
+  tool_name: string;
+  server: string;
+  package_name?: string;
+  cve_ids: string[];
+  severity: string;
+  reason: string;
+  span_id: string;
+}
+
+export interface TraceIngestResponse {
+  traces: number;
+  flagged: TraceFlaggedCall[];
+  message?: string;
 }
 
 // ─── Proxy Runtime types ─────────────────────────────────────────────────────

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -36,7 +36,7 @@ describe('api.listJobs', () => {
 
   it('throws on non-ok response', async () => {
     global.fetch = mockFetch({ detail: 'Not found' }, false, 404)
-    await expect(api.listJobs()).rejects.toThrow('404')
+    await expect(api.listJobs()).rejects.toThrow('Not found')
   })
 })
 


### PR DESCRIPTION
## Summary
- tighten the dashboard, agents, fleet, registry, remediation, and vulnerabilities surfaces for a more concise operator UX
- replace raw optional-integration error states with guided setup states and harden null-safe score rendering in mesh/detail views
- align the traces API/UI payload so trace review shows server, package, and CVE correlation instead of a thin sandbox-style response

## Validation
- npm --prefix ui run test:run
- npm --prefix ui run build
- uv run pytest tests/test_otel_ingest.py -q
- uv run python -m compileall src/agent_bom
