### PR TITLE
Focus operator graph views

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -40,9 +40,17 @@ import {
   type LateralPath,
   type InteractionRisk,
 } from "@/lib/context-graph";
-import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, minimapNodeColor } from "@/lib/graph-utils";
+import {
+  CONTROLS_CLASS,
+  MINIMAP_BG,
+  MINIMAP_CLASS,
+  MINIMAP_MASK,
+  BACKGROUND_COLOR,
+  BACKGROUND_GAP,
+  legendItemsForVisibleNodes,
+  minimapNodeColor,
+} from "@/lib/graph-utils";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
-import { CONTEXT_LEGEND } from "@/lib/graph-utils";
 
 // ─── Stats Bar ──────────────────────────────────────────────────────────────
 
@@ -84,7 +92,10 @@ function LateralPanel({
   const filtered = selectedAgent
     ? paths.filter((p) => p.source === `agent:${selectedAgent}`)
     : paths;
-  const top10 = filtered.slice(0, 10);
+  const distinctPaths = Array.from(
+    new Map(filtered.map((path) => [`${path.hops.join("->")}::${path.vuln_ids.join(",")}`, path])).values(),
+  );
+  const topPaths = distinctPaths.slice(0, 6);
 
   return (
     <div className="w-72 border-l border-zinc-800 overflow-y-auto bg-zinc-950">
@@ -93,11 +104,11 @@ function LateralPanel({
         <h3 className="text-xs font-semibold text-zinc-300 mb-2">
           Lateral Movement{selectedAgent ? ` from ${selectedAgent}` : ""}
         </h3>
-        {top10.length === 0 ? (
+        {topPaths.length === 0 ? (
           <p className="text-[10px] text-zinc-600">No lateral paths found</p>
         ) : (
           <div className="space-y-2">
-            {top10?.map((p, i) => (
+            {topPaths?.map((p, i) => (
               <div
                 key={i}
                 className="bg-zinc-900 border border-zinc-800 rounded-lg p-2"
@@ -231,6 +242,24 @@ export default function ContextPage() {
       .finally(() => setLoading(false));
   }, []);
 
+  const activeJob = useMemo(
+    () => jobs.find((job) => job.job_id === selectedJobId) ?? null,
+    [jobs, selectedJobId],
+  );
+
+  const agentNames = useMemo(
+    () => activeJob?.result?.agents.map((agent) => agent.name).sort((left, right) => left.localeCompare(right)) ?? [],
+    [activeJob],
+  );
+
+  useEffect(() => {
+    if (agentNames.length === 0) {
+      setSelectedAgent(null);
+      return;
+    }
+    setSelectedAgent((current) => (current && agentNames.includes(current) ? current : agentNames[0]));
+  }, [agentNames]);
+
   // Fetch context graph when job changes
   useEffect(() => {
     if (!selectedJobId) return;
@@ -310,6 +339,14 @@ export default function ContextPage() {
     }));
   }, [layoutEdges, connectedIds, searchMatches]);
 
+  const legendItems = useMemo(() => {
+    const extras =
+      displayEdges.some((edge) => edge.animated || Boolean(edge.style?.strokeDasharray))
+        ? [{ label: "Lateral", color: "#f97316", dashed: true, shape: "diamond" as const }]
+        : [];
+    return legendItemsForVisibleNodes(displayNodes, extras);
+  }, [displayEdges, displayNodes]);
+
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     setSelectedNode(node.data as LineageNodeData);
     setHoveredNodeId(null);
@@ -325,14 +362,6 @@ export default function ContextPage() {
   const onNodeMouseLeave = useCallback(() => {
     setHoveredNodeId(null);
   }, []);
-
-  // Agent names for the selector
-  const agentNames = useMemo(() => {
-    if (!graphData) return [];
-    return graphData.nodes
-      .filter((n) => n.kind === "agent")
-      .map((n) => n.label);
-  }, [graphData]);
 
   if (loading) {
     return (
@@ -377,7 +406,7 @@ export default function ContextPage() {
             Context Graph
           </h1>
           <p className="text-xs text-zinc-500">
-            Agent interaction graph — lateral movement analysis
+            Focused lateral-movement map for one agent scope at a time
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -418,13 +447,13 @@ export default function ContextPage() {
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search nodes..."
+              placeholder="Search agent, server, tool, or CVE"
               className="w-full bg-zinc-900 border border-zinc-700 rounded pl-7 pr-2 py-1.5 text-xs text-zinc-300 placeholder:text-zinc-600 focus:outline-none focus:border-emerald-600"
             />
           </div>
 
           <FullscreenButton />
-          <GraphLegend items={CONTEXT_LEGEND} />
+          <GraphLegend items={legendItems} />
         </div>
       </div>
 
@@ -446,8 +475,10 @@ export default function ContextPage() {
               edges={displayEdges}
               nodeTypes={lineageNodeTypes}
               fitView
-              minZoom={0.05}
+              fitViewOptions={{ padding: 0.18, maxZoom: 1.05 }}
+              minZoom={0.16}
               maxZoom={2.5}
+              onlyRenderVisibleElements
               defaultEdgeOptions={{ type: "smoothstep" }}
               proOptions={{ hideAttribution: true }}
               onNodeClick={onNodeClick}
@@ -460,7 +491,12 @@ export default function ContextPage() {
             >
               <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
               <Controls className={CONTROLS_CLASS} />
-              <MiniMap nodeColor={minimapNodeColor} className={MINIMAP_CLASS} />
+              <MiniMap
+                nodeColor={minimapNodeColor}
+                className={MINIMAP_CLASS}
+                bgColor={MINIMAP_BG}
+                maskColor={MINIMAP_MASK}
+              />
             </ReactFlow>
           )}
 

--- a/ui/app/graph/page.tsx
+++ b/ui/app/graph/page.tsx
@@ -15,7 +15,13 @@ import { AlertTriangle, Loader2, ShieldAlert } from "lucide-react";
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphLegend, FullscreenButton } from "@/components/graph-chrome";
 import { LineageDetailPanel } from "@/components/lineage-detail";
-import { FilterPanel, DEFAULT_FILTERS, type FilterState } from "@/components/lineage-filter";
+import {
+  FilterPanel,
+  DEFAULT_FILTERS,
+  createExpandedGraphFilters,
+  createFocusedGraphFilters,
+  type FilterState,
+} from "@/components/lineage-filter";
 import { lineageNodeTypes, type LineageNodeData, type LineageNodeType } from "@/components/lineage-nodes";
 import { applyDagreLayout } from "@/lib/dagre-layout";
 import {
@@ -28,7 +34,9 @@ import {
   BACKGROUND_COLOR,
   BACKGROUND_GAP,
   CONTROLS_CLASS,
+  MINIMAP_BG,
   MINIMAP_CLASS,
+  MINIMAP_MASK,
   minimapNodeColor,
 } from "@/lib/graph-utils";
 import {
@@ -328,6 +336,7 @@ export default function GraphPage() {
   const [searching, setSearching] = useState(false);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const [initializedFocus, setInitializedFocus] = useState(false);
 
   useEffect(() => {
     setLoadingSnapshots(true);
@@ -372,6 +381,8 @@ export default function GraphPage() {
     setSearchResults([]);
     setSearchQuery("");
     setSelectedAttackPathKey(null);
+    setFilters(DEFAULT_FILTERS);
+    setInitializedFocus(false);
   }, [selectedScanId]);
 
   useEffect(() => {
@@ -485,6 +496,12 @@ export default function GraphPage() {
     return buildUnifiedFlowGraph(graphData, filters);
   }, [graphData, filters]);
 
+  useEffect(() => {
+    if (initializedFocus || flow.agentNames.length === 0) return;
+    setFilters(createFocusedGraphFilters(flow.agentNames[0]));
+    setInitializedFocus(true);
+  }, [flow.agentNames, initializedFocus]);
+
   const flowNodeDataById = useMemo(
     () => new Map(flow.nodes.map((node) => [node.id, node.data])),
     [flow.nodes],
@@ -494,14 +511,14 @@ export default function GraphPage() {
     () =>
       flow.nodes.length > 0
         ? applyDagreLayout(flow.nodes, flow.edges, {
-            direction: "LR",
-            nodeWidth: 180,
-            nodeHeight: 64,
-            rankSep: 110,
-            nodeSep: 28,
+            direction: filters.agentName || filters.vulnOnly ? "TB" : "LR",
+            nodeWidth: filters.agentName ? 208 : 188,
+            nodeHeight: 72,
+            rankSep: filters.agentName ? 118 : 104,
+            nodeSep: filters.agentName ? 22 : 28,
           })
         : { nodes: [], edges: [] },
-    [flow.nodes, flow.edges],
+    [flow.nodes, flow.edges, filters.agentName, filters.vulnOnly],
   );
 
   const connectedIds = useMemo(
@@ -680,7 +697,7 @@ export default function GraphPage() {
             <p className="text-[10px] uppercase tracking-[0.24em] text-sky-400">Unified graph</p>
             <h1 className="mt-1 text-lg font-semibold text-zinc-100">Security Graph</h1>
             <p className="text-xs text-zinc-500">
-              Provider → Agent → Server → Package → Findings · Models · Datasets · Containers · Cloud resources · Runtime edges
+              Focused agent-to-finding graph with packages, credentials, tools, and runtime links.
             </p>
           </div>
 
@@ -735,6 +752,37 @@ export default function GraphPage() {
             </button>
           </form>
 
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px]">
+            <button
+              type="button"
+              onClick={() => setFilters(createFocusedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))}
+              className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-2.5 py-1 text-sky-200 transition hover:border-sky-400/60"
+            >
+              Focused view
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilters(createExpandedGraphFilters(null))}
+              className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-2.5 py-1 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
+            >
+              Expanded view
+            </button>
+            <span className="rounded-lg border border-zinc-800 bg-zinc-900/80 px-2.5 py-1 text-zinc-400">
+              {filters.agentName ? `agent ${filters.agentName}` : "all agents"}
+            </span>
+            <span className="rounded-lg border border-zinc-800 bg-zinc-900/80 px-2.5 py-1 text-zinc-400">
+              {filters.severity ? `${filters.severity}+` : "all severities"}
+            </span>
+            <span className="rounded-lg border border-zinc-800 bg-zinc-900/80 px-2.5 py-1 text-zinc-400">
+              depth {filters.maxDepth}
+            </span>
+            {filters.vulnOnly && (
+              <span className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1 text-emerald-200">
+                vulnerable only
+              </span>
+            )}
+          </div>
+
           {searchResults.length > 0 && (
             <div className="mt-2 rounded-2xl border border-zinc-800 bg-zinc-950/90 p-2">
               <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
@@ -751,7 +799,12 @@ export default function GraphPage() {
                     </p>
                     <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-zinc-500">
                       {result.severity && <span>{result.severity}</span>}
-                      <span>risk {result.risk_score.toFixed(1)}</span>
+                      <span>
+                        risk{" "}
+                        {typeof result.risk_score === "number" && Number.isFinite(result.risk_score)
+                          ? result.risk_score.toFixed(1)
+                          : "N/A"}
+                      </span>
                     </div>
                   </button>
                 ))}
@@ -893,8 +946,10 @@ export default function GraphPage() {
             edges={displayEdges}
             nodeTypes={lineageNodeTypes}
             fitView
-            minZoom={0.05}
+            fitViewOptions={{ padding: 0.18, maxZoom: 1.05 }}
+            minZoom={0.16}
             maxZoom={2.5}
+            onlyRenderVisibleElements
             defaultEdgeOptions={{ type: "smoothstep" }}
             proOptions={{ hideAttribution: true }}
             onNodeClick={onNodeClick}
@@ -908,7 +963,12 @@ export default function GraphPage() {
           >
             <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
             <Controls className={CONTROLS_CLASS} />
-            <MiniMap nodeColor={minimapNodeColor} className={MINIMAP_CLASS} />
+            <MiniMap
+              nodeColor={minimapNodeColor}
+              className={MINIMAP_CLASS}
+              bgColor={MINIMAP_BG}
+              maskColor={MINIMAP_MASK}
+            />
           </ReactFlow>
 
           {selectedNode && (

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -24,9 +24,17 @@ import {
   type SeverityFilter,
   type MeshStatsData,
 } from "@/lib/mesh-graph";
-import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, minimapNodeColor } from "@/lib/graph-utils";
+import {
+  CONTROLS_CLASS,
+  MINIMAP_BG,
+  MINIMAP_CLASS,
+  MINIMAP_MASK,
+  BACKGROUND_COLOR,
+  BACKGROUND_GAP,
+  legendItemsForVisibleNodes,
+  minimapNodeColor,
+} from "@/lib/graph-utils";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
-import { MESH_LEGEND } from "@/lib/graph-utils";
 
 // ─── Filter Toolbar ─────────────────────────────────────────────────────────
 
@@ -37,6 +45,11 @@ function MeshToolbar({
   setSeverityFilter,
   searchQuery,
   setSearchQuery,
+  vulnerableOnly,
+  setVulnerableOnly,
+  agentNames,
+  selectedAgents,
+  toggleAgent,
 }: {
   nodeFilter: NodeTypeFilter;
   setNodeFilter: (f: NodeTypeFilter) => void;
@@ -44,6 +57,11 @@ function MeshToolbar({
   setSeverityFilter: (f: SeverityFilter) => void;
   searchQuery: string;
   setSearchQuery: (q: string) => void;
+  vulnerableOnly: boolean;
+  setVulnerableOnly: (next: boolean) => void;
+  agentNames: string[];
+  selectedAgents: string[];
+  toggleAgent: (name: string) => void;
 }) {
   const toggles: { key: keyof NodeTypeFilter; label: string; color: string }[] = [
     { key: "packages", label: "Packages", color: "text-zinc-400" },
@@ -84,6 +102,16 @@ function MeshToolbar({
         <option value="low">Low+</option>
       </select>
 
+      <label className="flex items-center gap-1.5 text-zinc-400">
+        <input
+          type="checkbox"
+          checked={vulnerableOnly}
+          onChange={(event) => setVulnerableOnly(event.target.checked)}
+          className="w-3 h-3 rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-0 focus:ring-offset-0"
+        />
+        Vulnerable only
+      </label>
+
       <div className="w-px h-4 bg-zinc-700" />
 
       {/* Search */}
@@ -105,6 +133,31 @@ function MeshToolbar({
           </button>
         )}
       </div>
+
+      {agentNames.length > 0 && (
+        <>
+          <div className="w-px h-4 bg-zinc-700" />
+          <div className="flex items-center gap-1.5 overflow-x-auto max-w-[28rem] pb-1">
+            {agentNames.map((name) => {
+              const active = selectedAgents.includes(name);
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => toggleAgent(name)}
+                  className={`rounded-full border px-2.5 py-1 text-[11px] transition ${
+                    active
+                      ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-200"
+                      : "border-zinc-700 bg-zinc-900/70 text-zinc-500 hover:border-zinc-500 hover:text-zinc-300"
+                  }`}
+                >
+                  {name}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -129,7 +182,9 @@ export default function MeshPage() {
     credentials: true,
     tools: true,
   });
-  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("high");
+  const [vulnerableOnly, setVulnerableOnly] = useState(true);
+  const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
@@ -159,6 +214,22 @@ export default function MeshPage() {
     [jobs, selectedJob]
   );
 
+  const agentNames = useMemo(
+    () => activeResult?.agents.map((agent) => agent.name).sort((left, right) => left.localeCompare(right)) ?? [],
+    [activeResult],
+  );
+
+  useEffect(() => {
+    if (agentNames.length === 0) {
+      setSelectedAgents([]);
+      return;
+    }
+    setSelectedAgents((current) => {
+      const retained = current.filter((name) => agentNames.includes(name));
+      return retained.length > 0 ? retained : [agentNames[0]];
+    });
+  }, [agentNames]);
+
   const { rawNodes, rawEdges, stats } = useMemo(() => {
     const empty: MeshStatsData = {
       totalAgents: 0, sharedServers: 0, uniqueCredentials: 0, toolOverlap: 0,
@@ -166,9 +237,12 @@ export default function MeshPage() {
       criticalCount: 0, highCount: 0, mediumCount: 0, lowCount: 0, kevCount: 0,
     };
     if (!activeResult) return { rawNodes: [] as Node[], rawEdges: [] as Edge[], stats: empty };
-    const { nodes, edges, stats } = buildMeshGraph(activeResult, nodeFilter, severityFilter);
+    const { nodes, edges, stats } = buildMeshGraph(activeResult, nodeFilter, severityFilter, {
+      selectedAgents,
+      vulnerableOnly,
+    });
     return { rawNodes: nodes, rawEdges: edges, stats };
-  }, [activeResult, nodeFilter, severityFilter]);
+  }, [activeResult, nodeFilter, severityFilter, selectedAgents, vulnerableOnly]);
 
   const { nodes: layoutNodes, edges: layoutEdges } = useMemo(
     () =>
@@ -189,6 +263,15 @@ export default function MeshPage() {
     () => (searchQuery ? searchNodes(layoutNodes, searchQuery) : null),
     [layoutNodes, searchQuery]
   );
+
+  const toggleAgent = useCallback((name: string) => {
+    setSelectedAgents((current) => {
+      if (current.includes(name)) {
+        return current.length === 1 ? current : current.filter((entry) => entry !== name);
+      }
+      return [...current, name];
+    });
+  }, []);
 
   // Hover highlighting
   const connectedIds = useMemo(
@@ -221,6 +304,8 @@ export default function MeshPage() {
       },
     }));
   }, [layoutEdges, connectedIds, searchMatches]);
+
+  const legendItems = useMemo(() => legendItemsForVisibleNodes(displayNodes), [displayNodes]);
 
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     setSelectedNode(node.data as LineageNodeData);
@@ -271,7 +356,7 @@ export default function MeshPage() {
         <div>
           <h1 className="text-lg font-semibold text-zinc-100">Agent Mesh</h1>
           <p className="text-xs text-zinc-500">
-            Cross-agent topology — packages, vulnerabilities, credentials, tools
+            Selected agents, shared servers, packages, and findings
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -313,7 +398,7 @@ export default function MeshPage() {
             ))}
           </select>
           <FullscreenButton />
-          <GraphLegend items={MESH_LEGEND} />
+          <GraphLegend items={legendItems} />
         </div>
       </div>
 
@@ -328,6 +413,11 @@ export default function MeshPage() {
         setSeverityFilter={setSeverityFilter}
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
+        vulnerableOnly={vulnerableOnly}
+        setVulnerableOnly={setVulnerableOnly}
+        agentNames={agentNames}
+        selectedAgents={selectedAgents}
+        toggleAgent={toggleAgent}
       />
 
       {/* Graph */}
@@ -337,8 +427,10 @@ export default function MeshPage() {
           edges={displayEdges}
           nodeTypes={lineageNodeTypes}
           fitView
-          minZoom={0.05}
+          fitViewOptions={{ padding: 0.18, maxZoom: 1.05 }}
+          minZoom={0.16}
           maxZoom={2.5}
+          onlyRenderVisibleElements
           defaultEdgeOptions={{ type: "smoothstep" }}
           proOptions={{ hideAttribution: true }}
           onNodeClick={onNodeClick}
@@ -348,7 +440,12 @@ export default function MeshPage() {
         >
           <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
           <Controls className={CONTROLS_CLASS} />
-          <MiniMap nodeColor={minimapNodeColor} className={MINIMAP_CLASS} />
+          <MiniMap
+            nodeColor={minimapNodeColor}
+            className={MINIMAP_CLASS}
+            bgColor={MINIMAP_BG}
+            maskColor={MINIMAP_MASK}
+          />
         </ReactFlow>
 
         {selectedNode && (

--- a/ui/app/proxy/page.tsx
+++ b/ui/app/proxy/page.tsx
@@ -210,17 +210,30 @@ export default function ProxyDashboard() {
 
       {/* No proxy session */}
       {!loading && !error && !isActive && (
-        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+        <div className="rounded-xl border border-dashed border-zinc-800 bg-zinc-950/70 p-8">
           <Shield className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-500 text-sm">No active proxy session</p>
-          <p className="text-zinc-600 text-xs mt-1 max-w-md mx-auto">
-            Start a proxy with{" "}
-            <code className="text-zinc-400 bg-zinc-800 px-1.5 py-0.5 rounded text-[11px]">
-              agent-bom proxy -- npx @modelcontextprotocol/server-fs /workspace
-            </code>{" "}
-            or set <code className="text-zinc-400 bg-zinc-800 px-1.5 py-0.5 rounded text-[11px]">AGENT_BOM_LOG</code> to
-            read from an audit log.
+          <p className="text-zinc-300 text-sm text-center">No runtime telemetry connected</p>
+          <p className="text-zinc-500 text-xs mt-2 max-w-2xl mx-auto text-center">
+            Proxy is an optional runtime feed for live tool-call review, policy enforcement, and audit alerts. Core scanning,
+            graph analysis, and compliance workflows do not depend on it.
           </p>
+          <div className="mt-6 grid gap-3 md:grid-cols-3">
+            <SetupCard
+              title="Local proxy"
+              body="Start an inline MCP proxy for live tool-call telemetry during local testing."
+              command="agent-bom proxy -- npx @modelcontextprotocol/server-fs /workspace"
+            />
+            <SetupCard
+              title="Audit log replay"
+              body="Point the API at an existing runtime log if you already capture MCP activity elsewhere."
+              command="export AGENT_BOM_LOG=/path/to/proxy-audit.log"
+            />
+            <SetupCard
+              title="Hosted runtime feed"
+              body="Forward proxy events or audit logs into the API when running agent-bom behind a central service."
+              command="POST /v1/proxy/events or /ws/proxy/metrics"
+            />
+          </div>
         </div>
       )}
 
@@ -484,6 +497,26 @@ export default function ProxyDashboard() {
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+function SetupCard({
+  title,
+  body,
+  command,
+}: {
+  title: string;
+  body: string;
+  command: string;
+}) {
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-4">
+      <p className="text-sm font-medium text-zinc-100">{title}</p>
+      <p className="mt-2 text-xs leading-5 text-zinc-500">{body}</p>
+      <code className="mt-3 block rounded-lg bg-zinc-950 px-3 py-2 text-[11px] text-zinc-300">
+        {command}
+      </code>
     </div>
   );
 }

--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -135,15 +135,6 @@ function NarrativeRow({
                 <span className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-400">
                   current {item.current_version}
                 </span>
-                {item.fixed_version ? (
-                  <span className="rounded border border-emerald-900/70 bg-emerald-950/40 px-1.5 py-0.5 font-mono text-emerald-400">
-                    fix {item.fixed_version}
-                  </span>
-                ) : (
-                  <span className="rounded border border-zinc-800 bg-zinc-900 px-1.5 py-0.5 text-zinc-600">
-                    no published fix
-                  </span>
-                )}
               </div>
             </div>
           </div>

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -131,6 +131,7 @@ function VulnsPage() {
         for (const job of fullJobs) {
           if (!job.result) continue;
           const result = job.result as ScanResult;
+          const blastById = new Map(result.blast_radius?.map((item) => [item.vulnerability_id, item]) ?? []);
 
           // Determine scan source labels
           const scanSources: string[] = [];
@@ -143,6 +144,7 @@ function VulnsPage() {
             for (const srv of agent.mcp_servers) {
               for (const pkg of srv.packages) {
                 for (const vuln of pkg.vulnerabilities ?? []) {
+                  const blast = blastById.get(vuln.id);
                   const existing = vulnMap.get(vuln.id);
                   if (existing) {
                     if (!existing.packages.includes(pkg.name)) existing.packages.push(pkg.name);
@@ -150,9 +152,17 @@ function VulnsPage() {
                     for (const src of scanSources) {
                       if (!existing.sources.includes(src)) existing.sources.push(src);
                     }
+                    existing.cvss_score = existing.cvss_score ?? blast?.cvss_score ?? vuln.cvss_score;
+                    existing.epss_score = existing.epss_score ?? blast?.epss_score ?? vuln.epss_score;
+                    existing.fixed_version = existing.fixed_version ?? blast?.fixed_version ?? vuln.fixed_version;
+                    existing.summary = existing.summary ?? blast?.attack_vector_summary ?? vuln.summary ?? vuln.description;
                   } else {
                     vulnMap.set(vuln.id, {
                       ...vuln,
+                      cvss_score: blast?.cvss_score ?? vuln.cvss_score,
+                      epss_score: blast?.epss_score ?? vuln.epss_score,
+                      fixed_version: blast?.fixed_version ?? vuln.fixed_version,
+                      summary: blast?.attack_vector_summary ?? vuln.summary ?? vuln.description,
                       packages: [pkg.name],
                       agents: [agent.name],
                       sources: [...scanSources],

--- a/ui/components/charts.tsx
+++ b/ui/components/charts.tsx
@@ -325,24 +325,40 @@ export function SupplyChainTreemap({
     name: agent.name,
     children: agent.mcp_servers?.map((srv) => ({
       name: srv.name,
-      children: srv.packages?.map((pkg) => {
-        const vulns = pkg.vulnerabilities ?? [];
-        const hasVuln = vulns.length > 0;
-        const worst = vulns.reduce(
-          (w, v) => {
-            const order: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
-            return (order[v.severity] ?? 0) > (order[w] ?? 0) ? v.severity : w;
-          },
-          "none" as string
-        );
-        const color = hasVuln
-          ? worst === "critical" ? "#ef4444"
-          : worst === "high" ? "#f97316"
-          : worst === "medium" ? "#eab308"
-          : "#3b82f6"
-          : "#22c55e";
-        return { name: `${pkg.name}@${pkg.version}`, size: Math.max(1, vulns.length || 1), color };
-      }),
+      children: (() => {
+        const vulnerablePackages = srv.packages
+          ?.filter((pkg) => (pkg.vulnerabilities?.length ?? 0) > 0)
+          .sort((left, right) => (right.vulnerabilities?.length ?? 0) - (left.vulnerabilities?.length ?? 0))
+          .map((pkg) => {
+            const vulns = pkg.vulnerabilities ?? [];
+            const worst = vulns.reduce(
+              (w, v) => {
+                const order: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+                return (order[v.severity] ?? 0) > (order[w] ?? 0) ? v.severity : w;
+              },
+              "none" as string
+            );
+            const color = worst === "critical"
+              ? "#ef4444"
+              : worst === "high"
+                ? "#f97316"
+                : worst === "medium"
+                  ? "#eab308"
+                  : "#3b82f6";
+            return {
+              name: `${pkg.name}@${pkg.version}`,
+              size: Math.max(2, vulns.length * 3),
+              color,
+            };
+          }) ?? [];
+        const cleanCount = srv.packages?.filter((pkg) => (pkg.vulnerabilities?.length ?? 0) === 0).length ?? 0;
+        return [
+          ...vulnerablePackages,
+          ...(cleanCount > 0
+            ? [{ name: `Clean packages (${cleanCount})`, size: cleanCount, color: "#22c55e", aggregate: true }]
+            : []),
+        ];
+      })(),
     })),
   }));
 
@@ -352,7 +368,7 @@ export function SupplyChainTreemap({
     <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
       <h3 className="text-sm font-semibold text-zinc-300 mb-1">Supply Chain Map</h3>
       <p className="text-[10px] text-zinc-600 mb-4">
-        Agent → Server → Package · green = clean · red/orange/yellow = vulnerable
+        Vulnerable packages stay expanded. Clean inventory is rolled up per server for readability.
       </p>
       <div className="h-64">
         <ResponsiveContainer width="100%" height="100%">
@@ -361,7 +377,13 @@ export function SupplyChainTreemap({
             dataKey="size"
             content={<TreemapCell />}
             onClick={(node: Record<string, unknown>) => {
-              if (onPackageClick && node && typeof node.name === "string" && node.size !== undefined) {
+              if (
+                onPackageClick &&
+                node &&
+                typeof node.name === "string" &&
+                node.size !== undefined &&
+                node.aggregate !== true
+              ) {
                 // Leaf node (package) — strip version suffix for package name
                 const name = node.name.replace(/@[^@]+$/, "");
                 onPackageClick(name);

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -17,18 +17,33 @@ export function GraphLegend({ items }: { items: LegendItem[] }) {
     <div className="flex items-center gap-3 text-[10px] text-zinc-500">
       {items?.map((item) => (
         <span key={item.label} className="flex items-center gap-1">
-          <span
-            className="w-2 h-2 rounded-full"
-            style={{
-              backgroundColor: item.color,
-              border: item.dashed ? `1px dashed ${item.color}` : undefined,
-              background: item.dashed ? "transparent" : item.color,
-            }}
-          />
+          <LegendMarker item={item} />
           {item.label}
         </span>
       ))}
     </div>
+  );
+}
+
+function LegendMarker({ item }: { item: LegendItem }) {
+  const className =
+    item.shape === "square"
+      ? "h-2.5 w-2.5 rounded-[3px]"
+      : item.shape === "diamond"
+        ? "h-2.5 w-2.5 rotate-45 rounded-[2px]"
+        : item.shape === "pill"
+          ? "h-2 w-3.5 rounded-full"
+          : "h-2.5 w-2.5 rounded-full";
+
+  return (
+    <span
+      className={className}
+      style={{
+        backgroundColor: item.color,
+        border: item.dashed ? `1px dashed ${item.color}` : undefined,
+        background: item.dashed ? "transparent" : item.color,
+      }}
+    />
   );
 }
 

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -13,36 +13,77 @@ export interface FilterState {
   pageSize: number;
 }
 
-export const DEFAULT_FILTERS: FilterState = {
-  layers: {
-    provider: true,
-    agent: true,
-    server: true,
-    sharedServer: true,
-    package: true,
-    model: true,
-    dataset: true,
-    container: true,
-    cloudResource: true,
-    environment: true,
-    fleet: true,
-    cluster: true,
-    user: true,
-    group: true,
-    serviceAccount: true,
-    vulnerability: true,
-    misconfiguration: true,
-    credential: true,
-    tool: true,
-  },
-  severity: null,
-  agentName: null,
-  vulnOnly: false,
-  runtimeMode: "all",
-  relationshipScope: "all",
-  maxDepth: 6,
-  pageSize: 1000,
+export const FOCUSED_LAYER_DEFAULTS: Record<LineageNodeType, boolean> = {
+  provider: false,
+  agent: true,
+  server: true,
+  sharedServer: true,
+  package: true,
+  model: false,
+  dataset: false,
+  container: false,
+  cloudResource: false,
+  environment: false,
+  fleet: false,
+  cluster: false,
+  user: false,
+  group: false,
+  serviceAccount: false,
+  vulnerability: true,
+  misconfiguration: true,
+  credential: true,
+  tool: true,
 };
+
+export const EXPANDED_LAYER_DEFAULTS: Record<LineageNodeType, boolean> = {
+  provider: true,
+  agent: true,
+  server: true,
+  sharedServer: true,
+  package: true,
+  model: true,
+  dataset: true,
+  container: true,
+  cloudResource: true,
+  environment: true,
+  fleet: true,
+  cluster: true,
+  user: true,
+  group: true,
+  serviceAccount: true,
+  vulnerability: true,
+  misconfiguration: true,
+  credential: true,
+  tool: true,
+};
+
+export function createFocusedGraphFilters(agentName: string | null = null): FilterState {
+  return {
+    layers: { ...FOCUSED_LAYER_DEFAULTS },
+    severity: "high",
+    agentName,
+    vulnOnly: true,
+    runtimeMode: "all",
+    relationshipScope: "all",
+    maxDepth: 3,
+    pageSize: 250,
+  };
+}
+
+export function createExpandedGraphFilters(agentName: string | null = null): FilterState {
+  return {
+    layers: { ...EXPANDED_LAYER_DEFAULTS },
+    severity: null,
+    agentName,
+    vulnOnly: false,
+    runtimeMode: "all",
+    relationshipScope: "all",
+    maxDepth: 6,
+    pageSize: 1000,
+  };
+}
+
+export const DEFAULT_FILTERS: FilterState = createFocusedGraphFilters();
 
 interface FilterPanelProps {
   filters: FilterState;
@@ -103,10 +144,10 @@ export function FilterPanel({ filters, onChange, agentNames }: FilterPanelProps)
           className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
         >
           <option value="">All</option>
-          <option value="critical">Critical</option>
-          <option value="high">High</option>
-          <option value="medium">Medium</option>
-          <option value="low">Low</option>
+          <option value="critical">Critical only</option>
+          <option value="high">High + critical</option>
+          <option value="medium">Medium + above</option>
+          <option value="low">Low + above</option>
         </select>
       </div>
 
@@ -159,6 +200,7 @@ export function FilterPanel({ filters, onChange, agentNames }: FilterPanelProps)
             className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
           >
             <option value="2">Depth 2</option>
+            <option value="3">Depth 3</option>
             <option value="4">Depth 4</option>
             <option value="6">Depth 6</option>
             <option value="8">Depth 8</option>
@@ -202,6 +244,7 @@ export function FilterPanel({ filters, onChange, agentNames }: FilterPanelProps)
           onChange={(e) => onChange({ ...filters, pageSize: Number(e.target.value) })}
           className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
         >
+          <option value="250">250 nodes</option>
           <option value="500">500 nodes</option>
           <option value="1000">1,000 nodes</option>
           <option value="2500">2,500 nodes</option>

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -99,6 +99,7 @@ type CardProps = {
   borderClass: string;
   bgClass: string;
   ringClass: string;
+  shapeClass?: string;
   icon: ComponentType<{ className?: string }>;
   iconClass: string;
   source?: boolean;
@@ -112,6 +113,7 @@ function NodeCard({
   borderClass,
   bgClass,
   ringClass,
+  shapeClass = "rounded-xl",
   icon: Icon,
   iconClass,
   source = true,
@@ -121,7 +123,7 @@ function NodeCard({
 }: CardProps) {
   return (
     <div
-      className={`rounded-lg border-2 px-3 py-2 min-w-[148px] max-w-[220px] shadow-lg backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
+      className={`${shapeClass} border-2 px-3 py-2 min-w-[148px] max-w-[220px] shadow-lg backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
         data.dimmed ? "opacity-25" : ""
       } ${data.highlighted ? `ring-2 ${ringClass}` : ""}`}
     >
@@ -130,12 +132,37 @@ function NodeCard({
       <div className="flex items-center gap-1.5 mb-0.5">
         <Icon className={`w-3.5 h-3.5 shrink-0 ${iconClass}`} />
         <span className="text-xs font-semibold text-zinc-100 truncate">{data.label}</span>
+        <span className="ml-auto rounded border border-white/10 bg-black/20 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.16em] text-zinc-500">
+          {NODE_TYPE_BADGES[data.nodeType]}
+        </span>
       </div>
       {subtitle && <div className="text-[10px] text-zinc-400 truncate">{subtitle}</div>}
       {footer}
     </div>
   );
 }
+
+const NODE_TYPE_BADGES: Record<LineageNodeType, string> = {
+  provider: "Provider",
+  agent: "Agent",
+  server: "Server",
+  package: "Package",
+  vulnerability: "CVE",
+  misconfiguration: "Config",
+  credential: "Credential",
+  tool: "Tool",
+  model: "Model",
+  dataset: "Dataset",
+  container: "Container",
+  cloudResource: "Cloud",
+  user: "User",
+  group: "Group",
+  serviceAccount: "Service",
+  environment: "Env",
+  fleet: "Fleet",
+  cluster: "Cluster",
+  sharedServer: "Shared",
+};
 
 function AgentNode({ data }: { data: LineageNodeData }) {
   const notConfigured = data.agentStatus === "installed-not-configured";
@@ -397,6 +424,7 @@ function FindingNode({
       borderClass={borderClass}
       bgClass={bgClass}
       ringClass="ring-white/50"
+      shapeClass={data.nodeType === "misconfiguration" ? "rounded-md" : "rounded-lg"}
       icon={data.nodeType === "misconfiguration" ? TriangleAlert : Bug}
       iconClass={accentClass}
       source={false}
@@ -448,6 +476,7 @@ function CredentialNode({ data }: { data: LineageNodeData }) {
       borderClass="border-amber-500 border-dashed"
       bgClass="bg-amber-950/60"
       ringClass="ring-amber-400"
+      shapeClass="rounded-2xl"
       icon={KeyRound}
       iconClass="text-amber-400"
       source={false}
@@ -463,6 +492,7 @@ function ToolNode({ data }: { data: LineageNodeData }) {
       borderClass="border-purple-600"
       bgClass="bg-purple-950/60"
       ringClass="ring-purple-400"
+      shapeClass="rounded-2xl"
       icon={Wrench}
       iconClass="text-purple-400"
       source={false}
@@ -534,6 +564,7 @@ function SharedServerNode({ data }: { data: LineageNodeData }) {
       borderClass="border-cyan-400"
       bgClass="bg-cyan-950/80"
       ringClass="ring-cyan-300"
+      shapeClass="rounded-[18px]"
       icon={Server}
       iconClass="text-cyan-300"
       subtitle={data.command}

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -13,9 +13,8 @@ import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nod
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import { MeshStats } from "@/components/mesh-stats";
 import { buildMeshGraph, getConnectedIds, type MeshStatsData } from "@/lib/mesh-graph";
-import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, minimapNodeColor } from "@/lib/graph-utils";
+import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, legendItemsForVisibleNodes, minimapNodeColor } from "@/lib/graph-utils";
 import { GraphLegend } from "@/components/graph-chrome";
-import { STANDARD_LEGEND } from "@/lib/graph-utils";
 
 export function ScanMeshView({ id }: { id: string }) {
   const [job, setJob] = useState<ScanJob | null>(null);
@@ -58,6 +57,8 @@ export function ScanMeshView({ id }: { id: string }) {
     return layoutEdges?.map((e) => ({ ...e, style: { ...e.style, opacity: connectedIds.has(e.source) && connectedIds.has(e.target) ? 1 : 0.12 } }));
   }, [layoutEdges, connectedIds]);
 
+  const legendItems = useMemo(() => legendItemsForVisibleNodes(displayNodes), [displayNodes]);
+
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => { setSelectedNode(node.data as LineageNodeData); setHoveredNodeId(null); }, []);
   const onNodeMouseEnter = useCallback((_event: React.MouseEvent, node: Node) => { setHoveredNodeId(node.id); }, []);
   const onNodeMouseLeave = useCallback(() => { setHoveredNodeId(null); }, []);
@@ -82,7 +83,7 @@ export function ScanMeshView({ id }: { id: string }) {
           </div>
           <p className="text-xs text-zinc-500 ml-6">Scan {id.slice(0, 8)} — {job.created_at ? new Date(job.created_at).toLocaleDateString() : ""}</p>
         </div>
-        <GraphLegend items={STANDARD_LEGEND} />
+        <GraphLegend items={legendItems} />
       </div>
       <MeshStats stats={stats} />
       <div className="flex-1 relative">

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -109,6 +109,17 @@ export function buildContextFlowGraph(
       }
     }
   }
+  if (selectedAgent && pathNodeIds.size === 0) {
+    const seedId = `agent:${selectedAgent}`;
+    pathNodeIds.add(seedId);
+    for (const edge of data.edges) {
+      if (edge.source === seedId) pathNodeIds.add(edge.target);
+      if (edge.target === seedId) pathNodeIds.add(edge.source);
+    }
+  }
+  const visibleIds = selectedAgent && pathNodeIds.size > 0
+    ? pathNodeIds
+    : new Set(data.nodes.map((node) => node.id));
 
   // Shared server IDs
   const sharedServerNames = new Set<string>();
@@ -119,7 +130,9 @@ export function buildContextFlowGraph(
     }
   }
 
-  const nodes: Node[] = data.nodes.map((n) => {
+  const nodes: Node[] = data.nodes
+    .filter((node) => visibleIds.has(node.id))
+    .map((n) => {
     let nodeType = KIND_TO_NODE_TYPE[n.kind] ?? "server";
     if (n.kind === "server" && sharedServerNames.has(n.label)) {
       nodeType = "sharedServer";
@@ -140,44 +153,46 @@ export function buildContextFlowGraph(
       serverCount: (n.metadata?.server_count as number) ?? undefined,
     };
 
-    return {
-      id: n.id,
-      type: nodeType,
-      data: nodeData,
-      position: { x: 0, y: 0 },
-    };
-  });
+      return {
+        id: n.id,
+        type: nodeType,
+        data: nodeData,
+        position: { x: 0, y: 0 },
+      };
+    });
 
-  const edges: Edge[] = data.edges.map((e, i) => {
+  const edges: Edge[] = data.edges
+    .filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target))
+    .map((e, i) => {
     const isOnPath = pathEdgePairs.has(`${e.source}→${e.target}`);
     const baseColor = EDGE_COLORS[e.kind] ?? "#52525b";
 
-    return {
-      id: `ctx-edge-${i}`,
-      source: e.source,
-      target: e.target,
-      type: "smoothstep",
-      animated: isOnPath,
-      style: {
-        stroke: isOnPath ? "#f97316" : baseColor,
-        strokeWidth: isOnPath ? 2.5 : 1.5,
-        strokeDasharray: isOnPath ? "8 4" : undefined,
-        opacity: selectedAgent && pathNodeIds.size > 0 && !isOnPath ? 0.15 : 1,
-      },
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        color: isOnPath ? "#f97316" : baseColor,
-        width: 12,
-        height: 12,
-      },
-      label: e.kind === "shares_server"
-        ? `shared: ${(e.metadata?.server as string) ?? ""}`
-        : e.kind === "shares_credential"
-        ? `shared: ${(e.metadata?.credential as string) ?? ""}`
-        : undefined,
-      labelStyle: { fontSize: 9, fill: "#71717a" },
-    };
-  });
+      return {
+        id: `ctx-edge-${i}`,
+        source: e.source,
+        target: e.target,
+        type: "smoothstep",
+        animated: isOnPath,
+        style: {
+          stroke: isOnPath ? "#f97316" : baseColor,
+          strokeWidth: isOnPath ? 2.5 : 1.5,
+          strokeDasharray: isOnPath ? "8 4" : undefined,
+          opacity: selectedAgent && pathNodeIds.size > 0 && !isOnPath ? 0.15 : 1,
+        },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          color: isOnPath ? "#f97316" : baseColor,
+          width: 12,
+          height: 12,
+        },
+        label: e.kind === "shares_server"
+          ? `shared: ${(e.metadata?.server as string) ?? ""}`
+          : e.kind === "shares_credential"
+          ? `shared: ${(e.metadata?.credential as string) ?? ""}`
+          : undefined,
+        labelStyle: { fontSize: 9, fill: "#71717a" },
+      };
+    });
 
   return { nodes, edges };
 }

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -11,6 +11,8 @@ export const CONTROLS_CLASS =
   "!bg-zinc-900/90 !border-zinc-700 !rounded-lg !backdrop-blur-sm [&>button]:!bg-zinc-800 [&>button]:!border-zinc-700 [&>button]:!text-zinc-300 [&>button:hover]:!bg-zinc-700";
 
 export const MINIMAP_CLASS = "!bg-zinc-900/90 !border-zinc-700 !rounded-lg !backdrop-blur-sm";
+export const MINIMAP_BG = "#09090b";
+export const MINIMAP_MASK = "rgba(24,24,27,0.82)";
 
 export const BACKGROUND_COLOR = "#1c1c1e";
 export const BACKGROUND_GAP = 24;
@@ -78,32 +80,106 @@ export interface LegendItem {
   label: string;
   color: string;
   dashed?: boolean;
+  shape?: "dot" | "square" | "diamond" | "pill";
+}
+
+const NODE_TYPE_LEGEND_ORDER: LineageNodeType[] = [
+  "provider",
+  "agent",
+  "sharedServer",
+  "server",
+  "package",
+  "model",
+  "dataset",
+  "container",
+  "cloudResource",
+  "environment",
+  "fleet",
+  "cluster",
+  "user",
+  "group",
+  "serviceAccount",
+  "vulnerability",
+  "misconfiguration",
+  "credential",
+  "tool",
+];
+
+const NODE_TYPE_LEGEND_ITEMS: Record<LineageNodeType, LegendItem> = {
+  provider: { label: "Provider", color: "#71717a", shape: "dot" },
+  agent: { label: "Agent", color: "#10b981", shape: "dot" },
+  sharedServer: { label: "Shared", color: "#22d3ee", shape: "square" },
+  server: { label: "Server", color: "#3b82f6", shape: "square" },
+  package: { label: "Package", color: "#52525b", shape: "pill" },
+  model: { label: "Model", color: "#8b5cf6", shape: "pill" },
+  dataset: { label: "Dataset", color: "#06b6d4", shape: "pill" },
+  container: { label: "Container", color: "#6366f1", shape: "square" },
+  cloudResource: { label: "Cloud", color: "#0ea5e9", shape: "square" },
+  environment: { label: "Env", color: "#14b8a6", shape: "square" },
+  fleet: { label: "Fleet", color: "#22d3ee", shape: "square" },
+  cluster: { label: "Cluster", color: "#38bdf8", shape: "square" },
+  user: { label: "User", color: "#34d399", shape: "dot" },
+  group: { label: "Group", color: "#d946ef", shape: "pill" },
+  serviceAccount: { label: "Svc", color: "#fbbf24", shape: "dot" },
+  vulnerability: { label: "Vuln", color: "#ef4444", shape: "diamond" },
+  misconfiguration: { label: "Config", color: "#f97316", shape: "diamond" },
+  credential: { label: "Cred", color: "#f59e0b", shape: "dot" },
+  tool: { label: "Tool", color: "#a855f7", shape: "pill" },
+};
+
+function isLineageNodeType(value: unknown): value is LineageNodeType {
+  return typeof value === "string" && value in NODE_TYPE_LEGEND_ITEMS;
+}
+
+export function legendItemsForVisibleNodes(
+  nodes: Array<{ data?: unknown }>,
+  extras: LegendItem[] = [],
+): LegendItem[] {
+  const visibleTypes = new Set<LineageNodeType>();
+  for (const node of nodes) {
+    const nodeType = (node.data as Partial<LineageNodeData> | undefined)?.nodeType;
+    if (isLineageNodeType(nodeType)) {
+      visibleTypes.add(nodeType);
+    }
+  }
+
+  const items = NODE_TYPE_LEGEND_ORDER
+    .filter((nodeType) => visibleTypes.has(nodeType))
+    .map((nodeType) => NODE_TYPE_LEGEND_ITEMS[nodeType]);
+
+  for (const extra of extras) {
+    if (!items.some((item) => item.label === extra.label)) {
+      items.push(extra);
+    }
+  }
+
+  return items;
 }
 
 export const STANDARD_LEGEND: LegendItem[] = [
-  { label: "Agent", color: "#10b981" },
-  { label: "Server", color: "#3b82f6" },
-  { label: "Package", color: "#52525b" },
-  { label: "CVE", color: "#ef4444" },
-  { label: "Cred", color: "#f59e0b" },
-  { label: "Tool", color: "#a855f7" },
+  { label: "Agent", color: "#10b981", shape: "dot" },
+  { label: "Server", color: "#3b82f6", shape: "square" },
+  { label: "Package", color: "#52525b", shape: "pill" },
+  { label: "CVE", color: "#ef4444", shape: "diamond" },
+  { label: "Cred", color: "#f59e0b", shape: "dot" },
+  { label: "Tool", color: "#a855f7", shape: "pill" },
 ];
 
 export const MESH_LEGEND: LegendItem[] = [
-  { label: "Agent", color: "#10b981" },
-  { label: "Shared", color: "#22d3ee" },
-  { label: "Server", color: "#3b82f6" },
-  { label: "Package", color: "#52525b" },
-  { label: "Vuln", color: "#ef4444" },
-  { label: "Cred", color: "#f59e0b" },
-  { label: "Tool", color: "#a855f7" },
+  { label: "Agent", color: "#10b981", shape: "dot" },
+  { label: "Shared", color: "#22d3ee", shape: "square" },
+  { label: "Server", color: "#3b82f6", shape: "square" },
+  { label: "Package", color: "#52525b", shape: "pill" },
+  { label: "Vuln", color: "#ef4444", shape: "diamond" },
+  { label: "Cred", color: "#f59e0b", shape: "dot" },
+  { label: "Tool", color: "#a855f7", shape: "pill" },
 ];
 
 export const CONTEXT_LEGEND: LegendItem[] = [
-  { label: "Agent", color: "#10b981" },
-  { label: "Shared", color: "#22d3ee" },
-  { label: "Cred", color: "#f59e0b" },
-  { label: "Tool", color: "#a855f7" },
-  { label: "Vuln", color: "#ef4444" },
-  { label: "Lateral", color: "#f97316", dashed: true },
+  { label: "Agent", color: "#10b981", shape: "dot" },
+  { label: "Shared", color: "#22d3ee", shape: "square" },
+  { label: "Cred", color: "#f59e0b", shape: "dot" },
+  { label: "Tool", color: "#a855f7", shape: "pill" },
+  { label: "Vuln", color: "#ef4444", shape: "diamond" },
+  { label: "Lateral", color: "#f97316", dashed: true, shape: "diamond" },
 ];

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -4,7 +4,7 @@
  */
 
 import { type Node, type Edge, MarkerType } from "@xyflow/react";
-import type { ScanResult, MCPServer } from "@/lib/api";
+import type { ScanResult, MCPServer, Agent, Vulnerability } from "@/lib/api";
 import type { LineageNodeData } from "@/components/lineage-nodes";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -42,6 +42,12 @@ export type NodeTypeFilter = {
 };
 
 export type SeverityFilter = "all" | "critical" | "high" | "medium" | "low";
+type VulnerabilitySeverity = Vulnerability["severity"];
+
+export interface MeshGraphScope {
+  selectedAgents?: string[];
+  vulnerableOnly?: boolean;
+}
 
 // ─── Credential detection ───────────────────────────────────────────────────
 
@@ -53,10 +59,10 @@ function getCredKeys(server: MCPServer): string[] {
 
 // ─── Shared Server Detection ────────────────────────────────────────────────
 
-export function detectSharedServers(result: ScanResult): Map<string, ServerGroup> {
+export function detectSharedServers(agents: Agent[]): Map<string, ServerGroup> {
   const groups = new Map<string, ServerGroup>();
 
-  for (const agent of result.agents) {
+  for (const agent of agents) {
     for (const server of agent.mcp_servers) {
       const key = server.name;
       const existing = groups.get(key);
@@ -89,6 +95,10 @@ export function detectSharedServers(result: ScanResult): Map<string, ServerGroup
 
 const SEV_ORDER: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1, none: 0 };
 
+function severityWeight(sev: string | undefined): number {
+  return SEV_ORDER[sev ?? "none"] ?? 0;
+}
+
 function sevColor(sev: string): string {
   switch (sev) {
     case "critical": return "#ef4444";
@@ -104,12 +114,29 @@ function meetsSeverityFilter(sev: string, filter: SeverityFilter): boolean {
   return (SEV_ORDER[sev] ?? 0) >= (SEV_ORDER[filter] ?? 0);
 }
 
+function compareVulnerabilities(left: Vulnerability, right: Vulnerability): number {
+  const severityDiff = severityWeight(right.severity) - severityWeight(left.severity);
+  if (severityDiff !== 0) return severityDiff;
+  const cvssDiff = (right.cvss_score ?? 0) - (left.cvss_score ?? 0);
+  if (cvssDiff !== 0) return cvssDiff;
+  return (right.epss_score ?? 0) - (left.epss_score ?? 0);
+}
+
+function normalizeSeverity(severity: string | undefined): VulnerabilitySeverity {
+  const normalized = String(severity ?? "none").toLowerCase();
+  if (normalized === "critical" || normalized === "high" || normalized === "medium" || normalized === "low") {
+    return normalized;
+  }
+  return "none";
+}
+
 // ─── Graph Builder ──────────────────────────────────────────────────────────
 
 export function buildMeshGraph(
   result: ScanResult,
   nodeFilter?: NodeTypeFilter,
   severityFilter?: SeverityFilter,
+  scope?: MeshGraphScope,
 ): {
   nodes: Node[];
   edges: Edge[];
@@ -124,8 +151,15 @@ export function buildMeshGraph(
   const showCreds = nodeFilter?.credentials ?? true;
   const showTools = nodeFilter?.tools ?? true;
   const sevFilter = severityFilter ?? "all";
+  const selectedAgents = scope?.selectedAgents ?? [];
+  const vulnerableOnly = scope?.vulnerableOnly ?? false;
+  const activeAgents =
+    selectedAgents.length > 0
+      ? result.agents.filter((agent) => selectedAgents.includes(agent.name))
+      : result.agents;
+  const blastByVulnId = new Map(result.blast_radius?.map((item) => [item.vulnerability_id, item]) ?? []);
 
-  const serverGroups = detectSharedServers(result);
+  const serverGroups = detectSharedServers(activeAgents);
   const sharedServerNames = new Set(
     [...serverGroups.entries()]
       .filter(([, g]) => g.agents.size > 1)
@@ -151,7 +185,7 @@ export function buildMeshGraph(
 
   // Tool overlap: tools available to >1 agent
   const toolAgentMap = new Map<string, Set<string>>();
-  for (const agent of result.agents) {
+  for (const agent of activeAgents) {
     for (const server of agent.mcp_servers) {
       for (const tool of server.tools ?? []) {
         const existing = toolAgentMap.get(tool.name) ?? new Set<string>();
@@ -162,7 +196,7 @@ export function buildMeshGraph(
   }
   const toolOverlap = [...toolAgentMap.values()].filter((a) => a.size > 1).length;
 
-  // Vulnerability stats
+  // View stats
   let totalPackages = 0;
   let totalVulnerabilities = 0;
   let criticalCount = 0;
@@ -171,46 +205,37 @@ export function buildMeshGraph(
   let lowCount = 0;
   let kevCount = 0;
 
-  for (const agent of result.agents) {
-    for (const server of agent.mcp_servers) {
-      totalPackages += server.packages.length;
-      for (const pkg of server.packages) {
-        for (const vuln of pkg.vulnerabilities ?? []) {
-          totalVulnerabilities++;
-          switch (vuln.severity) {
-            case "critical": criticalCount++; break;
-            case "high": highCount++; break;
-            case "medium": mediumCount++; break;
-            case "low": lowCount++; break;
-          }
-          if (vuln.cisa_kev) kevCount++;
-        }
-      }
-    }
-  }
-
-  const stats: MeshStatsData = {
-    totalAgents: result.agents.length,
-    sharedServers: sharedServerNames.size,
-    uniqueCredentials: allCreds.size,
-    toolOverlap,
-    credentialBlast,
-    totalPackages,
-    totalVulnerabilities,
-    criticalCount,
-    highCount,
-    mediumCount,
-    lowCount,
-    kevCount,
-  };
-
   // ── Agent nodes ──
-  for (const agent of result.agents) {
+  for (const agent of activeAgents) {
     const agentId = `agent:${agent.name}`;
-    const totalVulns = agent.mcp_servers.reduce(
-      (s, srv) => s + srv.packages.reduce((vs, p) => vs + (p.vulnerabilities?.length ?? 0), 0),
-      0
-    );
+    const visibleServers = agent.mcp_servers.filter((server) => {
+      if (!vulnerableOnly) return true;
+      return server.packages.some((pkg) =>
+        (pkg.vulnerabilities ?? []).some((vuln) => {
+          const blast = blastByVulnId.get(vuln.id);
+          return meetsSeverityFilter(blast?.severity ?? vuln.severity, sevFilter);
+        }),
+      );
+    });
+    const visiblePackageCount = visibleServers.reduce((sum, server) => {
+      return sum + server.packages.filter((pkg) => {
+        const matching = (pkg.vulnerabilities ?? []).some((vuln) => {
+          const blast = blastByVulnId.get(vuln.id);
+          return meetsSeverityFilter(blast?.severity ?? vuln.severity, sevFilter);
+        });
+        return vulnerableOnly ? matching : true;
+      }).length;
+    }, 0);
+    const totalVulns = agent.mcp_servers.reduce((sum, server) => {
+      return sum + server.packages.reduce((packageSum, pkg) => {
+        const matching = (pkg.vulnerabilities ?? []).filter((vuln) => {
+          const blast = blastByVulnId.get(vuln.id);
+          const severity = blast?.severity ?? vuln.severity;
+          return meetsSeverityFilter(severity, sevFilter);
+        });
+        return packageSum + matching.length;
+      }, 0);
+    }, 0);
     nodes.push({
       id: agentId,
       type: "agentNode",
@@ -220,8 +245,8 @@ export function buildMeshGraph(
         nodeType: "agent",
         agentType: agent.agent_type,
         agentStatus: agent.status,
-        serverCount: agent.mcp_servers.length,
-        packageCount: agent.mcp_servers.reduce((s, srv) => s + srv.packages.length, 0),
+        serverCount: visibleServers.length,
+        packageCount: visiblePackageCount,
         vulnCount: totalVulns,
       } satisfies LineageNodeData,
     });
@@ -354,16 +379,43 @@ export function buildMeshGraph(
       }
 
       // Show vulnerable packages first, then top 3 non-vulnerable
-      const vulnPkgs = [...pkgMap.values()].filter((p) => (p.pkg.vulnerabilities?.length ?? 0) > 0);
-      const cleanPkgs = [...pkgMap.values()].filter((p) => (p.pkg.vulnerabilities?.length ?? 0) === 0).slice(0, 3);
-      const displayPkgs = [...vulnPkgs, ...cleanPkgs];
+      const rankedPackages = [...pkgMap.values()].map((entry) => {
+        const matchingVulns = (entry.pkg.vulnerabilities ?? [])
+          .map((vuln) => {
+            const blast = blastByVulnId.get(vuln.id);
+            return {
+              ...vuln,
+              severity: normalizeSeverity(blast?.severity ?? vuln.severity),
+              cvss_score: blast?.cvss_score ?? vuln.cvss_score,
+              epss_score: blast?.epss_score ?? vuln.epss_score,
+              cisa_kev: (blast?.is_kev ?? blast?.cisa_kev ?? vuln.cisa_kev) || false,
+              fixed_version: blast?.fixed_version ?? vuln.fixed_version,
+            } satisfies Vulnerability;
+          })
+          .filter((vuln) => meetsSeverityFilter(vuln.severity, sevFilter))
+          .sort(compareVulnerabilities);
+        return { ...entry, matchingVulns };
+      });
+      const vulnPkgs = rankedPackages
+        .filter((entry) => entry.matchingVulns.length > 0)
+        .sort((left, right) => {
+          const severityDiff = severityWeight(right.matchingVulns[0]?.severity) - severityWeight(left.matchingVulns[0]?.severity);
+          if (severityDiff !== 0) return severityDiff;
+          return right.matchingVulns.length - left.matchingVulns.length;
+        });
+      const cleanPkgs = rankedPackages
+        .filter((entry) => entry.matchingVulns.length === 0)
+        .slice(0, vulnerableOnly ? 0 : 2);
+      const displayPkgs = [...vulnPkgs.slice(0, vulnerableOnly ? 8 : 6), ...cleanPkgs];
 
-      for (const { pkg, serverName } of displayPkgs) {
+      for (const { pkg, serverName, matchingVulns } of displayPkgs) {
         const pkgId = `pkg:${serverName}:${pkg.ecosystem}:${pkg.name}`;
         if (seen.has(pkgId)) continue;
         seen.add(pkgId);
 
-        const vulnCount = pkg.vulnerabilities?.length ?? 0;
+        const vulnCount = matchingVulns.length;
+        if (vulnerableOnly && vulnCount === 0) continue;
+        totalPackages++;
         nodes.push({
           id: pkgId,
           type: "packageNode",
@@ -392,15 +444,23 @@ export function buildMeshGraph(
         });
 
         // ── Vulnerability nodes ──
-        if (showVulns && pkg.vulnerabilities) {
-          for (const vuln of pkg.vulnerabilities) {
-            if (!meetsSeverityFilter(vuln.severity, sevFilter)) continue;
+        if (showVulns && matchingVulns.length > 0) {
+          for (const vuln of matchingVulns.slice(0, vulnerableOnly ? 6 : 5)) {
             const vulnId = `vuln:${pkg.name}:${vuln.id}`;
             if (seen.has(vulnId)) continue;
             seen.add(vulnId);
+            totalVulnerabilities++;
+            switch (vuln.severity) {
+              case "critical": criticalCount++; break;
+              case "high": highCount++; break;
+              case "medium": mediumCount++; break;
+              case "low": lowCount++; break;
+              default: break;
+            }
+            if (vuln.cisa_kev) kevCount++;
 
             // Look up blast radius data for this vuln
-            const br = result.blast_radius?.find((b) => b.vulnerability_id === vuln.id);
+            const br = blastByVulnId.get(vuln.id);
 
             nodes.push({
               id: vulnId,
@@ -438,6 +498,21 @@ export function buildMeshGraph(
       }
     }
   }
+
+  const stats: MeshStatsData = {
+    totalAgents: activeAgents.length,
+    sharedServers: sharedServerNames.size,
+    uniqueCredentials: allCreds.size,
+    toolOverlap,
+    credentialBlast,
+    totalPackages,
+    totalVulnerabilities,
+    criticalCount,
+    highCount,
+    mediumCount,
+    lowCount,
+    kevCount,
+  };
 
   return { nodes, edges, stats };
 }

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -16,6 +16,7 @@ export interface UnifiedGraphFlowFilters {
   severity: string | null;
   agentName: string | null;
   vulnOnly: boolean;
+  maxDepth: number;
 }
 
 export interface UnifiedGraphFlowSummary {
@@ -174,16 +175,30 @@ export function buildUnifiedFlowGraph(
     });
   }
 
-  const visibleNodeIds = new Set(nodes.map((node) => node.id));
-  const edges: Edge[] = graph.edges
-    .filter((edge) => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target))
+  const prePrunedNodeIds = new Set(nodes.map((node) => node.id));
+  const prePrunedEdges: Edge[] = graph.edges
+    .filter((edge) => prePrunedNodeIds.has(edge.source) && prePrunedNodeIds.has(edge.target))
     .map((edge) => toFlowEdge(edge));
 
-  const visibleNodeTypes = new Set(nodes.map((node) => node.data.nodeType));
-  const summary = buildSummary(nodes, graph);
+  const connectedNodeIds = new Set<string>();
+  for (const edge of prePrunedEdges) {
+    connectedNodeIds.add(edge.source);
+    connectedNodeIds.add(edge.target);
+  }
+  const anchorNodeIds = new Set(
+    nodes
+      .filter((node) => node.data.nodeType === "agent" || FINDING_NODE_TYPES.has(node.data.nodeType))
+      .map((node) => node.id),
+  );
+  const prunedNodes = nodes.filter((node) => connectedNodeIds.has(node.id) || anchorNodeIds.has(node.id));
+  const visibleNodeIds = new Set(prunedNodes.map((node) => node.id));
+  const edges = prePrunedEdges.filter((edge) => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target));
+
+  const visibleNodeTypes = new Set(prunedNodes.map((node) => node.data.nodeType));
+  const summary = buildSummary(prunedNodes, graph);
   const legend = legendForNodeTypes(visibleNodeTypes);
 
-  return { nodes, edges, agentNames, legend, summary };
+  return { nodes: prunedNodes, edges, agentNames, legend, summary };
 }
 
 function deriveVisibleNodeIds(
@@ -198,7 +213,7 @@ function deriveVisibleNodeIds(
       .filter((node) => node.entity_type === EntityType.AGENT && node.label === filters.agentName)
       .map((node) => node.id);
     if (seeds.length > 0) {
-      visible = intersectSets(visible, collectNeighborhood(seeds, undirected, 6));
+      visible = intersectSets(visible, collectNeighborhood(seeds, undirected, Math.max(filters.maxDepth, 2)));
     }
   }
 
@@ -208,10 +223,16 @@ function deriveVisibleNodeIds(
         const nodeType = mapNodeType(node);
         if (!nodeType || !FINDING_NODE_TYPES.has(nodeType)) return false;
         if (!filters.severity) return true;
-        return node.severity?.toLowerCase() === filters.severity.toLowerCase();
+        return meetsSeverityThreshold(node.severity, filters.severity);
       })
+      .sort((left, right) => {
+        const severityDiff = severityRank(right.severity) - severityRank(left.severity);
+        if (severityDiff !== 0) return severityDiff;
+        return (right.risk_score ?? 0) - (left.risk_score ?? 0);
+      })
+      .slice(0, filters.agentName ? 14 : 18)
       .map((node) => node.id);
-    visible = intersectSets(visible, collectNeighborhood(findingSeeds, undirected, 4));
+    visible = intersectSets(visible, collectNeighborhood(findingSeeds, undirected, Math.max(2, filters.maxDepth - 1)));
   }
 
   visible = new Set(
@@ -224,7 +245,7 @@ function deriveVisibleNodeIds(
       if (
         filters.severity &&
         FINDING_NODE_TYPES.has(nodeType) &&
-        node.severity?.toLowerCase() !== filters.severity.toLowerCase()
+        !meetsSeverityThreshold(node.severity, filters.severity)
       ) {
         return false;
       }
@@ -434,6 +455,7 @@ function legendForNodeTypes(nodeTypes: Set<LineageNodeType>): LegendItem[] {
     .map((nodeType) => ({
       label: NODE_LABELS[nodeType],
       color: NODE_COLORS[nodeType],
+      shape: legendShapeForNodeType(nodeType),
     }));
 }
 
@@ -540,6 +562,27 @@ function intersectSets(left: Set<string>, right: Set<string>): Set<string> {
   return new Set([...left].filter((value) => right.has(value)));
 }
 
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  unknown: 0,
+  none: 0,
+};
+
+function severityRank(severity: string | null | undefined): number {
+  return SEVERITY_RANK[String(severity ?? "unknown").toLowerCase()] ?? 0;
+}
+
+function meetsSeverityThreshold(
+  severity: string | null | undefined,
+  threshold: string | null | undefined,
+): boolean {
+  if (!threshold) return true;
+  return severityRank(severity) >= severityRank(threshold);
+}
+
 function addNeighbor(map: Map<string, Set<string>>, source: string, target: string): void {
   const existing = map.get(source);
   if (existing) {
@@ -547,6 +590,13 @@ function addNeighbor(map: Map<string, Set<string>>, source: string, target: stri
   } else {
     map.set(source, new Set([target]));
   }
+}
+
+function legendShapeForNodeType(nodeType: LineageNodeType): LegendItem["shape"] {
+  if (nodeType === "vulnerability" || nodeType === "misconfiguration") return "diamond";
+  if (nodeType === "server" || nodeType === "sharedServer" || nodeType === "container" || nodeType === "cloudResource") return "square";
+  if (nodeType === "package" || nodeType === "tool" || nodeType === "model" || nodeType === "dataset") return "pill";
+  return "dot";
 }
 
 function mapNodeType(node: UnifiedNode): LineageNodeType | null {


### PR DESCRIPTION
## Summary
- focus analyze graph surfaces on scoped, readable defaults instead of all-at-once layouts
- make legends data-driven, improve mesh/context/operator readability, and clean up graph chrome
- merge blast-radius enrichment into vulnerabilities and remove remediation fix duplication

## Validation
- npm --prefix ui run test:run
- npm --prefix ui run build

Validated in the main workspace with installed UI dependencies. The clean worktree used for branch packaging does not have local node_modules.