### PR TITLE
Expand notebook credential detection

### DIFF
--- a/src/agent_bom/jupyter.py
+++ b/src/agent_bom/jupyter.py
@@ -57,9 +57,15 @@ _AI_IMPORT_RE = re.compile(
 # Regex: pip install in notebook cells (! or % prefix)
 _PIP_INSTALL_RE = re.compile(r"[!%]pip\s+install\s+([^\n]+)", re.MULTILINE)
 
-# Regex: credential env vars
+# Regex: credential env vars and common notebook secret helpers
 _CRED_ENV_RE = re.compile(
-    r'os\.environ\s*[\[\.]\s*["\']([A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*)["\']',
+    r"(?:"
+    r'os\.environ\s*\[\s*["\']([A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*)["\']\s*\]'
+    r'|os\.environ\.get\(\s*["\']([A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*)["\']'
+    r'|os\.getenv\(\s*["\']([A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*)["\']'
+    r'|dbutils\.secrets\.get\(\s*["\'][^"\']+["\']\s*,\s*["\']([^"\']+)["\']'
+    r'|userdata\.get\(\s*["\']([^"\']+)["\']'
+    r")"
 )
 
 # Regex: hardcoded API keys (warning)
@@ -162,7 +168,7 @@ def scan_jupyter_notebooks(
 
         # 3. Detect credential env vars
         for match in _CRED_ENV_RE.finditer(full_source):
-            env_name = match.group(1)
+            env_name = next((group for group in match.groups() if group), "")
             if env_name not in credential_env_vars:
                 credential_env_vars.append(env_name)
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -88,6 +88,26 @@ def test_scan_credential_detection(tmp_path: Path):
     assert "OPENAI_API_KEY" in server.env
 
 
+def test_scan_credential_detection_getenv_forms(tmp_path: Path):
+    """Detect os.getenv() and os.environ.get() credential access."""
+    nb = _make_notebook([_code_cell('import os\napi_key = os.getenv("OPENAI_API_KEY")\ngh = os.environ.get("GITHUB_TOKEN")\n')])
+    (tmp_path / "getenv.ipynb").write_text(json.dumps(nb))
+    agents, _ = scan_jupyter_notebooks(tmp_path)
+    server = agents[0].mcp_servers[0]
+    assert "OPENAI_API_KEY" in server.env
+    assert "GITHUB_TOKEN" in server.env
+
+
+def test_scan_credential_detection_notebook_secret_helpers(tmp_path: Path):
+    """Detect notebook-native secret access helpers."""
+    nb = _make_notebook([_code_cell('token = dbutils.secrets.get("prod", "OPENAI_API_KEY")\ngithub = userdata.get("GITHUB_TOKEN")\n')])
+    (tmp_path / "helpers.ipynb").write_text(json.dumps(nb))
+    agents, _ = scan_jupyter_notebooks(tmp_path)
+    server = agents[0].mcp_servers[0]
+    assert "OPENAI_API_KEY" in server.env
+    assert "GITHUB_TOKEN" in server.env
+
+
 def test_scan_hardcoded_key_warning(tmp_path: Path):
     """Hardcoded API key should produce a warning."""
     nb = _make_notebook([_code_cell('api_key = "sk-1234567890abcdefghijklmnop"')])


### PR DESCRIPTION
Summary:
- expand local notebook credential detection beyond os.environ bracket access
- detect os.getenv, os.environ.get, dbutils.secrets.get, and userdata.get credential access patterns
- add regression coverage for the new notebook access shapes

Validation:
- uv run pytest -q tests/test_jupyter.py
- uv run ruff check src/agent_bom/jupyter.py tests/test_jupyter.py

Part of the runtime/notebook release hardening batch.