### PR TITLE
Improve sanitizer-aware early guard exits

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -788,6 +788,18 @@ def _returns_boolean_constant(statements: list[ast.stmt], value: bool) -> bool:
     )
 
 
+def _branch_definitely_exits(statements: list[ast.stmt]) -> bool:
+    """Return True when a branch definitely stops control flow."""
+    if not statements:
+        return False
+    last_statement = statements[-1]
+    if isinstance(last_statement, (ast.Return, ast.Raise)):
+        return True
+    if isinstance(last_statement, ast.If):
+        return _branch_definitely_exits(last_statement.body) and _branch_definitely_exits(last_statement.orelse)
+    return False
+
+
 def _is_guarded_call(node: ast.AST, parent_map: dict[ast.AST, ast.AST]) -> bool:
     """Return True when a dangerous call sits behind a validation-oriented branch."""
     current = parent_map.get(node)
@@ -2981,6 +2993,23 @@ def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFindin
             return guarded_names_from_expr(func, expr.operand)
         return set()
 
+    def post_if_guarded_names(
+        func: _FunctionAnalysis,
+        statement: ast.If,
+    ) -> set[str]:
+        """Return names guarded on the path that continues after an if-statement."""
+        test = statement.test
+        if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+            guarded = guarded_names_from_expr(func, test.operand)
+            if guarded and _branch_definitely_exits(statement.body):
+                return guarded
+            return set()
+
+        guarded = guarded_names_from_expr(func, test)
+        if guarded and _branch_definitely_exits(statement.orelse):
+            return guarded
+        return set()
+
     def analyze_function(
         func: _FunctionAnalysis,
         tainted_params: set[str],
@@ -3292,6 +3321,7 @@ def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFindin
                     findings_acc.extend(orelse_findings)
                     tainted_vars.update(body_tainted | orelse_tainted)
                     local_tainted.update(body_tainted | orelse_tainted)
+                    current_sanitized.update(post_if_guarded_names(func, statement))
                     local_returns_tainted |= body_returns_tainted or orelse_returns_tainted
                     continue
                 if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -280,6 +280,41 @@ def test_analyze_project_treats_helper_allowlist_validator_as_guard(tmp_path: Pa
     assert not [finding for finding in result.flow_findings if finding.category == "tainted_dangerous_sink"]
 
 
+def test_analyze_project_treats_early_return_validator_gate_as_guard(tmp_path: Path):
+    (tmp_path / "agent.py").write_text(
+        "import subprocess\n\n"
+        "def ok(cmd):\n"
+        "    return cmd in {'ls', 'pwd'}\n\n"
+        "@tool\n"
+        "def execute(cmd):\n"
+        "    if not ok(cmd):\n"
+        "        return None\n"
+        "    return subprocess.run(cmd, shell=True)\n"
+    )
+
+    result = analyze_project(tmp_path)
+
+    assert not [finding for finding in result.flow_findings if finding.category == "tainted_dangerous_sink"]
+
+
+def test_analyze_project_treats_early_raise_validator_gate_as_guard(tmp_path: Path):
+    (tmp_path / "agent.py").write_text(
+        "import re\n"
+        "import subprocess\n\n"
+        "def ok(cmd):\n"
+        "    return re.fullmatch(r'[a-z]+', cmd) is not None\n\n"
+        "@tool\n"
+        "def execute(cmd):\n"
+        "    if not ok(cmd):\n"
+        "        raise ValueError('bad command')\n"
+        "    return subprocess.run(cmd, shell=True)\n"
+    )
+
+    result = analyze_project(tmp_path)
+
+    assert not [finding for finding in result.flow_findings if finding.category == "tainted_dangerous_sink"]
+
+
 def test_analyze_project_reports_tainted_prompt_and_sink_flows(tmp_path: Path):
     (tmp_path / "agent.py").write_text(
         "import subprocess\n\n"


### PR DESCRIPTION
## Summary
- treat validator gates that exit early as sanitizing the path that continues after the guard
- reduce false positives for patterns like `if not ok(x): return` and `if not ok(x): raise`
- add regression tests for early-return and early-raise validation gates

## Validation
- `uv run pytest -q tests/test_ast_analyzer.py`
- `uv run ruff check src/agent_bom/ast_analyzer.py tests/test_ast_analyzer.py`
