### PR TITLE
Add Go template sink parity

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -545,6 +545,8 @@ _GO_DANGEROUS_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("exec.Command", re.compile(r"\bexec\.Command(?:Context)?\s*\(")),
     ("os.WriteFile", re.compile(r"\bos\.WriteFile\s*\(")),
     ("ioutil.WriteFile", re.compile(r"\bioutil\.WriteFile\s*\(")),
+    ("template.HTML", re.compile(r"\btemplate\.HTML\s*\(")),
+    ("template.JS", re.compile(r"\btemplate\.JS\s*\(")),
 ]
 _GO_LLM_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("openai.ChatCompletion", re.compile(r"\bCreateChatCompletion\b")),
@@ -1179,8 +1181,12 @@ def _is_go_path_sink_call_name(call_name: str) -> bool:
     return any(lower_name == suffix or lower_name.endswith(f".{suffix}") for suffix in _GO_PATH_CALL_SUFFIXES)
 
 
+def _is_go_xss_sink_call_name(call_name: str) -> bool:
+    return call_name in {"template.HTML", "template.JS"}
+
+
 def _is_go_dangerous_call_name(call_name: str) -> bool:
-    return _is_go_command_sink_call_name(call_name) or _is_go_path_sink_call_name(call_name)
+    return _is_go_command_sink_call_name(call_name) or _is_go_path_sink_call_name(call_name) or _is_go_xss_sink_call_name(call_name)
 
 
 def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
@@ -1672,6 +1678,9 @@ def _build_go_flow_findings(
                 elif _is_go_path_sink_call_name(call_site.name):
                     sink_category = "go_tainted_path_access"
                     title = "Go tool routes tainted input into a filesystem path sink"
+                elif _is_go_xss_sink_call_name(call_site.name):
+                    sink_category = "go_tainted_xss_sink"
+                    title = "Go tool routes tainted input into an HTML rendering sink"
 
                 if sink_category:
                     taint_dedup_key = (sink_category, registration.tool_name, call_site.name, call_site.line_number, current_display_name)

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -608,6 +608,29 @@ def test_analyze_project_reports_go_tainted_sql_and_path_sinks(tmp_path: Path):
     )
 
 
+def test_analyze_project_reports_go_tainted_html_sink(tmp_path: Path):
+    (tmp_path / "render.go").write_text(
+        "package main\n\n"
+        "import (\n"
+        '    "html/template"\n'
+        '    "github.com/modelcontextprotocol/go-sdk/mcp"\n'
+        ")\n\n"
+        "func renderHTML(userHTML string) template.HTML {\n"
+        "    return template.HTML(userHTML)\n"
+        "}\n\n"
+        "func register(server *mcp.Server) {\n"
+        '    server.AddTool("render_html", renderHTML)\n'
+        "}\n"
+    )
+
+    result = analyze_project(tmp_path)
+
+    assert any(
+        finding.category == "go_tainted_xss_sink" and finding.entrypoint == "render_html" and finding.sink == "template.HTML"
+        for finding in result.flow_findings
+    )
+
+
 def test_analyze_project_resolves_cross_file_import_alias_flow(tmp_path: Path):
     (tmp_path / "helpers.py").write_text("import subprocess\n\ndef run_shell(cmd):\n    return subprocess.run(cmd, shell=True)\n")
     (tmp_path / "agent.py").write_text("from helpers import run_shell as runner\n\n@tool\ndef execute(cmd):\n    return runner(cmd)\n")


### PR DESCRIPTION
## Summary
- add first-party Go template/HTML sink coverage for `template.HTML` and `template.JS`
- classify tainted Go input flowing into those sinks as `go_tainted_xss_sink`
- add regression coverage for a Go MCP tool that returns tainted HTML

## Validation
- `uv run pytest -q tests/test_ast_analyzer.py`
- `uv run ruff check src/agent_bom/ast_analyzer.py tests/test_ast_analyzer.py`
