### PR TITLE
Improve JS/TS default-export flow parity

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -3566,6 +3566,10 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         if js_ts_analysis is not None:
             for js_ts_function in js_ts_analysis.functions.values():
                 js_ts_functions[_js_ts_function_key(js_ts_function.module_name, js_ts_function.name)] = js_ts_function
+            if js_ts_analysis.default_export_name:
+                default_function = js_ts_analysis.functions.get(js_ts_analysis.default_export_name)
+                if default_function is not None:
+                    js_ts_functions[_js_ts_function_key(default_function.module_name, "default")] = default_function
             js_ts_tool_registrations.extend(js_ts_analysis.tool_registrations)
 
     for go_file in go_files:

--- a/src/agent_bom/js_ts_ast.py
+++ b/src/agent_bom/js_ts_ast.py
@@ -39,6 +39,7 @@ class JSTSAstAnalysis:
     functions: dict[str, "JSTSFunction"] = field(default_factory=dict)
     tool_registrations: list["JSTSToolRegistration"] = field(default_factory=list)
     dynamic_require_lines: list[int] = field(default_factory=list)
+    default_export_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -296,12 +297,11 @@ def _collect_import_aliases(root: TreeSitterNode, source: bytes, analysis: JSTSA
                 if canonical:
                     analysis.namespace_aliases[_identifier_like_text(alias_nodes[-1], source)] = canonical
             elif child.type == "identifier":
-                analysis.imported_module_refs[_identifier_like_text(child, source)] = JSImportRef(
-                    module_name=_normalize_module_name(module_name)
+                alias = _identifier_like_text(child, source)
+                analysis.imported_function_refs[alias] = JSImportRef(
+                    module_name=_normalize_module_name(module_name),
+                    exported_name="default",
                 )
-                canonical = _canonical_namespace(module_name)
-                if canonical:
-                    analysis.namespace_aliases[_identifier_like_text(child, source)] = canonical
 
 
 def _is_require_call(node: TreeSitterNode, source: bytes) -> bool:
@@ -575,6 +575,13 @@ def _register_function(
 
 def _collect_functions(root: TreeSitterNode, source: bytes, analysis: JSTSAstAnalysis) -> None:
     for node in _iter_nodes(root):
+        if node.type == "export_statement":
+            default_child = next((child for child in node.named_children if child.type == "function_declaration"), None)
+            if default_child is not None:
+                name_node = default_child.child_by_field_name("name")
+                default_name = _identifier_like_text(name_node, source)
+                if default_name:
+                    analysis.default_export_name = default_name
         if node.type == "function_declaration":
             name_node = node.child_by_field_name("name")
             params_node = node.child_by_field_name("parameters")

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -105,6 +105,26 @@ def test_analyze_project_builds_cross_file_js_ts_module_alias_flow(tmp_path: Pat
         )
 
 
+def test_analyze_project_builds_cross_file_js_ts_default_export_flow(tmp_path: Path):
+    (tmp_path / "helpers.ts").write_text(
+        'import { execSync as run } from "node:child_process";\nexport default function runShell(command) {\n  return run(command);\n}\n'
+    )
+    (tmp_path / "server.ts").write_text(
+        'import runShell from "./helpers";\nserver.tool("run_cmd", "Run a command", async () => runShell(userInput));\n'
+    )
+
+    result = analyze_project(tmp_path)
+
+    if _js_ts_parser_available():
+        assert any(edge.caller == "tool:run_cmd" and edge.callee == "runShell" for edge in result.call_edges)
+        assert any(
+            finding.category == "js_ts_interprocedural_dangerous_flow"
+            and finding.entrypoint == "run_cmd"
+            and finding.sink == "child_process.execSync"
+            for finding in result.flow_findings
+        )
+
+
 def test_analyze_project_reports_js_ts_tainted_command_execution(tmp_path: Path):
     (tmp_path / "helpers.ts").write_text(
         'import { execSync as run } from "node:child_process";\nexport function runShell(command) {\n  return run(command);\n}\n'


### PR DESCRIPTION
## Summary
- resolve JS/TS default-export helper flows in the interprocedural call graph
- treat `import helper from "./helpers"` as a function import instead of a module alias
- add regression coverage for cross-file default-export helper flow

## Validation
- targeted AST analyzer tests passed: 44 passed
- ruff check passed on touched files