### PR TITLE
Refresh latest image and actionable rescan alerts

### DIFF
--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -1,6 +1,6 @@
 name: Container Re-Scan
 
-# Weekly rescan of published multi-arch images for new CVEs.
+# Daily rescan of published multi-arch images for new fixable CVEs.
 # Trivy scans both linux/amd64 and linux/arm64 variants.
 # SARIF uploaded to GitHub Security tab. Never blocks main.
 
@@ -38,13 +38,14 @@ jobs:
       - name: Pull ${{ matrix.platform }} image
         run: docker pull --platform ${{ matrix.platform }} agentbom/agent-bom:latest
 
-      - name: Trivy scan — table (HIGH/CRITICAL)
+      - name: Trivy scan — table (fixable MEDIUM+/UNKNOWN)
         id: trivy-table
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: agentbom/agent-bom:latest
           format: table
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
+          ignore-unfixed: true
           exit-code: "1"
           trivyignores: .trivyignore
         continue-on-error: true
@@ -57,7 +58,8 @@ jobs:
           image-ref: agentbom/agent-bom:latest
           format: sarif
           output: trivy-${{ matrix.sarif_category }}.sarif
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
+          ignore-unfixed: true
           exit-code: "0"
           trivyignores: .trivyignore
 
@@ -85,10 +87,10 @@ jobs:
         run: |
           echo "::warning::Trivy SARIF was not generated for ${{ matrix.platform }}. Check the preceding Trivy step for workflow/config errors."
 
-      - name: Flag HIGH/CRITICAL CVEs found
+      - name: Flag actionable CVEs found
         if: steps.trivy-table.outcome == 'failure'
         run: |
-          echo "::warning::Trivy found HIGH/CRITICAL CVEs in agentbom/agent-bom:latest (${{ matrix.platform }}). Check SARIF in Security tab."
+          echo "::warning::Trivy found fixable MEDIUM+/UNKNOWN CVEs in agentbom/agent-bom:latest (${{ matrix.platform }}). Check SARIF in Security tab."
 
       - name: Open or close base image vulnerability issue
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
@@ -96,7 +98,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TITLE="base-image-vulnerability: agentbom/agent-bom:latest has HIGH/CRITICAL findings on ${{ matrix.platform }}"
+          TITLE="base-image-vulnerability: agentbom/agent-bom:latest has actionable findings on ${{ matrix.platform }}"
           gh label create base-image-vulnerability --color B60205 --description "Automated base image vulnerability findings" >/dev/null 2>&1 || true
           gh label create security-preventive --color 0E8A16 --description "Preventive daily security automation findings" >/dev/null 2>&1 || true
           gh label create automated --color 5319E7 --description "Opened or updated automatically by CI" >/dev/null 2>&1 || true
@@ -106,11 +108,12 @@ jobs:
             BODY=$(cat <<EOF
           ## Automated Base Image Vulnerability Alert
 
-          Daily image rescan found HIGH/CRITICAL findings in \`agentbom/agent-bom:latest\`.
+          Daily image rescan found fixable \`MEDIUM+\` or \`UNKNOWN\` findings in \`agentbom/agent-bom:latest\`.
 
           - Platform: \`${{ matrix.platform }}\`
           - SARIF category: \`${{ matrix.sarif_category }}\`
           - Source workflow: \`.github/workflows/container-rescan.yml\`
+          - Policy: Trivy scans with \`severity=MEDIUM,HIGH,CRITICAL,UNKNOWN\` and \`ignore-unfixed=true\`
 
           Review the GitHub Security tab and the workflow logs for the current image findings.
           EOF

--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -1,0 +1,139 @@
+name: Refresh Docker Latest
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: refresh-docker-latest
+  cancel-in-progress: false
+
+jobs:
+  refresh-latest:
+    name: Rebuild and publish latest from latest release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve latest release tag
+        id: release
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          TAG=$(git tag -l 'v*.*.*' --sort=-version:refname | head -n1)
+          if [ -z "$TAG" ]; then
+            echo "::error::No semver release tag found"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          git checkout "$TAG"
+
+      - name: Verify pyproject version matches release tag
+        run: |
+          set -euo pipefail
+          VERSION=$(python3 - <<'PY'
+          import re
+          from pathlib import Path
+          text = Path("pyproject.toml").read_text()
+          m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.M)
+          if not m:
+              raise SystemExit("pyproject.toml version not found")
+          print(m.group(1))
+          PY
+          )
+          if [ "$VERSION" != "${{ steps.release.outputs.version }}" ]; then
+            echo "::error::Checked out tag ${{ steps.release.outputs.tag }} but pyproject.toml reports $VERSION"
+            exit 1
+          fi
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build refresh candidate image
+        run: docker build -t agent-bom:latest-refresh-test .
+
+      - name: Smoke test refresh candidate
+        run: docker run --rm agent-bom:latest-refresh-test --version
+
+      - name: Trivy refresh gate
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: agent-bom:latest-refresh-test
+          format: table
+          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+
+      - name: Build and push refreshed latest
+        id: build-push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: VERSION=${{ steps.release.outputs.version }}
+          provenance: true
+          sbom: true
+          tags: |
+            agentbom/agent-bom:latest
+          labels: |
+            org.opencontainers.image.version=${{ steps.release.outputs.version }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.title=agent-bom
+            org.opencontainers.image.description=Open security scanner for agentic infrastructure — agents, MCP, packages, containers, cloud, and runtime.
+            org.opencontainers.image.created=${{ github.run_id }}
+            org.opencontainers.image.revision=${{ steps.release.outputs.tag }}
+
+      - name: Sync Docker Hub README
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          SHORT_DESCRIPTION="Open security scanner for agentic infrastructure: agents, MCP, containers, cloud, and runtime."
+          TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
+            | jq -r '.token')
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "::error::Docker Hub login failed"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          DESCRIPTION=$(jq -Rs . < DOCKER_HUB_README.md)
+          SHORT_DESCRIPTION_JSON=$(printf '%s' "$SHORT_DESCRIPTION" | jq -Rs .)
+          RESPONSE_FILE=$(mktemp)
+          HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" -X PATCH \
+            "https://hub.docker.com/v2/repositories/agentbom/agent-bom/" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"full_description\": ${DESCRIPTION}, \"description\": ${SHORT_DESCRIPTION_JSON}}")
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Docker Hub README sync failed (HTTP $HTTP_CODE)"
+            cat "$RESPONSE_FILE"
+            exit 1
+          fi
+          rm -f "$RESPONSE_FILE"

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -99,6 +99,16 @@ Images published:
 
 The Git tag remains `v{version}`. Docker Hub image tags are published without the `v` prefix.
 
+`latest` is also refreshed independently by `.github/workflows/refresh-latest-container.yml`.
+That workflow checks out the newest released tag, rebuilds it with current Alpine packages,
+and republishes only `latest`. This keeps the floating tag current for base-image security
+fixes without rewriting immutable semver image tags.
+
+The daily `.github/workflows/container-rescan.yml` job should be treated as the alerting
+surface for post-release base-image drift. It scans `latest` for fixable `MEDIUM+` and
+`UNKNOWN` image findings, uploads SARIF into GitHub Security, and opens or updates the
+automated base-image vulnerability issue when new actionable findings appear.
+
 ---
 
 ## 6. GitHub Container Registry (GHCR)


### PR DESCRIPTION
## Summary
- add a dedicated workflow to rebuild and republish Docker Hub `latest` from the newest released tag
- widen daily container rescan to flag fixable `MEDIUM+` and `UNKNOWN` findings instead of only `HIGH/CRITICAL`
- document the post-release image refresh and alerting policy

## Why
`agentbom/agent-bom:latest` can go stale between releases when Alpine ships patched base packages. This change gives us a controlled way to refresh the floating tag without rewriting immutable semver tags, and it makes post-release base-image drift visible in GitHub instead of relying on manual Docker Hub checks.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/refresh-latest-container.yml"); YAML.load_file(".github/workflows/container-rescan.yml"); puts "yaml ok"'`