### PR TITLE
Fix dashboard summary loading and API hydration

### DIFF
--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 # ─── Enums ─────────────────────────────────────────────────────────────────
 
@@ -248,6 +248,8 @@ class ModelFilesRequest(BaseModel):
 
 
 class PushPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     source_id: str = ""
     agents: list = []
     blast_radii: list = []

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -102,13 +102,9 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
-    job.result = {
-        "agents": body.agents,
-        "blast_radii": body.blast_radii,
-        "warnings": body.warnings,
-        "source_id": body.source_id,
-        "pushed": True,
-    }
+    job_result = body.model_dump()
+    job_result["pushed"] = True
+    job.result = job_result
     job.progress.append(f"Received via push from source={body.source_id}")
     _get_store().put(job)
     return {"job_id": job.job_id, "source_id": body.source_id, "status": "stored"}

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -120,6 +120,23 @@ def _visible_to_tenant(job: ScanJob, tenant_id: str) -> bool:
     return getattr(job, "tenant_id", "default") == tenant_id
 
 
+def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
+    """Build a lightweight summary payload for list surfaces."""
+    result = job.result if isinstance(job.result, dict) else {}
+    summary = result.get("summary") if isinstance(result.get("summary"), dict) else None
+    return {
+        "job_id": job.job_id,
+        "tenant_id": job.tenant_id,
+        "status": job.status,
+        "created_at": job.created_at,
+        "completed_at": job.completed_at,
+        "request": job.request.model_dump(exclude_defaults=True, exclude_none=True),
+        "summary": summary,
+        "scan_timestamp": result.get("scan_timestamp"),
+        "pushed": bool(result.get("pushed")),
+    }
+
+
 def _job_for_request(request: Request, job_id: str) -> ScanJob:
     tenant_id = _tenant_id(request)
     in_mem = _jobs_get(job_id)
@@ -484,9 +501,13 @@ async def list_jobs(request: Request, limit: int = 50, offset: int = 0) -> dict:
     summary = [j for j in _get_store().list_summary() if j.get("tenant_id", "default") == tenant_id]
     total = len(summary)
     page = summary[offset : offset + limit]
+    enriched: list[dict[str, Any]] = []
+    for item in page:
+        full_job = _get_store().get(item["job_id"])
+        enriched.append(_job_summary_payload(full_job) if full_job is not None else item)
     return {
-        "jobs": page,
-        "count": len(page),
+        "jobs": enriched,
+        "count": len(enriched),
         "total": total,
         "limit": limit,
         "offset": offset,

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -498,13 +498,21 @@ async def list_jobs(request: Request, limit: int = 50, offset: int = 0) -> dict:
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
     tenant_id = _tenant_id(request)
-    summary = [j for j in _get_store().list_summary() if j.get("tenant_id", "default") == tenant_id]
+    store = _get_store()
+    summary = [j for j in store.list_summary() if j.get("tenant_id", "default") == tenant_id]
     total = len(summary)
     page = summary[offset : offset + limit]
     enriched: list[dict[str, Any]] = []
     for item in page:
-        full_job = _get_store().get(item["job_id"])
-        enriched.append(_job_summary_payload(full_job) if full_job is not None else item)
+        # Keep list surfaces compatible with lightweight stores and tests that
+        # only implement paged summaries. Hydrate when available, otherwise
+        # return the summary row unchanged.
+        try:
+            get_job = getattr(store, "get", None)
+            full_job = get_job(item["job_id"]) if callable(get_job) else None
+        except Exception:
+            full_job = None
+        enriched.append(_job_summary_payload(full_job) if isinstance(full_job, ScanJob) else item)
     return {
         "jobs": enriched,
         "count": len(enriched),

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -65,6 +65,7 @@ try:
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import RedirectResponse
     from pydantic import BaseModel  # noqa: F401 — presence check for [api] extra
+    from starlette.middleware import Middleware
 except ImportError as exc:  # pragma: no cover
     raise ImportError("agent-bom API requires extra dependencies.\nInstall with:  pip install 'agent-bom[api]'") from exc
 
@@ -287,20 +288,39 @@ app = FastAPI(
     lifespan=_lifespan,
 )
 
-_default_origins = ["http://localhost:3000", "http://127.0.0.1:3000"]
+_default_origins = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:3001",
+    "http://127.0.0.1:3001",
+]
 _cors_env = os.environ.get("CORS_ORIGINS")
 _cors_origins: list[str] = [o.strip() for o in _cors_env.split(",") if o.strip()] if _cors_env else _default_origins
 _api_key: str | None = None
 _rate_limit_rpm: int = 60
 
+
+def _apply_cors_middleware(origins: list[str]) -> None:
+    """Install or refresh the CORS middleware with the current origin policy."""
+    _replace_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials="*" not in origins,
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization", "X-API-Key"],
+    )
+    if app.middleware_stack is not None:
+        app.middleware_stack = app.build_middleware_stack()
+
+
+def _replace_middleware(middleware_cls: type, /, **kwargs: object) -> None:
+    """Replace a middleware class in-place so runtime config updates actually apply."""
+    app.user_middleware = [m for m in app.user_middleware if m.cls is not middleware_cls]
+    app.user_middleware.insert(0, Middleware(middleware_cls, **kwargs))
+
+
 # CORS: defaults to localhost; configure via configure_api() before startup
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_cors_origins,
-    allow_credentials="*" not in _cors_origins,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["Content-Type", "Authorization", "X-API-Key"],
-)
+_apply_cors_middleware(_cors_origins)
 
 
 # ─── Trust headers middleware ──────────────────────────────────────────────────
@@ -326,6 +346,8 @@ def configure_api(
     elif cors_origins:
         _cors_origins = cors_origins
 
+    _apply_cors_middleware(_cors_origins)
+
     _api_key = api_key
     _rate_limit_rpm = rate_limit_rpm
 
@@ -336,12 +358,16 @@ def configure_api(
             "Set AGENT_BOM_API_KEY environment variable for production deployments."
         )
 
-    # Add optional middleware
+    # Refresh runtime-configurable middleware
     if api_key:
-        app.add_middleware(APIKeyMiddleware, api_key=api_key)
+        _replace_middleware(APIKeyMiddleware, api_key=api_key)
+    else:
+        app.user_middleware = [m for m in app.user_middleware if m.cls is not APIKeyMiddleware]
 
-    app.add_middleware(RateLimitMiddleware, scan_rpm=rate_limit_rpm, read_rpm=rate_limit_rpm * 5)
-    app.add_middleware(MaxBodySizeMiddleware)
+    _replace_middleware(RateLimitMiddleware, scan_rpm=rate_limit_rpm, read_rpm=rate_limit_rpm * 5)
+    _replace_middleware(MaxBodySizeMiddleware)
+    if app.middleware_stack is not None:
+        app.middleware_stack = app.build_middleware_stack()
 
 
 # ─── Scan Pipeline (extracted to api/pipeline.py) ────────────────────────────

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -11,6 +11,7 @@ from agent_bom.api.server import (
     MaxBodySizeMiddleware,
     RateLimitMiddleware,
     app,
+    configure_api,
 )
 
 
@@ -27,6 +28,21 @@ def test_trust_headers_present():
     resp = client.get("/health")
     assert resp.headers.get("x-agent-bom-read-only") == "true"
     assert resp.headers.get("x-agent-bom-no-credential-storage") == "true"
+
+
+def test_configure_api_refreshes_cors_policy():
+    """configure_api() should update the live CORS middleware, not just a module variable."""
+    configure_api(cors_allow_all=True)
+    client = TestClient(app)
+    resp = client.get("/health", headers={"Origin": "http://127.0.0.1:3001"})
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "*"
+
+    configure_api(cors_origins=["http://127.0.0.1:3000"])
+    client = TestClient(app)
+    resp = client.get("/health", headers={"Origin": "http://127.0.0.1:3001"})
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") is None
 
 
 def test_api_key_middleware_blocks_without_key():

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -199,6 +199,8 @@ async def test_scan_routes_are_tenant_scoped():
     listed = await scan_routes.list_jobs(req)
     assert [j["job_id"] for j in listed["jobs"]] == ["job-alpha"]
     assert listed["jobs"][0]["tenant_id"] == "tenant-alpha"
+    assert listed["jobs"][0]["request"] == {}
+    assert listed["jobs"][0]["summary"] is None
 
     got = await scan_routes.get_scan(req, "job-alpha")
     assert got.job_id == "job-alpha"
@@ -227,8 +229,22 @@ async def test_create_scan_and_push_stamp_request_tenant(monkeypatch):
 
     pushed = await observability_routes.receive_push(
         req,
-        PushPayload(source_id="source-a", agents=[], blast_radii=[], warnings=[]),
+        PushPayload(
+            source_id="source-a",
+            agents=[],
+            blast_radii=[],
+            warnings=[],
+            summary={"total_packages": 12, "total_vulnerabilities": 55},
+            posture_scorecard={"overall_score": 82},
+        ),
     )
     pushed_job = store.get(pushed["job_id"])
     assert pushed_job is not None
     assert pushed_job.tenant_id == "tenant-alpha"
+    assert pushed_job.result["summary"]["total_packages"] == 12
+    assert pushed_job.result["posture_scorecard"]["overall_score"] == 82
+
+    listed = await scan_routes.list_jobs(req)
+    pushed_summary = next(job for job in listed["jobs"] if job["job_id"] == pushed["job_id"])
+    assert pushed_summary["summary"]["total_packages"] == 12
+    assert listed["jobs"][0]["request"] == {}

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
-import { api, ScanJob, ScanResult, BlastRadius, Agent, PostureResponse, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS } from "@/lib/api";
+import { api, ScanJob, ScanResult, BlastRadius, Agent, JobListItem, PostureResponse, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS } from "@/lib/api";
 import { AgentTopology } from "@/components/agent-topology";
 import { TrustStack } from "@/components/trust-stack";
 import { SeverityBadge } from "@/components/severity-badge";
@@ -315,10 +315,12 @@ function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {
 // ─── Dashboard ────────────────────────────────────────────────────────────────
 
 export default function Dashboard() {
-  const [jobs, setJobs] = useState<ScanJob[]>([]);
+  const [jobs, setJobs] = useState<JobListItem[]>([]);
+  const [detailJobs, setDetailJobs] = useState<ScanJob[]>([]);
   const [agentCount, setAgentCount] = useState<number>(0);
   const [agentList, setAgentList] = useState<Agent[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(true);
   const [apiError, setApiError] = useState(false);
   const [importedReport, setImportedReport] = useState<ScanResult | null>(null);
   const [posture, setPosture] = useState<PostureResponse | null>(null);
@@ -330,31 +332,83 @@ export default function Dashboard() {
 
   useEffect(() => {
     async function load() {
+      setSummaryLoading(true);
       try {
-        const [jobsRes, agentsRes] = await Promise.all([
-          api.listJobs(),
-          api.listAgents(),
-        ]);
-        const jobsList = jobsRes?.jobs ?? [];
-        const fullJobs = await Promise.all(
-          jobsList?.map((j) => api.getScan(j.job_id))
-        );
-        setJobs(fullJobs.sort((a, b) => b.created_at.localeCompare(a.created_at)));
-        setAgentCount(agentsRes?.count ?? 0);
-        setAgentList(agentsRes?.agents ?? []);
+        const [jobsRes, agentsRes] = await Promise.allSettled([api.listJobs(), api.listAgents()]);
+
+        if (jobsRes.status === "fulfilled") {
+          const jobsList = Array.isArray(jobsRes.value?.jobs)
+            ? [...jobsRes.value.jobs].sort((a, b) => b.created_at.localeCompare(a.created_at))
+            : [];
+          setJobs(jobsList);
+          setApiError(false);
+        } else {
+          setApiError(true);
+          setJobs([]);
+          setDetailJobs([]);
+        }
+
+        if (agentsRes.status === "fulfilled") {
+          setAgentCount(agentsRes.value?.count ?? 0);
+          setAgentList(Array.isArray(agentsRes.value?.agents) ? agentsRes.value.agents : []);
+        } else {
+          setAgentCount(0);
+          setAgentList([]);
+        }
       } catch {
         setApiError(true);
+        setJobs([]);
+        setDetailJobs([]);
+        setAgentCount(0);
+        setAgentList([]);
       } finally {
-        setLoading(false);
+        setSummaryLoading(false);
       }
     }
     load();
   }, []);
 
+  useEffect(() => {
+    async function hydrateDetails() {
+      if (apiError) {
+        setDetailJobs([]);
+        setDetailLoading(false);
+        return;
+      }
+
+      const detailIds = jobs
+        .filter((job) => job.status === "done")
+        .slice(0, 10)
+        .map((job) => job.job_id);
+
+      if (detailIds.length === 0) {
+        setDetailJobs([]);
+        setDetailLoading(false);
+        return;
+      }
+
+      setDetailLoading(true);
+      try {
+        const fullJobs = await Promise.all(
+          detailIds.map((jobId) => api.getScan(jobId).catch(() => null))
+        );
+        const hydrated = fullJobs
+          .filter((job): job is ScanJob => Boolean(job))
+          .sort((a, b) => b.created_at.localeCompare(a.created_at));
+        setDetailJobs(hydrated);
+      } catch {
+        setDetailJobs([]);
+      } finally {
+        setDetailLoading(false);
+      }
+    }
+    hydrateDetails();
+  }, [jobs, apiError]);
+
   // When API is down but user imported a local report, synthesise a fake job
   // so all downstream useMemo aggregators work without changes.
   const effectiveJobs = useMemo<ScanJob[]>(() => {
-    if (!apiError || !importedReport) return jobs;
+    if (!apiError || !importedReport) return detailJobs;
     return [{
       job_id: "imported",
       status: "done",
@@ -363,6 +417,19 @@ export default function Dashboard() {
       progress: [],
       result: importedReport as unknown as Record<string, unknown>,
     } as unknown as ScanJob];
+  }, [detailJobs, apiError, importedReport]);
+
+  const effectiveRecentJobs = useMemo<JobListItem[]>(() => {
+    if (!apiError || !importedReport) return jobs;
+    return [{
+      job_id: "imported",
+      status: "done",
+      created_at: importedReport.scan_timestamp ?? new Date().toISOString(),
+      request: {},
+      summary: importedReport.summary,
+      scan_timestamp: importedReport.scan_timestamp,
+      pushed: false,
+    }];
   }, [jobs, apiError, importedReport]);
 
   const doneJobs = useMemo(
@@ -420,7 +487,12 @@ export default function Dashboard() {
   const effectiveAgentCount = importedReport
     ? (importedReport.agents?.length ?? 0)
     : agentCount;
-  const isLoading = loading && !importedReport;
+  const summaryStats = useMemo(() => {
+    const latest = effectiveRecentJobs.find((job) => job.status === "done" && job.summary);
+    return latest?.summary ?? null;
+  }, [effectiveRecentJobs]);
+  const isLoading = summaryLoading && !importedReport;
+  const detailsReady = !detailLoading || Boolean(importedReport);
 
   if (apiError && !importedReport) return <ApiOfflineState onImport={setImportedReport} />;
 
@@ -434,20 +506,20 @@ export default function Dashboard() {
               Risk overview
             </h1>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-300">
-              {doneJobs.length} scan{doneJobs.length !== 1 ? "s" : ""} · {effectiveAgentCount} agent{effectiveAgentCount !== 1 ? "s" : ""} · {totalPackages} packages · {uniqueCVEs} CVEs
+              {effectiveRecentJobs.length} scan{effectiveRecentJobs.length !== 1 ? "s" : ""} · {effectiveAgentCount} agent{effectiveAgentCount !== 1 ? "s" : ""} · {detailsReady ? totalPackages : (summaryStats?.total_packages ?? 0)} packages · {detailsReady ? uniqueCVEs : (summaryStats?.total_vulnerabilities ?? 0)} CVEs
             </p>
             <div className="mt-5 flex flex-wrap gap-2">
               <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-3 py-2">
                 <div className="text-[10px] uppercase tracking-[0.18em] text-red-200/70">Actively exploited</div>
-                <div className="mt-1 font-mono text-lg font-semibold text-red-100">{kevCount}</div>
+                <div className="mt-1 font-mono text-lg font-semibold text-red-100">{detailsReady ? kevCount : 0}</div>
               </div>
               <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-3 py-2">
                 <div className="text-[10px] uppercase tracking-[0.18em] text-amber-200/70">Credential exposed</div>
-                <div className="mt-1 font-mono text-lg font-semibold text-amber-100">{credentialExposureCount}</div>
+                <div className="mt-1 font-mono text-lg font-semibold text-amber-100">{detailsReady ? credentialExposureCount : 0}</div>
               </div>
               <div className="rounded-2xl border border-sky-500/20 bg-sky-500/10 px-3 py-2">
                 <div className="text-[10px] uppercase tracking-[0.18em] text-sky-200/70">Reachable tools</div>
-                <div className="mt-1 font-mono text-lg font-semibold text-sky-100">{reachableToolCount}</div>
+                <div className="mt-1 font-mono text-lg font-semibold text-sky-100">{detailsReady ? reachableToolCount : 0}</div>
               </div>
               {topRisk && (
                 <div className="rounded-2xl border border-zinc-700 bg-zinc-900/80 px-3 py-2">
@@ -541,11 +613,11 @@ export default function Dashboard() {
 
       {/* Key stats bar */}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
-        <StatCard icon={Layers} label="Total scans" value={isLoading ? "—" : String(doneJobs.length)} color="zinc" href="/jobs" />
+        <StatCard icon={Layers} label="Total scans" value={isLoading ? "—" : String(effectiveRecentJobs.length)} color="zinc" href="/jobs" />
         <StatCard icon={Server} label="Agents" value={isLoading ? "—" : String(effectiveAgentCount)} color="blue" href="/agents" />
-        <StatCard icon={Package} label="Packages" value={isLoading ? "—" : String(totalPackages)} color="orange" href="/vulns" />
-        <StatCard icon={Bug} label="Unique CVEs" value={isLoading ? "—" : String(uniqueCVEs)} color="red" href="/vulns" />
-        <StatCard icon={Zap} label="Critical" value={isLoading ? "—" : String(severity.critical)} color="red" href="/vulns?severity=critical" />
+        <StatCard icon={Package} label="Packages" value={isLoading ? "—" : String(detailsReady ? totalPackages : (summaryStats?.total_packages ?? 0))} color="orange" href="/vulns" />
+        <StatCard icon={Bug} label="Unique CVEs" value={isLoading ? "—" : String(detailsReady ? uniqueCVEs : (summaryStats?.total_vulnerabilities ?? 0))} color="red" href="/vulns" />
+        <StatCard icon={Zap} label="Critical" value={isLoading ? "—" : String(detailsReady ? severity.critical : (summaryStats?.critical_findings ?? 0))} color="red" href="/vulns?severity=critical" />
       </div>
 
       {/* Severity distribution + Sources — side by side */}
@@ -709,7 +781,7 @@ export default function Dashboard() {
             <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest">
               Recent scans
             </h2>
-            {jobs.length > 8 && (
+            {effectiveRecentJobs.length > 8 && (
               <Link href="/jobs" className="text-xs text-emerald-500 hover:text-emerald-400 flex items-center gap-1">
                 View all <ArrowRight className="w-3 h-3" />
               </Link>
@@ -717,11 +789,11 @@ export default function Dashboard() {
           </div>
           {isLoading ? (
             <div className="text-zinc-500 text-sm">Loading...</div>
-          ) : effectiveJobs.length === 0 ? (
+          ) : effectiveRecentJobs.length === 0 ? (
             <EmptyState />
           ) : (
             <div className="space-y-2">
-              {effectiveJobs.slice(0, 8).map((job) => (
+              {effectiveRecentJobs.slice(0, 8).map((job) => (
                 <JobRow key={job.job_id} job={job} />
               ))}
             </div>
@@ -912,7 +984,7 @@ function BlastCard({ blast }: { blast: BlastRadius }) {
   );
 }
 
-function JobRow({ job }: { job: ScanJob }) {
+function JobRow({ job }: { job: JobListItem }) {
   const statusColors: Record<string, string> = {
     done: "bg-emerald-500",
     failed: "bg-red-500",
@@ -920,16 +992,15 @@ function JobRow({ job }: { job: ScanJob }) {
     pending: "bg-zinc-500",
     cancelled: "bg-zinc-600",
   };
-  const result = job.result as ScanResult | undefined;
-  const vulnCount = result?.summary?.total_vulnerabilities ?? 0;
-  const critCount = result?.summary?.critical_findings ?? 0;
+  const vulnCount = job.summary?.total_vulnerabilities ?? 0;
+  const critCount = job.summary?.critical_findings ?? 0;
 
   // Detect scan source tags
   const tags: string[] = [];
-  if (job.request.images && job.request.images.length > 0) tags.push(`${job.request.images.length} image${job.request.images.length > 1 ? "s" : ""}`);
-  if (job.request.k8s) tags.push("k8s");
-  if (job.request.sbom) tags.push("sbom");
-  if (job.request.inventory) tags.push("inventory");
+  if (job.request?.images && job.request.images.length > 0) tags.push(`${job.request.images.length} image${job.request.images.length > 1 ? "s" : ""}`);
+  if (job.request?.k8s) tags.push("k8s");
+  if (job.request?.sbom) tags.push("sbom");
+  if (job.request?.inventory) tags.push("inventory");
   if (tags.length === 0 && job.status === "done") tags.push("agents");
 
   return (

--- a/ui/components/activity-feed.tsx
+++ b/ui/components/activity-feed.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useState, useMemo } from "react";
 import { api } from "@/lib/api";
-import type { ScanJob } from "@/lib/api";
+import type { JobListItem } from "@/lib/api";
 import {
   Search,
   CheckCircle,
@@ -52,7 +52,7 @@ function timeAgo(iso: string): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
-function jobsToEvents(jobs: ScanJob[]): ActivityEvent[] {
+function jobsToEvents(jobs: JobListItem[]): ActivityEvent[] {
   const events: ActivityEvent[] = [];
   for (const job of jobs) {
     events.push({
@@ -63,17 +63,16 @@ function jobsToEvents(jobs: ScanJob[]): ActivityEvent[] {
       meta: { job_id: job.job_id },
     });
     if (job.status === "done" && job.completed_at) {
-      const result = job.result as Record<string, unknown> | undefined;
-      const blast = (result?.blast_radius as Array<Record<string, unknown>>) ?? [];
-      const critCount = blast.filter((b) => b.severity === "critical").length;
+      const findingCount = job.summary?.total_vulnerabilities ?? 0;
+      const critCount = job.summary?.critical_findings ?? 0;
       events.push({
         id: `${job.job_id}-done`,
         type: "scan_completed",
-        message: `Scan completed: ${blast.length} findings${critCount > 0 ? `, ${critCount} critical` : ""}`,
+        message: `Scan completed: ${findingCount} findings${critCount > 0 ? `, ${critCount} critical` : ""}`,
         timestamp: job.completed_at,
         meta: {
           job_id: job.job_id,
-          cve_count: blast.length,
+          cve_count: findingCount,
           critical_count: critCount,
         },
       });
@@ -98,7 +97,7 @@ interface ActivityFeedProps {
 }
 
 export function ActivityFeed({ maxItems = 20, className }: ActivityFeedProps) {
-  const [jobs, setJobs] = useState<ScanJob[]>([]);
+  const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [filter, setFilter] = useState<ActivityType | "all">("all");
   const [loading, setLoading] = useState(true);
 
@@ -106,10 +105,7 @@ export function ActivityFeed({ maxItems = 20, className }: ActivityFeedProps) {
     async function load() {
       try {
         const jobsRes = await api.listJobs();
-        const full = await Promise.all(
-          jobsRes.jobs.slice(0, 20).map((j) => api.getScan(j.job_id))
-        );
-        setJobs(full);
+        setJobs(jobsRes.jobs.slice(0, 20));
       } catch {
         /* ignore */
       } finally {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -415,13 +415,19 @@ export interface VersionInfo {
 }
 
 export interface JobsResponse {
-  jobs: Array<{
-    job_id: string;
-    status: JobStatus;
-    created_at: string;
-    completed_at?: string;
-  }>;
+  jobs: JobListItem[];
   count: number;
+}
+
+export interface JobListItem {
+  job_id: string;
+  status: JobStatus;
+  created_at: string;
+  completed_at?: string;
+  request?: ScanRequest;
+  summary?: Summary;
+  scan_timestamp?: string;
+  pushed?: boolean;
 }
 
 export interface AgentsResponse {


### PR DESCRIPTION
## Summary
- decouple dashboard summaries from deep scan hydration
- enrich /v1/jobs with lightweight summary fields for list surfaces
- preserve pushed result summary and posture data for UI consumers
- refresh live API CORS middleware config at runtime

## Validation
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache-clean uv run pytest -q tests/test_api_hardening.py tests/test_api_tenant_isolation.py
- UV_CACHE_DIR=/tmp/agent-bom-uv-cache-clean uv run ruff check src/agent_bom/api/models.py src/agent_bom/api/routes/observability.py src/agent_bom/api/routes/scan.py src/agent_bom/api/server.py tests/test_api_hardening.py tests/test_api_tenant_isolation.py
- npm --prefix ui run test:run

## Notes
- next build under Turbopack still hits the known sandbox worker-port restriction in this environment
- README and screenshot refresh are intentionally left out of this batch
