### PR TITLE
Improve modular loading for mesh, context, and insights

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -25,7 +25,7 @@ import {
   ChevronDown,
   ChevronRight,
 } from "lucide-react";
-import { api, type ScanJob } from "@/lib/api";
+import { api, type JobListItem, type ScanJob } from "@/lib/api";
 import { applyDagreLayout } from "@/lib/dagre-layout";
 import {
   lineageNodeTypes,
@@ -209,32 +209,24 @@ function LateralPanel({
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function ContextPage() {
-  const [jobs, setJobs] = useState<ScanJob[]>([]);
+  const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [selectedJobId, setSelectedJobId] = useState<string>("");
   const [graphData, setGraphData] = useState<ContextGraphData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
 
   // Load completed jobs
   useEffect(() => {
     api
       .listJobs()
-      .then(async (res) => {
-        const doneJobs: ScanJob[] = [];
-        for (const j of res.jobs) {
-          if (j.status === "done") {
-            try {
-              const full = await api.getScan(j.job_id);
-              if (full.result) doneJobs.push(full);
-            } catch {
-              /* skip */
-            }
-          }
-        }
+      .then((res) => {
+        const doneJobs = res.jobs.filter((j) => j.status === "done");
         setJobs(doneJobs);
         if (doneJobs.length > 0) setSelectedJobId(doneJobs[0].job_id);
       })
@@ -242,10 +234,34 @@ export default function ContextPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  const activeJob = useMemo(
-    () => jobs.find((job) => job.job_id === selectedJobId) ?? null,
-    [jobs, selectedJobId],
-  );
+  useEffect(() => {
+    if (!selectedJobId) {
+      setActiveJob(null);
+      return;
+    }
+    let cancelled = false;
+    setDetailLoading(true);
+    api
+      .getScan(selectedJobId)
+      .then((job) => {
+        if (!cancelled) {
+          setActiveJob(job.result ? job : null);
+          setError(null);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setActiveJob(null);
+          setError(e.message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedJobId]);
 
   const agentNames = useMemo(
     () => activeJob?.result?.agents.map((agent) => agent.name).sort((left, right) => left.localeCompare(right)) ?? [],
@@ -363,11 +379,11 @@ export default function ContextPage() {
     setHoveredNodeId(null);
   }, []);
 
-  if (loading) {
+  if (loading || (detailLoading && !graphData)) {
     return (
       <div className="flex items-center justify-center h-[80vh] text-zinc-400">
         <Loader2 className="w-5 h-5 animate-spin mr-2" />
-        Loading scan data...
+        Loading context view...
       </div>
     );
   }
@@ -464,6 +480,12 @@ export default function ContextPage() {
       <div className="flex-1 flex overflow-hidden">
         {/* Graph */}
         <div className="flex-1 relative">
+          {detailLoading && graphData && (
+            <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-center py-2 text-xs text-zinc-400 bg-zinc-950/70 backdrop-blur-sm">
+              <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
+              Updating context graph...
+            </div>
+          )}
           {!graphData ? (
             <div className="flex items-center justify-center h-full text-zinc-400">
               <Loader2 className="w-5 h-5 animate-spin mr-2" />

--- a/ui/app/insights/page.tsx
+++ b/ui/app/insights/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   api,
+  JobListItem,
   ScanJob,
   ScanResult,
   Agent,
@@ -108,25 +109,39 @@ function buildTrendData(jobs: ScanJob[]): TrendDataPoint[] {
 
 export default function InsightsPage() {
   const router = useRouter();
-  const [jobs, setJobs] = useState<ScanJob[]>([]);
+  const [jobs, setJobs] = useState<JobListItem[]>([]);
+  const [latestJob, setLatestJob] = useState<ScanJob | null>(null);
+  const [trendJobs, setTrendJobs] = useState<ScanJob[]>([]);
   const [loading, setLoading] = useState(true);
+  const [trendLoading, setTrendLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = () => {
     setLoading(true);
     setError(null);
+    setLatestJob(null);
+    setTrendJobs([]);
+    setTrendLoading(false);
     api
       .listJobs()
       .then(async (res) => {
-        const doneIds = res.jobs
-          .filter((j) => j.status === "done")
-          .slice(0, 10)
-          .map((j) => j.job_id);
+        const doneJobs = res.jobs.filter((j) => j.status === "done");
+        setJobs(doneJobs);
+        if (doneJobs.length === 0) {
+          setLatestJob(null);
+          setTrendJobs([]);
+          return;
+        }
 
-        const fullJobs = await Promise.all(
-          doneIds?.map((id) => api.getScan(id).catch(() => null))
-        );
-        setJobs(fullJobs.filter(Boolean) as ScanJob[]);
+        const latest = await api.getScan(doneJobs[0].job_id);
+        setLatestJob(latest.result ? latest : null);
+
+        setTrendLoading(true);
+        Promise.all(doneJobs.slice(0, 10).map((job) => api.getScan(job.job_id).catch(() => null)))
+          .then((fullJobs) => {
+            setTrendJobs(fullJobs.filter((job): job is ScanJob => Boolean(job?.result)));
+          })
+          .finally(() => setTrendLoading(false));
       })
       .catch((e) => setError(String(e)))
       .finally(() => setLoading(false));
@@ -137,10 +152,7 @@ export default function InsightsPage() {
   }, []);
 
   // Use the most recent completed scan for single-scan charts
-  const latest = useMemo(
-    () => jobs.find((j) => j.status === "done" && j.result) ?? null,
-    [jobs]
-  );
+  const latest = latestJob;
   const result = latest?.result ?? null;
   const agents: Agent[] = result?.agents ?? [];
   const blasts: BlastRadius[] = result?.blast_radius ?? [];
@@ -151,7 +163,7 @@ export default function InsightsPage() {
   );
 
   const epssVsCvss = useMemo(() => buildEpssVsCvss(blasts), [blasts]);
-  const trendData = useMemo(() => buildTrendData(jobs), [jobs]);
+  const trendData = useMemo(() => buildTrendData(trendJobs), [trendJobs]);
 
   if (loading) {
     return (
@@ -237,7 +249,13 @@ export default function InsightsPage() {
         </div>
       )}
 
-      {trendData.length < 2 && (
+      {trendLoading && (
+        <div className="text-center py-6 text-zinc-600 text-xs border border-zinc-800 border-dashed rounded-xl">
+          Loading trend history...
+        </div>
+      )}
+
+      {!trendLoading && trendData.length < 2 && (
         <div className="text-center py-6 text-zinc-600 text-xs border border-zinc-800 border-dashed rounded-xl">
           Run 2+ scans to see vulnerability trend over time
         </div>

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { ShieldAlert, Loader2, AlertTriangle, Search, SlidersHorizontal, Network, GitBranch } from "lucide-react";
-import { api, type ScanJob } from "@/lib/api";
+import { api, type JobListItem, type ScanJob } from "@/lib/api";
 import { applyDagreLayout } from "@/lib/dagre-layout";
 import { lineageNodeTypes, type LineageNodeData, type LineageNodeType } from "@/components/lineage-nodes";
 import { LineageDetailPanel } from "@/components/lineage-detail";
@@ -165,12 +165,14 @@ function MeshToolbar({
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function MeshPage() {
-  const [jobs, setJobs] = useState<ScanJob[]>([]);
+  const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [selectedJob, setSelectedJob] = useState<string>("");
   const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
 
   // Layout direction: "LR" for topology, "TB" for spawn tree
   const [layoutMode, setLayoutMode] = useState<"LR" | "TB">("LR");
@@ -190,29 +192,45 @@ export default function MeshPage() {
   useEffect(() => {
     api
       .listJobs()
-      .then(async (res) => {
-        const fullJobs: ScanJob[] = [];
-        for (const j of res.jobs) {
-          if (j.status === "done") {
-            try {
-              const full = await api.getScan(j.job_id);
-              if (full.result) fullJobs.push(full);
-            } catch {
-              /* skip */
-            }
-          }
-        }
-        setJobs(fullJobs);
-        if (fullJobs.length > 0) setSelectedJob(fullJobs[0].job_id);
+      .then((res) => {
+        const doneJobs = res.jobs.filter((j) => j.status === "done");
+        setJobs(doneJobs);
+        if (doneJobs.length > 0) setSelectedJob(doneJobs[0].job_id);
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
 
-  const activeResult = useMemo(
-    () => jobs.find((j) => j.job_id === selectedJob)?.result ?? null,
-    [jobs, selectedJob]
-  );
+  useEffect(() => {
+    if (!selectedJob) {
+      setActiveJob(null);
+      return;
+    }
+    let cancelled = false;
+    setDetailLoading(true);
+    api
+      .getScan(selectedJob)
+      .then((job) => {
+        if (!cancelled) {
+          setActiveJob(job.result ? job : null);
+          setError(null);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setActiveJob(null);
+          setError(e.message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedJob]);
+
+  const activeResult = useMemo(() => activeJob?.result ?? null, [activeJob]);
 
   const agentNames = useMemo(
     () => activeResult?.agents.map((agent) => agent.name).sort((left, right) => left.localeCompare(right)) ?? [],
@@ -320,11 +338,11 @@ export default function MeshPage() {
     setHoveredNodeId(null);
   }, []);
 
-  if (loading) {
+  if (loading || (detailLoading && !activeResult)) {
     return (
       <div className="flex items-center justify-center h-[80vh] text-zinc-400">
         <Loader2 className="w-5 h-5 animate-spin mr-2" />
-        Loading scan data...
+        Loading mesh view...
       </div>
     );
   }
@@ -422,6 +440,12 @@ export default function MeshPage() {
 
       {/* Graph */}
       <div className="flex-1 relative">
+        {detailLoading && activeResult && (
+          <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-center py-2 text-xs text-zinc-400 bg-zinc-950/70 backdrop-blur-sm">
+            <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
+            Updating mesh...
+          </div>
+        )}
         <ReactFlow
           nodes={displayNodes}
           edges={displayEdges}


### PR DESCRIPTION
## Summary
- decouple mesh and context from full-job hydration lists by loading job summaries first and hydrating only the active scan
- load insights in two phases: latest scan first, trend history second
- keep existing data visible while switching scans instead of blanking the whole page

## Validation
- git diff --check
- code review of page-level data flow changes

## Notes
- clean worktree branch only; no README/demo assets mixed into this batch
- local frontend dependency tree in this environment is incomplete, so full vitest/next build could not be used as a reliable signal here