### PR TITLE
Polish README visuals and release surfaces

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -27,9 +27,14 @@ Try the built-in demo first:
 agent-bom agents --demo --offline
 ```
 
-The GIF uses that same curated sample so the output stays reproducible across releases. For real scans, run `agent-bom agents`, or add `-p .` to fold project manifests and lockfiles into the same result.
+The demo uses a curated sample so the output stays reproducible across releases. For real scans, run `agent-bom agents`, or add `-p .` to fold project manifests and lockfiles into the same result.
+
+<details>
+<summary><b>See the terminal demo</b></summary>
 
 ![agent-bom demo](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif)
+
+</details>
 
 ## Recommended starting points
 

--- a/README.md
+++ b/README.md
@@ -33,17 +33,28 @@ Blast radius is the core idea: `CVE -> package -> MCP server -> agent -> credent
 
 `agent-bom` scans local agent configs, MCP servers, instruction files, lockfiles, containers, cloud posture, GPU surfaces, and runtime evidence. CWE-aware impact keeps a DoS from being reported like credential compromise.
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom blast radius demo" width="900" />
-</p>
-
 Try the built-in demo first:
 
 ```bash
 agent-bom agents --demo --offline
 ```
 
-The GIF uses that same curated sample so the output stays reproducible across releases. For real scans, run `agent-bom agents`, or add `-p .` to fold project manifests and lockfiles into the same result.
+The demo uses a curated sample so the output stays reproducible across releases. For real scans, run `agent-bom agents`, or add `-p .` to fold project manifests and lockfiles into the same result.
+
+Choose the view that matches what you need:
+
+- CLI: fast local proof that blast radius and remediation are real
+- Graph: one focused path first, then expand only when needed
+- Dashboard: persistent state, diff, and review
+
+<details>
+<summary><b>See the terminal demo</b></summary>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo" width="820" />
+</p>
+
+</details>
 
 ## Recommended starting points
 
@@ -118,7 +129,7 @@ agent-bom serve                         # API + Next.js dashboard
 
 ## Graph explorer
 
-The README starts from the same scoped graph view as the product: one focused path first, then expand by agent, depth, or findings only when needed.
+The README should show the same pattern as the product: start from one scoped path, then expand by agent, depth, or findings only when you ask for more.
 
 <p align="center">
   <picture>
@@ -150,7 +161,7 @@ The active catalog metadata is also surfaced in JSON output (`framework_catalogs
 
 ## Architecture at a glance
 
-One graph, one path: discover, analyze, persist, then operate across CLI, CI, API, dashboard, and exports.
+One path: discover, analyze, persist, then operate across CLI, CI, API, dashboard, and exports.
 
 <p align="center">
   <picture>
@@ -275,7 +286,8 @@ Also on [Glama](https://glama.ai/mcp/servers/@msaad00/agent-bom), [Smithery](int
 
 ---
 
-## Trust & transparency
+<details>
+<summary><b>Trust & transparency</b></summary>
 
 | When | What's sent | Where | Opt out |
 |---|---|---|---|
@@ -287,6 +299,8 @@ Also on [Glama](https://glama.ai/mcp/servers/@msaad00/agent-bom), [Smithery](int
 | Optional push/integrations | Finding summaries or evidence bundles | Slack, Jira, Vanta, Drata | Don't pass those flags |
 
 No source code, config contents, or credential values are sent. No telemetry or analytics. [Sigstore-signed](docs/PERMISSIONS.md) releases. See [SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) and [PERMISSIONS.md](docs/PERMISSIONS.md) for the full trust model.
+
+</details>
 
 ---
 

--- a/docs/images/architecture-stack-dark.svg
+++ b/docs/images/architecture-stack-dark.svg
@@ -1,17 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" fill="none">
   <style>
     text { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
-    .title { font-size: 20px; font-weight: 800; fill: #f8fafc; }
-    .subtitle { font-size: 11px; font-weight: 500; fill: #94a3b8; }
-    .section { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; }
-    .card-title { font-size: 13px; font-weight: 760; fill: #f8fafc; }
-    .copy { font-size: 9.25px; font-weight: 500; fill: #94a3b8; }
-    .footer-title { font-size: 10px; font-weight: 800; fill: #f8fafc; }
-    .footer-copy { font-size: 10px; font-weight: 600; fill: #cbd5e1; }
+    .title { font-size: 24px; font-weight: 800; fill: #f8fafc; }
+    .subtitle { font-size: 12px; font-weight: 600; fill: #94a3b8; }
+    .section { font-size: 11px; font-weight: 800; letter-spacing: 0.14em; }
+    .card-title { font-size: 15px; font-weight: 760; fill: #f8fafc; }
+    .copy { font-size: 10px; font-weight: 600; fill: #cbd5e1; }
   </style>
-
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="520" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="460" gradientUnits="userSpaceOnUse">
       <stop stop-color="#09090b"/>
       <stop offset="1" stop-color="#111827"/>
     </linearGradient>
@@ -20,82 +17,56 @@
     </marker>
   </defs>
 
-  <rect width="960" height="520" rx="18" fill="url(#bg)" stroke="#1f2937"/>
+  <rect width="960" height="460" rx="18" fill="url(#bg)" stroke="#1f2937"/>
+  <text x="480" y="42" text-anchor="middle" class="title">Architecture at a glance</text>
+  <text x="480" y="64" text-anchor="middle" class="subtitle">Discover, analyze, persist one graph, then operate across every surface.</text>
 
-  <text x="480" y="38" text-anchor="middle" class="title">Architecture at a glance</text>
-  <text x="480" y="58" text-anchor="middle" class="subtitle">Discover, analyze, persist one graph, then operate across every surface.</text>
+  <path d="M234 220H256" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M470 220H492" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M706 220H728" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
 
-  <path d="M236 214H258" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M468 214H490" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M700 214H722" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <rect x="28" y="98" width="206" height="290" rx="18" fill="#111827" stroke="#1f2937"/>
+  <rect x="264" y="98" width="206" height="290" rx="18" fill="#111827" stroke="#1f2937"/>
+  <rect x="500" y="98" width="206" height="290" rx="18" fill="#111827" stroke="#1f2937"/>
+  <rect x="736" y="98" width="196" height="290" rx="18" fill="#111827" stroke="#1f2937"/>
 
-  <rect x="32" y="92" width="204" height="316" rx="18" fill="#111827" stroke="#1f2937"/>
-  <rect x="264" y="92" width="204" height="316" rx="18" fill="#111827" stroke="#1f2937"/>
-  <rect x="496" y="92" width="204" height="316" rx="18" fill="#111827" stroke="#1f2937"/>
-  <rect x="728" y="92" width="200" height="316" rx="18" fill="#111827" stroke="#1f2937"/>
+  <text x="48" y="128" class="section" fill="#a78bfa">DISCOVER</text>
+  <text x="284" y="128" class="section" fill="#fb7185">ANALYZE</text>
+  <text x="520" y="128" class="section" fill="#34d399">PERSIST</text>
+  <text x="756" y="128" class="section" fill="#60a5fa">OPERATE</text>
 
-  <text x="52" y="122" class="section" fill="#a78bfa">DISCOVER</text>
-  <text x="284" y="122" class="section" fill="#fb7185">ANALYZE</text>
-  <text x="516" y="122" class="section" fill="#34d399">PERSIST</text>
-  <text x="748" y="122" class="section" fill="#60a5fa">OPERATE</text>
+  <rect x="44" y="148" width="174" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="62" y="176" class="card-title">Agents + MCP</text>
+  <text x="62" y="198" class="copy">Clients, servers, tools, configs, and trust posture.</text>
 
-  <rect x="48" y="142" width="172" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="64" y="168" class="card-title">Agents + MCP</text>
-  <text x="64" y="188" class="copy">
-    <tspan x="64" dy="0">Local clients, servers, tools,</tspan>
-    <tspan x="64" dy="14">configs, and trust review.</tspan>
-  </text>
+  <rect x="44" y="250" width="174" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="62" y="278" class="card-title">Packages + runtime</text>
+  <text x="62" y="300" class="copy">Lockfiles, images, IaC, cloud, models, and runtime evidence.</text>
 
-  <rect x="48" y="242" width="172" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="64" y="268" class="card-title">Packages + infra</text>
-  <text x="64" y="288" class="copy">
-    <tspan x="64" dy="0">Lockfiles, images, IaC, cloud,</tspan>
-    <tspan x="64" dy="14">models, and runtime evidence.</tspan>
-  </text>
+  <rect x="280" y="148" width="174" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="298" y="176" class="card-title">Findings</text>
+  <text x="298" y="198" class="copy">CVEs, secrets, posture checks, and alerts.</text>
 
-  <rect x="280" y="142" width="172" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="296" y="168" class="card-title">Findings</text>
-  <text x="296" y="188" class="copy">
-    <tspan x="296" dy="0">CVEs, secrets, misconfigurations,</tspan>
-    <tspan x="296" dy="14">posture checks, and alerts.</tspan>
-  </text>
+  <rect x="280" y="250" width="174" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="298" y="278" class="card-title">Interpretation</text>
+  <text x="298" y="300" class="copy">Blast radius, CWE impact, fix-first plans, control mapping.</text>
 
-  <rect x="280" y="242" width="172" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="296" y="268" class="card-title">Interpretation</text>
-  <text x="296" y="288" class="copy">
-    <tspan x="296" dy="0">Blast radius, CWE impact,</tspan>
-    <tspan x="296" dy="14">fix-first plans, control mapping.</tspan>
-  </text>
+  <rect x="516" y="148" width="174" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="534" y="176" class="card-title">Graph model</text>
+  <text x="534" y="198" class="copy">Entities, edges, findings, paths, events, snapshots, diffs.</text>
 
-  <rect x="512" y="142" width="172" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="528" y="168" class="card-title">Graph model</text>
-  <text x="528" y="188" class="copy">
-    <tspan x="528" dy="0">Entities, edges, findings, paths,</tspan>
-    <tspan x="528" dy="14">events, snapshots, and diffs.</tspan>
-  </text>
+  <rect x="516" y="250" width="174" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="534" y="278" class="card-title">State + storage</text>
+  <text x="534" y="300" class="copy">SQLite or Postgres, latest state, history, and tenancy.</text>
 
-  <rect x="512" y="242" width="172" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="528" y="268" class="card-title">State + storage</text>
-  <text x="528" y="288" class="copy">
-    <tspan x="528" dy="0">SQLite or Postgres, latest state,</tspan>
-    <tspan x="528" dy="14">history, and tenancy.</tspan>
-  </text>
+  <rect x="752" y="148" width="164" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="770" y="176" class="card-title">CLI + CI</text>
+  <text x="770" y="198" class="copy">Local scans, GitHub Actions, Docker, SARIF, and policy gates.</text>
 
-  <rect x="744" y="142" width="168" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="760" y="168" class="card-title">CLI + CI</text>
-  <text x="760" y="188" class="copy">
-    <tspan x="760" dy="0">Local scans, GitHub Actions,</tspan>
-    <tspan x="760" dy="14">Docker, SARIF, and policy gates.</tspan>
-  </text>
+  <rect x="752" y="250" width="164" height="90" rx="14" fill="#18181b" stroke="#374151"/>
+  <text x="770" y="278" class="card-title">API + dashboard</text>
+  <text x="770" y="300" class="copy">Search, diff, node detail, compliance, evidence, and review.</text>
 
-  <rect x="744" y="242" width="168" height="88" rx="14" fill="#18181b" stroke="#374151"/>
-  <text x="760" y="268" class="card-title">API + dashboard</text>
-  <text x="760" y="288" class="copy">
-    <tspan x="760" dy="0">Search, diff, node detail,</tspan>
-    <tspan x="760" dy="14">compliance, evidence, and review.</tspan>
-  </text>
-
-  <rect x="32" y="436" width="896" height="54" rx="16" fill="#111827" stroke="#374151"/>
-  <text x="56" y="458" class="footer-title">Why this is here</text>
-  <text x="56" y="478" class="footer-copy">The same graph model powers CLI, CI, API, dashboard, exports, and runtime review. The diagram should explain that in one pass.</text>
+  <rect x="44" y="404" width="872" height="32" rx="16" fill="#111827" stroke="#374151"/>
+  <text x="66" y="425" class="copy">One graph model powers CLI, CI, API, dashboard, exports, and runtime review.</text>
 </svg>

--- a/docs/images/architecture-stack-light.svg
+++ b/docs/images/architecture-stack-light.svg
@@ -1,17 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" fill="none">
   <style>
     text { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
-    .title { font-size: 20px; font-weight: 800; fill: #111827; }
-    .subtitle { font-size: 11px; font-weight: 500; fill: #64748b; }
-    .section { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; }
-    .card-title { font-size: 13px; font-weight: 760; fill: #111827; }
-    .copy { font-size: 9.25px; font-weight: 500; fill: #475569; }
-    .footer-title { font-size: 10px; font-weight: 800; fill: #111827; }
-    .footer-copy { font-size: 10px; font-weight: 600; fill: #475569; }
+    .title { font-size: 24px; font-weight: 800; fill: #111827; }
+    .subtitle { font-size: 12px; font-weight: 600; fill: #64748b; }
+    .section { font-size: 11px; font-weight: 800; letter-spacing: 0.14em; }
+    .card-title { font-size: 15px; font-weight: 760; fill: #111827; }
+    .copy { font-size: 10px; font-weight: 600; fill: #475569; }
   </style>
-
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="520" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="460" gradientUnits="userSpaceOnUse">
       <stop stop-color="#ffffff"/>
       <stop offset="1" stop-color="#f8fafc"/>
     </linearGradient>
@@ -20,82 +17,56 @@
     </marker>
   </defs>
 
-  <rect width="960" height="520" rx="18" fill="url(#bg)" stroke="#e5e7eb"/>
+  <rect width="960" height="460" rx="18" fill="url(#bg)" stroke="#e5e7eb"/>
+  <text x="480" y="42" text-anchor="middle" class="title">Architecture at a glance</text>
+  <text x="480" y="64" text-anchor="middle" class="subtitle">Discover, analyze, persist one graph, then operate across every surface.</text>
 
-  <text x="480" y="38" text-anchor="middle" class="title">Architecture at a glance</text>
-  <text x="480" y="58" text-anchor="middle" class="subtitle">Discover, analyze, persist one graph, then operate across every surface.</text>
+  <path d="M234 220H256" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M470 220H492" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M706 220H728" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
 
-  <path d="M236 214H258" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M468 214H490" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M700 214H722" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <rect x="28" y="98" width="206" height="290" rx="18" fill="#f8fafc" stroke="#e5e7eb"/>
+  <rect x="264" y="98" width="206" height="290" rx="18" fill="#fcfcff" stroke="#e5e7eb"/>
+  <rect x="500" y="98" width="206" height="290" rx="18" fill="#f9fafb" stroke="#e5e7eb"/>
+  <rect x="736" y="98" width="196" height="290" rx="18" fill="#f8fafc" stroke="#e5e7eb"/>
 
-  <rect x="32" y="92" width="204" height="316" rx="18" fill="#f8fafc" stroke="#e5e7eb"/>
-  <rect x="264" y="92" width="204" height="316" rx="18" fill="#fcfcff" stroke="#e5e7eb"/>
-  <rect x="496" y="92" width="204" height="316" rx="18" fill="#f9fafb" stroke="#e5e7eb"/>
-  <rect x="728" y="92" width="200" height="316" rx="18" fill="#f8fafc" stroke="#e5e7eb"/>
+  <text x="48" y="128" class="section" fill="#7c3aed">DISCOVER</text>
+  <text x="284" y="128" class="section" fill="#e11d48">ANALYZE</text>
+  <text x="520" y="128" class="section" fill="#059669">PERSIST</text>
+  <text x="756" y="128" class="section" fill="#2563eb">OPERATE</text>
 
-  <text x="52" y="122" class="section" fill="#7c3aed">DISCOVER</text>
-  <text x="284" y="122" class="section" fill="#e11d48">ANALYZE</text>
-  <text x="516" y="122" class="section" fill="#059669">PERSIST</text>
-  <text x="748" y="122" class="section" fill="#2563eb">OPERATE</text>
+  <rect x="44" y="148" width="174" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="62" y="176" class="card-title">Agents + MCP</text>
+  <text x="62" y="198" class="copy">Clients, servers, tools, configs, and trust posture.</text>
 
-  <rect x="48" y="142" width="172" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="64" y="168" class="card-title">Agents + MCP</text>
-  <text x="64" y="188" class="copy">
-    <tspan x="64" dy="0">Local clients, servers, tools,</tspan>
-    <tspan x="64" dy="14">configs, and trust review.</tspan>
-  </text>
+  <rect x="44" y="250" width="174" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="62" y="278" class="card-title">Packages + runtime</text>
+  <text x="62" y="300" class="copy">Lockfiles, images, IaC, cloud, models, and runtime evidence.</text>
 
-  <rect x="48" y="242" width="172" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="64" y="268" class="card-title">Packages + infra</text>
-  <text x="64" y="288" class="copy">
-    <tspan x="64" dy="0">Lockfiles, images, IaC, cloud,</tspan>
-    <tspan x="64" dy="14">models, and runtime evidence.</tspan>
-  </text>
+  <rect x="280" y="148" width="174" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="298" y="176" class="card-title">Findings</text>
+  <text x="298" y="198" class="copy">CVEs, secrets, posture checks, and alerts.</text>
 
-  <rect x="280" y="142" width="172" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="296" y="168" class="card-title">Findings</text>
-  <text x="296" y="188" class="copy">
-    <tspan x="296" dy="0">CVEs, secrets, misconfigurations,</tspan>
-    <tspan x="296" dy="14">posture checks, and alerts.</tspan>
-  </text>
+  <rect x="280" y="250" width="174" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="298" y="278" class="card-title">Interpretation</text>
+  <text x="298" y="300" class="copy">Blast radius, CWE impact, fix-first plans, control mapping.</text>
 
-  <rect x="280" y="242" width="172" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="296" y="268" class="card-title">Interpretation</text>
-  <text x="296" y="288" class="copy">
-    <tspan x="296" dy="0">Blast radius, CWE impact,</tspan>
-    <tspan x="296" dy="14">fix-first plans, control mapping.</tspan>
-  </text>
+  <rect x="516" y="148" width="174" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="534" y="176" class="card-title">Graph model</text>
+  <text x="534" y="198" class="copy">Entities, edges, findings, paths, events, snapshots, diffs.</text>
 
-  <rect x="512" y="142" width="172" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="528" y="168" class="card-title">Graph model</text>
-  <text x="528" y="188" class="copy">
-    <tspan x="528" dy="0">Entities, edges, findings, paths,</tspan>
-    <tspan x="528" dy="14">events, snapshots, and diffs.</tspan>
-  </text>
+  <rect x="516" y="250" width="174" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="534" y="278" class="card-title">State + storage</text>
+  <text x="534" y="300" class="copy">SQLite or Postgres, latest state, history, and tenancy.</text>
 
-  <rect x="512" y="242" width="172" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="528" y="268" class="card-title">State + storage</text>
-  <text x="528" y="288" class="copy">
-    <tspan x="528" dy="0">SQLite or Postgres, latest state,</tspan>
-    <tspan x="528" dy="14">history, and tenancy.</tspan>
-  </text>
+  <rect x="752" y="148" width="164" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="770" y="176" class="card-title">CLI + CI</text>
+  <text x="770" y="198" class="copy">Local scans, GitHub Actions, Docker, SARIF, and policy gates.</text>
 
-  <rect x="744" y="142" width="168" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="760" y="168" class="card-title">CLI + CI</text>
-  <text x="760" y="188" class="copy">
-    <tspan x="760" dy="0">Local scans, GitHub Actions,</tspan>
-    <tspan x="760" dy="14">Docker, SARIF, and policy gates.</tspan>
-  </text>
+  <rect x="752" y="250" width="164" height="90" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="770" y="278" class="card-title">API + dashboard</text>
+  <text x="770" y="300" class="copy">Search, diff, node detail, compliance, evidence, and review.</text>
 
-  <rect x="744" y="242" width="168" height="88" rx="14" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="760" y="268" class="card-title">API + dashboard</text>
-  <text x="760" y="288" class="copy">
-    <tspan x="760" dy="0">Search, diff, node detail,</tspan>
-    <tspan x="760" dy="14">compliance, evidence, and review.</tspan>
-  </text>
-
-  <rect x="32" y="436" width="896" height="54" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="56" y="458" class="footer-title">Why this is here</text>
-  <text x="56" y="478" class="footer-copy">The same graph model powers CLI, CI, API, dashboard, exports, and runtime review. The diagram should explain that in one pass.</text>
+  <rect x="44" y="404" width="872" height="32" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="66" y="425" class="copy">One graph model powers CLI, CI, API, dashboard, exports, and runtime review.</text>
 </svg>

--- a/docs/images/topology-dark.svg
+++ b/docs/images/topology-dark.svg
@@ -1,18 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 440" fill="none">
   <style>
     text { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
-    .title { font-size: 20px; font-weight: 800; fill: #f8fafc; }
-    .subtitle { font-size: 11px; font-weight: 500; fill: #94a3b8; }
-    .section { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; }
-    .card-title { font-size: 13px; font-weight: 760; fill: #f8fafc; }
-    .copy { font-size: 10px; font-weight: 500; fill: #94a3b8; }
-    .pill { font-size: 8.5px; font-weight: 700; fill: #e2e8f0; }
-    .footer-title { font-size: 10px; font-weight: 800; fill: #f8fafc; }
-    .footer-copy { font-size: 10px; font-weight: 600; fill: #cbd5e1; }
+    .title { font-size: 24px; font-weight: 800; fill: #f8fafc; }
+    .subtitle { font-size: 12px; font-weight: 600; fill: #94a3b8; }
+    .section { font-size: 11px; font-weight: 800; letter-spacing: 0.14em; }
+    .card-title { font-size: 15px; font-weight: 760; fill: #f8fafc; }
+    .copy { font-size: 10px; font-weight: 600; fill: #cbd5e1; }
+    .pill { font-size: 9px; font-weight: 700; fill: #e2e8f0; }
   </style>
-
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="520" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="440" gradientUnits="userSpaceOnUse">
       <stop stop-color="#09090b"/>
       <stop offset="1" stop-color="#111827"/>
     </linearGradient>
@@ -21,94 +18,75 @@
     </marker>
   </defs>
 
-  <rect width="960" height="520" rx="18" fill="url(#bg)" stroke="#1f2937"/>
+  <rect width="960" height="440" rx="18" fill="url(#bg)" stroke="#1f2937"/>
 
-  <text x="480" y="38" text-anchor="middle" class="title">Focused graph view</text>
-  <text x="480" y="58" text-anchor="middle" class="subtitle">Built-in demo, scoped to one agent and the highest-risk reachable surfaces.</text>
+  <text x="480" y="42" text-anchor="middle" class="title">Focused graph view</text>
+  <text x="480" y="64" text-anchor="middle" class="subtitle">One scoped path first. Expand later by agent, depth, or findings.</text>
 
-  <rect x="286" y="76" width="78" height="24" rx="12" fill="#172554" stroke="#2563eb"/>
-  <text x="325" y="92" text-anchor="middle" class="pill">2 agents</text>
-  <rect x="376" y="76" width="92" height="24" rx="12" fill="#312e81" stroke="#7c3aed"/>
-  <text x="422" y="92" text-anchor="middle" class="pill">4 MCP servers</text>
-  <rect x="480" y="76" width="92" height="24" rx="12" fill="#083344" stroke="#06b6d4"/>
-  <text x="526" y="92" text-anchor="middle" class="pill">12 packages</text>
-  <rect x="584" y="76" width="92" height="24" rx="12" fill="#450a0a" stroke="#ef4444"/>
-  <text x="630" y="92" text-anchor="middle" class="pill">2 critical</text>
+  <rect x="302" y="82" width="86" height="26" rx="13" fill="#172554" stroke="#2563eb"/>
+  <text x="345" y="99" text-anchor="middle" class="pill">2 agents</text>
+  <rect x="402" y="82" width="104" height="26" rx="13" fill="#312e81" stroke="#7c3aed"/>
+  <text x="454" y="99" text-anchor="middle" class="pill">4 MCP servers</text>
+  <rect x="520" y="82" width="100" height="26" rx="13" fill="#083344" stroke="#06b6d4"/>
+  <text x="570" y="99" text-anchor="middle" class="pill">12 packages</text>
+  <rect x="634" y="82" width="92" height="26" rx="13" fill="#450a0a" stroke="#ef4444"/>
+  <text x="680" y="99" text-anchor="middle" class="pill">2 critical</text>
 
-  <text x="56" y="136" class="section" fill="#60a5fa">STARTING SCOPE</text>
-  <text x="356" y="136" class="section" fill="#a78bfa">IN-SCOPE SERVERS</text>
-  <text x="680" y="136" class="section" fill="#34d399">REACHABLE SURFACES</text>
+  <text x="72" y="142" class="section" fill="#60a5fa">STARTING SCOPE</text>
+  <text x="384" y="142" class="section" fill="#a78bfa">IN-SCOPE SERVERS</text>
+  <text x="694" y="142" class="section" fill="#34d399">REACHABLE SURFACES</text>
 
-  <path d="M268 216C306 216 316 208 350 208" stroke="#334155" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M268 216C306 216 316 284 350 284" stroke="#334155" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M620 208C648 208 648 208 676 208" stroke="#334155" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M620 284C648 284 648 284 676 284" stroke="#334155" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M268 198H358" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M268 286H358" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M594 198H684" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M594 286H684" stroke="#334155" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
 
-  <rect x="48" y="150" width="220" height="88" rx="16" fill="#111827" stroke="#1d4ed8"/>
-  <rect x="48" y="150" width="6" height="88" rx="3" fill="#2563eb"/>
-  <text x="68" y="176" class="card-title">cursor</text>
-  <text x="68" y="194" class="copy">
-    <tspan x="68" dy="0">Default focused agent.</tspan>
-    <tspan x="68" dy="13">Two servers in scope and the highest-risk path.</tspan>
-  </text>
-  <rect x="68" y="210" width="84" height="18" rx="9" fill="#1d4ed8"/><text x="110" y="222" text-anchor="middle" class="pill">2 servers</text>
-  <rect x="158" y="210" width="86" height="18" rx="9" fill="#7f1d1d"/><text x="201" y="222" text-anchor="middle" class="pill">critical path</text>
+  <rect x="56" y="156" width="212" height="84" rx="16" fill="#111827" stroke="#1d4ed8"/>
+  <rect x="56" y="156" width="6" height="84" rx="3" fill="#2563eb"/>
+  <text x="78" y="184" class="card-title">cursor</text>
+  <text x="78" y="204" class="copy">Default focused agent with the highest-risk path.</text>
+  <rect x="78" y="214" width="84" height="20" rx="10" fill="#1d4ed8"/>
+  <text x="120" y="227" text-anchor="middle" class="pill">2 servers</text>
+  <rect x="170" y="214" width="84" height="20" rx="10" fill="#7f1d1d"/>
+  <text x="212" y="227" text-anchor="middle" class="pill">critical path</text>
 
-  <rect x="48" y="254" width="220" height="64" rx="16" fill="#111827" stroke="#374151"/>
-  <text x="68" y="278" class="card-title">Other agents stay available</text>
-  <text x="68" y="296" class="copy">
-    <tspan x="68" dy="0">Expand later by agent, depth, or severity.</tspan>
-    <tspan x="68" dy="13">The default stays scoped and readable.</tspan>
-  </text>
+  <rect x="56" y="256" width="212" height="64" rx="16" fill="#111827" stroke="#374151"/>
+  <text x="78" y="282" class="card-title">Other agents</text>
+  <text x="78" y="302" class="copy">Available on demand, not loaded into the first view.</text>
 
-  <rect x="350" y="150" width="270" height="76" rx="16" fill="#111827" stroke="#ef4444"/>
-  <rect x="350" y="150" width="6" height="76" rx="3" fill="#ef4444"/>
-  <text x="372" y="176" class="card-title">database-server</text>
-  <text x="372" y="194" class="copy">
-    <tspan x="372" dy="0">Critical server in scope.</tspan>
-    <tspan x="372" dy="13">5 packages and 2 creds feed reachable tools.</tspan>
-  </text>
-  <rect x="372" y="206" width="86" height="18" rx="9" fill="#7f1d1d"/><text x="415" y="218" text-anchor="middle" class="pill">5 packages</text>
-  <rect x="464" y="206" width="76" height="18" rx="9" fill="#78350f"/><text x="502" y="218" text-anchor="middle" class="pill">2 creds</text>
-  <rect x="546" y="206" width="56" height="18" rx="9" fill="#7f1d1d"/><text x="574" y="218" text-anchor="middle" class="pill">critical</text>
+  <rect x="358" y="156" width="236" height="84" rx="16" fill="#111827" stroke="#ef4444"/>
+  <rect x="358" y="156" width="6" height="84" rx="3" fill="#ef4444"/>
+  <text x="382" y="184" class="card-title">database-server</text>
+  <text x="382" y="204" class="copy">Critical path server with reachable packages and creds.</text>
+  <rect x="382" y="214" width="88" height="20" rx="10" fill="#7f1d1d"/>
+  <text x="426" y="227" text-anchor="middle" class="pill">5 packages</text>
+  <rect x="478" y="214" width="76" height="20" rx="10" fill="#78350f"/>
+  <text x="516" y="227" text-anchor="middle" class="pill">2 creds</text>
 
-  <rect x="350" y="246" width="270" height="76" rx="16" fill="#111827" stroke="#4f46e5"/>
-  <rect x="350" y="246" width="6" height="76" rx="3" fill="#6366f1"/>
-  <text x="372" y="272" class="card-title">filesystem-server</text>
-  <text x="372" y="290" class="copy">
-    <tspan x="372" dy="0">Local file operations stay visible.</tspan>
-    <tspan x="372" dy="13">They are reachable in the same focused scope.</tspan>
-  </text>
-  <rect x="372" y="302" width="86" height="18" rx="9" fill="#312e81"/><text x="415" y="314" text-anchor="middle" class="pill">3 packages</text>
-  <rect x="464" y="302" width="70" height="18" rx="9" fill="#14532d"/><text x="499" y="314" text-anchor="middle" class="pill">3 tools</text>
+  <rect x="358" y="244" width="236" height="84" rx="16" fill="#111827" stroke="#6366f1"/>
+  <rect x="358" y="244" width="6" height="84" rx="3" fill="#6366f1"/>
+  <text x="382" y="272" class="card-title">filesystem-server</text>
+  <text x="382" y="292" class="copy">Local file tools stay visible inside the same scope.</text>
+  <rect x="382" y="302" width="88" height="20" rx="10" fill="#312e81"/>
+  <text x="426" y="315" text-anchor="middle" class="pill">3 packages</text>
+  <rect x="478" y="302" width="74" height="20" rx="10" fill="#14532d"/>
+  <text x="515" y="315" text-anchor="middle" class="pill">3 tools</text>
 
-  <rect x="676" y="150" width="236" height="76" rx="16" fill="#111827" stroke="#ef4444"/>
-  <text x="698" y="176" class="card-title">Database blast radius</text>
-  <text x="698" y="194" class="copy">
-    <tspan x="698" dy="0">Creds: DATABASE_URL, ANTHROPIC_API_KEY</tspan>
-    <tspan x="698" dy="13">Tools: run_query, execute_sql, export_csv</tspan>
-  </text>
-  <rect x="698" y="206" width="64" height="18" rx="9" fill="#7f1d1d"/><text x="730" y="218" text-anchor="middle" class="pill">2 creds</text>
-  <rect x="768" y="206" width="62" height="18" rx="9" fill="#7f1d1d"/><text x="799" y="218" text-anchor="middle" class="pill">3 tools</text>
+  <rect x="684" y="156" width="220" height="84" rx="16" fill="#111827" stroke="#ef4444"/>
+  <text x="708" y="184" class="card-title">Database blast radius</text>
+  <text x="708" y="204" class="copy">DATABASE_URL, ANTHROPIC_API_KEY, run_query, execute_sql</text>
+  <rect x="708" y="214" width="64" height="20" rx="10" fill="#7f1d1d"/>
+  <text x="740" y="227" text-anchor="middle" class="pill">2 creds</text>
+  <rect x="780" y="214" width="62" height="20" rx="10" fill="#7f1d1d"/>
+  <text x="811" y="227" text-anchor="middle" class="pill">3 tools</text>
 
-  <rect x="676" y="246" width="236" height="76" rx="16" fill="#111827" stroke="#16a34a"/>
-  <text x="698" y="272" class="card-title">Local file surface</text>
-  <text x="698" y="290" class="copy">
-    <tspan x="698" dy="0">Tools: read_file, write_file, list_directory</tspan>
-    <tspan x="698" dy="13">Same focused scope, no extra sprawl.</tspan>
-  </text>
-  <rect x="698" y="302" width="62" height="18" rx="9" fill="#14532d"/><text x="729" y="314" text-anchor="middle" class="pill">3 tools</text>
+  <rect x="684" y="244" width="220" height="84" rx="16" fill="#111827" stroke="#16a34a"/>
+  <text x="708" y="272" class="card-title">Local file surface</text>
+  <text x="708" y="292" class="copy">read_file, write_file, list_directory</text>
+  <rect x="708" y="302" width="62" height="20" rx="10" fill="#14532d"/>
+  <text x="739" y="315" text-anchor="middle" class="pill">3 tools</text>
 
-  <rect x="48" y="356" width="864" height="112" rx="16" fill="#111827" stroke="#374151"/>
-  <text x="72" y="384" class="footer-title">Why this is here</text>
-  <text x="72" y="406" class="footer-copy">
-    <tspan x="72" dy="0">The README should show the same operator pattern as the product: start with one scoped graph,</tspan>
-    <tspan x="72" dy="15">see the risky path clearly, then expand only when more context is needed.</tspan>
-  </text>
-  <rect x="72" y="428" width="202" height="20" rx="10" fill="#172554" stroke="#2563eb"/>
-  <text x="173" y="441" text-anchor="middle" class="pill">Default: one agent in focus</text>
-  <rect x="286" y="428" width="194" height="20" rx="10" fill="#083344" stroke="#06b6d4"/>
-  <text x="383" y="441" text-anchor="middle" class="pill">Expand by depth or agent</text>
-  <rect x="492" y="428" width="202" height="20" rx="10" fill="#052e16" stroke="#22c55e"/>
-  <text x="593" y="441" text-anchor="middle" class="pill">Readable before exhaustive</text>
+  <rect x="56" y="352" width="848" height="56" rx="16" fill="#111827" stroke="#374151"/>
+  <text x="80" y="374" class="card-title">Why this is here</text>
+  <text x="80" y="394" class="copy">Show the first risky path clearly. Let users expand only when they need more context.</text>
 </svg>

--- a/docs/images/topology-light.svg
+++ b/docs/images/topology-light.svg
@@ -1,18 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 440" fill="none">
   <style>
     text { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
-    .title { font-size: 20px; font-weight: 800; fill: #111827; }
-    .subtitle { font-size: 11px; font-weight: 500; fill: #64748b; }
-    .section { font-size: 10px; font-weight: 800; letter-spacing: 0.14em; }
-    .card-title { font-size: 13px; font-weight: 760; fill: #111827; }
-    .copy { font-size: 10px; font-weight: 500; fill: #475569; }
-    .pill { font-size: 8.5px; font-weight: 700; fill: #334155; }
-    .footer-title { font-size: 10px; font-weight: 800; fill: #111827; }
-    .footer-copy { font-size: 10px; font-weight: 600; fill: #475569; }
+    .title { font-size: 24px; font-weight: 800; fill: #111827; }
+    .subtitle { font-size: 12px; font-weight: 600; fill: #64748b; }
+    .section { font-size: 11px; font-weight: 800; letter-spacing: 0.14em; }
+    .card-title { font-size: 15px; font-weight: 760; fill: #111827; }
+    .copy { font-size: 10px; font-weight: 600; fill: #475569; }
+    .pill { font-size: 9px; font-weight: 700; fill: #334155; }
   </style>
-
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="520" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bg" x1="0" y1="0" x2="960" y2="440" gradientUnits="userSpaceOnUse">
       <stop stop-color="#ffffff"/>
       <stop offset="1" stop-color="#f8fafc"/>
     </linearGradient>
@@ -21,94 +18,75 @@
     </marker>
   </defs>
 
-  <rect width="960" height="520" rx="18" fill="url(#bg)" stroke="#e5e7eb"/>
+  <rect width="960" height="440" rx="18" fill="url(#bg)" stroke="#e5e7eb"/>
 
-  <text x="480" y="38" text-anchor="middle" class="title">Focused graph view</text>
-  <text x="480" y="58" text-anchor="middle" class="subtitle">Built-in demo, scoped to one agent and the highest-risk reachable surfaces.</text>
+  <text x="480" y="42" text-anchor="middle" class="title">Focused graph view</text>
+  <text x="480" y="64" text-anchor="middle" class="subtitle">One scoped path first. Expand later by agent, depth, or findings.</text>
 
-  <rect x="286" y="76" width="78" height="24" rx="12" fill="#eff6ff" stroke="#bfdbfe"/>
-  <text x="325" y="92" text-anchor="middle" class="pill">2 agents</text>
-  <rect x="376" y="76" width="92" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe"/>
-  <text x="422" y="92" text-anchor="middle" class="pill">4 MCP servers</text>
-  <rect x="480" y="76" width="92" height="24" rx="12" fill="#ecfeff" stroke="#a5f3fc"/>
-  <text x="526" y="92" text-anchor="middle" class="pill">12 packages</text>
-  <rect x="584" y="76" width="92" height="24" rx="12" fill="#fef2f2" stroke="#fca5a5"/>
-  <text x="630" y="92" text-anchor="middle" class="pill">2 critical</text>
+  <rect x="302" y="82" width="86" height="26" rx="13" fill="#eff6ff" stroke="#bfdbfe"/>
+  <text x="345" y="99" text-anchor="middle" class="pill">2 agents</text>
+  <rect x="402" y="82" width="104" height="26" rx="13" fill="#eef2ff" stroke="#c7d2fe"/>
+  <text x="454" y="99" text-anchor="middle" class="pill">4 MCP servers</text>
+  <rect x="520" y="82" width="100" height="26" rx="13" fill="#ecfeff" stroke="#a5f3fc"/>
+  <text x="570" y="99" text-anchor="middle" class="pill">12 packages</text>
+  <rect x="634" y="82" width="92" height="26" rx="13" fill="#fef2f2" stroke="#fca5a5"/>
+  <text x="680" y="99" text-anchor="middle" class="pill">2 critical</text>
 
-  <text x="56" y="136" class="section" fill="#2563eb">STARTING SCOPE</text>
-  <text x="356" y="136" class="section" fill="#7c3aed">IN-SCOPE SERVERS</text>
-  <text x="680" y="136" class="section" fill="#059669">REACHABLE SURFACES</text>
+  <text x="72" y="142" class="section" fill="#2563eb">STARTING SCOPE</text>
+  <text x="384" y="142" class="section" fill="#7c3aed">IN-SCOPE SERVERS</text>
+  <text x="694" y="142" class="section" fill="#059669">REACHABLE SURFACES</text>
 
-  <path d="M268 216C304 216 316 208 350 208" stroke="#cbd5e1" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M268 216C304 216 316 284 350 284" stroke="#cbd5e1" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M620 208C648 208 648 208 676 208" stroke="#cbd5e1" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <path d="M620 284C648 284 648 284 676 284" stroke="#cbd5e1" stroke-width="2.5" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M268 198H358" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M268 286H358" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M594 198H684" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M594 286H684" stroke="#cbd5e1" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
 
-  <rect x="48" y="150" width="220" height="88" rx="16" fill="#ffffff" stroke="#dbeafe"/>
-  <rect x="48" y="150" width="6" height="88" rx="3" fill="#2563eb"/>
-  <text x="68" y="176" class="card-title">cursor</text>
-  <text x="68" y="194" class="copy">
-    <tspan x="68" dy="0">Default focused agent.</tspan>
-    <tspan x="68" dy="13">Two servers in scope and the highest-risk path.</tspan>
-  </text>
-  <rect x="68" y="210" width="84" height="18" rx="9" fill="#dbeafe"/><text x="110" y="222" text-anchor="middle" class="pill">2 servers</text>
-  <rect x="158" y="210" width="86" height="18" rx="9" fill="#fee2e2"/><text x="201" y="222" text-anchor="middle" class="pill">critical path</text>
+  <rect x="56" y="156" width="212" height="84" rx="16" fill="#ffffff" stroke="#dbeafe"/>
+  <rect x="56" y="156" width="6" height="84" rx="3" fill="#2563eb"/>
+  <text x="78" y="184" class="card-title">cursor</text>
+  <text x="78" y="204" class="copy">Default focused agent with the highest-risk path.</text>
+  <rect x="78" y="214" width="84" height="20" rx="10" fill="#dbeafe"/>
+  <text x="120" y="227" text-anchor="middle" class="pill">2 servers</text>
+  <rect x="170" y="214" width="84" height="20" rx="10" fill="#fee2e2"/>
+  <text x="212" y="227" text-anchor="middle" class="pill">critical path</text>
 
-  <rect x="48" y="254" width="220" height="64" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="68" y="278" class="card-title">Other agents stay available</text>
-  <text x="68" y="296" class="copy">
-    <tspan x="68" dy="0">Expand later by agent, depth, or severity.</tspan>
-    <tspan x="68" dy="13">The default stays scoped and readable.</tspan>
-  </text>
+  <rect x="56" y="256" width="212" height="64" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="78" y="282" class="card-title">Other agents</text>
+  <text x="78" y="302" class="copy">Available on demand, not loaded into the first view.</text>
 
-  <rect x="350" y="150" width="270" height="76" rx="16" fill="#ffffff" stroke="#fca5a5"/>
-  <rect x="350" y="150" width="6" height="76" rx="3" fill="#ef4444"/>
-  <text x="372" y="176" class="card-title">database-server</text>
-  <text x="372" y="194" class="copy">
-    <tspan x="372" dy="0">Critical server in scope.</tspan>
-    <tspan x="372" dy="13">5 packages and 2 creds feed reachable tools.</tspan>
-  </text>
-  <rect x="372" y="206" width="86" height="18" rx="9" fill="#fee2e2"/><text x="415" y="218" text-anchor="middle" class="pill">5 packages</text>
-  <rect x="464" y="206" width="76" height="18" rx="9" fill="#fef3c7"/><text x="502" y="218" text-anchor="middle" class="pill">2 creds</text>
-  <rect x="546" y="206" width="56" height="18" rx="9" fill="#fee2e2"/><text x="574" y="218" text-anchor="middle" class="pill">critical</text>
+  <rect x="358" y="156" width="236" height="84" rx="16" fill="#ffffff" stroke="#fca5a5"/>
+  <rect x="358" y="156" width="6" height="84" rx="3" fill="#ef4444"/>
+  <text x="382" y="184" class="card-title">database-server</text>
+  <text x="382" y="204" class="copy">Critical path server with reachable packages and creds.</text>
+  <rect x="382" y="214" width="88" height="20" rx="10" fill="#fee2e2"/>
+  <text x="426" y="227" text-anchor="middle" class="pill">5 packages</text>
+  <rect x="478" y="214" width="76" height="20" rx="10" fill="#fef3c7"/>
+  <text x="516" y="227" text-anchor="middle" class="pill">2 creds</text>
 
-  <rect x="350" y="246" width="270" height="76" rx="16" fill="#ffffff" stroke="#cbd5e1"/>
-  <rect x="350" y="246" width="6" height="76" rx="3" fill="#6366f1"/>
-  <text x="372" y="272" class="card-title">filesystem-server</text>
-  <text x="372" y="290" class="copy">
-    <tspan x="372" dy="0">Local file operations stay visible.</tspan>
-    <tspan x="372" dy="13">They are reachable in the same focused scope.</tspan>
-  </text>
-  <rect x="372" y="302" width="86" height="18" rx="9" fill="#e0e7ff"/><text x="415" y="314" text-anchor="middle" class="pill">3 packages</text>
-  <rect x="464" y="302" width="70" height="18" rx="9" fill="#dcfce7"/><text x="499" y="314" text-anchor="middle" class="pill">3 tools</text>
+  <rect x="358" y="244" width="236" height="84" rx="16" fill="#ffffff" stroke="#c7d2fe"/>
+  <rect x="358" y="244" width="6" height="84" rx="3" fill="#6366f1"/>
+  <text x="382" y="272" class="card-title">filesystem-server</text>
+  <text x="382" y="292" class="copy">Local file tools stay visible inside the same scope.</text>
+  <rect x="382" y="302" width="88" height="20" rx="10" fill="#e0e7ff"/>
+  <text x="426" y="315" text-anchor="middle" class="pill">3 packages</text>
+  <rect x="478" y="302" width="74" height="20" rx="10" fill="#dcfce7"/>
+  <text x="515" y="315" text-anchor="middle" class="pill">3 tools</text>
 
-  <rect x="676" y="150" width="236" height="76" rx="16" fill="#ffffff" stroke="#fecaca"/>
-  <text x="698" y="176" class="card-title">Database blast radius</text>
-  <text x="698" y="194" class="copy">
-    <tspan x="698" dy="0">Creds: DATABASE_URL, ANTHROPIC_API_KEY</tspan>
-    <tspan x="698" dy="13">Tools: run_query, execute_sql, export_csv</tspan>
-  </text>
-  <rect x="698" y="206" width="64" height="18" rx="9" fill="#fee2e2"/><text x="730" y="218" text-anchor="middle" class="pill">2 creds</text>
-  <rect x="768" y="206" width="62" height="18" rx="9" fill="#fee2e2"/><text x="799" y="218" text-anchor="middle" class="pill">3 tools</text>
+  <rect x="684" y="156" width="220" height="84" rx="16" fill="#ffffff" stroke="#fecaca"/>
+  <text x="708" y="184" class="card-title">Database blast radius</text>
+  <text x="708" y="204" class="copy">DATABASE_URL, ANTHROPIC_API_KEY, run_query, execute_sql</text>
+  <rect x="708" y="214" width="64" height="20" rx="10" fill="#fee2e2"/>
+  <text x="740" y="227" text-anchor="middle" class="pill">2 creds</text>
+  <rect x="780" y="214" width="62" height="20" rx="10" fill="#fee2e2"/>
+  <text x="811" y="227" text-anchor="middle" class="pill">3 tools</text>
 
-  <rect x="676" y="246" width="236" height="76" rx="16" fill="#ffffff" stroke="#bbf7d0"/>
-  <text x="698" y="272" class="card-title">Local file surface</text>
-  <text x="698" y="290" class="copy">
-    <tspan x="698" dy="0">Tools: read_file, write_file, list_directory</tspan>
-    <tspan x="698" dy="13">Same focused scope, no extra sprawl.</tspan>
-  </text>
-  <rect x="698" y="302" width="62" height="18" rx="9" fill="#dcfce7"/><text x="729" y="314" text-anchor="middle" class="pill">3 tools</text>
+  <rect x="684" y="244" width="220" height="84" rx="16" fill="#ffffff" stroke="#bbf7d0"/>
+  <text x="708" y="272" class="card-title">Local file surface</text>
+  <text x="708" y="292" class="copy">read_file, write_file, list_directory</text>
+  <rect x="708" y="302" width="62" height="20" rx="10" fill="#dcfce7"/>
+  <text x="739" y="315" text-anchor="middle" class="pill">3 tools</text>
 
-  <rect x="48" y="356" width="864" height="112" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
-  <text x="72" y="384" class="footer-title">Why this is here</text>
-  <text x="72" y="406" class="footer-copy">
-    <tspan x="72" dy="0">The README should show the same operator pattern as the product: start with one scoped graph,</tspan>
-    <tspan x="72" dy="15">see the risky path clearly, then expand only when more context is needed.</tspan>
-  </text>
-  <rect x="72" y="428" width="202" height="20" rx="10" fill="#eff6ff" stroke="#bfdbfe"/>
-  <text x="173" y="441" text-anchor="middle" class="pill">Default: one agent in focus</text>
-  <rect x="286" y="428" width="194" height="20" rx="10" fill="#ecfeff" stroke="#a5f3fc"/>
-  <text x="383" y="441" text-anchor="middle" class="pill">Expand by depth or agent</text>
-  <rect x="492" y="428" width="202" height="20" rx="10" fill="#f0fdf4" stroke="#86efac"/>
-  <text x="593" y="441" text-anchor="middle" class="pill">Readable before exhaustive</text>
+  <rect x="56" y="352" width="848" height="56" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
+  <text x="80" y="374" class="card-title">Why this is here</text>
+  <text x="80" y="394" class="copy">Show the first risky path clearly. Let users expand only when they need more context.</text>
 </svg>


### PR DESCRIPTION
## Summary
- tighten README and PyPI README flow for release readability
- simplify graph and architecture SVGs so text no longer collides with layout
- move the terminal demo behind a collapsible section and keep trust/transparency collapsible

## Validation
- git diff --check
- xmllint --noout docs/images/topology-light.svg docs/images/topology-dark.svg docs/images/architecture-stack-light.svg docs/images/architecture-stack-dark.svg