### PR TITLE
Harden Snowflake notebook and days SQL inputs

### DIFF
--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -103,6 +103,7 @@ def _resolve_snowflake_auth(
 
 # Snowflake identifier safety: only allow alphanumeric, underscore, dot, dollar
 _SAFE_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.$]*$")
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1F\x7F]")
 
 
 def _validate_sf_identifier(name: str) -> str:
@@ -110,6 +111,33 @@ def _validate_sf_identifier(name: str) -> str:
     if not _SAFE_IDENT_RE.match(name):
         raise ValueError(f"Unsafe Snowflake identifier: {name!r}")
     return name
+
+
+def _quote_sf_identifier(name: str) -> str:
+    """Safely quote a Snowflake identifier for SQL interpolation.
+
+    Unlike ``_validate_sf_identifier`` this supports legitimate quoted
+    identifiers such as notebook names containing spaces while still
+    preventing statement-breaking injection.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError("Snowflake identifier must be a non-empty string")
+    if _CONTROL_CHAR_RE.search(name):
+        raise ValueError(f"Unsafe Snowflake identifier: {name!r}")
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _coerce_snowflake_days(days: Any, *, max_days: int | None = None) -> int:
+    """Validate and normalize day-window inputs used in SQL interpolation."""
+    try:
+        value = int(days)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"days must be an integer, got {days!r}") from exc
+    if value < 1:
+        raise ValueError(f"days must be >= 1, got {value!r}")
+    if max_days is not None:
+        value = min(value, max_days)
+    return value
 
 
 def discover(
@@ -434,7 +462,7 @@ def _discover_snowflake_notebooks(
             # Try to extract notebook package dependencies from metadata
             # Snowflake stores notebook runtime packages in INFORMATION_SCHEMA
             try:
-                fqn = f'"{nb_db}"."{nb_schema}"."{nb_name}"'
+                fqn = ".".join(_quote_sf_identifier(part) for part in (nb_db, nb_schema, nb_name))
                 cursor.execute(
                     f"DESCRIBE NOTEBOOK {fqn}"  # noqa: S608
                 )
@@ -483,6 +511,8 @@ def _discover_snowflake_notebooks(
                                     )
                                 )
 
+            except ValueError as exc:
+                warnings.append(f"Skipping Snowflake notebook with unsafe identifier: {sanitize_error(exc)}")
             except Exception:
                 # DESCRIBE NOTEBOOK may not be available on all editions
                 pass
@@ -884,6 +914,7 @@ def discover_governance(
     resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
     resolved_user = user or os.environ.get("SNOWFLAKE_USER", "")
     report = GovernanceReport(account=resolved_account)
+    days = _coerce_snowflake_days(days)
 
     if not resolved_account:
         report.warnings.append("SNOWFLAKE_ACCOUNT not set.")
@@ -957,6 +988,7 @@ def _mine_access_history(
     records: list[AccessRecord] = []
     warnings: list[str] = []
     cursor = conn.cursor()
+    days = _coerce_snowflake_days(days)
 
     try:
         cursor.execute(
@@ -1134,6 +1166,7 @@ def _mine_cortex_agent_usage(
     records: list[AgentUsageRecord] = []
     warnings: list[str] = []
     cursor = conn.cursor()
+    days = _coerce_snowflake_days(days)
 
     try:
         cursor.execute(
@@ -1557,6 +1590,7 @@ def discover_activity(
     resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
     resolved_user = user or os.environ.get("SNOWFLAKE_USER", "")
     timeline = ActivityTimeline(account=resolved_account)
+    days = _coerce_snowflake_days(days, max_days=365)
 
     if not resolved_account:
         timeline.warnings.append("SNOWFLAKE_ACCOUNT not set.")
@@ -1619,6 +1653,7 @@ def _mine_query_history_365(
     records: list[QueryHistoryRecord] = []
     warnings: list[str] = []
     cursor = conn.cursor()
+    days = _coerce_snowflake_days(days, max_days=365)
 
     try:
         cursor.execute(
@@ -1694,6 +1729,7 @@ def _mine_observability_events(
     events: list[ObservabilityEvent] = []
     warnings: list[str] = []
     cursor = conn.cursor()
+    days = _coerce_snowflake_days(days, max_days=365)
 
     try:
         cursor.execute(

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -412,6 +412,50 @@ def test_snowflake_snowpark_packages():
     assert all(p.ecosystem == "pypi" for p in packages)
 
 
+def test_snowflake_notebooks_escape_identifier_in_describe():
+    """Notebook DESCRIBE should quote identifiers safely instead of interpolating raw names."""
+    _install_mock_snowflake()
+    importlib.reload(importlib.import_module("agent_bom.cloud.snowflake"))
+    from agent_bom.cloud.snowflake import _discover_snowflake_notebooks
+
+    class _Cursor:
+        def __init__(self):
+            self.description = []
+            self._rows = []
+            self.executed: list[str] = []
+
+        def execute(self, sql):
+            self.executed.append(sql)
+            if sql == "SHOW NOTEBOOKS IN ACCOUNT":
+                self.description = [
+                    ("name",),
+                    ("database_name",),
+                    ("schema_name",),
+                    ("owner",),
+                    ("comment",),
+                ]
+                self._rows = [('bad"name', "DB", "SCHEMA", "owner", "comment")]
+            elif sql.startswith("DESCRIBE NOTEBOOK "):
+                self.description = [("property",), ("value",)]
+                self._rows = []
+
+        def fetchall(self):
+            return self._rows
+
+        def close(self):
+            return None
+
+    mock_conn = MagicMock()
+    cursor = _Cursor()
+    mock_conn.cursor.return_value = cursor
+
+    agents, warnings = _discover_snowflake_notebooks(mock_conn, "myorg.us-east-1")
+
+    assert len(agents) == 1
+    assert warnings == []
+    assert cursor.executed[1] == 'DESCRIBE NOTEBOOK "DB"."SCHEMA"."bad""name"'
+
+
 # ─── Graph Output Tests ──────────────────────────────────────────────────────
 
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -82,6 +82,55 @@ class TestSnowflakeIdentifierValidation:
             _validate_sf_identifier("123start")
 
 
+class TestSnowflakeQuotedIdentifier:
+    """Quoted identifiers should be escaped safely for SQL interpolation."""
+
+    def test_quotes_plain_identifier(self):
+        from agent_bom.cloud.snowflake import _quote_sf_identifier
+
+        assert _quote_sf_identifier("NOTEBOOK_ONE") == '"NOTEBOOK_ONE"'
+
+    def test_escapes_embedded_quotes(self):
+        from agent_bom.cloud.snowflake import _quote_sf_identifier
+
+        assert _quote_sf_identifier('weird"name') == '"weird""name"'
+
+    def test_rejects_control_characters(self):
+        from agent_bom.cloud.snowflake import _quote_sf_identifier
+
+        with pytest.raises(ValueError):
+            _quote_sf_identifier("bad\nname")
+
+
+class TestSnowflakeDaysValidation:
+    """Snowflake day windows should be normalized before SQL interpolation."""
+
+    def test_accepts_positive_int_like_values(self):
+        from agent_bom.cloud.snowflake import _coerce_snowflake_days
+
+        assert _coerce_snowflake_days("7") == 7
+        assert _coerce_snowflake_days(30, max_days=365) == 30
+
+    def test_rejects_non_integer_values(self):
+        from agent_bom.cloud.snowflake import _coerce_snowflake_days
+
+        with pytest.raises(ValueError, match="days must be an integer"):
+            _coerce_snowflake_days("7; DROP TABLE")
+
+    def test_rejects_zero_or_negative_values(self):
+        from agent_bom.cloud.snowflake import _coerce_snowflake_days
+
+        with pytest.raises(ValueError, match="days must be >= 1"):
+            _coerce_snowflake_days(0)
+        with pytest.raises(ValueError, match="days must be >= 1"):
+            _coerce_snowflake_days(-5)
+
+    def test_caps_values_when_max_days_is_provided(self):
+        from agent_bom.cloud.snowflake import _coerce_snowflake_days
+
+        assert _coerce_snowflake_days(999, max_days=365) == 365
+
+
 # ─── Error Sanitization ──────────────────────────────────────────────────────
 
 

--- a/tests/test_snowflake_governance.py
+++ b/tests/test_snowflake_governance.py
@@ -217,6 +217,13 @@ class TestAccessHistory:
         assert len(records) == 0
         assert any("Enterprise edition" in w for w in warnings)
 
+    def test_mine_access_history_rejects_non_integer_days(self):
+        from agent_bom.cloud.snowflake import _mine_access_history
+
+        conn = _make_mock_conn()
+        with pytest.raises(ValueError, match="days must be an integer"):
+            _mine_access_history(conn, "7; DROP TABLE")
+
 
 class TestGrantsToRoles:
     def test_mine_grants(self):
@@ -339,6 +346,13 @@ class TestCortexAgentUsage:
         records, warnings = _mine_cortex_agent_usage(conn, 30)
         assert len(records) == 0
         assert any("CORTEX_AGENT_USAGE_HISTORY" in w for w in warnings)
+
+    def test_mine_cortex_agent_usage_rejects_invalid_days(self):
+        from agent_bom.cloud.snowflake import _mine_cortex_agent_usage
+
+        conn = _make_mock_conn()
+        with pytest.raises(ValueError, match="days must be >= 1"):
+            _mine_cortex_agent_usage(conn, 0)
 
 
 # ─── Finding derivation tests ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- safely quote Snowflake notebook identifiers before DESCRIBE NOTEBOOK
- validate and normalize interpolated day-window inputs before SQL construction
- add regression coverage for notebook identifier quoting and invalid day-window rejection

## Validation
- uv run pytest -q tests/test_security_hardening.py tests/test_cloud.py tests/test_snowflake_governance.py
- uv run ruff check src/agent_bom/cloud/snowflake.py tests/test_security_hardening.py tests/test_cloud.py tests/test_snowflake_governance.py