### PR TITLE
Make jobs summary-first by default

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -490,7 +490,12 @@ async def stream_scan(request: Request, job_id: str):
 
 
 @router.get("/v1/jobs", tags=["scan"])
-async def list_jobs(request: Request, limit: int = 50, offset: int = 0) -> dict:
+async def list_jobs(
+    request: Request,
+    limit: int = 50,
+    offset: int = 0,
+    include_details: bool = False,
+) -> dict:
     """List all scan jobs (for the UI job history panel).
 
     Supports pagination via ``limit`` (default 50, max 200) and ``offset``.
@@ -504,15 +509,24 @@ async def list_jobs(request: Request, limit: int = 50, offset: int = 0) -> dict:
     page = summary[offset : offset + limit]
     enriched: list[dict[str, Any]] = []
     for item in page:
-        # Keep list surfaces compatible with lightweight stores and tests that
-        # only implement paged summaries. Hydrate when available, otherwise
-        # return the summary row unchanged.
-        try:
-            get_job = getattr(store, "get", None)
-            full_job = get_job(item["job_id"]) if callable(get_job) else None
-        except Exception:
-            full_job = None
-        enriched.append(_job_summary_payload(full_job) if isinstance(full_job, ScanJob) else item)
+        in_mem = _jobs_get(item["job_id"])
+        if isinstance(in_mem, ScanJob) and _visible_to_tenant(in_mem, tenant_id):
+            enriched.append(_job_summary_payload(in_mem))
+            continue
+
+        if include_details:
+            # Keep list surfaces compatible with lightweight stores and tests
+            # that only implement paged summaries. Hydrate only when the caller
+            # asks for details and the job is not already in memory.
+            try:
+                get_job = getattr(store, "get", None)
+                full_job = get_job(item["job_id"]) if callable(get_job) else None
+            except Exception:
+                full_job = None
+            enriched.append(_job_summary_payload(full_job) if isinstance(full_job, ScanJob) else item)
+            continue
+
+        enriched.append(item)
     return {
         "jobs": enriched,
         "count": len(enriched),

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -246,5 +246,54 @@ async def test_create_scan_and_push_stamp_request_tenant(monkeypatch):
 
     listed = await scan_routes.list_jobs(req)
     pushed_summary = next(job for job in listed["jobs"] if job["job_id"] == pushed["job_id"])
-    assert pushed_summary["summary"]["total_packages"] == 12
+    assert "summary" not in pushed_summary
     assert listed["jobs"][0]["request"] == {}
+
+    hydrated = await scan_routes.list_jobs(req, include_details=True)
+    pushed_hydrated = next(job for job in hydrated["jobs"] if job["job_id"] == pushed["job_id"])
+    assert pushed_hydrated["summary"]["total_packages"] == 12
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
+    class _Store:
+        def __init__(self) -> None:
+            self.get_calls = 0
+
+        def list_summary(self) -> list[dict]:
+            return [
+                {
+                    "job_id": "job-alpha",
+                    "tenant_id": "tenant-alpha",
+                    "status": JobStatus.DONE,
+                    "created_at": _now(),
+                    "completed_at": _now(),
+                }
+            ]
+
+        def get(self, job_id: str) -> ScanJob | None:
+            self.get_calls += 1
+            return ScanJob(
+                job_id=job_id,
+                tenant_id="tenant-alpha",
+                status=JobStatus.DONE,
+                created_at=_now(),
+                completed_at=_now(),
+                request=ScanRequest(images=["example:latest"]),
+                result={"summary": {"total_packages": 12, "total_vulnerabilities": 3}},
+            )
+
+    req = _request("tenant-alpha")
+    store = _Store()
+
+    with patch.object(scan_routes, "_get_store", return_value=store):
+        listed = await scan_routes.list_jobs(req)
+        assert store.get_calls == 0
+        assert listed["jobs"][0]["job_id"] == "job-alpha"
+        assert "request" not in listed["jobs"][0]
+        assert "summary" not in listed["jobs"][0]
+
+        hydrated = await scan_routes.list_jobs(req, include_details=True)
+        assert store.get_calls == 1
+        assert hydrated["jobs"][0]["request"] == {"images": ["example:latest"]}
+        assert hydrated["jobs"][0]["summary"]["total_packages"] == 12

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -805,7 +805,7 @@ export default function Dashboard() {
           <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest mb-3">
             Activity
           </h2>
-          <ActivityFeed maxItems={15} initialJobs={effectiveRecentJobs.slice(0, 20)} />
+          <ActivityFeed maxItems={15} initialJobs={effectiveRecentJobs.slice(0, 20)} refresh={false} />
         </section>
       </div>
     </div>

--- a/ui/components/activity-feed.tsx
+++ b/ui/components/activity-feed.tsx
@@ -65,10 +65,14 @@ function jobsToEvents(jobs: JobListItem[]): ActivityEvent[] {
     if (job.status === "done" && job.completed_at) {
       const findingCount = job.summary?.total_vulnerabilities ?? 0;
       const critCount = job.summary?.critical_findings ?? 0;
+      const message =
+        job.summary == null
+          ? "Scan completed"
+          : `Scan completed: ${findingCount} findings${critCount > 0 ? `, ${critCount} critical` : ""}`;
       events.push({
         id: `${job.job_id}-done`,
         type: "scan_completed",
-        message: `Scan completed: ${findingCount} findings${critCount > 0 ? `, ${critCount} critical` : ""}`,
+        message,
         timestamp: job.completed_at,
         meta: {
           job_id: job.job_id,
@@ -95,9 +99,15 @@ interface ActivityFeedProps {
   maxItems?: number;
   className?: string;
   initialJobs?: JobListItem[];
+  refresh?: boolean;
 }
 
-export function ActivityFeed({ maxItems = 20, className, initialJobs = [] }: ActivityFeedProps) {
+export function ActivityFeed({
+  maxItems = 20,
+  className,
+  initialJobs = [],
+  refresh = true,
+}: ActivityFeedProps) {
   const [jobs, setJobs] = useState<JobListItem[]>(initialJobs);
   const [filter, setFilter] = useState<ActivityType | "all">("all");
   const [loading, setLoading] = useState(initialJobs.length === 0);
@@ -110,6 +120,11 @@ export function ActivityFeed({ maxItems = 20, className, initialJobs = [] }: Act
   }, [initialJobs]);
 
   useEffect(() => {
+    if (!refresh) {
+      setLoading(false);
+      return;
+    }
+
     async function load() {
       try {
         const jobsRes = await api.listJobs();
@@ -123,7 +138,7 @@ export function ActivityFeed({ maxItems = 20, className, initialJobs = [] }: Act
     load();
     const interval = setInterval(load, 15000);
     return () => clearInterval(interval);
-  }, []);
+  }, [refresh]);
 
   const events = useMemo(() => jobsToEvents(jobs), [jobs]);
   const filtered = useMemo(

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -417,6 +417,9 @@ export interface VersionInfo {
 export interface JobsResponse {
   jobs: JobListItem[];
   count: number;
+  total?: number;
+  limit?: number;
+  offset?: number;
 }
 
 export interface JobListItem {
@@ -789,7 +792,14 @@ export const api = {
   deleteScan: (jobId: string) => del(`/v1/scan/${jobId}`),
 
   /** List all jobs */
-  listJobs: () => get<JobsResponse>("/v1/jobs"),
+  listJobs: (options?: { includeDetails?: boolean; limit?: number; offset?: number }) => {
+    const params = new URLSearchParams();
+    if (options?.includeDetails) params.set("include_details", "true");
+    if (typeof options?.limit === "number") params.set("limit", String(options.limit));
+    if (typeof options?.offset === "number") params.set("offset", String(options.offset));
+    const qs = params.toString();
+    return get<JobsResponse>(`/v1/jobs${qs ? `?${qs}` : ""}`);
+  },
 
   /** Quick agent discovery (no CVE scan) */
   listAgents: () => get<AgentsResponse>("/v1/agents"),


### PR DESCRIPTION
Summary:
- make `/v1/jobs` a true summary endpoint by default
- keep full job hydration opt-in via `include_details=true`
- stop dashboard activity from duplicating the jobs fetch the page already owns
- preserve recent scans/activity usefulness while keeping the product path modular

Validation:
- `uv run pytest -q tests/test_api_tenant_isolation.py`
- `uv run ruff check src/agent_bom/api/routes/scan.py tests/test_api_tenant_isolation.py`
- `git diff --check`

Notes:
- `uv.lock` was intentionally left out of this PR
- frontend CI will validate the TypeScript side in GitHub Actions