### PR TITLE
Fix pushed result completion metadata

### DIFF
--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -102,6 +102,7 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
+    job.completed_at = _now()
     job_result = body.model_dump()
     job_result["pushed"] = True
     job.result = job_result

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -241,6 +241,7 @@ async def test_create_scan_and_push_stamp_request_tenant(monkeypatch):
     pushed_job = store.get(pushed["job_id"])
     assert pushed_job is not None
     assert pushed_job.tenant_id == "tenant-alpha"
+    assert pushed_job.completed_at is not None
     assert pushed_job.result["summary"]["total_packages"] == 12
     assert pushed_job.result["posture_scorecard"]["overall_score"] == 82
 


### PR DESCRIPTION
## Summary
- set completed_at when storing pushed scan results
- keep pushed jobs coherent in recent/completed summary views
- add regression coverage for the push path

## Validation
- uv run pytest -q tests/test_api_tenant_isolation.py
- uv run ruff check src/agent_bom/api/routes/observability.py tests/test_api_tenant_isolation.py