### PR TITLE
Fix release 0.76.4 build and summary alignment

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -134,6 +134,7 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
         "summary": summary,
         "scan_timestamp": result.get("scan_timestamp"),
         "pushed": bool(result.get("pushed")),
+        "error": job.error,
     }
 
 

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -201,6 +201,7 @@ async def test_scan_routes_are_tenant_scoped():
     assert listed["jobs"][0]["tenant_id"] == "tenant-alpha"
     assert listed["jobs"][0]["request"] == {}
     assert listed["jobs"][0]["summary"] is None
+    assert listed["jobs"][0]["error"] is None
 
     got = await scan_routes.get_scan(req, "job-alpha")
     assert got.job_id == "job-alpha"
@@ -269,6 +270,7 @@ async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
                     "status": JobStatus.DONE,
                     "created_at": _now(),
                     "completed_at": _now(),
+                    "error": "summary error",
                 }
             ]
 
@@ -293,6 +295,7 @@ async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
         assert listed["jobs"][0]["job_id"] == "job-alpha"
         assert "request" not in listed["jobs"][0]
         assert "summary" not in listed["jobs"][0]
+        assert listed["jobs"][0]["error"] == "summary error"
 
         hydrated = await scan_routes.list_jobs(req, include_details=True)
         assert store.get_calls == 1

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   api,
@@ -361,7 +361,7 @@ function FrameworkSection({
 
 // ─── Page ───────────────────────────────────────────────────────────────────
 
-export default function CompliancePage() {
+function CompliancePageContent() {
   const searchParams = useSearchParams();
   const queryParam = searchParams.get("q") ?? "";
   const [data, setData] = useState<ComplianceResponse | null>(null);
@@ -840,5 +840,20 @@ export default function CompliancePage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function CompliancePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-20 text-zinc-400">
+          <Loader2 className="mr-2 h-6 w-6 animate-spin" />
+          Loading compliance posture...
+        </div>
+      }
+    >
+      <CompliancePageContent />
+    </Suspense>
   );
 }

--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { api, JobStatus, formatDate } from "@/lib/api";
@@ -53,7 +53,7 @@ function statusColor(s: JobStatus) {
 
 const STATUS_TABS = ["all", "pending", "running", "done", "failed", "cancelled"];
 
-export default function JobsPage() {
+function JobsPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryParam = searchParams.get("q") ?? "";
@@ -298,5 +298,20 @@ export default function JobsPage() {
         </>
       )}
     </div>
+  );
+}
+
+export default function JobsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-20 text-zinc-400">
+          <Loader2 className="mr-2 h-6 w-6 animate-spin" />
+          Loading jobs...
+        </div>
+      }
+    >
+      <JobsPageContent />
+    </Suspense>
   );
 }

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -431,6 +431,7 @@ export interface JobListItem {
   summary?: Summary;
   scan_timestamp?: string;
   pushed?: boolean;
+  error?: string;
 }
 
 export interface AgentsResponse {


### PR DESCRIPTION
## Summary
- include `error` in jobs summary payloads and tests
- make jobs/compliance pages safe for app-router search params under Suspense
- align the UI job list type with the API payload

## Validation
- `uv run pytest -q tests/test_api_tenant_isolation.py`

## Notes
- local UI build/test in the main checkout is blocked by dependency drift in `ui/node_modules`; this PR is scoped to the code-path fixes only