### PR TITLE
Harden API auth and audit integrity

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -27,6 +27,12 @@ from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
+
+def _env_enabled(name: str) -> bool:
+    value = os.environ.get(name, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 # HMAC key for audit log tamper detection.  When unset, an ephemeral
 # per-process key is generated — signatures verify within the same process
 # but provide no cross-restart integrity.  Production deployments MUST set
@@ -35,6 +41,8 @@ _HMAC_ENV_KEY = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY")
 if _HMAC_ENV_KEY is not None:
     _HMAC_KEY = _HMAC_ENV_KEY.encode()
 else:
+    if _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC"):
+        raise RuntimeError("AGENT_BOM_REQUIRE_AUDIT_HMAC is enabled but AGENT_BOM_AUDIT_HMAC_KEY is not set")
     import secrets as _secrets
 
     _HMAC_KEY = _secrets.token_bytes(32)

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -124,7 +124,9 @@ def verify_api_key(raw_key: str, stored_keys: list[ApiKey]) -> ApiKey | None:
     Uses scrypt KDF with per-key salt and constant-time comparison.
     Returns the matching ApiKey if found and not expired, else None.
     """
-    for stored in stored_keys:
+    key_prefix = raw_key[:12]
+    candidates = [stored for stored in stored_keys if stored.key_prefix == key_prefix]
+    for stored in candidates:
         salt = bytes.fromhex(stored.key_salt)
         candidate = _derive_key(raw_key, salt)
         if hmac.compare_digest(stored.key_hash, candidate):

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -286,7 +286,6 @@ class JiraTicketRequest(BaseModel):
 
     jira_url: str
     email: str
-    api_token: str
     project_key: str
     finding: dict
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Header, HTTPException, Request
 
 from agent_bom.api.models import CreateKeyRequest, ExceptionRequest, FalsePositiveRequest, JiraTicketRequest
 from agent_bom.api.stores import _get_exception_store, _get_store, _get_trend_store
@@ -312,11 +312,17 @@ async def test_siem_connection(siem_type: str = "", url: str = "", token: str = 
 
 
 @router.post("/v1/findings/jira", tags=["enterprise"], status_code=201)
-async def create_jira_ticket_route(req: JiraTicketRequest) -> dict:
+async def create_jira_ticket_route(
+    req: JiraTicketRequest,
+    jira_api_token: str | None = Header(default=None, alias="X-Jira-Api-Token"),
+) -> dict:
     """Create a Jira ticket from a finding (admin/analyst only)."""
     from agent_bom.api.audit_log import log_action
     from agent_bom.integrations.jira import create_jira_ticket
     from agent_bom.security import validate_url
+
+    if not jira_api_token:
+        raise HTTPException(status_code=400, detail="Missing X-Jira-Api-Token header")
 
     # Validate Jira URL to prevent SSRF
     try:
@@ -328,7 +334,7 @@ async def create_jira_ticket_route(req: JiraTicketRequest) -> dict:
         ticket_key = await create_jira_ticket(
             jira_url=req.jira_url,
             email=req.email,
-            api_token=req.api_token,
+            api_token=jira_api_token,
             project_key=req.project_key,
             finding=req.finding,
         )

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -119,6 +119,53 @@ async def test_delete_exception_returns_404_for_cross_tenant(isolated_exception_
 
 
 @pytest.mark.asyncio
+async def test_create_jira_ticket_requires_header_token(monkeypatch):
+    req = enterprise.JiraTicketRequest(
+        jira_url="https://example.atlassian.net",
+        email="user@example.com",
+        project_key="SEC",
+        finding={"vulnerability_id": "CVE-1", "package": "pkg"},
+    )
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.create_jira_ticket_route(req, jira_api_token=None)
+
+    assert error.value.status_code == 400
+    assert "X-Jira-Api-Token" in error.value.detail
+
+
+@pytest.mark.asyncio
+async def test_create_jira_ticket_uses_header_token(monkeypatch):
+    req = enterprise.JiraTicketRequest(
+        jira_url="https://example.atlassian.net",
+        email="user@example.com",
+        project_key="SEC",
+        finding={"vulnerability_id": "CVE-1", "package": "pkg"},
+    )
+    captured: dict[str, str] = {}
+
+    async def fake_create_jira_ticket(*, jira_url: str, email: str, api_token: str, project_key: str, finding: dict):
+        captured.update(
+            {
+                "jira_url": jira_url,
+                "email": email,
+                "api_token": api_token,
+                "project_key": project_key,
+                "vuln_id": finding["vulnerability_id"],
+            }
+        )
+        return "SEC-42"
+
+    monkeypatch.setattr("agent_bom.integrations.jira.create_jira_ticket", fake_create_jira_ticket)
+
+    result = await enterprise.create_jira_ticket_route(req, jira_api_token="token-abc")
+
+    assert result == {"ticket_key": "SEC-42", "status": "created"}
+    assert captured["api_token"] == "token-abc"
+    assert captured["project_key"] == "SEC"
+
+
+@pytest.mark.asyncio
 async def test_remove_false_positive_returns_404_for_wrong_tenant(isolated_exception_store):
     exc = VulnException(
         vuln_id="CVE-1",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -122,6 +122,23 @@ class TestVerifyApiKey:
         assert verify_api_key(raw2, [key1, key2]) is not None
         assert verify_api_key("abom_nope", [key1, key2]) is None
 
+    def test_prefix_narrows_candidates_before_scrypt(self, monkeypatch):
+        raw1, key1 = create_api_key("key1", Role.ADMIN)
+        _, key2 = create_api_key("key2", Role.VIEWER)
+        calls: list[str] = []
+
+        from agent_bom.api import auth as auth_module
+
+        original = auth_module._derive_key
+
+        def tracked(raw_key: str, salt: bytes) -> str:
+            calls.append(salt.hex())
+            return original(raw_key, salt)
+
+        monkeypatch.setattr(auth_module, "_derive_key", tracked)
+        assert verify_api_key(raw1, [key1, key2]) is not None
+        assert calls == [key1.key_salt]
+
 
 # ---------------------------------------------------------------------------
 # ApiKey.is_expired

--- a/tests/test_hardening_phase2.py
+++ b/tests/test_hardening_phase2.py
@@ -220,8 +220,29 @@ class TestAuditHMAC:
         # Reload again without env var to restore ephemeral key
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            os.environ.pop("AGENT_BOM_REQUIRE_AUDIT_HMAC", None)
             importlib.reload(audit_log)
             assert isinstance(audit_log._HMAC_KEY, bytes)
+
+    def test_require_audit_hmac_fails_closed(self):
+        """When production enforcement is enabled, missing HMAC key should fail closed."""
+        import importlib
+
+        from agent_bom.api import audit_log
+
+        with patch.dict(
+            os.environ,
+            {"AGENT_BOM_REQUIRE_AUDIT_HMAC": "1"},
+            clear=False,
+        ):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            with pytest.raises(RuntimeError, match="AGENT_BOM_REQUIRE_AUDIT_HMAC"):
+                importlib.reload(audit_log)
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            os.environ.pop("AGENT_BOM_REQUIRE_AUDIT_HMAC", None)
+            importlib.reload(audit_log)
 
 
 # ── Exception Narrowing ────────────────────────────────────────────────────

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -750,10 +750,10 @@ async function get<T>(path: string): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
+async function post<T>(path: string, body: unknown, headers: Record<string, string> = {}): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: JSON.stringify(body),
     signal: withTimeout(),
   });
@@ -1014,7 +1014,17 @@ export const api = {
     api_token: string;
     project_key: string;
     finding: Record<string, unknown>;
-  }) => post<{ ticket_key: string; status: string }>("/v1/findings/jira", body),
+  }) =>
+    post<{ ticket_key: string; status: string }>(
+      "/v1/findings/jira",
+      {
+        jira_url: body.jira_url,
+        email: body.email,
+        project_key: body.project_key,
+        finding: body.finding,
+      },
+      { "X-Jira-Api-Token": body.api_token },
+    ),
 
   // ── False Positive Management ──
   markFalsePositive: (body: {

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -240,9 +240,14 @@ describe('api.createJiraTicket', () => {
     const [url, opts] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(url).toContain('/v1/findings/jira')
     expect(opts.method).toBe('POST')
+    expect(opts.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'X-Jira-Api-Token': 'token-abc',
+    })
     const sent = JSON.parse(opts.body as string)
     expect(sent.project_key).toBe('SEC')
     expect(sent.finding.cve).toBe('CVE-2024-1234')
+    expect(sent.api_token).toBeUndefined()
     expect(result.ticket_key).toBe('SEC-42')
     expect(result.status).toBe('created')
   })


### PR DESCRIPTION
Summary:
- fail closed when production audit HMAC enforcement is enabled without a persistent key
- move Jira API token transport out of the JSON body into the X-Jira-Api-Token header
- narrow API key verification by key_prefix before running scrypt verification

Validation:
- uv run pytest -q tests/test_auth.py tests/test_hardening_phase2.py tests/test_api_enterprise_tenant.py
- uv run ruff check src/agent_bom/api/audit_log.py src/agent_bom/api/auth.py src/agent_bom/api/models.py src/agent_bom/api/routes/enterprise.py tests/test_api_enterprise_tenant.py tests/test_auth.py tests/test_hardening_phase2.py
- npm --prefix ui ci --ignore-scripts
- npm --prefix ui run test:run -- tests/api.test.ts

Closes #1365