### PR TITLE
Normalize provider lifecycle state

### DIFF
--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -22,7 +22,7 @@ from typing import Any
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin
+from .normalization import build_cloud_origin, build_cloud_state
 
 logger = logging.getLogger(__name__)
 
@@ -249,7 +249,15 @@ def _discover_bedrock(session: Any, region: str) -> tuple[list[Agent], list[str]
                             "agentArn": agent_arn,
                             "agentName": agent_name,
                         },
-                    )
+                    ),
+                    "cloud_state": build_cloud_state(
+                        provider="aws",
+                        service="bedrock",
+                        resource_type="agent",
+                        lifecycle_state=agent_status.lower().replace("_", "-"),
+                        raw_state=agent_status,
+                        state_source="agentStatus",
+                    ),
                 },
             )
             agents.append(agent)

--- a/src/agent_bom/cloud/databricks.py
+++ b/src/agent_bom/cloud/databricks.py
@@ -28,6 +28,7 @@ from typing import Any, Optional
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
+from .normalization import build_cloud_state
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,16 @@ def discover(
             config_path=f"{resolved_host}/#/setting/clusters/{cluster_id}/configuration",
             source="databricks",
             mcp_servers=[server],
+            metadata={
+                "cloud_state": build_cloud_state(
+                    provider="databricks",
+                    service="clusters",
+                    resource_type="cluster",
+                    lifecycle_state=state_str.lower().replace("_", "-"),
+                    raw_state=state_str,
+                    state_source="cluster.state",
+                )
+            },
         )
         agents.append(agent)
 
@@ -134,6 +145,16 @@ def discover(
                 config_path=f"{resolved_host}/ml/endpoints/{ep_name}",
                 source="databricks",
                 mcp_servers=[server],
+                metadata={
+                    "cloud_state": build_cloud_state(
+                        provider="databricks",
+                        service="model-serving",
+                        resource_type="serving-endpoint",
+                        lifecycle_state=state_str.lower().replace("_", "-"),
+                        raw_state=state_str,
+                        state_source="state.ready",
+                    )
+                },
             )
             agents.append(agent)
 

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -49,3 +49,31 @@ def build_cloud_origin(
             key: value for key, value in raw_identity.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)
         }
     return envelope
+
+
+def build_cloud_state(
+    *,
+    provider: str,
+    service: str,
+    resource_type: str,
+    lifecycle_state: str,
+    raw_state: str | None = None,
+    state_source: str | None = None,
+) -> dict[str, Any]:
+    """Return a stable cloud-state envelope for provider lifecycle metadata.
+
+    Only use this when the provider exposes a real lifecycle/status field that
+    can be normalized without guesswork.
+    """
+    envelope: dict[str, Any] = {
+        "normalization_version": "1",
+        "provider": provider,
+        "service": service,
+        "resource_type": resource_type,
+        "lifecycle_state": lifecycle_state,
+    }
+    if raw_state:
+        envelope["raw_state"] = raw_state
+    if state_source:
+        envelope["state_source"] = state_source
+    return envelope

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -188,6 +188,12 @@ def test_aws_bedrock_agents_discovered():
     assert origin["service"] == "bedrock"
     assert origin["resource_type"] == "agent"
     assert origin["raw_identity"]["agentId"] == "ABC123"
+    state = bedrock_agents[0].metadata["cloud_state"]
+    assert state["provider"] == "aws"
+    assert state["service"] == "bedrock"
+    assert state["lifecycle_state"] == "prepared"
+    assert state["raw_state"] == "PREPARED"
+    assert state["state_source"] == "agentStatus"
 
 
 def test_aws_no_credentials_returns_warning():
@@ -323,6 +329,47 @@ def test_databricks_cluster_packages():
     assert "openai" in pkg_names
     assert all(p.ecosystem == "pypi" for p in server.packages)
     assert agents[0].source == "databricks"
+    state = agents[0].metadata["cloud_state"]
+    assert state["provider"] == "databricks"
+    assert state["service"] == "clusters"
+    assert state["resource_type"] == "cluster"
+    assert state["lifecycle_state"] == "running"
+    assert state["raw_state"] == "RUNNING"
+    assert state["state_source"] == "cluster.state"
+
+
+def test_databricks_serving_endpoint_state_normalized():
+    """Serving endpoints carry normalized readiness state for downstream consumers."""
+    _install_mock_databricks()
+
+    mock_ws = MagicMock()
+    mock_ws.clusters.list.return_value = []
+
+    endpoint = MagicMock()
+    endpoint.name = "prod-endpoint"
+    endpoint_state = MagicMock()
+    endpoint_ready = MagicMock()
+    endpoint_ready.value = "READY"
+    endpoint_state.ready = endpoint_ready
+    endpoint.state = endpoint_state
+    mock_ws.serving_endpoints.list.return_value = [endpoint]
+
+    with patch("databricks.sdk.WorkspaceClient", return_value=mock_ws):
+        importlib.reload(importlib.import_module("agent_bom.cloud.databricks"))
+        from agent_bom.cloud.databricks import discover
+
+        agents, warnings = discover(host="https://my.databricks.com", token="fake")
+
+    assert warnings == []
+    assert len(agents) == 1
+    assert agents[0].name == "databricks-serving:prod-endpoint"
+    state = agents[0].metadata["cloud_state"]
+    assert state["provider"] == "databricks"
+    assert state["service"] == "model-serving"
+    assert state["resource_type"] == "serving-endpoint"
+    assert state["lifecycle_state"] == "ready"
+    assert state["raw_state"] == "READY"
+    assert state["state_source"] == "state.ready"
 
 
 def test_databricks_maven_packages():

--- a/tests/test_discovery_enhanced.py
+++ b/tests/test_discovery_enhanced.py
@@ -46,12 +46,21 @@ def test_json_includes_agent_metadata():
                 "resource_name": "prod-endpoint",
                 "location": "us-central1",
                 "scope": {"project_id": "test"},
-            }
+            },
+            "cloud_state": {
+                "provider": "gcp",
+                "service": "vertex-ai",
+                "resource_type": "endpoint",
+                "lifecycle_state": "ready",
+                "raw_state": "READY",
+                "state_source": "state",
+            },
         },
     )
     data = to_json(AIBOMReport(agents=[agent]))
     assert data["agents"][0]["metadata"]["cloud_origin"]["provider"] == "gcp"
     assert data["agents"][0]["metadata"]["cloud_origin"]["scope"]["project_id"] == "test"
+    assert data["agents"][0]["metadata"]["cloud_state"]["lifecycle_state"] == "ready"
 
 
 # ── Claude Code project parsing ──────────────────────────────────────────────


### PR DESCRIPTION
Summary
- add a stable cloud_state envelope for providers that already expose real lifecycle fields
- normalize Bedrock agentStatus and Databricks cluster and serving readiness without forcing fake cross-provider parity
- carry the new metadata through JSON output tests so UI and API consumers can adopt it safely

Validation
- uv run pytest -q tests/test_cloud.py tests/test_discovery_enhanced.py
- uv run ruff check src/agent_bom/cloud/normalization.py src/agent_bom/cloud/aws.py src/agent_bom/cloud/databricks.py tests/test_cloud.py tests/test_discovery_enhanced.py
- git diff --check

Notes
- logically depends on #1373 and should be rebased after that merges
- additive only: no DB or schema migration and no breaking API change