### PR TITLE
Normalize provider timestamps

### DIFF
--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -17,7 +17,7 @@ from typing import Any
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin
+from .normalization import build_cloud_origin, build_cloud_timestamps
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +169,18 @@ def _discover_container_apps(
                             )
                         },
                     )
+                    system_data = getattr(app, "system_data", None)
+                    cloud_timestamps = build_cloud_timestamps(
+                        provider="azure",
+                        service="container-apps",
+                        resource_type="container-app",
+                        created_at=getattr(system_data, "created_at", None) if system_data else None,
+                        updated_at=getattr(system_data, "last_modified_at", None) if system_data else None,
+                        created_source="system_data.created_at",
+                        updated_source="system_data.last_modified_at",
+                    )
+                    if cloud_timestamps:
+                        agent.metadata["cloud_timestamps"] = cloud_timestamps
                     agents.append(agent)
 
     except Exception as exc:
@@ -225,6 +237,18 @@ def _discover_ai_foundry(
                     )
                 },
             )
+            system_data = getattr(resource, "system_data", None)
+            cloud_timestamps = build_cloud_timestamps(
+                provider="azure",
+                service="ai-foundry",
+                resource_type="workspace",
+                created_at=getattr(system_data, "created_at", None) if system_data else None,
+                updated_at=getattr(system_data, "last_modified_at", None) if system_data else None,
+                created_source="system_data.created_at",
+                updated_source="system_data.last_modified_at",
+            )
+            if cloud_timestamps:
+                agent.metadata["cloud_timestamps"] = cloud_timestamps
             agents.append(agent)
 
     except Exception as exc:

--- a/src/agent_bom/cloud/gcp.py
+++ b/src/agent_bom/cloud/gcp.py
@@ -16,7 +16,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin
+from .normalization import build_cloud_origin, build_cloud_timestamps
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +186,17 @@ def _discover_vertex_ai(
                     ),
                 },
             )
+            cloud_timestamps = build_cloud_timestamps(
+                provider="gcp",
+                service="vertex-ai",
+                resource_type="endpoint",
+                created_at=getattr(endpoint, "create_time", None),
+                updated_at=getattr(endpoint, "update_time", None),
+                created_source="create_time",
+                updated_source="update_time",
+            )
+            if cloud_timestamps:
+                agent.metadata["cloud_timestamps"] = cloud_timestamps
             agents.append(agent)
 
     except Exception as exc:

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -76,4 +77,65 @@ def build_cloud_state(
         envelope["raw_state"] = raw_state
     if state_source:
         envelope["state_source"] = state_source
+    return envelope
+
+
+def _normalize_timestamp(value: Any) -> str | None:
+    """Normalize provider timestamps into UTC ISO-8601 strings."""
+    if value in ("", None):
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        else:
+            value = value.astimezone(timezone.utc)
+        return value.isoformat().replace("+00:00", "Z")
+    if isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+        try:
+            parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+        except ValueError:
+            return candidate
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed.isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def build_cloud_timestamps(
+    *,
+    provider: str,
+    service: str,
+    resource_type: str,
+    created_at: Any = None,
+    updated_at: Any = None,
+    created_source: str | None = None,
+    updated_source: str | None = None,
+) -> dict[str, Any] | None:
+    """Return a stable cloud-timestamps envelope when provider timestamps exist."""
+    created = _normalize_timestamp(created_at)
+    updated = _normalize_timestamp(updated_at)
+    if not created and not updated:
+        return None
+    envelope: dict[str, Any] = {
+        "normalization_version": "1",
+        "provider": provider,
+        "service": service,
+        "resource_type": resource_type,
+    }
+    if created:
+        envelope["created_at"] = created
+    if updated:
+        envelope["updated_at"] = updated
+    sources: dict[str, str] = {}
+    if created and created_source:
+        sources["created_at"] = created_source
+    if updated and updated_source:
+        sources["updated_at"] = updated_source
+    if sources:
+        envelope["sources"] = sources
     return envelope

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -4,6 +4,7 @@ import importlib
 import json
 import sys
 import types
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1511,6 +1512,10 @@ def test_azure_container_apps_discovered():
     mock_app.name = "my-ai-agent-app"
     mock_app.id = "/subscriptions/sub-123/resourceGroups/rg-ai/providers/Microsoft.App/containerApps/my-ai-agent-app"
     mock_app.template = mock_template
+    mock_system_data = MagicMock()
+    mock_system_data.created_at = datetime(2026, 4, 10, 14, 30, tzinfo=timezone.utc)
+    mock_system_data.last_modified_at = datetime(2026, 4, 11, 16, 45, tzinfo=timezone.utc)
+    mock_app.system_data = mock_system_data
 
     mock_client.container_apps.list_by_subscription.return_value = [mock_app]
 
@@ -1528,6 +1533,10 @@ def test_azure_container_apps_discovered():
     assert origin["provider"] == "azure"
     assert origin["service"] == "container-apps"
     assert origin["scope"]["subscription_id"] == "sub-123"
+    timestamps = ca_agents[0].metadata["cloud_timestamps"]
+    assert timestamps["created_at"] == "2026-04-10T14:30:00Z"
+    assert timestamps["updated_at"] == "2026-04-11T16:45:00Z"
+    assert timestamps["sources"]["created_at"] == "system_data.created_at"
 
 
 def test_azure_ai_foundry_discovered():
@@ -1544,6 +1553,10 @@ def test_azure_ai_foundry_discovered():
     mock_workspace = MagicMock()
     mock_workspace.name = "my-ml-workspace"
     mock_workspace.id = "/subscriptions/sub-123/resourceGroups/rg-ai/providers/Microsoft.MachineLearningServices/workspaces/my-ml-workspace"
+    mock_system_data = MagicMock()
+    mock_system_data.created_at = "2026-04-01T12:00:00Z"
+    mock_system_data.last_modified_at = "2026-04-12T09:15:00Z"
+    mock_workspace.system_data = mock_system_data
     mock_rm_client.resources.list.return_value = [mock_workspace]
 
     with (
@@ -1560,6 +1573,9 @@ def test_azure_ai_foundry_discovered():
     assert origin["provider"] == "azure"
     assert origin["service"] == "ai-foundry"
     assert origin["resource_type"] == "workspace"
+    timestamps = ai_agents[0].metadata["cloud_timestamps"]
+    assert timestamps["created_at"] == "2026-04-01T12:00:00Z"
+    assert timestamps["updated_at"] == "2026-04-12T09:15:00Z"
 
 
 def test_azure_container_apps_by_resource_group():
@@ -1681,6 +1697,8 @@ def test_gcp_vertex_ai_endpoints_discovered():
     mock_endpoint.display_name = "prod-endpoint"
     mock_endpoint.resource_name = "projects/123/locations/us-central1/endpoints/456"
     mock_endpoint.gca_resource = mock_gca
+    mock_endpoint.create_time = "2026-04-05T08:00:00Z"
+    mock_endpoint.update_time = "2026-04-12T10:30:00Z"
 
     with patch("google.cloud.aiplatform.init"), patch("google.cloud.aiplatform.Endpoint.list", return_value=[mock_endpoint]):
         agents, warnings = discover(project_id="my-project", region="us-central1")
@@ -1694,6 +1712,10 @@ def test_gcp_vertex_ai_endpoints_discovered():
     assert origin["provider"] == "gcp"
     assert origin["service"] == "vertex-ai"
     assert origin["scope"]["project_id"] == "my-project"
+    timestamps = vertex_agents[0].metadata["cloud_timestamps"]
+    assert timestamps["created_at"] == "2026-04-05T08:00:00Z"
+    assert timestamps["updated_at"] == "2026-04-12T10:30:00Z"
+    assert timestamps["sources"]["updated_at"] == "update_time"
 
 
 def test_gcp_cloud_run_services_discovered():


### PR DESCRIPTION
Summary
- add a stable cloud_timestamps envelope for provider resources that already expose creation and update metadata
- normalize Azure ARM system_data timestamps and GCP Vertex endpoint timestamps into UTC ISO-8601 strings
- keep timestamp provenance explicit so downstream UI, API, and OCSF mapping can use one stable envelope without losing source semantics

Validation
- uv run pytest -q tests/test_cloud.py
- uv run ruff check src/agent_bom/cloud/normalization.py src/agent_bom/cloud/gcp.py src/agent_bom/cloud/azure.py tests/test_cloud.py
- git diff --check

Notes
- additive only: no DB or schema migration and no breaking API change
- logically follows the cloud normalization wave after #1373 and #1374