### PR TITLE
Normalize cloud execution principals

### DIFF
--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -17,9 +17,53 @@ from typing import Any
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_timestamps
+from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_timestamps
 
 logger = logging.getLogger(__name__)
+
+
+def _build_azure_principal(
+    *,
+    service: str,
+    resource_type: str,
+    identity: Any,
+) -> dict[str, Any] | None:
+    """Normalize Azure workload identity metadata when present."""
+    if not identity:
+        return None
+    identity_type = getattr(identity, "type", "") or ""
+    principal_id = getattr(identity, "principal_id", "") or ""
+    tenant_id = getattr(identity, "tenant_id", "") or ""
+    user_assigned = getattr(identity, "user_assigned_identities", None) or {}
+    principal_name = ""
+    if not principal_id and user_assigned:
+        first_identity = next(iter(user_assigned.keys()), "")
+        principal_id = first_identity
+        principal_name = first_identity
+    normalized_type = (
+        {
+            "SystemAssigned": "system-assigned-managed-identity",
+            "UserAssigned": "user-assigned-managed-identity",
+            "SystemAssigned, UserAssigned": "mixed-managed-identity",
+        }.get(identity_type)
+        or identity_type.lower().replace("_", "-").replace(" ", "-")
+        or "managed-identity"
+    )
+    return build_cloud_principal(
+        provider="azure",
+        service=service,
+        resource_type=resource_type,
+        principal_type=normalized_type,
+        principal_id=principal_id or None,
+        principal_name=principal_name or None,
+        tenant_id=tenant_id or None,
+        source_field="identity",
+        raw_identity={
+            "type": identity_type,
+            "principal_id": principal_id,
+            "tenant_id": tenant_id,
+        },
+    )
 
 
 def discover(
@@ -181,6 +225,13 @@ def _discover_container_apps(
                     )
                     if cloud_timestamps:
                         agent.metadata["cloud_timestamps"] = cloud_timestamps
+                    cloud_principal = _build_azure_principal(
+                        service="container-apps",
+                        resource_type="container-app",
+                        identity=getattr(app, "identity", None),
+                    )
+                    if cloud_principal:
+                        agent.metadata["cloud_principal"] = cloud_principal
                     agents.append(agent)
 
     except Exception as exc:
@@ -415,6 +466,13 @@ def _discover_azure_functions(
                 mcp_servers=[server],
                 metadata={"runtime": runtime_stack, "location": location},
             )
+            cloud_principal = _build_azure_principal(
+                service="functions",
+                resource_type="function-app",
+                identity=getattr(app, "identity", None),
+            )
+            if cloud_principal:
+                agent.metadata["cloud_principal"] = cloud_principal
             agents.append(agent)
 
     except Exception as exc:

--- a/src/agent_bom/cloud/gcp.py
+++ b/src/agent_bom/cloud/gcp.py
@@ -16,7 +16,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_timestamps
+from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_timestamps
 
 logger = logging.getLogger(__name__)
 
@@ -259,9 +259,11 @@ def _discover_cloud_functions(
 
             # Service config for URL and resource limits
             service_url = ""
+            service_account = ""
             service_config = getattr(function, "service_config", None)
             if service_config:
                 service_url = getattr(service_config, "uri", "") or ""
+                service_account = getattr(service_config, "service_account_email", "") or ""
 
             server = MCPServer(
                 name=f"cloud-function:{fn_name}",
@@ -284,6 +286,18 @@ def _discover_cloud_functions(
                     "source_uri": source_uri,
                 },
             )
+            cloud_principal = build_cloud_principal(
+                provider="gcp",
+                service="cloud-functions",
+                resource_type="function",
+                principal_type="service-account",
+                principal_id=service_account or None,
+                principal_name=service_account or None,
+                source_field="service_config.service_account_email",
+                raw_identity={"service_account_email": service_account},
+            )
+            if cloud_principal:
+                agent.metadata["cloud_principal"] = cloud_principal
             agents.append(agent)
 
             logger.debug(
@@ -428,6 +442,7 @@ def _discover_cloud_run(
             for container in template.containers:
                 image = container.image or ""
                 if image:
+                    service_account = getattr(template, "service_account", "") or ""
                     server = MCPServer(
                         name=f"cloud-run:{svc_name}",
                         command="docker",
@@ -456,6 +471,18 @@ def _discover_cloud_run(
                             ),
                         },
                     )
+                    cloud_principal = build_cloud_principal(
+                        provider="gcp",
+                        service="cloud-run",
+                        resource_type="service",
+                        principal_type="service-account",
+                        principal_id=service_account or None,
+                        principal_name=service_account or None,
+                        source_field="template.service_account",
+                        raw_identity={"service_account": service_account},
+                    )
+                    if cloud_principal:
+                        agent.metadata["cloud_principal"] = cloud_principal
                     agents.append(agent)
 
     except Exception as exc:

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -139,3 +139,44 @@ def build_cloud_timestamps(
     if sources:
         envelope["sources"] = sources
     return envelope
+
+
+def build_cloud_principal(
+    *,
+    provider: str,
+    service: str,
+    resource_type: str,
+    principal_type: str,
+    principal_id: str | None = None,
+    principal_name: str | None = None,
+    tenant_id: str | None = None,
+    source_field: str | None = None,
+    raw_identity: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Return a stable execution-principal envelope for discovered resources.
+
+    This models the workload identity attached to the resource itself. It does
+    not attempt to infer an actor or event initiator from inventory APIs.
+    """
+    if not principal_id and not principal_name:
+        return None
+    envelope: dict[str, Any] = {
+        "normalization_version": "1",
+        "provider": provider,
+        "service": service,
+        "resource_type": resource_type,
+        "principal_type": principal_type,
+    }
+    if principal_id:
+        envelope["principal_id"] = principal_id
+    if principal_name:
+        envelope["principal_name"] = principal_name
+    if tenant_id:
+        envelope["tenant_id"] = tenant_id
+    if source_field:
+        envelope["source_field"] = source_field
+    if raw_identity:
+        envelope["raw_identity"] = {
+            key: value for key, value in raw_identity.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)
+        }
+    return envelope

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1453,6 +1453,11 @@ def _install_mock_azure():
     azure_mgmt_resource.ResourceManagementClient = MagicMock
     azure_mgmt.resource = azure_mgmt_resource
 
+    # azure.mgmt.web
+    azure_mgmt_web = types.ModuleType("azure.mgmt.web")
+    azure_mgmt_web.WebSiteManagementClient = MagicMock
+    azure_mgmt.web = azure_mgmt_web
+
     # azure.ai.projects
     azure_ai = types.ModuleType("azure.ai")
     azure_ai_projects = types.ModuleType("azure.ai.projects")
@@ -1464,6 +1469,7 @@ def _install_mock_azure():
     sys.modules.setdefault("azure.mgmt", azure_mgmt)
     sys.modules.setdefault("azure.mgmt.appcontainers", azure_mgmt_appcontainers)
     sys.modules.setdefault("azure.mgmt.resource", azure_mgmt_resource)
+    sys.modules.setdefault("azure.mgmt.web", azure_mgmt_web)
     sys.modules.setdefault("azure.ai", azure_ai)
     sys.modules.setdefault("azure.ai.projects", azure_ai_projects)
     return azure
@@ -1512,6 +1518,11 @@ def test_azure_container_apps_discovered():
     mock_app.name = "my-ai-agent-app"
     mock_app.id = "/subscriptions/sub-123/resourceGroups/rg-ai/providers/Microsoft.App/containerApps/my-ai-agent-app"
     mock_app.template = mock_template
+    mock_identity = MagicMock()
+    mock_identity.type = "SystemAssigned"
+    mock_identity.principal_id = "11111111-2222-3333-4444-555555555555"
+    mock_identity.tenant_id = "tenant-123"
+    mock_app.identity = mock_identity
     mock_system_data = MagicMock()
     mock_system_data.created_at = datetime(2026, 4, 10, 14, 30, tzinfo=timezone.utc)
     mock_system_data.last_modified_at = datetime(2026, 4, 11, 16, 45, tzinfo=timezone.utc)
@@ -1537,6 +1548,10 @@ def test_azure_container_apps_discovered():
     assert timestamps["created_at"] == "2026-04-10T14:30:00Z"
     assert timestamps["updated_at"] == "2026-04-11T16:45:00Z"
     assert timestamps["sources"]["created_at"] == "system_data.created_at"
+    principal = ca_agents[0].metadata["cloud_principal"]
+    assert principal["principal_type"] == "system-assigned-managed-identity"
+    assert principal["principal_id"] == "11111111-2222-3333-4444-555555555555"
+    assert principal["tenant_id"] == "tenant-123"
 
 
 def test_azure_ai_foundry_discovered():
@@ -1729,6 +1744,7 @@ def test_gcp_cloud_run_services_discovered():
 
     mock_template = MagicMock()
     mock_template.containers = [mock_container]
+    mock_template.service_account = "run-sa@my-project.iam.gserviceaccount.com"
 
     mock_service = MagicMock()
     mock_service.name = "projects/my-project/locations/us-central1/services/ai-service"
@@ -1752,6 +1768,93 @@ def test_gcp_cloud_run_services_discovered():
     assert origin["provider"] == "gcp"
     assert origin["service"] == "cloud-run"
     assert origin["resource_type"] == "service"
+    principal = run_agents[0].metadata["cloud_principal"]
+    assert principal["principal_type"] == "service-account"
+    assert principal["principal_id"] == "run-sa@my-project.iam.gserviceaccount.com"
+    assert principal["source_field"] == "template.service_account"
+
+
+def test_gcp_cloud_functions_discovered_with_service_account():
+    """Cloud Functions capture workload service account metadata."""
+    _install_mock_gcp()
+    importlib.reload(importlib.import_module("agent_bom.cloud.gcp"))
+    from agent_bom.cloud.gcp import discover
+
+    mock_service_config = MagicMock()
+    mock_service_config.uri = "https://us-central1-my-project.cloudfunctions.net/hello"
+    mock_service_config.service_account_email = "functions-sa@my-project.iam.gserviceaccount.com"
+
+    mock_build_config = MagicMock()
+    mock_build_config.runtime = "python313"
+    mock_build_config.entry_point = "handler"
+
+    mock_function = MagicMock()
+    mock_function.name = "projects/my-project/locations/us-central1/functions/hello"
+    mock_function.build_config = mock_build_config
+    mock_function.service_config = mock_service_config
+
+    mock_fn_client = MagicMock()
+    mock_fn_client.list_functions.return_value = [mock_function]
+
+    with (
+        patch("google.cloud.aiplatform.init"),
+        patch("google.cloud.aiplatform.Endpoint.list", return_value=[]),
+        patch("google.cloud.functions_v2.FunctionServiceClient", return_value=mock_fn_client),
+    ):
+        agents, warnings = discover(project_id="my-project", region="us-central1")
+
+    fn_agents = [a for a in agents if a.source == "gcp-cloud-functions"]
+    assert len(fn_agents) == 1
+    principal = fn_agents[0].metadata["cloud_principal"]
+    assert principal["principal_type"] == "service-account"
+    assert principal["principal_id"] == "functions-sa@my-project.iam.gserviceaccount.com"
+    assert principal["source_field"] == "service_config.service_account_email"
+
+
+def test_azure_functions_discovered_with_managed_identity():
+    """Azure Function Apps capture managed identity metadata."""
+    _install_mock_azure()
+    importlib.reload(importlib.import_module("agent_bom.cloud.azure"))
+    from agent_bom.cloud.azure import discover
+
+    mock_credential = MagicMock()
+    mock_ca_client = MagicMock()
+    mock_ca_client.container_apps.list_by_subscription.return_value = []
+
+    mock_rm_client = MagicMock()
+    mock_rm_client.resources.list.return_value = []
+
+    mock_web_client = MagicMock()
+    mock_app = MagicMock()
+    mock_app.kind = "functionapp,linux"
+    mock_app.name = "my-func"
+    mock_app.id = "/subscriptions/sub-123/resourceGroups/rg-ai/providers/Microsoft.Web/sites/my-func"
+    mock_app.location = "eastus"
+    mock_identity = MagicMock()
+    mock_identity.type = "SystemAssigned"
+    mock_identity.principal_id = "principal-123"
+    mock_identity.tenant_id = "tenant-123"
+    mock_app.identity = mock_identity
+    mock_web_client.web_apps.list.return_value = [mock_app]
+
+    mock_config = MagicMock()
+    mock_config.python_version = "3.12"
+    mock_web_client.web_apps.get_configuration.return_value = mock_config
+
+    with (
+        patch("azure.identity.DefaultAzureCredential", return_value=mock_credential),
+        patch("azure.mgmt.appcontainers.ContainerAppsAPIClient", return_value=mock_ca_client),
+        patch("azure.mgmt.resource.ResourceManagementClient", return_value=mock_rm_client),
+        patch("azure.mgmt.web.WebSiteManagementClient", return_value=mock_web_client),
+    ):
+        agents, warnings = discover(subscription_id="sub-123")
+
+    fn_agents = [a for a in agents if a.source == "azure-functions"]
+    assert len(fn_agents) == 1
+    principal = fn_agents[0].metadata["cloud_principal"]
+    assert principal["principal_type"] == "system-assigned-managed-identity"
+    assert principal["principal_id"] == "principal-123"
+    assert principal["tenant_id"] == "tenant-123"
 
 
 def test_gcp_vertex_and_cloud_run_combined():


### PR DESCRIPTION
## Summary
- add a stable cloud_principal envelope for workload identity metadata
- normalize GCP Cloud Functions and Cloud Run service accounts
- normalize Azure Container Apps and Function App managed identities
- keep the change additive only so DB/API/UI consumers do not break

## Validation
- uv run pytest -q tests/test_cloud.py tests/test_discovery_enhanced.py
- uv run ruff check src/agent_bom/cloud/normalization.py src/agent_bom/cloud/gcp.py src/agent_bom/cloud/azure.py tests/test_cloud.py
- git diff --check