### PR TITLE
Make SIEM OCSF wrapping optional

### DIFF
--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -202,6 +202,7 @@ def run_integrations(
                 url=siem_url,
                 token=siem_token or "",
                 index=siem_index or "agent-bom-alerts",
+                event_format=siem_format,
             )
             connector = create_connector(siem_type, siem_config)
 

--- a/src/agent_bom/siem/__init__.py
+++ b/src/agent_bom/siem/__init__.py
@@ -41,6 +41,7 @@ class SIEMConfig:
     index: str = ""
     source_type: str = "agent-bom"
     verify_ssl: bool = True
+    event_format: str = "raw"
 
 
 class SplunkHEC:

--- a/src/agent_bom/siem/ocsf.py
+++ b/src/agent_bom/siem/ocsf.py
@@ -166,14 +166,25 @@ class SyslogConnector:
         self.use_tls = getattr(config, "verify_ssl", True)
         self.app_name = "agent-bom"
         self._product_version = os.environ.get("AGENT_BOM_VERSION", "0.0.0")
+        self._event_format = getattr(config, "event_format", "raw")
+
+    @staticmethod
+    def _looks_like_ocsf(event: dict[str, Any]) -> bool:
+        """Return True when the payload already looks like an OCSF event."""
+        return all(key in event for key in ("class_uid", "category_uid", "type_uid"))
 
     def send_event(self, event: dict) -> bool:
-        """Convert event to OCSF, format as RFC 5424, send over TCP."""
+        """Format event as RFC 5424 and send over TCP."""
         try:
-            ocsf = to_ocsf_detection_finding(event, self._product_version)
-            severity_id = ocsf.get("severity_id", 3)
+            if self._event_format == "ocsf":
+                payload = event if self._looks_like_ocsf(event) else to_ocsf_detection_finding(event, self._product_version)
+                severity_id = payload.get("severity_id", 3)
+            else:
+                payload = event
+                severity_str = str(event.get("severity", "medium")).lower()
+                severity_id = _SEVERITY_MAP.get(severity_str, 0)
             syslog_sev = _SYSLOG_SEVERITY.get(severity_id, 4)
-            msg = _format_rfc5424(_FACILITY, syslog_sev, self.app_name, json.dumps(ocsf))
+            msg = _format_rfc5424(_FACILITY, syslog_sev, self.app_name, json.dumps(payload))
             return self._send_tcp(msg)
         except Exception:
             logger.exception("Syslog send failed")

--- a/tests/test_ocsf.py
+++ b/tests/test_ocsf.py
@@ -194,7 +194,7 @@ class TestParseHostPort:
 
 class TestSyslogConnector:
     def test_send_event_mock(self):
-        config = SIEMConfig(name="syslog", url="syslog://localhost:1514")
+        config = SIEMConfig(name="syslog", url="syslog://localhost:1514", event_format="ocsf")
         conn = SyslogConnector(config)
 
         with patch.object(conn, "_send_tcp", return_value=True) as mock_tcp:
@@ -204,6 +204,29 @@ class TestSyslogConnector:
             sent_msg = mock_tcp.call_args[0][0]
             assert "agent-bom" in sent_msg
             assert "2004" in sent_msg  # class_uid in OCSF JSON
+
+    def test_send_event_raw_passthrough(self):
+        config = SIEMConfig(name="syslog", url="syslog://localhost:1514", event_format="raw")
+        conn = SyslogConnector(config)
+
+        with patch.object(conn, "_send_tcp", return_value=True) as mock_tcp:
+            result = conn.send_event(_sample_alert())
+            assert result is True
+            sent_msg = mock_tcp.call_args[0][0]
+            assert "Prompt injection detected in tool call" in sent_msg
+            assert '"class_uid": 2004' not in sent_msg
+
+    def test_send_event_ocsf_passthrough_when_already_formatted(self):
+        config = SIEMConfig(name="syslog", url="syslog://localhost:1514", event_format="ocsf")
+        conn = SyslogConnector(config)
+        event = to_ocsf_detection_finding(_sample_alert())
+
+        with patch.object(conn, "_send_tcp", return_value=True) as mock_tcp:
+            result = conn.send_event(event)
+            assert result is True
+            sent_msg = mock_tcp.call_args[0][0]
+            assert '"class_uid": 2004' in sent_msg
+            assert sent_msg.count('"class_uid": 2004') == 1
 
     def test_send_batch(self):
         config = SIEMConfig(name="syslog", url="localhost:514")


### PR DESCRIPTION
## Summary
- preserve raw syslog passthrough when the SIEM format is set to raw
- only wrap events as OCSF when the caller explicitly asks for OCSF
- avoid double-wrapping payloads that are already OCSF-formatted

## Testing
- uv run pytest -q tests/test_ocsf.py tests/test_siem_push.py tests/test_cli_integrations_post.py
- uv run ruff check src/agent_bom/siem/__init__.py src/agent_bom/siem/ocsf.py src/agent_bom/cli/agents/_post.py tests/test_ocsf.py
- git diff --check