### PR TITLE
Clarify canonical model and OCSF positioning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
   - Features:
       - Scanning & Discovery: features/scanning.md
       - Blast Radius: features/blast-radius.md
+      - Cloud Normalization: features/cloud-normalization.md
       - Compliance: features/compliance.md
       - Registry: features/registry.md
       - Runtime Proxy: features/runtime-proxy.md
@@ -92,6 +93,7 @@ nav:
       - Overview: deployment/overview.md
       - Docker: deployment/docker.md
       - Kubernetes: deployment/kubernetes.md
+      - SIEM Integration: deployment/siem-integration.md
       - Runtime Monitoring: deployment/runtime-monitoring.md
       - Grafana Dashboard: deployment/grafana.md
   - Architecture:

--- a/site-docs/deployment/siem-integration.md
+++ b/site-docs/deployment/siem-integration.md
@@ -1,0 +1,88 @@
+# SIEM Integration
+
+Agent BOM can push events downstream in two formats:
+
+- `raw`: the canonical `agent-bom` event shape
+- `ocsf`: a standardized OCSF projection for SIEM or security-lake workflows
+
+The product is not a SIEM and does not require OCSF to function. OCSF is an
+interoperability layer at the boundary.
+
+## Choosing `raw` vs `ocsf`
+
+Use `raw` when:
+
+- you want full Agent BOM fidelity
+- your destination can ingest custom JSON cleanly
+- you need vendor-specific or AI-specific fields that do not fit OCSF well
+
+Use `ocsf` when:
+
+- your downstream platform expects standardized event semantics
+- you want easier alignment to existing SIEM pipelines
+- the destination benefits from OCSF `category_uid`, `class_uid`, and
+  standardized detection finding structure
+
+## Example: Splunk with raw events
+
+Use the canonical event shape when you want to keep Agent BOM-native fields in
+the pipeline.
+
+```bash
+agent-bom agents \
+  --siem splunk \
+  --siem-url https://splunk.example.com:8088/services/collector \
+  --siem-token "$SPLUNK_HEC_TOKEN" \
+  --siem-index agent-bom \
+  --siem-format raw
+```
+
+This preserves Agent BOM-native details such as blast-radius context, canonical
+resource envelopes, and product-specific metadata without wrapping them into an
+OCSF Detection Finding.
+
+## Example: Syslog / enterprise SIEM with OCSF
+
+Use OCSF when the downstream system expects normalized security events.
+
+```bash
+agent-bom agents \
+  --siem datadog \
+  --siem-url tls://siem.example.com:6514 \
+  --siem-token "$SIEM_TOKEN" \
+  --siem-format ocsf
+```
+
+This projects the canonical finding/event into an OCSF-compatible envelope
+before delivery.
+
+## Example: Elasticsearch or OpenSearch
+
+Either mode can work:
+
+- choose `raw` for maximum product fidelity
+- choose `ocsf` if you want a more standardized event schema
+
+```bash
+agent-bom fs . \
+  --siem elasticsearch \
+  --siem-url https://search.example.com \
+  --siem-token "$ES_API_KEY" \
+  --siem-index agent-bom-findings \
+  --siem-format raw
+```
+
+## Design rules
+
+Agent BOM follows these rules for SIEM delivery:
+
+1. Canonical `agent-bom` data model stays primary
+2. OCSF is optional and derived
+3. Raw vendor/source semantics are not discarded just to fit a standard
+4. If a field does not map cleanly to OCSF, Agent BOM keeps it as native data
+   or an extension field
+
+This avoids lock-in in both directions:
+
+- customers are not forced into OCSF to use the product
+- customers who want OCSF still get a clean interoperability path

--- a/site-docs/features/cloud-normalization.md
+++ b/site-docs/features/cloud-normalization.md
@@ -1,0 +1,104 @@
+# Cloud Normalization
+
+Agent BOM keeps cloud ingestion accurate by separating three layers:
+
+1. Raw provider payloads from AWS, Azure, GCP, Databricks, and other sources
+2. A canonical `agent-bom` normalization layer
+3. Optional downstream projections such as OCSF
+
+The product does not force every cloud response into OCSF first. It preserves
+source-specific semantics, normalizes them into stable envelopes for the rest
+of the product, and projects to OCSF only where that mapping is accurate.
+
+## Canonical envelopes
+
+The current canonical cloud envelopes are additive metadata attached to
+discovered assets and emitted through JSON output. They give the CLI, API, UI,
+graphs, and future exports a stable internal contract without discarding
+provider-specific evidence.
+
+### `cloud_origin`
+
+Identity and provenance for the cloud asset:
+
+- `provider`
+- `service`
+- `resource_type`
+- `resource_id`
+- `resource_name`
+- `location`
+- scoped identifiers such as `account_id`, `subscription_id`, or `project_id`
+- constrained `raw_identity` fields for debugging and mapping verification
+
+### `cloud_state`
+
+Normalized lifecycle state for the asset:
+
+- `lifecycle_state`
+- `raw_state`
+- `state_source`
+
+This lets the product distinguish canonical status from provider-specific state
+strings without losing the original value.
+
+### `cloud_timestamps`
+
+Normalized timestamps for asset lifecycle history:
+
+- `created_at`
+- `updated_at`
+- `sources`
+
+Timestamps are normalized to UTC ISO-8601 so downstream graph, timeline, and
+history features do not need to guess provider formats.
+
+### `cloud_principal`
+
+Execution identity or attached principal where the provider exposes one:
+
+- `principal_type`
+- `principal_id`
+- `principal_name`
+- `tenant_id`
+- `source_field`
+- constrained `raw_identity`
+
+This helps preserve the relationship between a resource and the principal it
+runs as, without forcing every provider into a single vendor-specific schema.
+
+## Why this layer exists
+
+Cloud providers do not agree on:
+
+- field names
+- nested response shapes
+- lifecycle enums
+- timestamp formats
+- identity semantics
+
+The normalization layer prevents those differences from leaking into every
+product surface.
+
+## Relationship to OCSF
+
+OCSF is optional and sits downstream of the canonical model:
+
+- raw cloud payload in
+- source-specific adapter
+- canonical `agent-bom` envelope
+- optional OCSF projection
+
+If OCSF does not fit a provider-specific concept cleanly, Agent BOM keeps the
+canonical field or extension instead of forcing a bad mapping.
+
+## Persistence and history
+
+Canonical cloud metadata supports current-state and historical views:
+
+- `first_seen` and `last_seen` stay in the product model
+- lifecycle changes remain queryable over time
+- deactivated or disappeared entities can remain visible in history even when
+  they no longer appear in the latest inventory
+
+The design goal is persistent truth plus derived views, not transient
+recomputation of every cloud shape on every page load.

--- a/src/agent_bom/cli/options.py
+++ b/src/agent_bom/cli/options.py
@@ -988,7 +988,9 @@ def integration_options(fn):
                 envvar="AGENT_BOM_SIEM_FORMAT",
                 type=click.Choice(["raw", "ocsf"], case_sensitive=False),
                 show_default=True,
-                help="Event format for SIEM push: ocsf (default) or raw",
+                help=(
+                    "Event format for SIEM push: ocsf (standardized for enterprise SIEM ingestion) or raw (canonical agent-bom event shape)"
+                ),
             ),
             click.option(
                 "--clickhouse-url",

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -44,6 +44,9 @@ CREATE TABLE IF NOT EXISTS graph_nodes (
     id              TEXT NOT NULL,
     entity_type     TEXT NOT NULL,
     label           TEXT NOT NULL,
+    -- OCSF projection columns (derived from entity_type via graph/ocsf.py
+    -- ENTITY_OCSF_MAP) for classification/filtering. They are not the
+    -- canonical source of truth for graph entities.
     category_uid    INTEGER DEFAULT 0,
     class_uid       INTEGER DEFAULT 0,
     type_uid        INTEGER DEFAULT 0,


### PR DESCRIPTION
## Summary
- clarify that persisted OCSF graph columns are derived projection fields, not canonical truth
- clarify SIEM help text so raw vs OCSF is explicit at the CLI boundary
- document cloud normalization envelopes for canonical vendor-aware ingestion
- add a SIEM integration guide showing when to use raw vs OCSF

## Testing
- git -C /tmp/agent-bom-ocsf-clarify diff --check