### PR TITLE
Normalize cloud scope hierarchy

### DIFF
--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -17,9 +17,19 @@ from typing import Any
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_timestamps
+from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_scope, build_cloud_timestamps
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_azure_resource_group(resource_id: str) -> str:
+    """Extract Azure resource group name from a resource ID."""
+    if not resource_id:
+        return ""
+    rg_parts = resource_id.split("/resourceGroups/")
+    if len(rg_parts) < 2:
+        return ""
+    return rg_parts[1].split("/")[0]
 
 
 def _build_azure_principal(
@@ -213,6 +223,21 @@ def _discover_container_apps(
                             )
                         },
                     )
+                    rg_name = resource_group or _extract_azure_resource_group(app.id or "")
+                    cloud_scope = build_cloud_scope(
+                        provider="azure",
+                        service="container-apps",
+                        resource_type="container-app",
+                        scope_type="resource-group",
+                        scope_id=rg_name,
+                        scope_name=rg_name or None,
+                        parent_scope_type="subscription",
+                        parent_scope_id=subscription_id,
+                        location=getattr(app, "location", None),
+                        source_fields=["id", "location"],
+                    )
+                    if cloud_scope:
+                        agent.metadata["cloud_scope"] = cloud_scope
                     system_data = getattr(app, "system_data", None)
                     cloud_timestamps = build_cloud_timestamps(
                         provider="azure",
@@ -288,6 +313,21 @@ def _discover_ai_foundry(
                     )
                 },
             )
+            rg_name = resource_group or _extract_azure_resource_group(resource.id or "")
+            cloud_scope = build_cloud_scope(
+                provider="azure",
+                service="ai-foundry",
+                resource_type="workspace",
+                scope_type="resource-group",
+                scope_id=rg_name,
+                scope_name=rg_name or None,
+                parent_scope_type="subscription",
+                parent_scope_id=subscription_id,
+                location=getattr(resource, "location", None),
+                source_fields=["id", "location"],
+            )
+            if cloud_scope:
+                agent.metadata["cloud_scope"] = cloud_scope
             system_data = getattr(resource, "system_data", None)
             cloud_timestamps = build_cloud_timestamps(
                 provider="azure",
@@ -466,6 +506,20 @@ def _discover_azure_functions(
                 mcp_servers=[server],
                 metadata={"runtime": runtime_stack, "location": location},
             )
+            cloud_scope = build_cloud_scope(
+                provider="azure",
+                service="functions",
+                resource_type="function-app",
+                scope_type="resource-group",
+                scope_id=rg_name,
+                scope_name=rg_name or None,
+                parent_scope_type="subscription",
+                parent_scope_id=subscription_id,
+                location=location or None,
+                source_fields=["id", "location"],
+            )
+            if cloud_scope:
+                agent.metadata["cloud_scope"] = cloud_scope
             cloud_principal = _build_azure_principal(
                 service="functions",
                 resource_type="function-app",

--- a/src/agent_bom/cloud/gcp.py
+++ b/src/agent_bom/cloud/gcp.py
@@ -16,7 +16,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_timestamps
+from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_scope, build_cloud_timestamps
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +197,18 @@ def _discover_vertex_ai(
             )
             if cloud_timestamps:
                 agent.metadata["cloud_timestamps"] = cloud_timestamps
+            cloud_scope = build_cloud_scope(
+                provider="gcp",
+                service="vertex-ai",
+                resource_type="endpoint",
+                scope_type="project",
+                scope_id=project_id,
+                scope_name=project_id,
+                location=region,
+                source_fields=["resource_name", "create_time", "update_time"],
+            )
+            if cloud_scope:
+                agent.metadata["cloud_scope"] = cloud_scope
             agents.append(agent)
 
     except Exception as exc:
@@ -286,6 +298,18 @@ def _discover_cloud_functions(
                     "source_uri": source_uri,
                 },
             )
+            cloud_scope = build_cloud_scope(
+                provider="gcp",
+                service="cloud-functions",
+                resource_type="function",
+                scope_type="project",
+                scope_id=project_id,
+                scope_name=project_id,
+                location=region,
+                source_fields=["name", "service_config.uri"],
+            )
+            if cloud_scope:
+                agent.metadata["cloud_scope"] = cloud_scope
             cloud_principal = build_cloud_principal(
                 provider="gcp",
                 service="cloud-functions",
@@ -471,6 +495,18 @@ def _discover_cloud_run(
                             ),
                         },
                     )
+                    cloud_scope = build_cloud_scope(
+                        provider="gcp",
+                        service="cloud-run",
+                        resource_type="service",
+                        scope_type="project",
+                        scope_id=project_id,
+                        scope_name=project_id,
+                        location=region,
+                        source_fields=["name", "template.service_account"],
+                    )
+                    if cloud_scope:
+                        agent.metadata["cloud_scope"] = cloud_scope
                     cloud_principal = build_cloud_principal(
                         provider="gcp",
                         service="cloud-run",

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -180,3 +180,48 @@ def build_cloud_principal(
             key: value for key, value in raw_identity.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)
         }
     return envelope
+
+
+def build_cloud_scope(
+    *,
+    provider: str,
+    service: str,
+    resource_type: str,
+    scope_type: str,
+    scope_id: str,
+    scope_name: str | None = None,
+    parent_scope_type: str | None = None,
+    parent_scope_id: str | None = None,
+    parent_scope_name: str | None = None,
+    location: str | None = None,
+    source_fields: list[str] | None = None,
+) -> dict[str, Any] | None:
+    """Return a stable scope/ownership envelope for discovered resources.
+
+    This models where a resource lives in provider hierarchy, for example a
+    resource group inside a subscription or a service inside a project.
+    """
+    if not scope_id:
+        return None
+    envelope: dict[str, Any] = {
+        "normalization_version": "1",
+        "provider": provider,
+        "service": service,
+        "resource_type": resource_type,
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+    }
+    if scope_name:
+        envelope["scope_name"] = scope_name
+    if parent_scope_type and parent_scope_id:
+        envelope["parent_scope"] = {
+            "type": parent_scope_type,
+            "id": parent_scope_id,
+        }
+        if parent_scope_name:
+            envelope["parent_scope"]["name"] = parent_scope_name
+    if location:
+        envelope["location"] = location
+    if source_fields:
+        envelope["source_fields"] = [field for field in source_fields if field]
+    return envelope

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1517,6 +1517,7 @@ def test_azure_container_apps_discovered():
     mock_app = MagicMock()
     mock_app.name = "my-ai-agent-app"
     mock_app.id = "/subscriptions/sub-123/resourceGroups/rg-ai/providers/Microsoft.App/containerApps/my-ai-agent-app"
+    mock_app.location = "eastus"
     mock_app.template = mock_template
     mock_identity = MagicMock()
     mock_identity.type = "SystemAssigned"
@@ -1552,6 +1553,12 @@ def test_azure_container_apps_discovered():
     assert principal["principal_type"] == "system-assigned-managed-identity"
     assert principal["principal_id"] == "11111111-2222-3333-4444-555555555555"
     assert principal["tenant_id"] == "tenant-123"
+    scope = ca_agents[0].metadata["cloud_scope"]
+    assert scope["scope_type"] == "resource-group"
+    assert scope["scope_id"] == "rg-ai"
+    assert scope["parent_scope"]["type"] == "subscription"
+    assert scope["parent_scope"]["id"] == "sub-123"
+    assert scope["location"] == "eastus"
 
 
 def test_azure_ai_foundry_discovered():
@@ -1568,6 +1575,7 @@ def test_azure_ai_foundry_discovered():
     mock_workspace = MagicMock()
     mock_workspace.name = "my-ml-workspace"
     mock_workspace.id = "/subscriptions/sub-123/resourceGroups/rg-ai/providers/Microsoft.MachineLearningServices/workspaces/my-ml-workspace"
+    mock_workspace.location = "eastus2"
     mock_system_data = MagicMock()
     mock_system_data.created_at = "2026-04-01T12:00:00Z"
     mock_system_data.last_modified_at = "2026-04-12T09:15:00Z"
@@ -1591,6 +1599,10 @@ def test_azure_ai_foundry_discovered():
     timestamps = ai_agents[0].metadata["cloud_timestamps"]
     assert timestamps["created_at"] == "2026-04-01T12:00:00Z"
     assert timestamps["updated_at"] == "2026-04-12T09:15:00Z"
+    scope = ai_agents[0].metadata["cloud_scope"]
+    assert scope["scope_id"] == "rg-ai"
+    assert scope["parent_scope"]["id"] == "sub-123"
+    assert scope["location"] == "eastus2"
 
 
 def test_azure_container_apps_by_resource_group():
@@ -1731,6 +1743,10 @@ def test_gcp_vertex_ai_endpoints_discovered():
     assert timestamps["created_at"] == "2026-04-05T08:00:00Z"
     assert timestamps["updated_at"] == "2026-04-12T10:30:00Z"
     assert timestamps["sources"]["updated_at"] == "update_time"
+    scope = vertex_agents[0].metadata["cloud_scope"]
+    assert scope["scope_type"] == "project"
+    assert scope["scope_id"] == "my-project"
+    assert scope["location"] == "us-central1"
 
 
 def test_gcp_cloud_run_services_discovered():
@@ -1772,6 +1788,9 @@ def test_gcp_cloud_run_services_discovered():
     assert principal["principal_type"] == "service-account"
     assert principal["principal_id"] == "run-sa@my-project.iam.gserviceaccount.com"
     assert principal["source_field"] == "template.service_account"
+    scope = run_agents[0].metadata["cloud_scope"]
+    assert scope["scope_id"] == "my-project"
+    assert scope["location"] == "us-central1"
 
 
 def test_gcp_cloud_functions_discovered_with_service_account():
@@ -1809,6 +1828,9 @@ def test_gcp_cloud_functions_discovered_with_service_account():
     assert principal["principal_type"] == "service-account"
     assert principal["principal_id"] == "functions-sa@my-project.iam.gserviceaccount.com"
     assert principal["source_field"] == "service_config.service_account_email"
+    scope = fn_agents[0].metadata["cloud_scope"]
+    assert scope["scope_id"] == "my-project"
+    assert scope["location"] == "us-central1"
 
 
 def test_azure_functions_discovered_with_managed_identity():


### PR DESCRIPTION
## Summary
- add a stable cloud_scope envelope for provider hierarchy and placement
- normalize Azure resource group and subscription context for discovered resources
- normalize GCP project and region scope for discovered resources
- keep the change additive so canonical metadata grows without DB or API breakage

## Testing
- uv run pytest -q tests/test_cloud.py tests/test_discovery_enhanced.py
- uv run ruff check src/agent_bom/cloud/normalization.py src/agent_bom/cloud/azure.py src/agent_bom/cloud/gcp.py tests/test_cloud.py
- git -C /tmp/agent-bom-cloud-scope diff --check