### PR TITLE
Normalize canonical event relationships

### DIFF
--- a/src/agent_bom/event_normalization.py
+++ b/src/agent_bom/event_normalization.py
@@ -1,0 +1,145 @@
+"""Canonical event relationship normalization helpers.
+
+These helpers keep event producers source-aware while providing one stable
+relationship envelope for audit logs, graph delta alerts, and later
+event-oriented integrations. The canonical agent-bom model stays primary;
+OCSF remains a projection layered on top when it fits.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_RESOURCE_ARG_TYPES = {
+    "path": "path",
+    "url": "url",
+    "uri": "uri",
+    "resource_id": "resource",
+}
+
+
+def _scalar_attributes(attributes: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not attributes:
+        return {}
+    return {key: value for key, value in attributes.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)}
+
+
+def build_event_ref(
+    *,
+    ref_type: str,
+    ref_id: str,
+    name: str | None = None,
+    role: str | None = None,
+    source_field: str | None = None,
+    attributes: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Return a stable event relationship reference."""
+    if not ref_id:
+        return None
+
+    ref: dict[str, Any] = {
+        "type": ref_type,
+        "id": ref_id,
+    }
+    if name:
+        ref["name"] = name
+    if role:
+        ref["role"] = role
+    if source_field:
+        ref["source_field"] = source_field
+
+    scalar_attrs = _scalar_attributes(attributes)
+    if scalar_attrs:
+        ref["attributes"] = scalar_attrs
+    return ref
+
+
+def build_event_relationships(
+    *,
+    source: str,
+    actor: dict[str, Any] | None = None,
+    targets: list[dict[str, Any]] | None = None,
+    resources: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """Return a stable event relationship envelope."""
+    clean_targets = [target for target in (targets or []) if target]
+    clean_resources = [resource for resource in (resources or []) if resource]
+    if actor is None and not clean_targets and not clean_resources:
+        return None
+
+    envelope: dict[str, Any] = {
+        "normalization_version": "1",
+        "source": source,
+    }
+    if actor is not None:
+        envelope["actor"] = actor
+    if clean_targets:
+        envelope["targets"] = clean_targets
+    if clean_resources:
+        envelope["resources"] = clean_resources
+    return envelope
+
+
+def build_proxy_event_relationships(
+    *,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    agent_id: str | None,
+    anonymous_id: str,
+) -> dict[str, Any] | None:
+    """Normalize proxy tool-call relationships.
+
+    Tool calls expose a concrete target (the invoked tool), and may expose a
+    concrete caller identity when agent identity is resolved. Resource
+    references are only extracted from a small allowlist of direct argument
+    fields to avoid guesswork.
+    """
+    actor = None
+    if agent_id and agent_id != anonymous_id:
+        actor = build_event_ref(
+            ref_type="agent",
+            ref_id=agent_id,
+            name=agent_id,
+            role="caller",
+            source_field="agent_id",
+        )
+
+    targets: list[dict[str, Any]] = []
+    tool_target = build_event_ref(
+        ref_type="tool",
+        ref_id=tool_name,
+        name=tool_name,
+        role="invoked_tool",
+        source_field="tool",
+    )
+    if tool_target is not None:
+        targets.append(tool_target)
+
+    seen: set[tuple[str, str, str]] = set()
+    resources: list[dict[str, Any]] = []
+    for field_name, value in arguments.items():
+        resource_type = _RESOURCE_ARG_TYPES.get(field_name)
+        if resource_type is None or not isinstance(value, (str, int, float, bool)) or value in ("", None):
+            continue
+        resource_id = str(value)
+        dedupe_key = (resource_type, resource_id, field_name)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        resource = build_event_ref(
+            ref_type=resource_type,
+            ref_id=resource_id,
+            name=resource_id,
+            role="referenced_input",
+            source_field=field_name,
+        )
+        if resource is not None:
+            resources.append(resource)
+
+    return build_event_relationships(
+        source="proxy_tool_call",
+        actor=actor,
+        targets=targets,
+        resources=resources,
+    )

--- a/src/agent_bom/graph/webhooks.py
+++ b/src/agent_bom/graph/webhooks.py
@@ -16,11 +16,48 @@ import logging
 import os
 from typing import Any
 
+from agent_bom.event_normalization import build_event_ref, build_event_relationships
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.severity import SEVERITY_RANK
 from agent_bom.graph.types import EntityType
 
 logger = logging.getLogger(__name__)
+
+
+def _graph_node_ref(
+    graph: UnifiedGraph | None,
+    node_id: str,
+    *,
+    role: str,
+) -> dict[str, Any] | None:
+    """Resolve one graph node into a canonical event target reference."""
+    if graph is None:
+        return None
+    node = graph.nodes.get(node_id)
+    if node is None:
+        return None
+    return build_event_ref(
+        ref_type=node.entity_type.value,
+        ref_id=node.id,
+        name=node.label,
+        role=role,
+        attributes={
+            "severity": node.severity,
+            "status": node.status.value if hasattr(node.status, "value") else str(node.status),
+            "risk_score": node.risk_score,
+        },
+    )
+
+
+def _graph_relationships(
+    *,
+    graph: UnifiedGraph | None,
+    targets: list[tuple[str, str]],
+    source: str = "graph_delta",
+) -> dict[str, Any] | None:
+    """Build an additive canonical relationship envelope for delta alerts."""
+    target_refs = [_graph_node_ref(graph, node_id, role=role) for node_id, role in targets]
+    return build_event_relationships(source=source, targets=[ref for ref in target_refs if ref])
 
 
 def _dispatch_outbound_alert(dispatcher: Any, alert: dict[str, Any], outbound_channels: int) -> tuple[int, int]:
@@ -73,6 +110,10 @@ def compute_delta_alerts(
                     "node_ids": [nid],
                     "scan_id": new_graph.scan_id,
                     "details": details,
+                    "event_relationships": _graph_relationships(
+                        graph=new_graph,
+                        targets=[(nid, "affected_finding")],
+                    ),
                     "attributes": {
                         "cvss_score": node.attributes.get("cvss_score"),
                         "is_kev": node.attributes.get("is_kev", False),
@@ -102,6 +143,10 @@ def compute_delta_alerts(
                     "node_ids": [nid],
                     "scan_id": new_graph.scan_id,
                     "details": details,
+                    "event_relationships": _graph_relationships(
+                        graph=new_graph,
+                        targets=[(nid, "affected_finding")],
+                    ),
                 }
             )
 
@@ -131,6 +176,13 @@ def compute_delta_alerts(
                     "node_ids": path.hops,
                     "scan_id": new_graph.scan_id,
                     "details": details,
+                    "event_relationships": _graph_relationships(
+                        graph=new_graph,
+                        targets=[
+                            (path.source, "path_source"),
+                            (path.target, "path_target"),
+                        ],
+                    ),
                     "attributes": {
                         "composite_risk": path.composite_risk,
                         "credential_exposure": path.credential_exposure,
@@ -166,6 +218,10 @@ def compute_delta_alerts(
                     "node_ids": node_ids,
                     "scan_id": new_graph.scan_id,
                     "details": details,
+                    "event_relationships": _graph_relationships(
+                        graph=new_graph,
+                        targets=[(node_id, "affected_agent") for node_id in node_ids],
+                    ),
                     "attributes": {
                         "risk_score": risk.risk_score,
                         "pattern": risk.pattern,
@@ -195,6 +251,10 @@ def compute_delta_alerts(
                     "node_ids": agent_removed,
                     "scan_id": new_graph.scan_id,
                     "details": details,
+                    "event_relationships": _graph_relationships(
+                        graph=old_graph,
+                        targets=[(node_id, "removed_agent") for node_id in agent_removed],
+                    ),
                 }
             )
 

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -29,6 +29,7 @@ from urllib.parse import urlparse
 
 from agent_bom.agent_identity import ANONYMOUS, check_identity
 from agent_bom.async_stdin import create_async_stdin_reader, read_async_stdin_line
+from agent_bom.event_normalization import build_proxy_event_relationships
 from agent_bom.permissions import classify_tool
 from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call, scan_tool_response
 from agent_bom.security import validate_arguments, validate_command
@@ -525,6 +526,14 @@ def log_tool_call(
         record["payload_sha256"] = payload_sha256
     if message_id is not None:
         record["message_id"] = message_id
+    event_relationships = build_proxy_event_relationships(
+        tool_name=tool_name,
+        arguments=arguments,
+        agent_id=agent_id,
+        anonymous_id=ANONYMOUS,
+    )
+    if event_relationships is not None:
+        record["event_relationships"] = event_relationships
 
     log_file.write(json.dumps(record) + "\n")
     log_file.flush()

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -244,6 +244,8 @@ def test_log_tool_call_agent_id_written():
     buf.seek(0)
     record = json.loads(buf.readline())
     assert record["agent_id"] == "agent-eve"
+    assert record["event_relationships"]["actor"]["id"] == "agent-eve"
+    assert record["event_relationships"]["actor"]["role"] == "caller"
 
 
 def test_log_tool_call_anonymous_default():
@@ -252,6 +254,7 @@ def test_log_tool_call_anonymous_default():
     buf.seek(0)
     record = json.loads(buf.readline())
     assert record["agent_id"] == ANONYMOUS
+    assert "actor" not in record["event_relationships"]
 
 
 def test_log_tool_call_blocked_carries_agent_id():
@@ -261,3 +264,4 @@ def test_log_tool_call_blocked_carries_agent_id():
     record = json.loads(buf.readline())
     assert record["agent_id"] == "bad-bot"
     assert record["policy"] == "blocked"
+    assert record["event_relationships"]["actor"]["id"] == "bad-bot"

--- a/tests/test_graph_wave23.py
+++ b/tests/test_graph_wave23.py
@@ -12,6 +12,7 @@ import pytest
 
 from agent_bom.db.graph_store import _init_db, load_graph, save_graph
 from agent_bom.graph import (
+    AttackPath,
     EntityType,
     RelationshipType,
     UnifiedEdge,
@@ -128,6 +129,8 @@ class TestDeltaAlerts:
         assert len(vuln_alerts) == 1
         assert vuln_alerts[0]["severity"] == "critical"
         assert "CVE-1" in vuln_alerts[0]["title"]
+        assert vuln_alerts[0]["event_relationships"]["targets"][0]["id"] == "vuln:CVE-1"
+        assert vuln_alerts[0]["event_relationships"]["targets"][0]["role"] == "affected_finding"
 
     def test_no_alert_for_existing_vuln(self):
         from agent_bom.graph.webhooks import compute_delta_alerts
@@ -212,6 +215,31 @@ class TestDeltaAlerts:
         assert first["message"] == first["title"]
         assert first["details"]["risk_score"] == 9.5
         assert first["details"]["cvss_score"] == 9.8
+
+    def test_attack_path_alert_relationships(self):
+        from agent_bom.graph.webhooks import compute_delta_alerts
+
+        new = UnifiedGraph(scan_id="s1")
+        new.add_node(UnifiedNode(id="package:demo", entity_type=EntityType.PACKAGE, label="demo-pkg"))
+        new.add_node(UnifiedNode(id="agent:prod", entity_type=EntityType.AGENT, label="prod-agent"))
+        new.attack_paths.append(
+            AttackPath(
+                source="package:demo",
+                target="agent:prod",
+                hops=["package:demo", "agent:prod"],
+                composite_risk=8.0,
+                summary="demo-pkg -> prod-agent",
+            )
+        )
+
+        alerts = compute_delta_alerts(None, new)
+        attack_alerts = [a for a in alerts if a["type"] == "new_attack_path"]
+        assert len(attack_alerts) == 1
+        refs = attack_alerts[0]["event_relationships"]["targets"]
+        assert refs[0]["id"] == "package:demo"
+        assert refs[0]["role"] == "path_source"
+        assert refs[1]["id"] == "agent:prod"
+        assert refs[1]["role"] == "path_target"
 
     def test_dispatch_delta_alerts_without_outbound_channels(self, monkeypatch):
         from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts

--- a/tests/test_proxy_helpers.py
+++ b/tests/test_proxy_helpers.py
@@ -181,6 +181,9 @@ def test_log_tool_call_basic():
     assert record["type"] == "tools/call"
     assert record["tool"] == "read_file"
     assert record["policy"] == "allowed"
+    assert record["event_relationships"]["source"] == "proxy_tool_call"
+    assert record["event_relationships"]["targets"][0]["id"] == "read_file"
+    assert record["event_relationships"]["resources"][0]["id"] == "/tmp"
 
 
 def test_log_tool_call_blocked():
@@ -192,6 +195,7 @@ def test_log_tool_call_blocked():
     assert record["reason"] == "undeclared"
     assert record["payload_sha256"] == "abc123"
     assert record["message_id"] == 42
+    assert record["event_relationships"]["targets"][0]["id"] == "exec"
 
 
 def test_log_tool_call_no_optional_fields():
@@ -202,6 +206,8 @@ def test_log_tool_call_no_optional_fields():
     assert "reason" not in record
     assert "payload_sha256" not in record
     assert "message_id" not in record
+    assert record["event_relationships"]["targets"][0]["id"] == "test_tool"
+    assert "resources" not in record["event_relationships"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a canonical event relationship helper for actor, target, and resource references
- attach normalized event relationships to proxy tool-call audit records and graph delta alerts
- extend proxy and graph tests so event producers stay additive and canonical-model first

## Validation
- uv run pytest -q tests/test_agent_identity.py tests/test_proxy_helpers.py tests/test_graph_wave23.py
- uv run ruff check src/agent_bom/event_normalization.py src/agent_bom/proxy.py src/agent_bom/graph/webhooks.py tests/test_agent_identity.py tests/test_proxy_helpers.py tests/test_graph_wave23.py
- uv run mypy src/agent_bom/event_normalization.py
- git diff --check