### PR TITLE
Verify provider lifecycle state mappings

### DIFF
--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -22,7 +22,7 @@ from typing import Any
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_state
+from .normalization import build_cloud_origin, build_cloud_state, normalize_cloud_lifecycle_state
 
 logger = logging.getLogger(__name__)
 
@@ -213,8 +213,13 @@ def _discover_bedrock(session: Any, region: str) -> tuple[list[Agent], list[str]
             agent_id = summary["agentId"]
             agent_name = summary.get("agentName", agent_id)
             agent_status = summary.get("agentStatus", "UNKNOWN")
-
-            if agent_status not in ("PREPARED", "NOT_PREPARED"):
+            lifecycle_state = normalize_cloud_lifecycle_state(
+                provider="aws",
+                service="bedrock",
+                resource_type="agent",
+                raw_state=agent_status,
+            )
+            if lifecycle_state is None:
                 continue
 
             try:
@@ -254,7 +259,7 @@ def _discover_bedrock(session: Any, region: str) -> tuple[list[Agent], list[str]
                         provider="aws",
                         service="bedrock",
                         resource_type="agent",
-                        lifecycle_state=agent_status.lower().replace("_", "-"),
+                        lifecycle_state=lifecycle_state,
                         raw_state=agent_status,
                         state_source="agentStatus",
                     ),

--- a/src/agent_bom/cloud/databricks.py
+++ b/src/agent_bom/cloud/databricks.py
@@ -28,7 +28,7 @@ from typing import Any, Optional
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_state
+from .normalization import build_cloud_state, normalize_cloud_lifecycle_state
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,13 @@ def discover(
 
         # Only scan running or terminated (recently used) clusters
         state_str = str(state).upper() if state else ""
-        if state_str not in ("RUNNING", "TERMINATED", "RESIZING"):
+        lifecycle_state = normalize_cloud_lifecycle_state(
+            provider="databricks",
+            service="clusters",
+            resource_type="cluster",
+            raw_state=state_str,
+        )
+        if lifecycle_state is None:
             continue
 
         packages = _get_cluster_packages(ws, cluster_id, warnings)
@@ -113,7 +119,7 @@ def discover(
                     provider="databricks",
                     service="clusters",
                     resource_type="cluster",
-                    lifecycle_state=state_str.lower().replace("_", "-"),
+                    lifecycle_state=lifecycle_state,
                     raw_state=state_str,
                     state_source="cluster.state",
                 )
@@ -131,7 +137,13 @@ def discover(
             # the raw string ("READY" / "NOT_READY") rather than the repr.
             ready_enum = getattr(ep_state, "ready", None) if ep_state else None
             state_str = getattr(ready_enum, "value", str(ready_enum or "")).upper()
-            if state_str not in ("READY", "NOT_READY"):
+            lifecycle_state = normalize_cloud_lifecycle_state(
+                provider="databricks",
+                service="model-serving",
+                resource_type="serving-endpoint",
+                raw_state=state_str,
+            )
+            if lifecycle_state is None:
                 continue
 
             server = MCPServer(
@@ -150,7 +162,7 @@ def discover(
                         provider="databricks",
                         service="model-serving",
                         resource_type="serving-endpoint",
-                        lifecycle_state=state_str.lower().replace("_", "-"),
+                        lifecycle_state=lifecycle_state,
                         raw_state=state_str,
                         state_source="state.ready",
                     )

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -5,6 +5,42 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+_LIFECYCLE_STATE_MAPS: dict[tuple[str, str, str], dict[str, str]] = {
+    ("aws", "bedrock", "agent"): {
+        "PREPARED": "prepared",
+        "NOT_PREPARED": "not-prepared",
+    },
+    ("databricks", "clusters", "cluster"): {
+        "RUNNING": "running",
+        "RESIZING": "resizing",
+        "RESTARTING": "restarting",
+        "TERMINATED": "terminated",
+    },
+    ("databricks", "model-serving", "serving-endpoint"): {
+        "READY": "ready",
+        "NOT_READY": "not-ready",
+    },
+}
+
+
+def normalize_cloud_lifecycle_state(
+    *,
+    provider: str,
+    service: str,
+    resource_type: str,
+    raw_state: Any,
+) -> str | None:
+    """Map raw provider lifecycle values to canonical states.
+
+    Returns ``None`` when a source value is not part of the verified mapping.
+    That lets discovery code skip unknown states until the mapping is reviewed
+    and explicitly added, instead of silently guessing.
+    """
+    if raw_state in ("", None):
+        return None
+    mapping = _LIFECYCLE_STATE_MAPS.get((provider, service, resource_type), {})
+    return mapping.get(str(raw_state).strip().upper())
+
 
 def build_cloud_origin(
     *,

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 from agent_bom.cli import main
 from agent_bom.cloud import CloudDiscoveryError, discover_from_provider
 from agent_bom.cloud.base import CloudDiscoveryError as BaseCloudError
+from agent_bom.cloud.normalization import normalize_cloud_lifecycle_state
 from agent_bom.models import (
     Agent,
     AgentType,
@@ -197,6 +198,26 @@ def test_aws_bedrock_agents_discovered():
     assert state["state_source"] == "agentStatus"
 
 
+@pytest.mark.parametrize(
+    ("raw_state", "expected"),
+    [
+        ("PREPARED", "prepared"),
+        ("NOT_PREPARED", "not-prepared"),
+        ("UNKNOWN", None),
+    ],
+)
+def test_aws_bedrock_lifecycle_mapping(raw_state, expected):
+    assert (
+        normalize_cloud_lifecycle_state(
+            provider="aws",
+            service="bedrock",
+            resource_type="agent",
+            raw_state=raw_state,
+        )
+        == expected
+    )
+
+
 def test_aws_no_credentials_returns_warning():
     """NoCredentialsError becomes a warning, not an unhandled exception."""
     _, botocore_exc = _install_mock_boto3()
@@ -339,6 +360,28 @@ def test_databricks_cluster_packages():
     assert state["state_source"] == "cluster.state"
 
 
+@pytest.mark.parametrize(
+    ("raw_state", "expected"),
+    [
+        ("RUNNING", "running"),
+        ("RESIZING", "resizing"),
+        ("RESTARTING", "restarting"),
+        ("TERMINATED", "terminated"),
+        ("PENDING", None),
+    ],
+)
+def test_databricks_cluster_lifecycle_mapping(raw_state, expected):
+    assert (
+        normalize_cloud_lifecycle_state(
+            provider="databricks",
+            service="clusters",
+            resource_type="cluster",
+            raw_state=raw_state,
+        )
+        == expected
+    )
+
+
 def test_databricks_serving_endpoint_state_normalized():
     """Serving endpoints carry normalized readiness state for downstream consumers."""
     _install_mock_databricks()
@@ -371,6 +414,26 @@ def test_databricks_serving_endpoint_state_normalized():
     assert state["lifecycle_state"] == "ready"
     assert state["raw_state"] == "READY"
     assert state["state_source"] == "state.ready"
+
+
+@pytest.mark.parametrize(
+    ("raw_state", "expected"),
+    [
+        ("READY", "ready"),
+        ("NOT_READY", "not-ready"),
+        ("UPDATING", None),
+    ],
+)
+def test_databricks_serving_lifecycle_mapping(raw_state, expected):
+    assert (
+        normalize_cloud_lifecycle_state(
+            provider="databricks",
+            service="model-serving",
+            resource_type="serving-endpoint",
+            raw_state=raw_state,
+        )
+        == expected
+    )
 
 
 def test_databricks_maven_packages():


### PR DESCRIPTION
## Summary
- replace inline lifecycle string transforms with explicit provider-specific state maps
- verify the accepted raw lifecycle values for AWS Bedrock and Databricks in tests
- return None for unknown raw states so vendor drift is caught instead of silently normalized

## Validation
- uv run pytest -q tests/test_cloud.py tests/test_discovery_enhanced.py
- uv run ruff check src/agent_bom/cloud/normalization.py src/agent_bom/cloud/aws.py src/agent_bom/cloud/databricks.py tests/test_cloud.py
- git diff --check