### PR TITLE
Fix tenant scoping for SQLite job-backed aggregates

### DIFF
--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -216,18 +216,33 @@ class PostgresJobStore:
             conn.commit()
             return cursor.rowcount > 0
 
-    def list_all(self) -> list:
+    def list_all(self, tenant_id: str | None = None) -> list:
         from .server import ScanJob
 
         with _tenant_connection(self._pool) as conn:
-            rows = conn.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC").fetchall()
+            if tenant_id is None:
+                rows = conn.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC").fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT data FROM scan_jobs WHERE team_id = %s ORDER BY created_at DESC",
+                    (tenant_id,),
+                ).fetchall()
             return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
-    def list_summary(self) -> list[dict]:
+    def list_summary(self, tenant_id: str | None = None) -> list[dict]:
         with _tenant_connection(self._pool) as conn:
-            rows = conn.execute(
-                "SELECT job_id, team_id, status, created_at, completed_at FROM scan_jobs ORDER BY created_at DESC"
-            ).fetchall()
+            if tenant_id is None:
+                rows = conn.execute(
+                    "SELECT job_id, team_id, status, created_at, completed_at FROM scan_jobs ORDER BY created_at DESC"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """SELECT job_id, team_id, status, created_at, completed_at
+                       FROM scan_jobs
+                       WHERE team_id = %s
+                       ORDER BY created_at DESC""",
+                    (tenant_id,),
+                ).fetchall()
             return [{"job_id": r[0], "tenant_id": r[1], "status": r[2], "created_at": r[3], "completed_at": r[4]} for r in rows]
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_store
@@ -27,8 +27,16 @@ if TYPE_CHECKING:
 router = APIRouter()
 
 
+def _tenant_id(request: Request) -> str:
+    return getattr(request.state, "tenant_id", "default")
+
+
+def _tenant_jobs(request: Request) -> list:
+    return _get_store().list_all(tenant_id=_tenant_id(request))
+
+
 @router.get("/v1/compliance", tags=["compliance"])
-async def get_compliance() -> dict:
+async def get_compliance(request: Request) -> dict:
     """Aggregate OWASP LLM Top 10, OWASP MCP Top 10, MITRE ATLAS, NIST AI RMF,
     OWASP Agentic Top 10, and EU AI Act compliance posture across all completed scans.
 
@@ -46,7 +54,7 @@ async def get_compliance() -> dict:
     has_agent_context = False
     all_scan_sources: set[str] = set()
 
-    for job in _get_store().list_all():
+    for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:
             continue
         scan_count += 1
@@ -257,7 +265,7 @@ async def get_compliance() -> dict:
 # ─── Compliance Narrative ─────────────────────────────────────────────────
 
 
-def _latest_report() -> "AIBOMReport | None":
+def _latest_report(request: Request) -> "AIBOMReport | None":
     """Return a synthetic AIBOMReport built from the latest completed scan result.
 
     The narrative generator expects a real ``AIBOMReport`` model object, but the
@@ -281,7 +289,7 @@ def _latest_report() -> "AIBOMReport | None":
     total_agents_count = 0
     total_packages_count = 0
 
-    for job in _get_store().list_all():
+    for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:
             continue
         all_blast_dicts.extend(job.result.get("blast_radius", []))
@@ -397,7 +405,7 @@ def _narrative_to_dict(narrative: "ComplianceNarrative") -> dict:
 
 
 @router.get("/v1/compliance/narrative", tags=["compliance"])
-async def get_compliance_narrative() -> dict:
+async def get_compliance_narrative(request: Request) -> dict:
     """Generate an auditor-ready compliance narrative from all completed scans.
 
     Produces human-readable stories for all 11 supported frameworks, a
@@ -411,7 +419,7 @@ async def get_compliance_narrative() -> dict:
         generate_compliance_narrative,
     )
 
-    report = _latest_report()
+    report = _latest_report(request)
     if report is None:
         return {
             "executive_summary": "No completed scans available. Run agent-bom scan first.",
@@ -426,7 +434,7 @@ async def get_compliance_narrative() -> dict:
 
 
 @router.get("/v1/compliance/narrative/{framework}", tags=["compliance"])
-async def get_compliance_narrative_by_framework(framework: str) -> dict:
+async def get_compliance_narrative_by_framework(request: Request, framework: str) -> dict:
     """Generate a single-framework compliance narrative.
 
     Supported framework slugs: owasp-llm, owasp-mcp, atlas, nist,
@@ -446,7 +454,7 @@ async def get_compliance_narrative_by_framework(framework: str) -> dict:
             detail=(f"Unknown framework '{framework}'. Supported: {', '.join(ALL_FRAMEWORK_SLUGS)}"),
         )
 
-    report = _latest_report()
+    report = _latest_report(request)
     if report is None:
         return {
             "executive_summary": "No completed scans available. Run agent-bom scan first.",
@@ -461,13 +469,13 @@ async def get_compliance_narrative_by_framework(framework: str) -> dict:
 
 
 @router.get("/v1/compliance/{framework}", tags=["compliance"])
-async def get_compliance_by_framework(framework: str) -> dict:
+async def get_compliance_by_framework(request: Request, framework: str) -> dict:
     """Get compliance posture for a single framework.
 
     Supported frameworks: owasp-llm, owasp-mcp, atlas, nist, owasp-agentic, eu-ai-act,
     nist-csf, iso-27001, soc2, cis, cmmc
     """
-    full = await get_compliance()
+    full = await get_compliance(request)
 
     framework_map = {
         "owasp-llm": "owasp_llm_top10",
@@ -510,7 +518,7 @@ async def get_compliance_by_framework(framework: str) -> dict:
 
 
 @router.get("/v1/posture", tags=["compliance"])
-async def get_posture_scorecard() -> dict:
+async def get_posture_scorecard(request: Request) -> dict:
     """Compute enterprise posture scorecard from the latest completed scan.
 
     Returns a letter grade (A-F), numeric score (0-100), and per-dimension
@@ -518,7 +526,7 @@ async def get_posture_scorecard() -> dict:
     chain quality, compliance coverage, active exploitation, and configuration.
     """
     latest_result = None
-    for job in _get_store().list_all():
+    for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:
             continue
         latest_result = job.result
@@ -545,7 +553,7 @@ async def get_posture_scorecard() -> dict:
 
 
 @router.get("/v1/posture/counts", tags=["compliance"])
-async def get_posture_counts() -> dict:
+async def get_posture_counts(request: Request) -> dict:
     """Aggregate vulnerability counts across all completed scans.
 
     Lightweight endpoint used by the dashboard nav to show Critical/High
@@ -569,7 +577,7 @@ async def get_posture_counts() -> dict:
     all_scan_sources: set[str] = set()
     scan_count = 0
 
-    for job in _get_store().list_all():
+    for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:
             continue
         scan_count += 1
@@ -608,14 +616,14 @@ async def get_posture_counts() -> dict:
 
 
 @router.get("/v1/posture/credentials", tags=["compliance"])
-async def get_credential_risk_ranking() -> dict:
+async def get_credential_risk_ranking(request: Request) -> dict:
     """Rank credentials by blast radius exposure from the latest scan.
 
     Returns credentials sorted by risk tier (critical to low) with
     associated vulnerability counts and affected agents.
     """
     latest_result = None
-    for job in _get_store().list_all():
+    for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:
             continue
         latest_result = job.result
@@ -629,14 +637,14 @@ async def get_credential_risk_ranking() -> dict:
 
 
 @router.get("/v1/posture/incidents", tags=["compliance"])
-async def get_incident_correlation() -> dict:
+async def get_incident_correlation(request: Request) -> dict:
     """Group vulnerabilities by agent for SOC incident correlation.
 
     Returns agent-centric incident summaries with priority (P1-P4),
     severity counts, credential exposure, and recommended actions.
     """
     latest_result = None
-    for job in _get_store().list_all():
+    for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:
             continue
         latest_result = job.result

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_store
@@ -19,6 +19,10 @@ from agent_bom.security import sanitize_error
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
+
+
+def _tenant_id(request: Request) -> str:
+    return getattr(request.state, "tenant_id", "default")
 
 
 @router.get("/v1/agents", tags=["discovery"])
@@ -49,7 +53,7 @@ async def list_agents() -> dict:
 
 
 @router.get("/v1/agents/{agent_name}", tags=["discovery"])
-async def get_agent_detail(agent_name: str) -> dict:
+async def get_agent_detail(request: Request, agent_name: str) -> dict:
     """Get detailed view of a single agent with cross-referenced scan data."""
     try:
         from dataclasses import asdict
@@ -73,7 +77,7 @@ async def get_agent_detail(agent_name: str) -> dict:
 
         # Cross-reference blast radii from completed scans
         agent_blast: list[dict] = []
-        for job in _get_store().list_all():
+        for job in _get_store().list_all(tenant_id=_tenant_id(request)):
             if job.status != JobStatus.DONE or not job.result:
                 continue
             for br in job.result.get("blast_radius", []):
@@ -113,14 +117,14 @@ async def get_agent_detail(agent_name: str) -> dict:
 
 
 @router.get("/v1/agents/{agent_name}/lifecycle", tags=["discovery"])
-async def get_agent_lifecycle(agent_name: str) -> dict:
+async def get_agent_lifecycle(request: Request, agent_name: str) -> dict:
     """Get React Flow nodes/edges for an agent's full lifecycle graph.
 
     Shows: Agent -> MCP Servers -> Tools/Credentials -> Packages -> CVEs
     """
     from agent_bom.output.attack_flow import _severity_color
 
-    detail = await get_agent_detail(agent_name)
+    detail = await get_agent_detail(request, agent_name)
     agent_data = detail["agent"]
 
     nodes: list[dict] = []
@@ -296,7 +300,7 @@ async def get_agent_lifecycle(agent_name: str) -> dict:
 
 
 @router.get("/v1/agents/mesh", tags=["discovery"])
-async def get_agent_mesh() -> dict:
+async def get_agent_mesh(request: Request) -> dict:
     """Get a ReactFlow-compatible mesh topology of all discovered agents.
 
     Shows agents, their MCP servers, tools, and vulnerability overlay
@@ -319,7 +323,7 @@ async def get_agent_mesh() -> dict:
 
         # Gather blast radius from completed scans for vuln overlay
         all_blast: list[dict] = []
-        for job in _get_store().list_all():
+        for job in _get_store().list_all(tenant_id=_tenant_id(request)):
             if job.status == JobStatus.DONE and job.result:
                 all_blast.extend(job.result.get("blast_radius", []))
 

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -27,8 +27,12 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _tenant_id(request: Request) -> str:
+    return getattr(request.state, "tenant_id", "default")
+
+
 @router.post("/v1/traces", tags=["observability"])
-async def ingest_traces(body: dict) -> dict:
+async def ingest_traces(request: Request, body: dict) -> dict:
     """Ingest OpenTelemetry trace data and flag vulnerable tool calls.
 
     Accepts OTLP JSON format traces containing `adk.tool.*` spans.
@@ -45,7 +49,7 @@ async def ingest_traces(body: dict) -> dict:
         # Gather vulnerable packages and servers from scan history
         vuln_packages: dict[str, set[str]] = defaultdict(set)
         vuln_servers: dict[str, set[str]] = defaultdict(set)
-        for job in _get_store().list_all():
+        for job in _get_store().list_all(tenant_id=_tenant_id(request)):
             if job.status == JobStatus.DONE and job.result:
                 for br in job.result.get("blast_radius", []):
                     cve_id = br.get("vulnerability_id", "")
@@ -97,7 +101,7 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
     """
     job = ScanJob(
         job_id=str(uuid.uuid4()),
-        tenant_id=getattr(request.state, "tenant_id", "default"),
+        tenant_id=_tenant_id(request),
         created_at=_now(),
         request=ScanRequest(),
     )

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -160,7 +160,7 @@ async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
     # Enforce max concurrent jobs
     store = _get_store()
     tenant_id = _tenant_id(request)
-    active = sum(1 for j in store.list_all() if _visible_to_tenant(j, tenant_id) and j.status in (JobStatus.PENDING, JobStatus.RUNNING))
+    active = sum(1 for j in store.list_all(tenant_id=tenant_id) if j.status in (JobStatus.PENDING, JobStatus.RUNNING))
     if active >= _MAX_CONCURRENT_JOBS:
         raise HTTPException(
             status_code=429,
@@ -505,7 +505,7 @@ async def list_jobs(
     offset = max(0, offset)
     tenant_id = _tenant_id(request)
     store = _get_store()
-    summary = [j for j in store.list_summary() if j.get("tenant_id", "default") == tenant_id]
+    summary = store.list_summary(tenant_id=tenant_id)
     total = len(summary)
     page = summary[offset : offset + limit]
     enriched: list[dict[str, Any]] = []

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -84,9 +84,11 @@ class SnowflakeJobStore:
                     status VARCHAR NOT NULL,
                     created_at TIMESTAMP_TZ NOT NULL,
                     completed_at TIMESTAMP_TZ,
+                    tenant_id VARCHAR NOT NULL DEFAULT 'default',
                     data VARIANT NOT NULL
                 )
             """)
+            conn.cursor().execute("ALTER TABLE scan_jobs ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
 
     def put(self, job: ScanJob) -> None:
         with self._connect() as conn:
@@ -94,21 +96,23 @@ class SnowflakeJobStore:
                 """MERGE INTO scan_jobs t USING (SELECT %s AS job_id) s
                    ON t.job_id = s.job_id
                    WHEN MATCHED THEN UPDATE SET
-                     status = %s, created_at = %s, completed_at = %s,
+                     status = %s, created_at = %s, completed_at = %s, tenant_id = %s,
                      data = PARSE_JSON(%s)
                    WHEN NOT MATCHED THEN INSERT
-                     (job_id, status, created_at, completed_at, data)
-                     VALUES (%s, %s, %s, %s, PARSE_JSON(%s))""",
+                     (job_id, status, created_at, completed_at, tenant_id, data)
+                     VALUES (%s, %s, %s, %s, %s, PARSE_JSON(%s))""",
                 (
                     job.job_id,
                     job.status.value,
                     job.created_at,
                     job.completed_at,
+                    job.tenant_id,
                     job.model_dump_json(),
                     job.job_id,
                     job.status.value,
                     job.created_at,
                     job.completed_at,
+                    job.tenant_id,
                     job.model_dump_json(),
                 ),
             )
@@ -131,29 +135,35 @@ class SnowflakeJobStore:
     def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC")
-            jobs = [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
             if tenant_id is None:
-                return jobs
-            return [job for job in jobs if job.tenant_id == tenant_id]
+                cur.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC")
+            else:
+                cur.execute("SELECT data FROM scan_jobs WHERE tenant_id = %s ORDER BY created_at DESC", (tenant_id,))
+            return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
 
     def list_summary(self, tenant_id: str | None = None) -> list[dict]:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT data, job_id, status, created_at, completed_at FROM scan_jobs ORDER BY created_at DESC")
-            rows = [
+            if tenant_id is None:
+                cur.execute("SELECT job_id, tenant_id, status, created_at, completed_at FROM scan_jobs ORDER BY created_at DESC")
+            else:
+                cur.execute(
+                    """SELECT job_id, tenant_id, status, created_at, completed_at
+                       FROM scan_jobs
+                       WHERE tenant_id = %s
+                       ORDER BY created_at DESC""",
+                    (tenant_id,),
+                )
+            return [
                 {
-                    "tenant_id": ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])).tenant_id,
-                    "job_id": r[1],
+                    "job_id": r[0],
+                    "tenant_id": r[1],
                     "status": r[2],
                     "created_at": str(r[3]) if r[3] else None,
                     "completed_at": str(r[4]) if r[4] else None,
                 }
                 for r in cur.fetchall()
             ]
-            if tenant_id is None:
-                return rows
-            return [row for row in rows if row["tenant_id"] == tenant_id]
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         with self._connect() as conn:

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -128,25 +128,32 @@ class SnowflakeJobStore:
             cur.execute("DELETE FROM scan_jobs WHERE job_id = %s", (job_id,))
             return (cur.rowcount or 0) > 0
 
-    def list_all(self) -> list[ScanJob]:
+    def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC")
-            return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+            jobs = [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+            if tenant_id is None:
+                return jobs
+            return [job for job in jobs if job.tenant_id == tenant_id]
 
-    def list_summary(self) -> list[dict]:
+    def list_summary(self, tenant_id: str | None = None) -> list[dict]:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT job_id, status, created_at, completed_at FROM scan_jobs ORDER BY created_at DESC")
-            return [
+            cur.execute("SELECT data, job_id, status, created_at, completed_at FROM scan_jobs ORDER BY created_at DESC")
+            rows = [
                 {
-                    "job_id": r[0],
-                    "status": r[1],
-                    "created_at": str(r[2]) if r[2] else None,
-                    "completed_at": str(r[3]) if r[3] else None,
+                    "tenant_id": ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])).tenant_id,
+                    "job_id": r[1],
+                    "status": r[2],
+                    "created_at": str(r[3]) if r[3] else None,
+                    "completed_at": str(r[4]) if r[4] else None,
                 }
                 for r in cur.fetchall()
             ]
+            if tenant_id is None:
+                return rows
+            return [row for row in rows if row["tenant_id"] == tenant_id]
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         with self._connect() as conn:

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -23,8 +23,8 @@ class JobStore(Protocol):
     def put(self, job: ScanJob) -> None: ...
     def get(self, job_id: str) -> ScanJob | None: ...
     def delete(self, job_id: str) -> bool: ...
-    def list_all(self) -> list[ScanJob]: ...
-    def list_summary(self) -> list[dict]: ...
+    def list_all(self, tenant_id: str | None = None) -> list[ScanJob]: ...
+    def list_summary(self, tenant_id: str | None = None) -> list[dict]: ...
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int: ...
 
 
@@ -50,13 +50,16 @@ class InMemoryJobStore:
                 return True
             return False
 
-    def list_all(self) -> list[ScanJob]:
+    def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
         with self._lock:
-            return list(self._jobs.values())
+            jobs = list(self._jobs.values())
+            if tenant_id is None:
+                return jobs
+            return [job for job in jobs if job.tenant_id == tenant_id]
 
-    def list_summary(self) -> list[dict]:
+    def list_summary(self, tenant_id: str | None = None) -> list[dict]:
         with self._lock:
-            return [
+            rows = [
                 {
                     "job_id": j.job_id,
                     "tenant_id": j.tenant_id,
@@ -66,6 +69,9 @@ class InMemoryJobStore:
                 }
                 for j in self._jobs.values()
             ]
+            if tenant_id is None:
+                return rows
+            return [row for row in rows if row["tenant_id"] == tenant_id]
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         with self._lock:
@@ -149,14 +155,29 @@ class SQLiteJobStore:
         self._conn.commit()
         return cursor.rowcount > 0
 
-    def list_all(self) -> list[ScanJob]:
-        rows = self._conn.execute("SELECT data FROM jobs ORDER BY created_at DESC").fetchall()
+    def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
+        if tenant_id is None:
+            rows = self._conn.execute("SELECT data FROM jobs ORDER BY created_at DESC").fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT data FROM jobs WHERE tenant_id = ? ORDER BY created_at DESC",
+                (tenant_id,),
+            ).fetchall()
         return [self._deserialize(r[0]) for r in rows]
 
-    def list_summary(self) -> list[dict]:
-        rows = self._conn.execute(
-            "SELECT job_id, tenant_id, status, created_at, completed_at FROM jobs ORDER BY created_at DESC"
-        ).fetchall()
+    def list_summary(self, tenant_id: str | None = None) -> list[dict]:
+        if tenant_id is None:
+            rows = self._conn.execute(
+                "SELECT job_id, tenant_id, status, created_at, completed_at FROM jobs ORDER BY created_at DESC"
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """SELECT job_id, tenant_id, status, created_at, completed_at
+                   FROM jobs
+                   WHERE tenant_id = ?
+                   ORDER BY created_at DESC""",
+                (tenant_id,),
+            ).fetchall()
         return [{"job_id": r[0], "tenant_id": r[1], "status": r[2], "created_at": r[3], "completed_at": r[4]} for r in rows]
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -11,12 +12,14 @@ from fastapi import HTTPException
 
 from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState, InMemoryFleetStore
 from agent_bom.api.models import FleetAgentUpdate, JobStatus, PushPayload, ScanJob, ScanRequest, ScheduleCreate, StateUpdate
+from agent_bom.api.routes import compliance as compliance_routes
+from agent_bom.api.routes import discovery as discovery_routes
 from agent_bom.api.routes import fleet as fleet_routes
 from agent_bom.api.routes import observability as observability_routes
 from agent_bom.api.routes import scan as scan_routes
 from agent_bom.api.routes import schedules as schedule_routes
 from agent_bom.api.schedule_store import InMemoryScheduleStore, ScanSchedule
-from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.store import InMemoryJobStore, SQLiteJobStore
 from agent_bom.api.stores import _jobs, set_fleet_store, set_job_store, set_schedule_store
 
 
@@ -262,7 +265,8 @@ async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
         def __init__(self) -> None:
             self.get_calls = 0
 
-        def list_summary(self) -> list[dict]:
+        def list_summary(self, tenant_id: str | None = None) -> list[dict]:
+            assert tenant_id == "tenant-alpha"
             return [
                 {
                     "job_id": "job-alpha",
@@ -301,3 +305,183 @@ async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
         assert store.get_calls == 1
         assert hydrated["jobs"][0]["request"] == {"images": ["example:latest"]}
         assert hydrated["jobs"][0]["summary"]["total_packages"] == 12
+
+
+def test_sqlite_job_store_filters_by_tenant(tmp_path):
+    store = SQLiteJobStore(str(tmp_path / "jobs.db"))
+    alpha_job = ScanJob(
+        job_id="job-alpha",
+        tenant_id="tenant-alpha",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        request=ScanRequest(),
+    )
+    beta_job = ScanJob(
+        job_id="job-beta",
+        tenant_id="tenant-beta",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        request=ScanRequest(),
+    )
+    store.put(alpha_job)
+    store.put(beta_job)
+
+    assert [job.job_id for job in store.list_all(tenant_id="tenant-alpha")] == ["job-alpha"]
+    assert [row["job_id"] for row in store.list_summary(tenant_id="tenant-alpha")] == ["job-alpha"]
+
+
+@pytest.mark.asyncio
+async def test_compliance_routes_are_tenant_scoped():
+    store = InMemoryJobStore()
+    set_job_store(store)
+    alpha_job = ScanJob(
+        job_id="job-alpha",
+        tenant_id="tenant-alpha",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        completed_at=_now(),
+        request=ScanRequest(),
+        result={
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-alpha",
+                    "severity": "critical",
+                    "package": "alpha@1.0.0",
+                    "affected_agents": ["alpha-agent"],
+                    "owasp_tags": ["LLM01"],
+                }
+            ],
+            "summary": {"total_agents": 1, "total_packages": 1},
+            "posture_scorecard": {"grade": "A", "score": 97},
+            "credential_risk_ranking": [{"name": "ALPHA_KEY"}],
+            "incident_correlation": [{"agent": "alpha-agent"}],
+        },
+    )
+    beta_job = ScanJob(
+        job_id="job-beta",
+        tenant_id="tenant-beta",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        completed_at=_now(),
+        request=ScanRequest(),
+        result={
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-beta",
+                    "severity": "high",
+                    "package": "beta@1.0.0",
+                    "affected_agents": ["beta-agent"],
+                    "owasp_tags": ["LLM01"],
+                }
+            ],
+            "summary": {"total_agents": 1, "total_packages": 1},
+            "posture_scorecard": {"grade": "F", "score": 10},
+            "credential_risk_ranking": [{"name": "BETA_KEY"}],
+            "incident_correlation": [{"agent": "beta-agent"}],
+        },
+    )
+    store.put(alpha_job)
+    store.put(beta_job)
+
+    req = _request("tenant-alpha")
+
+    compliance = await compliance_routes.get_compliance(req)
+    assert compliance["scan_count"] == 1
+    llm01 = next(control for control in compliance["owasp_llm_top10"] if control["code"] == "LLM01")
+    assert llm01["affected_agents"] == ["alpha-agent"]
+
+    scorecard = await compliance_routes.get_posture_scorecard(req)
+    assert scorecard["score"] == 97
+
+    counts = await compliance_routes.get_posture_counts(req)
+    assert counts["critical"] == 1
+    assert counts["high"] == 0
+
+    creds = await compliance_routes.get_credential_risk_ranking(req)
+    assert creds["credentials"] == [{"name": "ALPHA_KEY"}]
+
+    incidents = await compliance_routes.get_incident_correlation(req)
+    assert incidents["incidents"] == [{"agent": "alpha-agent"}]
+
+
+@pytest.mark.asyncio
+async def test_discovery_and_traces_are_tenant_scoped():
+    store = InMemoryJobStore()
+    set_job_store(store)
+    alpha_job = ScanJob(
+        job_id="job-alpha",
+        tenant_id="tenant-alpha",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        completed_at=_now(),
+        request=ScanRequest(),
+        result={
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-alpha",
+                    "severity": "critical",
+                    "package": "langchain",
+                    "affected_agents": ["alpha"],
+                    "affected_servers": ["sqlite-mcp"],
+                }
+            ]
+        },
+    )
+    beta_job = ScanJob(
+        job_id="job-beta",
+        tenant_id="tenant-beta",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        completed_at=_now(),
+        request=ScanRequest(),
+        result={
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-beta",
+                    "severity": "high",
+                    "package": "requests",
+                    "affected_agents": ["beta"],
+                    "affected_servers": ["beta-mcp"],
+                }
+            ]
+        },
+    )
+    store.put(alpha_job)
+    store.put(beta_job)
+
+    req = _request("tenant-alpha")
+
+    @dataclass
+    class _Server:
+        name: str = "sqlite-mcp"
+        packages: list = field(default_factory=list)
+        tools: list = field(default_factory=list)
+        credential_names: list[str] = field(default_factory=list)
+        env: dict = field(default_factory=dict)
+        transport: str = "stdio"
+
+    @dataclass
+    class _Agent:
+        name: str = "alpha"
+        agent_type: str = "claude-desktop"
+        mcp_servers: list[_Server] = field(default_factory=lambda: [_Server()])
+
+    with patch("agent_bom.discovery.discover_all", return_value=[_Agent()]):
+        with patch("agent_bom.parsers.extract_packages", return_value=[]):
+            detail = await discovery_routes.get_agent_detail(req, "alpha")
+            assert [item["vulnerability_id"] for item in detail["blast_radius"]] == ["CVE-alpha"]
+
+    def _parse(_body: dict) -> list:
+        from agent_bom.otel_ingest import ToolCallTrace
+
+        return [ToolCallTrace(trace_id="t1", span_id="s1", tool_name="read_file", server_name="sqlite-mcp", package_name="langchain")]
+
+    def _flag(_traces, vuln_packages, vuln_servers):
+        assert vuln_packages == {"langchain": ["CVE-alpha"]}
+        assert vuln_servers == {"sqlite-mcp": ["CVE-alpha"]}
+        return []
+
+    with patch("agent_bom.otel_ingest.parse_otel_traces", side_effect=_parse):
+        with patch("agent_bom.otel_ingest.flag_vulnerable_tool_calls", side_effect=_flag):
+            result = await observability_routes.ingest_traces(req, {"resourceSpans": []})
+    assert result["traces"] == 1

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -295,13 +295,14 @@ class TestSnowflakeJobStore:
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_list_summary(self, mock_connect):
-        cur = _mock_cursor(fetchall_val=[("j1", "done", "2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z")])
+        cur = _mock_cursor(fetchall_val=[("j1", "tenant-alpha", "done", "2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z")])
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
         result = store.list_summary()
         assert len(result) == 1
         assert result[0]["job_id"] == "j1"
+        assert result[0]["tenant_id"] == "tenant-alpha"
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_cleanup_expired(self, mock_connect):


### PR DESCRIPTION
## Summary
- add optional tenant-aware filtering to job store list APIs across in-memory, SQLite, Postgres, and Snowflake backends
- scope job-backed aggregate routes to the authenticated tenant instead of iterating global job history
- add regression tests for SQLite filtering plus compliance, discovery, and observability tenant isolation

## Validation
- uv run pytest -q tests/test_api_tenant_isolation.py
- uv run ruff check src/agent_bom/api/store.py src/agent_bom/api/postgres_store.py src/agent_bom/api/snowflake_store.py src/agent_bom/api/routes/scan.py src/agent_bom/api/routes/observability.py src/agent_bom/api/routes/discovery.py src/agent_bom/api/routes/compliance.py tests/test_api_tenant_isolation.py
- git diff --check