### PR TITLE
Normalize runtime alert event relationships

### DIFF
--- a/src/agent_bom/alerts/dispatcher.py
+++ b/src/agent_bom/alerts/dispatcher.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Protocol, runtime_checkable
 
+from agent_bom.event_normalization import build_runtime_alert_relationships
+
 logger = logging.getLogger(__name__)
 
 
@@ -163,6 +165,28 @@ def _build_slack_payload(alert: dict) -> dict:
     return {"blocks": blocks}
 
 
+def _normalize_alert_event(alert: dict) -> dict:
+    """Attach canonical relationship metadata to runtime alerts when possible."""
+    if alert.get("type") != "runtime_alert" or "event_relationships" in alert:
+        return alert
+
+    detector = str(alert.get("detector", "unknown"))
+    details = alert.get("details")
+    if not isinstance(details, dict):
+        return alert
+
+    event_relationships = build_runtime_alert_relationships(
+        detector=detector,
+        details=details,
+    )
+    if event_relationships is None:
+        return alert
+    return {
+        **alert,
+        "event_relationships": event_relationships,
+    }
+
+
 # ─── Generic Webhook Channel ─────────────────────────────────────────────────
 
 
@@ -281,6 +305,7 @@ class AlertDispatcher:
         # Ensure timestamp
         if "ts" not in alert_dict:
             alert_dict["ts"] = datetime.now(timezone.utc).isoformat()
+        alert_dict = _normalize_alert_event(alert_dict)
 
         successes = 0
         for ch in self._channels:

--- a/src/agent_bom/event_normalization.py
+++ b/src/agent_bom/event_normalization.py
@@ -17,6 +17,10 @@ _RESOURCE_ARG_TYPES = {
     "uri": "uri",
     "resource_id": "resource",
 }
+_RUNTIME_DETAIL_TARGET_LIST_FIELDS = {
+    "new_tools": "observed_tool",
+    "removed_tools": "removed_tool",
+}
 
 
 def _scalar_attributes(attributes: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -139,6 +143,90 @@ def build_proxy_event_relationships(
 
     return build_event_relationships(
         source="proxy_tool_call",
+        actor=actor,
+        targets=targets,
+        resources=resources,
+    )
+
+
+def build_runtime_alert_relationships(
+    *,
+    detector: str,
+    details: Mapping[str, Any] | None,
+    agent_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Normalize runtime alert relationships.
+
+    Runtime alerts are event-like, but the exact actor/target/resource shape
+    varies by detector. Only explicit fields are normalized. Unknown or
+    detector-specific fields remain in ``details``.
+    """
+    clean_details = details if isinstance(details, Mapping) else {}
+
+    actor = None
+    resolved_agent_id = agent_id or clean_details.get("agent_id")
+    if isinstance(resolved_agent_id, str) and resolved_agent_id:
+        actor = build_event_ref(
+            ref_type="agent",
+            ref_id=resolved_agent_id,
+            name=resolved_agent_id,
+            role="caller",
+            source_field="agent_id",
+        )
+
+    targets: list[dict[str, Any]] = []
+    tool_name = clean_details.get("tool")
+    if isinstance(tool_name, str) and tool_name:
+        tool_target = build_event_ref(
+            ref_type="tool",
+            ref_id=tool_name,
+            name=tool_name,
+            role="implicated_tool",
+            source_field="details.tool",
+        )
+        if tool_target is not None:
+            targets.append(tool_target)
+
+    for field_name, role in _RUNTIME_DETAIL_TARGET_LIST_FIELDS.items():
+        raw_values = clean_details.get(field_name)
+        if not isinstance(raw_values, list):
+            continue
+        for value in raw_values:
+            if not isinstance(value, str) or not value:
+                continue
+            target = build_event_ref(
+                ref_type="tool",
+                ref_id=value,
+                name=value,
+                role=role,
+                source_field=f"details.{field_name}",
+            )
+            if target is not None:
+                targets.append(target)
+
+    resources: list[dict[str, Any]] = []
+    seen_resources: set[tuple[str, str, str]] = set()
+    for field_name, resource_type in _RESOURCE_ARG_TYPES.items():
+        value = clean_details.get(field_name)
+        if not isinstance(value, (str, int, float, bool)) or value in ("", None):
+            continue
+        resource_id = str(value)
+        dedupe_key = (resource_type, resource_id, field_name)
+        if dedupe_key in seen_resources:
+            continue
+        seen_resources.add(dedupe_key)
+        resource = build_event_ref(
+            ref_type=resource_type,
+            ref_id=resource_id,
+            name=resource_id,
+            role="referenced_resource",
+            source_field=f"details.{field_name}",
+        )
+        if resource is not None:
+            resources.append(resource)
+
+    return build_event_relationships(
+        source=f"runtime_alert:{detector}",
         actor=actor,
         targets=targets,
         resources=resources,

--- a/tests/test_alert_dispatcher.py
+++ b/tests/test_alert_dispatcher.py
@@ -123,12 +123,39 @@ def test_dispatcher_dispatch_alert_object():
     from agent_bom.runtime.detectors import Alert, AlertSeverity
 
     d = AlertDispatcher()
-    alert = Alert(detector="test", severity=AlertSeverity.HIGH, message="from detector")
+    alert = Alert(
+        detector="test",
+        severity=AlertSeverity.HIGH,
+        message="from detector",
+        details={"tool": "read_file", "path": "/tmp/example.txt"},
+    )
     count = asyncio.run(d.dispatch(alert))
     assert count == 1
     stored = d.list_alerts()[0]
     assert stored["detector"] == "test"
     assert stored["severity"] == "high"
+    assert stored["event_relationships"]["targets"][0]["id"] == "read_file"
+    assert stored["event_relationships"]["resources"][0]["id"] == "/tmp/example.txt"
+
+
+def test_dispatcher_dispatch_runtime_dict_adds_relationships():
+    d = AlertDispatcher()
+    count = asyncio.run(
+        d.dispatch(
+            {
+                "type": "runtime_alert",
+                "severity": "critical",
+                "detector": "shield_killswitch",
+                "message": "blocked",
+                "details": {"tool": "exec", "agent_id": "agent-1", "path": "/etc/passwd"},
+            }
+        )
+    )
+    assert count == 1
+    stored = d.list_alerts()[0]
+    assert stored["event_relationships"]["actor"]["id"] == "agent-1"
+    assert stored["event_relationships"]["targets"][0]["id"] == "exec"
+    assert stored["event_relationships"]["resources"][0]["id"] == "/etc/passwd"
 
 
 def test_dispatcher_add_webhook():


### PR DESCRIPTION
## Summary
- add canonical runtime alert relationship normalization for actor, tool targets, and explicit resource references
- attach event_relationships in the alert dispatcher so detector Alert objects and hand-built runtime alert dicts stay consistent
- add dispatcher regression tests for runtime alert relationship enrichment

## Validation
- uv run pytest -q tests/test_alert_dispatcher.py tests/test_ocsf.py tests/test_siem_push.py
- uv run ruff check src/agent_bom/event_normalization.py src/agent_bom/alerts/dispatcher.py tests/test_alert_dispatcher.py
- git diff --check