### PR TITLE
Harden proxy-configure secure defaults

### DIFF
--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -55,7 +55,14 @@ Codex uses TOML, so `agent-bom proxy-configure` does not auto-rewrite the config
 ```toml
 [mcp_servers.filesystem]
 command = "agent-bom"
-args = ["proxy", "--log", "~/.agent-bom/logs/filesystem.jsonl", "--", "npx", "@modelcontextprotocol/server-filesystem", "/workspace"]
+args = [
+  "proxy",
+  "--log", "~/.agent-bom/logs/filesystem.jsonl",
+  "--detect-credentials",
+  "--block-undeclared",
+  "--",
+  "npx", "@modelcontextprotocol/server-filesystem", "/workspace"
+]
 ```
 
 That gives you:
@@ -65,6 +72,12 @@ That gives you:
 - credential leak detection
 - response inspection
 - sequence and rate analysis
+
+Important boundary:
+
+- `agent-bom mcp server` is read-only
+- `agent-bom agents` is read-only
+- `agent-bom proxy` intentionally runs the wrapped stdio server so it can enforce policy on live traffic
 
 For deeper protection workflows beyond the lighter proxy path, use the broader runtime engine documented in [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md).
 

--- a/site-docs/features/runtime-proxy.md
+++ b/site-docs/features/runtime-proxy.md
@@ -2,6 +2,12 @@
 
 The `agent-bom proxy` command sits between MCP clients and servers, intercepting all JSON-RPC messages for real-time security enforcement.
 
+Important boundary:
+
+- scanner mode is read-only
+- MCP server mode is read-only
+- proxy mode intentionally executes the wrapped stdio server or connects to the remote SSE/HTTP server so it can enforce policy on live traffic
+
 ## Architecture
 
 ```
@@ -32,13 +38,21 @@ MCP Server (filesystem, postgres, etc.)
 agent-bom proxy --log audit.jsonl \
   -- npx @modelcontextprotocol/server-filesystem /workspace
 
-# With policy enforcement
+# Recommended hardened proxy
 agent-bom proxy \
   --policy policy.json \
   --log audit.jsonl \
+  --detect-credentials \
   --block-undeclared \
   -- npx @modelcontextprotocol/server-filesystem /workspace
 ```
+
+Recommended minimum hardening for developer workstations:
+
+- `--log` for auditable JSONL records
+- `--detect-credentials` to inspect responses for leaked secrets
+- `--block-undeclared` to stop tools that were never declared in `tools/list`
+- `--policy` when you want explicit allowlist/blocklist/read-only enforcement
 
 ## Claude Desktop integration
 
@@ -51,6 +65,7 @@ agent-bom proxy \
         "proxy",
         "--log", "audit.jsonl",
         "--policy", "policy.json",
+        "--detect-credentials",
         "--block-undeclared",
         "--",
         "npx", "@modelcontextprotocol/server-filesystem", "/workspace"

--- a/site-docs/security.md
+++ b/site-docs/security.md
@@ -17,4 +17,10 @@ We aim to respond within 48 hours and provide a fix within 7 days for critical i
 
 ## Security Design
 
-agent-bom is a read-only scanner. It reads config files and queries public APIs (OSV.dev, NVD, EPSS, CISA KEV). It never writes to agent configs, never executes MCP servers, and never stores credentials — only their names appear in output as `***REDACTED***`.
+agent-bom has three distinct security postures:
+
+- **Scanner mode** (`agent-bom agents`, `agent-bom fs`, `agent-bom check`) is read-only. It reads config files and queries public APIs (OSV.dev, NVD, EPSS, CISA KEV).
+- **MCP server mode** (`agent-bom mcp server`) is read-only. It exposes scan/governance tools and does not execute third-party MCP servers.
+- **Proxy mode** (`agent-bom proxy`) is an execution and enforcement surface. It intentionally launches or connects to the target MCP server so it can inspect, block, and audit tool traffic in real time.
+
+Across all modes, agent-bom never stores credential values — only their names appear in output as `***REDACTED***`.

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -58,18 +58,23 @@ def proxy_cmd(
     - Rate limiting and suspicious sequence detection
     - HMAC-SHA256 response signing in audit log (--response-sign-key)
 
+    Boundary:
+    - scanner and MCP server modes are read-only
+    - proxy mode intentionally executes the wrapped stdio server or connects
+      to the remote MCP endpoint so it can enforce policy on live traffic
+
     \b
     Usage (stdio — subprocess):
       agent-bom proxy -- npx @modelcontextprotocol/server-filesystem /tmp
       agent-bom proxy --log audit.jsonl -- npx @mcp/server-github
-      agent-bom proxy --policy policy.json --block-undeclared -- npx @mcp/server-postgres
+      agent-bom proxy --policy policy.json --detect-credentials --block-undeclared -- npx @mcp/server-postgres
       agent-bom proxy --detect-credentials --log-only -- npx @mcp/server-github
       agent-bom proxy --log audit.jsonl --response-sign-key $MY_SECRET -- npx @mcp/server-github
 
     \b
     Usage (SSE/HTTP — remote server):
       agent-bom proxy --url http://localhost:3000
-      agent-bom proxy --url https://mcp.example.com --log audit.jsonl --block-undeclared
+      agent-bom proxy --url https://mcp.example.com --log audit.jsonl --detect-credentials --block-undeclared
       agent-bom proxy --url http://localhost:3000 --policy policy.json
 
     \b
@@ -78,8 +83,9 @@ def proxy_cmd(
         "mcpServers": {
           "filesystem": {
             "command": "agent-bom",
-            "args": ["proxy", "--log", "audit.jsonl", "--detect-credentials",
-                     "--", "npx", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        "args": ["proxy", "--log", "audit.jsonl", "--detect-credentials",
+                 "--block-undeclared",
+                 "--", "npx", "@modelcontextprotocol/server-filesystem", "/tmp"]
           }
         }
       }
@@ -136,6 +142,12 @@ def proxy_cmd(
 @click.command("proxy-configure")
 @click.option("--policy", type=click.Path(exists=True), default=None, help="Policy JSON file to pass to each proxy instance")
 @click.option("--log-dir", default=None, type=click.Path(), help="Directory for per-server audit JSONL logs")
+@click.option(
+    "--secure-defaults/--no-secure-defaults",
+    default=True,
+    show_default=True,
+    help="Inject the recommended hardening flags (--detect-credentials and --block-undeclared)",
+)
 @click.option("--detect-credentials", is_flag=True, help="Enable credential leak detection in each proxy")
 @click.option("--block-undeclared", is_flag=True, help="Block undeclared tools in each proxy")
 @click.option(
@@ -144,7 +156,7 @@ def proxy_cmd(
     help="Write proxy config back to source JSON config files (default: preview only)",
 )
 @click.option("--project", default=None, type=click.Path(exists=True), help="Project directory to scan for MCP configs")
-def proxy_configure_cmd(policy, log_dir, detect_credentials, block_undeclared, apply, project):
+def proxy_configure_cmd(policy, log_dir, secure_defaults, detect_credentials, block_undeclared, apply, project):
     """Auto-configure the agent-bom proxy for discovered MCP servers.
 
     \b
@@ -159,10 +171,16 @@ def proxy_configure_cmd(policy, log_dir, detect_credentials, block_undeclared, a
     By default, shows a preview.  Use --apply to write changes back to the
     original config files (JSON only — claude_desktop_config.json, mcp.json…).
 
+    Recommended hardening for developer environments:
+    - secure defaults already inject --detect-credentials and --block-undeclared
+    - --log-dir for auditable JSONL logs
+    - --policy for explicit allowlist/blocklist/read-only enforcement
+
     \b
     Example:
-      agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials
-      agent-bom proxy-configure --policy policy.json --block-undeclared --apply
+      agent-bom proxy-configure --log-dir ~/.agent-bom/logs
+      agent-bom proxy-configure --policy policy.json --log-dir ~/.agent-bom/logs --apply
+      agent-bom proxy-configure --no-secure-defaults --apply
     """
     from agent_bom.discovery import discover_all
     from agent_bom.proxy_configure import apply_proxy_configs, auto_configure_proxies
@@ -174,6 +192,7 @@ def proxy_configure_cmd(policy, log_dir, detect_credentials, block_undeclared, a
         agents,
         policy_path=policy,
         log_dir=log_dir,
+        secure_defaults=secure_defaults,
         detect_credentials=detect_credentials,
         block_undeclared=block_undeclared,
     )

--- a/src/agent_bom/proxy_configure.py
+++ b/src/agent_bom/proxy_configure.py
@@ -72,6 +72,7 @@ def auto_configure_proxies(
     agents: list[Agent],
     policy_path: Optional[str] = None,
     log_dir: Optional[str] = None,
+    secure_defaults: bool = True,
     detect_credentials: bool = False,
     block_undeclared: bool = False,
 ) -> list[ProxyConfig]:
@@ -86,6 +87,9 @@ def auto_configure_proxies(
         policy_path: Optional policy JSON file to pass to each proxy instance.
         log_dir: Directory for per-server audit logs.  Each server gets a file
             named ``<server_name_slug>.jsonl`` inside this directory.
+        secure_defaults: When True, inject the recommended protective flags
+            (currently ``--detect-credentials`` and ``--block-undeclared``)
+            even if they are not explicitly requested by the caller.
         detect_credentials: Pass ``--detect-credentials`` to each proxy.
         block_undeclared: Pass ``--block-undeclared`` to each proxy.
 
@@ -111,10 +115,10 @@ def auto_configure_proxies(
                 log_file = str(Path(log_dir) / f"{slug}.jsonl")
                 proxy_flags += ["--log", log_file]
 
-            if detect_credentials:
+            if secure_defaults or detect_credentials:
                 proxy_flags.append("--detect-credentials")
 
-            if block_undeclared:
+            if secure_defaults or block_undeclared:
                 proxy_flags.append("--block-undeclared")
 
             proxied_args = [*proxy_flags, "--", server.command, *server.args]

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -129,6 +129,30 @@ def test_proxy_configure_apply_no_patch():
         assert result.exit_code == 0
 
 
+def test_proxy_configure_secure_defaults_enabled_by_default():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.discovery.discover_all", return_value=[]),
+        patch("agent_bom.proxy_configure.auto_configure_proxies", return_value=[]) as mock_auto_configure,
+    ):
+        result = runner.invoke(proxy_configure_cmd, [])
+        assert result.exit_code == 0
+    mock_auto_configure.assert_called_once()
+    assert mock_auto_configure.call_args.kwargs["secure_defaults"] is True
+
+
+def test_proxy_configure_secure_defaults_can_be_disabled():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.discovery.discover_all", return_value=[]),
+        patch("agent_bom.proxy_configure.auto_configure_proxies", return_value=[]) as mock_auto_configure,
+    ):
+        result = runner.invoke(proxy_configure_cmd, ["--no-secure-defaults"])
+        assert result.exit_code == 0
+    mock_auto_configure.assert_called_once()
+    assert mock_auto_configure.call_args.kwargs["secure_defaults"] is False
+
+
 # ---------------------------------------------------------------------------
 # watch_cmd
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_configure.py
+++ b/tests/test_proxy_configure.py
@@ -66,6 +66,8 @@ def test_generates_config_for_stdio_server():
     assert "--" in cfg.proxied_args
     assert "npx" in cfg.proxied_args
     assert "@modelcontextprotocol/server-fs" in cfg.proxied_args
+    assert "--detect-credentials" in cfg.proxied_args
+    assert "--block-undeclared" in cfg.proxied_args
 
 
 def test_skips_sse_server():
@@ -130,10 +132,18 @@ def test_all_flags_together():
 def test_no_flags_minimal_proxied_args():
     server = _stdio(command="uvx", args=["mcp-server-git"])
     agents = [_agent([server])]
-    configs = auto_configure_proxies(agents)
+    configs = auto_configure_proxies(agents, secure_defaults=False)
     cfg = configs[0]
     # Should be: ["--", "uvx", "mcp-server-git"]
     assert cfg.proxied_args == ["--", "uvx", "mcp-server-git"]
+
+
+def test_secure_defaults_can_be_disabled():
+    agents = [_agent([_stdio()])]
+    configs = auto_configure_proxies(agents, secure_defaults=False)
+    args = configs[0].proxied_args
+    assert "--detect-credentials" not in args
+    assert "--block-undeclared" not in args
 
 
 def test_original_command_and_args_preserved():


### PR DESCRIPTION
## Summary
- add secure defaults to proxy-configure so generated proxy entries include credential leak detection and undeclared-tool blocking by default
- clarify scanner/MCP-server read-only posture versus proxy execution in runtime and security docs
- update runtime CLI help and Codex examples to reflect the recommended hardened proxy path

## Validation
- uv run pytest -q tests/test_proxy_configure.py tests/test_cli_runtime.py
- uv run ruff check src/agent_bom/proxy_configure.py src/agent_bom/cli/_runtime.py tests/test_proxy_configure.py tests/test_cli_runtime.py
- git diff --check