### PR TITLE
Polish CLI wayfinding and doctor output

### DIFF
--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -23,15 +23,17 @@ def doctor_cmd() -> None:
 
     from agent_bom import __version__
 
-    checks: list[tuple[str, str, str]] = []  # (label, value, status)
+    core_checks: list[tuple[str, str, str]] = []
+    runtime_checks: list[tuple[str, str, str]] = []
+    platform_checks: list[tuple[str, str, str]] = []
 
     # Python version
     py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     py_ok = sys.version_info >= (3, 11)
-    checks.append(("Python", py_ver, "ok" if py_ok else "warn"))
+    core_checks.append(("Python", py_ver, "ok" if py_ok else "warn"))
 
     # agent-bom version
-    checks.append(("agent-bom", __version__, "ok"))
+    core_checks.append(("agent-bom", __version__, "ok"))
 
     # Local vulnerability DB — check the same path ScanCache() uses
     try:
@@ -51,47 +53,47 @@ def doctor_cmd() -> None:
                 _conn.close()
                 entry_count = _row[0] if _row else 0
                 if entry_count == 0:
-                    checks.append(("Local DB", f"exists but empty ({size_kb} KB) — run a scan to populate", "info"))
+                    core_checks.append(("Local DB", f"exists but empty ({size_kb} KB) — run a scan to populate", "info"))
                 else:
-                    checks.append(("Local DB", f"exists ({size_kb} KB, {entry_count} cached entries)", "ok"))
+                    core_checks.append(("Local DB", f"exists ({size_kb} KB, {entry_count} cached entries)", "ok"))
             except Exception:
-                checks.append(("Local DB", f"exists ({size_kb} KB)", "ok"))
+                core_checks.append(("Local DB", f"exists ({size_kb} KB)", "ok"))
         else:
-            checks.append(("Local DB", "not yet created (run a scan first)", "info"))
+            core_checks.append(("Local DB", "not yet created (run a scan first)", "info"))
     except Exception:
-        checks.append(("Local DB", "not available", "info"))
+        core_checks.append(("Local DB", "not available", "info"))
 
     # Network — OSV API
     try:
         import urllib.request
 
         urllib.request.urlopen("https://api.osv.dev/v1", timeout=5)  # nosec B310 — hardcoded HTTPS URL
-        checks.append(("Network", "api.osv.dev reachable", "ok"))
+        core_checks.append(("Network", "api.osv.dev reachable", "ok"))
     except Exception:
-        checks.append(("Network", "api.osv.dev unreachable", "warn"))
+        core_checks.append(("Network", "api.osv.dev unreachable", "warn"))
 
     # Docker
     docker_path = shutil.which("docker")
     if docker_path:
-        checks.append(("Docker", "available", "ok"))
+        runtime_checks.append(("Docker", "available", "ok"))
     else:
-        checks.append(("Docker", "not found", "info"))
+        runtime_checks.append(("Docker", "not found", "info"))
 
     # kubectl
     kubectl_path = shutil.which("kubectl")
     if kubectl_path:
-        checks.append(("kubectl", "available", "ok"))
+        runtime_checks.append(("kubectl", "available", "ok"))
     else:
-        checks.append(("kubectl", "not found", "info"))
+        runtime_checks.append(("kubectl", "not found", "info"))
 
     # MCP configs
     try:
         from agent_bom.discovery import discover_global_configs
 
         configs = discover_global_configs()
-        checks.append(("MCP configs", f"{len(configs)} found", "ok" if configs else "info"))
+        runtime_checks.append(("MCP configs", f"{len(configs)} found", "ok" if configs else "info"))
     except Exception:
-        checks.append(("MCP configs", "discovery error", "warn"))
+        runtime_checks.append(("MCP configs", "discovery error", "warn"))
 
     # API keys
     api_keys = {
@@ -101,13 +103,36 @@ def doctor_cmd() -> None:
     }
     for key, label in api_keys.items():
         if os.environ.get(key):
-            checks.append((label, "configured", "ok"))
+            platform_checks.append((label, "configured", "ok"))
         else:
-            checks.append((label, "not set", "info"))
+            platform_checks.append((label, "not set", "info"))
 
     # Print results
     console.print("  [bold]agent-bom doctor[/bold]")
     console.print()
+
+    _print_section(console, "Core readiness", core_checks)
+    _print_section(console, "Runtime surfaces", runtime_checks)
+    _print_section(console, "Platform integrations", platform_checks)
+
+    console.print()
+
+    checks = [*core_checks, *runtime_checks, *platform_checks]
+    warns = sum(1 for _, _, s in checks if s == "warn")
+    if warns == 0:
+        console.print("  [green]Ready to scan.[/green]")
+    else:
+        console.print(f"  [yellow]{warns} warning(s) — scanning may be limited.[/yellow]")
+    console.print()
+    console.print("  [bold]Next commands[/bold]")
+    console.print("    • agent-bom agents --demo --offline")
+    console.print("    • agent-bom where")
+    console.print("    • agent-bom proxy --help")
+    console.print()
+
+
+def _print_section(console: Console, title: str, checks: list[tuple[str, str, str]]) -> None:
+    console.print(f"  [bold]{title}[/bold]")
     for label, value, status in checks:
         if status == "ok":
             icon = "[green]✓[/green]"
@@ -115,13 +140,5 @@ def doctor_cmd() -> None:
             icon = "[yellow]⚠[/yellow]"
         else:
             icon = "[dim]○[/dim]"
-        console.print(f"  {icon}  {label + ':':<20s} {value}")
-
-    console.print()
-
-    warns = sum(1 for _, _, s in checks if s == "warn")
-    if warns == 0:
-        console.print("  [green]Ready to scan.[/green]")
-    else:
-        console.print(f"  [yellow]{warns} warning(s) — scanning may be limited.[/yellow]")
+        console.print(f"    {icon}  {label + ':':<20s} {value}")
     console.print()

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -41,6 +41,17 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
     ]
 )
 
+CATEGORY_DESCRIPTIONS: dict[str, str] = {
+    "Scanning": "Inventory, package, image, IaC, cloud, and skills scanning entry points.",
+    "Runtime": "Live MCP enforcement, replay, and runtime monitoring surfaces.",
+    "MCP": "Discovery, inventory, introspection, and MCP server operations.",
+    "Reporting": "Graph, mesh, dashboard, history, and narrative reporting workflows.",
+    "Governance": "Policy, fleet, API, scheduling, and operational control-plane commands.",
+    "Database": "Local cache, vuln database, and framework catalog maintenance.",
+    "Utilities": "Shell completions and upgrade helpers.",
+    "Other": "Additional commands that do not fit a primary workflow bucket.",
+}
+
 
 class GroupedGroup(click.Group):
     """A Click group that displays commands organized by category.
@@ -82,6 +93,9 @@ class GroupedGroup(click.Group):
 
             if rows:
                 with formatter.section(category):
+                    description = CATEGORY_DESCRIPTIONS.get(category)
+                    if description:
+                        formatter.write_text(description)
                     formatter.write_dl(rows)
 
         # Any commands not in a category go under "Other"
@@ -93,4 +107,15 @@ class GroupedGroup(click.Group):
 
         if other:
             with formatter.section("Other"):
+                description = CATEGORY_DESCRIPTIONS.get("Other")
+                if description:
+                    formatter.write_text(description)
                 formatter.write_dl(other)
+
+    def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        formatter.write_paragraph()
+        formatter.write_text(
+            "Navigation tips: start with `agent-bom doctor` for readiness, "
+            "`agent-bom agents --demo` for a reproducible local run, and "
+            "`agent-bom COMMAND --help` for command-specific flags."
+        )

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -22,6 +22,8 @@ class TestAgentBom:
         r = CliRunner().invoke(main, ["--help"])
         assert r.exit_code == 0
         assert "agent-bom" in r.output
+        assert "Core readiness" not in r.output
+        assert "Navigation tips:" in r.output
 
     def test_version(self):
         from agent_bom.cli import main

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -45,6 +45,7 @@ def test_main_help():
     assert result.exit_code == 0
     assert "scan" in result.output
     assert "where" in result.output
+    assert "Navigation tips:" in result.output
 
 
 def test_main_version():

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+def test_doctor_groups_output_and_shows_next_steps():
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "Core readiness" in result.output
+    assert "Runtime surfaces" in result.output
+    assert "Platform integrations" in result.output
+    assert "Next commands" in result.output
+    assert "agent-bom agents --demo --offline" in result.output


### PR DESCRIPTION
Summary:
- add category descriptions and a navigation footer to grouped CLI help
- restructure doctor output into core, runtime, and platform sections with explicit next commands
- add regression coverage for the new help and doctor output

Validation:
- uv run pytest -q tests/test_cli_scan.py tests/test_cli_entry_points.py tests/test_doctor_cli.py
- uv run ruff check src/agent_bom/cli/_grouped_help.py src/agent_bom/cli/_doctor.py tests/test_cli_scan.py tests/test_cli_entry_points.py tests/test_doctor_cli.py
