### PR TITLE
Link dashboard attack paths to security graph

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -632,6 +632,7 @@ export default function Dashboard() {
                     key={b.vulnerability_id}
                     nodes={nodes}
                     riskScore={b.risk_score ?? b.blast_score / 10}
+                    href="/security-graph"
                   />
                 );
               })}

--- a/ui/components/attack-path-card.tsx
+++ b/ui/components/attack-path-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
 import { Bot, Bug, ChevronRight, KeyRound, Package, Server } from "lucide-react";
 
@@ -13,6 +14,7 @@ interface AttackPathCardProps {
   nodes: AttackPathNode[];
   riskScore: number;
   onClick?: () => void;
+  href?: string;
 }
 
 const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string; ring: string }> = {
@@ -23,7 +25,7 @@ const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string
   credential: { icon: KeyRound, tint: "text-fuchsia-300 bg-fuchsia-500/12", ring: "border-fuchsia-500/25" },
 };
 
-export function AttackPathCard({ nodes, riskScore, onClick }: AttackPathCardProps) {
+export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCardProps) {
   const riskTone =
     riskScore >= 8
       ? "text-red-400 text-red-300 border-red-500/25 bg-red-500/10"
@@ -31,11 +33,8 @@ export function AttackPathCard({ nodes, riskScore, onClick }: AttackPathCardProp
         ? "text-orange-400 text-amber-300 border-amber-500/25 bg-amber-500/10"
         : "text-zinc-400 text-zinc-300 border-zinc-700 bg-zinc-800/70";
 
-  return (
-    <button
-      onClick={onClick}
-      className="group w-full rounded-2xl border border-zinc-800 bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(15,23,42,0.88))] px-4 py-3 text-left shadow-lg shadow-black/20 transition-all hover:-translate-y-0.5 hover:border-zinc-600 hover:shadow-xl hover:shadow-emerald-500/5"
-    >
+  const cardBody = (
+    <>
       <div className="mb-3 flex items-start justify-between gap-3">
         <div>
           <p className="text-[10px] uppercase tracking-[0.24em] text-zinc-500">Attack path</p>
@@ -76,6 +75,32 @@ export function AttackPathCard({ nodes, riskScore, onClick }: AttackPathCardProp
           );
         })}
       </div>
+      {href && (
+        <div className="mt-3 text-xs font-medium text-emerald-300">
+          Open focused security graph
+        </div>
+      )}
+    </>
+  );
+
+  const className =
+    "group block w-full rounded-2xl border border-zinc-800 bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(15,23,42,0.88))] px-4 py-3 text-left shadow-lg shadow-black/20 transition-all hover:-translate-y-0.5 hover:border-zinc-600 hover:shadow-xl hover:shadow-emerald-500/5";
+
+  if (href && !onClick) {
+    return (
+      <Link href={href} className={className}>
+        {cardBody}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={className}
+    >
+      {cardBody}
     </button>
   );
 }

--- a/ui/tests/attack-path-card.test.tsx
+++ b/ui/tests/attack-path-card.test.tsx
@@ -53,6 +53,13 @@ describe('AttackPathCard', () => {
     ).not.toThrow()
   })
 
+  it('renders as a link when href is provided without onClick', () => {
+    render(<AttackPathCard nodes={baseNodes} riskScore={5.5} href="/security-graph" />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/security-graph')
+    expect(screen.getByText('Open focused security graph')).toBeInTheDocument()
+  })
+
   it('applies critical severity styling to cve node', () => {
     const { container } = render(
       <AttackPathCard


### PR DESCRIPTION
Summary:
- let attack path cards render as links for navigation surfaces while keeping button behavior for local selection views
- wire dashboard top attack path cards into the focused security graph page
- add regression coverage for linked attack path cards

Validation:
- git diff --check
- local UI test execution remains blocked by the stale ui/node_modules install drift, so CI should validate this small UI follow-up
