### PR TITLE
Deep-link dashboard attack paths into focused security graph

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -7,7 +7,12 @@ import { AgentTopology } from "@/components/agent-topology";
 import { TrustStack } from "@/components/trust-stack";
 import { SeverityBadge } from "@/components/severity-badge";
 import { ActivityFeed } from "@/components/activity-feed";
-import { PostureGrade } from "@/components/posture-grade";
+import {
+  PostureGrade,
+  postureDimensionHint,
+  postureDimensionHref,
+  postureDimensionTone,
+} from "@/components/posture-grade";
 import { AttackPathCard } from "@/components/attack-path-card";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { buildSecurityGraphHref } from "@/lib/attack-paths";
@@ -1037,48 +1042,6 @@ function BlastCard({ blast, detailHref }: { blast: BlastRadius; detailHref: stri
       </div>
     </div>
   );
-}
-
-function postureDimensionTone(score: number) {
-  if (score >= 80) {
-    return {
-      label: "strong",
-      badge: "border border-emerald-800 bg-emerald-950/60 text-emerald-300",
-      bar: "bg-emerald-500",
-    };
-  }
-  if (score >= 60) {
-    return {
-      label: "watch",
-      badge: "border border-yellow-800 bg-yellow-950/60 text-yellow-300",
-      bar: "bg-yellow-500",
-    };
-  }
-  return {
-    label: "critical",
-    badge: "border border-red-800 bg-red-950/60 text-red-300",
-    bar: "bg-red-500",
-  };
-}
-
-function postureDimensionHref(key: string, label: string) {
-  const text = `${key} ${label}`.toLowerCase();
-  if (text.includes("vuln") || text.includes("package") || text.includes("fix")) return "/vulns";
-  if (text.includes("credential") || text.includes("tool")) return "/mesh";
-  if (text.includes("agent") || text.includes("server")) return "/agents";
-  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "/compliance";
-  if (text.includes("runtime") || text.includes("proxy") || text.includes("watch")) return "/proxy";
-  return "/graph";
-}
-
-function postureDimensionHint(key: string, label: string) {
-  const text = `${key} ${label}`.toLowerCase();
-  if (text.includes("vuln") || text.includes("package")) return "packages and CVEs";
-  if (text.includes("credential") || text.includes("tool")) return "reach and exposure";
-  if (text.includes("agent") || text.includes("server")) return "discovery and trust";
-  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "policy and controls";
-  if (text.includes("runtime") || text.includes("proxy")) return "live telemetry";
-  return "open evidence";
 }
 
 function JobRow({ job }: { job: JobListItem }) {

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -10,6 +10,7 @@ import { ActivityFeed } from "@/components/activity-feed";
 import { PostureGrade } from "@/components/posture-grade";
 import { AttackPathCard } from "@/components/attack-path-card";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { buildSecurityGraphHref } from "@/lib/attack-paths";
 import {
   ShieldAlert, Server, Package, Bug, Zap, ArrowRight, Clock,
   AlertTriangle, Container, Layers, FileText, ExternalLink, GitBranch,
@@ -632,7 +633,11 @@ export default function Dashboard() {
                     key={b.vulnerability_id}
                     nodes={nodes}
                     riskScore={b.risk_score ?? b.blast_score / 10}
-                    href="/security-graph"
+                    href={buildSecurityGraphHref({
+                      cve: b.vulnerability_id,
+                      packageName: b.package,
+                      agentName: b.affected_agents[0],
+                    })}
                   />
                 );
               })}

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   AlertTriangle,
   ArrowRight,
@@ -23,7 +24,7 @@ import {
   type PostureResponse,
   type UnifiedGraphResponse,
 } from "@/lib/api";
-import { attackPathKey, toAttackCardNodes } from "@/lib/attack-paths";
+import { attackPathKey, matchesAttackPathFocus, toAttackCardNodes } from "@/lib/attack-paths";
 import { EntityType } from "@/lib/graph-schema";
 
 const ATTACK_PATH_ENTITY_TYPES = [
@@ -70,7 +71,8 @@ function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
   };
 }
 
-export default function SecurityGraphPage() {
+function SecurityGraphPageContent() {
+  const searchParams = useSearchParams();
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
   const [selectedScanId, setSelectedScanId] = useState("");
   const [graphData, setGraphData] = useState<UnifiedGraphResponse | null>(null);
@@ -79,6 +81,22 @@ export default function SecurityGraphPage() {
   const [loadingGraph, setLoadingGraph] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
   const [selectedAttackPathKey, setSelectedAttackPathKey] = useState<string | null>(null);
+  const [focusApplied, setFocusApplied] = useState(false);
+
+  const focus = useMemo(
+    () => ({
+      scanId: searchParams.get("scan") ?? "",
+      cve: searchParams.get("cve") ?? "",
+      packageName: searchParams.get("package") ?? "",
+      agentName: searchParams.get("agent") ?? "",
+    }),
+    [searchParams],
+  );
+
+  const focusLabel = useMemo(() => {
+    const parts = [focus.cve, focus.packageName, focus.agentName].filter(Boolean);
+    return parts.length > 0 ? parts.join(" · ") : null;
+  }, [focus.agentName, focus.cve, focus.packageName]);
 
   useEffect(() => {
     let cancelled = false;
@@ -93,7 +111,12 @@ export default function SecurityGraphPage() {
         if (cancelled) return;
         setSnapshots(snapshotList);
         setPosture(postureData);
-        setSelectedScanId(snapshotList[0]?.scan_id ?? "");
+        const requestedScanId = focus.scanId;
+        const initialScanId =
+          requestedScanId && snapshotList.some((snapshot) => snapshot.scan_id === requestedScanId)
+            ? requestedScanId
+            : snapshotList[0]?.scan_id ?? "";
+        setSelectedScanId(initialScanId);
         setApiError(null);
       } catch (error) {
         if (cancelled) return;
@@ -109,7 +132,7 @@ export default function SecurityGraphPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [focus.scanId]);
 
   useEffect(() => {
     if (!selectedScanId) {
@@ -165,6 +188,8 @@ export default function SecurityGraphPage() {
     [graphData?.attack_paths],
   );
 
+  const hasFocusContext = Boolean(focus.cve || focus.packageName || focus.agentName);
+
   const selectedAttackPath = useMemo(
     () =>
       selectedAttackPathKey
@@ -174,8 +199,19 @@ export default function SecurityGraphPage() {
   );
 
   useEffect(() => {
+    setFocusApplied(false);
+  }, [focus.agentName, focus.cve, focus.packageName, selectedScanId]);
+
+  useEffect(() => {
     if (attackPaths.length === 0) {
       setSelectedAttackPathKey(null);
+      return;
+    }
+    if (!focusApplied && hasFocusContext) {
+      const focusedPath =
+        attackPaths.find((path) => matchesAttackPathFocus(path, graphNodeById, focus)) ?? attackPaths[0];
+      setSelectedAttackPathKey(attackPathKey(focusedPath));
+      setFocusApplied(true);
       return;
     }
     if (!selectedAttackPathKey) {
@@ -185,7 +221,7 @@ export default function SecurityGraphPage() {
     if (!attackPaths.some((path) => attackPathKey(path) === selectedAttackPathKey)) {
       setSelectedAttackPathKey(attackPathKey(attackPaths[0]));
     }
-  }, [attackPaths, selectedAttackPathKey]);
+  }, [attackPaths, focus, focusApplied, graphNodeById, hasFocusContext, selectedAttackPathKey]);
 
   if (apiError && !loadingSnapshots && snapshots.length === 0) {
     return (
@@ -328,6 +364,11 @@ export default function SecurityGraphPage() {
                 <p className="mt-1 text-sm text-zinc-500">
                   Focus one exploit chain at a time, then jump into the full graph only when you need broader topology.
                 </p>
+                {focusLabel && (
+                  <p className="mt-2 text-xs text-emerald-300">
+                    Focused from dashboard context: {focusLabel}
+                  </p>
+                )}
               </div>
               <div className="rounded-2xl border border-zinc-800 bg-zinc-900/70 px-4 py-3 text-sm text-zinc-300">
                 <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Highest composite risk</div>
@@ -487,6 +528,14 @@ export default function SecurityGraphPage() {
         </>
       )}
     </div>
+  );
+}
+
+export default function SecurityGraphPage() {
+  return (
+    <Suspense fallback={<div className="flex min-h-[40vh] items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-zinc-500" /></div>}>
+      <SecurityGraphPageContent />
+    </Suspense>
   );
 }
 

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -324,7 +324,12 @@ function SecurityGraphPageContent() {
             <p className="text-[10px] uppercase tracking-[0.2em] text-zinc-500">Current pressure</p>
             {posture ? (
               <div className="mt-3">
-                <PostureGrade grade={posture.grade} score={posture.score} dimensions={posture.dimensions} />
+                <PostureGrade
+                  grade={posture.grade}
+                  score={posture.score}
+                  dimensions={posture.dimensions}
+                  drilldown
+                />
               </div>
             ) : (
               <div className="mt-4 rounded-2xl border border-dashed border-zinc-800 bg-zinc-950/40 p-5 text-sm text-zinc-500">

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -1,12 +1,63 @@
 "use client";
 
+import Link from "next/link";
+
+export interface PostureDimension {
+  score: number;
+  label: string;
+  details?: string;
+}
+
 interface PostureGradeProps {
   grade: string;  // A, B, C, D, F, or N/A
   score: number;  // 0-100
-  dimensions?: Record<string, { score: number; label: string }>;
+  dimensions?: Record<string, PostureDimension>;
+  drilldown?: boolean;
 }
 
-export function PostureGrade({ grade, score, dimensions }: PostureGradeProps) {
+export function postureDimensionTone(score: number) {
+  if (score >= 80) {
+    return {
+      label: "strong",
+      badge: "border border-emerald-800 bg-emerald-950/60 text-emerald-300",
+      bar: "bg-emerald-500",
+    };
+  }
+  if (score >= 60) {
+    return {
+      label: "watch",
+      badge: "border border-yellow-800 bg-yellow-950/60 text-yellow-300",
+      bar: "bg-yellow-500",
+    };
+  }
+  return {
+    label: "critical",
+    badge: "border border-red-800 bg-red-950/60 text-red-300",
+    bar: "bg-red-500",
+  };
+}
+
+export function postureDimensionHref(key: string, label: string) {
+  const text = `${key} ${label}`.toLowerCase();
+  if (text.includes("vuln") || text.includes("package") || text.includes("fix")) return "/vulns";
+  if (text.includes("credential") || text.includes("tool")) return "/mesh";
+  if (text.includes("agent") || text.includes("server")) return "/agents";
+  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "/compliance";
+  if (text.includes("runtime") || text.includes("proxy") || text.includes("watch")) return "/proxy";
+  return "/graph";
+}
+
+export function postureDimensionHint(key: string, label: string) {
+  const text = `${key} ${label}`.toLowerCase();
+  if (text.includes("vuln") || text.includes("package")) return "packages and CVEs";
+  if (text.includes("credential") || text.includes("tool")) return "reach and exposure";
+  if (text.includes("agent") || text.includes("server")) return "discovery and trust";
+  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "policy and controls";
+  if (text.includes("runtime") || text.includes("proxy")) return "live telemetry";
+  return "open evidence";
+}
+
+export function PostureGrade({ grade, score, dimensions, drilldown = false }: PostureGradeProps) {
   // Color based on grade — matches architecture diagram semantics
   const gradeColor = {
     A: "#3fb950", // green  — output/governance layer
@@ -45,25 +96,71 @@ export function PostureGrade({ grade, score, dimensions }: PostureGradeProps) {
           </div>
           <div className="space-y-2">
             {orderedDimensions.map(([key, dim]) => (
-              <div key={key} className="space-y-1">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-xs font-medium text-zinc-300">{dim.label}</span>
-                  <span className="font-mono text-xs text-zinc-400">{dim.score}/100</span>
-                </div>
-                <div className="h-1.5 rounded-full bg-zinc-800">
-                  <div
-                    className="h-full rounded-full transition-all duration-500"
-                    style={{
-                      width: `${dim.score}%`,
-                      backgroundColor: dim.score >= 80 ? "#22c55e" : dim.score >= 60 ? "#eab308" : "#ef4444",
-                    }}
-                  />
-                </div>
-              </div>
+              <DimensionRow
+                key={key}
+                dimensionKey={key}
+                dimension={dim}
+                drilldown={drilldown}
+              />
             ))}
           </div>
         </div>
       )}
     </div>
+  );
+}
+
+function DimensionRow({
+  dimensionKey,
+  dimension,
+  drilldown,
+}: {
+  dimensionKey: string;
+  dimension: PostureDimension;
+  drilldown: boolean;
+}) {
+  const tone = postureDimensionTone(dimension.score);
+  const content = (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-medium text-zinc-300">{dimension.label}</span>
+        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${tone.badge}`}>
+          {tone.label}
+        </span>
+      </div>
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-mono text-xs text-zinc-400">{dimension.score}/100</span>
+        <span className="text-[11px] text-zinc-500">{postureDimensionHint(dimensionKey, dimension.label)}</span>
+      </div>
+      {dimension.details && (
+        <p className="text-[11px] leading-5 text-zinc-500">{dimension.details}</p>
+      )}
+      <div className="h-1.5 rounded-full bg-zinc-800">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${tone.bar}`}
+          style={{
+            width: `${dimension.score}%`,
+          }}
+        />
+      </div>
+    </div>
+  );
+
+  if (drilldown) {
+    return (
+      <Link
+        href={postureDimensionHref(dimensionKey, dimension.label)}
+        className="block rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-2.5 transition-colors hover:border-zinc-700 hover:bg-zinc-900"
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-transparent px-3 py-2.5">
+      {content}
+    </div>
+  );
   );
 }

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -6,6 +6,13 @@ export type AttackPathCardNode = {
   severity?: string;
 };
 
+export type AttackPathFocus = {
+  cve?: string;
+  packageName?: string;
+  agentName?: string;
+  scanId?: string;
+};
+
 export function attackPathKey(path: AttackPath): string {
   return `${path.source}::${path.target}::${path.hops.join("->")}`;
 }
@@ -47,4 +54,57 @@ export function toAttackCardNodes(path: AttackPath, nodeById: Map<string, Unifie
     });
   }
   return nodes;
+}
+
+export function buildSecurityGraphHref(focus: AttackPathFocus): string {
+  const params = new URLSearchParams();
+  if (focus.scanId) params.set("scan", focus.scanId);
+  if (focus.cve) params.set("cve", focus.cve);
+  if (focus.packageName) params.set("package", focus.packageName);
+  if (focus.agentName) params.set("agent", focus.agentName);
+  const query = params.toString();
+  return query ? `/security-graph?${query}` : "/security-graph";
+}
+
+function normalizeLabel(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function pathNodeLabels(path: AttackPath, nodeById: Map<string, UnifiedNode>) {
+  return path.hops
+    .map((hop) => nodeById.get(hop))
+    .filter((node): node is UnifiedNode => Boolean(node))
+    .map((node) => ({
+      label: normalizeLabel(node.label),
+      type: mapAttackPathNodeType(String(node.entity_type)),
+    }));
+}
+
+export function matchesAttackPathFocus(
+  path: AttackPath,
+  nodeById: Map<string, UnifiedNode>,
+  focus: AttackPathFocus,
+): boolean {
+  const cve = normalizeLabel(focus.cve);
+  const packageName = normalizeLabel(focus.packageName);
+  const agentName = normalizeLabel(focus.agentName);
+  if (!cve && !packageName && !agentName) return false;
+
+  const labels = pathNodeLabels(path, nodeById);
+
+  if (cve) {
+    const inPathVulns = path.vuln_ids.some((id) => normalizeLabel(id) === cve);
+    const inHopLabels = labels.some((node) => node.type === "cve" && node.label === cve);
+    if (!inPathVulns && !inHopLabels) return false;
+  }
+
+  if (packageName && !labels.some((node) => node.type === "package" && node.label === packageName)) {
+    return false;
+  }
+
+  if (agentName && !labels.some((node) => node.type === "agent" && node.label === agentName)) {
+    return false;
+  }
+
+  return true;
 }

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { attackPathKey, mapAttackPathNodeType, toAttackCardNodes } from "@/lib/attack-paths";
+import {
+  attackPathKey,
+  buildSecurityGraphHref,
+  mapAttackPathNodeType,
+  matchesAttackPathFocus,
+  toAttackCardNodes,
+} from "@/lib/attack-paths";
 import { EntityType, type AttackPath, type UnifiedNode } from "@/lib/graph-schema";
 
 describe("attack path helpers", () => {
@@ -112,5 +118,132 @@ describe("attack path helpers", () => {
       { type: "cve", label: "CVE-2026-0002", severity: "critical" },
       { type: "agent", label: "Claude Desktop", severity: "high" },
     ]);
+  });
+
+  it("builds a focused security-graph href from canonical context", () => {
+    expect(
+      buildSecurityGraphHref({
+        scanId: "scan-123",
+        cve: "CVE-2026-0002",
+        packageName: "flask",
+        agentName: "Claude Desktop",
+      }),
+    ).toBe("/security-graph?scan=scan-123&cve=CVE-2026-0002&package=flask&agent=Claude+Desktop");
+  });
+
+  it("matches a focused attack path by cve, package, and agent labels", () => {
+    const path: AttackPath = {
+      source: "cve-1",
+      target: "agent-1",
+      hops: ["cve-1", "pkg-1", "server-1", "agent-1"],
+      edges: [],
+      composite_risk: 8.4,
+      summary: "focused path",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: ["CVE-2026-7777"],
+    };
+
+    const nodes = new Map<string, UnifiedNode>([
+      [
+        "cve-1",
+        {
+          id: "cve-1",
+          entity_type: EntityType.VULNERABILITY,
+          label: "CVE-2026-7777",
+          category_uid: 2,
+          class_uid: 2001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 9,
+          severity: "critical",
+          severity_id: 5,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "pkg-1",
+        {
+          id: "pkg-1",
+          entity_type: EntityType.PACKAGE,
+          label: "flask",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 6,
+          severity: "high",
+          severity_id: 4,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "server-1",
+        {
+          id: "server-1",
+          entity_type: EntityType.SERVER,
+          label: "sqlite-mcp",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 6,
+          severity: "high",
+          severity_id: 4,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "agent-1",
+        {
+          id: "agent-1",
+          entity_type: EntityType.AGENT,
+          label: "Claude Desktop",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 6,
+          severity: "high",
+          severity_id: 4,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+    ]);
+
+    expect(
+      matchesAttackPathFocus(path, nodes, {
+        cve: "CVE-2026-7777",
+        packageName: "flask",
+        agentName: "Claude Desktop",
+      }),
+    ).toBe(true);
+
+    expect(
+      matchesAttackPathFocus(path, nodes, {
+        cve: "CVE-2026-7777",
+        packageName: "requests",
+      }),
+    ).toBe(false);
   });
 });

--- a/ui/tests/posture-grade.test.tsx
+++ b/ui/tests/posture-grade.test.tsx
@@ -1,86 +1,55 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
-import { PostureGrade } from '@/components/posture-grade'
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 
-describe('PostureGrade', () => {
-  it('renders the grade letter', () => {
-    render(<PostureGrade grade="A" score={95} />)
-    expect(screen.getByText('A')).toBeInTheDocument()
-  })
+import {
+  PostureGrade,
+  postureDimensionHint,
+  postureDimensionHref,
+  postureDimensionTone,
+} from "@/components/posture-grade";
 
-  it('renders the score number', () => {
-    render(<PostureGrade grade="B" score={72} />)
-    expect(screen.getByText('72/100')).toBeInTheDocument()
-  })
+describe("posture-grade helpers", () => {
+  it("maps dimension labels to evidence destinations", () => {
+    expect(postureDimensionHref("vulnerability_exposure", "Vulnerability Exposure")).toBe("/vulns");
+    expect(postureDimensionHref("credential_reach", "Credential Reach")).toBe("/mesh");
+    expect(postureDimensionHref("runtime_watch", "Runtime Watch")).toBe("/proxy");
+  });
 
-  it('renders grade F with correct score', () => {
-    render(<PostureGrade grade="F" score={22} />)
-    expect(screen.getByText('F')).toBeInTheDocument()
-    expect(screen.getByText('22/100')).toBeInTheDocument()
-  })
+  it("returns readable drilldown hints", () => {
+    expect(postureDimensionHint("agent_trust", "Agent Trust")).toBe("discovery and trust");
+    expect(postureDimensionHint("framework_alignment", "Framework Alignment")).toBe("policy and controls");
+  });
 
-  it('renders SVG ring with correct stroke-dashoffset for score 100', () => {
-    const { container } = render(<PostureGrade grade="A" score={100} />)
-    const circles = container.querySelectorAll('circle')
-    // second circle is the progress ring
-    const progressCircle = circles[1]
-    // circumference = 2 * π * 52 ≈ 326.726
-    // dashOffset at score=100 → 0
-    const dashOffset = parseFloat(progressCircle.getAttribute('stroke-dashoffset') ?? '1')
-    expect(dashOffset).toBeCloseTo(0, 0)
-  })
+  it("assigns score tones consistently", () => {
+    expect(postureDimensionTone(85).label).toBe("strong");
+    expect(postureDimensionTone(70).label).toBe("watch");
+    expect(postureDimensionTone(40).label).toBe("critical");
+  });
+});
 
-  it('renders SVG ring with correct stroke-dashoffset for score 0', () => {
-    const { container } = render(<PostureGrade grade="F" score={0} />)
-    const circles = container.querySelectorAll('circle')
-    const progressCircle = circles[1]
-    const circumference = 2 * Math.PI * 52
-    const dashOffset = parseFloat(progressCircle.getAttribute('stroke-dashoffset') ?? '0')
-    expect(dashOffset).toBeCloseTo(circumference, 0)
-  })
-
-  it('renders SVG ring with correct stroke-dashoffset for score 50', () => {
-    const { container } = render(<PostureGrade grade="C" score={50} />)
-    const circles = container.querySelectorAll('circle')
-    const progressCircle = circles[1]
-    const circumference = 2 * Math.PI * 52
-    const expectedOffset = circumference - 0.5 * circumference
-    const dashOffset = parseFloat(progressCircle.getAttribute('stroke-dashoffset') ?? '0')
-    expect(dashOffset).toBeCloseTo(expectedOffset, 0)
-  })
-
-  it('renders dimensions when provided', () => {
+describe("PostureGrade", () => {
+  it("renders linked score breakdown rows when drilldown is enabled", () => {
     render(
       <PostureGrade
         grade="B"
-        score={70}
+        score={78}
+        drilldown
         dimensions={{
-          vuln: { score: 65, label: 'Vulns' },
-          compliance: { score: 80, label: 'Compliance' },
+          vulnerability_exposure: {
+            label: "Vulnerability Exposure",
+            score: 81,
+            details: "High-risk packages remain reachable by agents.",
+          },
+          credential_reach: {
+            label: "Credential Reach",
+            score: 58,
+          },
         }}
-      />
-    )
-    expect(screen.getByText('Vulns')).toBeInTheDocument()
-    expect(screen.getByText('Compliance')).toBeInTheDocument()
-    expect(screen.getByText('Score breakdown')).toBeInTheDocument()
-  })
+      />,
+    );
 
-  it('does not render dimensions section when dimensions is undefined', () => {
-    render(<PostureGrade grade="A" score={90} />)
-    // No dimension labels should appear
-    expect(screen.queryByText('Vulns')).not.toBeInTheDocument()
-    expect(screen.queryByText('Score breakdown')).not.toBeInTheDocument()
-  })
-
-  it('does not render dimensions section when dimensions is empty object', () => {
-    render(<PostureGrade grade="A" score={90} dimensions={{}} />)
-    expect(screen.queryByText('Score breakdown')).not.toBeInTheDocument()
-  })
-
-  it('uses fallback color for unknown grade', () => {
-    // N/A grade — should not crash
-    const { container } = render(<PostureGrade grade="N/A" score={0} />)
-    expect(container).toBeTruthy()
-    expect(screen.getByText('N/A')).toBeInTheDocument()
-  })
-})
+    expect(screen.getByRole("link", { name: /Vulnerability Exposure/i })).toHaveAttribute("href", "/vulns");
+    expect(screen.getByRole("link", { name: /Credential Reach/i })).toHaveAttribute("href", "/mesh");
+    expect(screen.getByText("High-risk packages remain reachable by agents.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- pass focused attack-path context from the dashboard into /security-graph
- resolve the first matching precomputed path on load instead of dropping users into a generic queue
- keep the focus contract in shared attack-path helpers so dashboard and graph stay aligned

## Testing
- git diff --check
- local UI test/lint execution is still blocked by stale ui/node_modules; CI is the validator for this PR

## Notes
- no backend, schema, or API changes