### PR TITLE
Polish posture drilldowns across dashboard and security graph

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -7,7 +7,12 @@ import { AgentTopology } from "@/components/agent-topology";
 import { TrustStack } from "@/components/trust-stack";
 import { SeverityBadge } from "@/components/severity-badge";
 import { ActivityFeed } from "@/components/activity-feed";
-import { PostureGrade } from "@/components/posture-grade";
+import {
+  PostureGrade,
+  postureDimensionHint,
+  postureDimensionHref,
+  postureDimensionTone,
+} from "@/components/posture-grade";
 import { AttackPathCard } from "@/components/attack-path-card";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { buildSecurityGraphHref } from "@/lib/attack-paths";
@@ -1037,48 +1042,6 @@ function BlastCard({ blast, detailHref }: { blast: BlastRadius; detailHref: stri
       </div>
     </div>
   );
-}
-
-function postureDimensionTone(score: number) {
-  if (score >= 80) {
-    return {
-      label: "strong",
-      badge: "border border-emerald-800 bg-emerald-950/60 text-emerald-300",
-      bar: "bg-emerald-500",
-    };
-  }
-  if (score >= 60) {
-    return {
-      label: "watch",
-      badge: "border border-yellow-800 bg-yellow-950/60 text-yellow-300",
-      bar: "bg-yellow-500",
-    };
-  }
-  return {
-    label: "critical",
-    badge: "border border-red-800 bg-red-950/60 text-red-300",
-    bar: "bg-red-500",
-  };
-}
-
-function postureDimensionHref(key: string, label: string) {
-  const text = `${key} ${label}`.toLowerCase();
-  if (text.includes("vuln") || text.includes("package") || text.includes("fix")) return "/vulns";
-  if (text.includes("credential") || text.includes("tool")) return "/mesh";
-  if (text.includes("agent") || text.includes("server")) return "/agents";
-  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "/compliance";
-  if (text.includes("runtime") || text.includes("proxy") || text.includes("watch")) return "/proxy";
-  return "/graph";
-}
-
-function postureDimensionHint(key: string, label: string) {
-  const text = `${key} ${label}`.toLowerCase();
-  if (text.includes("vuln") || text.includes("package")) return "packages and CVEs";
-  if (text.includes("credential") || text.includes("tool")) return "reach and exposure";
-  if (text.includes("agent") || text.includes("server")) return "discovery and trust";
-  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "policy and controls";
-  if (text.includes("runtime") || text.includes("proxy")) return "live telemetry";
-  return "open evidence";
 }
 
 function JobRow({ job }: { job: JobListItem }) {

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -324,7 +324,12 @@ function SecurityGraphPageContent() {
             <p className="text-[10px] uppercase tracking-[0.2em] text-zinc-500">Current pressure</p>
             {posture ? (
               <div className="mt-3">
-                <PostureGrade grade={posture.grade} score={posture.score} dimensions={posture.dimensions} />
+                <PostureGrade
+                  grade={posture.grade}
+                  score={posture.score}
+                  dimensions={posture.dimensions}
+                  drilldown
+                />
               </div>
             ) : (
               <div className="mt-4 rounded-2xl border border-dashed border-zinc-800 bg-zinc-950/40 p-5 text-sm text-zinc-500">

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -1,12 +1,63 @@
 "use client";
 
+import Link from "next/link";
+
+export interface PostureDimension {
+  score: number;
+  label: string;
+  details?: string;
+}
+
 interface PostureGradeProps {
   grade: string;  // A, B, C, D, F, or N/A
   score: number;  // 0-100
-  dimensions?: Record<string, { score: number; label: string }>;
+  dimensions?: Record<string, PostureDimension>;
+  drilldown?: boolean;
 }
 
-export function PostureGrade({ grade, score, dimensions }: PostureGradeProps) {
+export function postureDimensionTone(score: number) {
+  if (score >= 80) {
+    return {
+      label: "strong",
+      badge: "border border-emerald-800 bg-emerald-950/60 text-emerald-300",
+      bar: "bg-emerald-500",
+    };
+  }
+  if (score >= 60) {
+    return {
+      label: "watch",
+      badge: "border border-yellow-800 bg-yellow-950/60 text-yellow-300",
+      bar: "bg-yellow-500",
+    };
+  }
+  return {
+    label: "critical",
+    badge: "border border-red-800 bg-red-950/60 text-red-300",
+    bar: "bg-red-500",
+  };
+}
+
+export function postureDimensionHref(key: string, label: string) {
+  const text = `${key} ${label}`.toLowerCase();
+  if (text.includes("vuln") || text.includes("package") || text.includes("fix")) return "/vulns";
+  if (text.includes("credential") || text.includes("tool")) return "/mesh";
+  if (text.includes("agent") || text.includes("server")) return "/agents";
+  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "/compliance";
+  if (text.includes("runtime") || text.includes("proxy") || text.includes("watch")) return "/proxy";
+  return "/graph";
+}
+
+export function postureDimensionHint(key: string, label: string) {
+  const text = `${key} ${label}`.toLowerCase();
+  if (text.includes("vuln") || text.includes("package")) return "packages and CVEs";
+  if (text.includes("credential") || text.includes("tool")) return "reach and exposure";
+  if (text.includes("agent") || text.includes("server")) return "discovery and trust";
+  if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "policy and controls";
+  if (text.includes("runtime") || text.includes("proxy")) return "live telemetry";
+  return "open evidence";
+}
+
+export function PostureGrade({ grade, score, dimensions, drilldown = false }: PostureGradeProps) {
   // Color based on grade — matches architecture diagram semantics
   const gradeColor = {
     A: "#3fb950", // green  — output/governance layer
@@ -45,25 +96,71 @@ export function PostureGrade({ grade, score, dimensions }: PostureGradeProps) {
           </div>
           <div className="space-y-2">
             {orderedDimensions.map(([key, dim]) => (
-              <div key={key} className="space-y-1">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-xs font-medium text-zinc-300">{dim.label}</span>
-                  <span className="font-mono text-xs text-zinc-400">{dim.score}/100</span>
-                </div>
-                <div className="h-1.5 rounded-full bg-zinc-800">
-                  <div
-                    className="h-full rounded-full transition-all duration-500"
-                    style={{
-                      width: `${dim.score}%`,
-                      backgroundColor: dim.score >= 80 ? "#22c55e" : dim.score >= 60 ? "#eab308" : "#ef4444",
-                    }}
-                  />
-                </div>
-              </div>
+              <DimensionRow
+                key={key}
+                dimensionKey={key}
+                dimension={dim}
+                drilldown={drilldown}
+              />
             ))}
           </div>
         </div>
       )}
     </div>
+  );
+}
+
+function DimensionRow({
+  dimensionKey,
+  dimension,
+  drilldown,
+}: {
+  dimensionKey: string;
+  dimension: PostureDimension;
+  drilldown: boolean;
+}) {
+  const tone = postureDimensionTone(dimension.score);
+  const content = (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-medium text-zinc-300">{dimension.label}</span>
+        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${tone.badge}`}>
+          {tone.label}
+        </span>
+      </div>
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-mono text-xs text-zinc-400">{dimension.score}/100</span>
+        <span className="text-[11px] text-zinc-500">{postureDimensionHint(dimensionKey, dimension.label)}</span>
+      </div>
+      {dimension.details && (
+        <p className="text-[11px] leading-5 text-zinc-500">{dimension.details}</p>
+      )}
+      <div className="h-1.5 rounded-full bg-zinc-800">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${tone.bar}`}
+          style={{
+            width: `${dimension.score}%`,
+          }}
+        />
+      </div>
+    </div>
+  );
+
+  if (drilldown) {
+    return (
+      <Link
+        href={postureDimensionHref(dimensionKey, dimension.label)}
+        className="block rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-2.5 transition-colors hover:border-zinc-700 hover:bg-zinc-900"
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-transparent px-3 py-2.5">
+      {content}
+    </div>
+  );
   );
 }

--- a/ui/tests/posture-grade.test.tsx
+++ b/ui/tests/posture-grade.test.tsx
@@ -1,86 +1,55 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
-import { PostureGrade } from '@/components/posture-grade'
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 
-describe('PostureGrade', () => {
-  it('renders the grade letter', () => {
-    render(<PostureGrade grade="A" score={95} />)
-    expect(screen.getByText('A')).toBeInTheDocument()
-  })
+import {
+  PostureGrade,
+  postureDimensionHint,
+  postureDimensionHref,
+  postureDimensionTone,
+} from "@/components/posture-grade";
 
-  it('renders the score number', () => {
-    render(<PostureGrade grade="B" score={72} />)
-    expect(screen.getByText('72/100')).toBeInTheDocument()
-  })
+describe("posture-grade helpers", () => {
+  it("maps dimension labels to evidence destinations", () => {
+    expect(postureDimensionHref("vulnerability_exposure", "Vulnerability Exposure")).toBe("/vulns");
+    expect(postureDimensionHref("credential_reach", "Credential Reach")).toBe("/mesh");
+    expect(postureDimensionHref("runtime_watch", "Runtime Watch")).toBe("/proxy");
+  });
 
-  it('renders grade F with correct score', () => {
-    render(<PostureGrade grade="F" score={22} />)
-    expect(screen.getByText('F')).toBeInTheDocument()
-    expect(screen.getByText('22/100')).toBeInTheDocument()
-  })
+  it("returns readable drilldown hints", () => {
+    expect(postureDimensionHint("agent_trust", "Agent Trust")).toBe("discovery and trust");
+    expect(postureDimensionHint("framework_alignment", "Framework Alignment")).toBe("policy and controls");
+  });
 
-  it('renders SVG ring with correct stroke-dashoffset for score 100', () => {
-    const { container } = render(<PostureGrade grade="A" score={100} />)
-    const circles = container.querySelectorAll('circle')
-    // second circle is the progress ring
-    const progressCircle = circles[1]
-    // circumference = 2 * π * 52 ≈ 326.726
-    // dashOffset at score=100 → 0
-    const dashOffset = parseFloat(progressCircle.getAttribute('stroke-dashoffset') ?? '1')
-    expect(dashOffset).toBeCloseTo(0, 0)
-  })
+  it("assigns score tones consistently", () => {
+    expect(postureDimensionTone(85).label).toBe("strong");
+    expect(postureDimensionTone(70).label).toBe("watch");
+    expect(postureDimensionTone(40).label).toBe("critical");
+  });
+});
 
-  it('renders SVG ring with correct stroke-dashoffset for score 0', () => {
-    const { container } = render(<PostureGrade grade="F" score={0} />)
-    const circles = container.querySelectorAll('circle')
-    const progressCircle = circles[1]
-    const circumference = 2 * Math.PI * 52
-    const dashOffset = parseFloat(progressCircle.getAttribute('stroke-dashoffset') ?? '0')
-    expect(dashOffset).toBeCloseTo(circumference, 0)
-  })
-
-  it('renders SVG ring with correct stroke-dashoffset for score 50', () => {
-    const { container } = render(<PostureGrade grade="C" score={50} />)
-    const circles = container.querySelectorAll('circle')
-    const progressCircle = circles[1]
-    const circumference = 2 * Math.PI * 52
-    const expectedOffset = circumference - 0.5 * circumference
-    const dashOffset = parseFloat(progressCircle.getAttribute('stroke-dashoffset') ?? '0')
-    expect(dashOffset).toBeCloseTo(expectedOffset, 0)
-  })
-
-  it('renders dimensions when provided', () => {
+describe("PostureGrade", () => {
+  it("renders linked score breakdown rows when drilldown is enabled", () => {
     render(
       <PostureGrade
         grade="B"
-        score={70}
+        score={78}
+        drilldown
         dimensions={{
-          vuln: { score: 65, label: 'Vulns' },
-          compliance: { score: 80, label: 'Compliance' },
+          vulnerability_exposure: {
+            label: "Vulnerability Exposure",
+            score: 81,
+            details: "High-risk packages remain reachable by agents.",
+          },
+          credential_reach: {
+            label: "Credential Reach",
+            score: 58,
+          },
         }}
-      />
-    )
-    expect(screen.getByText('Vulns')).toBeInTheDocument()
-    expect(screen.getByText('Compliance')).toBeInTheDocument()
-    expect(screen.getByText('Score breakdown')).toBeInTheDocument()
-  })
+      />,
+    );
 
-  it('does not render dimensions section when dimensions is undefined', () => {
-    render(<PostureGrade grade="A" score={90} />)
-    // No dimension labels should appear
-    expect(screen.queryByText('Vulns')).not.toBeInTheDocument()
-    expect(screen.queryByText('Score breakdown')).not.toBeInTheDocument()
-  })
-
-  it('does not render dimensions section when dimensions is empty object', () => {
-    render(<PostureGrade grade="A" score={90} dimensions={{}} />)
-    expect(screen.queryByText('Score breakdown')).not.toBeInTheDocument()
-  })
-
-  it('uses fallback color for unknown grade', () => {
-    // N/A grade — should not crash
-    const { container } = render(<PostureGrade grade="N/A" score={0} />)
-    expect(container).toBeTruthy()
-    expect(screen.getByText('N/A')).toBeInTheDocument()
-  })
-})
+    expect(screen.getByRole("link", { name: /Vulnerability Exposure/i })).toHaveAttribute("href", "/vulns");
+    expect(screen.getByRole("link", { name: /Credential Reach/i })).toHaveAttribute("href", "/mesh");
+    expect(screen.getByText("High-risk packages remain reachable by agents.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- move posture dimension tone, hint, and route logic into the shared posture component
- render linked drilldown rows in the reusable posture breakdown so /security-graph gets the same evidence navigation as the dashboard
- add focused helper and component coverage for posture drilldown behavior

## Testing
- git diff --check
- local UI test/lint execution is still blocked by stale ui/node_modules; CI is the validator for this stacked PR

## Notes
- stacked on #1397 because the security-graph page changes build on that branch
- no backend, schema, or API changes