### PR TITLE
Link security graph evidence chips to existing detail pages

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -24,7 +24,12 @@ import {
   type PostureResponse,
   type UnifiedGraphResponse,
 } from "@/lib/api";
-import { attackPathKey, matchesAttackPathFocus, toAttackCardNodes } from "@/lib/attack-paths";
+import {
+  attackPathKey,
+  labelsForAttackPathType,
+  matchesAttackPathFocus,
+  toAttackCardNodes,
+} from "@/lib/attack-paths";
 import { EntityType } from "@/lib/graph-schema";
 
 const ATTACK_PATH_ENTITY_TYPES = [
@@ -196,6 +201,14 @@ function SecurityGraphPageContent() {
         ? attackPaths.find((path) => attackPathKey(path) === selectedAttackPathKey) ?? null
         : attackPaths[0] ?? null,
     [attackPaths, selectedAttackPathKey],
+  );
+
+  const selectedPathAgents = useMemo(
+    () =>
+      selectedAttackPath
+        ? labelsForAttackPathType(selectedAttackPath, graphNodeById, "agent")
+        : [],
+    [graphNodeById, selectedAttackPath],
   );
 
   useEffect(() => {
@@ -441,8 +454,22 @@ function SecurityGraphPageContent() {
                   />
                 </div>
 
-                <div className="mt-4 grid gap-4 lg:grid-cols-3">
-                  <TagList label="Findings" tags={selectedAttackPath.vuln_ids} emptyLabel="No linked findings" />
+                <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                  <TagList
+                    label="Findings"
+                    tags={selectedAttackPath.vuln_ids}
+                    emptyLabel="No linked findings"
+                    hrefForTag={(tag) => `/vulns?cve=${encodeURIComponent(tag)}`}
+                  />
+                  <TagList
+                    label="Agents"
+                    tags={selectedPathAgents}
+                    emptyLabel="No agent hop resolved in this path"
+                    hrefForTag={(tag) => `/agents?name=${encodeURIComponent(tag)}`}
+                  />
+                </div>
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-2">
                   <TagList label="Credentials" tags={selectedAttackPath.credential_exposure} emptyLabel="No credential exposure" />
                   <TagList label="Tools" tags={selectedAttackPath.tool_exposure} emptyLabel="No tool exposure" />
                 </div>
@@ -489,9 +516,13 @@ function SecurityGraphPageContent() {
                           {risk.agents.length > 0 && (
                             <div className="mt-3 flex flex-wrap gap-2">
                               {risk.agents.slice(0, 4).map((agent) => (
-                                <span key={agent} className="rounded-full border border-zinc-700 bg-zinc-950 px-2 py-1 text-[11px] text-zinc-300">
+                                <Link
+                                  key={agent}
+                                  href={`/agents?name=${encodeURIComponent(agent)}`}
+                                  className="rounded-full border border-zinc-700 bg-zinc-950 px-2 py-1 text-[11px] text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
+                                >
                                   {agent}
-                                </span>
+                                </Link>
                               ))}
                             </div>
                           )}
@@ -571,10 +602,12 @@ function TagList({
   label,
   tags,
   emptyLabel,
+  hrefForTag,
 }: {
   label: string;
   tags: string[];
   emptyLabel: string;
+  hrefForTag?: (tag: string) => string;
 }) {
   return (
     <div className="rounded-2xl border border-zinc-800 bg-zinc-900/70 p-4">
@@ -582,9 +615,19 @@ function TagList({
       {tags.length > 0 ? (
         <div className="mt-3 flex flex-wrap gap-2">
           {tags.map((tag) => (
-            <span key={tag} className="rounded-full border border-zinc-700 bg-zinc-950 px-2 py-1 text-[11px] font-mono text-zinc-300">
-              {tag}
-            </span>
+            hrefForTag ? (
+              <Link
+                key={tag}
+                href={hrefForTag(tag)}
+                className="rounded-full border border-zinc-700 bg-zinc-950 px-2 py-1 text-[11px] font-mono text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
+              >
+                {tag}
+              </Link>
+            ) : (
+              <span key={tag} className="rounded-full border border-zinc-700 bg-zinc-950 px-2 py-1 text-[11px] font-mono text-zinc-300">
+                {tag}
+              </span>
+            )
           ))}
         </div>
       ) : (

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -80,6 +80,17 @@ function pathNodeLabels(path: AttackPath, nodeById: Map<string, UnifiedNode>) {
     }));
 }
 
+export function labelsForAttackPathType(
+  path: AttackPath,
+  nodeById: Map<string, UnifiedNode>,
+  type: AttackPathCardNode["type"],
+): string[] {
+  const labels = pathNodeLabels(path, nodeById)
+    .filter((node) => node.type === type)
+    .map((node) => node.label);
+  return Array.from(new Set(labels));
+}
+
 export function matchesAttackPathFocus(
   path: AttackPath,
   nodeById: Map<string, UnifiedNode>,

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   attackPathKey,
   buildSecurityGraphHref,
+  labelsForAttackPathType,
   mapAttackPathNodeType,
   matchesAttackPathFocus,
   toAttackCardNodes,
@@ -245,5 +246,87 @@ describe("attack path helpers", () => {
         packageName: "requests",
       }),
     ).toBe(false);
+  });
+
+  it("returns unique labels for a requested attack-path node type", () => {
+    const path: AttackPath = {
+      source: "cve-1",
+      target: "agent-1",
+      hops: ["agent-1", "agent-2", "agent-1", "cred-1"],
+      edges: [],
+      composite_risk: 5.3,
+      summary: "duplicate agent labels",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: [],
+    };
+
+    const nodes = new Map<string, UnifiedNode>([
+      [
+        "agent-1",
+        {
+          id: "agent-1",
+          entity_type: EntityType.AGENT,
+          label: "Claude Desktop",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 5,
+          severity: "medium",
+          severity_id: 3,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "agent-2",
+        {
+          id: "agent-2",
+          entity_type: EntityType.AGENT,
+          label: "Cursor",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 5,
+          severity: "medium",
+          severity_id: 3,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "cred-1",
+        {
+          id: "cred-1",
+          entity_type: EntityType.CREDENTIAL,
+          label: "ANTHROPIC_API_KEY",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 6,
+          severity: "high",
+          severity_id: 4,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+    ]);
+
+    expect(labelsForAttackPathType(path, nodes, "agent")).toEqual(["Claude Desktop", "Cursor"]);
   });
 });


### PR DESCRIPTION
## Summary
- make selected-path finding and agent chips navigate to existing detail pages
- add canonical helper support for unique labels by attack-path node type
- keep credentials and tools informational until those surfaces support direct search

## Testing
- git diff --check
- local UI test/lint execution is still blocked by stale ui/node_modules; CI is the validator for this PR

## Notes
- no backend, schema, or API changes