### PR TITLE
Add guided next actions to selected security graph paths

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -26,8 +26,10 @@ import {
 } from "@/lib/api";
 import {
   attackPathKey,
+  attackPathSequenceLabels,
   labelsForAttackPathType,
   matchesAttackPathFocus,
+  recommendedAttackPathActions,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
 import { EntityType } from "@/lib/graph-schema";
@@ -207,6 +209,22 @@ function SecurityGraphPageContent() {
     () =>
       selectedAttackPath
         ? labelsForAttackPathType(selectedAttackPath, graphNodeById, "agent")
+        : [],
+    [graphNodeById, selectedAttackPath],
+  );
+
+  const selectedPathSequence = useMemo(
+    () =>
+      selectedAttackPath
+        ? attackPathSequenceLabels(selectedAttackPath, graphNodeById)
+        : [],
+    [graphNodeById, selectedAttackPath],
+  );
+
+  const selectedPathActions = useMemo(
+    () =>
+      selectedAttackPath
+        ? recommendedAttackPathActions(selectedAttackPath, graphNodeById)
         : [],
     [graphNodeById, selectedAttackPath],
   );
@@ -454,6 +472,22 @@ function SecurityGraphPageContent() {
                   />
                 </div>
 
+                {selectedPathSequence.length > 0 && (
+                  <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-900/70 p-4">
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Path sequence</div>
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      {selectedPathSequence.map((label, index) => (
+                        <div key={`${label}-${index}`} className="flex items-center gap-2">
+                          {index > 0 && <ArrowRight className="h-3.5 w-3.5 text-zinc-600" />}
+                          <span className="rounded-full border border-zinc-700 bg-zinc-950 px-2.5 py-1 text-[11px] font-mono text-zinc-300">
+                            {label}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 <div className="mt-4 grid gap-4 lg:grid-cols-2">
                   <TagList
                     label="Findings"
@@ -474,22 +508,32 @@ function SecurityGraphPageContent() {
                   <TagList label="Tools" tags={selectedAttackPath.tool_exposure} emptyLabel="No tool exposure" />
                 </div>
 
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {selectedAttackPath.vuln_ids[0] && (
+                <div className="mt-4 grid gap-3 lg:grid-cols-3">
+                  {selectedPathActions.map((action) => (
                     <Link
-                      href={`/vulns?cve=${encodeURIComponent(selectedAttackPath.vuln_ids[0])}`}
-                      className="inline-flex items-center gap-2 rounded-xl border border-emerald-800 bg-emerald-950/40 px-4 py-2 text-sm font-medium text-emerald-300 transition hover:bg-emerald-950/70"
+                      key={action.title}
+                      href={action.href}
+                      className="rounded-2xl border border-zinc-800 bg-zinc-900/70 p-4 transition hover:border-zinc-600 hover:bg-zinc-900"
                     >
-                      Open finding evidence
-                      <ArrowRight className="h-4 w-4" />
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="text-sm font-medium text-zinc-100">{action.title}</div>
+                        <ArrowRight className="h-4 w-4 text-emerald-300" />
+                      </div>
+                      <p className="mt-2 text-xs leading-5 text-zinc-500">{action.detail}</p>
                     </Link>
-                  )}
+                  ))}
+
                   <Link
                     href="/graph"
-                    className="inline-flex items-center gap-2 rounded-xl border border-zinc-700 bg-zinc-900/80 px-4 py-2 text-sm font-medium text-zinc-200 transition hover:border-zinc-500 hover:text-zinc-100"
+                    className="rounded-2xl border border-zinc-800 bg-zinc-900/70 p-4 transition hover:border-zinc-600 hover:bg-zinc-900"
                   >
-                    Open full graph canvas
-                    <GitBranch className="h-4 w-4" />
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-sm font-medium text-zinc-100">Open full graph canvas</div>
+                      <GitBranch className="h-4 w-4 text-zinc-300" />
+                    </div>
+                    <p className="mt-2 text-xs leading-5 text-zinc-500">
+                      Switch to the full lineage view when you need broader topology, filters, or neighboring assets.
+                    </p>
                   </Link>
                 </div>
               </div>

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -13,6 +13,12 @@ export type AttackPathFocus = {
   scanId?: string;
 };
 
+export type AttackPathAction = {
+  title: string;
+  detail: string;
+  href: string;
+};
+
 export function attackPathKey(path: AttackPath): string {
   return `${path.source}::${path.target}::${path.hops.join("->")}`;
 }
@@ -56,6 +62,13 @@ export function toAttackCardNodes(path: AttackPath, nodeById: Map<string, Unifie
   return nodes;
 }
 
+export function attackPathSequenceLabels(path: AttackPath, nodeById: Map<string, UnifiedNode>): string[] {
+  return path.hops
+    .map((hop) => nodeById.get(hop))
+    .filter((node): node is UnifiedNode => Boolean(node))
+    .map((node) => node.label);
+}
+
 export function buildSecurityGraphHref(focus: AttackPathFocus): string {
   const params = new URLSearchParams();
   if (focus.scanId) params.set("scan", focus.scanId);
@@ -89,6 +102,55 @@ export function labelsForAttackPathType(
     .filter((node) => node.type === type)
     .map((node) => node.label);
   return Array.from(new Set(labels));
+}
+
+export function recommendedAttackPathActions(
+  path: AttackPath,
+  nodeById: Map<string, UnifiedNode>,
+): AttackPathAction[] {
+  const actions: AttackPathAction[] = [];
+  const leadingFinding = path.vuln_ids[0];
+  const leadAgent = labelsForAttackPathType(path, nodeById, "agent")[0];
+
+  if (leadingFinding) {
+    actions.push({
+      title: "Validate the lead finding",
+      detail: "Open the primary CVE evidence first so the exploit chain has a confirmed root cause.",
+      href: `/vulns?cve=${encodeURIComponent(leadingFinding)}`,
+    });
+  }
+
+  if (leadAgent) {
+    actions.push({
+      title: "Inspect the exposed agent",
+      detail: "Review the first affected agent and confirm its connected servers, tools, and configuration trust boundary.",
+      href: `/agents?name=${encodeURIComponent(leadAgent)}`,
+    });
+  }
+
+  if (path.credential_exposure.length > 0) {
+    actions.push({
+      title: "Contain credential exposure",
+      detail: "Rotate or scope exposed secrets before you widen blast radius by exploring deeper topology.",
+      href: "/mesh",
+    });
+  } else if (path.tool_exposure.length > 0) {
+    actions.push({
+      title: "Review reachable tools",
+      detail: "Check whether the reachable tools increase impact before choosing a fix sequence.",
+      href: "/mesh",
+    });
+  }
+
+  if (actions.length < 3) {
+    actions.push({
+      title: "Open full graph for neighbor context",
+      detail: "Use the full graph when you need broader topology, additional paths, or related assets outside this shortlist.",
+      href: "/graph",
+    });
+  }
+
+  return actions.slice(0, 3);
 }
 
 export function matchesAttackPathFocus(

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   attackPathKey,
+  attackPathSequenceLabels,
   buildSecurityGraphHref,
   labelsForAttackPathType,
   mapAttackPathNodeType,
   matchesAttackPathFocus,
+  recommendedAttackPathActions,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
 import { EntityType, type AttackPath, type UnifiedNode } from "@/lib/graph-schema";
@@ -328,5 +330,168 @@ describe("attack path helpers", () => {
     ]);
 
     expect(labelsForAttackPathType(path, nodes, "agent")).toEqual(["Claude Desktop", "Cursor"]);
+  });
+
+  it("returns ordered labels for the selected path sequence", () => {
+    const path: AttackPath = {
+      source: "cve-1",
+      target: "agent-1",
+      hops: ["cve-1", "pkg-1", "agent-1"],
+      edges: [],
+      composite_risk: 7.1,
+      summary: "ordered labels",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: ["CVE-2026-1212"],
+    };
+
+    const nodes = new Map<string, UnifiedNode>([
+      [
+        "cve-1",
+        {
+          id: "cve-1",
+          entity_type: EntityType.VULNERABILITY,
+          label: "CVE-2026-1212",
+          category_uid: 2,
+          class_uid: 2001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 9,
+          severity: "critical",
+          severity_id: 5,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "pkg-1",
+        {
+          id: "pkg-1",
+          entity_type: EntityType.PACKAGE,
+          label: "flask",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 5,
+          severity: "medium",
+          severity_id: 3,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "agent-1",
+        {
+          id: "agent-1",
+          entity_type: EntityType.AGENT,
+          label: "Claude Desktop",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 6,
+          severity: "high",
+          severity_id: 4,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+    ]);
+
+    expect(attackPathSequenceLabels(path, nodes)).toEqual([
+      "CVE-2026-1212",
+      "flask",
+      "Claude Desktop",
+    ]);
+  });
+
+  it("recommends deterministic next actions for a selected path", () => {
+    const path: AttackPath = {
+      source: "cve-1",
+      target: "agent-1",
+      hops: ["cve-1", "agent-1"],
+      edges: [],
+      composite_risk: 9.2,
+      summary: "actionable path",
+      credential_exposure: ["ANTHROPIC_API_KEY"],
+      tool_exposure: ["run_shell"],
+      vuln_ids: ["CVE-2026-3434"],
+    };
+
+    const nodes = new Map<string, UnifiedNode>([
+      [
+        "cve-1",
+        {
+          id: "cve-1",
+          entity_type: EntityType.VULNERABILITY,
+          label: "CVE-2026-3434",
+          category_uid: 2,
+          class_uid: 2001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 9,
+          severity: "critical",
+          severity_id: 5,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+      [
+        "agent-1",
+        {
+          id: "agent-1",
+          entity_type: EntityType.AGENT,
+          label: "Claude Desktop",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 6,
+          severity: "high",
+          severity_id: 4,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
+    ]);
+
+    expect(recommendedAttackPathActions(path, nodes)).toEqual([
+      {
+        title: "Validate the lead finding",
+        detail: "Open the primary CVE evidence first so the exploit chain has a confirmed root cause.",
+        href: "/vulns?cve=CVE-2026-3434",
+      },
+      {
+        title: "Inspect the exposed agent",
+        detail: "Review the first affected agent and confirm its connected servers, tools, and configuration trust boundary.",
+        href: "/agents?name=Claude%20Desktop",
+      },
+      {
+        title: "Contain credential exposure",
+        detail: "Rotate or scope exposed secrets before you widen blast radius by exploring deeper topology.",
+        href: "/mesh",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add ordered path sequence rendering for the selected attack path
- derive deterministic next actions from selected path evidence so operators know what to open first
- keep the action logic in shared attack-path helpers so the panel stays canonical and testable

## Testing
- git diff --check
- local UI test/lint execution is still blocked by stale ui/node_modules; CI is the validator for this stacked PR

## Notes
- stacked on #1399 because it builds on the evidence-chip linking work
- no backend, schema, or API changes