### PR TITLE
Add keyboard navigation for security graph path queue

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -30,6 +30,7 @@ import {
   labelsForAttackPathType,
   matchesAttackPathFocus,
   recommendedAttackPathActions,
+  moveAttackPathSelection,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
 import { EntityType } from "@/lib/graph-schema";
@@ -254,6 +255,14 @@ function SecurityGraphPageContent() {
     }
   }, [attackPaths, focus, focusApplied, graphNodeById, hasFocusContext, selectedAttackPathKey]);
 
+  function handleAttackPathQueueKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    setSelectedAttackPathKey((currentKey) =>
+      moveAttackPathSelection(attackPaths, currentKey, event.key === "ArrowRight" ? 1 : -1),
+    );
+  }
+
   if (apiError && !loadingSnapshots && snapshots.length === 0) {
     return (
       <ApiOfflineState
@@ -400,6 +409,9 @@ function SecurityGraphPageContent() {
                 <p className="mt-1 text-sm text-zinc-500">
                   Focus one exploit chain at a time, then jump into the full graph only when you need broader topology.
                 </p>
+                <p className="mt-2 text-xs text-zinc-500">
+                  Keyboard: focus this queue and use ← / → to step through paths.
+                </p>
                 {focusLabel && (
                   <p className="mt-2 text-xs text-emerald-300">
                     Focused from dashboard context: {focusLabel}
@@ -412,7 +424,12 @@ function SecurityGraphPageContent() {
               </div>
             </div>
 
-            <div className="mt-4 flex gap-3 overflow-x-auto pb-1">
+            <div
+              className="mt-4 flex gap-3 overflow-x-auto pb-1 outline-none"
+              tabIndex={0}
+              onKeyDown={handleAttackPathQueueKeyDown}
+              aria-label="Attack path queue"
+            >
               {attackPaths.slice(0, 8).map((path) => {
                 const key = attackPathKey(path);
                 const pathNodes = toAttackCardNodes(path, graphNodeById);

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -23,6 +23,21 @@ export function attackPathKey(path: AttackPath): string {
   return `${path.source}::${path.target}::${path.hops.join("->")}`;
 }
 
+export function moveAttackPathSelection(
+  attackPaths: AttackPath[],
+  currentKey: string | null,
+  direction: -1 | 1,
+): string | null {
+  if (attackPaths.length === 0) return null;
+  if (!currentKey) return attackPathKey(attackPaths[0]);
+
+  const currentIndex = attackPaths.findIndex((path) => attackPathKey(path) === currentKey);
+  if (currentIndex < 0) return attackPathKey(attackPaths[0]);
+
+  const nextIndex = (currentIndex + direction + attackPaths.length) % attackPaths.length;
+  return attackPathKey(attackPaths[nextIndex]);
+}
+
 export function mapAttackPathNodeType(entityType: string): AttackPathCardNode["type"] | null {
   switch (entityType) {
     case EntityType.VULNERABILITY:

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -8,6 +8,7 @@ import {
   mapAttackPathNodeType,
   matchesAttackPathFocus,
   recommendedAttackPathActions,
+  moveAttackPathSelection,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
 import { EntityType, type AttackPath, type UnifiedNode } from "@/lib/graph-schema";
@@ -27,6 +28,40 @@ describe("attack path helpers", () => {
     };
 
     expect(attackPathKey(path)).toBe("pkg::agent::cve->pkg->server->agent");
+  });
+
+  it("moves attack-path selection left and right with wraparound", () => {
+    const paths: AttackPath[] = [
+      {
+        source: "a",
+        target: "b",
+        hops: ["a", "b"],
+        edges: [],
+        composite_risk: 9.1,
+        summary: "path one",
+        credential_exposure: [],
+        tool_exposure: [],
+        vuln_ids: [],
+      },
+      {
+        source: "b",
+        target: "c",
+        hops: ["b", "c"],
+        edges: [],
+        composite_risk: 8.4,
+        summary: "path two",
+        credential_exposure: [],
+        tool_exposure: [],
+        vuln_ids: [],
+      },
+    ];
+
+    const firstKey = attackPathKey(paths[0]);
+    const secondKey = attackPathKey(paths[1]);
+
+    expect(moveAttackPathSelection(paths, firstKey, 1)).toBe(secondKey);
+    expect(moveAttackPathSelection(paths, secondKey, 1)).toBe(firstKey);
+    expect(moveAttackPathSelection(paths, firstKey, -1)).toBe(secondKey);
   });
 
   it("maps supported entity types into attack card node types", () => {


### PR DESCRIPTION
## Summary
- make the attack-path queue focusable and navigable with left/right arrow keys
- add a small keyboard hint in the queue header so the interaction is discoverable
- keep the selection logic in shared attack-path helpers so the behavior stays testable

## Testing
- git diff --check
- local UI test/lint execution is still blocked by stale ui/node_modules; CI is the validator for this PR

## Notes
- no backend, schema, or API changes