### PR TITLE
Polish security graph interaction risk panel

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -29,7 +29,9 @@ import {
   attackPathSequenceLabels,
   labelsForAttackPathType,
   matchesAttackPathFocus,
+  recommendedInteractionRiskActions,
   recommendedAttackPathActions,
+  summarizeInteractionRisks,
   moveAttackPathSelection,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
@@ -228,6 +230,11 @@ function SecurityGraphPageContent() {
         ? recommendedAttackPathActions(selectedAttackPath, graphNodeById)
         : [],
     [graphNodeById, selectedAttackPath],
+  );
+
+  const interactionRiskSummary = useMemo(
+    () => summarizeInteractionRisks(graphData?.interaction_risks ?? []),
+    [graphData?.interaction_risks],
   );
 
   useEffect(() => {
@@ -563,6 +570,11 @@ function SecurityGraphPageContent() {
                   </div>
                   {graphData?.interaction_risks?.length ? (
                     <div className="mt-4 space-y-3">
+                      <div className="grid grid-cols-3 gap-3">
+                        <QuickStat label="Patterns" value={String(interactionRiskSummary.total)} />
+                        <QuickStat label="Agents touched" value={String(interactionRiskSummary.uniqueAgents)} tone="blue" />
+                        <QuickStat label="Highest risk" value={interactionRiskSummary.highestRisk.toFixed(1)} tone="amber" />
+                      </div>
                       {graphData.interaction_risks.slice(0, 3).map((risk) => (
                         <div key={`${risk.pattern}-${risk.risk_score}`} className="rounded-2xl border border-zinc-800 bg-zinc-900/70 p-3">
                           <div className="flex items-start justify-between gap-3">
@@ -587,6 +599,18 @@ function SecurityGraphPageContent() {
                               ))}
                             </div>
                           )}
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {recommendedInteractionRiskActions(risk).map((action) => (
+                              <Link
+                                key={`${risk.pattern}-${action.label}`}
+                                href={action.href}
+                                className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-950 px-2.5 py-1 text-[11px] text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
+                              >
+                                {action.label}
+                                <ArrowRight className="h-3 w-3" />
+                              </Link>
+                            ))}
+                          </div>
                         </div>
                       ))}
                     </div>

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -19,6 +19,19 @@ export type AttackPathAction = {
   href: string;
 };
 
+export type InteractionRiskLike = {
+  pattern: string;
+  agents: string[];
+  risk_score: number;
+  description: string;
+  owasp_agentic_tag?: string;
+};
+
+export type InteractionRiskAction = {
+  label: string;
+  href: string;
+};
+
 export function attackPathKey(path: AttackPath): string {
   return `${path.source}::${path.target}::${path.hops.join("->")}`;
 }
@@ -166,6 +179,40 @@ export function recommendedAttackPathActions(
   }
 
   return actions.slice(0, 3);
+}
+
+export function summarizeInteractionRisks(risks: InteractionRiskLike[]) {
+  const uniqueAgents = new Set(risks.flatMap((risk) => risk.agents));
+  return {
+    total: risks.length,
+    uniqueAgents: uniqueAgents.size,
+    highestRisk: risks.reduce((max, risk) => Math.max(max, risk.risk_score), 0),
+  };
+}
+
+export function recommendedInteractionRiskActions(risk: InteractionRiskLike): InteractionRiskAction[] {
+  const actions: InteractionRiskAction[] = [];
+
+  if (risk.agents[0]) {
+    actions.push({
+      label: "Open lead agent",
+      href: `/agents?name=${encodeURIComponent(risk.agents[0])}`,
+    });
+  }
+
+  if (risk.owasp_agentic_tag) {
+    actions.push({
+      label: "Review tag evidence",
+      href: `/compliance?q=${encodeURIComponent(risk.owasp_agentic_tag)}`,
+    });
+  } else {
+    actions.push({
+      label: "Inspect runtime controls",
+      href: "/proxy",
+    });
+  }
+
+  return actions.slice(0, 2);
 }
 
 export function matchesAttackPathFocus(

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -7,8 +7,10 @@ import {
   labelsForAttackPathType,
   mapAttackPathNodeType,
   matchesAttackPathFocus,
-  recommendedAttackPathActions,
   moveAttackPathSelection,
+  recommendedInteractionRiskActions,
+  recommendedAttackPathActions,
+  summarizeInteractionRisks,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
 import { EntityType, type AttackPath, type UnifiedNode } from "@/lib/graph-schema";
@@ -526,6 +528,50 @@ describe("attack path helpers", () => {
         title: "Contain credential exposure",
         detail: "Rotate or scope exposed secrets before you widen blast radius by exploring deeper topology.",
         href: "/mesh",
+      },
+    ]);
+  });
+
+  it("summarizes interaction risks for panel-level metrics", () => {
+    expect(
+      summarizeInteractionRisks([
+        {
+          pattern: "credential + tool",
+          agents: ["Claude Desktop", "Cursor"],
+          risk_score: 8.8,
+          description: "shared exposure",
+        },
+        {
+          pattern: "runtime drift",
+          agents: ["Cursor"],
+          risk_score: 6.4,
+          description: "policy drift",
+        },
+      ]),
+    ).toEqual({
+      total: 2,
+      uniqueAgents: 2,
+      highestRisk: 8.8,
+    });
+  });
+
+  it("recommends deterministic follow-up actions for an interaction risk", () => {
+    expect(
+      recommendedInteractionRiskActions({
+        pattern: "credential + tool",
+        agents: ["Claude Desktop"],
+        risk_score: 8.2,
+        description: "shared exposure",
+        owasp_agentic_tag: "AGENT-001",
+      }),
+    ).toEqual([
+      {
+        label: "Open lead agent",
+        href: "/agents?name=Claude%20Desktop",
+      },
+      {
+        label: "Review tag evidence",
+        href: "/compliance?q=AGENT-001",
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- add interaction-risk summary stats to the focused security graph panel
- add deterministic follow-up actions for each interaction risk card
- keep the change scoped to shared attack-path helpers and security-graph UI

## Validation
- git diff --check
- local UI lint/test remains blocked by stale ui/node_modules drift, so CI is the validator for this PR
