### PR TITLE
Polish security graph readability follow-up

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -690,6 +690,16 @@ function SecurityGraphPageContent() {
                               ))}
                             </div>
                           )}
+                          {risk.owasp_agentic_tag && (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              <Link
+                                href={`/compliance?q=${encodeURIComponent(risk.owasp_agentic_tag)}`}
+                                className="rounded-full border border-emerald-900/70 bg-emerald-950/30 px-2 py-1 text-[11px] font-mono text-emerald-300 transition hover:border-emerald-700 hover:text-emerald-200"
+                              >
+                                {risk.owasp_agentic_tag}
+                              </Link>
+                            </div>
+                          )}
                           <div className="mt-3 flex flex-wrap gap-2">
                             {recommendedInteractionRiskActions(risk).map((action) => (
                               <Link


### PR DESCRIPTION
## Summary
- make the no-paths state focus-aware and add a clear-focus recovery path
- add a dedicated recommended-next-steps label above selected-path actions
- clarify interaction-risk context and expose OWASP tag chips when present
- include the shared AWS CIS stale-credential threshold fix so CI matches the intended policy

## Validation
- git diff --check
- uv run pytest -q tests/test_aws_cis_benchmark.py -k 'Check112 and stale'
- uv run pytest -q tests/test_aws_cis_benchmark.py
- local UI lint/test remains blocked by stale ui/node_modules drift, so CI is the validator for this PR
