### PR TITLE
Document backend parity and Snowflake modes

### DIFF
--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -87,7 +87,7 @@ Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oid
 
 ## Storage Compatibility
 
-`agent-bom` uses different backends for different jobs. The current documented default should be read this way:
+`agent-bom` uses different backends for different jobs. The short version is:
 
 | Backend | Status | Best fit |
 |---|---|---|
@@ -95,9 +95,14 @@ Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oid
 | Supabase | Full transactional control-plane backend because it is PostgreSQL | managed Postgres deployments |
 | SQLite | single-node / local persistence | local or small deployments |
 | ClickHouse | analytics backend | high-volume scan and posture analytics |
-| Snowflake | selected enterprise stores, not full transactional parity | governance / analytics / Snowflake-native environments |
+| Snowflake | selected enterprise stores, not full transactional parity | governance / warehouse-native environments |
 
 Today, if you want the broadest transactional feature coverage, use PostgreSQL or Supabase.
+
+For the explicit capability matrix and supported Snowflake deployment modes, see:
+
+- `site-docs/deployment/backend-parity.md`
+- `docs/ENTERPRISE_DEPLOYMENT.md`
 
 ## Multi-Tenant Reference Architecture
 

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -123,7 +123,16 @@ That keeps API roles and tenant boundaries aligned with the upstream identity pr
 
 For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated tenant into the database session (`app.tenant_id`) so Postgres row-level security can enforce the same tenant boundary for fleet and schedule data. Internal scheduler work uses an explicit trusted bypass rather than silently reading across tenants.
 
-**Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, audit, and trend state.
+**Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, schedules, graph state, and trend history.
+
+Use the backend story this way:
+
+- `SQLite`: local and single-node
+- `Postgres` / `Supabase`: control-plane default
+- `ClickHouse`: analytics add-on
+- `Snowflake`: warehouse-native and governance-oriented mode with explicit parity limits
+
+For the detailed matrix, see `site-docs/deployment/backend-parity.md`.
 
 For ClickHouse-backed analytics, make the backend explicit instead of relying on ambient environment alone:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Policy Engine: features/policy.md
   - Deployment:
       - Overview: deployment/overview.md
+      - Backend Parity: deployment/backend-parity.md
       - Docker: deployment/docker.md
       - Kubernetes: deployment/kubernetes.md
       - SIEM Integration: deployment/siem-integration.md

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -1,0 +1,109 @@
+# Backend Parity Matrix
+
+`agent-bom` does not treat every backend as interchangeable.
+
+The product contract is:
+
+- `SQLite`: local and single-node persistence
+- `Postgres` / `Supabase`: transactional control-plane default
+- `ClickHouse`: analytics and time-series backend
+- `Snowflake`: warehouse-native and governance-oriented backend where parity is explicitly implemented
+
+This page documents what is wired today, not what might exist as a class on disk.
+
+## Current API Backend Matrix
+
+| Capability | SQLite | Postgres / Supabase | ClickHouse | Snowflake |
+|---|---|---|---|---|
+| Scan job persistence | Yes | Yes | No | Yes |
+| Fleet agent persistence | Yes | Yes | No | Yes |
+| Gateway policy persistence | Yes | Yes | No | Yes |
+| Audit log persistence | Yes | Yes | No | Yes, via `SnowflakePolicyStore` |
+| Exception workflow persistence | No default API wiring | Yes | No | No |
+| API key persistence / RBAC store | No default API wiring | Yes | No | No |
+| Schedule persistence | Yes | Yes | No | No |
+| Trend / baseline persistence | Yes | Yes | No | No |
+| Graph persistence | Yes | Yes | No | No |
+| Analytics / OLAP writes | No | No | Yes | No |
+| Snowflake governance discovery routes | No | No | No | Yes |
+
+## What This Means
+
+If you need the broadest control-plane coverage today, use `Postgres` or `Supabase`.
+
+If you need local persistence, use `SQLite`.
+
+If you need high-volume analytics or time-series aggregation, add `ClickHouse`.
+
+If you need warehouse-native deployment or governance workflows in Snowflake, use `Snowflake` where the parity boundary is acceptable and explicit.
+
+## Supported Deployment Modes
+
+### 1. Postgres control plane with optional ClickHouse analytics
+
+This is the default enterprise deployment mode.
+
+Use when you want:
+
+- full transactional API coverage
+- tenant-scoped keys and exceptions
+- schedule persistence
+- graph persistence
+- trend and baseline history
+
+Typical layout:
+
+- `Postgres` / `Supabase` for control plane
+- optional `ClickHouse` for analytics
+- optional `Snowflake` governance discovery for account-level visibility
+
+### 2. Snowflake partial control plane
+
+This is supported, but intentionally partial.
+
+Use when you want:
+
+- Snowflake-hosted `scan_jobs`
+- Snowflake-hosted fleet inventory
+- Snowflake-hosted gateway policies and policy audit trail
+
+Current limitations:
+
+- schedules do not persist to Snowflake
+- graph persistence does not persist to Snowflake
+- exceptions do not persist to Snowflake
+- API keys do not persist to Snowflake
+- baseline/trend storage does not persist to Snowflake
+
+That makes Snowflake viable for selected control-plane paths, but not yet a full transactional replacement for Postgres.
+
+### 3. Warehouse-native governance mode
+
+Use when the primary goal is:
+
+- Snowflake governance discovery
+- activity and observability routes backed by Snowflake account data
+- Snowflake Native App or Snowpark-adjacent operator workflows
+
+This mode is compatible with:
+
+- local CLI scans
+- API/UI deployments
+- hybrid control planes where the warehouse is the authoritative governance data source
+
+## Recommended Selection
+
+| Need | Recommended backend |
+|---|---|
+| Laptop, demo, single-node | `SQLite` |
+| Team / enterprise API deployment | `Postgres` / `Supabase` |
+| Large analytics or trend workloads | `ClickHouse` alongside Postgres |
+| Snowflake-native governance and warehouse workflows | `Snowflake`, with explicit parity limits |
+
+## Related Docs
+
+- [Deployment Overview](overview.md)
+- [SIEM Integration](siem-integration.md)
+- [Canonical Model vs OCSF](../architecture/canonical-vs-ocsf.md)
+- `docs/ENTERPRISE.md`
+- `docs/ENTERPRISE_DEPLOYMENT.md`

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -111,7 +111,7 @@ def _analytics_health() -> AnalyticsHealth:
 async def _lifespan(app_instance: FastAPI):
     """Start background cleanup task on startup, cancel on shutdown."""
     configure_otel_tracing()
-    # Priority: Snowflake > SQLite > InMemory (lazy default)
+    # Priority: Snowflake > Postgres > SQLite > InMemory (lazy default)
     if os.environ.get("SNOWFLAKE_ACCOUNT"):
         from agent_bom.api.snowflake_store import (
             SnowflakeFleetStore,


### PR DESCRIPTION
## Summary
- document the current backend parity matrix across SQLite, Postgres/Supabase, ClickHouse, and Snowflake
- define supported Snowflake deployment modes and their explicit limits
- fix the API bootstrap backend-priority comment to match the actual order

## Validation
- git diff --check
