### PR TITLE
Add fixture-backed cloud normalization coverage

### DIFF
--- a/tests/fixtures/cloud/azure_ai_foundry_workspace.json
+++ b/tests/fixtures/cloud/azure_ai_foundry_workspace.json
@@ -1,0 +1,9 @@
+{
+  "name": "fixture-ml-workspace",
+  "id": "/subscriptions/sub-123/resourceGroups/rg-fixture/providers/Microsoft.MachineLearningServices/workspaces/fixture-ml-workspace",
+  "location": "eastus2",
+  "system_data": {
+    "created_at": "2026-04-01T12:00:00+03:00",
+    "last_modified_at": "2026-04-12T09:15:00-07:00"
+  }
+}

--- a/tests/fixtures/cloud/azure_container_app.json
+++ b/tests/fixtures/cloud/azure_container_app.json
@@ -1,0 +1,25 @@
+{
+  "name": "fixture-container-app",
+  "id": "/subscriptions/sub-123/resourceGroups/rg-fixture/providers/Microsoft.App/containerApps/fixture-container-app",
+  "location": "eastus2",
+  "template": {
+    "containers": [
+      {
+        "name": "api",
+        "image": "myregistry.azurecr.io/fixture-agent:v2"
+      }
+    ]
+  },
+  "identity": {
+    "type": "UserAssigned",
+    "principal_id": "",
+    "tenant_id": "tenant-123",
+    "user_assigned_identities": {
+      "/subscriptions/sub-123/resourceGroups/rg-identities/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fixture-id": {}
+    }
+  },
+  "system_data": {
+    "created_at": "2026-04-10T14:30:00+02:00",
+    "last_modified_at": "2026-04-11T16:45:00-04:00"
+  }
+}

--- a/tests/fixtures/cloud/gcp_vertex_endpoint.json
+++ b/tests/fixtures/cloud/gcp_vertex_endpoint.json
@@ -1,0 +1,14 @@
+{
+  "display_name": "fixture-endpoint",
+  "resource_name": "projects/123/locations/us-central1/endpoints/456",
+  "create_time": "2026-04-05T08:00:00+02:00",
+  "update_time": "2026-04-12T10:30:00-05:00",
+  "gca_resource": {
+    "deployed_models": [
+      {
+        "model": "projects/123/locations/us-central1/models/fixture-model",
+        "display_name": "fixture-model"
+      }
+    ]
+  }
+}

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -5,6 +5,8 @@ import json
 import sys
 import types
 from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +28,24 @@ from agent_bom.models import (
 )
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
+
+_CLOUD_FIXTURES = Path(__file__).parent / "fixtures" / "cloud"
+
+
+def _load_cloud_fixture(name: str) -> dict:
+    return json.loads((_CLOUD_FIXTURES / name).read_text())
+
+
+def _to_namespace(value):
+    if isinstance(value, dict):
+        if not value:
+            return {}
+        if not all(isinstance(key, str) and key.isidentifier() for key in value):
+            return {key: _to_namespace(item) for key, item in value.items()}
+        return SimpleNamespace(**{key: _to_namespace(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_to_namespace(item) for item in value]
+    return value
 
 
 def _install_mock_boto3():
@@ -1700,6 +1720,76 @@ def test_azure_container_apps_by_resource_group():
     mock_client.container_apps.list_by_resource_group.assert_called_once_with("rg-ai")
 
 
+def test_azure_container_app_fixture_normalizes_offsets_and_user_assigned_identity():
+    """Fixture-backed Azure Container App payloads keep scope, UTC timestamps, and user-assigned identity stable."""
+    _install_mock_azure()
+    importlib.reload(importlib.import_module("agent_bom.cloud.azure"))
+    from agent_bom.cloud.azure import discover
+
+    mock_credential = MagicMock()
+    mock_client = MagicMock()
+    mock_client.container_apps.list_by_subscription.return_value = [_to_namespace(_load_cloud_fixture("azure_container_app.json"))]
+
+    mock_rm_client = MagicMock()
+    mock_rm_client.resources.list.return_value = []
+    mock_web_client = MagicMock()
+    mock_web_client.web_apps.list.return_value = []
+
+    with (
+        patch("azure.identity.DefaultAzureCredential", return_value=mock_credential),
+        patch("azure.mgmt.appcontainers.ContainerAppsAPIClient", return_value=mock_client),
+        patch("azure.mgmt.resource.ResourceManagementClient", return_value=mock_rm_client),
+        patch("azure.mgmt.web.WebSiteManagementClient", return_value=mock_web_client),
+    ):
+        agents, warnings = discover(subscription_id="sub-123")
+
+    ca_agents = [a for a in agents if a.source == "azure-container-apps"]
+    assert len(ca_agents) == 1
+    timestamps = ca_agents[0].metadata["cloud_timestamps"]
+    assert timestamps["created_at"] == "2026-04-10T12:30:00Z"
+    assert timestamps["updated_at"] == "2026-04-11T20:45:00Z"
+    principal = ca_agents[0].metadata["cloud_principal"]
+    assert principal["principal_type"] == "user-assigned-managed-identity"
+    assert principal["principal_id"].endswith("/fixture-id")
+    assert principal["principal_name"].endswith("/fixture-id")
+    scope = ca_agents[0].metadata["cloud_scope"]
+    assert scope["scope_id"] == "rg-fixture"
+    assert scope["parent_scope"]["id"] == "sub-123"
+
+
+def test_azure_ai_foundry_fixture_normalizes_offset_timestamps():
+    """Fixture-backed Azure AI Foundry payloads normalize string offsets into UTC and preserve scope."""
+    _install_mock_azure()
+    importlib.reload(importlib.import_module("agent_bom.cloud.azure"))
+    from agent_bom.cloud.azure import discover
+
+    mock_credential = MagicMock()
+    mock_ca_client = MagicMock()
+    mock_ca_client.container_apps.list_by_subscription.return_value = []
+
+    mock_rm_client = MagicMock()
+    mock_rm_client.resources.list.return_value = [_to_namespace(_load_cloud_fixture("azure_ai_foundry_workspace.json"))]
+    mock_web_client = MagicMock()
+    mock_web_client.web_apps.list.return_value = []
+
+    with (
+        patch("azure.identity.DefaultAzureCredential", return_value=mock_credential),
+        patch("azure.mgmt.appcontainers.ContainerAppsAPIClient", return_value=mock_ca_client),
+        patch("azure.mgmt.resource.ResourceManagementClient", return_value=mock_rm_client),
+        patch("azure.mgmt.web.WebSiteManagementClient", return_value=mock_web_client),
+    ):
+        agents, warnings = discover(subscription_id="sub-123")
+
+    ai_agents = [a for a in agents if a.source == "azure-ai-foundry"]
+    assert len(ai_agents) == 1
+    timestamps = ai_agents[0].metadata["cloud_timestamps"]
+    assert timestamps["created_at"] == "2026-04-01T09:00:00Z"
+    assert timestamps["updated_at"] == "2026-04-12T16:15:00Z"
+    scope = ai_agents[0].metadata["cloud_scope"]
+    assert scope["scope_id"] == "rg-fixture"
+    assert scope["parent_scope"]["id"] == "sub-123"
+
+
 # ─── GCP Provider Tests ──────────────────────────────────────────────────
 
 
@@ -1808,6 +1898,28 @@ def test_gcp_vertex_ai_endpoints_discovered():
     assert timestamps["sources"]["updated_at"] == "update_time"
     scope = vertex_agents[0].metadata["cloud_scope"]
     assert scope["scope_type"] == "project"
+    assert scope["scope_id"] == "my-project"
+    assert scope["location"] == "us-central1"
+
+
+def test_gcp_vertex_fixture_normalizes_offset_timestamps():
+    """Fixture-backed Vertex endpoint payloads normalize offset timestamps through the discovery path."""
+    _install_mock_gcp()
+    importlib.reload(importlib.import_module("agent_bom.cloud.gcp"))
+    from agent_bom.cloud.gcp import discover
+
+    mock_endpoint = _to_namespace(_load_cloud_fixture("gcp_vertex_endpoint.json"))
+
+    with patch("google.cloud.aiplatform.init"), patch("google.cloud.aiplatform.Endpoint.list", return_value=[mock_endpoint]):
+        agents, warnings = discover(project_id="my-project", region="us-central1")
+
+    vertex_agents = [a for a in agents if a.source == "gcp-vertex-ai"]
+    assert len(vertex_agents) == 1
+    timestamps = vertex_agents[0].metadata["cloud_timestamps"]
+    assert timestamps["created_at"] == "2026-04-05T06:00:00Z"
+    assert timestamps["updated_at"] == "2026-04-12T15:30:00Z"
+    assert timestamps["sources"]["created_at"] == "create_time"
+    scope = vertex_agents[0].metadata["cloud_scope"]
     assert scope["scope_id"] == "my-project"
     assert scope["location"] == "us-central1"
 


### PR DESCRIPTION
## Summary
- add raw provider payload fixtures for Azure Container Apps, Azure AI Foundry workspaces, and GCP Vertex endpoints
- exercise the existing discovery paths with those fixtures to lock timestamp, scope, and principal normalization against real raw shapes
- keep the change additive and test-only so no schema or runtime contract changes are introduced

## Testing
- uv run pytest -q tests/test_cloud.py -k 'fixture or azure_container_app_fixture or azure_ai_foundry_fixture or gcp_vertex_fixture'
- uv run ruff check tests/test_cloud.py
- git diff --check