### PR TITLE
Extend theme support to graph state cards

### DIFF
--- a/ui/components/attack-path-card.tsx
+++ b/ui/components/attack-path-card.tsx
@@ -28,17 +28,17 @@ const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string
 export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCardProps) {
   const riskTone =
     riskScore >= 8
-      ? "text-red-400 text-red-300 border-red-500/25 bg-red-500/10"
+      ? "border-red-500/25 bg-red-500/10 text-red-200"
       : riskScore >= 5
-        ? "text-orange-400 text-amber-300 border-amber-500/25 bg-amber-500/10"
-        : "text-zinc-400 text-zinc-300 border-zinc-700 bg-zinc-800/70";
+        ? "border-amber-500/25 bg-amber-500/10 text-amber-200"
+        : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)]";
 
   const cardBody = (
     <>
       <div className="mb-3 flex items-start justify-between gap-3">
         <div>
-          <p className="text-[10px] uppercase tracking-[0.24em] text-zinc-500">Attack path</p>
-          <p className="mt-1 text-sm font-semibold text-zinc-100">Credential-aware blast radius</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-[color:var(--text-tertiary)]">Attack path</p>
+          <p className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">Credential-aware blast radius</p>
         </div>
         <div className={`rounded-xl border px-2.5 py-1 font-mono text-xs font-semibold ${riskTone}`}>
           <span className="text-[10px] uppercase tracking-[0.16em]">Risk</span>{" "}
@@ -59,7 +59,7 @@ export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCa
           return (
             <div key={`${node.type}-${node.label}-${i}`} className="flex items-center gap-1.5">
               {i > 0 && (
-                <div className="flex h-5 w-5 items-center justify-center text-zinc-600">
+                <div className="flex h-5 w-5 items-center justify-center text-[color:var(--text-tertiary)]">
                   <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
                   <span className="sr-only">→</span>
                 </div>
@@ -67,8 +67,8 @@ export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCa
               <div className={`flex items-center gap-2 rounded-xl border px-2.5 py-1.5 ${severityRing} ${meta.tint}`}>
                 <Icon className="h-3.5 w-3.5 shrink-0" />
                 <div className="min-w-0">
-                  <p className="max-w-[120px] truncate text-[11px] font-medium text-zinc-100">{node.label}</p>
-                  <p className="text-[9px] uppercase tracking-[0.16em] text-zinc-500">{node.type}</p>
+                  <p className="max-w-[120px] truncate text-[11px] font-medium text-[color:var(--foreground)]">{node.label}</p>
+                  <p className="text-[9px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{node.type}</p>
                 </div>
               </div>
             </div>
@@ -76,7 +76,7 @@ export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCa
         })}
       </div>
       {href && (
-        <div className="mt-3 text-xs font-medium text-emerald-300">
+        <div className="mt-3 text-xs font-medium text-emerald-500">
           Open focused security graph
         </div>
       )}
@@ -84,7 +84,7 @@ export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCa
   );
 
   const className =
-    "group block w-full rounded-2xl border border-zinc-800 bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(15,23,42,0.88))] px-4 py-3 text-left shadow-lg shadow-black/20 transition-all hover:-translate-y-0.5 hover:border-zinc-600 hover:shadow-xl hover:shadow-emerald-500/5";
+    "group block w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 text-left shadow-lg transition-all hover:-translate-y-0.5 hover:border-[color:var(--border-strong)] hover:shadow-xl hover:shadow-emerald-500/5";
 
   if (href && !onClick) {
     return (

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -14,7 +14,7 @@ export function GraphControlGroup({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="text-[10px] uppercase tracking-[0.2em] text-zinc-600">{label}</span>
+      <span className="text-[10px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">{label}</span>
       <div className="flex flex-wrap items-center gap-2">{children}</div>
     </div>
   );
@@ -31,20 +31,20 @@ export function GraphEmptyState({
 }) {
   return (
     <div className="flex h-full items-center justify-center">
-      <div className="max-w-xl rounded-2xl border border-zinc-800 bg-zinc-950/80 p-6 text-left shadow-lg shadow-zinc-950/40">
+      <div className="max-w-xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-6 text-left shadow-lg">
         <div className="flex items-start gap-3">
-          <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 p-2">
-            <SearchX className="h-5 w-5 text-zinc-400" />
+          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
+            <SearchX className="h-5 w-5 text-[color:var(--text-secondary)]" />
           </div>
           <div>
-            <h3 className="text-base font-semibold text-zinc-100">{title}</h3>
-            <p className="mt-2 text-sm leading-6 text-zinc-400">{detail}</p>
+            <h3 className="text-base font-semibold text-[color:var(--foreground)]">{title}</h3>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">{detail}</p>
           </div>
         </div>
-        <ul className="mt-4 space-y-2 text-sm text-zinc-500">
+        <ul className="mt-4 space-y-2 text-sm text-[color:var(--text-secondary)]">
           {suggestions.map((suggestion) => (
             <li key={suggestion} className="flex items-start gap-2">
-              <span className="mt-1 h-1.5 w-1.5 rounded-full bg-zinc-600" />
+              <span className="mt-1 h-1.5 w-1.5 rounded-full bg-[color:var(--text-tertiary)]" />
               <span>{suggestion}</span>
             </li>
           ))}
@@ -63,17 +63,17 @@ export function GraphFindingsFallback({
 }) {
   return (
     <div className="h-full overflow-y-auto">
-      <div className="border-b border-zinc-800 bg-zinc-950/60 px-4 py-3">
+      <div className="border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Findings scope</p>
-            <h3 className="mt-1 text-sm font-semibold text-zinc-100">This filter currently resolves to findings only</h3>
-            <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-500">
+            <h3 className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">This filter currently resolves to findings only</h3>
+            <p className="mt-1 max-w-3xl text-xs leading-5 text-[color:var(--text-secondary)]">
               You are looking at the vulnerability slice without enough surrounding package, server, or agent context to form a topology.
               Use this list for evidence and remediation, or relax the scope to recover the graph.
             </p>
           </div>
-          <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-xs text-zinc-400">
+          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-xs text-[color:var(--text-secondary)]">
             {nodes.length} finding{nodes.length !== 1 ? "s" : ""} in scope
           </div>
         </div>
@@ -89,14 +89,14 @@ export function GraphFindingsFallback({
               ? "border-red-800 bg-red-950/20"
               : data.severity === "high"
                 ? "border-orange-800 bg-orange-950/20"
-                : "border-zinc-800 bg-zinc-950/60";
+                : "border-[color:var(--border-subtle)] bg-[color:var(--surface)]";
 
           return (
             <div key={id} className={`rounded-2xl border p-4 ${tone}`}>
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <div className="flex items-center gap-2">
-                    <span className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-2 py-0.5 text-[10px] font-medium tracking-[0.16em] text-zinc-400">
+                    <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2 py-0.5 text-[10px] font-medium tracking-[0.16em] text-[color:var(--text-secondary)]">
                       {severity}
                     </span>
                     {data.isKev && (
@@ -105,15 +105,15 @@ export function GraphFindingsFallback({
                       </span>
                     )}
                   </div>
-                  <h4 className="mt-2 font-mono text-sm font-semibold text-zinc-100">{data.label}</h4>
+                  <h4 className="mt-2 font-mono text-sm font-semibold text-[color:var(--foreground)]">{data.label}</h4>
                   {data.description && (
-                    <p className="mt-2 text-sm leading-6 text-zinc-400">{data.description}</p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">{data.description}</p>
                   )}
                 </div>
                 <button
                   type="button"
                   onClick={() => onSelect(id, data)}
-                  className="rounded-xl border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-xs font-medium text-zinc-200 transition hover:border-zinc-500 hover:text-zinc-100"
+                  className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-xs font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
                 >
                   Open evidence
                 </button>
@@ -137,7 +137,7 @@ export function GraphFindingsFallback({
                   href={`https://osv.dev/vulnerability/${encodeURIComponent(data.label)}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:border-zinc-600 hover:text-zinc-100"
+                  className="inline-flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs font-medium text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                 >
                   View on OSV
                   <ExternalLink className="h-3 w-3" />
@@ -153,9 +153,9 @@ export function GraphFindingsFallback({
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-2">
-      <div className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">{label}</div>
-      <div className="mt-1 text-sm font-mono text-zinc-100">{value}</div>
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2">
+      <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{label}</div>
+      <div className="mt-1 text-sm font-mono text-[color:var(--foreground)]">{value}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- convert the shared attack-path card and graph-state panels from hard-coded dark classes to theme variables
- preserve the current dark visual language while making the same components render credibly in light mode
- keep the change scoped to shared operator-surface cards with no backend or schema changes

## Testing
- git diff --check