### PR TITLE
Rebuild docs on release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,15 @@ jobs:
           print(f"Version aligned: {pkg}")
           PY
 
+  docs-site:
+    name: Rebuild and deploy docs
+    needs: version-guard
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/docs.yml
+
   build:
     name: Build distribution
     needs: version-guard


### PR DESCRIPTION
## Summary
- make the docs workflow reusable via `workflow_call`
- invoke docs rebuild/deploy from the release workflow so every tag refreshes the site
- reuse the existing docs pipeline instead of duplicating mkdocs steps in release

## Testing
- python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/docs.yml','.github/workflows/release.yml']]; print('yaml ok')"
- git diff --check