### PR TITLE
Promote findings as a first-class UI surface

### DIFF
--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../vulns/page";

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -661,9 +661,9 @@ export default function Dashboard() {
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
         <StatCard icon={Layers} label="Total scans" value={summaryReady ? String(effectiveRecentJobs.length) : "—"} color="zinc" href="/jobs" />
         <StatCard icon={Server} label="Agents" value={agentsReady ? String(effectiveAgentCount) : "—"} color="blue" href="/agents" />
-        <StatCard icon={Package} label="Packages" value={summaryReady ? String(detailsReady ? totalPackages : (summaryStats?.total_packages ?? 0)) : "—"} color="orange" href="/vulns" />
-        <StatCard icon={Bug} label="Unique CVEs" value={summaryReady ? String(detailsReady ? uniqueCVEs : (summaryStats?.total_vulnerabilities ?? 0)) : "—"} color="red" href="/vulns" />
-        <StatCard icon={Zap} label="Critical" value={summaryReady ? String(detailsReady ? severity.critical : (summaryStats?.critical_findings ?? 0)) : "—"} color="red" href="/vulns?severity=critical" />
+        <StatCard icon={Package} label="Packages" value={summaryReady ? String(detailsReady ? totalPackages : (summaryStats?.total_packages ?? 0)) : "—"} color="orange" href="/findings" />
+        <StatCard icon={Bug} label="Unique CVEs" value={summaryReady ? String(detailsReady ? uniqueCVEs : (summaryStats?.total_vulnerabilities ?? 0)) : "—"} color="red" href="/findings" />
+        <StatCard icon={Zap} label="Critical" value={summaryReady ? String(detailsReady ? severity.critical : (summaryStats?.critical_findings ?? 0)) : "—"} color="red" href="/findings?severity=critical" />
       </div>
 
       {/* Severity distribution + Sources — side by side */}
@@ -699,7 +699,7 @@ export default function Dashboard() {
                 Findings that meet multiple independent risk criteria simultaneously
               </p>
             </div>
-            <Link href="/vulns" className="text-xs text-emerald-500 hover:text-emerald-400 flex items-center gap-1">
+            <Link href="/findings" className="text-xs text-emerald-500 hover:text-emerald-400 flex items-center gap-1">
               View all <ArrowRight className="w-3 h-3" />
             </Link>
           </div>
@@ -790,7 +790,7 @@ export default function Dashboard() {
           </div>
           {topPackages.length > 10 && (
             <p className="text-xs text-zinc-600 text-right mt-1">
-              Showing 10 of {topPackages.length} — <Link href="/vulns" className="text-emerald-500 hover:text-emerald-400">view all</Link>
+              Showing 10 of {topPackages.length} — <Link href="/findings" className="text-emerald-500 hover:text-emerald-400">view all</Link>
             </p>
           )}
         </section>
@@ -803,7 +803,7 @@ export default function Dashboard() {
             <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest">
               Highest risk findings
             </h2>
-            <Link href="/vulns" className="text-xs text-emerald-500 hover:text-emerald-400 flex items-center gap-1">
+            <Link href="/findings" className="text-xs text-emerald-500 hover:text-emerald-400 flex items-center gap-1">
               View all <ArrowRight className="w-3 h-3" />
             </Link>
           </div>
@@ -815,7 +815,7 @@ export default function Dashboard() {
                 <BlastCard
                   key={b.vulnerability_id}
                   blast={b}
-                  detailHref={`/vulns?cve=${b.vulnerability_id}`}
+                  detailHref={`/findings?cve=${b.vulnerability_id}`}
                 />
               ))}
           </div>
@@ -945,7 +945,7 @@ function SeverityChart({ severity }: { severity: SeverityCounts }) {
           b.count > 0 ? (
             <Link
               key={b.label}
-              href={`/vulns?severity=${b.label.toLowerCase()}`}
+              href={`/findings?severity=${b.label.toLowerCase()}`}
               className={`${b.color} transition-all duration-500 hover:brightness-125`}
               style={{ width: `${(b.count / total) * 100}%` }}
               title={`${b.label}: ${b.count}`}
@@ -957,7 +957,7 @@ function SeverityChart({ severity }: { severity: SeverityCounts }) {
       {/* Legend with hover rings */}
       <div className="grid grid-cols-4 gap-2">
         {bars?.map((b) => (
-          <Link key={b.label} href={`/vulns?severity=${b.label.toLowerCase()}`} className={`rounded-lg py-2 text-center transition-all hover:bg-[var(--surface-muted)] hover:ring-1 ${b.ring}`}>
+          <Link key={b.label} href={`/findings?severity=${b.label.toLowerCase()}`} className={`rounded-lg py-2 text-center transition-all hover:bg-[var(--surface-muted)] hover:ring-1 ${b.ring}`}>
             <div className={`text-xl font-bold font-mono ${b.text}`}>{b.count}</div>
             <div className="text-[10px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">{b.label}</div>
             <div className="text-[10px] font-mono text-[var(--text-tertiary)]">{total > 0 ? Math.round((b.count / total) * 100) : 0}%</div>
@@ -1161,7 +1161,7 @@ function CompoundIssueCard({ issue }: { issue: CompoundIssue }) {
   const countColor = isCrit ? "text-red-400" : "text-orange-400";
 
   return (
-    <Link href={`/vulns?${issue.filter}`}>
+    <Link href={`/findings?${issue.filter}`}>
       <div
         className={`bg-zinc-900 border ${borderColor} rounded-xl p-4 hover:bg-zinc-800/80 transition-colors cursor-pointer`}
       >

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -442,10 +442,10 @@ function SecurityGraphPageContent() {
               <GitBranch className="h-3.5 w-3.5" />
             </Link>
             <Link
-              href="/vulns"
+              href="/findings"
               className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
             >
-              Review vulnerabilities
+              Review findings
               <ArrowRight className="h-3.5 w-3.5" />
             </Link>
             {hasFocusContext && (
@@ -488,10 +488,10 @@ function SecurityGraphPageContent() {
                     <GitBranch className="h-3 w-3" />
                   </Link>
                   <Link
-                    href="/vulns"
+                    href="/findings"
                     className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                   >
-                    Vulns
+                    Findings
                     <ArrowRight className="h-3 w-3" />
                   </Link>
                   {hasFocusContext && (
@@ -597,7 +597,7 @@ function SecurityGraphPageContent() {
                     label="Findings"
                     tags={selectedAttackPath.vuln_ids}
                     emptyLabel="No linked findings"
-                    hrefForTag={(tag) => `/vulns?cve=${encodeURIComponent(tag)}`}
+                    hrefForTag={(tag) => `/findings?cve=${encodeURIComponent(tag)}`}
                   />
                   <TagList
                     label="Agents"

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -314,19 +314,19 @@ function VulnsPage() {
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Vulnerabilities</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Findings</h1>
           <p className="text-zinc-400 text-sm mt-1">
             {scope === "latest"
-              ? `${vulns.length} unique CVEs from the latest completed scan.`
-              : `${vulns.length} unique CVEs aggregated across all completed scans.`}{" "}
-            CVSS and EPSS appear only when the underlying advisory includes them.
+              ? `${vulns.length} vulnerability findings from the latest completed scan.`
+              : `${vulns.length} vulnerability findings aggregated across all completed scans.`}{" "}
+            This surface is vulnerability-first today and will expand to broader finding types over time. CVSS and EPSS appear only when the underlying advisory includes them.
           </p>
         </div>
         {vulns.length > 0 && (
           <button
-            onClick={() => downloadJson(displayed, `vulns-${new Date().toISOString().slice(0, 10)}.json`)}
+            onClick={() => downloadJson(displayed, `findings-${new Date().toISOString().slice(0, 10)}.json`)}
             className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
-            title="Export filtered vulnerabilities as JSON"
+            title="Export filtered findings as JSON"
           >
             <Download className="w-3.5 h-3.5" />
             Export
@@ -348,17 +348,17 @@ function VulnsPage() {
       )}
       {!loading && error && (
         <ApiOfflineState
-          title="Vulnerabilities need the agent-bom API"
+          title="Findings need the agent-bom API"
           detail={error}
         />
       )}
 
       {!loading && !error && vulns.length === 0 && (
-        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+          <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
           <Bug className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-500 text-sm">No vulnerabilities found.</p>
+          <p className="text-zinc-500 text-sm">No findings found.</p>
           <p className="text-zinc-600 text-xs mt-1">
-            Run a scan with enrichment enabled to see CVE data here.
+            Run a scan with enrichment enabled to see CVE-backed findings here.
           </p>
         </div>
       )}
@@ -406,7 +406,7 @@ function VulnsPage() {
                 </select>
               </div>
               <p className="text-xs text-zinc-600">
-                Default stays scoped for speed. Expand to all scans only when you need history-wide aggregation.
+                Default stays scoped for speed. Expand to all scans only when you need history-wide findings aggregation.
               </p>
             </div>
 
@@ -503,7 +503,7 @@ function VulnsPage() {
 
           {grouped && (
             <p className="text-xs text-zinc-600 text-right">
-              Showing {displayed.length} of {vulns.length} vulnerabilities
+              Showing {displayed.length} of {vulns.length} findings
             </p>
           )}
         </>

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -127,11 +127,11 @@ export function GraphFindingsFallback({
 
               <div className="mt-4 flex flex-wrap gap-2">
                 <Link
-                  href={`/vulns?cve=${encodeURIComponent(data.label)}`}
+                  href={`/findings?cve=${encodeURIComponent(data.label)}`}
                   className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70"
                 >
                   <Route className="h-3 w-3" />
-                  Open in vulnerabilities
+                  Open in findings
                 </Link>
                 <a
                   href={`https://osv.dev/vulnerability/${encodeURIComponent(data.label)}`}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -78,7 +78,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/sources", label: "Data Sources", icon: Database },
       { href: "/scan", label: "New Scan", icon: Scan },
       { href: "/jobs", label: "Scan Jobs", icon: Clock },
-      { href: "/vulns", label: "Vulnerabilities", icon: Bug, badge: "critical" },
+      { href: "/findings", label: "Findings", icon: Bug, badge: "critical" },
     ],
   },
   {
@@ -333,9 +333,14 @@ export function Nav() {
                     {group.description}
                   </p>
                   {group.links.map(({ href, label, icon: Icon, badge }) => {
-                    const active = href === "/" ? path === "/" : path.startsWith(href);
+                    const active =
+                      href === "/"
+                        ? path === "/"
+                        : href === "/findings"
+                        ? path.startsWith("/findings") || path.startsWith("/vulns")
+                        : path.startsWith(href);
                     const dimmed = isDimmed(href);
-                    const isVulns = href === "/vulns";
+                    const isVulns = href === "/findings";
 
                     return (
                       <Link

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -39,7 +39,7 @@ export function postureDimensionTone(score: number) {
 
 export function postureDimensionHref(key: string, label: string) {
   const text = `${key} ${label}`.toLowerCase();
-  if (text.includes("vuln") || text.includes("package") || text.includes("fix")) return "/vulns";
+  if (text.includes("vuln") || text.includes("package") || text.includes("fix")) return "/findings";
   if (text.includes("credential") || text.includes("tool")) return "/mesh";
   if (text.includes("agent") || text.includes("server")) return "/agents";
   if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "/compliance";

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -517,7 +517,7 @@ describe("attack path helpers", () => {
       {
         title: "Validate the lead finding",
         detail: "Open the primary CVE evidence first so the exploit chain has a confirmed root cause.",
-        href: "/vulns?cve=CVE-2026-3434",
+        href: "/findings?cve=CVE-2026-3434",
       },
       {
         title: "Inspect the exposed agent",

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -94,11 +94,11 @@ describe('Nav', () => {
     expect(links.some((l) => l.getAttribute('href') === '/jobs')).toBe(true)
   })
 
-  it('contains link to Vulnerabilities (/vulns)', () => {
+  it('contains link to Findings (/findings)', () => {
     render(<Nav />)
     fireEvent.click(screen.getByRole('button', { name: /scan/i }))
-    const links = screen.getAllByRole('link', { name: /vulnerabilities/i })
-    expect(links.some((l) => l.getAttribute('href') === '/vulns')).toBe(true)
+    const links = screen.getAllByRole('link', { name: /findings/i })
+    expect(links.some((l) => l.getAttribute('href') === '/findings')).toBe(true)
   })
 
   it('contains Remediation link', () => {
@@ -178,7 +178,7 @@ describe('Nav', () => {
     }
     const expectedHrefs = [
       '/', '/sources', '/scan', '/jobs',
-      '/agents', '/vulns', '/fleet',
+      '/agents', '/findings', '/fleet',
       '/security-graph', '/graph', '/mesh', '/context', '/insights',
       '/proxy', '/audit', '/gateway',
       '/compliance', '/remediation', '/governance', '/traces', '/activity',

--- a/ui/tests/posture-grade.test.tsx
+++ b/ui/tests/posture-grade.test.tsx
@@ -10,7 +10,7 @@ import {
 
 describe("posture-grade helpers", () => {
   it("maps dimension labels to evidence destinations", () => {
-    expect(postureDimensionHref("vulnerability_exposure", "Vulnerability Exposure")).toBe("/vulns");
+    expect(postureDimensionHref("vulnerability_exposure", "Vulnerability Exposure")).toBe("/findings");
     expect(postureDimensionHref("credential_reach", "Credential Reach")).toBe("/mesh");
     expect(postureDimensionHref("runtime_watch", "Runtime Watch")).toBe("/proxy");
   });
@@ -48,7 +48,7 @@ describe("PostureGrade", () => {
       />,
     );
 
-    expect(screen.getByRole("link", { name: /Vulnerability Exposure/i })).toHaveAttribute("href", "/vulns");
+    expect(screen.getByRole("link", { name: /Vulnerability Exposure/i })).toHaveAttribute("href", "/findings");
     expect(screen.getByRole("link", { name: /Credential Reach/i })).toHaveAttribute("href", "/mesh");
     expect(screen.getByText("High-risk packages remain reachable by agents.")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add a /findings route that reuses the current vulnerability explorer
- update navigation and the highest-signal dashboard/graph drilldowns to point to Findings
- broaden the page copy so the surface is framed as findings-first while keeping /vulns compatibility

## Testing
- git diff --check
- npm run test:run -- tests/nav.test.tsx tests/posture-grade.test.tsx tests/attack-paths.test.ts *(blocked locally by existing ui/node_modules css-tree/jsdom install issue; rely on CI for UI validation)*