### PR TITLE
Stitch IaC findings into the unified graph

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -666,6 +666,8 @@ def scan(
                     "line_number": f.line_number,
                     "category": f.category,
                     "compliance": f.compliance,
+                    "attack_techniques": f.attack_techniques,
+                    "remediation": f.remediation,
                 }
                 for f in all_iac_findings
             ],

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -1118,6 +1118,8 @@ def run_local_discovery(
                     "line_number": f.line_number,
                     "category": f.category,
                     "compliance": f.compliance,
+                    "attack_techniques": f.attack_techniques,
+                    "remediation": f.remediation,
                 }
                 for f in all_iac_findings
             ],

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -498,6 +498,59 @@ def build_unified_graph_from_report(
                 )
             )
 
+    # ── IaC findings as misconfiguration nodes ───────────────────────
+    iac_data = report_json.get("iac_findings") or report_json.get("iac_findings_data")
+    if iac_data:
+        for finding in iac_data.get("findings", []):
+            rule_id = finding.get("rule_id", "unknown")
+            finding_path = finding.get("file_path", "") or "unknown"
+            finding_line = finding.get("line_number", 0) or 0
+            category = str(finding.get("category", "iac") or "iac").lower()
+            compliance = list(finding.get("compliance", []))
+            attack_techniques = list(finding.get("attack_techniques", []))
+            remediation = finding.get("remediation", "")
+            iac_id = f"misconfig:iac:{rule_id}:{finding_path}:{finding_line}"
+            target_id = f"iac_target:{category}:{finding_path}"
+
+            graph.add_node(
+                UnifiedNode(
+                    id=iac_id,
+                    entity_type=EntityType.MISCONFIGURATION,
+                    label=finding.get("title", rule_id or "IaC finding"),
+                    severity=finding.get("severity", "medium").lower(),
+                    attributes={
+                        "rule_id": rule_id,
+                        "file_path": finding_path,
+                        "line_number": finding_line,
+                        "category": category,
+                        "message": finding.get("message", ""),
+                        "remediation": remediation,
+                    },
+                    compliance_tags=sorted(set(compliance + attack_techniques)),
+                    data_sources=sorted(set(["iac", category])),
+                )
+            )
+            graph.add_node(
+                UnifiedNode(
+                    id=target_id,
+                    entity_type=EntityType.CLOUD_RESOURCE,
+                    label=finding_path,
+                    attributes={
+                        "file_path": finding_path,
+                        "category": category,
+                        "target_type": "iac_file",
+                    },
+                    data_sources=sorted(set(["iac", category])),
+                )
+            )
+            graph.add_edge(
+                UnifiedEdge(
+                    source=iac_id,
+                    target=target_id,
+                    relationship=RelationshipType.AFFECTS,
+                )
+            )
+
     # ── Runtime session graph (dynamic edges) ──────────────────────
     runtime_graph = report_json.get("runtime_session_graph")
     if runtime_graph:

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -284,6 +284,44 @@ class TestSASTNodes:
         assert "A03:2021" in misconfigs[0].compliance_tags
 
 
+class TestIaCNodes:
+    def test_iac_findings_become_misconfig_nodes_and_target_anchors(self):
+        report = _minimal_report()
+        report["iac_findings"] = {
+            "findings": [
+                {
+                    "rule_id": "K8S-007",
+                    "title": "Secrets in plain env values",
+                    "message": "Container sets a plaintext secret in env.",
+                    "severity": "high",
+                    "file_path": "deploy/k8s/api.yaml",
+                    "line_number": 27,
+                    "category": "kubernetes",
+                    "compliance": ["CIS-5.4.1"],
+                    "attack_techniques": ["T1552.001"],
+                    "remediation": "Use Secret refs instead of plaintext values.",
+                }
+            ]
+        }
+
+        g = build_unified_graph_from_report(report)
+
+        misconfigs = g.nodes_by_type(EntityType.MISCONFIGURATION)
+        assert len(misconfigs) == 1
+        assert misconfigs[0].label == "Secrets in plain env values"
+        assert misconfigs[0].attributes["file_path"] == "deploy/k8s/api.yaml"
+        assert misconfigs[0].attributes["category"] == "kubernetes"
+        assert misconfigs[0].attributes["remediation"] == "Use Secret refs instead of plaintext values."
+        assert "CIS-5.4.1" in misconfigs[0].compliance_tags
+        assert "T1552.001" in misconfigs[0].compliance_tags
+
+        anchors = g.nodes_by_type(EntityType.CLOUD_RESOURCE)
+        assert any(anchor.label == "deploy/k8s/api.yaml" for anchor in anchors)
+        anchor = next(anchor for anchor in anchors if anchor.label == "deploy/k8s/api.yaml")
+        assert anchor.attributes["target_type"] == "iac_file"
+        assert g.has_edge("misconfig:iac:K8S-007:deploy/k8s/api.yaml:27", "iac_target:kubernetes:deploy/k8s/api.yaml")
+
+
 class TestModelProvenance:
     def test_model_nodes_created(self):
         report = _minimal_report()


### PR DESCRIPTION
## Summary
- project IaC findings into the unified graph as misconfiguration nodes
- anchor each finding to its affected IaC target path so graph traversal has a stable edge
- preserve remediation, ATT&CK technique, and compliance metadata on the graph nodes

## Testing
- uv run pytest -q tests/test_graph_builder.py -k 'IaC or SAST or CIS'
- uv run ruff check src/agent_bom/graph/builder.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_discovery.py tests/test_graph_builder.py
- git diff --check