### PR TITLE
Add programmable graph query traversal

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -6,6 +6,7 @@ Endpoints:
   GET  /v1/graph/paths          — attack paths from a source node
   GET  /v1/graph/impact         — blast radius of a node (reverse BFS)
   GET  /v1/graph/search         — full-text graph search
+  POST /v1/graph/query          — programmable traversal query
   GET  /v1/graph/node/{id}      — single node detail with edges + impact
   GET  /v1/graph/snapshots      — list persisted scan snapshots
   GET  /v1/graph/legend         — entity + relationship legends
@@ -17,12 +18,13 @@ Endpoints:
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from agent_bom.api.stores import _get_graph_store
+from agent_bom.graph import SEVERITY_RANK, GraphFilterOptions, RelationshipType, UnifiedGraph
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -64,6 +66,82 @@ class PresetCreate(BaseModel):
     name: str
     description: str = ""
     filters: dict
+
+
+class GraphQueryRequest(BaseModel):
+    roots: list[str] = Field(..., min_length=1, description="One or more starting node IDs")
+    scan_id: str = ""
+    direction: Literal["forward", "reverse", "both"] = "forward"
+    max_depth: int = Field(4, ge=1, le=10)
+    max_nodes: int = Field(500, ge=1, le=5000)
+    traversable_only: bool = False
+    static_only: bool = False
+    dynamic_only: bool = False
+    include_roots: bool = True
+    include_attack_paths: bool = False
+    min_severity: str = ""
+    entity_types: list[str] = Field(default_factory=list)
+    relationship_types: list[str] = Field(default_factory=list)
+    compliance_prefixes: list[str] = Field(default_factory=list)
+    data_sources: list[str] = Field(default_factory=list)
+
+
+def _node_matches_query(
+    node,
+    *,
+    entity_types: set[str],
+    min_severity_rank: int,
+    compliance_prefixes: set[str],
+    data_sources: set[str],
+) -> bool:
+    from agent_bom.graph import SEVERITY_RANK
+
+    if entity_types:
+        entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+        if entity_type not in entity_types:
+            return False
+    if min_severity_rank and SEVERITY_RANK.get(node.severity.lower(), 0) < min_severity_rank:
+        return False
+    if compliance_prefixes:
+        prefixes = {tag.split("-")[0].upper() if "-" in tag else tag.upper() for tag in node.compliance_tags}
+        if not prefixes.intersection(compliance_prefixes):
+            return False
+    if data_sources and not set(node.data_sources).intersection(data_sources):
+        return False
+    return True
+
+
+def _filtered_query_graph(
+    graph,
+    *,
+    roots: list[str],
+    entity_types: set[str],
+    min_severity_rank: int,
+    compliance_prefixes: set[str],
+    data_sources: set[str],
+):
+    filtered = UnifiedGraph(scan_id=graph.scan_id, tenant_id=graph.tenant_id, created_at=graph.created_at)
+    keep_ids = {
+        node.id
+        for node in graph.nodes.values()
+        if _node_matches_query(
+            node,
+            entity_types=entity_types,
+            min_severity_rank=min_severity_rank,
+            compliance_prefixes=compliance_prefixes,
+            data_sources=data_sources,
+        )
+    }
+    keep_ids.update(root for root in roots if root in graph.nodes)
+
+    for node_id in keep_ids:
+        node = graph.nodes.get(node_id)
+        if node:
+            filtered.add_node(node)
+    for edge in graph.edges:
+        if edge.source in keep_ids and edge.target in keep_ids:
+            filtered.add_edge(edge)
+    return filtered
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -231,6 +309,68 @@ async def search_graph(
             "limit": limit,
             "has_more": offset + limit < total,
         },
+    }
+
+
+@router.post("/v1/graph/query", tags=["graph"])
+async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
+    """Run a bounded programmable traversal over the canonical graph."""
+
+    graph = _get_graph_store_or_503().load_graph(scan_id=body.scan_id or "", tenant_id=_tenant(request))
+    missing_roots = [root for root in body.roots if not graph.has_node(root)]
+    if missing_roots:
+        raise HTTPException(status_code=404, detail={"message": "Root nodes not found", "missing_roots": missing_roots})
+
+    rel_types = {RelationshipType(rel) for rel in body.relationship_types} if body.relationship_types else None
+    traversal_graph, depth_by_node, truncated = graph.traverse_subgraph(
+        body.roots,
+        direction=body.direction,
+        max_depth=body.max_depth,
+        max_nodes=body.max_nodes,
+        traversable_only=body.traversable_only,
+        relationship_types=rel_types,
+        static_only=body.static_only,
+        dynamic_only=body.dynamic_only,
+        include_roots=body.include_roots,
+    )
+
+    filtered_graph = _filtered_query_graph(
+        traversal_graph,
+        roots=body.roots,
+        entity_types=set(body.entity_types),
+        min_severity_rank=SEVERITY_RANK.get(body.min_severity.lower(), 0) if body.min_severity else 0,
+        compliance_prefixes={prefix.upper() for prefix in body.compliance_prefixes},
+        data_sources=set(body.data_sources),
+    )
+
+    attack_paths = []
+    if body.include_attack_paths:
+        attack_paths = [
+            ap.to_dict() for ap in graph.attack_paths if ap.source in body.roots and all(hop in filtered_graph.nodes for hop in ap.hops)
+        ]
+
+    return {
+        "scan_id": filtered_graph.scan_id,
+        "tenant_id": filtered_graph.tenant_id,
+        "roots": body.roots,
+        "direction": body.direction,
+        "max_depth": body.max_depth,
+        "max_nodes": body.max_nodes,
+        "truncated": truncated,
+        "missing_roots": [],
+        "depth_by_node": {node_id: depth for node_id, depth in depth_by_node.items() if node_id in filtered_graph.nodes},
+        "nodes": [node.to_dict() for node in filtered_graph.nodes.values()],
+        "edges": [edge.to_dict() for edge in filtered_graph.edges],
+        "attack_paths": attack_paths,
+        "stats": filtered_graph.stats(),
+        "filters": GraphFilterOptions(
+            max_depth=body.max_depth,
+            min_severity=body.min_severity,
+            relationship_types=rel_types or set(),
+            static_only=body.static_only,
+            dynamic_only=body.dynamic_only,
+            include_ids=set(body.roots),
+        ).to_dict(),
     }
 
 

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -412,6 +412,96 @@ class UnifiedGraph:
             visited.discard(source)
         return visited
 
+    def traverse_subgraph(
+        self,
+        roots: list[str],
+        *,
+        direction: str = "forward",
+        max_depth: int = 4,
+        max_nodes: int = 500,
+        traversable_only: bool = False,
+        relationship_types: set[RelationshipType] | None = None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+        include_roots: bool = True,
+    ) -> tuple[UnifiedGraph, dict[str, int], bool]:
+        """Traverse the graph from one or more roots and return a bounded subgraph.
+
+        ``direction`` controls whether traversal follows outgoing edges,
+        incoming edges, or both. The returned edges always preserve their
+        original orientation in the canonical graph.
+        """
+        sub = UnifiedGraph(scan_id=self.scan_id, tenant_id=self.tenant_id, created_at=self.created_at)
+        if not roots:
+            return sub, {}, False
+
+        visited: set[str] = set()
+        depth_by_node: dict[str, int] = {}
+        traversed_edges: dict[tuple[str, str, str], UnifiedEdge] = {}
+        queue: deque[tuple[str, int]] = deque()
+
+        for root in roots:
+            if root not in self.nodes:
+                continue
+            queue.append((root, 0))
+            if include_roots:
+                visited.add(root)
+            depth_by_node[root] = 0
+
+        truncated = False
+
+        def _edge_allowed(edge: UnifiedEdge) -> bool:
+            if relationship_types and edge.relationship not in relationship_types:
+                return False
+            if traversable_only and not edge.traversable:
+                return False
+            if static_only and edge.relationship in _DYNAMIC_RELS:
+                return False
+            if dynamic_only and edge.relationship not in _DYNAMIC_RELS:
+                return False
+            return True
+
+        while queue:
+            current, depth = queue.popleft()
+            if depth >= max_depth:
+                continue
+
+            candidates: list[tuple[str, UnifiedEdge]] = []
+            if direction in {"forward", "both"}:
+                candidates.extend((edge.target, edge) for edge in self.adjacency.get(current, []))
+            if direction in {"reverse", "both"}:
+                candidates.extend((edge.source, edge) for edge in self.reverse_adjacency.get(current, []))
+
+            for neighbor, edge in candidates:
+                if not _edge_allowed(edge):
+                    continue
+
+                rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+                traversed_edges[(edge.source, edge.target, rel)] = edge
+
+                if neighbor in visited:
+                    continue
+                if len(visited) >= max_nodes:
+                    truncated = True
+                    continue
+                visited.add(neighbor)
+                depth_by_node[neighbor] = depth + 1
+                queue.append((neighbor, depth + 1))
+
+        if include_roots:
+            visited.update(root for root in roots if root in self.nodes)
+
+        for node_id in visited:
+            node = self.nodes.get(node_id)
+            if node:
+                sub.add_node(node)
+
+        for edge in traversed_edges.values():
+            if edge.source in sub.nodes and edge.target in sub.nodes:
+                sub.add_edge(edge)
+
+        return sub, depth_by_node, truncated
+
     # ── Centrality ───────────────────────────────────────────────────────
 
     def degree_centrality(self) -> dict[str, float]:

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -433,3 +433,117 @@ class TestGraphStoreBackendSelection:
         assert body["reachable_count"] == 1
         assert body["reachable_nodes"] == ["server:s"]
         assert [path["target"] for path in body["paths"]] == ["server:s"]
+
+    def test_graph_query_returns_bounded_directional_subgraph(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:CVE-2026-1",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-1",
+                severity="critical",
+                risk_score=9.8,
+                data_sources=["osv"],
+            )
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(
+                source="server:s",
+                target="vuln:CVE-2026-1",
+                relationship=RelationshipType.VULNERABLE_TO,
+                traversable=True,
+            )
+        )
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:CVE-2026-1",
+                hops=["agent:a", "server:s", "vuln:CVE-2026-1"],
+                edges=["uses", "vulnerable_to"],
+                composite_risk=9.8,
+                summary="agent-a -> server-s -> CVE-2026-1",
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/v1/graph/query",
+            json={
+                "roots": ["agent:a"],
+                "direction": "forward",
+                "max_depth": 2,
+                "relationship_types": ["uses", "vulnerable_to"],
+                "include_attack_paths": True,
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["roots"] == ["agent:a"]
+        assert body["truncated"] is False
+        assert set(body["depth_by_node"]) == {"agent:a", "server:s", "vuln:CVE-2026-1"}
+        assert {node["id"] for node in body["nodes"]} == {"agent:a", "server:s", "vuln:CVE-2026-1"}
+        assert {(edge["source"], edge["target"]) for edge in body["edges"]} == {
+            ("agent:a", "server:s"),
+            ("server:s", "vuln:CVE-2026-1"),
+        }
+        assert body["attack_paths"][0]["target"] == "vuln:CVE-2026-1"
+
+    def test_graph_query_filters_by_compliance_and_source(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="misconfig:iac:K8S-007:file.yaml:12",
+                entity_type=EntityType.MISCONFIGURATION,
+                label="Secrets in env",
+                severity="high",
+                compliance_tags=["CIS-5.4.1", "T1552.001"],
+                data_sources=["iac", "kubernetes"],
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="cloud_resource:k8s:file.yaml",
+                entity_type=EntityType.CLOUD_RESOURCE,
+                label="deploy/k8s/file.yaml",
+                data_sources=["iac", "kubernetes"],
+            )
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(
+                source="misconfig:iac:K8S-007:file.yaml:12",
+                target="cloud_resource:k8s:file.yaml",
+                relationship=RelationshipType.AFFECTS,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/v1/graph/query",
+            json={
+                "roots": ["misconfig:iac:K8S-007:file.yaml:12"],
+                "direction": "forward",
+                "max_depth": 1,
+                "compliance_prefixes": ["CIS"],
+                "data_sources": ["iac"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [node["id"] for node in body["nodes"]] == ["misconfig:iac:K8S-007:file.yaml:12"]
+        assert body["edges"] == []
+
+    def test_graph_query_returns_404_for_missing_roots(self, recording_graph_store):
+        client = TestClient(app)
+
+        response = client.post("/v1/graph/query", json={"roots": ["agent:missing"]})
+
+        assert response.status_code == 404
+        assert response.json()["detail"]["missing_roots"] == ["agent:missing"]


### PR DESCRIPTION
## Summary
- add a bounded POST /v1/graph/query endpoint for structured graph traversal
- support directional traversal, relationship filtering, severity/source/framework filters, and attack-path inclusion
- keep the canonical graph model and existing stores intact with no schema changes

## Testing
- uv run pytest -q tests/test_graph_api.py -k 'query or paths or search or presets'
- uv run ruff check src/agent_bom/api/routes/graph.py src/agent_bom/graph/container.py tests/test_graph_api.py
- git diff --check