### PR TITLE
Batch analytics ingest for flagged trace events

### DIFF
--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -45,6 +45,10 @@ class AnalyticsStore(Protocol):
         """Append a runtime protection event."""
         ...
 
+    def record_events(self, events: list[dict]) -> None:
+        """Append multiple runtime protection events in one batch."""
+        ...
+
     def record_posture(self, agent_name: str, snapshot: dict) -> None:
         """Append a posture score snapshot."""
         ...
@@ -106,6 +110,9 @@ class NullAnalyticsStore:
         pass
 
     def record_event(self, event: dict) -> None:
+        pass
+
+    def record_events(self, events: list[dict]) -> None:
         pass
 
     def record_posture(self, agent_name: str, snapshot: dict) -> None:
@@ -200,7 +207,12 @@ class ClickHouseAnalyticsStore:
         ]
 
     def record_event(self, event: dict) -> None:
-        self._client.insert_json("runtime_events", [self._event_row(event)])
+        self.record_events([event])
+
+    def record_events(self, events: list[dict]) -> None:
+        rows = [self._event_row(event) for event in events if event]
+        if rows:
+            self._client.insert_json("runtime_events", rows)
 
     def _event_row(self, event: dict) -> dict[str, Any]:
         return {
@@ -382,6 +394,10 @@ class BufferedAnalyticsStore:
     def record_event(self, event: dict) -> None:
         self._queue.put(("event", (event,)))
 
+    def record_events(self, events: list[dict]) -> None:
+        if events:
+            self._queue.put(("event_batch", (events,)))
+
     def record_posture(self, agent_name: str, snapshot: dict) -> None:
         self._queue.put(("posture", (agent_name, snapshot)))
 
@@ -461,6 +477,9 @@ class BufferedAnalyticsStore:
             elif kind == "event":
                 (event,) = payload
                 event_rows.append(self._store._event_row(dict(event)))
+            elif kind == "event_batch":
+                (events,) = payload
+                event_rows.extend(self._store._event_row(dict(event)) for event in events if event)
             elif kind == "posture":
                 agent_name, snapshot = payload
                 posture_rows.append(self._store._posture_row(str(agent_name), dict(snapshot)))

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from fastapi import APIRouter, HTTPException, Request
 
 from agent_bom.api.models import JobStatus, PushPayload, ScanJob, ScanRequest
-from agent_bom.api.stores import _get_fleet_store, _get_store
+from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_store
 from agent_bom.security import sanitize_error
 
 router = APIRouter()
@@ -73,8 +73,27 @@ async def ingest_traces(request: Request, body: dict) -> dict:
             {server: sorted(cves) for server, cves in vuln_servers.items()},
         )
 
+        if flagged:
+            analytics_events = [
+                {
+                    "event_id": f"{flag.trace.trace_id}:{flag.trace.span_id}",
+                    "event_type": "vulnerable_tool_call",
+                    "detector": "otel_vulnerable_tool_call",
+                    "severity": flag.severity,
+                    "tool_name": flag.trace.tool_name,
+                    "message": flag.reason,
+                    "agent_name": "",
+                }
+                for flag in flagged
+            ]
+            try:
+                _get_analytics_store().record_events(analytics_events)
+            except Exception:  # noqa: BLE001
+                _logger.warning("Trace analytics sync skipped", exc_info=True)
+
         return {
             "traces": len(traces),
+            "persisted_events": len(flagged),
             "flagged": [
                 {
                     "tool_name": f.trace.tool_name,

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -479,9 +479,42 @@ async def test_discovery_and_traces_are_tenant_scoped():
     def _flag(_traces, vuln_packages, vuln_servers):
         assert vuln_packages == {"langchain": ["CVE-alpha"]}
         assert vuln_servers == {"sqlite-mcp": ["CVE-alpha"]}
-        return []
+        from agent_bom.otel_ingest import FlaggedCall, ToolCallTrace
+
+        return [
+            FlaggedCall(
+                trace=ToolCallTrace(
+                    trace_id="t1",
+                    span_id="s1",
+                    tool_name="read_file",
+                    server_name="sqlite-mcp",
+                    package_name="langchain",
+                ),
+                reason="Tool hit package langchain with known CVE",
+                severity="high",
+                server="sqlite-mcp",
+                package_name="langchain",
+                matched_cves=["CVE-alpha"],
+            )
+        ]
+
+    class _Analytics:
+        def __init__(self):
+            self.events = []
+
+        def record_events(self, events):
+            self.events.extend(events)
+
+        def record_event(self, event):
+            self.events.append(event)
+
+    analytics = _Analytics()
 
     with patch("agent_bom.otel_ingest.parse_otel_traces", side_effect=_parse):
         with patch("agent_bom.otel_ingest.flag_vulnerable_tool_calls", side_effect=_flag):
-            result = await observability_routes.ingest_traces(req, {"resourceSpans": []})
+            with patch("agent_bom.api.routes.observability._get_analytics_store", return_value=analytics):
+                result = await observability_routes.ingest_traces(req, {"resourceSpans": []})
     assert result["traces"] == 1
+    assert result["persisted_events"] == 1
+    assert analytics.events[0]["event_type"] == "vulnerable_tool_call"
+    assert analytics.events[0]["detector"] == "otel_vulnerable_tool_call"

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -302,6 +302,32 @@ class TestClickHouseAnalyticsStore:
         assert result == [{"day": "2026-04-05", "severity": "high", "cnt": 1}]
         assert any(table == "vulnerability_scans" for table, _rows in inserted)
 
+    def test_record_events_batches_runtime_rows(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        inserted = {}
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                inserted["table"] = table
+                inserted["rows"] = rows
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_events(
+                [
+                    {"event_type": "vulnerable_tool_call", "severity": "high", "tool_name": "read_file", "message": "flagged"},
+                    {"event_type": "vulnerable_tool_call", "severity": "medium", "tool_name": "exec_sql", "message": "flagged"},
+                ]
+            )
+
+        assert inserted["table"] == "runtime_events"
+        assert len(inserted["rows"]) == 2
+        assert inserted["rows"][0]["event_type"] == "vulnerable_tool_call"
+
 
 def test_clickhouse_escape_strips_control_chars_and_quotes():
     from agent_bom.api.clickhouse_store import _escape


### PR DESCRIPTION
## Summary
- add batched runtime-event writes to the analytics contract and ClickHouse store
- persist flagged vulnerable tool-call events from /v1/traces through the analytics path
- keep the existing ClickHouse schema and canonical event model intact

## Testing
- uv run pytest -q tests/test_clickhouse.py
- uv run pytest -q tests/test_api_tenant_isolation.py
- uv run ruff check src/agent_bom/api/clickhouse_store.py src/agent_bom/api/routes/observability.py tests/test_clickhouse.py tests/test_api_tenant_isolation.py
- git diff --check