### PR TITLE
Expand Snowflake CIS password policy checks

### DIFF
--- a/src/agent_bom/cloud/snowflake_cis_benchmark.py
+++ b/src/agent_bom/cloud/snowflake_cis_benchmark.py
@@ -227,6 +227,72 @@ def _check_1_4(cursor: Any) -> CISCheckResult:
     return result
 
 
+def _check_1_5(cursor: Any) -> CISCheckResult:
+    """CIS 1.5 — Ensure password reuse is limited by password history of 24 or greater."""
+    result = CISCheckResult(
+        check_id="1.5",
+        title="Ensure password reuse is limited by password history of 24 or greater",
+        status=CheckStatus.PASS,
+        severity="medium",
+        cis_section=_AUTH_SECTION,
+        recommendation="Set password policy: CREATE OR REPLACE PASSWORD POLICY ... PASSWORD_HISTORY = 24;",
+    )
+    rows = _run_query(
+        cursor,
+        """
+        SELECT policy_name, password_history
+        FROM SNOWFLAKE.ACCOUNT_USAGE.PASSWORD_POLICIES
+        WHERE deleted IS NULL
+    """,
+    )
+    if not rows:
+        result.status = CheckStatus.FAIL
+        result.evidence = "No password policies configured."
+        return result
+
+    weak = [r for r in rows if int(r.get("password_history", 0) or 0) < 24]
+    if weak:
+        result.status = CheckStatus.FAIL
+        names = [f"{r['policy_name']} (history={r.get('password_history', 0)})" for r in weak]
+        result.evidence = f"Password policies with weak password history: {', '.join(names[:5])}"
+    else:
+        result.evidence = f"All {len(rows)} password policies enforce password history of 24 or greater."
+    return result
+
+
+def _check_1_6(cursor: Any) -> CISCheckResult:
+    """CIS 1.6 — Ensure password maximum age is set to 90 days or less."""
+    result = CISCheckResult(
+        check_id="1.6",
+        title="Ensure password maximum age is set to 90 days or less",
+        status=CheckStatus.PASS,
+        severity="medium",
+        cis_section=_AUTH_SECTION,
+        recommendation="Set password policy: CREATE OR REPLACE PASSWORD POLICY ... PASSWORD_MAX_AGE_DAYS = 90;",
+    )
+    rows = _run_query(
+        cursor,
+        """
+        SELECT policy_name, password_max_age_days
+        FROM SNOWFLAKE.ACCOUNT_USAGE.PASSWORD_POLICIES
+        WHERE deleted IS NULL
+    """,
+    )
+    if not rows:
+        result.status = CheckStatus.FAIL
+        result.evidence = "No password policies configured."
+        return result
+
+    weak = [r for r in rows if int(r.get("password_max_age_days", 0) or 0) == 0 or int(r.get("password_max_age_days", 0) or 0) > 90]
+    if weak:
+        result.status = CheckStatus.FAIL
+        names = [f"{r['policy_name']} (max_age={r.get('password_max_age_days', 0)})" for r in weak]
+        result.evidence = f"Password policies with weak maximum age: {', '.join(names[:5])}"
+    else:
+        result.evidence = f"All {len(rows)} password policies enforce a maximum password age of 90 days or less."
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Individual checks — CIS 2.x (Network Security)
 # ---------------------------------------------------------------------------
@@ -526,7 +592,7 @@ def run_benchmark(
         )
 
     resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
-    resolved_user = user or os.environ.get("SNOWFLAKE_USER", "")
+    resolved_user = user or os.environ.get("SNOWFLAKE_USER") or ""
 
     if not resolved_account:
         raise CloudDiscoveryError("SNOWFLAKE_ACCOUNT not set. Provide --snowflake-account or set the env var.")
@@ -551,6 +617,8 @@ def run_benchmark(
         ("1.2", _check_1_2),
         ("1.3", _check_1_3),
         ("1.4", _check_1_4),
+        ("1.5", _check_1_5),
+        ("1.6", _check_1_6),
         ("2.1", _check_2_1),
         ("2.2", _check_2_2),
         ("3.1", _check_3_1),

--- a/tests/test_snowflake_cis_benchmark.py
+++ b/tests/test_snowflake_cis_benchmark.py
@@ -13,6 +13,8 @@ from agent_bom.cloud.snowflake_cis_benchmark import (
     _check_1_2,
     _check_1_3,
     _check_1_4,
+    _check_1_5,
+    _check_1_6,
     _check_2_1,
     _check_2_2,
     _check_3_1,
@@ -189,6 +191,50 @@ class TestCheck14:
 
 
 # ---------------------------------------------------------------------------
+# 1.5 — Password history
+# ---------------------------------------------------------------------------
+
+
+class TestCheck15:
+    def test_pass_history_strong(self):
+        cursor = _mock_cursor([{"policy_name": "DEFAULT", "password_history": 24}])
+        result = _check_1_5(cursor)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_history_weak(self):
+        cursor = _mock_cursor([{"policy_name": "DEFAULT", "password_history": 5}])
+        result = _check_1_5(cursor)
+        assert result.status == CheckStatus.FAIL
+
+    def test_fail_no_policies(self):
+        cursor = _empty_cursor()
+        result = _check_1_5(cursor)
+        assert result.status == CheckStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# 1.6 — Password max age
+# ---------------------------------------------------------------------------
+
+
+class TestCheck16:
+    def test_pass_max_age_strong(self):
+        cursor = _mock_cursor([{"policy_name": "DEFAULT", "password_max_age_days": 90}])
+        result = _check_1_6(cursor)
+        assert result.status == CheckStatus.PASS
+
+    def test_fail_max_age_too_high(self):
+        cursor = _mock_cursor([{"policy_name": "DEFAULT", "password_max_age_days": 180}])
+        result = _check_1_6(cursor)
+        assert result.status == CheckStatus.FAIL
+
+    def test_fail_max_age_zero(self):
+        cursor = _mock_cursor([{"policy_name": "DEFAULT", "password_max_age_days": 0}])
+        result = _check_1_6(cursor)
+        assert result.status == CheckStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
 # 2.1 — Account-level network policy
 # ---------------------------------------------------------------------------
 
@@ -357,7 +403,7 @@ class TestRunBenchmark:
                 run_benchmark(account="test_acct")
 
     def test_run_benchmark_all_checks(self):
-        """Runner executes all 12 checks and returns report."""
+        """Runner executes all checks and returns report."""
         mock_connector = MagicMock()
         mock_errors = MagicMock()
         mock_errors.DatabaseError = Exception
@@ -384,7 +430,7 @@ class TestRunBenchmark:
                 report = run_benchmark(account="test_acct", user="test_user", authenticator="externalbrowser")
 
         assert report.account == "test_acct"
-        assert report.total == 12
+        assert report.total == 14
 
     def test_run_benchmark_filter_checks(self):
         """Runner only runs requested checks when filtered."""


### PR DESCRIPTION
## Summary
- add password history and password max-age checks to the Snowflake CIS benchmark
- raise Snowflake depth with bounded, testable password-policy coverage
- keep the benchmark contract and report shape unchanged

## Testing
- uv run pytest -q tests/test_snowflake_cis_benchmark.py
- uv run ruff check src/agent_bom/cloud/snowflake_cis_benchmark.py tests/test_snowflake_cis_benchmark.py
- git diff --check