### PR TITLE
Split MCP server runtime helpers

### DIFF
--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -66,6 +66,7 @@ from mcp.server.lowlevel.server import request_ctx as _mcp_request_ctx
 from mcp.types import ToolAnnotations
 from pydantic import AnyHttpUrl, Field, TypeAdapter
 
+from agent_bom import mcp_server_runtime as _mcp_runtime
 from agent_bom.config import MCP_CALLER_RATE_LIMIT as _MCP_CALLER_RATE_LIMIT
 from agent_bom.config import MCP_CALLER_WINDOW_SECONDS as _MCP_CALLER_WINDOW_SECONDS
 from agent_bom.config import MCP_MAX_CALLER_STATES as _MCP_MAX_CALLER_STATES
@@ -108,56 +109,31 @@ class _StaticBearerTokenVerifier:
 
 def _validate_ecosystem(ecosystem: str) -> str:
     """Return cleaned ecosystem string or raise ValueError."""
-    cleaned = ecosystem.lower().strip()
-    if cleaned not in _VALID_ECOSYSTEMS:
-        raise ValueError(f"Invalid ecosystem: {ecosystem!r}. Valid: {', '.join(sorted(_VALID_ECOSYSTEMS))}")
-    return cleaned
+    return _mcp_runtime.validate_ecosystem(ecosystem, _VALID_ECOSYSTEMS)
 
 
 def _validate_cve_id(cve_id: str) -> str:
     """Return cleaned CVE/GHSA ID or raise ValueError."""
-    cleaned = cve_id.strip()
-    if not cleaned:
-        raise ValueError("CVE ID cannot be empty")
-    if not (_CVE_RE.match(cleaned) or _GHSA_RE.match(cleaned)):
-        raise ValueError(f"Invalid CVE ID format: {cleaned!r}. Expected CVE-YYYY-NNNNN or GHSA-xxxx-xxxx-xxxx")
-    return cleaned
+    return _mcp_runtime.validate_cve_id(cve_id, _CVE_RE, _GHSA_RE)
 
 
 def _truncate_response(response_str: str) -> str:
     """Truncate response if it exceeds _MAX_RESPONSE_CHARS."""
-    if len(response_str) <= _MAX_RESPONSE_CHARS:
-        return response_str
-    return (
-        response_str[:_MAX_RESPONSE_CHARS] + '\n\n{"_truncated": true, "message": '
-        '"Response truncated at 500,000 characters. '
-        'Use more specific parameters to reduce output size."}'
-    )
+    return _mcp_runtime.truncate_response(response_str, _MAX_RESPONSE_CHARS)
 
 
 def _safe_path(path_str: str) -> Path:
     """Resolve a user-provided path and validate against directory traversal."""
-    from agent_bom.security import SecurityError, validate_path
-
-    try:
-        return validate_path(path_str, restrict_to_home=True)
-    except SecurityError as exc:
-        raise ValueError(str(exc)) from exc
+    return _mcp_runtime.safe_path(path_str)
 
 
 def _get_tool_semaphore() -> asyncio.Semaphore:
     """Return a semaphore bound to the current running event loop."""
-    loop = asyncio.get_running_loop()
-    loop_id = id(loop)
-    semaphore = _loop_tool_semaphores.get(loop_id)
-    if semaphore is None:
-        if len(_loop_tool_semaphores) >= _MAX_CACHED_TOOL_LOOPS:
-            _loop_tool_semaphores.popitem(last=False)
-        semaphore = asyncio.Semaphore(_MCP_MAX_CONCURRENT_TOOLS)
-        _loop_tool_semaphores[loop_id] = semaphore
-    else:
-        _loop_tool_semaphores.move_to_end(loop_id)
-    return semaphore
+    return _mcp_runtime.get_tool_semaphore(
+        _loop_tool_semaphores,
+        max_cached_tool_loops=_MAX_CACHED_TOOL_LOOPS,
+        max_concurrent_tools=_MCP_MAX_CONCURRENT_TOOLS,
+    )
 
 
 def _record_tool_metric(
@@ -169,121 +145,45 @@ def _record_tool_metric(
     error: str | None = None,
 ) -> None:
     """Update bounded in-memory metrics for MCP tool calls."""
-    metrics = _tool_metrics.get(tool_name)
-    if metrics is None:
-        if len(_tool_metrics) >= _MCP_MAX_TOOL_METRICS:
-            _tool_metrics.popitem(last=False)
-        metrics = {
-            "tool": tool_name,
-            "calls": 0,
-            "failures": 0,
-            "timeouts": 0,
-            "last_status": "unknown",
-            "last_error": None,
-            "last_elapsed_ms": 0,
-            "max_elapsed_ms": 0,
-            "total_elapsed_ms": 0,
-        }
-        _tool_metrics[tool_name] = metrics
-    else:
-        _tool_metrics.move_to_end(tool_name)
-
-    metrics["calls"] += 1
-    metrics["last_status"] = "ok" if success else ("timeout" if timed_out else "error")
-    metrics["last_error"] = None if success else error
-    metrics["last_elapsed_ms"] = elapsed_ms
-    metrics["max_elapsed_ms"] = max(metrics["max_elapsed_ms"], elapsed_ms)
-    metrics["total_elapsed_ms"] += elapsed_ms
-    if not success:
-        metrics["failures"] += 1
-    if timed_out:
-        metrics["timeouts"] += 1
+    _mcp_runtime.record_tool_metric(
+        _tool_metrics,
+        max_tool_metrics=_MCP_MAX_TOOL_METRICS,
+        tool_name=tool_name,
+        elapsed_ms=elapsed_ms,
+        success=success,
+        timed_out=timed_out,
+        error=error,
+    )
 
 
 def _tool_metrics_snapshot() -> dict[str, Any]:
     """Return structured MCP tool metrics for resources and health checks."""
-    tool_stats = []
-    total_calls = 0
-    total_failures = 0
-    total_timeouts = 0
-    for name, metrics in _tool_metrics.items():
-        calls = int(metrics["calls"])
-        total_calls += calls
-        total_failures += int(metrics["failures"])
-        total_timeouts += int(metrics["timeouts"])
-        tool_stats.append(
-            {
-                "tool": name,
-                "calls": calls,
-                "failures": int(metrics["failures"]),
-                "timeouts": int(metrics["timeouts"]),
-                "last_status": metrics["last_status"],
-                "last_error": metrics["last_error"],
-                "last_elapsed_ms": int(metrics["last_elapsed_ms"]),
-                "max_elapsed_ms": int(metrics["max_elapsed_ms"]),
-                "avg_elapsed_ms": round(int(metrics["total_elapsed_ms"]) / calls, 2) if calls else 0.0,
-            }
-        )
-    return {
-        "summary": {
-            "tool_count": len(tool_stats),
-            "total_calls": total_calls,
-            "total_failures": total_failures,
-            "total_timeouts": total_timeouts,
-            "max_concurrent_tools": _MCP_MAX_CONCURRENT_TOOLS,
-            "default_timeout_seconds": _MCP_TOOL_TIMEOUT_SECONDS,
-            "caller_rate_limit_per_window": _MCP_CALLER_RATE_LIMIT,
-            "caller_rate_limit_window_seconds": _MCP_CALLER_WINDOW_SECONDS,
-            "tracked_callers": len(_caller_rate_windows),
-            "recent_request_count": len(_recent_tool_requests),
-        },
-        "tools": tool_stats,
-        "recent_requests": list(_recent_tool_requests),
-    }
+    return _mcp_runtime.tool_metrics_snapshot(
+        _tool_metrics,
+        caller_rate_windows=_caller_rate_windows,
+        recent_tool_requests=_recent_tool_requests,
+        max_concurrent_tools=_MCP_MAX_CONCURRENT_TOOLS,
+        tool_timeout_seconds=_MCP_TOOL_TIMEOUT_SECONDS,
+        caller_rate_limit=_MCP_CALLER_RATE_LIMIT,
+        caller_window_seconds=_MCP_CALLER_WINDOW_SECONDS,
+    )
 
 
 def _current_tool_request() -> dict[str, str | None]:
     """Return request identity metadata when running inside an MCP request."""
-    try:
-        current_request = _mcp_request_ctx.get()
-    except LookupError:
-        return {"caller": "local", "client_id": None, "request_id": None}
-
-    meta = getattr(current_request, "meta", None)
-    client_id = getattr(meta, "client_id", None) if meta else None
-    session = getattr(current_request, "session", None)
-    session_label = f"session-{id(session) % 1_000_000}" if session is not None else "local"
-    return {
-        "caller": client_id or session_label,
-        "client_id": client_id,
-        "request_id": str(getattr(current_request, "request_id", "")) or None,
-    }
+    return _mcp_runtime.current_tool_request(_mcp_request_ctx.get)
 
 
 def _check_caller_rate_limit(caller: str) -> float | None:
     """Return retry-after seconds when a caller exceeds the bounded MCP rate window."""
-    if _MCP_CALLER_RATE_LIMIT <= 0:
-        return None
-
-    now = time.monotonic()
-    window = _caller_rate_windows.get(caller)
-    if window is None:
-        if len(_caller_rate_windows) >= _MCP_MAX_CALLER_STATES:
-            _caller_rate_windows.popitem(last=False)
-        window = deque()
-        _caller_rate_windows[caller] = window
-    else:
-        _caller_rate_windows.move_to_end(caller)
-
-    cutoff = now - _MCP_CALLER_WINDOW_SECONDS
-    while window and window[0] <= cutoff:
-        window.popleft()
-
-    if len(window) >= _MCP_CALLER_RATE_LIMIT:
-        return round(max(0.0, _MCP_CALLER_WINDOW_SECONDS - (now - window[0])), 3)
-
-    window.append(now)
-    return None
+    return _mcp_runtime.check_caller_rate_limit(
+        _caller_rate_windows,
+        caller,
+        caller_rate_limit=_MCP_CALLER_RATE_LIMIT,
+        caller_window_seconds=_MCP_CALLER_WINDOW_SECONDS,
+        max_caller_states=_MCP_MAX_CALLER_STATES,
+        monotonic_now=time.monotonic(),
+    )
 
 
 def _record_tool_request(
@@ -297,17 +197,15 @@ def _record_tool_request(
     error: str | None = None,
 ) -> None:
     """Store a bounded trace of recent MCP tool requests."""
-    _recent_tool_requests.append(
-        {
-            "tool": tool_name,
-            "caller": caller or "local",
-            "client_id": client_id,
-            "request_id": request_id,
-            "status": status,
-            "elapsed_ms": elapsed_ms,
-            "error": error,
-            "ts": int(time.time()),
-        }
+    _mcp_runtime.record_tool_request(
+        _recent_tool_requests,
+        tool_name,
+        caller=caller,
+        client_id=client_id,
+        request_id=request_id,
+        status=status,
+        elapsed_ms=elapsed_ms,
+        error=error,
     )
 
 
@@ -321,90 +219,21 @@ async def _execute_tool_async(
 ) -> _ToolReturn | str:
     """Run an async MCP tool with bounded concurrency, timeout, and metrics."""
     timeout_seconds = timeout if timeout and timeout > 0 else _MCP_TOOL_TIMEOUT_SECONDS
-    request_meta = _current_tool_request()
-    retry_after = _check_caller_rate_limit(request_meta["caller"] or "local")
-    if retry_after is not None:
-        _record_tool_metric(tool_name, elapsed_ms=0, success=False, error="rate limited")
-        _record_tool_request(
-            tool_name,
-            caller=request_meta["caller"],
-            client_id=request_meta["client_id"],
-            request_id=request_meta["request_id"],
-            status="rate_limited",
-            elapsed_ms=0,
-            error="rate limited",
-        )
-        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, request_meta["caller"], retry_after)
-        return _truncate_response(
-            json.dumps(
-                {
-                    "error": f"Tool '{tool_name}' exceeded the caller rate limit",
-                    "tool": tool_name,
-                    "rate_limited": True,
-                    "retry_after_seconds": retry_after,
-                }
-            )
-        )
-    start = time.perf_counter()
-    logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, request_meta["caller"], request_meta["request_id"])
-    try:
-        async with _get_tool_semaphore():
-            result = await asyncio.wait_for(handler(*args, **kwargs), timeout=timeout_seconds)
-    except TimeoutError:
-        elapsed_ms = int((time.perf_counter() - start) * 1000)
-        _record_tool_metric(
-            tool_name,
-            elapsed_ms=elapsed_ms,
-            success=False,
-            timed_out=True,
-            error=f"timed out after {timeout_seconds:.1f}s",
-        )
-        _record_tool_request(
-            tool_name,
-            caller=request_meta["caller"],
-            client_id=request_meta["client_id"],
-            request_id=request_meta["request_id"],
-            status="timeout",
-            elapsed_ms=elapsed_ms,
-            error=f"timed out after {timeout_seconds:.1f}s",
-        )
-        logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, request_meta["caller"], timeout_seconds)
-        return _truncate_response(
-            json.dumps(
-                {
-                    "error": f"Tool '{tool_name}' timed out after {timeout_seconds:.1f}s",
-                    "tool": tool_name,
-                    "timed_out": True,
-                }
-            )
-        )
-    except Exception as exc:
-        elapsed_ms = int((time.perf_counter() - start) * 1000)
-        sanitized = sanitize_error(exc)
-        _record_tool_metric(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
-        _record_tool_request(
-            tool_name,
-            caller=request_meta["caller"],
-            client_id=request_meta["client_id"],
-            request_id=request_meta["request_id"],
-            status="error",
-            elapsed_ms=elapsed_ms,
-            error=sanitized,
-        )
-        logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, request_meta["caller"], sanitized)
-        raise
-    elapsed_ms = int((time.perf_counter() - start) * 1000)
-    _record_tool_metric(tool_name, elapsed_ms=elapsed_ms, success=True)
-    _record_tool_request(
+    return await _mcp_runtime.execute_tool_async(
         tool_name,
-        caller=request_meta["caller"],
-        client_id=request_meta["client_id"],
-        request_id=request_meta["request_id"],
-        status="ok",
-        elapsed_ms=elapsed_ms,
+        handler,
+        *args,
+        timeout_seconds=timeout_seconds,
+        request_meta_factory=_current_tool_request,
+        check_caller_rate_limit_fn=_check_caller_rate_limit,
+        record_tool_metric_fn=_record_tool_metric,
+        record_tool_request_fn=_record_tool_request,
+        truncate_response_fn=_truncate_response,
+        get_tool_semaphore_fn=_get_tool_semaphore,
+        sanitize_error_fn=sanitize_error,
+        logger=logger,
+        **kwargs,
     )
-    logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, request_meta["caller"], elapsed_ms)
-    return result
 
 
 async def _execute_tool_sync_async(
@@ -414,97 +243,25 @@ async def _execute_tool_sync_async(
     *args,
     tool_timeout: float | None = None,
     **kwargs,
-) -> _ToolReturn:
+) -> _ToolReturn | str:
     """Run a sync MCP tool under the shared async governance envelope."""
     timeout_seconds = _MCP_TOOL_TIMEOUT_SECONDS if tool_timeout is None else tool_timeout
     response_truncator = kwargs.get("_truncate_response", _truncate_response)
-    request_meta = _current_tool_request()
-    retry_after = _check_caller_rate_limit(request_meta["caller"] or "local")
-    if retry_after is not None:
-        _record_tool_metric(tool_name, elapsed_ms=0, success=False, error="rate limited")
-        _record_tool_request(
-            tool_name,
-            caller=request_meta["caller"],
-            client_id=request_meta["client_id"],
-            request_id=request_meta["request_id"],
-            status="rate_limited",
-            elapsed_ms=0,
-            error="rate limited",
-        )
-        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, request_meta["caller"], retry_after)
-        return response_truncator(
-            json.dumps(
-                {
-                    "error": f"Tool '{tool_name}' exceeded the caller rate limit",
-                    "tool": tool_name,
-                    "rate_limited": True,
-                    "retry_after_seconds": retry_after,
-                }
-            )
-        )
-    async with _get_tool_semaphore():
-        start = time.perf_counter()
-        logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, request_meta["caller"], request_meta["request_id"])
-        try:
-            result = await asyncio.wait_for(
-                asyncio.to_thread(handler, *args, **kwargs),
-                timeout=timeout_seconds,
-            )
-        except asyncio.TimeoutError:
-            elapsed_ms = int((time.perf_counter() - start) * 1000)
-            _record_tool_metric(
-                tool_name,
-                elapsed_ms=elapsed_ms,
-                success=False,
-                timed_out=True,
-                error=f"timed out after {timeout_seconds:.1f}s",
-            )
-            _record_tool_request(
-                tool_name,
-                caller=request_meta["caller"],
-                client_id=request_meta["client_id"],
-                request_id=request_meta["request_id"],
-                status="timeout",
-                elapsed_ms=elapsed_ms,
-                error=f"timed out after {timeout_seconds:.1f}s",
-            )
-            logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, request_meta["caller"], timeout_seconds)
-            return response_truncator(
-                json.dumps(
-                    {
-                        "error": f"Tool '{tool_name}' timed out after {timeout_seconds:.1f}s",
-                        "tool": tool_name,
-                        "timed_out": True,
-                    }
-                )
-            )
-        except Exception as exc:
-            elapsed_ms = int((time.perf_counter() - start) * 1000)
-            sanitized = sanitize_error(exc)
-            _record_tool_metric(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
-            _record_tool_request(
-                tool_name,
-                caller=request_meta["caller"],
-                client_id=request_meta["client_id"],
-                request_id=request_meta["request_id"],
-                status="error",
-                elapsed_ms=elapsed_ms,
-                error=sanitized,
-            )
-            logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, request_meta["caller"], sanitized)
-            raise
-        elapsed_ms = int((time.perf_counter() - start) * 1000)
-        _record_tool_metric(tool_name, elapsed_ms=elapsed_ms, success=True)
-        _record_tool_request(
-            tool_name,
-            caller=request_meta["caller"],
-            client_id=request_meta["client_id"],
-            request_id=request_meta["request_id"],
-            status="ok",
-            elapsed_ms=elapsed_ms,
-        )
-        logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, request_meta["caller"], elapsed_ms)
-        return result
+    return await _mcp_runtime.execute_tool_sync_async(
+        tool_name,
+        handler,
+        *args,
+        timeout_seconds=timeout_seconds,
+        request_meta_factory=_current_tool_request,
+        check_caller_rate_limit_fn=_check_caller_rate_limit,
+        record_tool_metric_fn=_record_tool_metric,
+        record_tool_request_fn=_record_tool_request,
+        truncate_response_fn=response_truncator,
+        get_tool_semaphore_fn=_get_tool_semaphore,
+        sanitize_error_fn=sanitize_error,
+        logger=logger,
+        **kwargs,
+    )
 
 
 def _build_dep_graph_from_agents(agents_data: list[dict[str, Any]]):
@@ -553,18 +310,16 @@ _MAX_CACHED_TOOL_LOOPS = 8
 def _get_registry_data() -> dict:
     """Load and cache the MCP registry JSON as a dict."""
     global _registry_cache
-    if _registry_cache is None:
-        registry_path = Path(__file__).parent / "mcp_registry.json"
-        _registry_cache = json.loads(registry_path.read_text())
+    registry_path = Path(__file__).parent / "mcp_registry.json"
+    _registry_cache = _mcp_runtime.get_registry_data(_registry_cache, registry_path)
     return _registry_cache
 
 
 def _get_registry_data_raw() -> str:
     """Load and cache the MCP registry JSON as raw text."""
     global _registry_raw_cache
-    if _registry_raw_cache is None:
-        registry_path = Path(__file__).parent / "mcp_registry.json"
-        _registry_raw_cache = registry_path.read_text()
+    registry_path = Path(__file__).parent / "mcp_registry.json"
+    _registry_raw_cache = _mcp_runtime.get_registry_data_raw(_registry_raw_cache, registry_path)
     return _registry_raw_cache
 
 
@@ -574,10 +329,7 @@ _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempoten
 
 def _check_mcp_sdk() -> None:
     """Ensure the mcp SDK is available."""
-    try:
-        import mcp  # noqa: F401
-    except ImportError:
-        raise ImportError("mcp SDK is required for the MCP server. Install with: pip install 'agent-bom[mcp-server]'") from None
+    _mcp_runtime.check_mcp_sdk()
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -1,0 +1,463 @@
+"""Shared runtime helpers for the MCP server.
+
+This module intentionally contains implementation details behind the stable
+``agent_bom.mcp_server`` wrapper functions so the public import surface can stay
+unchanged while the monolith is decomposed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import AbstractSet, Any, Awaitable, Callable, TypeVar
+
+_ToolReturn = TypeVar("_ToolReturn")
+
+
+def validate_ecosystem(ecosystem: str, valid_ecosystems: AbstractSet[str]) -> str:
+    cleaned = ecosystem.lower().strip()
+    if cleaned not in valid_ecosystems:
+        raise ValueError(f"Invalid ecosystem: {ecosystem!r}. Valid: {', '.join(sorted(valid_ecosystems))}")
+    return cleaned
+
+
+def validate_cve_id(cve_id: str, cve_re, ghsa_re) -> str:  # noqa: ANN001
+    cleaned = cve_id.strip()
+    if not cleaned:
+        raise ValueError("CVE ID cannot be empty")
+    if not (cve_re.match(cleaned) or ghsa_re.match(cleaned)):
+        raise ValueError(f"Invalid CVE ID format: {cleaned!r}. Expected CVE-YYYY-NNNNN or GHSA-xxxx-xxxx-xxxx")
+    return cleaned
+
+
+def truncate_response(response_str: str, max_response_chars: int) -> str:
+    if len(response_str) <= max_response_chars:
+        return response_str
+    return (
+        response_str[:max_response_chars] + '\n\n{"_truncated": true, "message": '
+        '"Response truncated at 500,000 characters. '
+        'Use more specific parameters to reduce output size."}'
+    )
+
+
+def safe_path(path_str: str) -> Path:
+    from agent_bom.security import SecurityError, validate_path
+
+    try:
+        return validate_path(path_str, restrict_to_home=True)
+    except SecurityError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def get_tool_semaphore(
+    loop_tool_semaphores,
+    *,
+    max_cached_tool_loops: int,
+    max_concurrent_tools: int,
+) -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    loop_id = id(loop)
+    semaphore = loop_tool_semaphores.get(loop_id)
+    if semaphore is None:
+        if len(loop_tool_semaphores) >= max_cached_tool_loops:
+            loop_tool_semaphores.popitem(last=False)
+        semaphore = asyncio.Semaphore(max_concurrent_tools)
+        loop_tool_semaphores[loop_id] = semaphore
+    else:
+        loop_tool_semaphores.move_to_end(loop_id)
+    return semaphore
+
+
+def record_tool_metric(
+    tool_metrics,
+    *,
+    max_tool_metrics: int,
+    tool_name: str,
+    elapsed_ms: int,
+    success: bool,
+    timed_out: bool = False,
+    error: str | None = None,
+) -> None:
+    metrics = tool_metrics.get(tool_name)
+    if metrics is None:
+        if len(tool_metrics) >= max_tool_metrics:
+            tool_metrics.popitem(last=False)
+        metrics = {
+            "tool": tool_name,
+            "calls": 0,
+            "failures": 0,
+            "timeouts": 0,
+            "last_status": "unknown",
+            "last_error": None,
+            "last_elapsed_ms": 0,
+            "max_elapsed_ms": 0,
+            "total_elapsed_ms": 0,
+        }
+        tool_metrics[tool_name] = metrics
+    else:
+        tool_metrics.move_to_end(tool_name)
+
+    metrics["calls"] += 1
+    metrics["last_status"] = "ok" if success else ("timeout" if timed_out else "error")
+    metrics["last_error"] = None if success else error
+    metrics["last_elapsed_ms"] = elapsed_ms
+    metrics["max_elapsed_ms"] = max(metrics["max_elapsed_ms"], elapsed_ms)
+    metrics["total_elapsed_ms"] += elapsed_ms
+    if not success:
+        metrics["failures"] += 1
+    if timed_out:
+        metrics["timeouts"] += 1
+
+
+def tool_metrics_snapshot(
+    tool_metrics,
+    *,
+    caller_rate_windows,
+    recent_tool_requests,
+    max_concurrent_tools: int,
+    tool_timeout_seconds: float,
+    caller_rate_limit: int,
+    caller_window_seconds: float,
+) -> dict[str, Any]:
+    tool_stats = []
+    total_calls = 0
+    total_failures = 0
+    total_timeouts = 0
+    for name, metrics in tool_metrics.items():
+        calls = int(metrics["calls"])
+        total_calls += calls
+        total_failures += int(metrics["failures"])
+        total_timeouts += int(metrics["timeouts"])
+        tool_stats.append(
+            {
+                "tool": name,
+                "calls": calls,
+                "failures": int(metrics["failures"]),
+                "timeouts": int(metrics["timeouts"]),
+                "last_status": metrics["last_status"],
+                "last_error": metrics["last_error"],
+                "last_elapsed_ms": int(metrics["last_elapsed_ms"]),
+                "max_elapsed_ms": int(metrics["max_elapsed_ms"]),
+                "avg_elapsed_ms": round(int(metrics["total_elapsed_ms"]) / calls, 2) if calls else 0.0,
+            }
+        )
+    return {
+        "summary": {
+            "tool_count": len(tool_stats),
+            "total_calls": total_calls,
+            "total_failures": total_failures,
+            "total_timeouts": total_timeouts,
+            "max_concurrent_tools": max_concurrent_tools,
+            "default_timeout_seconds": tool_timeout_seconds,
+            "caller_rate_limit_per_window": caller_rate_limit,
+            "caller_rate_limit_window_seconds": caller_window_seconds,
+            "tracked_callers": len(caller_rate_windows),
+            "recent_request_count": len(recent_tool_requests),
+        },
+        "tools": tool_stats,
+        "recent_requests": list(recent_tool_requests),
+    }
+
+
+def current_tool_request(request_ctx_getter: Callable[[], Any]) -> dict[str, str | None]:
+    try:
+        current_request = request_ctx_getter()
+    except LookupError:
+        return {"caller": "local", "client_id": None, "request_id": None}
+
+    meta = getattr(current_request, "meta", None)
+    client_id = getattr(meta, "client_id", None) if meta else None
+    session = getattr(current_request, "session", None)
+    session_label = f"session-{id(session) % 1_000_000}" if session is not None else "local"
+    return {
+        "caller": client_id or session_label,
+        "client_id": client_id,
+        "request_id": str(getattr(current_request, "request_id", "")) or None,
+    }
+
+
+def check_caller_rate_limit(
+    caller_rate_windows,
+    caller: str,
+    *,
+    caller_rate_limit: int,
+    caller_window_seconds: float,
+    max_caller_states: int,
+    monotonic_now: float,
+) -> float | None:
+    if caller_rate_limit <= 0:
+        return None
+
+    window = caller_rate_windows.get(caller)
+    if window is None:
+        if len(caller_rate_windows) >= max_caller_states:
+            caller_rate_windows.popitem(last=False)
+        from collections import deque
+
+        window = deque()
+        caller_rate_windows[caller] = window
+    else:
+        caller_rate_windows.move_to_end(caller)
+
+    cutoff = monotonic_now - caller_window_seconds
+    while window and window[0] <= cutoff:
+        window.popleft()
+
+    if len(window) >= caller_rate_limit:
+        return round(max(0.0, caller_window_seconds - (monotonic_now - window[0])), 3)
+
+    window.append(monotonic_now)
+    return None
+
+
+def record_tool_request(
+    recent_tool_requests,
+    tool_name: str,
+    *,
+    caller: str | None,
+    client_id: str | None,
+    request_id: str | None,
+    status: str,
+    elapsed_ms: int,
+    error: str | None = None,
+) -> None:
+    recent_tool_requests.append(
+        {
+            "tool": tool_name,
+            "caller": caller or "local",
+            "client_id": client_id,
+            "request_id": request_id,
+            "status": status,
+            "elapsed_ms": elapsed_ms,
+            "error": error,
+            "ts": int(time.time()),
+        }
+    )
+
+
+async def execute_tool_async(
+    tool_name: str,
+    handler: Callable[..., Awaitable[_ToolReturn]],
+    /,
+    *args,
+    timeout_seconds: float,
+    request_meta_factory: Callable[[], dict[str, str | None]],
+    check_caller_rate_limit_fn: Callable[[str], float | None],
+    record_tool_metric_fn: Callable[..., None],
+    record_tool_request_fn: Callable[..., None],
+    truncate_response_fn: Callable[[str], str],
+    get_tool_semaphore_fn: Callable[[], asyncio.Semaphore],
+    sanitize_error_fn: Callable[[Exception], str],
+    logger,
+    **kwargs,
+) -> _ToolReturn | str:
+    request_meta = request_meta_factory()
+    retry_after = check_caller_rate_limit_fn(request_meta["caller"] or "local")
+    if retry_after is not None:
+        record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="rate limited")
+        record_tool_request_fn(
+            tool_name,
+            caller=request_meta["caller"],
+            client_id=request_meta["client_id"],
+            request_id=request_meta["request_id"],
+            status="rate_limited",
+            elapsed_ms=0,
+            error="rate limited",
+        )
+        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, request_meta["caller"], retry_after)
+        return truncate_response_fn(
+            json.dumps(
+                {
+                    "error": f"Tool '{tool_name}' exceeded the caller rate limit",
+                    "tool": tool_name,
+                    "rate_limited": True,
+                    "retry_after_seconds": retry_after,
+                }
+            )
+        )
+    start = time.perf_counter()
+    logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, request_meta["caller"], request_meta["request_id"])
+    try:
+        async with get_tool_semaphore_fn():
+            result = await asyncio.wait_for(handler(*args, **kwargs), timeout=timeout_seconds)
+    except TimeoutError:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        record_tool_metric_fn(
+            tool_name,
+            elapsed_ms=elapsed_ms,
+            success=False,
+            timed_out=True,
+            error=f"timed out after {timeout_seconds:.1f}s",
+        )
+        record_tool_request_fn(
+            tool_name,
+            caller=request_meta["caller"],
+            client_id=request_meta["client_id"],
+            request_id=request_meta["request_id"],
+            status="timeout",
+            elapsed_ms=elapsed_ms,
+            error=f"timed out after {timeout_seconds:.1f}s",
+        )
+        logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, request_meta["caller"], timeout_seconds)
+        return truncate_response_fn(
+            json.dumps(
+                {
+                    "error": f"Tool '{tool_name}' timed out after {timeout_seconds:.1f}s",
+                    "tool": tool_name,
+                    "timed_out": True,
+                }
+            )
+        )
+    except Exception as exc:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        sanitized = sanitize_error_fn(exc)
+        record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
+        record_tool_request_fn(
+            tool_name,
+            caller=request_meta["caller"],
+            client_id=request_meta["client_id"],
+            request_id=request_meta["request_id"],
+            status="error",
+            elapsed_ms=elapsed_ms,
+            error=sanitized,
+        )
+        logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, request_meta["caller"], sanitized)
+        raise
+    elapsed_ms = int((time.perf_counter() - start) * 1000)
+    record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=True)
+    record_tool_request_fn(
+        tool_name,
+        caller=request_meta["caller"],
+        client_id=request_meta["client_id"],
+        request_id=request_meta["request_id"],
+        status="ok",
+        elapsed_ms=elapsed_ms,
+    )
+    logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, request_meta["caller"], elapsed_ms)
+    return result
+
+
+async def execute_tool_sync_async(
+    tool_name: str,
+    handler: Callable[..., _ToolReturn],
+    /,
+    *args,
+    timeout_seconds: float,
+    request_meta_factory: Callable[[], dict[str, str | None]],
+    check_caller_rate_limit_fn: Callable[[str], float | None],
+    record_tool_metric_fn: Callable[..., None],
+    record_tool_request_fn: Callable[..., None],
+    truncate_response_fn: Callable[[str], str],
+    get_tool_semaphore_fn: Callable[[], asyncio.Semaphore],
+    sanitize_error_fn: Callable[[Exception], str],
+    logger,
+    **kwargs,
+) -> _ToolReturn | str:
+    request_meta = request_meta_factory()
+    retry_after = check_caller_rate_limit_fn(request_meta["caller"] or "local")
+    if retry_after is not None:
+        record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="rate limited")
+        record_tool_request_fn(
+            tool_name,
+            caller=request_meta["caller"],
+            client_id=request_meta["client_id"],
+            request_id=request_meta["request_id"],
+            status="rate_limited",
+            elapsed_ms=0,
+            error="rate limited",
+        )
+        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, request_meta["caller"], retry_after)
+        return truncate_response_fn(
+            json.dumps(
+                {
+                    "error": f"Tool '{tool_name}' exceeded the caller rate limit",
+                    "tool": tool_name,
+                    "rate_limited": True,
+                    "retry_after_seconds": retry_after,
+                }
+            )
+        )
+    async with get_tool_semaphore_fn():
+        start = time.perf_counter()
+        logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, request_meta["caller"], request_meta["request_id"])
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(handler, *args, **kwargs),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            record_tool_metric_fn(
+                tool_name,
+                elapsed_ms=elapsed_ms,
+                success=False,
+                timed_out=True,
+                error=f"timed out after {timeout_seconds:.1f}s",
+            )
+            record_tool_request_fn(
+                tool_name,
+                caller=request_meta["caller"],
+                client_id=request_meta["client_id"],
+                request_id=request_meta["request_id"],
+                status="timeout",
+                elapsed_ms=elapsed_ms,
+                error=f"timed out after {timeout_seconds:.1f}s",
+            )
+            logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, request_meta["caller"], timeout_seconds)
+            return truncate_response_fn(
+                json.dumps(
+                    {
+                        "error": f"Tool '{tool_name}' timed out after {timeout_seconds:.1f}s",
+                        "tool": tool_name,
+                        "timed_out": True,
+                    }
+                )
+            )
+        except Exception as exc:
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            sanitized = sanitize_error_fn(exc)
+            record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
+            record_tool_request_fn(
+                tool_name,
+                caller=request_meta["caller"],
+                client_id=request_meta["client_id"],
+                request_id=request_meta["request_id"],
+                status="error",
+                elapsed_ms=elapsed_ms,
+                error=sanitized,
+            )
+            logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, request_meta["caller"], sanitized)
+            raise
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=True)
+        record_tool_request_fn(
+            tool_name,
+            caller=request_meta["caller"],
+            client_id=request_meta["client_id"],
+            request_id=request_meta["request_id"],
+            status="ok",
+            elapsed_ms=elapsed_ms,
+        )
+        logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, request_meta["caller"], elapsed_ms)
+        return result
+
+
+def get_registry_data(registry_cache: dict | None, registry_path: Path) -> dict:
+    if registry_cache is None:
+        return json.loads(registry_path.read_text())
+    return registry_cache
+
+
+def get_registry_data_raw(registry_raw_cache: str | None, registry_path: Path) -> str:
+    if registry_raw_cache is None:
+        return registry_path.read_text()
+    return registry_raw_cache
+
+
+def check_mcp_sdk() -> None:
+    try:
+        import mcp  # noqa: F401
+    except ImportError:
+        raise ImportError("mcp SDK is required for the MCP server. Install with: pip install 'agent-bom[mcp-server]'") from None

--- a/tests/test_aws_cis_benchmark.py
+++ b/tests/test_aws_cis_benchmark.py
@@ -235,26 +235,42 @@ class TestCheck110:
 
 class TestCheck112:
     def test_pass_no_stale(self):
+        recent_use = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
         client = _iam_client()
         client.generate_credential_report.return_value = {"State": "COMPLETE"}
         client.get_credential_report.return_value = {
             "Content": (
                 "user,password_last_used,access_key_1_last_used_date,access_key_2_last_used_date\n"
                 "<root_account>,N/A,N/A,N/A\n"
-                "alice,2026-03-01T00:00:00+00:00,N/A,N/A\n"
+                f"alice,{recent_use},N/A,N/A\n"
+            ).encode()
+        }
+        result = _check_1_12(client)
+        assert result.status == CheckStatus.PASS
+
+    def test_pass_on_45_day_boundary(self):
+        boundary_use = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+        client = _iam_client()
+        client.generate_credential_report.return_value = {"State": "COMPLETE"}
+        client.get_credential_report.return_value = {
+            "Content": (
+                "user,password_last_used,access_key_1_last_used_date,access_key_2_last_used_date\n"
+                "<root_account>,N/A,N/A,N/A\n"
+                f"alice,{boundary_use},N/A,N/A\n"
             ).encode()
         }
         result = _check_1_12(client)
         assert result.status == CheckStatus.PASS
 
     def test_fail_stale_user(self):
+        stale_use = (datetime.now(timezone.utc) - timedelta(days=46)).isoformat()
         client = _iam_client()
         client.generate_credential_report.return_value = {"State": "COMPLETE"}
         client.get_credential_report.return_value = {
             "Content": (
                 "user,password_last_used,access_key_1_last_used_date,access_key_2_last_used_date\n"
                 "<root_account>,N/A,N/A,N/A\n"
-                "stale-bob,2020-01-01T00:00:00+00:00,N/A,N/A\n"
+                f"stale-bob,{stale_use},N/A,N/A\n"
             ).encode()
         }
         result = _check_1_12(client)


### PR DESCRIPTION
## Summary
- extract MCP server validation, rate limiting, metrics, and execution helper implementations into a dedicated runtime module
- keep the public agent_bom.mcp_server helper surface stable for tests and callers
- leave create_mcp_server and the tool registry contract intact

## Validation
- uv run pytest -q tests/test_mcp_server.py tests/test_mcp_server_cov.py tests/test_cli_server.py tests/test_deployment.py tests/test_marketplace_check.py tests/test_trust_assessment.py tests/test_fleet_scan.py tests/test_os_package_scanning.py
- uv run ruff check src/agent_bom/mcp_server.py src/agent_bom/mcp_server_runtime.py
- uv run mypy src/agent_bom/mcp_server.py src/agent_bom/mcp_server_runtime.py
- git diff --check