### PR TITLE
Make supply-chain trust and extras audits explicit

### DIFF
--- a/.github/workflows/extras-audit.yml
+++ b/.github/workflows/extras-audit.yml
@@ -1,0 +1,64 @@
+name: Extras Dependency Audit
+
+on:
+  pull_request:
+    paths:
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/extras-audit.yml
+  schedule:
+    - cron: "0 8 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit-extras:
+    name: Audit extras (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api-runtime
+            extras: "api oidc runtime"
+          - name: mcp-surface
+            extras: "mcp-server graph"
+          - name: analytics-ui
+            extras: "postgres dashboard"
+          - name: cloud-surface
+            extras: "cloud"
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.11"
+
+      - name: Install selected extras
+        run: |
+          args=""
+          for extra in ${{ matrix.extras }}; do
+            args="$args --extra $extra"
+          done
+          uv sync $args
+
+      - name: Capture resolved dependency tree
+        run: |
+          mkdir -p audit
+          uv tree > "audit/${{ matrix.name }}-tree.txt"
+
+      - name: Audit selected extras with pip-audit
+        run: |
+          mkdir -p audit
+          uv run --with pip-audit pip-audit \
+            --format json \
+            --output "audit/${{ matrix.name }}-pip-audit.json"
+
+      - name: Upload extras audit artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: extras-audit-${{ matrix.name }}
+          path: audit/

--- a/README.md
+++ b/README.md
@@ -210,8 +210,23 @@ Product references:
 - [docs/PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md)
 - [docs/PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md)
 - [docs/ENTERPRISE.md](docs/ENTERPRISE.md)
+- [docs/SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md)
 - [docs/RELEASE_VERIFICATION.md](docs/RELEASE_VERIFICATION.md)
 - [How Agent-BOM Works](site-docs/architecture/how-agent-bom-works.md)
+
+## Supply chain and release trust
+
+The dependency and release story is explicit:
+
+- bounded runtime dependency ranges in [pyproject.toml](pyproject.toml)
+- locked Python and UI resolution in [uv.lock](uv.lock) and [ui/package-lock.json](ui/package-lock.json)
+- per-PR dependency review plus scheduled extras audits
+- signed release artifacts, provenance bundles, and published self-SBOMs
+
+If you need the operator-facing details:
+
+- [Supply Chain and Dependency Controls](docs/SUPPLY_CHAIN.md)
+- [Release Verification](docs/RELEASE_VERIFICATION.md)
 
 ### CI/CD in 60 seconds
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,13 @@ agent-bom is a **read-only scanner**. It does not modify agent configurations, e
 - **Pre-commit hooks**: ruff, ruff-format, detect-private-key, check-yaml, end-of-file-fixer
 - No third-party penetration testing yet (planned for v1.0)
 
+## Release verification and dependency controls
+
+The public verification path is documented:
+
+- [docs/RELEASE_VERIFICATION.md](docs/RELEASE_VERIFICATION.md) — Sigstore bundle verification, SLSA provenance inspection, and self-SBOM review
+- [docs/SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md) — dependency bounds, lockfiles, extras audit coverage, fuzz targets, and release trust controls
+
 ## Vulnerability Disclosure Timeline
 
 1. Reporter submits via GitHub Security Advisories

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -1,0 +1,157 @@
+# Supply Chain and Dependency Controls
+
+`agent-bom` keeps its dependency and release trust posture explicit:
+
+- small required runtime footprint
+- optional extras for heavier surfaces
+- locked dependency resolution
+- per-PR dependency review
+- signed and attested release artifacts
+- published self-SBOMs
+- self-scan and fuzz coverage in CI
+
+This page is the operator-facing map of those controls.
+
+## Dependency model
+
+There are three layers to understand:
+
+1. Core runtime dependencies in [pyproject.toml](../pyproject.toml)
+2. Fully resolved Python dependencies in [uv.lock](../uv.lock)
+3. Fully resolved UI dependencies in [ui/package-lock.json](../ui/package-lock.json)
+
+The core runtime stays intentionally small. Heavier surfaces are behind extras
+such as:
+
+- `api`
+- `mcp-server`
+- `graph`
+- `cloud`
+- `dashboard`
+- `postgres`
+- `oidc`
+
+That keeps the default install lean while still allowing fuller deployments to
+turn on additional capability explicitly.
+
+Some extras also carry platform markers where an upstream provider package is
+not yet compatible with the full supported Python/platform matrix. Those
+constraints are intentional and documented rather than hidden.
+
+## Version control and drift boundaries
+
+`agent-bom` uses bounded runtime version ranges in `pyproject.toml` and locked
+resolution in `uv.lock`.
+
+That gives two protections:
+
+- maintainers and CI get exact, reproducible transitive resolution
+- users installing without the lockfile still stay inside known-compatible major
+  ranges instead of drifting arbitrarily
+
+Transitive security pins that close specific advisories are annotated inline
+with GHSA/CVE context in `pyproject.toml`.
+
+## Extras audit coverage
+
+The root dependency graph is not the only surface that matters. Optional extras
+pull in additional transitive dependencies, so they need independent visibility.
+
+The extras audit workflow is:
+
+- workflow: [extras-audit.yml](../.github/workflows/extras-audit.yml)
+- trigger: pull requests touching dependency surfaces, weekly schedule, or
+  manual dispatch
+- output: per-surface dependency trees and `pip-audit` JSON artifacts
+
+Current audit groups:
+
+- `api-runtime`
+- `mcp-surface`
+- `analytics-ui`
+- `cloud-surface`
+
+Those groups are intentionally broader than a single extra so the artifacts map
+to real deployment surfaces rather than individual package toggles.
+
+## CI and scanning controls
+
+Dependency and supply-chain controls are enforced through multiple workflows:
+
+- `dependency-review.yml` for per-PR dependency diffs
+- `dependency-submission.yml` for GitHub dependency graph visibility
+- `dependency-pin-check.yml` for transitive security pin discipline
+- `cve-freshness.yml` for daily dependency vulnerability checks
+- `container-rescan.yml` for image rescans
+- `cflite-pr.yml` for parser and ingestion fuzzing
+- `post-merge-self-scan.yml` for dogfooding scans against `agent-bom` itself
+- `release.yml` and `publish-mcp.yml` for signed, attested release output
+
+This is additive by design. No single workflow is treated as the entire trust
+story.
+
+## Parser and fuzz coverage
+
+High-risk ingestion surfaces are fuzzed because they process untrusted external
+data:
+
+- `fuzz/fuzz_policy.py`
+- `fuzz/fuzz_sbom.py`
+- `fuzz/fuzz_skill_parser.py`
+- `fuzz/fuzz_external_scanners.py`
+
+The external scanner fuzz target covers:
+
+- Trivy JSON ingestion
+- Grype JSON ingestion
+- Syft JSON ingestion
+- format auto-detection via `detect_and_parse()`
+
+That keeps the import path for third-party scanner results under the same
+hardening discipline as SBOM and policy ingest.
+
+## Release verification and SBOMs
+
+Tagged releases publish:
+
+- Python distributions
+- Sigstore bundles (`*.sigstore.json`)
+- SLSA provenance bundles (`*.intoto.jsonl`)
+- CycloneDX self-SBOM (`agent-bom-sbom.cdx.json`)
+
+Use the release verification guide:
+
+- [Release Verification](RELEASE_VERIFICATION.md)
+
+That document includes:
+
+- `cosign verify-blob` examples
+- provenance inspection
+- self-SBOM inspection and rescanning
+
+This is the public verification path. Release trust is not hidden inside CI.
+
+## Where to inspect the current posture
+
+- [Security Policy](../SECURITY.md)
+- [Security Architecture](SECURITY_ARCHITECTURE.md)
+- [Image Security](IMAGE_SECURITY.md)
+- [Threat Model](THREAT_MODEL.md)
+- [Release Verification](RELEASE_VERIFICATION.md)
+- [Permissions and Trust](PERMISSIONS.md)
+
+## Operational guidance
+
+For maintainers:
+
+- keep runtime dependency ranges bounded
+- refresh `uv.lock` whenever dependency policy changes
+- review extras audit artifacts, not just the default environment
+- treat parser fuzz coverage as part of release trust, not optional polish
+
+For operators:
+
+- verify release assets before internal distribution
+- archive the published self-SBOM with the release artifact set
+- use the same release verification process for both PyPI and GitHub release
+  consumption

--- a/fuzz/fuzz_external_scanners.py
+++ b/fuzz/fuzz_external_scanners.py
@@ -1,0 +1,62 @@
+"""Atheris fuzz target for external scanner JSON ingestion.
+
+Fuzzes:
+1. detect_and_parse() — auto-detect external scanner JSON format
+2. parse_trivy_json() — Trivy findings ingestion
+3. parse_grype_json() — Grype findings ingestion
+4. parse_syft_json() — Syft inventory ingestion
+
+These parsers accept customer-supplied JSON exports and must reject malformed
+input safely without crashes, runaway recursion, or unsafe assumptions about
+shape.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from agent_bom.parsers.external_scanners import (
+        detect_and_parse,
+        parse_grype_json,
+        parse_syft_json,
+        parse_trivy_json,
+    )
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    choice = fdp.ConsumeIntInRange(0, 3)
+    raw = fdp.ConsumeUnicodeNoSurrogates(4096)
+
+    try:
+        obj = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return
+
+    if not isinstance(obj, dict):
+        return
+
+    try:
+        if choice == 0:
+            detect_and_parse(obj)
+        elif choice == 1:
+            parse_trivy_json(obj)
+        elif choice == 2:
+            parse_grype_json(obj)
+        else:
+            parse_syft_json(obj)
+    except (ValueError, TypeError, KeyError, AttributeError, IndexError):
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - How Agent-BOM Works: architecture/how-agent-bom-works.md
       - AI Infrastructure Scanning: architecture/ai-infrastructure.md
       - Data Ingestion and Security: architecture/data-ingestion-and-security.md
+      - Supply Chain and Trust: architecture/supply-chain-and-trust.md
       - Canonical Model vs OCSF: architecture/canonical-vs-ocsf.md
   - Reference:
       - MCP Tools: reference/mcp-tools.md

--- a/site-docs/architecture/supply-chain-and-trust.md
+++ b/site-docs/architecture/supply-chain-and-trust.md
@@ -1,0 +1,88 @@
+# Supply Chain and Trust
+
+`agent-bom` keeps its dependency and release trust controls explicit:
+
+- bounded runtime dependency ranges
+- locked Python and UI dependency resolution
+- extras-specific audit coverage
+- parser fuzzing for untrusted ingest surfaces
+- signed and attested release artifacts
+- published self-SBOMs
+
+## Dependency model
+
+There are three important layers:
+
+1. runtime dependency policy in `pyproject.toml`
+2. exact Python resolution in `uv.lock`
+3. exact UI resolution in `ui/package-lock.json`
+
+The default install stays lean. Heavier surfaces are behind extras such as:
+
+- `api`
+- `mcp-server`
+- `graph`
+- `cloud`
+- `dashboard`
+- `postgres`
+- `oidc`
+
+That keeps the base scanner smaller while making deployment-specific dependency
+surfaces explicit.
+
+## Extras audit coverage
+
+Optional extras pull in additional transitive packages, so they are audited as
+deployment surfaces instead of being treated as invisible add-ons.
+
+The extras audit workflow runs for grouped surfaces such as:
+
+- `api-runtime`
+- `mcp-surface`
+- `analytics-ui`
+- `cloud-surface`
+
+It captures:
+
+- resolved dependency trees
+- `pip-audit` JSON results
+
+This complements the default dependency review workflow rather than replacing
+it.
+
+## Parser and fuzz coverage
+
+High-risk ingest surfaces are fuzzed because they accept external data:
+
+- policy ingest
+- SBOM ingest
+- skill/instruction parsing
+- external scanner JSON ingest
+
+The external scanner fuzz target covers:
+
+- Trivy JSON
+- Grype JSON
+- Syft JSON
+- auto-detection of scanner formats
+
+## Release trust
+
+Tagged releases publish:
+
+- Python distribution files
+- Sigstore bundles (`*.sigstore.json`)
+- SLSA provenance bundles (`*.intoto.jsonl`)
+- CycloneDX self-SBOMs
+
+The repository documentation includes a release verification guide with:
+
+- `cosign verify-blob` examples
+- provenance inspection
+- self-SBOM inspection and rescanning
+
+## Related docs
+
+- [Data Ingestion and Security](data-ingestion-and-security.md)
+- [Runtime Proxy](../features/runtime-proxy.md)
+- [Security Policy](../security.md)

--- a/site-docs/security.md
+++ b/site-docs/security.md
@@ -24,3 +24,10 @@ agent-bom has three distinct security postures:
 - **Proxy mode** (`agent-bom proxy`) is an execution and enforcement surface. It intentionally launches or connects to the target MCP server so it can inspect, block, and audit tool traffic in real time.
 
 Across all modes, agent-bom never stores credential values — only their names appear in output as `***REDACTED***`.
+
+## Release trust and dependency controls
+
+For dependency controls, extras audit coverage, parser fuzzing, and release
+trust posture, see:
+
+- [Supply Chain and Trust](architecture/supply-chain-and-trust.md)


### PR DESCRIPTION
## Summary
- add a dedicated extras dependency audit workflow for real deployment surfaces
- document supply-chain controls, release verification discoverability, and a site architecture page for trust posture
- add an external scanner fuzz target for Trivy, Grype, Syft, and auto-detect ingest

## Validation
- `git diff --check`
- `uv run ruff check README.md SECURITY.md fuzz/fuzz_external_scanners.py`
- pre-commit hooks on commit

## Notes
- this intentionally does not try to solve the separate Snowflake/OIDC compatibility decision in `pyproject.toml`
- ClusterFuzzLite already auto-discovers `fuzz/fuzz_*.py` via `.clusterfuzzlite/build.sh`, so the new fuzz target is live without a workflow edit