### PR TITLE
Harden marketplace publishing surfaces

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -1,7 +1,8 @@
 name: Deployment Freshness
 
-# Checks that all live deployments (Railway/Smithery) serve the latest
-# released version.  Runs daily and on-demand.  Opens an issue if stale.
+# Checks that the protected Railway surface and the public marketplace/Smithery
+# surface serve the latest release and that the public endpoint is not auth-gated.
+# Runs daily and on-demand. Opens an issue if stale or misconfigured.
 
 on:
   schedule:
@@ -63,20 +64,32 @@ jobs:
             echo "stale=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check Smithery tool count
-        id: smithery
+      - name: Check public marketplace deployment
+        id: public
         continue-on-error: true
         env:
-          RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
-          RAILWAY_MCP_BEARER_TOKEN: ${{ secrets.RAILWAY_MCP_BEARER_TOKEN }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
         run: |
-          DEPLOY_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app}"
+          if [ -z "${SMITHERY_MCP_URL:-}" ]; then
+            echo "::notice::SMITHERY_MCP_URL not configured — skipping public marketplace freshness checks"
+            echo "not_configured=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          DEPLOY_URL="${SMITHERY_MCP_URL}"
           RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
             --base-url "$DEPLOY_URL" \
-            --bearer-token "${RAILWAY_MCP_BEARER_TOKEN:-}" \
             --attempts 3 \
             --backoff-seconds 5 \
             --timeout 15 2>/dev/null || echo '{}')
+          DEPLOYED=$(echo "$RESPONSE" | python3 -c "
+          import sys, json
+          try:
+              data = json.load(sys.stdin)
+              print(data.get('version', 'unknown'))
+          except Exception:
+              print('unknown')
+          ")
           TOOL_COUNT=$(echo "$RESPONSE" | python3 -c "
           import sys, json
           try:
@@ -85,18 +98,41 @@ jobs:
           except Exception:
               print('unknown')
           ")
+          AUTH_REQUIRED=$(echo "$RESPONSE" | python3 -c "
+          import sys, json
+          try:
+              data = json.load(sys.stdin)
+              print('true' if data.get('auth_required') else 'false')
+          except Exception:
+              print('unknown')
+          ")
+          echo "public_version=$DEPLOYED" >> "$GITHUB_OUTPUT"
           echo "tool_count=$TOOL_COUNT" >> "$GITHUB_OUTPUT"
-          echo "Deployed tool count: $TOOL_COUNT"
+          echo "auth_required=$AUTH_REQUIRED" >> "$GITHUB_OUTPUT"
+          echo "Public marketplace version: $DEPLOYED (expected: ${{ steps.expected.outputs.version }})"
+          echo "Public marketplace tool count: $TOOL_COUNT"
+          echo "Public marketplace auth_required: $AUTH_REQUIRED"
+          if [ "$DEPLOYED" = "unknown" ]; then
+            echo "probe_failed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not verify public marketplace version from $DEPLOY_URL"
+          elif [ "$AUTH_REQUIRED" = "true" ]; then
+            echo "auth_gate=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Public marketplace endpoint is auth-gated"
+          elif [ "$DEPLOYED" != "${{ steps.expected.outputs.version }}" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Open issue if stale
-        if: steps.railway.outputs.stale == 'true'
+      - name: Open issue if deployment surfaces drift or public endpoint is misconfigured
+        if: steps.railway.outputs.stale == 'true' || steps.public.outputs.stale == 'true' || steps.public.outputs.auth_gate == 'true' || steps.public.outputs.probe_failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           EXPECTED="${{ steps.expected.outputs.version }}"
           RAILWAY="${{ steps.railway.outputs.railway_version }}"
-          TOOLS="${{ steps.smithery.outputs.tool_count }}"
-          TITLE="supply-chain-drift: Railway serving $RAILWAY, expected $EXPECTED"
+          PUBLIC="${{ steps.public.outputs.public_version }}"
+          PUBLIC_TOOLS="${{ steps.public.outputs.tool_count }}"
+          PUBLIC_AUTH="${{ steps.public.outputs.auth_required }}"
+          TITLE="supply-chain-drift: deployment surfaces out of sync with $EXPECTED"
 
           gh label create supply-chain-drift --color FBCA04 --description "Automated supply-chain or deployment drift detection" >/dev/null 2>&1 || true
           gh label create security-preventive --color 0E8A16 --description "Preventive daily security automation findings" >/dev/null 2>&1 || true
@@ -108,12 +144,12 @@ jobs:
             gh issue comment "$EXISTING" --body "$(cat <<EOF
           ## Supply-Chain Drift Check Failed
 
-          | Surface | Deployed | Expected |
-          |---------|----------|----------|
-          | Railway | $RAILWAY | $EXPECTED |
-          | Tool count | $TOOLS | (check mcp_server.py) |
+          | Surface | Version | Expected | Auth Required | Tool Count |
+          |---------|---------|----------|---------------|------------|
+          | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
+          | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
-          **Action**: Re-run the Deploy MCP SSE workflow or trigger a new release.
+          **Action**: Ensure Smithery points at a separate public unauthenticated endpoint, and re-run the relevant deployment or release workflow.
 
           This issue was auto-updated by the deployment-freshness workflow.
           EOF
@@ -127,19 +163,19 @@ jobs:
             --body "$(cat <<EOF
           ## Supply-Chain Drift Check Failed
 
-          | Surface | Deployed | Expected |
-          |---------|----------|----------|
-          | Railway | $RAILWAY | $EXPECTED |
-          | Tool count | $TOOLS | (check mcp_server.py) |
+          | Surface | Version | Expected | Auth Required | Tool Count |
+          |---------|---------|----------|---------------|------------|
+          | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
+          | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
-          **Action**: Re-run the Deploy MCP SSE workflow or trigger a new release.
+          **Action**: Ensure Smithery points at a separate public unauthenticated endpoint, and re-run the relevant deployment or release workflow.
 
           This issue was auto-created by the deployment-freshness workflow.
           EOF
           )"
 
       - name: Close supply-chain drift issue when deployment is fresh
-        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true'
+        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true' && (steps.public.outputs.not_configured == 'true' || (steps.public.outputs.stale != 'true' && steps.public.outputs.probe_failed != 'true' && steps.public.outputs.auth_gate != 'true'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -5,7 +5,7 @@ name: Publish to Registries
 #   SMITHERY_API_TOKEN  — Smithery service token (smithery.ai → API tokens)
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
 # Optional vars:
-#   RAILWAY_MCP_URL     — Override Railway MCP endpoint URL
+#   SMITHERY_MCP_URL    — Explicit public, unauthenticated MCP endpoint for Smithery
 
 on:
   workflow_run:
@@ -48,10 +48,39 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Validate Smithery public endpoint
+        env:
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
+        run: |
+          if [ -z "$SMITHERY_MCP_URL" ]; then
+            echo "::error::SMITHERY_MCP_URL not set — Smithery must publish a separate public MCP surface, not the protected Railway endpoint"
+            exit 1
+          fi
+
+          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
+            --base-url "$SMITHERY_MCP_URL" \
+            --attempts 3 \
+            --backoff-seconds 5 \
+            --timeout 15 \
+            --forbid-auth-required)
+
+          PUBLIC_VERSION=$(echo "$RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          print(data.get('version', 'unknown'))
+          ")
+          PUBLIC_TOOLS=$(echo "$RESPONSE" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          print(data.get('tool_count', data.get('mcp_metrics', {}).get('tool_count', 'unknown')))
+          ")
+          echo "Smithery public endpoint version: ${PUBLIC_VERSION}"
+          echo "Smithery public endpoint tool count: ${PUBLIC_TOOLS}"
+
       - name: Publish to Smithery
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
-          RAILWAY_MCP_URL: ${{ vars.RAILWAY_MCP_URL }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           if [ -z "$SMITHERY_API_TOKEN" ]; then
@@ -60,7 +89,7 @@ jobs:
           fi
 
           QUALIFIED_NAME="agent-bom%2Fagent-bom"
-          MCP_URL="${RAILWAY_MCP_URL:-https://agent-bom-mcp.up.railway.app/mcp}"
+          MCP_URL="${SMITHERY_MCP_URL}"
 
           echo "Publishing agent-bom v${VERSION} to Smithery..."
 
@@ -236,11 +265,9 @@ jobs:
             fi
           }
 
-          # Main consolidated skill (fatal on failure)
-          _publish_skill "integrations/openclaw" "agent-bom" true "agent-bom"
-
-          # Focused sub-skills (non-fatal — best-effort)
-          _publish_skill "integrations/openclaw/scan"       "agent-bom-scan"       false "agent-bom scan"
+          # Curated, focused skills only. Do not publish the oversized omnibus root
+          # skill to ClawHub — keep the marketplace surface small and guardrailed.
+          _publish_skill "integrations/openclaw/scan"       "agent-bom-scan"       true  "agent-bom scan"
           _publish_skill "integrations/openclaw/compliance" "agent-bom-compliance" false "agent-bom compliance"
           _publish_skill "integrations/openclaw/registry"   "agent-bom-registry"   false "agent-bom registry"
           _publish_skill "integrations/openclaw/runtime"    "agent-bom-runtime"    false "agent-bom runtime"

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ OCSF is currently used for runtime and SIEM event delivery, not as a general `-f
 }
 ```
 
-Also on [Glama](https://glama.ai/mcp/servers/@msaad00/agent-bom), [Smithery](integrations/smithery.yaml), [MCP Registry](integrations/mcp-registry/server.json), and [OpenClaw](integrations/openclaw/SKILL.md).
+Also on [Glama](https://glama.ai/mcp/servers/@msaad00/agent-bom), [Smithery](integrations/smithery.yaml), [MCP Registry](integrations/mcp-registry/server.json), and [OpenClaw](integrations/openclaw/README.md).
 
 ---
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -23,6 +23,8 @@ ingress or platform edge.
 
 If you need a public unauthenticated registry/demo endpoint, treat that as a separate,
 explicitly less-trusted deployment surface rather than weakening the primary service.
+Release automation now requires that public endpoint to be set explicitly via
+`SMITHERY_MCP_URL`. It does not fall back to the protected Railway URL.
 
 ### Step 2: Publish to Smithery
 
@@ -30,11 +32,18 @@ explicitly less-trusted deployment surface rather than weakening the primary ser
 1. Go to https://smithery.ai/servers/new
 2. Namespace: `agent-bom`
 3. Server ID: `agent-bom`
-4. MCP Server URL: `https://agent-bom-mcp.up.railway.app/mcp`
+4. MCP Server URL: your separate public unauthenticated endpoint, e.g. `https://agent-bom--agent-bom.run.tools`
 5. Click **Continue**
 
 **Option B — Automated**:
-The `publish-registries.yml` workflow auto-publishes to Smithery on each release using `SMITHERY_API_TOKEN`.
+The `publish-registries.yml` workflow auto-publishes to Smithery on each release using:
+- `SMITHERY_API_TOKEN`
+- `SMITHERY_MCP_URL`
+
+Before publish, CI probes the public endpoint and fails if:
+- the endpoint is unreachable
+- the endpoint reports `auth_required=true`
+- the endpoint is otherwise unsuitable for public registry publishing
 
 ### Verification
 
@@ -71,20 +80,30 @@ Search for "agent-bom" at: https://registry.modelcontextprotocol.io
 
 Automated via `publish-registries.yml` using `CLAWHUB_TOKEN`.
 
+The public ClawHub surface is intentionally curated. Release automation publishes only:
+- `agent-bom-scan`
+- `agent-bom-registry`
+- `agent-bom-compliance`
+- `agent-bom-runtime`
+
+See [`integrations/openclaw/README.md`](../integrations/openclaw/README.md) for the
+curated publish set and rationale. The oversized omnibus root skill is kept in-repo
+but is not part of the public ClawHub release surface.
+
 ### Manual publish
 
 ```bash
 npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN"
-clawhub publish integrations/openclaw \
-  --slug agent-bom --name "agent-bom" \
+clawhub publish integrations/openclaw/scan \
+  --slug agent-bom-scan --name "agent-bom scan" \
   --version "0.76.4"
 ```
 
 ### Verification
 
 ```bash
-clawhub install agent-bom
+clawhub install agent-bom-scan
 ```
 
 ---
@@ -171,6 +190,6 @@ For dependency-heavy or security-driven releases, also verify:
 | **GHCR (stdio)** | `Dockerfile.mcp` | publish-mcp.yml | workflow_run |
 | **GHCR (SSE)** | `deploy/docker/Dockerfile.sse` | publish-mcp.yml | workflow_run |
 | **Smithery** | workflow API | publish-registries.yml | workflow_run |
-| **ClawHub** | `integrations/openclaw/` | publish-registries.yml | workflow_run |
+| **ClawHub** | curated `integrations/openclaw/*/SKILL.md` set | publish-registries.yml | workflow_run |
 | **MCP Registry** | `integrations/mcp-registry/server.json` | publish-mcp-registry.yml | workflow_run |
 | **Railway** | `deploy/docker/Dockerfile.sse` | deploy-mcp-sse.yml | workflow_run |

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,28 @@
+# OpenClaw / ClawHub Skill Publishing
+
+`agent-bom` keeps the public ClawHub surface intentionally small.
+
+Published skills:
+- `agent-bom-scan`
+- `agent-bom-registry`
+- `agent-bom-compliance`
+- `agent-bom-runtime`
+
+These are the only skills pushed by release automation. They are:
+- focused enough for individual and team use
+- small enough to review and understand quickly
+- explicit about credentials, file reads, network calls, and guardrails
+
+Not published to ClawHub:
+- the oversized omnibus root skill in [`SKILL.md`](SKILL.md)
+- internal or narrower sub-skills such as `discover`, `analyze`, `enforce`, `monitor`, `scan-infra`, and `troubleshoot`
+
+Reason:
+- public marketplace skills should be curated, guardrailed, and easy to audit
+- broader internal skill composition can stay in-repo without becoming the default public install surface
+
+When updating versions for release, update only the published skill frontmatter unless a private/internal skill is intentionally being prepared for publication:
+- [`scan/SKILL.md`](scan/SKILL.md)
+- [`registry/SKILL.md`](registry/SKILL.md)
+- [`compliance/SKILL.md`](compliance/SKILL.md)
+- [`runtime/SKILL.md`](runtime/SKILL.md)

--- a/site-docs/contributing.md
+++ b/site-docs/contributing.md
@@ -63,7 +63,7 @@ When preparing a release, update the version in all of these files:
 3. `Dockerfile` — version label
 4. `deploy/docker/Dockerfile.sse` — `ARG VERSION=X.Y.Z`
 5. `integrations/mcp-registry/server.json` — `version`
-6. `integrations/openclaw/*/SKILL.md` — version in frontmatter (scan, compliance, registry, runtime)
+6. `integrations/openclaw/*/SKILL.md` — version in frontmatter for the published ClawHub skills (scan, compliance, registry, runtime)
 7. `action.yml` — version in description + branding
 8. `README.md` — version references in examples
 9. `docs/PUBLISHING.md` — version references

--- a/src/agent_bom/deployment_probe.py
+++ b/src/agent_bom/deployment_probe.py
@@ -84,6 +84,20 @@ def fetch_health(
     raise RuntimeError(f"unable to fetch MCP health from {health_url}: {last_error}")
 
 
+def validate_health_payload(
+    payload: dict[str, Any],
+    *,
+    forbid_auth_required: bool = False,
+) -> dict[str, Any]:
+    """Validate parsed health payload contract for deployment checks."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("health response must be a JSON object")
+    if forbid_auth_required and bool(payload.get("auth_required")):
+        raise ValueError("deployment surface requires auth and is not suitable for public registry publishing")
+    return payload
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Probe the MCP health endpoint used by CI workflows.")
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="Railway base URL or MCP endpoint URL.")
@@ -100,6 +114,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--resolve-only",
         action="store_true",
         help="Print the normalized health URL without making a network request.",
+    )
+    parser.add_argument(
+        "--forbid-auth-required",
+        action="store_true",
+        help="Fail if the health payload reports auth_required=true.",
     )
     return parser
 
@@ -119,6 +138,10 @@ def main(argv: list[str] | None = None) -> int:
             attempts=args.attempts,
             backoff_seconds=args.backoff_seconds,
             timeout=args.timeout,
+        )
+        payload = validate_health_payload(
+            payload,
+            forbid_auth_required=args.forbid_auth_required,
         )
     except (RuntimeError, ValueError) as exc:
         print(str(exc), file=sys.stderr)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -221,11 +221,25 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     """Deployment freshness should probe authenticated MCP health endpoints safely."""
     workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
     assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
+    assert "SMITHERY_MCP_URL" in workflow
     assert "python3 -m agent_bom.deployment_probe" in workflow
     assert "tool_count" in workflow
+    assert "auth_required" in workflow
     assert "probe_failed=true" in workflow
     assert "steps.railway.outputs.probe_failed != 'true'" in workflow
     assert "--resolve-only" in workflow
+
+
+def test_publish_registries_workflow_requires_public_smithery_surface_and_curated_clawhub_set():
+    """Registry publishing should fail fast on auth-gated Smithery URLs and avoid omnibus ClawHub skills."""
+    workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
+    assert "SMITHERY_MCP_URL" in workflow
+    assert "--forbid-auth-required" in workflow
+    assert "integrations/openclaw/scan" in workflow
+    assert "integrations/openclaw/compliance" in workflow
+    assert "integrations/openclaw/registry" in workflow
+    assert "integrations/openclaw/runtime" in workflow
+    assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
 
 
 def test_deploy_mcp_sse_workflow_uses_bearer_token_for_health_check():

--- a/tests/test_deployment_probe.py
+++ b/tests/test_deployment_probe.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import urllib.error
 
-from agent_bom.deployment_probe import fetch_health, resolve_health_url
+import pytest
+
+from agent_bom.deployment_probe import fetch_health, resolve_health_url, validate_health_payload
 
 
 class _Response:
@@ -58,3 +60,13 @@ def test_fetch_health_retries_normalized_url(monkeypatch):
         "https://agent-bom-mcp.up.railway.app/health",
         "https://agent-bom-mcp.up.railway.app/health",
     ]
+
+
+def test_validate_health_payload_rejects_auth_required_for_public_registry():
+    with pytest.raises(ValueError, match="requires auth"):
+        validate_health_payload({"version": "0.76.0", "auth_required": True}, forbid_auth_required=True)
+
+
+def test_validate_health_payload_allows_public_surface():
+    payload = validate_health_payload({"version": "0.76.0", "auth_required": False}, forbid_auth_required=True)
+    assert payload["version"] == "0.76.0"


### PR DESCRIPTION
## Summary
- require an explicit public unauthenticated Smithery endpoint and fail fast if it is auth-gated
- extend deployment freshness checks to watch the public marketplace surface
- curate ClawHub publishing to the focused scan, registry, compliance, and runtime skills only

## Testing
- `uv run pytest -q tests/test_deployment_probe.py tests/test_deployment.py`
- YAML parse for `.github/workflows/publish-registries.yml` and `.github/workflows/deployment-freshness.yml`
- `git diff --check`