### PR TITLE
Anchor remediation score to blast-radius risk

### DIFF
--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1027,7 +1027,7 @@ def print_threat_frameworks(report: AIBOMReport) -> None:
 def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
     """Group blast radii into a prioritized remediation plan.
 
-    Returns items sorted by impact: each item = one upgrade action that clears
+    Returns items sorted by grouped blast-radius risk: each item = one upgrade action that clears
     N vulns across M agents and frees exposed credentials.
     """
     from collections import defaultdict
@@ -1062,6 +1062,7 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
             "high_count": 0,
             "has_kev": False,
             "ai_risk": False,
+            "max_risk_score": 0.0,
             "references": set(),
             "suppressed_prerelease_fixes": set(),
         }
@@ -1113,6 +1114,7 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
             g["has_kev"] = True
         if br.ai_risk_context:
             g["ai_risk"] = True
+        g["max_risk_score"] = max(g["max_risk_score"], br.risk_score)
 
     plan = []
     for g in groups.values():
@@ -1132,9 +1134,10 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
         g["cis"] = sorted(g["cis"])
         g["references"] = sorted(g["references"])
         g["suppressed_prerelease_fixes"] = sorted(g["suppressed_prerelease_fixes"])
-        g["impact"] = (
-            len(g["agents"]) * 10 + len(g["creds"]) * 3 + len(g["vulns"]) + (5 if g["has_kev"] else 0) + (3 if g["ai_risk"] else 0)
-        )
+        # Use the highest grouped blast-radius risk score so remediation stays
+        # anchored to the canonical vulnerability risk model instead of a
+        # separate package-level heuristic.
+        g["impact"] = round(g["max_risk_score"], 1)
         if g["has_kev"] or g["critical_count"] >= 3:
             g["priority"] = "P1"
         elif g["critical_count"] > 0 or (g["high_count"] > 0 and g["creds"]):
@@ -1200,7 +1203,7 @@ def print_remediation_plan(report: AIBOMReport) -> None:
     }
 
     if fixable:
-        console.print(f"  [bold]{len(fixable)} fixable upgrade(s) — ordered by blast radius impact:[/bold]\n")
+        console.print(f"  [bold]{len(fixable)} fixable upgrade(s) — ordered by grouped blast-radius risk:[/bold]\n")
         for i, item in enumerate(fixable, 1):
             sev = item["max_severity"]
             style = sev_style.get(sev, "white")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3133,13 +3133,12 @@ def test_remediation_plan_named_assets(sample_report):
 
 
 def test_remediation_plan_impact_score(sample_report):
-    """Impact score accounts for agents, creds, and vulns."""
+    """Remediation score mirrors the grouped blast-radius risk score."""
     from agent_bom.output import build_remediation_plan
 
     plan = build_remediation_plan(sample_report.blast_radii)
     item = plan[0]
-    # 1 agent * 10 + 1 cred * 3 + 1 vuln = 14
-    assert item["impact"] == 14
+    assert item["impact"] == round(sample_report.blast_radii[0].risk_score, 1)
 
 
 def test_remediation_json_in_output(sample_report):

--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -182,7 +182,7 @@ function NarrativeRow({
           )}
         </td>
 
-        {/* Impact score */}
+        {/* Risk score */}
         <td className="px-4 py-3">
           <div className="flex items-center gap-2">
             <div className="w-16 h-1.5 bg-zinc-800 rounded-full overflow-hidden">
@@ -807,7 +807,7 @@ function RemediationPage() {
                   </th>
                   <th className="text-left px-4 py-3">
                     <SortButton
-                      label="Impact"
+                      label="Risk"
                       field="impact_score"
                       current={sortKey}
                       dir={sortDir}

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -382,8 +382,8 @@ function RemediationPlan({ items }: { items: RemediationItem[] }) {
               </div>
             </div>
             <div className="text-right flex-shrink-0">
-              <div className="text-lg font-bold font-mono text-emerald-400">{item.impact_score}</div>
-              <div className="text-xs text-zinc-600">impact</div>
+              <div className="text-lg font-bold font-mono text-emerald-400">{item.impact_score.toFixed(1)}</div>
+              <div className="text-xs text-zinc-600">risk</div>
             </div>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-3">

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -142,6 +142,7 @@ export interface RemediationItem {
   fixed_version: string | null;
   severity: string;
   is_kev: boolean;
+  /** Normalized 0-10 remediation risk derived from grouped blast-radius risk. */
   impact_score: number;
   priority?: number;
   action?: string;

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -122,7 +122,7 @@ describe('api.getScan', () => {
             fixed_version: null,
             severity: 'high',
             is_kev: false,
-            impact_score: 70,
+            impact_score: 7.0,
             priority: 1,
             action: 'review',
             reason: 'Only prerelease fixes were available and suppressed by default.',


### PR DESCRIPTION
## Summary
- replace remediation package scoring with the grouped canonical blast-radius risk score
- relabel remediation and scan-result UI surfaces from impact to risk
- update remediation tests and UI fixtures to use normalized 0-10 risk values

## Validation
- uv run pytest -q tests/test_core.py tests/test_output_cov.py tests/test_nvd_status.py -k remediation
- uv run ruff check src/agent_bom/output/__init__.py src/agent_bom/output/json_fmt.py tests/test_core.py
- git diff --check