### PR TITLE
Clarify deployment and hosting choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,31 @@ docker run --rm agentbom/agent-bom agents    # Docker
 |------|---------|----------|
 | CLI | `agent-bom agents` | Local audit + project scan |
 | GitHub Action | `uses: msaad00/agent-bom@v0.76.4` | CI/CD + SARIF |
-| Docker | `docker run agentbom/agent-bom` | Isolated scans |
+| Docker | `docker run agentbom/agent-bom` | Isolated scans and containerized self-hosting surfaces |
+| REST API | `agent-bom api` | Platform integration and self-hosted control plane |
 | MCP Server | `agent-bom mcp server` | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
 | Shield SDK | `from agent_bom.shield import Shield` | In-process protection |
 | API + dashboard | `agent-bom serve` | Fleet visibility, audit exports, and central review. Requires `pip install 'agent-bom[ui]'` once. |
+
+Backend choices stay explicit and optional:
+
+- `SQLite` for local and single-node use
+- `Postgres` / `Supabase` for the primary transactional control plane
+- `ClickHouse` for analytics and event-scale persistence
+- `Snowflake` for warehouse-native governance and selected backend paths with explicit parity limits
+
+That means enterprises can run `agent-bom`:
+
+- locally
+- in CI
+- in Docker
+- in Kubernetes / Helm
+- as a self-hosted API + dashboard
+- as an MCP server for local or remote clients
+- with Postgres, ClickHouse, and Snowflake where each backend actually fits
+
+We do not require one hosted control plane or one cloud vendor.
 
 Product references:
 - [docs/PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md)

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -1,14 +1,70 @@
 # Deployment Overview
 
-| Mode | Best for | Command |
-|------|----------|---------|
-| **CLI** | Local scanning, CI/CD | `pip install agent-bom` |
-| **MCP Server** | AI agent integration | `agent-bom mcp server` |
-| **Docker** | Isolated scanning | `docker run ghcr.io/msaad00/agent-bom scan` |
-| **GitHub Action** | PR checks | `uses: msaad00/agent-bom@v0.76.4` |
-| **Kubernetes** | Fleet monitoring | Helm chart |
-| **REST API** | Platform integration | `agent-bom serve` |
-| **Runtime Proxy** | Real-time enforcement | `agent-bom runtime proxy` |
+`agent-bom` is intentionally deployable in multiple ways. The product contract is
+interoperable and self-hostable:
+
+- run it locally as a CLI
+- run it in CI
+- run it in Docker or Kubernetes
+- expose it as an MCP server
+- self-host the API + dashboard
+- pair the control plane with Postgres / Supabase, ClickHouse, or Snowflake where
+  parity is explicitly documented
+
+That gives users real choices instead of locking the product to one control
+plane or one hosting provider.
+
+## Runtime Surfaces
+
+| Surface | Best for | Command / entrypoint |
+|---|---|---|
+| **CLI** | local scans, endpoint runs, CI jobs | `pip install agent-bom` then `agent-bom agents` |
+| **GitHub Action** | PR and release gates | `uses: msaad00/agent-bom@v0.76.4` |
+| **Docker** | isolated scans and reproducible runners | `docker run ghcr.io/msaad00/agent-bom agents` |
+| **API + dashboard** | team and enterprise self-hosting | `agent-bom serve` |
+| **REST API only** | platform integration without bundled UI | `agent-bom api` |
+| **MCP server** | Claude Desktop, Claude Code, Codex, Cursor, Windsurf, Smithery-style remote use | `agent-bom mcp server` |
+| **Runtime proxy** | live MCP traffic inspection and policy enforcement | `agent-bom proxy` |
+| **Shield SDK** | in-process protection inside an app or service | `from agent_bom.shield import Shield` |
+
+## Hosting and Storage Choices
+
+| Choice | What it means today | Best for |
+|---|---|---|
+| **Local laptop / workstation** | local CLI or `agent-bom serve` with SQLite | individuals, demos, endpoint audit |
+| **Self-hosted VM / container** | `agent-bom api` or `agent-bom serve` behind your ingress/auth | teams and platform operators |
+| **Docker Compose / container platforms** | containerized API, proxy, or MCP server | repeatable deployment without vendor lock-in |
+| **Kubernetes / Helm** | cluster deployment for API, proxy, and runtime surfaces | larger team and enterprise rollout |
+| **Postgres / Supabase** | primary transactional control plane | full API/UI and tenant-aware persistence |
+| **ClickHouse** | analytics and event-scale persistence | trends, runtime event analytics, OLAP |
+| **Snowflake** | warehouse-native governance and selected control-plane paths | governance/activity workflows and Snowflake-native operators |
+
+## Important Boundary
+
+`Snowflake` is a supported backend and governance surface, not the default full
+application hosting contract.
+
+Today the honest story is:
+
+- `Postgres` / `Supabase`: primary control-plane backend
+- `ClickHouse`: analytics add-on
+- `Snowflake`: warehouse/governance/native-data option with explicit parity limits
+
+For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).
+
+## Deployment Selection
+
+| Need | Recommended path |
+|---|---|
+| Run one scan locally | CLI |
+| Gate pull requests | GitHub Action |
+| Keep the runtime isolated | Docker |
+| Self-host UI + API for a team | `agent-bom serve` + `Postgres` / `Supabase` |
+| Integrate with internal platforms | `agent-bom api` |
+| Expose agent-bom as a tool server | `agent-bom mcp server` |
+| Add runtime enforcement | `agent-bom proxy` |
+| Add analytics at scale | `ClickHouse` alongside the control plane |
+| Use warehouse-native governance data | `Snowflake` with explicit parity limits |
 
 ## Available on
 


### PR DESCRIPTION
## Summary
- document the real deployment and hosting choices agent-bom supports today
- add an explicit runtime surface matrix for CLI, API, dashboard, MCP, Docker, proxy, and Shield SDK
- clarify backend and hosting choices for SQLite, Postgres/Supabase, ClickHouse, and Snowflake without implying lock-in

## Testing
- git -C /tmp/agent-bom-deploy-options diff --check
