### PR TITLE
Unify dashboard posture card

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -9,9 +9,6 @@ import { SeverityBadge } from "@/components/severity-badge";
 import { ActivityFeed } from "@/components/activity-feed";
 import {
   PostureGrade,
-  postureDimensionHint,
-  postureDimensionHref,
-  postureDimensionTone,
 } from "@/components/posture-grade";
 import { AttackPathCard } from "@/components/attack-path-card";
 import { ApiOfflineState } from "@/components/api-offline-state";
@@ -570,54 +567,16 @@ export default function Dashboard() {
         </div>
 
         {posture && (
-          <div className="mt-6 grid grid-cols-1 gap-6 xl:grid-cols-[auto_1fr]">
-            <PostureGrade grade={posture.grade} score={posture.score} dimensions={posture.dimensions} />
-            <div
-              className="rounded-2xl border p-5"
-              style={{ backgroundColor: "var(--surface)", borderColor: "var(--border-subtle)" }}
-            >
-              <div className="flex flex-wrap items-center gap-3">
-                <h2 className="text-lg font-semibold text-zinc-100">
-                  Security posture <span style={{ color: posture.grade === "A" ? "#22c55e" : posture.grade === "B" ? "#3b82f6" : posture.grade === "C" ? "#eab308" : posture.grade === "D" ? "#f97316" : posture.grade === "F" ? "#ef4444" : "#71717a" }}>{posture.grade}</span>
-                </h2>
-                <span
-                  className="rounded-full border px-2.5 py-1 text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]"
-                  style={{ backgroundColor: "var(--surface-elevated)", borderColor: "var(--border-subtle)" }}
-                >
-                  score {posture.score.toFixed(1)}
-                </span>
-              </div>
-              <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">{posture.summary}</p>
-              {posture.dimensions && Object.keys(posture.dimensions).length > 0 && (
-                <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
-                  {Object.entries(posture.dimensions).map(([key, dim]) => (
-                    <Link
-                      key={key}
-                      href={postureDimensionHref(key, dim.label)}
-                      className="rounded-xl border px-3 py-2.5 transition-colors hover:border-[var(--border-strong)]"
-                      style={{ backgroundColor: "var(--surface-elevated)", borderColor: "var(--border-subtle)" }}
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <span className="text-xs font-medium text-zinc-200">{dim.label}</span>
-                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${postureDimensionTone(dim.score).badge}`}>
-                          {postureDimensionTone(dim.score).label}
-                        </span>
-                      </div>
-                      <div className="mt-2 flex items-baseline justify-between gap-3">
-                        <span className="font-mono text-lg text-zinc-100">{dim.score}/100</span>
-                        <span className="text-[11px] text-[var(--text-tertiary)]">{postureDimensionHint(key, dim.label)}</span>
-                      </div>
-                      <div className="mt-2 h-1.5 w-full rounded-full bg-[var(--surface-muted)]">
-                        <div
-                          className={`h-full rounded-full ${postureDimensionTone(dim.score).bar}`}
-                          style={{ width: `${dim.score}%` }}
-                        />
-                      </div>
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
+          <div className="mt-6">
+            <PostureGrade
+              grade={posture.grade}
+              score={posture.score}
+              dimensions={posture.dimensions}
+              summary={posture.summary}
+              variant="panel"
+              defaultExpanded={false}
+              drilldown
+            />
           </div>
         )}
       </section>

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 
 export interface PostureDimension {
   score: number;
@@ -13,6 +14,9 @@ interface PostureGradeProps {
   score: number;  // 0-100
   dimensions?: Record<string, PostureDimension>;
   drilldown?: boolean;
+  summary?: string;
+  variant?: "compact" | "panel";
+  defaultExpanded?: boolean;
 }
 
 export function postureDimensionTone(score: number) {
@@ -57,7 +61,15 @@ export function postureDimensionHint(key: string, label: string) {
   return "open evidence";
 }
 
-export function PostureGrade({ grade, score, dimensions, drilldown = false }: PostureGradeProps) {
+export function PostureGrade({
+  grade,
+  score,
+  dimensions,
+  drilldown = false,
+  summary,
+  variant = "compact",
+  defaultExpanded = false,
+}: PostureGradeProps) {
   // Color based on grade — matches architecture diagram semantics
   const gradeColor = {
     A: "#3fb950", // green  — output/governance layer
@@ -74,6 +86,93 @@ export function PostureGrade({ grade, score, dimensions, drilldown = false }: Po
   const orderedDimensions = Object.entries(dimensions ?? {})
     .sort((left, right) => right[1].score - left[1].score)
     .slice(0, 6);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  if (variant === "panel") {
+    return (
+      <div
+        className="rounded-2xl border p-5"
+        style={{ backgroundColor: "var(--surface)", borderColor: "var(--border-subtle)" }}
+      >
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-start">
+          <div className="flex shrink-0 items-center gap-4 lg:min-w-[180px]">
+            <div className="relative h-[108px] w-[108px]">
+              <svg viewBox="0 0 120 120" className="h-full w-full -rotate-90">
+                <circle cx="60" cy="60" r={radius} fill="none" stroke="var(--border-subtle)" strokeWidth="8" />
+                <circle cx="60" cy="60" r={radius} fill="none" stroke={gradeColor} strokeWidth="8"
+                  strokeDasharray={circumference} strokeDashoffset={dashOffset}
+                  strokeLinecap="round" className="transition-all duration-700" />
+              </svg>
+              <div className="absolute inset-0 flex flex-col items-center justify-center">
+                <span className="text-3xl font-bold" style={{ color: gradeColor }}>{grade}</span>
+                <span className="text-xs text-[var(--text-tertiary)]">{score}/100</span>
+              </div>
+            </div>
+            <div className="space-y-1">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                Security posture
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-2xl font-semibold" style={{ color: gradeColor }}>
+                  {grade}
+                </span>
+                <span
+                  className="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--text-secondary)]"
+                  style={{ backgroundColor: "var(--surface-elevated)", borderColor: "var(--border-subtle)" }}
+                >
+                  {score.toFixed(1)} / 100
+                </span>
+              </div>
+              <div className="text-xs text-[var(--text-tertiary)]">
+                Unified score with evidence drilldown
+              </div>
+            </div>
+          </div>
+          <div className="min-w-0 flex-1 space-y-4">
+            {summary && (
+              <p className="text-sm leading-6 text-[var(--text-secondary)]">{summary}</p>
+            )}
+            {orderedDimensions.length > 0 && (
+              <>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                  {orderedDimensions.map(([key, dim]) => (
+                    <CompactDimensionCard
+                      key={key}
+                      dimensionKey={key}
+                      dimension={dim}
+                      drilldown={drilldown}
+                    />
+                  ))}
+                </div>
+                <div className="border-t border-[var(--border-subtle)] pt-4">
+                  <button
+                    type="button"
+                    onClick={() => setExpanded((current) => !current)}
+                    className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+                    style={{ backgroundColor: "var(--surface-elevated)", borderColor: "var(--border-subtle)" }}
+                  >
+                    {expanded ? "Hide evidence breakdown" : "Show evidence breakdown"}
+                  </button>
+                </div>
+                {expanded && (
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                    {orderedDimensions.map(([key, dim]) => (
+                      <DimensionRow
+                        key={key}
+                        dimensionKey={key}
+                        dimension={dim}
+                        drilldown={drilldown}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col items-center gap-4">
@@ -109,6 +208,59 @@ export function PostureGrade({ grade, score, dimensions, drilldown = false }: Po
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function CompactDimensionCard({
+  dimensionKey,
+  dimension,
+  drilldown,
+}: {
+  dimensionKey: string;
+  dimension: PostureDimension;
+  drilldown: boolean;
+}) {
+  const tone = postureDimensionTone(dimension.score);
+  const content = (
+    <>
+      <div className="flex items-center justify-between gap-3">
+        <span className="truncate text-xs font-medium text-zinc-200">{dimension.label}</span>
+        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${tone.badge}`}>
+          {tone.label}
+        </span>
+      </div>
+      <div className="mt-2 flex items-baseline justify-between gap-3">
+        <span className="font-mono text-lg text-zinc-100">{dimension.score}/100</span>
+        <span className="text-[11px] text-[var(--text-tertiary)]">{postureDimensionHint(dimensionKey, dimension.label)}</span>
+      </div>
+      <div className="mt-2 h-1.5 rounded-full bg-[var(--surface-muted)]">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${tone.bar}`}
+          style={{ width: `${dimension.score}%` }}
+        />
+      </div>
+    </>
+  );
+
+  if (drilldown) {
+    return (
+      <Link
+        href={postureDimensionHref(dimensionKey, dimension.label)}
+        className="block rounded-xl border px-3 py-3 transition-colors hover:border-[var(--border-strong)]"
+        style={{ backgroundColor: "var(--surface-elevated)", borderColor: "var(--border-subtle)" }}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-xl border px-3 py-3"
+      style={{ backgroundColor: "var(--surface-elevated)", borderColor: "var(--border-subtle)" }}
+    >
+      {content}
     </div>
   );
 }

--- a/ui/tests/posture-grade.test.tsx
+++ b/ui/tests/posture-grade.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -51,5 +51,38 @@ describe("PostureGrade", () => {
     expect(screen.getByRole("link", { name: /Vulnerability Exposure/i })).toHaveAttribute("href", "/findings");
     expect(screen.getByRole("link", { name: /Credential Reach/i })).toHaveAttribute("href", "/mesh");
     expect(screen.getByText("High-risk packages remain reachable by agents.")).toBeInTheDocument();
+  });
+
+  it("renders one unified panel with a collapsible evidence breakdown", () => {
+    render(
+      <PostureGrade
+        grade="F"
+        score={40.4}
+        drilldown
+        variant="panel"
+        summary="Weak security posture driven by credential exposure and undeclared MCP tools."
+        dimensions={{
+          vulnerability_exposure: {
+            label: "Packages and CVEs",
+            score: 10,
+            details: "44 vulnerable packages remain in scope.",
+          },
+          credential_reach: {
+            label: "Reach and exposure",
+            score: 23,
+            details: "7 credentials remain exposed across reachable agents.",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Weak security posture driven by credential exposure/i)).toBeInTheDocument();
+    expect(screen.queryByText("44 vulnerable packages remain in scope.")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Show evidence breakdown/i }));
+
+    expect(screen.getByText("44 vulnerable packages remain in scope.")).toBeInTheDocument();
+    const packageLinks = screen.getAllByRole("link", { name: /Packages and CVEs/i });
+    expect(packageLinks[0]).toHaveAttribute("href", "/findings");
   });
 });


### PR DESCRIPTION
## Summary
- replace the duplicated dashboard posture surfaces with one unified posture card
- keep score dimensions clickable while moving the full evidence breakdown behind a single expand/collapse control
- reduce the empty-space problem in the overview layout and lock the behavior in posture UI tests

## Validation
- cd ui && npm run lint
- cd ui && npm run test:run -- posture-grade
- cd ui && npm run build
