### PR TITLE
Make UI API endpoint runtime-configurable

### DIFF
--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -169,6 +169,13 @@ You still own:
 - Secrets Manager / IRSA / ingress-controller wiring
 - operator runbooks and load testing
 
+For the UI specifically, the container now reads `NEXT_PUBLIC_API_URL` at
+startup. That means:
+
+- set a full internal or external API URL when you want cross-origin calls
+- set `NEXT_PUBLIC_API_URL=` for same-origin ingress and route `/v1/*`,
+  `/health`, and `/ws/*` to the API service in your ingress/controller
+
 That is still a valid no-lock-in story. The repo gives you the container entry
 points, storage paths, proxy surface, and scanner/discovery chart knobs without
 forcing you into a hosted control plane.

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -30,9 +30,12 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy standalone output
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --chown=nextjs:nodejs docker-entrypoint.sh ./docker-entrypoint.sh
+
+RUN chmod +x /app/docker-entrypoint.sh
 
 USER nextjs
 
@@ -43,4 +46,5 @@ ENV HOSTNAME="0.0.0.0"
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD node -e "const http = require('http'); http.get('http://localhost:3000', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));" || exit 1
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/ui/README.md
+++ b/ui/README.md
@@ -22,7 +22,22 @@ agent-bom api
 npm run dev
 ```
 
-The UI reads `NEXT_PUBLIC_API_URL`. If it is unset, the dev server proxies `/v1/*`, `/health`, and `/ws/*` to `http://localhost:8422`.
+The UI reads `NEXT_PUBLIC_API_URL`.
+
+- in development, the Next server uses it for local rewrites
+- in containers, the runtime entrypoint writes it into `public/runtime-config.js`
+  so the same image can be pointed at a different API endpoint at startup
+
+If it is unset, the dev server proxies `/v1/*`, `/health`, and `/ws/*` to `http://localhost:8422`.
+
+For same-origin ingress in Kubernetes or other reverse-proxy setups, set:
+
+```bash
+NEXT_PUBLIC_API_URL=
+```
+
+That keeps browser requests relative (`/v1/...`) so the ingress can route API
+paths to the backend service without rebuilding the UI image.
 
 If you see `Failed to fetch`:
 

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import Script from "next/script";
 import "./globals.css";
 import { Nav } from "@/components/nav";
 
@@ -46,6 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" data-theme="dark" suppressHydrationWarning>
       <body className={`${inter.variable} ${mono.variable} font-sans bg-background text-foreground min-h-screen antialiased selection:bg-emerald-500/20`}>
+        <Script src="/runtime-config.js" strategy="beforeInteractive" />
         <script dangerouslySetInnerHTML={{ __html: themeBootstrap }} />
         <Nav />
         {/* Main content — offset by sidebar width on desktop, offset by top bar on mobile */}

--- a/ui/app/proxy/page.tsx
+++ b/ui/app/proxy/page.tsx
@@ -7,6 +7,7 @@ import {
   type ProxyAlert,
   formatDate,
 } from "@/lib/api";
+import { getConfiguredApiUrl } from "@/lib/runtime-config";
 import {
   ResponsiveContainer,
   BarChart,
@@ -93,7 +94,7 @@ export default function ProxyDashboard() {
 
   // WebSocket for live metrics
   useEffect(() => {
-    const base = process.env.NEXT_PUBLIC_API_URL ?? window.location.origin;
+    const base = getConfiguredApiUrl() || window.location.origin;
     const wsUrl = base.replace(/^http/, "ws") + "/ws/proxy/metrics";
 
     let ws: WebSocket;

--- a/ui/components/api-offline-state.tsx
+++ b/ui/components/api-offline-state.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { AlertTriangle, FileText, PlayCircle, Server } from "lucide-react";
 
 import type { ScanResult } from "@/lib/api";
+import { getDisplayApiUrl } from "@/lib/runtime-config";
 import { checkFileSize, validateScanReport } from "@/lib/validators";
 
 interface ApiOfflineStateProps {
@@ -13,14 +14,13 @@ interface ApiOfflineStateProps {
   onImport?: (data: ScanResult) => void;
 }
 
-const DEFAULT_API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8422";
-
 export function ApiOfflineState({
   title = "Cannot connect to the agent-bom API",
   detail,
   onImport,
 }: ApiOfflineStateProps) {
   const [importError, setImportError] = useState<string | null>(null);
+  const apiUrl = getDisplayApiUrl();
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -61,7 +61,7 @@ export function ApiOfflineState({
           <p className="mt-3 text-sm leading-6 text-zinc-400">
             Run the local stack at{" "}
             <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">
-              {DEFAULT_API_URL}
+              {apiUrl}
             </code>{" "}
             so the dashboard can load live scan data, graph views, and compliance surfaces.
           </p>
@@ -108,7 +108,7 @@ export function ApiOfflineState({
           If the API is already running and you still see this page, check the browser console for CORS errors and confirm{" "}
           <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">NEXT_PUBLIC_API_URL</code>{" "}
           points to{" "}
-          <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">{DEFAULT_API_URL}</code>.
+          <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">{apiUrl}</code>.
         </div>
 
         {onImport ? (

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+API_URL_JSON="$(node -p 'JSON.stringify(process.env.NEXT_PUBLIC_API_URL ?? "")')"
+
+cat > /app/public/runtime-config.js <<EOF
+window.__AGENT_BOM_CONFIG__ = Object.assign({}, window.__AGENT_BOM_CONFIG__, {
+  apiUrl: ${API_URL_JSON},
+});
+EOF
+
+exec "$@"

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -4,8 +4,7 @@
  */
 
 import type { UnifiedEdge, UnifiedGraphData, UnifiedNode } from "./graph-schema";
-
-const BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
+import { getConfiguredApiUrl } from "./runtime-config";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -746,13 +745,13 @@ async function errorMessage(res: Response): Promise<string> {
 }
 
 async function get<T>(path: string): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, { signal: withTimeout() });
+  const res = await fetch(`${getConfiguredApiUrl()}${path}`, { signal: withTimeout() });
   if (!res.ok) throw new Error(await errorMessage(res));
   return res.json() as Promise<T>;
 }
 
 async function post<T>(path: string, body: unknown, headers: Record<string, string> = {}): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
+  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...headers },
     body: JSON.stringify(body),
@@ -763,7 +762,7 @@ async function post<T>(path: string, body: unknown, headers: Record<string, stri
 }
 
 async function put<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
+  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -774,7 +773,7 @@ async function put<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function del(path: string): Promise<void> {
-  const res = await fetch(`${BASE}${path}`, { method: "DELETE", signal: withTimeout() });
+  const res = await fetch(`${getConfiguredApiUrl()}${path}`, { method: "DELETE", signal: withTimeout() });
   if (!res.ok) throw new Error(await errorMessage(res));
 }
 
@@ -891,7 +890,7 @@ export const api = {
 
   /** Connect to SSE stream for real-time progress */
   streamScan: (jobId: string, onMessage: (data: SSEEvent) => void, onDone: () => void) => {
-    const es = new EventSource(`${BASE}/v1/scan/${jobId}/stream`);
+    const es = new EventSource(`${getConfiguredApiUrl()}/v1/scan/${jobId}/stream`);
     es.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data as string);

--- a/ui/lib/runtime-config.ts
+++ b/ui/lib/runtime-config.ts
@@ -1,0 +1,30 @@
+declare global {
+  interface Window {
+    __AGENT_BOM_CONFIG__?: {
+      apiUrl?: string;
+    };
+  }
+}
+
+const DEFAULT_API_URL = "http://localhost:8422";
+
+function normalizeApiUrl(value: string | undefined | null): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  return value.trim();
+}
+
+export function getConfiguredApiUrl(): string {
+  if (typeof window !== "undefined") {
+    const runtimeValue = normalizeApiUrl(window.__AGENT_BOM_CONFIG__?.apiUrl);
+    if (runtimeValue !== undefined) {
+      return runtimeValue;
+    }
+  }
+  return normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL) ?? "";
+}
+
+export function getDisplayApiUrl(): string {
+  return getConfiguredApiUrl() || DEFAULT_API_URL;
+}

--- a/ui/public/runtime-config.js
+++ b/ui/public/runtime-config.js
@@ -1,0 +1,3 @@
+window.__AGENT_BOM_CONFIG__ = Object.assign({}, window.__AGENT_BOM_CONFIG__, {
+  apiUrl: "",
+});

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -20,6 +20,50 @@ afterEach(() => {
 })
 
 describe('api.listJobs', () => {
+  it('prefers the runtime API URL over the build-time env', async () => {
+    const oldApiUrl = process.env.NEXT_PUBLIC_API_URL
+    process.env.NEXT_PUBLIC_API_URL = "https://build.example"
+    window.__AGENT_BOM_CONFIG__ = { apiUrl: "https://runtime.example" }
+
+    const fetchMock = mockFetch({ jobs: [], count: 0 })
+    global.fetch = fetchMock
+
+    await api.listJobs()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://runtime.example/v1/jobs",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+
+    if (oldApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = oldApiUrl
+    }
+  })
+
+  it('allows same-origin runtime routing when the runtime API URL is blank', async () => {
+    const oldApiUrl = process.env.NEXT_PUBLIC_API_URL
+    process.env.NEXT_PUBLIC_API_URL = "https://build.example"
+    window.__AGENT_BOM_CONFIG__ = { apiUrl: "" }
+
+    const fetchMock = mockFetch({ jobs: [], count: 0 })
+    global.fetch = fetchMock
+
+    await api.listJobs()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/jobs",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+
+    if (oldApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = oldApiUrl
+    }
+  })
+
   it('returns expected shape', async () => {
     const payload = {
       jobs: [

--- a/ui/tests/setup.ts
+++ b/ui/tests/setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  delete window.__AGENT_BOM_CONFIG__
+})


### PR DESCRIPTION
## Summary
- load the UI API endpoint from runtime-config.js before the app boots
- write runtime-config.js from the container entrypoint so the same UI image can target different APIs at startup
- document the same-origin ingress pattern for self-hosted EKS deployments

## Validation
- cd ui && npm run lint
- cd ui && npm run test:run
- cd ui && npm run build