### PR TITLE
Package control plane in Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ docker run --rm agentbom/agent-bom agents    # Docker
 | CLI | `agent-bom agents` | Local audit + project scan |
 | GitHub Action | `uses: msaad00/agent-bom@v0.76.4` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom` | Isolated scans and containerized self-hosting surfaces |
+| Kubernetes / Helm | `helm install agent-bom deploy/helm/agent-bom --set controlPlane.enabled=true` | Packaged self-hosted API + dashboard, scheduled discovery, and optional runtime monitor |
 | REST API | `agent-bom api` | Platform integration and self-hosted control plane |
 | MCP Server | `agent-bom mcp server` | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |
 | Runtime proxy | `agent-bom proxy` | MCP traffic enforcement |
@@ -226,6 +227,7 @@ That means enterprises can run `agent-bom`:
 - in Docker
 - in Kubernetes / Helm
 - as a self-hosted API + dashboard
+- as a Helm-packaged API + dashboard control plane in your own Kubernetes / EKS cluster
 - as an MCP server for local or remote clients
 - with Postgres, ClickHouse, and Snowflake where each backend actually fits
 

--- a/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
@@ -1,0 +1,75 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.api.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-bom.name" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.controlPlane.api.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "agent-bom.labels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- range .Values.controlPlane.api.args }}
+            - {{ . | quote }}
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.controlPlane.api.port }}
+              name: http
+              protocol: TCP
+          {{- with .Values.controlPlane.api.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.controlPlane.api.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.controlPlane.api.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.controlPlane.api.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.controlPlane.api.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.controlPlane.api.startupProbe | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-api-service.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.api.enabled .Values.controlPlane.api.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-bom.name" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.controlPlane.api.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.controlPlane.api.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      port: {{ .Values.controlPlane.api.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-ingress.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-ingress.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agent-bom.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+  {{- with .Values.controlPlane.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.controlPlane.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  rules:
+    {{- range .Values.controlPlane.ingress.hosts }}
+    - {{- if .host }}
+      host: {{ .host | quote }}
+      {{- end }}
+      http:
+        paths:
+          {{- if and $.Values.controlPlane.api.enabled $.Values.controlPlane.api.service.enabled }}
+          {{- range .apiPaths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "agent-bom.name" $ }}-api
+                port:
+                  name: http
+          {{- end }}
+          {{- end }}
+          {{- if and $.Values.controlPlane.ui.enabled $.Values.controlPlane.ui.service.enabled }}
+          {{- range .uiPaths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "agent-bom.name" $ }}-ui
+                port:
+                  name: http
+          {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.controlPlane.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-pdb.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-pdb.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.controlPlane.enabled .Values.pdb.enabled }}
+{{- if and .Values.controlPlane.api.enabled (gt (int .Values.controlPlane.api.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "agent-bom.name" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      app.kubernetes.io/component: api
+  {{- if ne .Values.pdb.maxUnavailable nil }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+---
+{{- end }}
+{{- if and .Values.controlPlane.ui.enabled (gt (int .Values.controlPlane.ui.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "agent-bom.name" . }}-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      app.kubernetes.io/component: ui
+  {{- if ne .Values.pdb.maxUnavailable nil }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-ui-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-ui-deployment.yaml
@@ -1,28 +1,29 @@
-{{- if .Values.monitor.enabled }}
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.ui.enabled }}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
-  name: {{ include "agent-bom.name" . }}-monitor
+  name: {{ include "agent-bom.name" . }}-ui
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agent-bom.labels" . | nindent 4 }}
-    app.kubernetes.io/component: monitor
+    app.kubernetes.io/component: ui
 spec:
+  replicas: {{ .Values.controlPlane.ui.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "agent-bom.name" . }}
-      app.kubernetes.io/component: monitor
+      app.kubernetes.io/component: ui
   template:
     metadata:
       labels:
         {{- include "agent-bom.labels" . | nindent 8 }}
-        app.kubernetes.io/component: monitor
+        app.kubernetes.io/component: ui
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ include "agent-bom.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -30,32 +31,31 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: monitor
-          image: "{{ .Values.runtimeImage.repository }}:{{ .Values.runtimeImage.tag }}"
-          imagePullPolicy: {{ .Values.runtimeImage.pullPolicy }}
-          command: ["agent-bom"]
-          args:
-            - "protect"
-            - "--mode"
-            - {{ .Values.monitor.mode | quote }}
-            - "--host"
-            - "0.0.0.0"
-            - "--port"
-            - {{ .Values.monitor.port | quote }}
+        - name: ui
+          image: "{{ .Values.uiImage.repository }}:{{ .Values.uiImage.tag }}"
+          imagePullPolicy: {{ .Values.uiImage.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.monitor.port }}
-              name: protect
+            - containerPort: {{ .Values.controlPlane.ui.port }}
+              name: http
               protocol: TCP
+          {{- with .Values.controlPlane.ui.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.controlPlane.ui.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.controlPlane.ui.resources | nindent 12 }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.controlPlane.ui.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.controlPlane.ui.readinessProbe | nindent 12 }}
           startupProbe:
-            {{- toYaml .Values.startupProbe | nindent 12 }}
+            {{- toYaml .Values.controlPlane.ui.startupProbe | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/agent-bom/templates/controlplane-ui-service.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-ui-service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.ui.enabled .Values.controlPlane.ui.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-bom.name" . }}-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+  {{- with .Values.controlPlane.ui.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.controlPlane.ui.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+    app.kubernetes.io/component: ui
+  ports:
+    - name: http
+      port: {{ .Values.controlPlane.ui.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/agent-bom/templates/cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/cronjob.yaml
@@ -18,8 +18,16 @@ spec:
           labels:
             {{- include "agent-bom.labels" . | nindent 12 }}
             app.kubernetes.io/component: scanner
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         spec:
           serviceAccountName: {{ include "agent-bom.serviceAccountName" . }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
           containers:
@@ -54,5 +62,17 @@ spec:
           volumes:
             - name: output
               emptyDir: {}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: OnFailure
 {{- end }}

--- a/deploy/helm/agent-bom/templates/networkpolicy.yaml
+++ b/deploy/helm/agent-bom/templates/networkpolicy.yaml
@@ -11,9 +11,18 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "agent-bom.name" . }}
   policyTypes:
-    - Ingress
     - Egress
-  ingress: []
+    {{- if or .Values.networkPolicy.restrictIngress (gt (len .Values.networkPolicy.ingress) 0) }}
+    - Ingress
+    {{- end }}
+  {{- if or .Values.networkPolicy.restrictIngress (gt (len .Values.networkPolicy.ingress) 0) }}
+  ingress:
+    {{- if gt (len .Values.networkPolicy.ingress) 0 }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
+    []
+    {{- end }}
+  {{- end }}
   egress:
     {{- if .Values.networkPolicy.allowDns }}
     - ports:

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -3,10 +3,21 @@ image:
   tag: "0.76.4"
   pullPolicy: IfNotPresent
 
+uiImage:
+  repository: agentbom/agent-bom-ui
+  tag: "0.76.4"
+  pullPolicy: IfNotPresent
+
 runtimeImage:
   repository: agentbom/agent-bom-runtime
   tag: "0.76.4"
   pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 scanner:
   enabled: true
@@ -39,6 +50,110 @@ monitor:
     hosts:
       - host: ""
         paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+
+controlPlane:
+  enabled: false
+  api:
+    enabled: true
+    replicas: 2
+    port: 8422
+    args:
+      - api
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8422"
+    env: []
+    envFrom: []
+    service:
+      enabled: true
+      type: ClusterIP
+      annotations: {}
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "1Gi"
+        cpu: "1000m"
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: http
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    startupProbe:
+      httpGet:
+        path: /health
+        port: http
+      failureThreshold: 18
+      periodSeconds: 5
+  ui:
+    enabled: true
+    replicas: 2
+    port: 3000
+    env:
+      - name: NEXT_PUBLIC_API_URL
+        value: ""
+    envFrom: []
+    service:
+      enabled: true
+      type: ClusterIP
+      annotations: {}
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+    livenessProbe:
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readinessProbe:
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    startupProbe:
+      httpGet:
+        path: /
+        port: http
+      failureThreshold: 18
+      periodSeconds: 5
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: ""
+        apiPaths:
+          - path: /v1
+            pathType: Prefix
+          - path: /health
+            pathType: Prefix
+          - path: /docs
+            pathType: Prefix
+          - path: /redoc
+            pathType: Prefix
+          - path: /openapi.json
+            pathType: Prefix
+          - path: /ws
+            pathType: Prefix
+        uiPaths:
           - path: /
             pathType: Prefix
     tls: []
@@ -96,6 +211,8 @@ startupProbe:
 
 networkPolicy:
   enabled: true
+  restrictIngress: false
+  ingress: []
   allowDns: true
   allowWeb: true
   webPorts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
   - Deployment:
       - Overview: deployment/overview.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md
+      - Packaged API + UI Control Plane: deployment/control-plane-helm.md
       - Backend Parity: deployment/backend-parity.md
       - Docker: deployment/docker.md
       - Kubernetes: deployment/kubernetes.md

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -1,0 +1,144 @@
+# Packaged API + UI Control Plane
+
+`agent-bom` now ships a Helm-packaged control plane for teams that want the API
+and dashboard inside their own Kubernetes environment instead of running custom
+Deployment manifests by hand.
+
+This is the right path when you want:
+
+- the API and UI in your own cluster
+- same-origin browser traffic through your own ingress
+- Postgres, ClickHouse, OIDC, and secrets kept in your own environment
+- the scanner CronJob and optional runtime monitor packaged alongside the
+  control plane
+
+## What the chart deploys
+
+When you set `controlPlane.enabled=true`, the Helm chart can package:
+
+- API Deployment + Service
+- UI Deployment + Service
+- same-origin Ingress that routes API paths to the API service and `/` to the UI
+- scanner CronJob
+- optional runtime monitor DaemonSet
+
+```mermaid
+flowchart LR
+    A[Browser] --> B[Ingress]
+    B -->|/| C[agent-bom-ui Service]
+    B -->|/v1 /health /docs /ws| D[agent-bom-api Service]
+    D --> E[(Postgres)]
+    D --> F[(ClickHouse optional)]
+    G[Scanner CronJob] --> D
+    H[OIDC / API key auth] --> D
+```
+
+## Same-origin default
+
+The UI runtime contract from `#1452` is what makes this honest.
+
+By default the chart leaves `NEXT_PUBLIC_API_URL` blank in the UI pod, so the
+browser uses relative paths:
+
+- `/v1/*`
+- `/health`
+- `/docs`
+- `/redoc`
+- `/openapi.json`
+- `/ws/*`
+
+The packaged ingress routes those paths to the API service and everything else
+to the UI service. That means:
+
+- one hostname
+- no CORS setup for the default path
+- no UI image rebuild per environment
+
+If you want cross-origin instead, set `controlPlane.ui.env` so
+`NEXT_PUBLIC_API_URL` points at the API host you own.
+
+## Secure-by-default boundaries
+
+The chart packages the control plane, but it does not quietly weaken the
+runtime model.
+
+- API and UI pods run with `automountServiceAccountToken: false`
+- the discovery service account and IRSA path stay attached to the scanner
+- the API still refuses non-loopback startup without `AGENT_BOM_API_KEY`,
+  OIDC, or an explicit insecure override
+- same-origin ingress avoids default CORS sprawl
+- network policy stays enabled, with configurable ingress restrictions
+
+## Minimal values example
+
+Create a Secret with the database URL and auth settings you actually use:
+
+```bash
+kubectl create secret generic agent-bom-control-plane \
+  -n agent-bom \
+  --from-literal=AGENT_BOM_POSTGRES_URL='postgresql://agent_bom:...@postgres-rw:5432/agent_bom' \
+  --from-literal=AGENT_BOM_API_KEY='replace-me'
+```
+
+Then install with a values file like:
+
+```yaml
+controlPlane:
+  enabled: true
+  api:
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: agent-bom.internal.example.com
+
+scanner:
+  enabled: true
+  allNamespaces: true
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-discovery
+```
+
+Install:
+
+```bash
+helm install agent-bom deploy/helm/agent-bom \
+  -n agent-bom --create-namespace \
+  -f values.agent-bom.yaml
+```
+
+## What you still own
+
+This is a real packaged control plane, but not a magic managed service.
+
+You still own:
+
+- Postgres and optional ClickHouse
+- ingress controller and TLS
+- OIDC provider configuration or API key secret management
+- HPA, topology spread, and cluster-specific scaling policy
+- operator runbooks and load testing
+
+## Production guidance
+
+- keep `controlPlane.api.replicas` and `controlPlane.ui.replicas` at `2+`
+- use `Postgres`, not SQLite
+- keep same-origin ingress unless you have a strong reason not to
+- use `envFrom` / Secrets for `AGENT_BOM_POSTGRES_URL`, API keys, OIDC issuer,
+  audience, and audit HMAC settings
+- enable PDBs when you are running multi-replica workloads
+
+## Current boundary
+
+The chart now packages the control plane honestly, but it still does not claim:
+
+- a bundled Postgres subchart
+- built-in autoscaling or benchmarked throughput guarantees
+- completed auth hardening beyond the currently shipped server contract
+
+Those are the next operator-hardening layers, not hidden assumptions.

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -12,6 +12,11 @@ Located in `deploy/k8s/`:
 | `daemonset.yaml` | Runtime protection on every node |
 | `sidecar-example.yaml` | Proxy sidecar alongside an MCP server |
 
+Those static manifests are still the scanner/runtime path.
+
+If you want the packaged API + dashboard control plane, use the Helm chart
+described below.
+
 ## Quick start
 
 ```bash
@@ -32,6 +37,12 @@ helm install agent-bom deploy/helm/agent-bom/ \
   -n agent-bom --create-namespace \
   --set monitor.enabled=true
 
+# Package the API + UI control plane
+helm install agent-bom deploy/helm/agent-bom/ \
+  -n agent-bom --create-namespace \
+  --set controlPlane.enabled=true \
+  --set controlPlane.ingress.enabled=true
+
 # Custom schedule
 helm install agent-bom deploy/helm/agent-bom/ \
   -n agent-bom --create-namespace \
@@ -49,5 +60,12 @@ helm install agent-bom deploy/helm/agent-bom/ \
 | `scanner.env` | `[]` | Extra environment variables for the scanner CronJob |
 | `monitor.enabled` | `false` | Deploy DaemonSet monitor |
 | `monitor.port` | `8423` | HTTP port for protect endpoint |
+| `controlPlane.enabled` | `false` | Package API + dashboard Deployments and Services |
+| `controlPlane.ingress.enabled` | `false` | Add same-origin ingress routing for UI + API |
+| `controlPlane.ui.env` | `NEXT_PUBLIC_API_URL=\"\"` | Blank by default so the browser uses same-origin paths |
+| `networkPolicy.restrictIngress` | `false` | Keep ingress open unless you explicitly provide ingress policy rules |
 | `rbac.create` | `true` | Create RBAC resources |
 | `serviceAccount.annotations` | `{}` | Attach provider-specific identity such as AWS IRSA |
+
+For the full control-plane topology and secret wiring, see
+[Packaged API + UI Control Plane](control-plane-helm.md).

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -34,7 +34,7 @@ plane or one hosting provider.
 | **Local laptop / workstation** | local CLI or `agent-bom serve` with SQLite | individuals, demos, endpoint audit |
 | **Self-hosted VM / container** | `agent-bom api` or `agent-bom serve` behind your ingress/auth | teams and platform operators |
 | **Docker Compose / container platforms** | containerized API, proxy, or MCP server | repeatable deployment without vendor lock-in |
-| **Kubernetes / Helm** | cluster deployment for API, proxy, and runtime surfaces | larger team and enterprise rollout |
+| **Kubernetes / Helm** | cluster deployment for scanner, proxy, optional runtime monitor, and packaged API + UI control plane | larger team and enterprise rollout |
 | **Postgres / Supabase** | primary transactional control plane | full API/UI and tenant-aware persistence |
 | **ClickHouse** | analytics and event-scale persistence | trends, runtime event analytics, OLAP |
 | **Snowflake** | warehouse-native governance and selected control-plane paths | governance/activity workflows and Snowflake-native operators |

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -19,7 +19,7 @@ It is a good fit when you want:
 - runtime proxy sidecar:
   - [`deploy/docker-compose.runtime.yml`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/docker-compose.runtime.yml)
   - [`deploy/k8s/sidecar-example.yaml`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/k8s/sidecar-example.yaml)
-- Helm chart for scanner and runtime-monitoring helper surfaces:
+- Helm chart for scanner, runtime-monitoring, and packaged API/UI control-plane surfaces:
   - [`deploy/helm/agent-bom`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom)
 - Postgres-backed control-plane path:
   - [`deploy/supabase/postgres/init.sql`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/supabase/postgres/init.sql)
@@ -28,11 +28,10 @@ It is a good fit when you want:
 
 Important boundary:
 
-- the Helm chart currently ships the scanner CronJob and runtime monitoring
-  surfaces
-- it does not yet ship a full API/UI Deployment for the control plane
-- for EKS, the control plane is still best treated as your own Deployment/Ingress
-  manifests plus the existing container images and database wiring
+- the Helm chart now packages the API + UI control plane
+- Postgres, ClickHouse, secrets, ingress-controller specifics, and autoscaling
+  policy are still operator-owned
+- this is now a real self-host packaging path, not just a container-and-docs story
 
 ## Reference Shape
 
@@ -71,9 +70,10 @@ policy, and only the integrations you intend to allow.
 Use two layers:
 
 1. control plane
-- run the API and UI behind your own ingress
-- back it with `Postgres`
+- enable `controlPlane.enabled=true` in Helm
+- back the API with `Postgres`
 - add `ClickHouse` only if you want event-scale analytics
+- use the packaged same-origin ingress unless you have a reason to split hosts
 
 2. dataplane and discovery
 - run `agent-bom proxy` beside or in front of MCP servers
@@ -86,6 +86,10 @@ The chart now supports the EKS wiring you actually need:
 
 | Value | Why it matters |
 |---|---|
+| `controlPlane.enabled` | package the API + dashboard in-cluster |
+| `controlPlane.ingress.enabled` | route `/` to UI and `/v1`, `/health`, `/docs`, `/ws` to API |
+| `controlPlane.api.envFrom` | load Postgres URL, API key, OIDC, and audit settings from Secrets |
+| `controlPlane.ui.env` | keep `NEXT_PUBLIC_API_URL=\"\"` for same-origin or set a full API URL for cross-origin |
 | `serviceAccount.annotations` | attach an IRSA role to the scanner service account |
 | `scanner.extraArgs` | add `--k8s-mcp`, `--enforce`, `--introspect`, or stricter presets |
 | `scanner.env` | inject operator-owned environment like API endpoints or auth context |
@@ -97,6 +101,8 @@ Example:
 ```bash
 helm install agent-bom deploy/helm/agent-bom \
   -n agent-bom --create-namespace \
+  --set controlPlane.enabled=true \
+  --set controlPlane.ingress.enabled=true \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/agent-bom-discovery \
   --set scanner.allNamespaces=true \
   --set-json 'scanner.extraArgs=["--k8s-mcp","--k8s-all-namespaces","--enforce","--introspect","--preset","enterprise"]'
@@ -164,8 +170,8 @@ This path is self-hostable today, but not every enterprise primitive is encoded
 
 You still own:
 
-- control-plane Deployment / Service / Ingress manifests
-- HPA, PDB, and failover settings for your own workloads
+- Postgres, optional ClickHouse, and secret storage
+- HPA, topology, and failover settings for your own workloads
 - Secrets Manager / IRSA / ingress-controller wiring
 - operator runbooks and load testing
 
@@ -176,6 +182,6 @@ startup. That means:
 - set `NEXT_PUBLIC_API_URL=` for same-origin ingress and route `/v1/*`,
   `/health`, and `/ws/*` to the API service in your ingress/controller
 
-That is still a valid no-lock-in story. The repo gives you the container entry
-points, storage paths, proxy surface, and scanner/discovery chart knobs without
-forcing you into a hosted control plane.
+That is now a stronger no-lock-in story. The repo packages the control plane,
+proxy surface, and scanner/discovery knobs without forcing you into a hosted
+vendor plane.


### PR DESCRIPTION
## Summary
- add Helm-packaged API and UI control-plane Deployments, Services, ingress, and optional PDBs
- make same-origin ingress the default chart contract so the runtime-configurable UI can target the API without rebuilds
- document the packaged topology and the remaining operator-owned production boundaries

## Validation
- git diff --check
- uv run python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('deploy/helm/agent-bom/values.yaml').read_text()); print('values-yaml-ok')"
- pre-commit hooks on commit

## Notes
- Local `helm template` validation was not available in this environment because Helm is not installed and the local Docker daemon is not running.