### PR TITLE
Scope EKS pilot to MCP fleet and proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ For teams self-hosting in their own AWS / EKS environment, see the focused
 operator guide:
 
 - [Deploy In Your Own AWS / EKS Infrastructure](site-docs/deployment/own-infra-eks.md)
+- [Focused EKS MCP Pilot](site-docs/deployment/eks-mcp-pilot.md)
 
 That means enterprises can run `agent-bom`:
 

--- a/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
@@ -1,0 +1,43 @@
+controlPlane:
+  enabled: true
+  api:
+    replicas: 2
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane
+  ui:
+    replicas: 2
+    env:
+      - name: NEXT_PUBLIC_API_URL
+        value: ""
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: agent-bom.internal.example.com
+
+scanner:
+  enabled: true
+  allNamespaces: true
+  extraArgs:
+    - --k8s-mcp
+    - --k8s-all-namespaces
+    - --introspect
+    - --enforce
+    - --preset
+    - enterprise
+
+monitor:
+  enabled: false
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-discovery
+
+networkPolicy:
+  enabled: true
+  restrictIngress: false

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: msaad02/agent-bom-runtime:latest
+          image: agentbom/agent-bom-runtime:latest
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -1,0 +1,145 @@
+# Focused MCP pilot sidecar example for selected workloads.
+#
+# This is the honest runtime-enforcement path for EKS today:
+# add agent-bom proxy only to the MCP workloads you want inline enforcement on.
+#
+# Replace the sample MCP server command/image with your own workload image and
+# runtime command before applying.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-bom-proxy-policy
+  namespace: agent-bom
+data:
+  policy.json: |
+    {
+      "version": "2",
+      "rules": [
+        { "id": "no-unverified-high", "unverified_server": true, "severity_gte": "HIGH", "action": "fail" },
+        { "id": "high-epss-with-creds", "condition": "epss_score > 0.7 and has_credentials", "action": "fail" },
+        { "id": "warn-high-with-creds", "has_credentials": true, "severity_gte": "HIGH", "action": "warn" }
+      ]
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-server-with-proxy-metrics
+  namespace: agent-bom
+  labels:
+    app.kubernetes.io/name: mcp-server
+    app.kubernetes.io/component: proxy-pilot
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mcp-server
+    app.kubernetes.io/component: proxy-pilot
+  ports:
+    - name: metrics
+      port: 8422
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-server-with-proxy
+  namespace: agent-bom
+  labels:
+    app.kubernetes.io/name: mcp-server
+    app.kubernetes.io/component: proxy-pilot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-server
+      app.kubernetes.io/component: proxy-pilot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mcp-server
+        app.kubernetes.io/component: proxy-pilot
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8422"
+        prometheus.io/path: "/metrics"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mcp-server
+          image: node:20-slim
+          command:
+            - "npx"
+            - "-y"
+            - "@modelcontextprotocol/server-filesystem"
+            - "/workspace"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+
+        - name: agent-bom-proxy
+          image: agentbom/agent-bom-runtime:latest
+          args:
+            - "--policy"
+            - "/etc/agent-bom/policy.json"
+            - "--log"
+            - "/var/log/agent-bom/audit.jsonl"
+            - "--detect-credentials"
+            - "--block-undeclared"
+            - "--rate-limit-threshold"
+            - "60"
+            - "--"
+            - "npx"
+            - "-y"
+            - "@modelcontextprotocol/server-filesystem"
+            - "/workspace"
+          ports:
+            - containerPort: 8422
+              name: metrics
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: audit-logs
+              mountPath: /var/log/agent-bom
+            - name: workspace
+              mountPath: /workspace
+            - name: proxy-policy
+              mountPath: /etc/agent-bom
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: workspace
+          emptyDir: {}
+        - name: audit-logs
+          emptyDir: {}
+        - name: proxy-policy
+          configMap:
+            name: agent-bom-proxy-policy

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: msaad02/agent-bom-runtime:latest
+          image: agentbom/agent-bom-runtime:latest
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Policy Engine: features/policy.md
   - Deployment:
       - Overview: deployment/overview.md
+      - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
       - Backend Parity: deployment/backend-parity.md

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -1,0 +1,126 @@
+# Focused EKS MCP Pilot
+
+This is the recommended pilot scope for a company that wants to run
+`agent-bom` in its own AWS / EKS environment specifically for:
+
+- MCP and agent discovery
+- fleet and mesh visibility
+- gateway policy management
+- selected inline proxy enforcement
+
+This is intentionally narrower than a full platform rollout.
+
+## Pilot scope
+
+Enable:
+
+- Helm-packaged API + UI control plane
+- Postgres-backed persistence
+- same-origin ingress
+- scanner CronJob focused on MCP and agent discovery
+- selected workload proxy sidecars
+
+Leave out unless you need them:
+
+- ClickHouse
+- Snowflake backend path
+- broad cloud CSPM rollout
+- full runtime monitor DaemonSet on every node
+- every export and output surface
+
+## What to install
+
+Use the packaged control-plane chart with the focused pilot values file:
+
+- [deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
+
+Install:
+
+```bash
+helm install agent-bom deploy/helm/agent-bom \
+  -n agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
+```
+
+That pilot profile gives you:
+
+- packaged API + UI control plane
+- same-origin ingress
+- scanner CronJob running cluster-wide discovery
+- enterprise-oriented MCP scan args:
+  - `--k8s-mcp`
+  - `--k8s-all-namespaces`
+  - `--introspect`
+  - `--enforce`
+- monitor DaemonSet left disabled
+
+## Selected inline enforcement
+
+The honest runtime-enforcement path for this pilot is sidecar deployment on the
+specific MCP workloads you want to guard.
+
+Use:
+
+- [deploy/k8s/proxy-sidecar-pilot.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/k8s/proxy-sidecar-pilot.yaml)
+
+This manifest shows:
+
+- a starter proxy policy `ConfigMap`
+- a metrics `Service`
+- a sample MCP workload with `agent-bom-runtime` sidecar
+- audit logging, undeclared tool blocking, credential detection, and basic rate limiting
+
+Important boundary:
+
+- `agent-bom proxy` is not a generic shared network gateway service today
+- it is a stdio wrapper or local proxy-to-remote-server path
+- for EKS, that means selected-workload sidecars are the honest enforcement
+  model today
+
+## What the pilot surfaces
+
+This pilot should focus operators on a short list of product surfaces:
+
+- `/fleet`
+- `/agents`
+- `/mesh`
+- `/security-graph`
+- `/gateway`
+- `/findings`
+
+That gives the team a clean story:
+
+1. discover agents and MCP servers
+2. inventory and score them
+3. review fleet and graph posture
+4. define gateway policies
+5. enforce selected runtime traffic through sidecars
+
+## Recommended secrets and auth
+
+At minimum, put these in a Kubernetes Secret referenced by the API Deployment:
+
+- `AGENT_BOM_POSTGRES_URL`
+- `AGENT_BOM_API_KEY` or OIDC settings
+- `AGENT_BOM_AUDIT_HMAC_KEY`
+
+For enterprise pilots, prefer:
+
+- OIDC for user access
+- persistent audit HMAC keys
+- IRSA on the scanner service account
+- internal ingress / VPN-only access
+
+## What this pilot is not
+
+This pilot is not trying to prove every `agent-bom` surface at once.
+
+It is not:
+
+- a Snowflake-native backend evaluation
+- a full cloud posture rollout
+- a ClickHouse analytics rollout
+- a node-wide runtime monitor deployment
+- a benchmarked production-scale signoff
+
+Those can come later if the MCP + agents + fleet + proxy story lands.

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -11,6 +11,7 @@ Located in `deploy/k8s/`:
 | `cronjob.yaml` | Scheduled scan every 6 hours |
 | `daemonset.yaml` | Runtime protection on every node |
 | `sidecar-example.yaml` | Proxy sidecar alongside an MCP server |
+| `proxy-sidecar-pilot.yaml` | Focused EKS pilot sidecar pattern for selected MCP workloads |
 
 Those static manifests are still the scanner/runtime path.
 
@@ -69,3 +70,6 @@ helm install agent-bom deploy/helm/agent-bom/ \
 
 For the full control-plane topology and secret wiring, see
 [Packaged API + UI Control Plane](control-plane-helm.md).
+
+For the narrower MCP and agents pilot, see
+[Focused EKS MCP Pilot](eks-mcp-pilot.md).

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -60,6 +60,7 @@ For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).
 | Gate pull requests | GitHub Action |
 | Keep the runtime isolated | Docker |
 | Self-host UI + API for a team | `agent-bom serve` + `Postgres` / `Supabase` |
+| Run a focused MCP / agents / fleet pilot on EKS | Helm control plane + scanner CronJob + selected proxy sidecars |
 | Integrate with internal platforms | `agent-bom api` |
 | Expose agent-bom as a tool server | `agent-bom mcp server` |
 | Add runtime enforcement | `agent-bom proxy` |

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -3,6 +3,10 @@
 This is the self-hosted path for teams that want `agent-bom` inside their own
 AWS account, VPC, EKS cluster, and databases.
 
+If you want the narrower pilot shape for MCP discovery, fleet, mesh, gateway
+policy, and selected runtime enforcement, start with
+[Focused EKS MCP Pilot](eks-mcp-pilot.md).
+
 It is a good fit when you want:
 
 - your API, audit logs, and findings in your own infrastructure


### PR DESCRIPTION
## Summary
- add a focused EKS MCP pilot values file for the Helm-packaged control plane and scanner surfaces
- add a selected-workload proxy sidecar manifest for inline MCP enforcement instead of pretending the proxy is a generic shared service
- update deployment docs to scope the pilot to agents, fleet, mesh, gateway policy, and selected runtime enforcement

## Validation
- git diff --check
- uv run python -c "import yaml, pathlib; files=['deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml','deploy/k8s/proxy-sidecar-pilot.yaml','deploy/k8s/sidecar-example.yaml','deploy/k8s/daemonset.yaml']; [list(yaml.safe_load_all(pathlib.Path(f).read_text())) for f in files]; print('yaml-ok')"
- pre-commit hooks on commit

## Notes
- Corrects stale runtime image references in the existing Kubernetes examples so the pilot path matches the current runtime image contract.
- Keeps the pilot intentionally narrow: control plane, scanner-driven MCP discovery, fleet/mesh/gateway surfaces, and selected workload proxy sidecars.