### PR TITLE
Link proxy to control plane for enterprise pilot

### DIFF
--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -1,0 +1,6 @@
+Enterprise pilot notes:
+
+- Set `AGENT_BOM_AUDIT_HMAC_KEY` in the control-plane secret.
+- Set `AGENT_BOM_REQUIRE_AUDIT_HMAC=1` to fail closed if the key is missing.
+- Use Postgres for the pilot control plane; SQLite is not the multi-replica path.
+- Prefer internal ingress / VPN-only exposure for the API and UI.

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -95,10 +95,14 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom-runtime:latest
+          image: agentbom/agent-bom-runtime:0.76.4
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"
+            - "--policy-refresh-seconds"
+            - "30"
+            - "--audit-push-interval"
+            - "10"
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
             - "--detect-credentials"
@@ -110,6 +114,14 @@ spec:
             - "-y"
             - "@modelcontextprotocol/server-filesystem"
             - "/workspace"
+          env:
+            - name: AGENT_BOM_API_URL
+              value: "https://agent-bom.internal.example.com"
+            - name: AGENT_BOM_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: agent-bom-proxy-auth
+                  key: token
           ports:
             - containerPort: 8422
               name: metrics

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -68,6 +68,7 @@ This manifest shows:
 - a starter proxy policy `ConfigMap`
 - a metrics `Service`
 - a sample MCP workload with `agent-bom-runtime` sidecar
+- control-plane policy pull and proxy audit push
 - audit logging, undeclared tool blocking, credential detection, and basic rate limiting
 
 Important boundary:
@@ -102,12 +103,12 @@ At minimum, put these in a Kubernetes Secret referenced by the API Deployment:
 
 - `AGENT_BOM_POSTGRES_URL`
 - `AGENT_BOM_API_KEY` or OIDC settings
-- `AGENT_BOM_AUDIT_HMAC_KEY`
+- `AGENT_BOM_AUDIT_HMAC_KEY` (required for pilot sign-off; do not rely on the ephemeral fallback)
 
 For enterprise pilots, prefer:
 
 - OIDC for user access
-- persistent audit HMAC keys
+- persistent audit HMAC keys with `AGENT_BOM_REQUIRE_AUDIT_HMAC=1`
 - IRSA on the scanner service account
 - internal ingress / VPN-only access
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -250,6 +250,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("DELETE", "/v1/findings/false-positive/", "analyst"),
         ("POST", "/v1/scan", "analyst"),
         ("POST", "/v1/gateway/evaluate", "analyst"),
+        ("POST", "/v1/proxy/audit", "analyst"),
         ("POST", "/v1/traces", "analyst"),
         ("POST", "/v1/results/push", "analyst"),
         ("POST", "/v1/schedules", "analyst"),

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -204,6 +204,13 @@ class EvaluateRequest(BaseModel):
     arguments: dict = {}
 
 
+class ProxyAuditIngestRequest(BaseModel):
+    source_id: str = ""
+    session_id: str = ""
+    alerts: list[dict] = []
+    summary: dict | None = None
+
+
 # ─── Scan Type Request Models ─────────────────────────────────────────────
 
 

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -13,19 +13,36 @@ Endpoints:
 
 from __future__ import annotations
 
+import hashlib
+import json
 import uuid
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
 
 from agent_bom.api.models import EvaluateRequest, PolicyCreate, PolicyUpdate
 from agent_bom.api.stores import _get_policy_store
 from agent_bom.rbac import require_permission
 
+if TYPE_CHECKING:
+    from agent_bom.api.policy_store import GatewayPolicy
+
 router = APIRouter()
 
 
-@router.get("/v1/gateway/policies", tags=["gateway"], dependencies=[require_permission("policy_read")])
+def _dep(permission: str) -> Any:
+    return cast(Any, require_permission(permission))
+
+
+def _policy_collection_etag(policies: list["GatewayPolicy"]) -> str:
+    payload = json.dumps([p.model_dump() for p in policies], sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(payload.encode()).hexdigest()
+    return f'"{digest}"'
+
+
+@router.get("/v1/gateway/policies", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def list_gateway_policies(request: Request, enabled: bool | None = None, mode: str | None = None):
     """List all gateway policies."""
     tenant_id = getattr(request.state, "tenant_id", "default")
@@ -34,12 +51,19 @@ async def list_gateway_policies(request: Request, enabled: bool | None = None, m
         policies = [p for p in policies if p.enabled == enabled]
     if mode:
         policies = [p for p in policies if p.mode.value == mode]
-    return {"policies": [p.model_dump() for p in policies], "count": len(policies)}
+    etag = _policy_collection_etag(policies)
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers={"ETag": etag, "Cache-Control": "no-store"})
+    return JSONResponse(
+        {"policies": [p.model_dump() for p in policies], "count": len(policies)},
+        headers={"ETag": etag, "Cache-Control": "no-store"},
+    )
 
 
-@router.post("/v1/gateway/policies", tags=["gateway"], status_code=201, dependencies=[require_permission("policy_write")])
+@router.post("/v1/gateway/policies", tags=["gateway"], status_code=201, dependencies=[_dep("policy_write")])
 async def create_gateway_policy(body: PolicyCreate, request: Request):
     """Create a new gateway policy."""
+    from agent_bom.api.audit_log import log_action
     from agent_bom.api.policy_store import GatewayPolicy, GatewayRule, PolicyMode
 
     try:
@@ -66,10 +90,20 @@ async def create_gateway_policy(body: PolicyCreate, request: Request):
         tenant_id=getattr(request.state, "tenant_id", "default"),
     )
     _get_policy_store().put_policy(policy)
+    actor = getattr(request.state, "api_key_name", "unknown")
+    log_action(
+        "gateway.policy_created",
+        actor=actor,
+        resource=f"gateway-policy/{policy.policy_id}",
+        name=policy.name,
+        mode=policy.mode.value,
+        enabled=policy.enabled,
+        rule_count=len(policy.rules),
+    )
     return policy.model_dump()
 
 
-@router.get("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[require_permission("policy_read")])
+@router.get("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def get_gateway_policy(policy_id: str, request: Request):
     """Get a gateway policy by ID."""
     tenant_id = getattr(request.state, "tenant_id", "default")
@@ -79,9 +113,10 @@ async def get_gateway_policy(policy_id: str, request: Request):
     return policy.model_dump()
 
 
-@router.put("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[require_permission("policy_write")])
+@router.put("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_write")])
 async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Request):
     """Update an existing gateway policy."""
+    from agent_bom.api.audit_log import log_action
     from agent_bom.api.policy_store import GatewayRule, PolicyMode
 
     store = _get_policy_store()
@@ -89,6 +124,7 @@ async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Req
     policy = store.get_policy(policy_id, tenant_id=tenant_id)
     if policy is None:
         raise HTTPException(status_code=404, detail="Policy not found")
+    original = policy.model_dump()
     if body.name is not None:
         policy.name = body.name
     if body.description is not None:
@@ -110,19 +146,46 @@ async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Req
         policy.enabled = body.enabled
     policy.updated_at = datetime.now(timezone.utc).isoformat()
     store.put_policy(policy)
+    actor = getattr(request.state, "api_key_name", "unknown")
+    updated = policy.model_dump()
+    changed_fields = sorted(key for key, value in updated.items() if original.get(key) != value)
+    log_action(
+        "gateway.policy_updated",
+        actor=actor,
+        resource=f"gateway-policy/{policy.policy_id}",
+        name=policy.name,
+        changed_fields=changed_fields,
+        enabled=policy.enabled,
+        rule_count=len(policy.rules),
+    )
     return policy.model_dump()
 
 
-@router.delete("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[require_permission("policy_write")])
+@router.delete("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_write")])
 async def delete_gateway_policy(policy_id: str, request: Request):
     """Delete a gateway policy."""
     tenant_id = getattr(request.state, "tenant_id", "default")
-    if not _get_policy_store().delete_policy(policy_id, tenant_id=tenant_id):
+    store = _get_policy_store()
+    policy = store.get_policy(policy_id, tenant_id=tenant_id)
+    if policy is None:
         raise HTTPException(status_code=404, detail="Policy not found")
+    if not store.delete_policy(policy_id, tenant_id=tenant_id):
+        raise HTTPException(status_code=404, detail="Policy not found")
+    from agent_bom.api.audit_log import log_action
+
+    actor = getattr(request.state, "api_key_name", "unknown")
+    log_action(
+        "gateway.policy_deleted",
+        actor=actor,
+        resource=f"gateway-policy/{policy_id}",
+        name=policy.name,
+        mode=policy.mode.value,
+        rule_count=len(policy.rules),
+    )
     return {"deleted": True, "policy_id": policy_id}
 
 
-@router.post("/v1/gateway/evaluate", tags=["gateway"], dependencies=[require_permission("policy_read")])
+@router.post("/v1/gateway/evaluate", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def evaluate_gateway(body: EvaluateRequest, request: Request):
     """Dry-run evaluation of gateway policies against a tool call."""
     from agent_bom.gateway import evaluate_gateway_policies
@@ -143,7 +206,7 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
     }
 
 
-@router.get("/v1/gateway/audit", tags=["gateway"], dependencies=[require_permission("audit_read")])
+@router.get("/v1/gateway/audit", tags=["gateway"], dependencies=[_dep("audit_read")])
 async def list_gateway_audit(
     request: Request,
     policy_id: str | None = None,
@@ -161,7 +224,7 @@ async def list_gateway_audit(
     return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
 
 
-@router.get("/v1/gateway/stats", tags=["gateway"], dependencies=[require_permission("audit_read")])
+@router.get("/v1/gateway/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
 async def gateway_stats(request: Request):
     """Gateway-wide statistics."""
     tenant_id = getattr(request.state, "tenant_id", "default")

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -21,6 +21,8 @@ from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
 if TYPE_CHECKING:
     from agent_bom.runtime.protection import ProtectionEngine
 
+from agent_bom.api.models import ProxyAuditIngestRequest
+
 router = APIRouter()
 
 # ── In-process ring buffer for proxy alerts/metrics ──────────────────────────
@@ -51,6 +53,44 @@ def push_proxy_metrics(metrics: dict) -> None:
     """Called by the proxy to record latest metrics summary."""
     global _proxy_metrics
     _proxy_metrics = metrics
+
+
+@router.post("/v1/proxy/audit", tags=["proxy"])
+async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) -> dict:
+    """Ingest alerts and summary from an external proxy process."""
+    from agent_bom.api.audit_log import log_action
+
+    actor = getattr(request.state, "api_key_name", "") or "proxy-client"
+    source_id = body.source_id or "unknown"
+    session_id = body.session_id or "default"
+
+    for alert in body.alerts:
+        enriched = dict(alert)
+        enriched.setdefault("source_id", source_id)
+        enriched.setdefault("session_id", session_id)
+        push_proxy_alert(enriched)
+
+    if body.summary:
+        summary = dict(body.summary)
+        summary.setdefault("source_id", source_id)
+        summary.setdefault("session_id", session_id)
+        push_proxy_metrics(summary)
+
+    log_action(
+        "proxy.audit_ingested",
+        actor=actor,
+        resource=f"proxy/{source_id}",
+        session_id=session_id,
+        alert_count=len(body.alerts),
+        has_summary=body.summary is not None,
+    )
+    return {
+        "ingested": True,
+        "source_id": source_id,
+        "session_id": session_id,
+        "alert_count": len(body.alerts),
+        "has_summary": body.summary is not None,
+    }
 
 
 def _get_configured_log_path() -> _Path | None:

--- a/src/agent_bom/api/scheduler.py
+++ b/src/agent_bom/api/scheduler.py
@@ -7,9 +7,11 @@ Checks for due schedules every 60 seconds, triggers scans.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
+_SCHEDULER_LEADER_LOCK_ID = 4_197_042_001
 
 
 def parse_cron_next(cron_expr: str, after: datetime) -> datetime | None:
@@ -95,53 +97,87 @@ async def scheduler_loop(
     import asyncio
 
     consecutive_failures = 0
+    leader_conn = None
 
-    while True:
+    def _try_acquire_postgres_leader_lock():
+        if not os.environ.get("AGENT_BOM_POSTGRES_URL"):
+            return None
         try:
-            now = datetime.now(timezone.utc)
-            now_iso = now.isoformat()
-            try:
-                from agent_bom.api.postgres_store import bypass_tenant_rls
-            except Exception:  # pragma: no cover - optional postgres backend
-                due = schedule_store.list_due(now_iso)
-            else:
-                with bypass_tenant_rls():
-                    due = schedule_store.list_due(now_iso)
+            from agent_bom.api.postgres_store import _get_pool
 
-            for schedule in due:
-                if not schedule.enabled:
-                    continue
-                logger.info("Triggering scheduled scan: %s (%s)", schedule.name, schedule.schedule_id)
-                try:
-                    job_id = run_scan_fn(schedule.scan_config)
-                    schedule.last_run = now_iso
-                    schedule.last_job_id = job_id
-
-                    # Compute next run
-                    next_run = parse_cron_next(schedule.cron_expression, now)
-                    schedule.next_run = next_run.isoformat() if next_run else None
-                    schedule.updated_at = now_iso
-                    try:
-                        from agent_bom.api.postgres_store import bypass_tenant_rls
-                    except Exception:  # pragma: no cover - optional postgres backend
-                        schedule_store.put(schedule)
-                    else:
-                        with bypass_tenant_rls():
-                            schedule_store.put(schedule)
-                except Exception:
-                    logger.exception("Failed to trigger scheduled scan: %s", schedule.name)
-
-            # Success — reset backoff counter
-            consecutive_failures = 0
+            pool = _get_pool()
+            conn = pool.getconn()
+            row = conn.execute("SELECT pg_try_advisory_lock(%s)", (_SCHEDULER_LEADER_LOCK_ID,)).fetchone()
+            if row and bool(row[0]):
+                logger.info("Scheduler leader lock acquired")
+                return conn
+            pool.putconn(conn)
         except Exception:
-            consecutive_failures += 1
-            backoff = min(interval_seconds * (2**consecutive_failures), max_backoff)
-            logger.exception(
-                "Scheduler loop error (attempt %d, next retry in %ds)",
-                consecutive_failures,
-                backoff,
-            )
-            await asyncio.sleep(backoff)
-            continue
+            logger.exception("Failed to acquire scheduler leader lock")
+        return None
 
-        await asyncio.sleep(interval_seconds)
+    try:
+        while True:
+            try:
+                if os.environ.get("AGENT_BOM_POSTGRES_URL") and leader_conn is None:
+                    leader_conn = _try_acquire_postgres_leader_lock()
+                    if leader_conn is None:
+                        await asyncio.sleep(interval_seconds)
+                        continue
+
+                now = datetime.now(timezone.utc)
+                now_iso = now.isoformat()
+                try:
+                    from agent_bom.api.postgres_store import bypass_tenant_rls
+                except Exception:  # pragma: no cover - optional postgres backend
+                    due = schedule_store.list_due(now_iso)
+                else:
+                    with bypass_tenant_rls():
+                        due = schedule_store.list_due(now_iso)
+
+                for schedule in due:
+                    if not schedule.enabled:
+                        continue
+                    logger.info("Triggering scheduled scan: %s (%s)", schedule.name, schedule.schedule_id)
+                    try:
+                        job_id = run_scan_fn(schedule.scan_config)
+                        schedule.last_run = now_iso
+                        schedule.last_job_id = job_id
+
+                        # Compute next run
+                        next_run = parse_cron_next(schedule.cron_expression, now)
+                        schedule.next_run = next_run.isoformat() if next_run else None
+                        schedule.updated_at = now_iso
+                        try:
+                            from agent_bom.api.postgres_store import bypass_tenant_rls
+                        except Exception:  # pragma: no cover - optional postgres backend
+                            schedule_store.put(schedule)
+                        else:
+                            with bypass_tenant_rls():
+                                schedule_store.put(schedule)
+                    except Exception:
+                        logger.exception("Failed to trigger scheduled scan: %s", schedule.name)
+
+                # Success — reset backoff counter
+                consecutive_failures = 0
+            except Exception:
+                consecutive_failures += 1
+                backoff = min(interval_seconds * (2**consecutive_failures), max_backoff)
+                logger.exception(
+                    "Scheduler loop error (attempt %d, next retry in %ds)",
+                    consecutive_failures,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            await asyncio.sleep(interval_seconds)
+    finally:
+        if leader_conn is not None:
+            try:
+                from agent_bom.api.postgres_store import _get_pool
+
+                leader_conn.execute("SELECT pg_advisory_unlock(%s)", (_SCHEDULER_LEADER_LOCK_ID,))
+                _get_pool().putconn(leader_conn)
+            except Exception:
+                logger.exception("Failed to release scheduler leader lock")

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -21,6 +21,32 @@ from rich.console import Console
 @click.option("--metrics-port", default=8422, show_default=True, help="Prometheus metrics port (0 to disable)")
 @click.option("--metrics-token", default=None, envvar="AGENT_BOM_METRICS_TOKEN", help="Bearer token for Prometheus /metrics endpoint")
 @click.option(
+    "--control-plane-url",
+    default=None,
+    envvar="AGENT_BOM_API_URL",
+    help="Control-plane base URL for gateway policy pull and proxy audit push",
+)
+@click.option(
+    "--control-plane-token",
+    default=None,
+    envvar="AGENT_BOM_API_TOKEN",
+    help="Bearer token or API key for control-plane auth",
+)
+@click.option(
+    "--policy-refresh-seconds",
+    type=int,
+    default=30,
+    show_default=True,
+    help="How often to refresh enabled gateway policies from the control plane",
+)
+@click.option(
+    "--audit-push-interval",
+    type=int,
+    default=10,
+    show_default=True,
+    help="How often to batch-push proxy alerts to the control plane",
+)
+@click.option(
     "--response-sign-key",
     default=None,
     envvar="AGENT_BOM_RESPONSE_SIGN_KEY",
@@ -43,6 +69,10 @@ def proxy_cmd(
     alert_webhook,
     metrics_port,
     metrics_token,
+    control_plane_url,
+    control_plane_token,
+    policy_refresh_seconds,
+    audit_push_interval,
     response_sign_key,
     url,
     server_cmd,
@@ -133,6 +163,10 @@ def proxy_cmd(
             alert_webhook=alert_webhook,
             metrics_port=metrics_port,
             metrics_token=metrics_token,
+            control_plane_url=control_plane_url,
+            control_plane_token=control_plane_token,
+            policy_refresh_seconds=policy_refresh_seconds,
+            audit_push_interval=audit_push_interval,
             response_signing_key=response_sign_key,
         )
     )

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -12,13 +12,16 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
+import platform
 import sys
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from agent_bom import proxy_audit as _proxy_audit
 from agent_bom import proxy_policy as _proxy_policy
@@ -28,6 +31,9 @@ from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call
 from agent_bom.security import validate_arguments, validate_command
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from agent_bom.api.policy_store import GatewayPolicy
 
 # Re-export stable helper names for tests and existing callers while keeping the
 # implementation split across dedicated proxy helper modules.
@@ -134,6 +140,76 @@ def set_gateway_evaluator(fn) -> None:  # noqa: ANN001
     """
     global _gateway_evaluator
     _gateway_evaluator = fn
+
+
+def _generate_proxy_source_id() -> str:
+    hostname = platform.node() or "unknown"
+    return hashlib.sha256(hostname.encode()).hexdigest()[:12]
+
+
+def _control_plane_headers(token: str | None, etag: str | None = None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if etag:
+        headers["If-None-Match"] = etag
+    return headers
+
+
+async def _fetch_enabled_gateway_policies(
+    base_url: str,
+    token: str | None,
+    etag: str | None = None,
+) -> tuple[list["GatewayPolicy"] | None, str | None]:
+    from agent_bom.api.policy_store import GatewayPolicy
+    from agent_bom.http_client import create_client
+
+    url = base_url.rstrip("/") + "/v1/gateway/policies?enabled=true"
+    async with create_client(timeout=15.0) as client:
+        response = await client.get(url, headers=_control_plane_headers(token, etag))
+    if response.status_code == 304:
+        return None, response.headers.get("ETag", etag)
+    response.raise_for_status()
+    payload = response.json()
+    policies = [GatewayPolicy(**item) for item in payload.get("policies", [])]
+    return policies, response.headers.get("ETag")
+
+
+def _evaluate_gateway_policy_bundle(policies: list["GatewayPolicy"], agent_name: str, tool_name: str, arguments: dict) -> tuple[bool, str]:
+    from agent_bom.gateway import evaluate_gateway_policies
+
+    scoped = []
+    for policy in policies:
+        if getattr(policy, "bound_agents", None) and agent_name not in getattr(policy, "bound_agents", []):
+            continue
+        scoped.append(policy)
+    allowed, reason, _policy_id = evaluate_gateway_policies(scoped, tool_name, arguments)
+    return allowed, reason
+
+
+async def _push_proxy_audit_batch(
+    base_url: str,
+    token: str | None,
+    source_id: str,
+    session_id: str,
+    alerts: list[dict],
+    summary: dict | None = None,
+) -> bool:
+    from agent_bom.http_client import create_client
+
+    if not alerts and summary is None:
+        return True
+    url = base_url.rstrip("/") + "/v1/proxy/audit"
+    payload = {
+        "source_id": source_id,
+        "session_id": session_id,
+        "alerts": alerts,
+        "summary": summary,
+    }
+    async with create_client(timeout=15.0) as client:
+        response = await client.post(url, json=payload, headers=_control_plane_headers(token))
+    response.raise_for_status()
+    return True
 
 
 async def _send_webhook(url: str, payload: dict) -> None:
@@ -438,6 +514,10 @@ async def run_proxy(
     alert_webhook: Optional[str] = None,
     metrics_port: int = 8422,
     metrics_token: Optional[str] = None,
+    control_plane_url: Optional[str] = None,
+    control_plane_token: Optional[str] = None,
+    policy_refresh_seconds: int = 30,
+    audit_push_interval: int = 10,
     response_signing_key: Optional[str] = None,
 ) -> int:
     """Main proxy loop. Spawns server subprocess, relays JSON-RPC.
@@ -452,6 +532,8 @@ async def run_proxy(
         log_only: Log alerts without blocking (advisory mode).
         alert_webhook: Optional webhook URL for runtime alert notifications.
         metrics_token: Optional bearer token for Prometheus /metrics endpoint.
+        control_plane_url: Optional control-plane URL for policy pull and audit push.
+        control_plane_token: Optional bearer/API token for control-plane auth.
 
     Returns the server process exit code.
     """
@@ -503,6 +585,75 @@ async def run_proxy(
     replay_detector = ReplayDetector()
     scan_config = load_scan_config(policy) if policy else ScanConfig()
     runtime_alerts: list[dict] = []
+    control_plane_source_id = _generate_proxy_source_id()
+    control_plane_session_id = str(uuid.uuid4())
+    control_plane_policies: list["GatewayPolicy"] = []
+    control_plane_etag: str | None = None
+    audit_buffer: list[dict] = []
+    audit_lock = asyncio.Lock()
+
+    async def _refresh_control_plane_policies(initial: bool = False) -> None:
+        nonlocal control_plane_policies, control_plane_etag
+        if not control_plane_url:
+            return
+        try:
+            policies, next_etag = await _fetch_enabled_gateway_policies(
+                control_plane_url,
+                control_plane_token,
+                control_plane_etag,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if initial:
+                logger.error("Failed to load enabled gateway policies from %s: %s", control_plane_url, exc)
+                raise SystemExit(1) from exc
+            logger.warning("Gateway policy refresh failed: %s", exc)
+            return
+        if policies is not None:
+            control_plane_policies = policies
+        if next_etag:
+            control_plane_etag = next_etag
+
+    async def _flush_audit_buffer(summary: dict | None = None) -> None:
+        if not control_plane_url:
+            return
+        async with audit_lock:
+            alerts = list(audit_buffer)
+            audit_buffer.clear()
+        try:
+            await _push_proxy_audit_batch(
+                control_plane_url,
+                control_plane_token,
+                control_plane_source_id,
+                control_plane_session_id,
+                alerts,
+                summary,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Proxy audit push failed: %s", exc)
+            async with audit_lock:
+                audit_buffer[:0] = alerts
+
+    if control_plane_url:
+        await _refresh_control_plane_policies(initial=True)
+
+        def _control_plane_gateway_evaluator(agent_id, tool_name, arguments):
+            return _evaluate_gateway_policy_bundle(control_plane_policies, agent_id, tool_name, arguments)
+
+        set_gateway_evaluator(_control_plane_gateway_evaluator)
+
+    async def _policy_refresh_loop() -> None:
+        if not control_plane_url:
+            return
+        while True:
+            await asyncio.sleep(max(policy_refresh_seconds, 5))
+            await _refresh_control_plane_policies()
+
+    async def _audit_push_loop() -> None:
+        if not control_plane_url:
+            return
+        while True:
+            await asyncio.sleep(max(audit_push_interval, 5))
+            await _flush_audit_buffer()
 
     def _handle_alerts(alerts, log_f=None):
         """Log alerts and optionally record them + dispatch webhook."""
@@ -515,6 +666,11 @@ async def run_proxy(
                 log_f.flush()
             if alert_webhook:
                 asyncio.ensure_future(_send_webhook(alert_webhook, alert_dict))
+            if control_plane_url:
+                enriched = dict(alert_dict)
+                enriched.setdefault("source_id", control_plane_source_id)
+                enriched.setdefault("session_id", control_plane_session_id)
+                audit_buffer.append(enriched)
 
     # Track declared tools from tools/list responses
     declared_tools: set[str] = set()
@@ -901,6 +1057,9 @@ async def run_proxy(
             sys.stderr.buffer.write(line)
             sys.stderr.buffer.flush()
 
+    refresh_task = asyncio.create_task(_policy_refresh_loop()) if control_plane_url else None
+    audit_task = asyncio.create_task(_audit_push_loop()) if control_plane_url else None
+
     try:
         results = await asyncio.gather(
             relay_client_to_server(),
@@ -927,13 +1086,20 @@ async def run_proxy(
                     log_file.write(err_entry)
     finally:
         # Write metrics summary + runtime alerts to audit log before closing
+        summary = metrics.summary()
+        summary.update(summarize_runtime_alerts(runtime_alerts))
+        if audit_task:
+            audit_task.cancel()
+        if refresh_task:
+            refresh_task.cancel()
+        if control_plane_url:
+            await _flush_audit_buffer(summary=summary)
         if log_file:
-            summary = metrics.summary()
-            summary.update(summarize_runtime_alerts(runtime_alerts))
             summary_line = json.dumps(summary) + "\n"
             log_file.write(summary_line)
             log_file.close()
         await metrics_server.stop()
+        set_gateway_evaluator(None)
         if process.returncode is None:
             process.terminate()
             try:

--- a/tests/test_api_gateway.py
+++ b/tests/test_api_gateway.py
@@ -2,6 +2,7 @@
 
 from starlette.testclient import TestClient
 
+from agent_bom.api.audit_log import InMemoryAuditLog, set_audit_log
 from agent_bom.api.policy_store import (
     GatewayPolicy,
     GatewayRule,
@@ -68,6 +69,17 @@ def test_list_filter_mode():
     store.put_policy(_make_policy(policy_id="p-2", mode=PolicyMode.ENFORCE))
     resp = client.get("/v1/gateway/policies?mode=enforce")
     assert resp.json()["count"] == 1
+
+
+def test_list_policies_emits_etag_and_supports_not_modified():
+    client, store = _fresh_client()
+    store.put_policy(_make_policy(policy_id="p-1", name="alpha"))
+    resp = client.get("/v1/gateway/policies?enabled=true")
+    assert resp.status_code == 200
+    etag = resp.headers["etag"]
+    cached = client.get("/v1/gateway/policies?enabled=true", headers={"If-None-Match": etag})
+    assert cached.status_code == 304
+    assert cached.headers["etag"] == etag
 
 
 # ── Create ────────────────────────────────────────────────────────────────────
@@ -156,6 +168,30 @@ def test_delete_not_found():
     client, _ = _fresh_client()
     resp = client.delete("/v1/gateway/policies/missing", headers=ADMIN_HEADERS)
     assert resp.status_code == 404
+
+
+def test_policy_crud_writes_general_audit_log():
+    client, store = _fresh_client()
+    audit_store = InMemoryAuditLog()
+    set_audit_log(audit_store)
+    store.put_policy(_make_policy())
+
+    created = client.post(
+        "/v1/gateway/policies",
+        json={"name": "block-exec", "mode": "enforce", "rules": [{"id": "r1", "action": "block", "block_tools": ["exec"]}]},
+        headers=ADMIN_HEADERS,
+    )
+    assert created.status_code == 201
+
+    updated = client.put("/v1/gateway/policies/p-1", json={"name": "renamed"}, headers=ADMIN_HEADERS)
+    assert updated.status_code == 200
+
+    deleted = client.delete("/v1/gateway/policies/p-1", headers=ADMIN_HEADERS)
+    assert deleted.status_code == 200
+
+    assert audit_store.count("gateway.policy_created") == 1
+    assert audit_store.count("gateway.policy_updated") == 1
+    assert audit_store.count("gateway.policy_deleted") == 1
 
 
 def test_write_routes_require_policy_write_permission():

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -177,6 +177,39 @@ def test_proxy_alerts_with_data():
     proxy_mod._proxy_alerts.clear()
 
 
+def test_proxy_audit_ingest_updates_alerts_and_status():
+    import agent_bom.api.routes.proxy as proxy_mod
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+
+    client = TestClient(app)
+    ingest = client.post(
+        "/v1/proxy/audit",
+        json={
+            "source_id": "laptop-1",
+            "session_id": "sess-1",
+            "alerts": [{"type": "runtime_alert", "detector": "credential_leak", "severity": "critical", "message": "AWS key"}],
+            "summary": {"type": "proxy_summary", "total_tool_calls": 7, "total_blocked": 2},
+        },
+    )
+    assert ingest.status_code == 200
+    assert ingest.json()["alert_count"] == 1
+
+    alerts = client.get("/v1/proxy/alerts")
+    assert alerts.status_code == 200
+    assert alerts.json()["count"] == 1
+    assert alerts.json()["alerts"][0]["source_id"] == "laptop-1"
+
+    status = client.get("/v1/proxy/status")
+    assert status.status_code == 200
+    assert status.json()["total_tool_calls"] == 7
+    assert status.json()["source_id"] == "laptop-1"
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+
+
 def test_proxy_alerts_filter_severity():
     """Filters alerts by severity query param."""
     import agent_bom.api.routes.proxy as proxy_mod

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -56,6 +56,35 @@ def test_proxy_cmd_with_project_config():
         assert result.exit_code == 0
 
 
+def test_proxy_cmd_passes_control_plane_settings():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.proxy.run_proxy", new_callable=AsyncMock, return_value=0) as mock_run,
+        patch("agent_bom.project_config.load_project_config", return_value=None),
+    ):
+        result = runner.invoke(
+            proxy_cmd,
+            [
+                "--control-plane-url",
+                "https://agent-bom.internal.example.com",
+                "--control-plane-token",
+                "token-123",
+                "--policy-refresh-seconds",
+                "45",
+                "--audit-push-interval",
+                "15",
+                "--",
+                "echo",
+                "hello",
+            ],
+        )
+        assert result.exit_code == 0
+    assert mock_run.await_args.kwargs["control_plane_url"] == "https://agent-bom.internal.example.com"
+    assert mock_run.await_args.kwargs["control_plane_token"] == "token-123"
+    assert mock_run.await_args.kwargs["policy_refresh_seconds"] == 45
+    assert mock_run.await_args.kwargs["audit_push_interval"] == 15
+
+
 # ---------------------------------------------------------------------------
 # proxy_configure_cmd
 # ---------------------------------------------------------------------------

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 from agent_bom.api.schedule_store import (
     InMemoryScheduleStore,
@@ -271,3 +272,46 @@ class TestSchedulerLoop:
         updated = store.get("s1")
         assert updated.last_run is not None
         assert updated.last_job_id == "job-456"
+
+    def test_skips_due_scans_without_postgres_leader_lock(self, monkeypatch):
+        """Only the replica holding the advisory lock should trigger schedules."""
+        from agent_bom.api.scheduler import scheduler_loop
+
+        store = InMemoryScheduleStore()
+        store.put(_make_schedule("s1", next_run="2020-01-01T00:00:00+00:00", enabled=True))
+        monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://example.invalid/agent_bom")
+
+        triggered = []
+
+        class _FakeCursor:
+            def fetchone(self):
+                return (False,)
+
+        class _FakeConn:
+            def execute(self, sql, params):
+                return _FakeCursor()
+
+        class _FakePool:
+            def getconn(self):
+                return _FakeConn()
+
+            def putconn(self, conn):
+                return None
+
+        def mock_scan(config):
+            triggered.append(config)
+            return "job-123"
+
+        async def _run():
+            task = asyncio.create_task(scheduler_loop(store, mock_scan, interval_seconds=0))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        with patch("agent_bom.api.postgres_store._get_pool", return_value=_FakePool()):
+            asyncio.run(_run())
+
+        assert triggered == []


### PR DESCRIPTION
## Summary
- wire endpoint/runtime proxy to pull enabled gateway policies from the control plane with ETag-based refresh
- ingest proxy audit back into the control plane, add gateway policy CRUD audit trail, and make the scheduler single-leader on Postgres
- align the EKS pilot artifacts with the new contract by pinning the runtime image, documenting required audit HMAC settings, and adding Helm pilot notes

## Testing
- uv run pytest -q tests/test_api_gateway.py tests/test_api_proxy_scorecard.py tests/test_cli_runtime.py tests/test_schedule_store.py tests/test_deploy_manifests.py
- uv run ruff check src/agent_bom/api/models.py src/agent_bom/api/routes/gateway.py src/agent_bom/api/routes/proxy.py src/agent_bom/api/middleware.py src/agent_bom/api/scheduler.py src/agent_bom/cli/_runtime.py src/agent_bom/proxy.py tests/test_api_gateway.py tests/test_api_proxy_scorecard.py tests/test_cli_runtime.py tests/test_schedule_store.py
- uv run mypy src/agent_bom/api/routes/gateway.py src/agent_bom/proxy.py