### PR TITLE
Harden pilot auth and endpoint fleet path

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ docker run --rm agentbom/agent-bom agents    # Docker
 | Mode | Command | Best for |
 |------|---------|----------|
 | CLI | `agent-bom agents` | Local audit + project scan |
+| Endpoint fleet | `agent-bom agents --preset enterprise --introspect --push-url https://.../v1/fleet/sync` | Employee laptops and workstations pushing into a self-hosted fleet view |
 | GitHub Action | `uses: msaad00/agent-bom@v0.76.4` | CI/CD + SARIF |
 | Docker | `docker run agentbom/agent-bom` | Isolated scans and containerized self-hosting surfaces |
 | Kubernetes / Helm | `helm install agent-bom deploy/helm/agent-bom --set controlPlane.enabled=true` | Packaged self-hosted API + dashboard, scheduled discovery, and optional runtime monitor |
@@ -219,6 +220,7 @@ For teams self-hosting in their own AWS / EKS environment, see the focused
 operator guide:
 
 - [Deploy In Your Own AWS / EKS Infrastructure](site-docs/deployment/own-infra-eks.md)
+- [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md)
 - [Focused EKS MCP Pilot](site-docs/deployment/eks-mcp-pilot.md)
 
 That means enterprises can run `agent-bom`:

--- a/deploy/endpoints/agent-bom-fleet-sync.service
+++ b/deploy/endpoints/agent-bom-fleet-sync.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=agent-bom endpoint fleet sync
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/agent-bom/fleet-sync.env
+ExecStart=%h/.local/share/agent-bom/agent-bom-fleet-sync.sh
+WorkingDirectory=%h
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/endpoints/agent-bom-fleet-sync.sh
+++ b/deploy/endpoints/agent-bom-fleet-sync.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${AGENT_BOM_PUSH_URL:?set AGENT_BOM_PUSH_URL to your control-plane /v1/fleet/sync URL}"
+
+if [ -n "${AGENT_BOM_PUSH_API_KEY:-}" ]; then
+  exec agent-bom agents \
+    --preset enterprise \
+    --introspect \
+    --push-url "${AGENT_BOM_PUSH_URL}" \
+    --push-api-key "${AGENT_BOM_PUSH_API_KEY}" \
+    "$@"
+fi
+
+exec agent-bom agents \
+  --preset enterprise \
+  --introspect \
+  --push-url "${AGENT_BOM_PUSH_URL}" \
+  "$@"

--- a/deploy/endpoints/agent-bom-fleet-sync.timer
+++ b/deploy/endpoints/agent-bom-fleet-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run agent-bom endpoint fleet sync every 30 minutes
+
+[Timer]
+OnBootSec=5m
+OnUnitActiveSec=30m
+RandomizedDelaySec=5m
+Unit=agent-bom-fleet-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/endpoints/com.agentbom.fleet-sync.plist
+++ b/deploy/endpoints/com.agentbom.fleet-sync.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentbom.fleet-sync</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-lc</string>
+    <string>$HOME/.local/share/agent-bom/agent-bom-fleet-sync.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AGENT_BOM_PUSH_URL</key>
+    <string>https://agent-bom.internal.example.com/v1/fleet/sync</string>
+    <key>AGENT_BOM_PUSH_API_KEY</key>
+    <string>replace-me</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>1800</integer>
+  <key>StandardOutPath</key>
+  <string>/tmp/agent-bom-fleet-sync.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/agent-bom-fleet-sync.log</string>
+</dict>
+</plist>

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -15,9 +15,10 @@ data:
     {
       "version": "2",
       "rules": [
-        { "id": "no-unverified-high", "unverified_server": true, "severity_gte": "HIGH", "action": "fail" },
-        { "id": "high-epss-with-creds", "condition": "epss_score > 0.7 and has_credentials", "action": "fail" },
-        { "id": "warn-high-with-creds", "has_credentials": true, "severity_gte": "HIGH", "action": "warn" }
+        { "id": "deny-exec", "action": "block", "deny_tool_classes": ["execute", "destructive"] },
+        { "id": "protect-secret-paths", "action": "block", "block_secret_paths": true },
+        { "id": "deny-unknown-egress", "action": "block", "block_unknown_egress": true, "allowed_hosts": ["api.openai.com", "api.anthropic.com"] },
+        { "id": "runtime-rate-limit", "action": "block", "rate_limit": 60 }
       ]
     }
 ---

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom-runtime:latest
+          image: agentbom/agent-bom-runtime:0.76.4
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -78,10 +78,11 @@ Implementation source: `src/agent_bom/api/middleware.py`
    - non-loopback binds require `AGENT_BOM_API_KEY` or stored API keys
 3. OIDC bearer enforcement
    - set `AGENT_BOM_OIDC_ISSUER`
-   - optionally set `AGENT_BOM_OIDC_AUDIENCE`
+   - set `AGENT_BOM_OIDC_AUDIENCE`
    - map roles with `AGENT_BOM_OIDC_ROLE_CLAIM`
    - map tenants with `AGENT_BOM_OIDC_TENANT_CLAIM`
    - fail closed with `AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1`
+   - optionally set `AGENT_BOM_OIDC_REQUIRED_NONCE` when your IdP flow includes a nonce claim
 
 Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`
 

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -117,6 +117,7 @@ export AGENT_BOM_OIDC_AUDIENCE="agent-bom"
 export AGENT_BOM_OIDC_ROLE_CLAIM="agent_bom_role"
 export AGENT_BOM_OIDC_TENANT_CLAIM="tenant_id"      # or a custom claim like org_slug
 export AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1        # fail closed if the claim is absent
+# export AGENT_BOM_OIDC_REQUIRED_NONCE="replace-me"  # optional when your IdP flow emits nonce
 ```
 
 That keeps API roles and tenant boundaries aligned with the upstream identity provider instead of silently falling back to a shared tenant when you expect strict isolation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Policy Engine: features/policy.md
   - Deployment:
       - Overview: deployment/overview.md
+      - Endpoint Fleet: deployment/endpoint-fleet.md
       - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -130,7 +130,7 @@ You still own:
 - use `Postgres`, not SQLite
 - keep same-origin ingress unless you have a strong reason not to
 - use `envFrom` / Secrets for `AGENT_BOM_POSTGRES_URL`, API keys, OIDC issuer,
-  audience, and audit HMAC settings
+  audience, optional required nonce, and audit HMAC settings
 - enable PDBs when you are running multi-replica workloads
 
 ## Current boundary

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -10,6 +10,10 @@ This is the recommended pilot scope for a company that wants to run
 
 This is intentionally narrower than a full platform rollout.
 
+If you also want employee laptops and workstations in the same pilot, pair this
+with [Endpoint Fleet](endpoint-fleet.md). That is a separate endpoint scan +
+push path, not the sidecar/runtime path described here.
+
 ## Pilot scope
 
 Enable:
@@ -108,6 +112,8 @@ At minimum, put these in a Kubernetes Secret referenced by the API Deployment:
 For enterprise pilots, prefer:
 
 - OIDC for user access
+- explicit `AGENT_BOM_OIDC_AUDIENCE`
+- optional `AGENT_BOM_OIDC_REQUIRED_NONCE` when your IdP flow includes a nonce claim
 - persistent audit HMAC keys with `AGENT_BOM_REQUIRE_AUDIT_HMAC=1`
 - IRSA on the scanner service account
 - internal ingress / VPN-only access

--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -1,0 +1,132 @@
+# Endpoint Fleet
+
+Use this path when `fleet` means employee laptops and workstations running
+local agent clients and MCP configs:
+
+- Cursor
+- Claude Desktop / Claude Code
+- VS Code / Copilot / Continue.dev
+- Windsurf
+- Cline / Roo / Zed
+- Cortex Code
+- other local MCP-capable developer tooling
+
+This is different from:
+
+- `runtime fleet`: EKS workloads and server-side MCP deployments
+- `cloud / platform inventory`: AWS, Snowflake, IaC, registries, containers
+
+## What ships today
+
+The endpoint-fleet path is real, but it is an opt-in scan + push model:
+
+1. the laptop runs `agent-bom agents`
+2. discovery and live MCP introspection happen locally
+3. the result is sanitized and pushed to the control plane with `--push-url`
+4. the control plane surfaces it in `/fleet`, `/agents`, `/mesh`, `/security-graph`,
+   `/gateway`, and `/findings`
+
+The endpoint command is:
+
+```bash
+agent-bom agents \
+  --preset enterprise \
+  --introspect \
+  --push-url https://agent-bom.internal.example.com/v1/fleet/sync \
+  --push-api-key "$AGENT_BOM_PUSH_API_KEY"
+```
+
+That gives you:
+
+- endpoint MCP config discovery
+- live MCP read-only introspection
+- sanitized fleet sync to the self-hosted control plane
+- the same fleet/mesh/gateway review path as cluster-discovered MCPs
+
+Important boundary:
+
+- this is not a managed endpoint agent
+- there is no MDM or quarantine control channel today
+- the pilot model is explicit local execution on a schedule you control
+
+## Endpoint service templates
+
+Shipped templates:
+
+- [deploy/endpoints/agent-bom-fleet-sync.sh](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/agent-bom-fleet-sync.sh)
+- [deploy/endpoints/agent-bom-fleet-sync.service](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/agent-bom-fleet-sync.service)
+- [deploy/endpoints/agent-bom-fleet-sync.timer](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/agent-bom-fleet-sync.timer)
+- [deploy/endpoints/com.agentbom.fleet-sync.plist](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/com.agentbom.fleet-sync.plist)
+
+The wrapper script expects:
+
+- `AGENT_BOM_PUSH_URL`
+- optionally `AGENT_BOM_PUSH_API_KEY`
+
+## Linux systemd example
+
+1. put the wrapper script at `~/.local/share/agent-bom/agent-bom-fleet-sync.sh`
+2. make it executable
+3. create `~/.config/agent-bom/fleet-sync.env`
+
+Example env file:
+
+```bash
+AGENT_BOM_PUSH_URL=https://agent-bom.internal.example.com/v1/fleet/sync
+AGENT_BOM_PUSH_API_KEY=replace-me
+```
+
+4. install the unit files:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp deploy/endpoints/agent-bom-fleet-sync.service ~/.config/systemd/user/
+cp deploy/endpoints/agent-bom-fleet-sync.timer ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now agent-bom-fleet-sync.timer
+```
+
+## macOS launchd example
+
+1. put the wrapper script at `~/.local/share/agent-bom/agent-bom-fleet-sync.sh`
+2. update the environment values in the plist
+3. load it:
+
+```bash
+mkdir -p ~/Library/LaunchAgents
+cp deploy/endpoints/com.agentbom.fleet-sync.plist ~/Library/LaunchAgents/
+launchctl unload ~/Library/LaunchAgents/com.agentbom.fleet-sync.plist 2>/dev/null || true
+launchctl load ~/Library/LaunchAgents/com.agentbom.fleet-sync.plist
+```
+
+## Proxy enforcement on endpoints
+
+Endpoint enforcement is separate from endpoint sync.
+
+For laptops, the proxy runs locally as a stdio wrapper around the editor's MCP
+command:
+
+```bash
+agent-bom proxy \
+  --control-plane-url https://agent-bom.internal.example.com \
+  --control-plane-token "$AGENT_BOM_API_TOKEN" \
+  --detect-credentials \
+  --block-undeclared \
+  -- npx @modelcontextprotocol/server-filesystem ~/workspace
+```
+
+That path now supports:
+
+- control-plane policy pull
+- control-plane audit push
+- local inline MCP enforcement
+
+## How this fits with the EKS pilot
+
+Use both when you want one pilot across laptops and infra:
+
+- `endpoint fleet`: employee laptops push local discovery into the control plane
+- `runtime fleet`: the EKS pilot discovers cluster-side MCP workloads and uses
+  selected proxy sidecars for server-side enforcement
+
+The control plane stays the same. Only the discovery and enforcement path differs.

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -73,3 +73,6 @@ For the full control-plane topology and secret wiring, see
 
 For the narrower MCP and agents pilot, see
 [Focused EKS MCP Pilot](eks-mcp-pilot.md).
+
+For employee laptops and workstations that should sync into the same control
+plane, see [Endpoint Fleet](endpoint-fleet.md).

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -57,6 +57,7 @@ For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).
 | Need | Recommended path |
 |---|---|
 | Run one scan locally | CLI |
+| Sync employee laptops into the same control plane | endpoint fleet `agent-bom agents --push-url .../v1/fleet/sync` |
 | Gate pull requests | GitHub Action |
 | Keep the runtime isolated | Docker |
 | Self-host UI + API for a team | `agent-bom serve` + `Postgres` / `Supabase` |

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -92,7 +92,7 @@ The chart now supports the EKS wiring you actually need:
 |---|---|
 | `controlPlane.enabled` | package the API + dashboard in-cluster |
 | `controlPlane.ingress.enabled` | route `/` to UI and `/v1`, `/health`, `/docs`, `/ws` to API |
-| `controlPlane.api.envFrom` | load Postgres URL, API key, OIDC, and audit settings from Secrets |
+| `controlPlane.api.envFrom` | load Postgres URL, API key, OIDC issuer/audience, optional required nonce, and audit settings from Secrets |
 | `controlPlane.ui.env` | keep `NEXT_PUBLIC_API_URL=\"\"` for same-origin or set a full API URL for cross-origin |
 | `serviceAccount.annotations` | attach an IRSA role to the scanner service account |
 | `scanner.extraArgs` | add `--k8s-mcp`, `--enforce`, `--introspect`, or stricter presets |
@@ -162,7 +162,7 @@ all sit under one operator-controlled plane.
 
 - use `Postgres`, not SQLite, for the control plane
 - keep the proxy and API internal to your VPC unless exposure is intentional
-- use OIDC for user access and map roles explicitly
+- use OIDC for user access, set `AGENT_BOM_OIDC_AUDIENCE` explicitly, and map roles explicitly
 - set a persistent audit HMAC key and require it
 - attach the scanner service account to IRSA instead of static cloud keys
 - start with audit-only policies where rollout risk is unclear, then move to deny

--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -7,10 +7,11 @@ existing API key authentication.
 Configuration via environment variables::
 
     AGENT_BOM_OIDC_ISSUER   = "https://accounts.google.com"
-    AGENT_BOM_OIDC_AUDIENCE = "agent-bom"            # optional, defaults to ISSUER
+    AGENT_BOM_OIDC_AUDIENCE = "agent-bom"            # required when OIDC is enabled
     AGENT_BOM_OIDC_ROLE_CLAIM = "agent_bom_role"      # optional JWT claim for role
     AGENT_BOM_OIDC_TENANT_CLAIM = "tenant_id"         # optional JWT claim for tenant
     AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM = "1"         # fail closed when claim absent
+    AGENT_BOM_OIDC_REQUIRED_NONCE = "random-nonce"    # optional fail-closed nonce check
 
 Role mapping (claim value → agent-bom Role):
 
@@ -128,6 +129,7 @@ def verify_oidc_token(
     issuer: str,
     audience: Optional[str] = None,
     jwks_uri: Optional[str] = None,
+    required_nonce: Optional[str] = None,
 ) -> dict:
     """Verify an OIDC JWT and return its claims.
 
@@ -137,8 +139,9 @@ def verify_oidc_token(
     Args:
         token: Raw JWT string (without "Bearer " prefix).
         issuer: Expected issuer (``iss`` claim). Must match exactly.
-        audience: Expected audience (``aud`` claim). If None, not verified.
+        audience: Expected audience (``aud`` claim). Required for production OIDC use.
         jwks_uri: Override JWKS URI. If None, fetched from OIDC discovery.
+        required_nonce: Optional nonce value that must match the token ``nonce`` claim.
 
     Returns:
         Decoded JWT claims dict.
@@ -175,6 +178,11 @@ def verify_oidc_token(
         claims = jwt.decode(token, signing_key.key, **decode_kwargs)
     except PyJWTError as exc:
         raise OIDCError(f"JWT verification failed: {exc}") from exc
+
+    if required_nonce is not None:
+        token_nonce = claims.get("nonce")
+        if token_nonce != required_nonce:
+            raise OIDCError("JWT verification failed: nonce claim mismatch")
 
     return claims
 
@@ -243,9 +251,10 @@ class OIDCConfig:
     Environment variables:
 
     - ``AGENT_BOM_OIDC_ISSUER`` — OIDC provider issuer URL (required to enable OIDC)
-    - ``AGENT_BOM_OIDC_AUDIENCE`` — Expected JWT audience (defaults to issuer)
+    - ``AGENT_BOM_OIDC_AUDIENCE`` — Expected JWT audience (required when OIDC is enabled)
     - ``AGENT_BOM_OIDC_ROLE_CLAIM`` — JWT claim name for role (default: ``agent_bom_role``)
     - ``AGENT_BOM_OIDC_JWKS_URI`` — Override JWKS URI (optional, auto-discovered if absent)
+    - ``AGENT_BOM_OIDC_REQUIRED_NONCE`` — Optional expected ``nonce`` claim for fail-closed checks
     """
 
     def __init__(
@@ -256,12 +265,14 @@ class OIDCConfig:
         jwks_uri: Optional[str] = None,
         tenant_claim: str = "tenant_id",
         require_tenant_claim: Optional[bool] = None,
+        required_nonce: Optional[str] = None,
     ) -> None:
         self.issuer = issuer or os.environ.get("AGENT_BOM_OIDC_ISSUER", "")
-        self.audience = audience or os.environ.get("AGENT_BOM_OIDC_AUDIENCE", self.issuer) or None
+        self.audience = audience or os.environ.get("AGENT_BOM_OIDC_AUDIENCE") or None
         self.role_claim = role_claim or os.environ.get("AGENT_BOM_OIDC_ROLE_CLAIM", "agent_bom_role")
         self.jwks_uri = jwks_uri or os.environ.get("AGENT_BOM_OIDC_JWKS_URI", "") or None
         self.tenant_claim = tenant_claim or os.environ.get("AGENT_BOM_OIDC_TENANT_CLAIM", "tenant_id")
+        self.required_nonce = required_nonce or os.environ.get("AGENT_BOM_OIDC_REQUIRED_NONCE", "") or None
         if require_tenant_claim is None:
             require_tenant_claim = os.environ.get("AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM", "").strip().lower() in {
                 "1",
@@ -279,7 +290,9 @@ class OIDCConfig:
         """
         if not self.enabled or not self.issuer:
             raise OIDCError("OIDC is not configured (set AGENT_BOM_OIDC_ISSUER)")
-        claims = verify_oidc_token(token, self.issuer, self.audience, self.jwks_uri)
+        if not self.audience:
+            raise OIDCError("OIDC is configured but AGENT_BOM_OIDC_AUDIENCE is not set")
+        claims = verify_oidc_token(token, self.issuer, self.audience, self.jwks_uri, self.required_nonce)
         role = claims_to_role(claims, self.role_claim)
         return claims, role
 

--- a/src/agent_bom/gateway.py
+++ b/src/agent_bom/gateway.py
@@ -43,6 +43,8 @@ def gateway_policy_to_proxy_format(policy: "GatewayPolicy") -> dict:
             d["block_unknown_egress"] = True
         if rule.allowed_hosts:
             d["allowed_hosts"] = rule.allowed_hosts
+        if rule.rate_limit is not None:
+            d["rate_limit"] = rule.rate_limit
         rules.append(d)
     return {"rules": rules}
 

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -51,6 +51,7 @@ _safe_compile = _proxy_policy._safe_compile
 _safe_regex_match = _proxy_policy._safe_regex_match
 _safe_regex_search = _proxy_policy._safe_regex_search
 check_policy = _proxy_policy.check_policy
+resolve_rate_limit_threshold = _proxy_policy.resolve_rate_limit_threshold
 
 # Maximum JSON-RPC message size accepted from client or server (10 MB).
 # Guards against DoS via oversized payloads in the stdio relay loop.
@@ -185,6 +186,22 @@ def _evaluate_gateway_policy_bundle(policies: list["GatewayPolicy"], agent_name:
         scoped.append(policy)
     allowed, reason, _policy_id = evaluate_gateway_policies(scoped, tool_name, arguments)
     return allowed, reason
+
+
+def _resolve_control_plane_rate_limit_threshold(policies: list["GatewayPolicy"], agent_name: str | None = None) -> int | None:
+    from agent_bom.gateway import gateway_policy_to_proxy_format
+
+    limits: list[int] = []
+    for policy in policies:
+        if not getattr(policy, "enabled", False):
+            continue
+        if agent_name and getattr(policy, "bound_agents", None) and agent_name not in getattr(policy, "bound_agents", []):
+            continue
+        proxy_fmt = gateway_policy_to_proxy_format(policy)
+        limit = resolve_rate_limit_threshold(proxy_fmt)
+        if limit is not None:
+            limits.append(limit)
+    return min(limits) if limits else None
 
 
 async def _push_proxy_audit_batch(
@@ -578,7 +595,9 @@ async def run_proxy(
     drift_detector = ToolDriftDetector()
     arg_analyzer = ArgumentAnalyzer()
     cred_detector = CredentialLeakDetector() if detect_credentials else None
-    rate_tracker = RateLimitTracker(threshold=rate_limit_threshold) if rate_limit_threshold > 0 else None
+    local_policy_rate_limit = resolve_rate_limit_threshold(policy) if policy else None
+    effective_rate_limit_threshold = rate_limit_threshold or local_policy_rate_limit or 0
+    rate_tracker = RateLimitTracker(threshold=max(effective_rate_limit_threshold, 0))
     seq_analyzer = SequenceAnalyzer()
     response_inspector = ResponseInspector()
     vector_detector = VectorDBInjectionDetector()
@@ -612,6 +631,12 @@ async def run_proxy(
             control_plane_policies = policies
         if next_etag:
             control_plane_etag = next_etag
+        if rate_limit_threshold <= 0:
+            control_plane_limit = _resolve_control_plane_rate_limit_threshold(control_plane_policies)
+            if control_plane_limit and control_plane_limit > 0:
+                rate_tracker._threshold = control_plane_limit
+            else:
+                rate_tracker._threshold = local_policy_rate_limit or 0
 
     async def _flush_audit_buffer(summary: dict | None = None) -> None:
         if not control_plane_url:
@@ -839,8 +864,15 @@ async def run_proxy(
                     _handle_alerts(arg_alerts, log_file)
 
                     # Runtime detectors: rate limiting
-                    if rate_tracker:
-                        rate_alerts = rate_tracker.record(tool_name)
+                    effective_rule_rate_limit = 0
+                    if _gateway_evaluator is not None and control_plane_policies:
+                        effective_rule_rate_limit = _resolve_control_plane_rate_limit_threshold(control_plane_policies, agent_id) or 0
+                    if effective_rule_rate_limit <= 0 and local_policy_rate_limit:
+                        effective_rule_rate_limit = local_policy_rate_limit
+                    if rate_limit_threshold > 0:
+                        effective_rule_rate_limit = rate_limit_threshold
+                    if rate_tracker and effective_rule_rate_limit > 0:
+                        rate_alerts = rate_tracker.record(tool_name, threshold=effective_rule_rate_limit)
                         _handle_alerts(rate_alerts, log_file)
                         if rate_alerts and not log_only:
                             rl_reason = rate_alerts[0].message

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -131,6 +131,16 @@ def _host_allowed(host: str, allowed_hosts: list[str]) -> bool:
     return any(host == allowed or host.endswith(f".{allowed}") for allowed in normalized)
 
 
+def resolve_rate_limit_threshold(policy: dict) -> int | None:
+    """Return the strictest positive ``rate_limit`` configured in a policy bundle."""
+    limits: list[int] = []
+    for rule in policy.get("rules", []):
+        limit = rule.get("rate_limit")
+        if isinstance(limit, int) and limit > 0:
+            limits.append(limit)
+    return min(limits) if limits else None
+
+
 def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, str]:
     """Evaluate runtime policy against a tools/call request."""
     rules = policy.get("rules", [])

--- a/src/agent_bom/runtime/detectors.py
+++ b/src/agent_bom/runtime/detectors.py
@@ -382,12 +382,15 @@ class RateLimitTracker:
         self._window = window_seconds
         self._calls: dict[str, deque[float]] = {}
 
-    def record(self, tool_name: str) -> list[Alert]:
+    def record(self, tool_name: str, threshold: int | None = None) -> list[Alert]:
         """Record a tool call and check rate limits.
 
         Returns a CRITICAL alert with ``details.blocked = True`` when the
         rate limit is exceeded, signaling the caller to deny the call.
         """
+        effective_threshold = threshold if threshold is not None else self._threshold
+        if effective_threshold <= 0:
+            return []
         now = time.monotonic()
         if tool_name not in self._calls:
             self._calls[tool_name] = deque()
@@ -400,19 +403,19 @@ class RateLimitTracker:
             q.popleft()
 
         alerts: list[Alert] = []
-        if len(q) >= self._threshold:
+        if len(q) >= effective_threshold:
             # Escalate severity based on how far over the limit
-            over_ratio = len(q) / self._threshold
+            over_ratio = len(q) / effective_threshold
             severity = AlertSeverity.CRITICAL if over_ratio >= 2.0 else AlertSeverity.HIGH
             alerts.append(
                 Alert(
                     detector="rate_limit",
                     severity=severity,
-                    message=f"Rate limit exceeded: {tool_name} called {len(q)} times in {self._window}s (threshold: {self._threshold})",
+                    message=f"Rate limit exceeded: {tool_name} called {len(q)} times in {self._window}s (threshold: {effective_threshold})",
                     details={
                         "tool": tool_name,
                         "count": len(q),
-                        "threshold": self._threshold,
+                        "threshold": effective_threshold,
                         "window_seconds": self._window,
                         "blocked": True,
                     },

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -192,7 +192,7 @@ def test_api_key_middleware_oidc_sets_tenant_from_custom_claim():
     test_app = Starlette(routes=[Route("/v1/test", dummy)])
     test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
 
-    cfg = OIDCConfig(issuer="https://corp.okta.com", tenant_claim="org_slug")
+    cfg = OIDCConfig(issuer="https://corp.okta.com", audience="agent-bom", tenant_claim="org_slug")
     with (
         patch("agent_bom.api.oidc.OIDCConfig.from_env", return_value=cfg),
         patch(

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -49,9 +49,9 @@ def test_oidc_config_from_env_reads_issuer():
         assert cfg.issuer == "https://test.okta.com"
 
 
-def test_oidc_config_audience_defaults_to_issuer():
+def test_oidc_config_audience_is_unset_without_explicit_value():
     cfg = OIDCConfig(issuer="https://myissuer.example.com")
-    assert cfg.audience == "https://myissuer.example.com"
+    assert cfg.audience is None
 
 
 def test_oidc_config_explicit_audience():
@@ -59,9 +59,20 @@ def test_oidc_config_explicit_audience():
     assert cfg.audience == "my-app"
 
 
+def test_oidc_config_reads_required_nonce():
+    cfg = OIDCConfig(issuer="https://myissuer.example.com", required_nonce="nonce-123")
+    assert cfg.required_nonce == "nonce-123"
+
+
 def test_oidc_config_verify_raises_when_not_enabled():
     cfg = OIDCConfig()  # no issuer
     with pytest.raises(OIDCError, match="not configured"):
+        cfg.verify("any.jwt.token")
+
+
+def test_oidc_config_verify_requires_explicit_audience():
+    cfg = OIDCConfig(issuer="https://corp.example.com")
+    with pytest.raises(OIDCError, match="AGENT_BOM_OIDC_AUDIENCE"):
         cfg.verify("any.jwt.token")
 
 
@@ -149,7 +160,7 @@ def test_verify_raises_oidc_error_when_pyjwt_missing():
     """If PyJWT is not installed, OIDCError is raised with install hint."""
     with patch("agent_bom.api.oidc._check_pyjwt", side_effect=OIDCError("mocked: PyJWT missing")):
         with pytest.raises(OIDCError, match="PyJWT"):
-            cfg = OIDCConfig(issuer="https://example.com")
+            cfg = OIDCConfig(issuer="https://example.com", audience="agent-bom")
             cfg.verify("bad.token.here")
 
 
@@ -183,7 +194,7 @@ def test_verify_raises_oidc_error_on_bad_jwt():
 
 def test_oidc_config_verify_returns_claims_and_role():
     """verify() on OIDCConfig returns (claims, role) on success."""
-    cfg = OIDCConfig(issuer="https://example.com")
+    cfg = OIDCConfig(issuer="https://example.com", audience="agent-bom")
 
     mock_claims = {"sub": "user1", "email": "user@example.com", "agent_bom_role": "analyst"}
 
@@ -195,12 +206,12 @@ def test_oidc_config_verify_returns_claims_and_role():
 
 
 def test_oidc_config_resolve_tenant_defaults_when_not_required():
-    cfg = OIDCConfig(issuer="https://corp.example.com")
+    cfg = OIDCConfig(issuer="https://corp.example.com", audience="agent-bom")
     assert cfg.resolve_tenant({"sub": "user-1"}) == "default"
 
 
 def test_oidc_config_resolve_tenant_raises_when_required_claim_missing():
-    cfg = OIDCConfig(issuer="https://corp.example.com", require_tenant_claim=True)
+    cfg = OIDCConfig(issuer="https://corp.example.com", audience="agent-bom", require_tenant_claim=True)
     with pytest.raises(OIDCError, match="tenant claim"):
         cfg.resolve_tenant({"sub": "user-1"})
 
@@ -222,7 +233,7 @@ def test_middleware_oidc_success_sets_request_state():
     """When OIDC verifies a Bearer token, request state is set correctly."""
     mock_claims = {"sub": "u1", "email": "alice@corp.com", "agent_bom_role": "analyst"}
 
-    cfg = OIDCConfig(issuer="https://corp.okta.com")
+    cfg = OIDCConfig(issuer="https://corp.okta.com", audience="agent-bom")
     with patch("agent_bom.api.oidc.verify_oidc_token", return_value=mock_claims):
         claims, role = cfg.verify("eyJ.valid.token")
 
@@ -232,9 +243,23 @@ def test_middleware_oidc_success_sets_request_state():
 
 def test_middleware_oidc_failure_does_not_raise():
     """OIDCError is caught and falls through — does not propagate."""
-    cfg = OIDCConfig(issuer="https://corp.okta.com")
+    cfg = OIDCConfig(issuer="https://corp.okta.com", audience="agent-bom")
 
     with patch("agent_bom.api.oidc.verify_oidc_token", side_effect=OIDCError("expired")):
         with pytest.raises(OIDCError):
             # verify() re-raises — caller (middleware) catches it
             cfg.verify("expired.jwt.token")
+
+
+def test_oidc_config_passes_required_nonce_to_verifier():
+    cfg = OIDCConfig(issuer="https://corp.okta.com", audience="agent-bom", required_nonce="nonce-123")
+
+    with patch(
+        "agent_bom.api.oidc.verify_oidc_token",
+        return_value={"sub": "u1", "agent_bom_role": "admin", "nonce": "nonce-123"},
+    ) as mock_verify:
+        claims, role = cfg.verify("valid.jwt.token")
+
+    assert claims["sub"] == "u1"
+    assert role == "admin"
+    assert mock_verify.call_args.args[4] == "nonce-123"

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -9,6 +9,7 @@ import yaml
 DEPLOY_DIR = Path(__file__).parent.parent / "deploy"
 K8S_DIR = DEPLOY_DIR / "k8s"
 HELM_DIR = DEPLOY_DIR / "helm" / "agent-bom"
+ENDPOINTS_DIR = DEPLOY_DIR / "endpoints"
 
 
 # ─── K8s manifest validation ────────────────────────────────────────────────
@@ -86,6 +87,39 @@ def test_sidecar_has_prometheus_annotations():
     annotations = doc["spec"]["template"]["metadata"]["annotations"]
     assert annotations["prometheus.io/scrape"] == "true"
     assert annotations["prometheus.io/port"] == "8422"
+
+
+def test_sidecar_example_pins_runtime_image():
+    """Static sidecar example should not rely on :latest for the runtime image."""
+    doc = yaml.safe_load((K8S_DIR / "sidecar-example.yaml").read_text())
+    containers = doc["spec"]["template"]["spec"]["containers"]
+    proxy = next(container for container in containers if container["name"] == "agent-bom-proxy")
+    assert proxy["image"].startswith("agentbom/agent-bom-runtime:")
+    assert not proxy["image"].endswith(":latest")
+
+
+def test_proxy_sidecar_pilot_uses_runtime_proxy_policy_fields():
+    """Pilot sidecar policy example should use the proxy's real local policy DSL."""
+    docs = list(yaml.safe_load_all((K8S_DIR / "proxy-sidecar-pilot.yaml").read_text()))
+    config_map = next(doc for doc in docs if doc and doc["kind"] == "ConfigMap")
+    policy = yaml.safe_load(config_map["data"]["policy.json"])
+    rules = policy["rules"]
+    assert any(rule.get("deny_tool_classes") for rule in rules)
+    assert any(rule.get("block_secret_paths") for rule in rules)
+    assert any(rule.get("block_unknown_egress") for rule in rules)
+    assert any(rule.get("rate_limit") == 60 for rule in rules)
+
+
+def test_endpoint_fleet_templates_exist():
+    """Endpoint fleet pilot templates should ship for macOS and Linux."""
+    expected = {
+        "agent-bom-fleet-sync.sh",
+        "agent-bom-fleet-sync.service",
+        "agent-bom-fleet-sync.timer",
+        "com.agentbom.fleet-sync.plist",
+    }
+    actual = {path.name for path in ENDPOINTS_DIR.iterdir() if path.is_file()}
+    assert expected.issubset(actual)
 
 
 def test_namespace_manifest():

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -71,6 +71,12 @@ def test_convert_runtime_enforcement_fields():
     assert fmt["rules"][0]["allowed_hosts"] == ["api.openai.com"]
 
 
+def test_convert_rate_limit():
+    p = _policy(rules=[GatewayRule(id="r1", action="block", rate_limit=25)])
+    fmt = gateway_policy_to_proxy_format(p)
+    assert fmt["rules"][0]["rate_limit"] == 25
+
+
 # ── Evaluation ────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_runtime_detectors.py
+++ b/tests/test_runtime_detectors.py
@@ -316,6 +316,20 @@ def test_rate_limit_properties():
     assert r.window == 30.0
 
 
+def test_rate_limit_dynamic_threshold_override():
+    r = RateLimitTracker(threshold=50, window_seconds=60.0)
+    assert r.record("tool1", threshold=3) == []
+    assert r.record("tool1", threshold=3) == []
+    alerts = r.record("tool1", threshold=3)
+    assert len(alerts) == 1
+    assert alerts[0].details["threshold"] == 3
+
+
+def test_rate_limit_zero_threshold_disables_check():
+    r = RateLimitTracker(threshold=0, window_seconds=60.0)
+    assert r.record("tool1", threshold=0) == []
+
+
 # ─── SequenceAnalyzer ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Summary
- require explicit OIDC audience and support optional fail-closed nonce validation
- make gateway rate-limit rules affect proxy runtime enforcement
- add endpoint fleet pilot docs and launchd/systemd templates for agent-bom agents push to v1/fleet/sync
- fix pilot deployment examples to use proxy-supported local policy fields and pinned runtime images

Validation
- uv run pytest -q tests/test_api_oidc.py tests/test_api_hardening.py tests/test_gateway.py tests/test_runtime_detectors.py tests/test_deploy_manifests.py
- uv run ruff check src/agent_bom/api/oidc.py src/agent_bom/gateway.py src/agent_bom/proxy.py src/agent_bom/proxy_policy.py src/agent_bom/runtime/detectors.py tests/test_api_oidc.py tests/test_api_hardening.py tests/test_gateway.py tests/test_runtime_detectors.py tests/test_deploy_manifests.py
- uv run mypy src/agent_bom/api/oidc.py src/agent_bom/gateway.py src/agent_bom/proxy.py src/agent_bom/proxy_policy.py src/agent_bom/runtime/detectors.py
- git diff --check
- template sanity parse for plist and pilot YAMLs