### PR TITLE
Close remaining pilot hardening gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Backend choices stay explicit and optional:
 For teams self-hosting in their own AWS / EKS environment, see the focused
 operator guide:
 
+- [Enterprise MCP / Endpoint Pilot](site-docs/deployment/enterprise-pilot.md)
 - [Deploy In Your Own AWS / EKS Infrastructure](site-docs/deployment/own-infra-eks.md)
 - [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md)
 - [Focused EKS MCP Pilot](site-docs/deployment/eks-mcp-pilot.md)

--- a/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
@@ -40,4 +40,13 @@ serviceAccount:
 
 networkPolicy:
   enabled: true
-  restrictIngress: false
+  restrictIngress: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-bom
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx

--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -4,3 +4,8 @@ Enterprise pilot notes:
 - Set `AGENT_BOM_REQUIRE_AUDIT_HMAC=1` to fail closed if the key is missing.
 - Use Postgres for the pilot control plane; SQLite is not the multi-replica path.
 - Prefer internal ingress / VPN-only exposure for the API and UI.
+- Run Alembic before first multi-replica rollout: `alembic -c deploy/supabase/postgres/alembic.ini upgrade head`.
+- For existing databases bootstrapped from `init.sql`, stamp the baseline first: `alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01`.
+- Label the namespace with Pod Security Admission restricted mode before applying sidecars:
+  `kubectl label namespace {{ .Release.Namespace }} pod-security.kubernetes.io/enforce=restricted pod-security.kubernetes.io/audit=restricted pod-security.kubernetes.io/warn=restricted --overwrite`
+- The focused EKS pilot values lock ingress down; adjust `networkPolicy.ingress` if your ingress controller does not run in `ingress-nginx`.

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: agent-bom
     app.kubernetes.io/part-of: agent-bom
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -6,6 +6,17 @@
 # Replace the sample MCP server command/image with your own workload image and
 # runtime command before applying.
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: agent-bom
+  labels:
+    app.kubernetes.io/name: agent-bom
+    app.kubernetes.io/part-of: agent-bom
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: agent-bom-proxy-policy
@@ -49,6 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-server
     app.kubernetes.io/component: proxy-pilot
+    security.agent-bom.io/pod-security-level: restricted
 spec:
   replicas: 1
   selector:
@@ -60,6 +72,7 @@ spec:
       labels:
         app.kubernetes.io/name: mcp-server
         app.kubernetes.io/component: proxy-pilot
+        security.agent-bom.io/pod-security-level: restricted
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8422"

--- a/deploy/supabase/postgres/alembic.ini
+++ b/deploy/supabase/postgres/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = deploy/supabase/postgres/alembic
+prepend_sys_path = .
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/deploy/supabase/postgres/alembic/bootstrap.py
+++ b/deploy/supabase/postgres/alembic/bootstrap.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+INIT_SQL = Path(__file__).resolve().parents[1] / "init.sql"
+
+
+def rewrite_bootstrap_sql(sql: str, database_name: str) -> str:
+    sql = sql.replace(
+        "GRANT CONNECT ON DATABASE agent_bom TO agent_bom_app;",
+        f"GRANT CONNECT ON DATABASE {database_name} TO agent_bom_app;",
+    )
+    sql = sql.replace(
+        "GRANT CONNECT ON DATABASE agent_bom TO agent_bom_readonly;",
+        f"GRANT CONNECT ON DATABASE {database_name} TO agent_bom_readonly;",
+    )
+    return sql
+
+
+def load_bootstrap_sql(database_name: str) -> str:
+    return rewrite_bootstrap_sql(INIT_SQL.read_text(), database_name)

--- a/deploy/supabase/postgres/alembic/env.py
+++ b/deploy/supabase/postgres/alembic/env.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def _database_url() -> str:
+    url = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("AGENT_BOM_POSTGRES_URL")
+    if not url:
+        raise RuntimeError("Set ALEMBIC_DATABASE_URL or AGENT_BOM_POSTGRES_URL before running Alembic migrations.")
+    return url
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    section = config.get_section(config.config_ini_section, {})
+    section["sqlalchemy.url"] = _database_url()
+
+    connectable = engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/deploy/supabase/postgres/alembic/script.py.mako
+++ b/deploy/supabase/postgres/alembic/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/deploy/supabase/postgres/alembic/versions/20260416_01_control_plane_baseline.py
+++ b/deploy/supabase/postgres/alembic/versions/20260416_01_control_plane_baseline.py
@@ -1,0 +1,34 @@
+"""Bootstrap the enterprise control-plane schema from the Postgres baseline SQL."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260416_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+_ALEMBIC_ROOT = Path(__file__).resolve().parents[1]
+if str(_ALEMBIC_ROOT) not in sys.path:
+    sys.path.append(str(_ALEMBIC_ROOT))
+
+from bootstrap import load_bootstrap_sql  # noqa: E402
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    database_name = bind.exec_driver_sql("SELECT current_database()").scalar_one()
+    bootstrap_sql = load_bootstrap_sql(database_name)
+    bind.exec_driver_sql(bootstrap_sql)
+
+
+def downgrade() -> None:  # pragma: no cover - baseline downgrade is intentionally manual
+    raise NotImplementedError(
+        "The baseline control-plane migration is not automatically reversible. "
+        "Restore from backup or recreate the database for a full teardown."
+    )

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -1,6 +1,8 @@
 -- agent-bom PostgreSQL initialization
 -- Runs once on first container start via docker-entrypoint-initdb.d
--- Also used as the Supabase project schema migration.
+-- Also used as the Supabase project schema bootstrap.
+-- Long-lived enterprise control planes should move forward with Alembic after
+-- this baseline is established.
 --
 -- Principle: POSTGRES_USER (admin) owns the schema and creates tables.
 -- A separate app user (agent_bom_app) gets DML-only access.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Policy Engine: features/policy.md
   - Deployment:
       - Overview: deployment/overview.md
+      - Enterprise MCP / Endpoint Pilot: deployment/enterprise-pilot.md
       - Endpoint Fleet: deployment/endpoint-fleet.md
       - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -128,6 +128,9 @@ You still own:
 
 - keep `controlPlane.api.replicas` and `controlPlane.ui.replicas` at `2+`
 - use `Postgres`, not SQLite
+- run Alembic for long-lived Postgres control planes:
+  - `alembic -c deploy/supabase/postgres/alembic.ini upgrade head`
+  - existing `init.sql` databases should be stamped once with `20260416_01`
 - keep same-origin ingress unless you have a strong reason not to
 - use `envFrom` / Secrets for `AGENT_BOM_POSTGRES_URL`, API keys, OIDC issuer,
   audience, optional required nonce, and audit HMAC settings

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -50,6 +50,7 @@ That pilot profile gives you:
 
 - packaged API + UI control plane
 - same-origin ingress
+- ingress restricted to the pilot namespace and the ingress controller namespace
 - scanner CronJob running cluster-wide discovery
 - enterprise-oriented MCP scan args:
   - `--k8s-mcp`
@@ -69,6 +70,7 @@ Use:
 
 This manifest shows:
 
+- a namespace labeled for Pod Security Admission `restricted`
 - a starter proxy policy `ConfigMap`
 - a metrics `Service`
 - a sample MCP workload with `agent-bom-runtime` sidecar
@@ -100,6 +102,39 @@ That gives the team a clean story:
 3. review fleet and graph posture
 4. define gateway policies
 5. enforce selected runtime traffic through sidecars
+
+## Required platform hardening
+
+Before calling this pilot production-like, apply the namespace labels and run
+the control-plane migrations explicitly:
+
+```bash
+kubectl label namespace agent-bom \
+  pod-security.kubernetes.io/enforce=restricted \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/warn=restricted \
+  --overwrite
+
+alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+```
+
+If the database was already bootstrapped from
+[deploy/supabase/postgres/init.sql](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/supabase/postgres/init.sql),
+stamp the baseline once before future upgrades:
+
+```bash
+alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
+```
+
+The focused pilot values also set `networkPolicy.restrictIngress=true` and only
+allow ingress from:
+
+- the `agent-bom` namespace
+- the `ingress-nginx` namespace
+
+If your ingress controller runs elsewhere, change
+[deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
+before install.
 
 ## Recommended secrets and auth
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -1,0 +1,136 @@
+# Enterprise MCP / Endpoint Pilot
+
+This is the canonical `agent-bom` pilot shape for a company that wants one
+open-source control plane for:
+
+- employee endpoint fleet visibility
+- server-side MCP visibility in EKS
+- gateway policy management
+- selected inline proxy enforcement
+
+It is intentionally not an EDR-style managed agent product. The current
+contract is opt-in endpoint scans plus self-hosted control-plane and proxy
+surfaces.
+
+## Scope
+
+```mermaid
+flowchart LR
+    subgraph EndpointFleet["Endpoint fleet"]
+      Cursor["Cursor / Windsurf / Cline"]
+      Claude["Claude Desktop / Claude Code"]
+      VSCode["VS Code / Copilot / Continue / Roo / Amazon Q / Cortex Code"]
+      Scan["agent-bom agents --preset enterprise --introspect --push-url .../v1/fleet/sync"]
+      Cursor --> Scan
+      Claude --> Scan
+      VSCode --> Scan
+    end
+
+    subgraph RuntimeFleet["Runtime fleet on EKS"]
+      Cron["Scanner CronJob"]
+      Sidecars["Selected MCP sidecars"]
+      Workloads["In-cluster MCP workloads"]
+      Workloads --> Cron
+      Workloads --> Sidecars
+    end
+
+    subgraph ControlPlane["Self-hosted control plane"]
+      API["FastAPI API"]
+      UI["Next.js UI"]
+      Gateway["Gateway policy UI/API"]
+      Audit["Audit + findings + fleet stores"]
+      API --> Gateway
+      API --> Audit
+      UI --> API
+    end
+
+    subgraph DataPlane["Persistence"]
+      PG["Postgres / Supabase"]
+      CH["ClickHouse (optional analytics)"]
+    end
+
+    Scan --> API
+    Cron --> API
+    Sidecars --> API
+    API --> PG
+    API --> CH
+```
+
+## Control flow
+
+```mermaid
+sequenceDiagram
+    participant Admin as Security admin
+    participant UI as /gateway UI
+    participant API as Control-plane API
+    participant Proxy as agent-bom proxy
+    participant MCP as MCP server
+
+    Admin->>UI: Create / update policy
+    UI->>API: POST /v1/gateway/policies
+    API-->>UI: ETag + persisted policy
+    Proxy->>API: GET /v1/gateway/policies?enabled=true
+    API-->>Proxy: Cached policy bundle
+    Proxy->>MCP: Forward allowed JSON-RPC
+    Proxy-->>API: POST /v1/proxy/audit
+    API-->>UI: Fleet / findings / audit visible
+```
+
+## What is in scope
+
+| Surface | Included in the pilot | Why |
+|---|---|---|
+| Endpoint fleet | Yes | Employee laptops push MCP and agent discovery into the shared control plane |
+| Runtime fleet | Yes | EKS scanner + selected sidecars cover server-side MCPs |
+| Gateway policies | Yes | Control-plane policy management is now linked to proxy pull |
+| Proxy audit push | Yes | SOC sees blocks and warnings centrally |
+| Same-origin UI | Yes | One ingress, one internal control plane |
+| Postgres | Yes | Primary transactional backend for multi-replica pilots |
+| ClickHouse | Optional | Bring it in once pilot event volume justifies it |
+| Snowflake backend | No | Not part of the focused pilot contract |
+| Managed endpoint agent | No | Still roadmap, not current product contract |
+| MDM integration | No | Still roadmap |
+
+## Security properties
+
+- self-hosted API, UI, audit log, and Postgres stay in the company's infra
+- OIDC, API keys, RBAC, and Postgres RLS are the control-plane boundary
+- proxy policy pull and audit push are now real, not cosmetic
+- `AGENT_BOM_AUDIT_HMAC_KEY` is required for pilot sign-off
+- the EKS pilot path assumes Pod Security Admission `restricted`
+- focused pilot values lock ingress down instead of leaving it wide open
+
+## Scale properties
+
+- API is horizontally scalable behind Postgres-backed state
+- scheduler leader election uses Postgres advisory locking
+- endpoint fleet is batch-driven and scales to pilot size without a managed agent
+- ClickHouse is available when pilot volume grows beyond what Postgres should carry for analytics
+- sidecar proxy rollout stays workload-by-workload instead of forcing universal inline routing
+
+## Required rollout steps
+
+1. Run Postgres migrations.
+2. Install the Helm control plane with the focused pilot values.
+3. Label the namespace for Pod Security Admission `restricted`.
+4. Start endpoint fleet scan-and-push on employee workstations.
+5. Add proxy sidecars only to the MCP workloads you want inline enforcement on.
+
+## Migration contract
+
+Long-lived control-plane databases now have an Alembic baseline:
+
+```bash
+alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+```
+
+If a database was already initialized from
+[deploy/supabase/postgres/init.sql](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/supabase/postgres/init.sql),
+stamp it once before future changes:
+
+```bash
+alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
+```
+
+Use `init.sql` for disposable bootstrap paths and local compose; use Alembic as
+the authoritative migration path for long-lived enterprise control planes.

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -68,6 +68,15 @@ For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).
 | Add analytics at scale | `ClickHouse` alongside the control plane |
 | Use warehouse-native governance data | `Snowflake` with explicit parity limits |
 
+## Canonical Pilot
+
+If you want the deployment shape we actively defend with enterprise pilot
+buyers, use the consolidated guide:
+
+- [Enterprise MCP / Endpoint Fleet Pilot](enterprise-pilot.md)
+- [Endpoint Fleet](endpoint-fleet.md)
+- [Focused EKS MCP Pilot](eks-mcp-pilot.md)
+
 ## Available on
 
 - [PyPI](https://pypi.org/project/agent-bom/)

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -161,6 +161,7 @@ all sit under one operator-controlled plane.
 ## Recommended Production Defaults
 
 - use `Postgres`, not SQLite, for the control plane
+- use Alembic as the migration path for long-lived Postgres control planes
 - keep the proxy and API internal to your VPC unless exposure is intentional
 - use OIDC for user access, set `AGENT_BOM_OIDC_AUDIENCE` explicitly, and map roles explicitly
 - set a persistent audit HMAC key and require it

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -110,6 +110,16 @@ def test_proxy_sidecar_pilot_uses_runtime_proxy_policy_fields():
     assert any(rule.get("rate_limit") == 60 for rule in rules)
 
 
+def test_proxy_sidecar_pilot_bootstraps_restricted_namespace():
+    """Pilot sidecar manifest should include the namespace with PSA restricted labels."""
+    docs = list(yaml.safe_load_all((K8S_DIR / "proxy-sidecar-pilot.yaml").read_text()))
+    namespace = next(doc for doc in docs if doc and doc["kind"] == "Namespace")
+    labels = namespace["metadata"]["labels"]
+    assert labels["pod-security.kubernetes.io/enforce"] == "restricted"
+    assert labels["pod-security.kubernetes.io/audit"] == "restricted"
+    assert labels["pod-security.kubernetes.io/warn"] == "restricted"
+
+
 def test_endpoint_fleet_templates_exist():
     """Endpoint fleet pilot templates should ship for macOS and Linux."""
     expected = {
@@ -127,6 +137,15 @@ def test_namespace_manifest():
     doc = yaml.safe_load((K8S_DIR / "namespace.yaml").read_text())
     assert doc["kind"] == "Namespace"
     assert doc["metadata"]["name"] == "agent-bom"
+
+
+def test_namespace_manifest_sets_psa_restricted():
+    """Namespace manifest should enforce restricted Pod Security Admission."""
+    doc = yaml.safe_load((K8S_DIR / "namespace.yaml").read_text())
+    labels = doc["metadata"]["labels"]
+    assert labels["pod-security.kubernetes.io/enforce"] == "restricted"
+    assert labels["pod-security.kubernetes.io/audit"] == "restricted"
+    assert labels["pod-security.kubernetes.io/warn"] == "restricted"
 
 
 # ─── Helm chart validation ──────────────────────────────────────────────────
@@ -238,3 +257,12 @@ def test_helm_monitor_ingress_defaults_are_defined():
     assert ingress["enabled"] is False
     assert ingress["hosts"][0]["paths"][0]["path"] == "/"
     assert ingress["hosts"][0]["paths"][0]["pathType"] == "Prefix"
+
+
+def test_pilot_values_restrict_ingress():
+    """Focused EKS pilot values should not leave ingress wide open."""
+    pilot = yaml.safe_load((HELM_DIR / "examples" / "eks-mcp-pilot-values.yaml").read_text())
+    policy = pilot["networkPolicy"]
+    assert policy["enabled"] is True
+    assert policy["restrictIngress"] is True
+    assert len(policy["ingress"]) >= 2

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -1,0 +1,49 @@
+"""Tests for the Alembic migration scaffolding on the enterprise Postgres path."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+POSTGRES_DIR = Path(__file__).parent.parent / "deploy" / "supabase" / "postgres"
+ALEMBIC_DIR = POSTGRES_DIR / "alembic"
+VERSIONS_DIR = ALEMBIC_DIR / "versions"
+BASELINE = VERSIONS_DIR / "20260416_01_control_plane_baseline.py"
+BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_alembic_scaffolding_exists():
+    assert (POSTGRES_DIR / "alembic.ini").exists()
+    assert (ALEMBIC_DIR / "env.py").exists()
+    assert BOOTSTRAP.exists()
+    assert (ALEMBIC_DIR / "script.py.mako").exists()
+    assert BASELINE.exists()
+
+
+def test_baseline_migration_points_at_bootstrap_sql():
+    bootstrap = _load_module(BOOTSTRAP, "abom_alembic_bootstrap")
+    sql = BASELINE.read_text()
+    assert bootstrap.INIT_SQL.exists()
+    assert re.search(r'revision\s*=\s*"20260416_01"', sql)
+    assert re.search(r"down_revision\s*=\s*None", sql)
+
+
+def test_baseline_migration_rewrites_database_specific_grants():
+    module = _load_module(BOOTSTRAP, "abom_alembic_bootstrap")
+    sql = """
+GRANT CONNECT ON DATABASE agent_bom TO agent_bom_app;
+GRANT CONNECT ON DATABASE agent_bom TO agent_bom_readonly;
+"""
+    rewritten = module.rewrite_bootstrap_sql(sql, "pilot_customer")
+    assert "GRANT CONNECT ON DATABASE pilot_customer TO agent_bom_app;" in rewritten
+    assert "GRANT CONNECT ON DATABASE pilot_customer TO agent_bom_readonly;" in rewritten
+    assert "GRANT CONNECT ON DATABASE agent_bom TO agent_bom_app;" not in rewritten


### PR DESCRIPTION
## Summary
- add Alembic scaffolding and a Postgres control-plane baseline migration for long-lived enterprise deployments
- harden the focused EKS pilot with restricted Pod Security Admission labels and ingress-restricting NetworkPolicy values
- add a canonical enterprise pilot deployment guide with architecture diagrams and update the pilot/control-plane docs to use it

## Testing
- uv run pytest -q tests/test_deploy_manifests.py tests/test_postgres_schema.py tests/test_postgres_migrations.py
- uv run ruff check deploy/supabase/postgres/alembic/bootstrap.py deploy/supabase/postgres/alembic/env.py deploy/supabase/postgres/alembic/versions/20260416_01_control_plane_baseline.py tests/test_deploy_manifests.py tests/test_postgres_migrations.py
- git diff --check