### PR TITLE
Package production operator defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ operator guide:
 - [Deploy In Your Own AWS / EKS Infrastructure](site-docs/deployment/own-infra-eks.md)
 - [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md)
 - [Focused EKS MCP Pilot](site-docs/deployment/eks-mcp-pilot.md)
+- [Packaged API + UI Control Plane](site-docs/deployment/control-plane-helm.md)
 
 That means enterprises can run `agent-bom`:
 

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -1,0 +1,96 @@
+controlPlane:
+  enabled: true
+  api:
+    replicas: 2
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 6
+      targetCPUUtilizationPercentage: 70
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane
+  ui:
+    replicas: 2
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 70
+    env:
+      - name: NEXT_PUBLIC_API_URL
+        value: ""
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-internal
+    hosts:
+      - host: agent-bom.internal.example.com
+    tls:
+      - hosts:
+          - agent-bom.internal.example.com
+        secretName: agent-bom-control-plane-tls
+  externalSecrets:
+    enabled: true
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: aws-secrets-manager
+    target:
+      name: agent-bom-control-plane
+    data:
+      - secretKey: AGENT_BOM_POSTGRES_URL
+        remoteRef:
+          key: /agent-bom/prod/control-plane
+          property: AGENT_BOM_POSTGRES_URL
+      - secretKey: AGENT_BOM_OIDC_ISSUER
+        remoteRef:
+          key: /agent-bom/prod/control-plane
+          property: AGENT_BOM_OIDC_ISSUER
+      - secretKey: AGENT_BOM_OIDC_AUDIENCE
+        remoteRef:
+          key: /agent-bom/prod/control-plane
+          property: AGENT_BOM_OIDC_AUDIENCE
+      - secretKey: AGENT_BOM_AUDIT_HMAC_KEY
+        remoteRef:
+          key: /agent-bom/prod/control-plane
+          property: AGENT_BOM_AUDIT_HMAC_KEY
+      - secretKey: AGENT_BOM_REQUIRE_AUDIT_HMAC
+        remoteRef:
+          key: /agent-bom/prod/control-plane
+          property: AGENT_BOM_REQUIRE_AUDIT_HMAC
+
+scanner:
+  enabled: true
+  allNamespaces: true
+  extraArgs:
+    - --k8s-mcp
+    - --k8s-all-namespaces
+    - --introspect
+    - --enforce
+    - --preset
+    - enterprise
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-discovery
+
+topologySpread:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  restrictIngress: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-bom
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+
+pdb:
+  enabled: true
+  minAvailable: 1

--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -9,3 +9,4 @@ Enterprise pilot notes:
 - Label the namespace with Pod Security Admission restricted mode before applying sidecars:
   `kubectl label namespace {{ .Release.Namespace }} pod-security.kubernetes.io/enforce=restricted pod-security.kubernetes.io/audit=restricted pod-security.kubernetes.io/warn=restricted --overwrite`
 - The focused EKS pilot values lock ingress down; adjust `networkPolicy.ingress` if your ingress controller does not run in `ingress-nginx`.
+- For production operator defaults, start from `deploy/helm/agent-bom/examples/eks-production-values.yaml`.

--- a/deploy/helm/agent-bom/templates/_helpers.tpl
+++ b/deploy/helm/agent-bom/templates/_helpers.tpl
@@ -25,3 +25,30 @@ Service account name.
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Control-plane topology spread constraints.
+*/}}
+{{- define "agent-bom.controlPlaneTopologySpreadConstraints" -}}
+{{- if .Values.topologySpread.enabled }}
+topologySpreadConstraints:
+  {{- if .Values.topologySpread.zone.enabled }}
+  - maxSkew: 1
+    topologyKey: {{ .Values.topologySpread.zone.topologyKey }}
+    whenUnsatisfiable: {{ .Values.topologySpread.whenUnsatisfiable }}
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+        app.kubernetes.io/component: {{ .component }}
+  {{- end }}
+  {{- if .Values.topologySpread.node.enabled }}
+  - maxSkew: 1
+    topologyKey: {{ .Values.topologySpread.node.topologyKey }}
+    whenUnsatisfiable: {{ .Values.topologySpread.whenUnsatisfiable }}
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+        app.kubernetes.io/component: {{ .component }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- include "agent-bom.controlPlaneTopologySpreadConstraints" (dict "Values" .Values "component" "api" "Chart" .Chart "Release" .Release) | nindent 6 }}
       containers:
         - name: api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/helm/agent-bom/templates/controlplane-api-hpa.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.api.enabled .Values.controlPlane.api.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agent-bom.name" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agent-bom.name" . }}-api
+  minReplicas: {{ .Values.controlPlane.api.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controlPlane.api.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlane.api.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.controlPlane.api.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlane.api.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "agent-bom.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+spec:
+  refreshInterval: {{ .Values.controlPlane.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    kind: {{ .Values.controlPlane.externalSecrets.secretStoreRef.kind }}
+    name: {{ .Values.controlPlane.externalSecrets.secretStoreRef.name | quote }}
+  target:
+    name: {{ .Values.controlPlane.externalSecrets.target.name | quote }}
+    creationPolicy: {{ .Values.controlPlane.externalSecrets.target.creationPolicy }}
+  data:
+    {{- toYaml .Values.controlPlane.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-ui-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-ui-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- include "agent-bom.controlPlaneTopologySpreadConstraints" (dict "Values" .Values "component" "ui" "Chart" .Chart "Release" .Release) | nindent 6 }}
       containers:
         - name: ui
           image: "{{ .Values.uiImage.repository }}:{{ .Values.uiImage.tag }}"

--- a/deploy/helm/agent-bom/templates/controlplane-ui-hpa.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-ui-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.ui.enabled .Values.controlPlane.ui.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agent-bom.name" . }}-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agent-bom.name" . }}-ui
+  minReplicas: {{ .Values.controlPlane.ui.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controlPlane.ui.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlane.ui.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.controlPlane.ui.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controlPlane.ui.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -18,6 +18,15 @@ podAnnotations: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpread:
+  enabled: false
+  whenUnsatisfiable: ScheduleAnyway
+  zone:
+    enabled: true
+    topologyKey: topology.kubernetes.io/zone
+  node:
+    enabled: true
+    topologyKey: kubernetes.io/hostname
 
 scanner:
   enabled: true
@@ -59,6 +68,12 @@ controlPlane:
   api:
     enabled: true
     replicas: 2
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 6
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: null
     port: 8422
     args:
       - api
@@ -100,6 +115,12 @@ controlPlane:
   ui:
     enabled: true
     replicas: 2
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: null
     port: 3000
     env:
       - name: NEXT_PUBLIC_API_URL
@@ -157,6 +178,16 @@ controlPlane:
           - path: /
             pathType: Prefix
     tls: []
+  externalSecrets:
+    enabled: false
+    refreshInterval: 1h
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: ""
+    target:
+      name: agent-bom-control-plane
+      creationPolicy: Owner
+    data: []
 
 rbac:
   create: true

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -11,6 +11,7 @@ This is the right path when you want:
 - Postgres, ClickHouse, OIDC, and secrets kept in your own environment
 - the scanner CronJob and optional runtime monitor packaged alongside the
   control plane
+- production operator defaults without pretending there is a managed vendor plane
 
 ## What the chart deploys
 
@@ -112,6 +113,20 @@ helm install agent-bom deploy/helm/agent-bom \
   -f values.agent-bom.yaml
 ```
 
+## Production defaults example
+
+For the stronger self-hosted operator path, start from:
+
+- [deploy/helm/agent-bom/examples/eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+
+That example adds:
+
+- `HPA` for API and UI
+- topology spread across zones and nodes
+- `cert-manager` ingress annotations and TLS wiring
+- `external-secrets` integration for the control-plane secret
+- restricted ingress defaults for the chart network policy
+
 ## What you still own
 
 This is a real packaged control plane, but not a magic managed service.
@@ -121,7 +136,7 @@ You still own:
 - Postgres and optional ClickHouse
 - ingress controller and TLS
 - OIDC provider configuration or API key secret management
-- HPA, topology spread, and cluster-specific scaling policy
+- cluster-specific autoscaling thresholds and failure-domain policy
 - operator runbooks and load testing
 
 ## Production guidance
@@ -131,6 +146,8 @@ You still own:
 - run Alembic for long-lived Postgres control planes:
   - `alembic -c deploy/supabase/postgres/alembic.ini upgrade head`
   - existing `init.sql` databases should be stamped once with `20260416_01`
+- enable the control-plane HPAs before higher-volume rollout
+- enable topology spread when you run multi-AZ EKS
 - keep same-origin ingress unless you have a strong reason not to
 - use `envFrom` / Secrets for `AGENT_BOM_POSTGRES_URL`, API keys, OIDC issuer,
   audience, optional required nonce, and audit HMAC settings
@@ -141,7 +158,7 @@ You still own:
 The chart now packages the control plane honestly, but it still does not claim:
 
 - a bundled Postgres subchart
-- built-in autoscaling or benchmarked throughput guarantees
+- benchmarked throughput guarantees
 - completed auth hardening beyond the currently shipped server contract
 
 Those are the next operator-hardening layers, not hidden assumptions.

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -62,6 +62,7 @@ For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).
 | Keep the runtime isolated | Docker |
 | Self-host UI + API for a team | `agent-bom serve` + `Postgres` / `Supabase` |
 | Run a focused MCP / agents / fleet pilot on EKS | Helm control plane + scanner CronJob + selected proxy sidecars |
+| Run a production-shaped self-hosted control plane on EKS | Helm control plane + production values example + Postgres + external-secrets |
 | Integrate with internal platforms | `agent-bom api` |
 | Expose agent-bom as a tool server | `agent-bom mcp server` |
 | Add runtime enforcement | `agent-bom proxy` |
@@ -76,6 +77,7 @@ buyers, use the consolidated guide:
 - [Enterprise MCP / Endpoint Fleet Pilot](enterprise-pilot.md)
 - [Endpoint Fleet](endpoint-fleet.md)
 - [Focused EKS MCP Pilot](eks-mcp-pilot.md)
+- [Packaged API + UI Control Plane](control-plane-helm.md)
 
 ## Available on
 

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -95,6 +95,10 @@ The chart now supports the EKS wiring you actually need:
 | `controlPlane.api.envFrom` | load Postgres URL, API key, OIDC issuer/audience, optional required nonce, and audit settings from Secrets |
 | `controlPlane.ui.env` | keep `NEXT_PUBLIC_API_URL=\"\"` for same-origin or set a full API URL for cross-origin |
 | `serviceAccount.annotations` | attach an IRSA role to the scanner service account |
+| `controlPlane.api.autoscaling.*` | autoscale the API deployment with HPA |
+| `controlPlane.ui.autoscaling.*` | autoscale the UI deployment with HPA |
+| `topologySpread.*` | spread API and UI replicas across zones and nodes |
+| `controlPlane.externalSecrets.*` | map control-plane env vars from external-secrets |
 | `scanner.extraArgs` | add `--k8s-mcp`, `--enforce`, `--introspect`, or stricter presets |
 | `scanner.env` | inject operator-owned environment like API endpoints or auth context |
 | `scanner.allNamespaces` | scan cluster-wide instead of one namespace |
@@ -162,6 +166,9 @@ all sit under one operator-controlled plane.
 
 - use `Postgres`, not SQLite, for the control plane
 - use Alembic as the migration path for long-lived Postgres control planes
+- start from the production values example when you want HPA, cert-manager,
+  topology spread, and external-secrets wiring:
+  - [deploy/helm/agent-bom/examples/eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
 - keep the proxy and API internal to your VPC unless exposure is intentional
 - use OIDC for user access, set `AGENT_BOM_OIDC_AUDIENCE` explicitly, and map roles explicitly
 - set a persistent audit HMAC key and require it

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -165,9 +165,11 @@ def test_helm_values_yaml_keys():
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
     expected_keys = {
         "image",
+        "uiImage",
         "runtimeImage",
         "scanner",
         "monitor",
+        "controlPlane",
         "rbac",
         "serviceAccount",
         "resources",
@@ -178,6 +180,7 @@ def test_helm_values_yaml_keys():
         "startupProbe",
         "networkPolicy",
         "pdb",
+        "topologySpread",
     }
     assert expected_keys.issubset(set(doc.keys()))
 
@@ -187,6 +190,15 @@ def test_helm_templates_exist():
     templates_dir = HELM_DIR / "templates"
     expected = {
         "_helpers.tpl",
+        "controlplane-api-deployment.yaml",
+        "controlplane-api-hpa.yaml",
+        "controlplane-api-service.yaml",
+        "controlplane-externalsecret.yaml",
+        "controlplane-ingress.yaml",
+        "controlplane-pdb.yaml",
+        "controlplane-ui-deployment.yaml",
+        "controlplane-ui-hpa.yaml",
+        "controlplane-ui-service.yaml",
         "serviceaccount.yaml",
         "rbac.yaml",
         "cronjob.yaml",
@@ -207,6 +219,38 @@ def test_helm_scanner_defaults():
     assert scanner["enabled"] is True
     assert scanner["allNamespaces"] is True
     assert "schedule" in scanner
+
+
+def test_helm_control_plane_autoscaling_defaults():
+    """Control plane ships explicit HPA defaults without enabling autoscaling by default."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    api = doc["controlPlane"]["api"]["autoscaling"]
+    ui = doc["controlPlane"]["ui"]["autoscaling"]
+    assert api["enabled"] is False
+    assert api["minReplicas"] == 2
+    assert api["maxReplicas"] == 6
+    assert api["targetCPUUtilizationPercentage"] == 70
+    assert ui["enabled"] is False
+    assert ui["minReplicas"] == 2
+    assert ui["maxReplicas"] == 4
+
+
+def test_helm_topology_spread_defaults():
+    """Topology spread knobs are explicit for production operators."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    spread = doc["topologySpread"]
+    assert spread["enabled"] is False
+    assert spread["zone"]["enabled"] is True
+    assert spread["node"]["enabled"] is True
+
+
+def test_helm_external_secrets_defaults():
+    """External secrets support is packaged but disabled by default."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    ext = doc["controlPlane"]["externalSecrets"]
+    assert ext["enabled"] is False
+    assert ext["secretStoreRef"]["kind"] == "ClusterSecretStore"
+    assert ext["target"]["name"] == "agent-bom-control-plane"
 
 
 def test_helm_monitor_disabled_by_default():
@@ -266,3 +310,14 @@ def test_pilot_values_restrict_ingress():
     assert policy["enabled"] is True
     assert policy["restrictIngress"] is True
     assert len(policy["ingress"]) >= 2
+
+
+def test_production_values_enable_operator_defaults():
+    """Production example should turn on the packaged operator defaults."""
+    production = yaml.safe_load((HELM_DIR / "examples" / "eks-production-values.yaml").read_text())
+    assert production["controlPlane"]["api"]["autoscaling"]["enabled"] is True
+    assert production["controlPlane"]["ui"]["autoscaling"]["enabled"] is True
+    assert production["controlPlane"]["externalSecrets"]["enabled"] is True
+    assert production["topologySpread"]["enabled"] is True
+    assert production["networkPolicy"]["restrictIngress"] is True
+    assert "cert-manager.io/cluster-issuer" in production["controlPlane"]["ingress"]["annotations"]


### PR DESCRIPTION
## Summary
- add packaged production operator defaults for the Helm control plane: API/UI HPA templates, topology spread support, and external-secrets wiring
- add a production EKS values example with cert-manager annotations, TLS, restricted ingress, and secret-manager driven control-plane env
- update the operator docs and manifest tests so the production self-host path is explicit and validated

## Testing
- uv run pytest -q tests/test_deploy_manifests.py
- uv run ruff check tests/test_deploy_manifests.py
- git diff --check