### PR TITLE
Publish enterprise scale guidance and benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ operator guide:
 - [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md)
 - [Focused EKS MCP Pilot](site-docs/deployment/eks-mcp-pilot.md)
 - [Packaged API + UI Control Plane](site-docs/deployment/control-plane-helm.md)
+- [Performance, Sizing, and Benchmarks](site-docs/deployment/performance-and-sizing.md)
 
 That means enterprises can run `agent-bom`:
 

--- a/deploy/loadtest/README.md
+++ b/deploy/loadtest/README.md
@@ -1,0 +1,77 @@
+# Load-test harness
+
+These scripts are a compact validation harness for self-hosted `agent-bom`
+deployments. They are not a full benchmark lab. They exercise the real
+control-plane and proxy-ingest paths that matter for enterprise rollout.
+
+## What is covered
+
+- control-plane API health and authenticated fleet reads
+- proxy audit ingest writes
+
+## Prerequisites
+
+- `k6` installed locally or in your CI runner
+- a reachable `agent-bom` control plane
+- an API token with access to the paths you are testing
+
+Set:
+
+```bash
+export AGENT_BOM_BASE_URL=https://agent-bom.internal.example.com
+export AGENT_BOM_API_TOKEN=replace-me
+```
+
+## Control-plane API baseline
+
+```bash
+k6 run deploy/loadtest/k6-control-plane-api.js
+```
+
+Optional overrides:
+
+- `AGENT_BOM_BASE_URL`
+- `AGENT_BOM_API_TOKEN`
+- `K6_VUS`
+- `K6_DURATION`
+
+What it hits:
+
+- `GET /health`
+- `GET /v1/fleet`
+- `GET /v1/fleet/stats`
+
+## Proxy audit ingest baseline
+
+```bash
+k6 run deploy/loadtest/k6-proxy-audit.js
+```
+
+Optional overrides:
+
+- `AGENT_BOM_BASE_URL`
+- `AGENT_BOM_API_TOKEN`
+- `K6_VUS`
+- `K6_DURATION`
+- `AGENT_BOM_PROXY_ALERT_BATCH`
+
+What it hits:
+
+- `POST /v1/proxy/audit`
+
+## How to use the results
+
+Use these runs to answer four operator questions:
+
+1. Are API replicas sized correctly for steady-state reads?
+2. Does proxy audit ingest stay healthy under expected concurrency?
+3. At what point should `HPA` thresholds be widened?
+4. At what point should analytics move from `Postgres`-only to
+   `Postgres + ClickHouse`?
+
+Do not treat one green run as a certification. Re-run after:
+
+- changing replica counts
+- enabling `HPA`
+- changing storage backends
+- widening endpoint or proxy rollout

--- a/deploy/loadtest/k6-control-plane-api.js
+++ b/deploy/loadtest/k6-control-plane-api.js
@@ -1,0 +1,43 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const baseUrl = (__ENV.AGENT_BOM_BASE_URL || "http://127.0.0.1:8422").replace(/\/$/, "");
+const token = __ENV.AGENT_BOM_API_TOKEN || "";
+
+export const options = {
+  vus: Number(__ENV.K6_VUS || 10),
+  duration: __ENV.K6_DURATION || "60s",
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<1000"],
+  },
+};
+
+function authHeaders() {
+  const headers = { Accept: "application/json" };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export default function () {
+  const health = http.get(`${baseUrl}/health`, { headers: authHeaders() });
+  check(health, {
+    "health returns 200": (r) => r.status === 200,
+  });
+
+  if (token) {
+    const fleet = http.get(`${baseUrl}/v1/fleet?limit=25`, { headers: authHeaders() });
+    check(fleet, {
+      "fleet returns 200": (r) => r.status === 200,
+    });
+
+    const stats = http.get(`${baseUrl}/v1/fleet/stats`, { headers: authHeaders() });
+    check(stats, {
+      "fleet stats returns 200": (r) => r.status === 200,
+    });
+  }
+
+  sleep(1);
+}

--- a/deploy/loadtest/k6-proxy-audit.js
+++ b/deploy/loadtest/k6-proxy-audit.js
@@ -1,0 +1,66 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const baseUrl = (__ENV.AGENT_BOM_BASE_URL || "http://127.0.0.1:8422").replace(/\/$/, "");
+const token = __ENV.AGENT_BOM_API_TOKEN || "";
+const batchSize = Number(__ENV.AGENT_BOM_PROXY_ALERT_BATCH || 10);
+
+export const options = {
+  vus: Number(__ENV.K6_VUS || 10),
+  duration: __ENV.K6_DURATION || "60s",
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<1000"],
+  },
+};
+
+function authHeaders() {
+  const headers = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+function buildAlerts() {
+  const alerts = [];
+  const now = new Date().toISOString();
+  for (let i = 0; i < batchSize; i += 1) {
+    alerts.push({
+      type: "runtime_alert",
+      ts: now,
+      detector: "rate_limit",
+      severity: "medium",
+      message: `synthetic benchmark alert ${i}`,
+      details: {
+        action: "warned",
+        tool_name: "filesystem.read_file",
+      },
+    });
+  }
+  return alerts;
+}
+
+export default function () {
+  const payload = JSON.stringify({
+    source_id: `k6-${__VU}`,
+    session_id: `bench-${__ITER}`,
+    alerts: buildAlerts(),
+    summary: {
+      total_alerts: batchSize,
+      blocked_alerts: 0,
+      alerts_by_detector: { rate_limit: batchSize },
+      alerts_by_severity: { medium: batchSize },
+    },
+  });
+
+  const response = http.post(`${baseUrl}/v1/proxy/audit`, payload, { headers: authHeaders() });
+  check(response, {
+    "proxy audit returns 200": (r) => r.status === 200,
+  });
+
+  sleep(1);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
+      - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Backend Parity: deployment/backend-parity.md
       - Docker: deployment/docker.md
       - Kubernetes: deployment/kubernetes.md

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -118,6 +118,7 @@ helm install agent-bom deploy/helm/agent-bom \
 For the stronger self-hosted operator path, start from:
 
 - [deploy/helm/agent-bom/examples/eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+- [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
 
 That example adds:
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -108,6 +108,9 @@ sequenceDiagram
 - ClickHouse is available when pilot volume grows beyond what Postgres should carry for analytics
 - sidecar proxy rollout stays workload-by-workload instead of forcing universal inline routing
 
+For concrete sizing, autoscaling, and load-test guidance, use
+[Performance, Sizing, and Benchmarks](performance-and-sizing.md).
+
 ## Required rollout steps
 
 1. Run Postgres migrations.

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -78,6 +78,7 @@ buyers, use the consolidated guide:
 - [Endpoint Fleet](endpoint-fleet.md)
 - [Focused EKS MCP Pilot](eks-mcp-pilot.md)
 - [Packaged API + UI Control Plane](control-plane-helm.md)
+- [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
 
 ## Available on
 

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -1,0 +1,194 @@
+# Performance, Sizing, and Benchmarks
+
+This guide is the operator-facing follow-up to the packaged Helm control plane
+and enterprise pilot docs. It does not promise fixed throughput numbers the
+repo has not published. It gives a defensible starting point for sizing,
+autoscaling, and validating a self-hosted `agent-bom` deployment in EKS.
+
+## What this guide covers
+
+- control-plane API and UI sizing
+- endpoint-fleet and proxy-audit growth boundaries
+- when to keep analytics in `Postgres` and when to turn on `ClickHouse`
+- what to load test before calling the deployment production-ready
+
+## Reference topology
+
+```mermaid
+flowchart LR
+    subgraph EndpointFleet["Endpoint fleet"]
+      Endpoints["Employee laptops<br/>agent-bom agents --push-url ..."]
+      EndpointProxy["Local agent-bom proxy<br/>(selected employees)"]
+    end
+
+    subgraph EKS["EKS control plane"]
+      Ingress["Ingress / TLS"]
+      API["API Deployment<br/>2+ replicas"]
+      UI["UI Deployment<br/>2+ replicas"]
+      Scanner["Scanner CronJob"]
+      RuntimeProxy["Selected MCP sidecars"]
+    end
+
+    subgraph Data["Persistence"]
+      PG["Postgres"]
+      CH["ClickHouse optional"]
+    end
+
+    Endpoints --> API
+    EndpointProxy --> API
+    RuntimeProxy --> API
+    Scanner --> API
+    Ingress --> UI
+    Ingress --> API
+    API --> PG
+    API --> CH
+```
+
+## Starting point by deployment size
+
+These are starting bands, not SLA guarantees. Use them to choose the right
+backend and Helm values before running your own load tests.
+
+| Shape | Typical use | Recommended path |
+|---|---|---|
+| Small team | up to ~250 endpoints, selected proxy sidecars, low audit retention needs | `Postgres` only, 2 API replicas, 2 UI replicas, no `ClickHouse` |
+| Initial enterprise pilot | ~250-2,000 endpoints, scheduled endpoint sync, selected runtime sidecars, retained proxy audit | `Postgres`, packaged `HPA`, topology spread, internal ingress, add `ClickHouse` only if audit/query latency grows |
+| Broader rollout | 2,000+ endpoints or sustained high-volume proxy audit/event analytics | `Postgres` for transactional state plus `ClickHouse` for analytics, explicit retention policy, benchmark before rollout |
+
+## Control-plane sizing guidance
+
+Start from the packaged production example:
+
+- [eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+
+That example already enables:
+
+- API and UI `HPA`
+- topology spread
+- `external-secrets`
+- `cert-manager`-friendly ingress annotations
+- restricted ingress policy
+
+### API
+
+Current chart defaults in [values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/values.yaml):
+
+- replicas: `2`
+- requests: `100m` CPU / `256Mi` memory
+- limits: `1000m` CPU / `1Gi` memory
+- `HPA` packaged but off by default
+
+Recommended production operator posture:
+
+- keep `2` replicas as the minimum steady-state floor
+- enable the shipped API `HPA` before larger endpoint or proxy rollouts
+- raise requests before raising limits when sustained CPU stays above `70%`
+- keep the API same-origin behind one ingress hostname unless you have a
+  strong reason to split UI and API
+
+### UI
+
+Current chart defaults:
+
+- replicas: `2`
+- requests: `100m` CPU / `128Mi` memory
+- limits: `500m` CPU / `512Mi` memory
+
+Recommended posture:
+
+- keep `2` replicas for zone and node failure tolerance
+- enable the shipped UI `HPA` for heavier internal usage or dashboard-heavy
+  SOC workflows
+- scale UI based on browser concurrency, not endpoint count alone
+
+### Scanner CronJob
+
+The scanner is batch-oriented. The main knobs are:
+
+- schedule frequency
+- namespace scope
+- `--introspect`
+- `--enforce`
+
+If scans begin overlapping, do not immediately add more control-plane replicas.
+First widen the CronJob interval, split scope, or reduce introspection scope for
+the rollout phase.
+
+## Postgres vs ClickHouse
+
+Use `Postgres` as the source of truth for:
+
+- fleet and policy state
+- RBAC and tenant-scoped reads
+- audit and control-plane writes
+- scheduler coordination
+
+Turn on `ClickHouse` when analytics starts behaving like analytics rather than
+control-plane state:
+
+- large retained proxy audit history
+- heavy dashboard trend queries
+- many endpoints with long retention windows
+- event-style workloads where write buffering matters more than relational reads
+
+Do not move the transactional control plane out of `Postgres` just because
+analytics volume grows. The intended shape is:
+
+- `Postgres` for the control plane
+- `ClickHouse` for optional analytics scale-out
+
+## Operational thresholds to watch
+
+Watch these before widening rollout:
+
+- API `p95` latency on authenticated reads and writes
+- Postgres CPU, memory, and connection pressure
+- scanner run duration versus schedule interval
+- proxy audit ingest rate and retained volume
+- UI response time under simultaneous SOC usage
+
+If any of these fail first:
+
+- API CPU saturation: increase API requests and enable or widen the API `HPA`
+- Postgres pressure: tune connection pool, size the database, and move
+  analytics-heavy reads toward `ClickHouse`
+- overlapping scans: lengthen schedule or split scope
+- audit query drag: add retention boundaries and move analytics to `ClickHouse`
+
+## Benchmark before production rollout
+
+The repo now ships a small benchmark harness under:
+
+- [deploy/loadtest/README.md](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/loadtest/README.md)
+- [k6-control-plane-api.js](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/loadtest/k6-control-plane-api.js)
+- [k6-proxy-audit.js](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/loadtest/k6-proxy-audit.js)
+
+Use that harness to validate:
+
+1. authenticated control-plane read paths
+2. proxy audit ingest write paths
+3. scaling behavior after enabling `HPA`
+4. the point where analytics should move to `ClickHouse`
+
+## Minimal benchmark checklist
+
+Run these in your own environment before broader rollout:
+
+1. Baseline the API with the control-plane script at low and medium concurrency.
+2. Baseline proxy audit ingest with realistic batch sizes.
+3. Repeat both runs with `HPA` enabled.
+4. Repeat with `ClickHouse` disabled, then enabled if your rollout expects high
+   retained analytics volume.
+5. Record your chosen replica floor, resource requests, and retention policy in
+   your operator runbook.
+
+## Current boundary
+
+`agent-bom` now ships the packaged control plane, pilot path, and operator
+defaults. What it still does not claim is:
+
+- fixed throughput guarantees
+- a bundled benchmark certification suite
+- a managed control plane that hides storage or scaling choices from the buyer
+
+Those choices stay explicit, which is why the self-hosted story remains honest.

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -10,6 +10,7 @@ DEPLOY_DIR = Path(__file__).parent.parent / "deploy"
 K8S_DIR = DEPLOY_DIR / "k8s"
 HELM_DIR = DEPLOY_DIR / "helm" / "agent-bom"
 ENDPOINTS_DIR = DEPLOY_DIR / "endpoints"
+LOADTEST_DIR = DEPLOY_DIR / "loadtest"
 
 
 # ─── K8s manifest validation ────────────────────────────────────────────────
@@ -130,6 +131,27 @@ def test_endpoint_fleet_templates_exist():
     }
     actual = {path.name for path in ENDPOINTS_DIR.iterdir() if path.is_file()}
     assert expected.issubset(actual)
+
+
+def test_loadtest_harness_assets_exist():
+    """Self-hosted operator load-test assets should ship with the repo."""
+    expected = {
+        "README.md",
+        "k6-control-plane-api.js",
+        "k6-proxy-audit.js",
+    }
+    actual = {path.name for path in LOADTEST_DIR.iterdir() if path.is_file()}
+    assert expected.issubset(actual)
+
+
+def test_loadtest_scripts_target_real_endpoints():
+    """k6 scripts should exercise the real shipped API and proxy paths."""
+    control_plane = (LOADTEST_DIR / "k6-control-plane-api.js").read_text()
+    proxy_audit = (LOADTEST_DIR / "k6-proxy-audit.js").read_text()
+    assert "/health" in control_plane
+    assert "/v1/fleet" in control_plane
+    assert "/v1/fleet/stats" in control_plane
+    assert "/v1/proxy/audit" in proxy_audit
 
 
 def test_namespace_manifest():


### PR DESCRIPTION
## Summary
- add a canonical performance, sizing, and benchmark guide for self-hosted enterprise deployments
- ship a small k6-based load-test harness for control-plane API reads and proxy audit ingest
- link the new guidance from the packaged control-plane, pilot, overview, README, and regression tests

## Validation
- uv run pytest -q tests/test_deploy_manifests.py
- git diff --check