### PR TITLE
Harden pilot rate limiting and control-plane HA

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
@@ -50,3 +50,11 @@ networkPolicy:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+      ports:
+        - protocol: TCP
+          port: 8422
+        - protocol: TCP
+          port: 3000

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -1,12 +1,23 @@
 controlPlane:
   enabled: true
+  podAntiAffinity:
+    enabled: true
+  priorityClass:
+    create: true
+    name: agent-bom-control-plane
   api:
     replicas: 2
+    env:
+      - name: AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT
+        value: "1"
     autoscaling:
       enabled: true
       minReplicas: 2
       maxReplicas: 6
       targetCPUUtilizationPercentage: 70
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
     envFrom:
       - secretRef:
           name: agent-bom-control-plane
@@ -17,6 +28,9 @@ controlPlane:
       minReplicas: 2
       maxReplicas: 4
       targetCPUUtilizationPercentage: 70
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
     env:
       - name: NEXT_PUBLIC_API_URL
         value: ""
@@ -33,6 +47,7 @@ controlPlane:
         secretName: agent-bom-control-plane-tls
   externalSecrets:
     enabled: true
+    refreshInterval: 5m
     secretStoreRef:
       kind: ClusterSecretStore
       name: aws-secrets-manager
@@ -90,6 +105,14 @@ networkPolicy:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+      ports:
+        - protocol: TCP
+          port: 8422
+        - protocol: TCP
+          port: 3000
 
 pdb:
   enabled: true

--- a/deploy/helm/agent-bom/templates/_helpers.tpl
+++ b/deploy/helm/agent-bom/templates/_helpers.tpl
@@ -27,6 +27,40 @@ Service account name.
 {{- end }}
 
 {{/*
+Control-plane affinity helper. If the operator provides a full affinity block,
+use it verbatim. Otherwise, optionally emit preferred pod anti-affinity so API
+and UI replicas avoid co-location on the same node.
+*/}}
+{{- define "agent-bom.controlPlaneAffinity" -}}
+{{- if .Values.affinity }}
+affinity:
+  {{- toYaml .Values.affinity | nindent 2 }}
+{{- else if .Values.controlPlane.podAntiAffinity.enabled }}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: {{ .Values.controlPlane.podAntiAffinity.topologyKey }}
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+              app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolved PriorityClass name for control-plane workloads.
+*/}}
+{{- define "agent-bom.controlPlanePriorityClassName" -}}
+{{- if .Values.controlPlane.priorityClass.create -}}
+{{- default (printf "%s-control-plane" (include "agent-bom.name" .)) .Values.controlPlane.priorityClass.name -}}
+{{- else -}}
+{{- .Values.controlPlane.priorityClass.name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Control-plane topology spread constraints.
 */}}
 {{- define "agent-bom.controlPlaneTopologySpreadConstraints" -}}

--- a/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- $priorityClassName := include "agent-bom.controlPlanePriorityClassName" . }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -31,6 +35,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- include "agent-bom.controlPlaneTopologySpreadConstraints" (dict "Values" .Values "component" "api" "Chart" .Chart "Release" .Release) | nindent 6 }}
+      {{- include "agent-bom.controlPlaneAffinity" (dict "Values" .Values "component" "api" "Chart" .Chart "Release" .Release) | nindent 6 }}
       containers:
         - name: api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -63,10 +68,6 @@ spec:
             {{- toYaml .Values.controlPlane.api.startupProbe | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}

--- a/deploy/helm/agent-bom/templates/controlplane-api-hpa.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-hpa.yaml
@@ -14,6 +14,10 @@ spec:
     name: {{ include "agent-bom.name" . }}-api
   minReplicas: {{ .Values.controlPlane.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controlPlane.api.autoscaling.maxReplicas }}
+  {{- with .Values.controlPlane.api.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
     - type: Resource
       resource:

--- a/deploy/helm/agent-bom/templates/controlplane-priorityclass.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-priorityclass.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.priorityClass.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "agent-bom.controlPlanePriorityClassName" . }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+value: {{ .Values.controlPlane.priorityClass.value }}
+preemptionPolicy: {{ .Values.controlPlane.priorityClass.preemptionPolicy }}
+globalDefault: false
+description: {{ .Values.controlPlane.priorityClass.description | quote }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-ui-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-ui-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- $priorityClassName := include "agent-bom.controlPlanePriorityClassName" . }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -31,6 +35,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- include "agent-bom.controlPlaneTopologySpreadConstraints" (dict "Values" .Values "component" "ui" "Chart" .Chart "Release" .Release) | nindent 6 }}
+      {{- include "agent-bom.controlPlaneAffinity" (dict "Values" .Values "component" "ui" "Chart" .Chart "Release" .Release) | nindent 6 }}
       containers:
         - name: ui
           image: "{{ .Values.uiImage.repository }}:{{ .Values.uiImage.tag }}"
@@ -59,10 +64,6 @@ spec:
             {{- toYaml .Values.controlPlane.ui.startupProbe | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}

--- a/deploy/helm/agent-bom/templates/controlplane-ui-hpa.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-ui-hpa.yaml
@@ -14,6 +14,10 @@ spec:
     name: {{ include "agent-bom.name" . }}-ui
   minReplicas: {{ .Values.controlPlane.ui.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controlPlane.ui.autoscaling.maxReplicas }}
+  {{- with .Values.controlPlane.ui.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
     - type: Resource
       resource:

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -65,6 +65,15 @@ monitor:
 
 controlPlane:
   enabled: false
+  podAntiAffinity:
+    enabled: false
+    topologyKey: kubernetes.io/hostname
+  priorityClass:
+    create: false
+    name: ""
+    value: 100000
+    preemptionPolicy: PreemptLowerPriority
+    description: "Priority class for agent-bom control-plane API and UI workloads."
   api:
     enabled: true
     replicas: 2
@@ -74,6 +83,7 @@ controlPlane:
       maxReplicas: 6
       targetCPUUtilizationPercentage: 70
       targetMemoryUtilizationPercentage: null
+      behavior: {}
     port: 8422
     args:
       - api
@@ -121,6 +131,7 @@ controlPlane:
       maxReplicas: 4
       targetCPUUtilizationPercentage: 70
       targetMemoryUtilizationPercentage: null
+      behavior: {}
     port: 3000
     env:
       - name: NEXT_PUBLIC_API_URL

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -122,7 +122,11 @@ For the stronger self-hosted operator path, start from:
 That example adds:
 
 - `HPA` for API and UI
+- `HPA` scale-down stabilization
 - topology spread across zones and nodes
+- preferred pod anti-affinity for API and UI replicas
+- optional control-plane `PriorityClass`
+- fail-closed shared rate limiting when the Postgres-backed limiter is unavailable
 - `cert-manager` ingress annotations and TLS wiring
 - `external-secrets` integration for the control-plane secret
 - restricted ingress defaults for the chart network policy
@@ -147,10 +151,13 @@ You still own:
   - `alembic -c deploy/supabase/postgres/alembic.ini upgrade head`
   - existing `init.sql` databases should be stamped once with `20260416_01`
 - enable the control-plane HPAs before higher-volume rollout
+- use anti-affinity and a control-plane `PriorityClass` when you expect node pressure
 - enable topology spread when you run multi-AZ EKS
 - keep same-origin ingress unless you have a strong reason not to
 - use `envFrom` / Secrets for `AGENT_BOM_POSTGRES_URL`, API keys, OIDC issuer,
   audience, optional required nonce, and audit HMAC settings
+- set `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1` for multi-replica production
+  control planes so the API refuses to start if the shared limiter backend is unavailable
 - enable PDBs when you are running multi-replica workloads
 
 ## Current boundary

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import secrets
 import sys
 import time
 import uuid
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from agent_bom import __version__
@@ -23,6 +25,7 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp
 
 _logger = logging.getLogger(__name__)
+_RATE_LIMIT_FINGERPRINT_FALLBACK = secrets.token_bytes(32)
 
 
 class InMemoryRateLimitStore:
@@ -44,7 +47,15 @@ class InMemoryRateLimitStore:
         for k in stale:
             del self._hits[k]
         if len(self._hits) > self._MAX_ENTRIES:
-            self._hits.clear()
+            overflow = len(self._hits) - self._MAX_ENTRIES
+            oldest_keys = sorted(self._hits, key=lambda key: self._hits[key][-1] if self._hits[key] else 0.0)[:overflow]
+            for key in oldest_keys:
+                del self._hits[key]
+            _logger.warning(
+                "In-memory rate limiter pruned %s oldest buckets to stay under %s entries",
+                overflow,
+                self._MAX_ENTRIES,
+            )
 
     def hit(self, key: str, now: float) -> tuple[int, int]:
         """Record a request and return (hit_count, reset_epoch)."""
@@ -380,17 +391,33 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             try:
                 return PostgresRateLimitStore(window_seconds=self._window)
             except Exception:
+                if _env_flag("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT"):
+                    raise RuntimeError("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1 but Postgres rate limiter could not initialize") from None
                 _logger.warning("Postgres rate limiter unavailable, falling back to in-memory store", exc_info=True)
         return InMemoryRateLimitStore(window_seconds=self._window)
 
+    def _bucket_key(self, request: StarletteRequest, is_scan: bool) -> str:
+        bucket_type = "scan" if is_scan else "read"
+        tenant_id = getattr(request.state, "tenant_id", "").strip() or None
+        auth = request.headers.get("authorization", "")
+        raw_key = auth[7:] if auth.startswith("Bearer ") else request.headers.get("x-api-key", "")
+        if raw_key:
+            auth_hash = _rate_limit_fingerprint(raw_key)
+            scope = f"auth:{auth_hash}"
+        else:
+            client_ip = request.client.host if request.client else "unknown"
+            scope = f"ip:{client_ip}"
+        if tenant_id and tenant_id != "default":
+            scope = f"tenant:{tenant_id}:{scope}"
+        return f"{scope}:{bucket_type}"
+
     async def dispatch(self, request: StarletteRequest, call_next):
-        client_ip = request.client.host if request.client else "unknown"
         now = time.time()
 
         is_scan = request.url.path.startswith("/v1/scan") and request.method == "POST"
         limit = self._scan_rpm if is_scan else self._read_rpm
 
-        key = f"{client_ip}:{'scan' if is_scan else 'read'}"
+        key = self._bucket_key(request, is_scan)
         hit_count, reset_at = await asyncio.to_thread(self._store.hit, key, now)
         remaining = max(0, limit - hit_count)
 
@@ -412,6 +439,26 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         response.headers["X-RateLimit-Remaining"] = str(remaining)
         response.headers["X-RateLimit-Reset"] = str(reset_at)
         return response
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _rate_limit_fingerprint_key() -> bytes:
+    key = (os.environ.get("AGENT_BOM_RATE_LIMIT_KEY") or os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") or "").strip()
+    return key.encode() if key else _RATE_LIMIT_FINGERPRINT_FALLBACK
+
+
+@lru_cache(maxsize=4096)
+def _rate_limit_fingerprint(raw_key: str) -> str:
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        raw_key.encode(),
+        _rate_limit_fingerprint_key(),
+        200_000,
+        dklen=8,
+    ).hex()
 
 
 class MaxBodySizeMiddleware(BaseHTTPMiddleware):

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -1,10 +1,12 @@
 """Tests for API server hardening — auth, rate limiting, CORS, body size."""
 
+import time
 from unittest.mock import MagicMock, patch
 
 from starlette.testclient import TestClient
 
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
+from agent_bom.api.middleware import InMemoryRateLimitStore
 from agent_bom.api.oidc import OIDCConfig
 from agent_bom.api.server import (
     APIKeyMiddleware,
@@ -271,6 +273,61 @@ def test_rate_limit_middleware_falls_back_when_postgres_store_unavailable(monkey
         resp = client.get("/v1/test")
 
     assert resp.status_code == 200
+
+
+def test_rate_limit_middleware_can_fail_closed_when_shared_store_required(monkeypatch):
+    """Production-style deployments should be able to refuse startup without shared limiter state."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://example/test")
+    monkeypatch.setenv("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT", "1")
+    with patch("agent_bom.api.middleware.PostgresRateLimitStore", side_effect=RuntimeError("boom")):
+        test_app = Starlette(routes=[Route("/v1/test", dummy)])
+        test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=10)
+        client = TestClient(test_app)
+        try:
+            client.get("/v1/test")
+            raise AssertionError("expected shared rate-limit initialization to fail")
+        except RuntimeError as exc:
+            assert "AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT" in str(exc)
+
+
+def test_rate_limit_middleware_scopes_by_auth_credential():
+    """Different API credentials behind one shared IP should not starve each other."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=2)
+
+    client = TestClient(test_app)
+    assert client.get("/v1/test", headers={"X-API-Key": "alpha"}).status_code == 200
+    assert client.get("/v1/test", headers={"X-API-Key": "alpha"}).status_code == 200
+    assert client.get("/v1/test", headers={"X-API-Key": "beta"}).status_code == 200
+
+
+def test_in_memory_rate_limit_store_prunes_oldest_entries_instead_of_clearing_all():
+    """Overflow should evict oldest buckets, not reset every limiter bucket at once."""
+    store = InMemoryRateLimitStore(window_seconds=60)
+    now = time.time()
+    store._hits = {f"bucket-{idx}": [now - 1] for idx in range(store._MAX_ENTRIES)}
+    store._hits["important"] = [now - 1]
+    store._last_cleanup = 0
+
+    count, _ = store.hit("important", now)
+
+    assert count == 2
+    assert "important" in store._hits
+    assert len(store._hits) <= store._MAX_ENTRIES
 
 
 def test_max_body_size_middleware():

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -196,6 +196,7 @@ def test_helm_templates_exist():
         "controlplane-externalsecret.yaml",
         "controlplane-ingress.yaml",
         "controlplane-pdb.yaml",
+        "controlplane-priorityclass.yaml",
         "controlplane-ui-deployment.yaml",
         "controlplane-ui-hpa.yaml",
         "controlplane-ui-service.yaml",
@@ -230,9 +231,11 @@ def test_helm_control_plane_autoscaling_defaults():
     assert api["minReplicas"] == 2
     assert api["maxReplicas"] == 6
     assert api["targetCPUUtilizationPercentage"] == 70
+    assert api["behavior"] == {}
     assert ui["enabled"] is False
     assert ui["minReplicas"] == 2
     assert ui["maxReplicas"] == 4
+    assert ui["behavior"] == {}
 
 
 def test_helm_topology_spread_defaults():
@@ -242,6 +245,17 @@ def test_helm_topology_spread_defaults():
     assert spread["enabled"] is False
     assert spread["zone"]["enabled"] is True
     assert spread["node"]["enabled"] is True
+
+
+def test_helm_control_plane_priority_and_anti_affinity_defaults():
+    """Control-plane HA knobs are explicit and opt-in by default."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    anti_affinity = doc["controlPlane"]["podAntiAffinity"]
+    priority_class = doc["controlPlane"]["priorityClass"]
+    assert anti_affinity["enabled"] is False
+    assert anti_affinity["topologyKey"] == "kubernetes.io/hostname"
+    assert priority_class["create"] is False
+    assert priority_class["name"] == ""
 
 
 def test_helm_external_secrets_defaults():
@@ -317,7 +331,24 @@ def test_production_values_enable_operator_defaults():
     production = yaml.safe_load((HELM_DIR / "examples" / "eks-production-values.yaml").read_text())
     assert production["controlPlane"]["api"]["autoscaling"]["enabled"] is True
     assert production["controlPlane"]["ui"]["autoscaling"]["enabled"] is True
+    assert production["controlPlane"]["api"]["autoscaling"]["behavior"]["scaleDown"]["stabilizationWindowSeconds"] == 300
+    assert production["controlPlane"]["ui"]["autoscaling"]["behavior"]["scaleDown"]["stabilizationWindowSeconds"] == 300
     assert production["controlPlane"]["externalSecrets"]["enabled"] is True
+    assert production["controlPlane"]["externalSecrets"]["refreshInterval"] == "5m"
+    assert production["controlPlane"]["podAntiAffinity"]["enabled"] is True
+    assert production["controlPlane"]["priorityClass"]["create"] is True
     assert production["topologySpread"]["enabled"] is True
     assert production["networkPolicy"]["restrictIngress"] is True
     assert "cert-manager.io/cluster-issuer" in production["controlPlane"]["ingress"]["annotations"]
+
+
+def test_pilot_and_production_values_narrow_ingress_to_controller_pods_and_ports():
+    """Focused values should narrow ingress traffic to controller pods on UI/API ports."""
+    for name in ("eks-mcp-pilot-values.yaml", "eks-production-values.yaml"):
+        values = yaml.safe_load((HELM_DIR / "examples" / name).read_text())
+        ingress_rule = values["networkPolicy"]["ingress"][1]
+        source = ingress_rule["from"][0]
+        ports = {port["port"] for port in ingress_rule["ports"]}
+        assert source["namespaceSelector"]["matchLabels"]["kubernetes.io/metadata.name"] == "ingress-nginx"
+        assert source["podSelector"]["matchLabels"]["app.kubernetes.io/component"] == "controller"
+        assert ports == {3000, 8422}


### PR DESCRIPTION
## Summary
- fix the in-memory rate limiter overflow behavior and add a fail-closed shared-rate-limit option for multi-replica control planes
- scope control-plane rate-limit buckets by credential instead of shared IP alone
- harden the Helm production path with narrower ingress policy examples, pod anti-affinity, optional PriorityClass support, and HPA scale-down behavior

## Validation
- uv run pytest -q tests/test_api_hardening.py tests/test_deploy_manifests.py
- uv run ruff check src/agent_bom/api/middleware.py tests/test_api_hardening.py tests/test_deploy_manifests.py
- git diff --check