### PR TITLE
Package operator observability and backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Operator guides:
 - [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md)
 - [Focused EKS MCP Pilot](site-docs/deployment/eks-mcp-pilot.md)
 - [Packaged API + UI Control Plane](site-docs/deployment/control-plane-helm.md)
+- [Grafana Dashboard](site-docs/deployment/grafana.md)
 - [Performance, Sizing, and Benchmarks](site-docs/deployment/performance-and-sizing.md)
 
 ## Product views

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -1,5 +1,10 @@
 controlPlane:
   enabled: true
+  observability:
+    grafanaDashboard:
+      enabled: true
+    prometheusRule:
+      enabled: true
   podAntiAffinity:
     enabled: true
   priorityClass:
@@ -83,6 +88,16 @@ controlPlane:
             remoteRef:
               key: /agent-bom/prod/control-plane
               property: AGENT_BOM_REQUIRE_AUDIT_HMAC
+  backup:
+    enabled: true
+    schedule: "0 3 * * *"
+    destination:
+      bucket: agent-bom-prod-backups
+      prefix: agent-bom/postgres
+      region: us-east-1
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane-db
 
 scanner:
   enabled: true

--- a/deploy/helm/agent-bom/files/grafana-agent-bom.json
+++ b/deploy/helm/agent-bom/files/grafana-agent-bom.json
@@ -1,0 +1,818 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source for agent-bom metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "" },
+    { "type": "panel", "id": "barchart", "name": "Bar chart", "version": "" },
+    { "type": "panel", "id": "piechart", "name": "Pie chart", "version": "" }
+  ],
+  "id": null,
+  "uid": "agent-bom-overview",
+  "title": "agent-bom — AI Supply Chain Security",
+  "description": "Security posture overview for AI agent infrastructure scanned by agent-bom",
+  "tags": ["agent-bom", "security", "ai", "mcp", "sbom"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      },
+      {
+        "name": "agent",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(agent_bom_agent_vulnerabilities_total, agent)",
+        "includeAll": true,
+        "allValue": ".*",
+        "current": { "text": "All", "value": "$__all" },
+        "hide": 0,
+        "multi": true,
+        "refresh": 2
+      }
+    ]
+  },
+  "annotations": { "list": [] },
+  "links": [
+    {
+      "title": "agent-bom GitHub",
+      "url": "https://github.com/msaad00/agent-bom",
+      "icon": "external link",
+      "type": "link",
+      "targetBlank": true
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Total Vulnerabilities",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "orange", "value": 20 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "sum(agent_bom_vulnerabilities_total)",
+          "legendFormat": "Total"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Critical",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_vulnerabilities_total{severity=\"critical\"}",
+          "legendFormat": "Critical"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "High",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_vulnerabilities_total{severity=\"high\"}",
+          "legendFormat": "High"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Agents Discovered",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_agents_total",
+          "legendFormat": "Agents"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "MCP Servers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_mcp_servers_total",
+          "legendFormat": "Servers"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Packages Scanned",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [{ "color": "purple", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_packages_total",
+          "legendFormat": "Packages"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "Severity Distribution",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "critical" }, "properties": [{ "id": "color", "value": { "fixedColor": "#E02F44", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "high" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "medium" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FADE2A", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "low" }, "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "pieType": "donut",
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "agent_bom_vulnerabilities_total",
+          "legendFormat": "{{severity}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Vulnerability Trend",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "pointSize": 5,
+            "stacking": { "mode": "none" }
+          }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "critical" }, "properties": [{ "id": "color", "value": { "fixedColor": "#E02F44", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "high" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "medium" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FADE2A", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "low" }, "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }] }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "agent_bom_vulnerabilities_total{severity=\"critical\"}",
+          "legendFormat": "critical"
+        },
+        {
+          "expr": "agent_bom_vulnerabilities_total{severity=\"high\"}",
+          "legendFormat": "high"
+        },
+        {
+          "expr": "agent_bom_vulnerabilities_total{severity=\"medium\"}",
+          "legendFormat": "medium"
+        },
+        {
+          "expr": "agent_bom_vulnerabilities_total{severity=\"low\"}",
+          "legendFormat": "low"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 12,
+      "title": "KEV Findings",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "dark-red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "unit": "short"
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value_and_name" },
+      "targets": [
+        {
+          "expr": "agent_bom_kev_findings_total",
+          "legendFormat": "CISA KEV"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Fixable Vulnerabilities",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 70 }
+            ]
+          },
+          "min": 0,
+          "max": 100,
+          "unit": "percent"
+        }
+      },
+      "options": { "showThresholdLabels": false, "showThresholdMarkers": true },
+      "targets": [
+        {
+          "expr": "agent_bom_fixable_vulnerabilities_total / clamp_min(sum(agent_bom_vulnerabilities_total), 1) * 100",
+          "legendFormat": "Fixable %"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "Credentials Exposed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "sum(agent_bom_credentials_exposed_total{agent=~\"$agent\"})",
+          "legendFormat": "Exposed"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "title": "Proxy Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        }
+      },
+      "options": { "colorMode": "none", "graphMode": "none", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_proxy_uptime_seconds",
+          "legendFormat": "Uptime"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Proxy — Blocked Calls",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_proxy_total_blocked",
+          "legendFormat": "Blocked"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "title": "Proxy — Total Calls",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "value" },
+      "targets": [
+        {
+          "expr": "agent_bom_proxy_total_tool_calls",
+          "legendFormat": "Total"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 19,
+      "title": "Top Blast Radius Scores",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 3 },
+              { "color": "orange", "value": 5 },
+              { "color": "red", "value": 7 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "max": 10
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "barWidth": 0.7,
+        "showValue": "always",
+        "legend": { "displayMode": "hidden" }
+      },
+      "targets": [
+        {
+          "expr": "topk(15, agent_bom_blast_radius_score)",
+          "legendFormat": "{{vuln_id}} ({{package}})",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "sortBy", "options": { "sort": [{ "field": "Value", "desc": true }] } }
+      ]
+    },
+    {
+      "id": 20,
+      "title": "EPSS Exploit Probability (Top 15)",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "orange", "value": 0.4 },
+              { "color": "red", "value": 0.7 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "unit": "percentunit",
+          "max": 1
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "barWidth": 0.7,
+        "showValue": "always",
+        "legend": { "displayMode": "hidden" }
+      },
+      "targets": [
+        {
+          "expr": "topk(15, agent_bom_vulnerability_epss_score)",
+          "legendFormat": "{{vuln_id}} ({{package}})",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "sortBy", "options": { "sort": [{ "field": "Value", "desc": true }] } }
+      ]
+    },
+    {
+      "id": 21,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 28 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 22,
+      "title": "Vulnerabilities by Agent",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 29 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Value", "desc": true }]
+      },
+      "targets": [
+        {
+          "expr": "agent_bom_agent_vulnerabilities_total{agent=~\"$agent\"}",
+          "legendFormat": "{{agent}} — {{severity}}",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true }, "renameByName": { "agent": "Agent", "severity": "Severity", "Value": "Count" } } }
+      ]
+    },
+    {
+      "id": 23,
+      "title": "Credentials Exposed by Agent",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 29 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "barWidth": 0.7,
+        "showValue": "always",
+        "legend": { "displayMode": "hidden" }
+      },
+      "targets": [
+        {
+          "expr": "agent_bom_credentials_exposed_total{agent=~\"$agent\"}",
+          "legendFormat": "{{agent}}",
+          "instant": true,
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 37 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 25,
+      "title": "Proxy — Tool Call Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 38 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "rate(agent_bom_proxy_total_tool_calls[5m])",
+          "legendFormat": "calls/sec"
+        },
+        {
+          "expr": "rate(agent_bom_proxy_total_blocked[5m])",
+          "legendFormat": "blocked/sec"
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "title": "Proxy — Block Reasons",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 38 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] },
+        "pieType": "donut",
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "agent_bom_proxy_blocked_total",
+          "legendFormat": "{{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 27,
+      "title": "Proxy — Latency (p50 / p95)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 38 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "agent_bom_proxy_latency_ms{quantile=\"0.5\"}",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "agent_bom_proxy_latency_ms{quantile=\"0.95\"}",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "id": 28,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 46 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 29,
+      "title": "Proxy — Calls per Tool",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 47 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Value", "desc": true }]
+      },
+      "targets": [
+        {
+          "expr": "agent_bom_proxy_tool_calls_total",
+          "legendFormat": "{{tool}}",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true }, "renameByName": { "tool": "Tool", "Value": "Calls" } } }
+      ]
+    },
+    {
+      "id": 30,
+      "title": "CVSS Score Distribution",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 47 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 4 },
+              { "color": "orange", "value": 7 },
+              { "color": "red", "value": 9 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "max": 10
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "barWidth": 0.7,
+        "showValue": "always",
+        "legend": { "displayMode": "hidden" }
+      },
+      "targets": [
+        {
+          "expr": "topk(15, agent_bom_vulnerability_cvss_score)",
+          "legendFormat": "{{vuln_id}} ({{package}})",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        { "id": "sortBy", "options": { "sort": [{ "field": "Value", "desc": true }] } }
+      ]
+    },
+    {
+      "id": 31,
+      "title": "",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 55 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 32,
+      "title": "JSON-RPC Message Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 56 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          },
+          "unit": "reqps"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(agent_bom_proxy_messages_total{direction=\"client_to_server\"}[5m])",
+          "legendFormat": "client -> server"
+        },
+        {
+          "expr": "rate(agent_bom_proxy_messages_total{direction=\"server_to_client\"}[5m])",
+          "legendFormat": "server -> client"
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "title": "Replay Rejections",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 56 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50
+          },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      },
+      "targets": [
+        {
+          "expr": "increase(agent_bom_proxy_replay_rejections_total[5m])",
+          "legendFormat": "Replay rejections"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
@@ -1,0 +1,90 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "agent-bom.name" . }}-control-plane-backup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane-backup
+spec:
+  schedule: {{ .Values.controlPlane.backup.schedule | quote }}
+  suspend: {{ .Values.controlPlane.backup.suspend }}
+  successfulJobsHistoryLimit: {{ .Values.controlPlane.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.controlPlane.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "agent-bom.labels" . | nindent 12 }}
+            app.kubernetes.io/component: control-plane-backup
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ default (include "agent-bom.serviceAccountName" .) .Values.controlPlane.backup.serviceAccountName }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: dump
+              image: "{{ .Values.controlPlane.backup.image.dumpRepository }}:{{ .Values.controlPlane.backup.image.dumpTag }}"
+              imagePullPolicy: {{ .Values.controlPlane.backup.image.pullPolicy }}
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+                  out="/backup/agent-bom-${ts}.dump"
+                  pg_dump "$AGENT_BOM_POSTGRES_URL" --format=custom --file "$out"
+                  echo "$out" > /backup/latest-path
+              env:
+                - name: PGCONNECT_TIMEOUT
+                  value: "10"
+                {{- with .Values.controlPlane.backup.env }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              {{- with .Values.controlPlane.backup.envFrom }}
+              envFrom:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: backup-data
+                  mountPath: /backup
+              resources:
+                {{- toYaml .Values.controlPlane.backup.resources.dump | nindent 16 }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+            - name: upload
+              image: "{{ .Values.controlPlane.backup.image.uploadRepository }}:{{ .Values.controlPlane.backup.image.uploadTag }}"
+              imagePullPolicy: {{ .Values.controlPlane.backup.image.pullPolicy }}
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  for _ in $(seq 1 180); do
+                    if [ -s /backup/latest-path ]; then
+                      break
+                    fi
+                    sleep 2
+                  done
+                  dump_path="$(cat /backup/latest-path)"
+                  test -f "$dump_path"
+                  key="{{ trimSuffix "/" .Values.controlPlane.backup.destination.prefix }}/$(basename "$dump_path")"
+                  set -- s3 cp "$dump_path" "s3://{{ .Values.controlPlane.backup.destination.bucket }}/$key" --region "{{ .Values.controlPlane.backup.destination.region }}"
+                  {{- if .Values.controlPlane.backup.destination.endpoint }}
+                  set -- "$@" --endpoint-url "{{ .Values.controlPlane.backup.destination.endpoint }}"
+                  {{- end }}
+                  {{- range .Values.controlPlane.backup.destination.extraArgs }}
+                  set -- "$@" "{{ . }}"
+                  {{- end }}
+                  aws "$@"
+              volumeMounts:
+                - name: backup-data
+                  mountPath: /backup
+              resources:
+                {{- toYaml .Values.controlPlane.backup.resources.upload | nindent 16 }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+          volumes:
+            - name: backup-data
+              emptyDir: {}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-grafana-dashboard.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-grafana-dashboard.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.observability.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agent-bom.name" . }}-grafana-dashboard
+  namespace: {{ default .Release.Namespace .Values.controlPlane.observability.grafanaDashboard.namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+    grafana_dashboard: "1"
+    {{- with .Values.controlPlane.observability.grafanaDashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    grafana_folder: {{ .Values.controlPlane.observability.grafanaDashboard.folder | quote }}
+    {{- with .Values.controlPlane.observability.grafanaDashboard.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  agent-bom-dashboard.json: |
+{{ .Files.Get "files/grafana-agent-bom.json" | indent 4 }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-prometheusrule.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-prometheusrule.yaml
@@ -1,0 +1,73 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.observability.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "agent-bom.name" . }}-control-plane
+  namespace: {{ default .Release.Namespace .Values.controlPlane.observability.prometheusRule.namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+    {{- with .Values.controlPlane.observability.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.controlPlane.observability.prometheusRule.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    - name: agent-bom.control-plane
+      rules:
+        {{- if .Values.controlPlane.observability.prometheusRule.rules.apiErrorRate.enabled }}
+        - alert: AgentBomApiHighErrorRate
+          expr: |
+            (
+              sum(rate(http_requests_total{job=~".*agent-bom.*",status=~"5.."}[5m]))
+              /
+              clamp_min(sum(rate(http_requests_total{job=~".*agent-bom.*"}[5m])), 1)
+            ) > {{ .Values.controlPlane.observability.prometheusRule.rules.apiErrorRate.errorRateThreshold }}
+          for: {{ .Values.controlPlane.observability.prometheusRule.rules.apiErrorRate.for }}
+          labels:
+            severity: warning
+            service: agent-bom-api
+          annotations:
+            summary: agent-bom API 5xx rate is elevated
+            description: agent-bom API error rate has exceeded the configured threshold for 10 minutes.
+        {{- end }}
+        {{- if .Values.controlPlane.observability.prometheusRule.rules.scannerFailures.enabled }}
+        - alert: AgentBomScannerFailures
+          expr: |
+            increase(kube_job_status_failed{job_name=~".*agent-bom.*"}[15m]) > 0
+          for: {{ .Values.controlPlane.observability.prometheusRule.rules.scannerFailures.for }}
+          labels:
+            severity: warning
+            service: agent-bom-scanner
+          annotations:
+            summary: agent-bom scanner job failures detected
+            description: One or more recent agent-bom scheduled jobs have failed in Kubernetes.
+        {{- end }}
+        {{- if .Values.controlPlane.observability.prometheusRule.rules.oidcFailures.enabled }}
+        - alert: AgentBomOidcDecodeFailures
+          expr: |
+            increase(agent_bom_oidc_decode_failures_total[5m]) > {{ .Values.controlPlane.observability.prometheusRule.rules.oidcFailures.increaseThreshold }}
+          for: {{ .Values.controlPlane.observability.prometheusRule.rules.oidcFailures.for }}
+          labels:
+            severity: warning
+            service: agent-bom-api
+          annotations:
+            summary: agent-bom OIDC decode failures are rising
+            description: OIDC token decode failures exceeded the configured threshold during the last 5 minutes.
+        {{- end }}
+        {{- if .Values.controlPlane.observability.prometheusRule.rules.proxyAuditBacklog.enabled }}
+        - alert: AgentBomProxyAuditBacklog
+          expr: |
+            max(agent_bom_proxy_audit_buffer_bytes + agent_bom_proxy_audit_spillover_bytes) > {{ .Values.controlPlane.observability.prometheusRule.rules.proxyAuditBacklog.backlogBytesThreshold }}
+          for: {{ .Values.controlPlane.observability.prometheusRule.rules.proxyAuditBacklog.for }}
+          labels:
+            severity: warning
+            service: agent-bom-proxy
+          annotations:
+            summary: agent-bom proxy audit backlog is growing
+            description: The proxy audit queue plus spillover file size exceeded the configured threshold.
+        {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -65,6 +65,34 @@ monitor:
 
 controlPlane:
   enabled: false
+  observability:
+    grafanaDashboard:
+      enabled: false
+      namespace: ""
+      labels: {}
+      annotations: {}
+      folder: agent-bom
+    prometheusRule:
+      enabled: false
+      namespace: ""
+      labels: {}
+      annotations: {}
+      rules:
+        apiErrorRate:
+          enabled: true
+          errorRateThreshold: 0.05
+          for: 10m
+        scannerFailures:
+          enabled: true
+          for: 15m
+        oidcFailures:
+          enabled: true
+          for: 10m
+          increaseThreshold: 5
+        proxyAuditBacklog:
+          enabled: true
+          for: 10m
+          backlogBytesThreshold: 10485760
   podAntiAffinity:
     enabled: false
     topologyKey: kubernetes.io/hostname
@@ -200,6 +228,43 @@ controlPlane:
       creationPolicy: Owner
     data: []
     secrets: []
+  backup:
+    enabled: false
+    schedule: "0 3 * * *"
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    suspend: false
+    serviceAccountName: ""
+    image:
+      dumpRepository: postgres
+      dumpTag: "16-alpine"
+      uploadRepository: amazon/aws-cli
+      uploadTag: "2.17.52"
+      pullPolicy: IfNotPresent
+    resources:
+      dump:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "512Mi"
+          cpu: "500m"
+      upload:
+        requests:
+          memory: "128Mi"
+          cpu: "50m"
+        limits:
+          memory: "256Mi"
+          cpu: "250m"
+    destination:
+      bucket: ""
+      prefix: "agent-bom/postgres"
+      region: us-east-1
+      endpoint: ""
+      extraArgs: []
+    retentionDays: 14
+    env: []
+    envFrom: []
 
 rbac:
   create: true

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -130,6 +130,9 @@ That example adds:
 - fail-closed shared rate limiting when the Postgres-backed limiter is unavailable
 - `cert-manager` ingress annotations and TLS wiring
 - `external-secrets` integration for the control-plane secrets, including split refresh cadence for DB vs auth/HMAC material
+- packaged `PrometheusRule` alerts for API error rate, scanner failures, OIDC decode failures, and proxy audit backlog
+- packaged Grafana dashboard `ConfigMap` for clusters that already watch dashboard config
+- packaged Postgres backup `CronJob` that runs `pg_dump` and uploads to S3 through IRSA
 - restricted ingress defaults for the chart network policy
 
 ## What you still own
@@ -162,6 +165,9 @@ You still own:
   while `AGENT_BOM_POSTGRES_URL` stays at `1h`
 - set `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1` for multi-replica production
   control planes so the API refuses to start if the shared limiter backend is unavailable
+- enable `controlPlane.observability.prometheusRule.enabled=true` when the cluster already runs Prometheus Operator
+- enable `controlPlane.observability.grafanaDashboard.enabled=true` when Grafana watches dashboard `ConfigMap`s
+- enable `controlPlane.backup.enabled=true` only after setting a real S3 bucket, prefix, and IRSA-backed upload permissions
 - enable PDBs when you are running multi-replica workloads
 
 ## Current boundary

--- a/site-docs/deployment/grafana.md
+++ b/site-docs/deployment/grafana.md
@@ -1,13 +1,29 @@
 # Grafana Dashboard
 
-A pre-built Grafana dashboard for visualizing agent-bom Prometheus metrics.
+`agent-bom` ships a pre-built Grafana dashboard for visualizing Prometheus
+metrics from the API and proxy.
 
-## Import
+## Manual import
 
 1. Go to **Dashboards > Import** in Grafana
 2. Upload `deploy/grafana/grafana-agent-bom.json`
 3. Select your Prometheus data source
 4. Click **Import**
+
+## Helm-packaged dashboard
+
+If you are using the packaged control plane, enable:
+
+```yaml
+controlPlane:
+  enabled: true
+  observability:
+    grafanaDashboard:
+      enabled: true
+```
+
+The chart renders a `ConfigMap` with `grafana_dashboard=1` so a Grafana
+sidecar or operator can pick it up automatically.
 
 ## Panels
 
@@ -56,3 +72,4 @@ annotations:
 
 - Grafana 10+
 - Prometheus data source with agent-bom metrics
+- For the packaged path, a Grafana sidecar or operator that watches dashboard `ConfigMap`s

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -100,6 +100,9 @@ The chart now supports the EKS wiring you actually need:
 | `topologySpread.*` | spread API and UI replicas across zones and nodes |
 | `controlPlane.externalSecrets.*` | map control-plane env vars from external-secrets |
 | `controlPlane.externalSecrets.secrets[]` | split DB secret cadence from faster OIDC / audit-HMAC rotation |
+| `controlPlane.observability.prometheusRule.*` | package alert rules for API, scanner, OIDC, and proxy backlog |
+| `controlPlane.observability.grafanaDashboard.*` | package the shipped Grafana dashboard as a `ConfigMap` |
+| `controlPlane.backup.*` | package Postgres backup jobs that dump and upload to S3 through IRSA |
 | `scanner.extraArgs` | add `--k8s-mcp`, `--enforce`, `--introspect`, or stricter presets |
 | `scanner.env` | inject operator-owned environment like API endpoints or auth context |
 | `scanner.allNamespaces` | scan cluster-wide instead of one namespace |
@@ -175,6 +178,10 @@ all sit under one operator-controlled plane.
 - split external secrets by cadence in production:
   - `AGENT_BOM_POSTGRES_URL` at `1h`
   - `AGENT_BOM_OIDC_*` and `AGENT_BOM_AUDIT_HMAC_KEY` at `5m`
+- enable the packaged PrometheusRule and Grafana dashboard when your cluster
+  already runs Prometheus Operator and Grafana sidecar discovery
+- enable the packaged backup CronJob only after setting a real S3 destination
+  and granting `s3:PutObject` via IRSA
 - set a persistent audit HMAC key and require it
 - attach the scanner service account to IRSA instead of static cloud keys
 - start with audit-only policies where rollout risk is unclear, then move to deny

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -154,6 +154,14 @@ def test_loadtest_scripts_target_real_endpoints():
     assert "/v1/proxy/audit" in proxy_audit
 
 
+def test_chart_packages_grafana_dashboard_asset():
+    """The Helm chart should package the shipped Grafana dashboard JSON."""
+    dashboard = HELM_DIR / "files" / "grafana-agent-bom.json"
+    assert dashboard.exists()
+    payload = yaml.safe_load(dashboard.read_text())
+    assert payload["title"] == "agent-bom — AI Supply Chain Security"
+
+
 def test_namespace_manifest():
     """Namespace manifest creates agent-bom namespace."""
     doc = yaml.safe_load((K8S_DIR / "namespace.yaml").read_text())
@@ -215,10 +223,13 @@ def test_helm_templates_exist():
         "controlplane-api-deployment.yaml",
         "controlplane-api-hpa.yaml",
         "controlplane-api-service.yaml",
+        "controlplane-backup-cronjob.yaml",
         "controlplane-externalsecret.yaml",
+        "controlplane-grafana-dashboard.yaml",
         "controlplane-ingress.yaml",
         "controlplane-pdb.yaml",
         "controlplane-priorityclass.yaml",
+        "controlplane-prometheusrule.yaml",
         "controlplane-ui-deployment.yaml",
         "controlplane-ui-hpa.yaml",
         "controlplane-ui-service.yaml",
@@ -290,6 +301,28 @@ def test_helm_external_secrets_defaults():
     assert ext["secrets"] == []
 
 
+def test_helm_control_plane_observability_defaults():
+    """PrometheusRule and Grafana dashboard packaging is explicit and opt-in."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    observability = doc["controlPlane"]["observability"]
+    assert observability["grafanaDashboard"]["enabled"] is False
+    assert observability["grafanaDashboard"]["folder"] == "agent-bom"
+    assert observability["prometheusRule"]["enabled"] is False
+    assert observability["prometheusRule"]["rules"]["apiErrorRate"]["enabled"] is True
+    assert observability["prometheusRule"]["rules"]["proxyAuditBacklog"]["backlogBytesThreshold"] == 10485760
+
+
+def test_helm_control_plane_backup_defaults():
+    """Postgres backup packaging is explicit and disabled by default."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    backup = doc["controlPlane"]["backup"]
+    assert backup["enabled"] is False
+    assert backup["schedule"] == "0 3 * * *"
+    assert backup["destination"]["prefix"] == "agent-bom/postgres"
+    assert backup["image"]["dumpRepository"] == "postgres"
+    assert backup["image"]["uploadRepository"] == "amazon/aws-cli"
+
+
 def test_helm_monitor_disabled_by_default():
     """Monitor is disabled by default."""
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
@@ -357,6 +390,10 @@ def test_production_values_enable_operator_defaults():
     assert production["controlPlane"]["api"]["autoscaling"]["behavior"]["scaleDown"]["stabilizationWindowSeconds"] == 300
     assert production["controlPlane"]["ui"]["autoscaling"]["behavior"]["scaleDown"]["stabilizationWindowSeconds"] == 300
     assert production["controlPlane"]["externalSecrets"]["enabled"] is True
+    assert production["controlPlane"]["observability"]["grafanaDashboard"]["enabled"] is True
+    assert production["controlPlane"]["observability"]["prometheusRule"]["enabled"] is True
+    assert production["controlPlane"]["backup"]["enabled"] is True
+    assert production["controlPlane"]["backup"]["destination"]["bucket"] == "agent-bom-prod-backups"
     secrets = production["controlPlane"]["externalSecrets"]["secrets"]
     assert {secret["target"]["name"] for secret in secrets} == {
         "agent-bom-control-plane-auth",


### PR DESCRIPTION
## Summary
- package PrometheusRule, Grafana dashboard ConfigMap, and Postgres backup CronJob in the Helm control-plane path
- extend the production EKS example and operator docs for alerts, dashboards, and IRSA-backed backups
- add manifest tests for the new observability and backup surfaces

## Validation
- uv run pytest -q tests/test_deploy_manifests.py
- git diff --check