### PR TITLE
Add idempotent fleet and proxy ingest

### DIFF
--- a/src/agent_bom/api/idempotency_store.py
+++ b/src/agent_bom/api/idempotency_store.py
@@ -1,0 +1,108 @@
+"""Idempotency key storage for retry-safe write endpoints."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+
+@dataclass
+class IdempotencyRecord:
+    endpoint: str
+    tenant_id: str
+    source_id: str
+    idempotency_key: str
+    response_json: str
+    created_at: str
+
+
+class IdempotencyStore(Protocol):
+    def get(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str) -> dict | None: ...
+    def put(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str, response: dict) -> None: ...
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class InMemoryIdempotencyStore:
+    def __init__(self, ttl_hours: int = 24) -> None:
+        self._records: dict[tuple[str, str, str, str], IdempotencyRecord] = {}
+        self._ttl = timedelta(hours=ttl_hours)
+        self._lock = threading.Lock()
+
+    def _prune(self) -> None:
+        cutoff = datetime.now(timezone.utc) - self._ttl
+        stale = [key for key, record in self._records.items() if datetime.fromisoformat(record.created_at) < cutoff]
+        for key in stale:
+            self._records.pop(key, None)
+
+    def get(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str) -> dict | None:
+        with self._lock:
+            self._prune()
+            record = self._records.get((endpoint, tenant_id, source_id, idempotency_key))
+            return json.loads(record.response_json) if record else None
+
+    def put(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str, response: dict) -> None:
+        with self._lock:
+            self._prune()
+            self._records[(endpoint, tenant_id, source_id, idempotency_key)] = IdempotencyRecord(
+                endpoint=endpoint,
+                tenant_id=tenant_id,
+                source_id=source_id,
+                idempotency_key=idempotency_key,
+                response_json=json.dumps(response, sort_keys=True),
+                created_at=_utcnow(),
+            )
+
+
+class SQLiteIdempotencyStore:
+    def __init__(self, db_path: str = "agent_bom_jobs.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        return self._local.conn
+
+    def _init_db(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS idempotency_keys (
+                endpoint TEXT NOT NULL,
+                tenant_id TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL,
+                response_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (endpoint, tenant_id, source_id, idempotency_key)
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_idempotency_created_at ON idempotency_keys(created_at)")
+        self._conn.commit()
+
+    def get(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str) -> dict | None:
+        row = self._conn.execute(
+            """SELECT response_json FROM idempotency_keys
+               WHERE endpoint = ? AND tenant_id = ? AND source_id = ? AND idempotency_key = ?""",
+            (endpoint, tenant_id, source_id, idempotency_key),
+        ).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def put(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str, response: dict) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO idempotency_keys
+               (endpoint, tenant_id, source_id, idempotency_key, response_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (endpoint, tenant_id, source_id, idempotency_key, json.dumps(response, sort_keys=True), _utcnow()),
+        )
+        self._conn.commit()

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -207,6 +207,7 @@ class EvaluateRequest(BaseModel):
 class ProxyAuditIngestRequest(BaseModel):
     source_id: str = ""
     session_id: str = ""
+    idempotency_key: str = ""
     alerts: list[dict] = []
     summary: dict | None = None
 
@@ -272,6 +273,7 @@ class PushPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     source_id: str = ""
+    idempotency_key: str = ""
     agents: list = []
     blast_radii: list = []
     warnings: list = []

--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -12,12 +12,13 @@ Configuration via environment variables::
     AGENT_BOM_OIDC_TENANT_CLAIM = "tenant_id"         # optional JWT claim for tenant
     AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM = "1"         # fail closed when claim absent
     AGENT_BOM_OIDC_REQUIRED_NONCE = "random-nonce"    # optional fail-closed nonce check
+    AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM = "1"           # optional fail-closed role requirement
 
 Role mapping (claim value → agent-bom Role):
 
     "admin"   → Role.ADMIN
     "analyst" → Role.ANALYST
-    any other → Role.VIEWER  (default when claim absent)
+    any other → Role.VIEWER  (default when claim absent unless strict mode enabled)
 
 Install the optional dependency::
 
@@ -250,6 +251,25 @@ def claims_to_role(claims: dict, role_claim: str = "agent_bom_role") -> str:
     return "viewer"
 
 
+def claims_have_role_signal(claims: dict, role_claim: str = "agent_bom_role") -> bool:
+    """Return True when claims include an explicit recognizable role signal."""
+    admin_values = {"admin", "administrator", "superuser"}
+    analyst_values = {"analyst", "security-analyst", "engineer", "developer"}
+
+    role_val = claims.get(role_claim, "")
+    if isinstance(role_val, str) and role_val and role_val.lower() in (admin_values | analyst_values):
+        return True
+
+    for array_claim in ("roles", "groups", "permissions"):
+        values = claims.get(array_claim, [])
+        if isinstance(values, list):
+            lowered = {str(v).lower() for v in values}
+            if lowered & (admin_values | analyst_values):
+                return True
+
+    return False
+
+
 def claims_to_tenant(claims: dict, tenant_claim: str = "tenant_id") -> str | None:
     """Map OIDC JWT claims to a tenant identifier."""
     tenant_val = claims.get(tenant_claim)
@@ -277,6 +297,7 @@ class OIDCConfig:
     - ``AGENT_BOM_OIDC_ROLE_CLAIM`` — JWT claim name for role (default: ``agent_bom_role``)
     - ``AGENT_BOM_OIDC_JWKS_URI`` — Override JWKS URI (optional, auto-discovered if absent)
     - ``AGENT_BOM_OIDC_REQUIRED_NONCE`` — Optional expected ``nonce`` claim for fail-closed checks
+    - ``AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM`` — Fail closed when no explicit mapped role claim is present
     """
 
     def __init__(
@@ -288,6 +309,7 @@ class OIDCConfig:
         tenant_claim: str = "tenant_id",
         require_tenant_claim: Optional[bool] = None,
         required_nonce: Optional[str] = None,
+        require_role_claim: Optional[bool] = None,
     ) -> None:
         self.issuer = issuer or os.environ.get("AGENT_BOM_OIDC_ISSUER", "")
         self.audience = audience or os.environ.get("AGENT_BOM_OIDC_AUDIENCE") or None
@@ -302,6 +324,13 @@ class OIDCConfig:
                 "yes",
             }
         self.require_tenant_claim = require_tenant_claim
+        if require_role_claim is None:
+            require_role_claim = os.environ.get("AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+        self.require_role_claim = require_role_claim
         self.enabled = bool(self.issuer)
 
     def verify(self, token: str) -> tuple[dict, str]:
@@ -315,6 +344,8 @@ class OIDCConfig:
         if not self.audience:
             raise OIDCError("OIDC is configured but AGENT_BOM_OIDC_AUDIENCE is not set")
         claims = verify_oidc_token(token, self.issuer, self.audience, self.jwks_uri, self.required_nonce)
+        if self.require_role_claim and not claims_have_role_signal(claims, self.role_claim):
+            raise OIDCError(f"JWT missing required role claim '{self.role_claim}'")
         role = claims_to_role(claims, self.role_claim)
         return claims, role
 

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -16,8 +16,8 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
 
-from agent_bom.api.models import FleetAgentUpdate, StateUpdate
-from agent_bom.api.stores import _get_fleet_store
+from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
+from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store
 
 router = APIRouter()
 
@@ -95,8 +95,29 @@ async def get_fleet_agent(request: Request, agent_id: str):
     return agent.model_dump()
 
 
+def _server_counts(agent) -> tuple[int, int, int, int]:
+    server_count = len(agent.mcp_servers)
+    pkg_count = sum(len(s.packages) for s in agent.mcp_servers)
+    cred_count = sum(len(s.credential_names) for s in agent.mcp_servers)
+    vuln_count = sum(s.total_vulnerabilities for s in agent.mcp_servers)
+    return server_count, pkg_count, cred_count, vuln_count
+
+
+def _payload_counts(agent: dict) -> tuple[int, int, int, int]:
+    servers = agent.get("mcp_servers", []) or []
+    server_count = len(servers)
+    pkg_count = 0
+    cred_count = 0
+    vuln_count = 0
+    for server in servers:
+        pkg_count += len(server.get("packages", []) or [])
+        cred_count += len(server.get("credential_names", []) or [])
+        vuln_count += int(server.get("total_vulnerabilities", 0) or 0)
+    return server_count, pkg_count, cred_count, vuln_count
+
+
 @router.post("/v1/fleet/sync", tags=["fleet"])
-async def sync_fleet(request: Request):
+async def sync_fleet(request: Request, body: PushPayload | None = None):
     """Run discovery and sync results into the fleet registry.
 
     New agents -> state=DISCOVERED. Existing agents -> counts updated.
@@ -106,60 +127,109 @@ async def sync_fleet(request: Request):
     from agent_bom.discovery import discover_all
     from agent_bom.fleet.trust_scoring import compute_trust_score
 
-    discovered = discover_all()
     store = _get_fleet_store()
     tenant_id = getattr(request.state, "tenant_id", "default")
     now = datetime.now(timezone.utc).isoformat()
+    source_id = (body.source_id if body else "") or request.headers.get("X-Agent-Bom-Source-Id", "") or "server-discovery"
+    idem_key = (body.idempotency_key if body else "") or request.headers.get("Idempotency-Key", "")
+    if idem_key:
+        cached = _get_idempotency_store().get("/v1/fleet/sync", tenant_id, source_id, idem_key)
+        if cached is not None:
+            cached["idempotent_replay"] = True
+            return cached
     new_count = 0
     updated_count = 0
 
-    for agent in discovered:
-        existing = next((a for a in store.list_by_tenant(tenant_id) if a.name == agent.name), None)
-        server_count = len(agent.mcp_servers)
-        pkg_count = sum(len(s.packages) for s in agent.mcp_servers)
-        cred_count = sum(len(s.credential_names) for s in agent.mcp_servers)
-        vuln_count = sum(s.total_vulnerabilities for s in agent.mcp_servers)
+    if body and body.agents:
+        payload_agents = body.agents
+        for agent in payload_agents:
+            name = agent.get("name", "unknown-agent")
+            existing = next((a for a in store.list_by_tenant(tenant_id) if a.name == name), None)
+            server_count, pkg_count, cred_count, vuln_count = _payload_counts(agent)
+            score = float(agent.get("trust_score", 0.0) or 0.0)
+            factors = dict(agent.get("trust_factors", {}) or {})
+            if existing:
+                existing.server_count = server_count
+                existing.package_count = pkg_count
+                existing.credential_count = cred_count
+                existing.vuln_count = vuln_count
+                existing.trust_score = score
+                existing.trust_factors = factors
+                existing.last_discovery = now
+                existing.updated_at = now
+                existing.config_path = ""
+                existing.agent_type = str(agent.get("agent_type", existing.agent_type))
+                store.put(existing)
+                updated_count += 1
+            else:
+                fleet_agent = FleetAgent(
+                    agent_id=str(uuid.uuid4()),
+                    name=name,
+                    agent_type=str(agent.get("agent_type", "unknown")),
+                    config_path="",
+                    lifecycle_state=FleetLifecycleState.DISCOVERED,
+                    trust_score=score,
+                    trust_factors=factors,
+                    server_count=server_count,
+                    package_count=pkg_count,
+                    credential_count=cred_count,
+                    vuln_count=vuln_count,
+                    tenant_id=tenant_id,
+                    last_discovery=now,
+                    created_at=now,
+                    updated_at=now,
+                )
+                store.put(fleet_agent)
+                new_count += 1
+    else:
+        discovered = discover_all()
+        for agent in discovered:
+            existing = next((a for a in store.list_by_tenant(tenant_id) if a.name == agent.name), None)
+            server_count, pkg_count, cred_count, vuln_count = _server_counts(agent)
+            score, factors = compute_trust_score(agent)
 
-        score, factors = compute_trust_score(agent)
+            if existing:
+                existing.server_count = server_count
+                existing.package_count = pkg_count
+                existing.credential_count = cred_count
+                existing.vuln_count = vuln_count
+                existing.trust_score = score
+                existing.trust_factors = factors
+                existing.last_discovery = now
+                existing.updated_at = now
+                existing.config_path = agent.config_path or ""
+                store.put(existing)
+                updated_count += 1
+            else:
+                fleet_agent = FleetAgent(
+                    agent_id=str(uuid.uuid4()),
+                    name=agent.name,
+                    agent_type=agent.agent_type.value if hasattr(agent.agent_type, "value") else str(agent.agent_type),
+                    config_path=agent.config_path or "",
+                    lifecycle_state=FleetLifecycleState.DISCOVERED,
+                    trust_score=score,
+                    trust_factors=factors,
+                    server_count=server_count,
+                    package_count=pkg_count,
+                    credential_count=cred_count,
+                    vuln_count=vuln_count,
+                    tenant_id=tenant_id,
+                    last_discovery=now,
+                    created_at=now,
+                    updated_at=now,
+                )
+                store.put(fleet_agent)
+                new_count += 1
 
-        if existing:
-            existing.server_count = server_count
-            existing.package_count = pkg_count
-            existing.credential_count = cred_count
-            existing.vuln_count = vuln_count
-            existing.trust_score = score
-            existing.trust_factors = factors
-            existing.last_discovery = now
-            existing.updated_at = now
-            existing.config_path = agent.config_path or ""
-            store.put(existing)
-            updated_count += 1
-        else:
-            fleet_agent = FleetAgent(
-                agent_id=str(uuid.uuid4()),
-                name=agent.name,
-                agent_type=agent.agent_type.value if hasattr(agent.agent_type, "value") else str(agent.agent_type),
-                config_path=agent.config_path or "",
-                lifecycle_state=FleetLifecycleState.DISCOVERED,
-                trust_score=score,
-                trust_factors=factors,
-                server_count=server_count,
-                package_count=pkg_count,
-                credential_count=cred_count,
-                vuln_count=vuln_count,
-                tenant_id=tenant_id,
-                last_discovery=now,
-                created_at=now,
-                updated_at=now,
-            )
-            store.put(fleet_agent)
-            new_count += 1
-
-    return {
+    response = {
         "synced": new_count + updated_count,
         "new": new_count,
         "updated": updated_count,
+        "source_id": source_id,
     }
+    if idem_key:
+        _get_idempotency_store().put("/v1/fleet/sync", tenant_id, source_id, idem_key, response)
+    return response
 
 
 @router.put("/v1/fleet/{agent_id}/state", tags=["fleet"])

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -22,6 +22,13 @@ from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store
 router = APIRouter()
 
 
+def _request_header(request: Request, key: str) -> str:
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return ""
+    return str(headers.get(key, "") or "")
+
+
 @router.get("/v1/fleet", tags=["fleet"])
 async def list_fleet(
     request: Request,
@@ -130,8 +137,8 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
     store = _get_fleet_store()
     tenant_id = getattr(request.state, "tenant_id", "default")
     now = datetime.now(timezone.utc).isoformat()
-    source_id = (body.source_id if body else "") or request.headers.get("X-Agent-Bom-Source-Id", "") or "server-discovery"
-    idem_key = (body.idempotency_key if body else "") or request.headers.get("Idempotency-Key", "")
+    source_id = (body.source_id if body else "") or _request_header(request, "X-Agent-Bom-Source-Id") or "server-discovery"
+    idem_key = (body.idempotency_key if body else "") or _request_header(request, "Idempotency-Key")
     if idem_key:
         cached = _get_idempotency_store().get("/v1/fleet/sync", tenant_id, source_id, idem_key)
         if cached is not None:

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from agent_bom.runtime.protection import ProtectionEngine
 
 from agent_bom.api.models import ProxyAuditIngestRequest
+from agent_bom.api.stores import _get_idempotency_store
 
 router = APIRouter()
 
@@ -61,8 +62,14 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
     from agent_bom.api.audit_log import log_action
 
     actor = getattr(request.state, "api_key_name", "") or "proxy-client"
+    tenant_id = getattr(request.state, "tenant_id", "default")
     source_id = body.source_id or "unknown"
     session_id = body.session_id or "default"
+    if body.idempotency_key:
+        cached = _get_idempotency_store().get("/v1/proxy/audit", tenant_id, source_id, body.idempotency_key)
+        if cached is not None:
+            cached["idempotent_replay"] = True
+            return cached
 
     for alert in body.alerts:
         enriched = dict(alert)
@@ -84,13 +91,16 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         alert_count=len(body.alerts),
         has_summary=body.summary is not None,
     )
-    return {
+    response = {
         "ingested": True,
         "source_id": source_id,
         "session_id": session_id,
         "alert_count": len(body.alerts),
         "has_summary": body.summary is not None,
     }
+    if body.idempotency_key:
+        _get_idempotency_store().put("/v1/proxy/audit", tenant_id, source_id, body.idempotency_key, response)
+    return response
 
 
 def _get_configured_log_path() -> _Path | None:

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -88,6 +88,7 @@ def _jobs_pop(job_id: str) -> ScanJob | None:
 
 # ─── Fleet store (pluggable) ────────────────────────────────────────────────
 _fleet_store: Any = None
+_idempotency_store: Any = None
 
 
 def _get_fleet_store():
@@ -106,6 +107,29 @@ def set_fleet_store(store: Any) -> None:
     """Switch the fleet store backend. Call before server startup."""
     global _fleet_store
     _fleet_store = store
+
+
+def _get_idempotency_store():
+    """Get the active idempotency store for retry-safe write endpoints."""
+    global _idempotency_store
+    if _idempotency_store is None:
+        with _store_lock:
+            if _idempotency_store is None:
+                if os.environ.get("AGENT_BOM_DB"):
+                    from agent_bom.api.idempotency_store import SQLiteIdempotencyStore
+
+                    _idempotency_store = SQLiteIdempotencyStore(os.environ["AGENT_BOM_DB"])
+                else:
+                    from agent_bom.api.idempotency_store import InMemoryIdempotencyStore
+
+                    _idempotency_store = InMemoryIdempotencyStore()
+    return _idempotency_store
+
+
+def set_idempotency_store(store: Any) -> None:
+    """Switch the idempotency store backend. Call before server startup."""
+    global _idempotency_store
+    _idempotency_store = store
 
 
 # ─── Policy store (pluggable) ───────────────────────────────────────────────

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -12,6 +12,7 @@ import copy
 import hashlib
 import logging
 import platform
+import uuid
 
 import httpx
 
@@ -44,6 +45,7 @@ def sanitize_results(results: dict) -> dict:
 
     # Add source identifier
     sanitized["source_id"] = generate_source_id()
+    sanitized["idempotency_key"] = str(uuid.uuid4())
 
     return sanitized
 

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -152,6 +152,65 @@ def test_sync_updates_existing(_mock):
     assert len(store.list_all()) == 1
 
 
+def test_sync_accepts_endpoint_push_payload():
+    client, store = _fresh_client()
+    resp = client.post(
+        "/v1/fleet/sync",
+        json={
+            "source_id": "laptop-a",
+            "agents": [
+                {
+                    "name": "cursor",
+                    "agent_type": "cursor",
+                    "trust_score": 82.5,
+                    "trust_factors": {"registry": 20},
+                    "mcp_servers": [
+                        {
+                            "name": "filesystem",
+                            "packages": [{"name": "express", "version": "4.18.2"}],
+                            "credential_names": ["OPENAI_API_KEY"],
+                            "total_vulnerabilities": 2,
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source_id"] == "laptop-a"
+    assert data["new"] == 1
+    agents = store.list_all()
+    assert len(agents) == 1
+    assert agents[0].name == "cursor"
+    assert agents[0].server_count == 1
+    assert agents[0].package_count == 1
+    assert agents[0].credential_count == 1
+    assert agents[0].vuln_count == 2
+
+
+def test_sync_endpoint_push_is_idempotent():
+    client, store = _fresh_client()
+    payload = {
+        "source_id": "laptop-a",
+        "idempotency_key": "fleet-sync-1",
+        "agents": [
+            {
+                "name": "cursor",
+                "agent_type": "cursor",
+                "trust_score": 82.5,
+                "mcp_servers": [],
+            }
+        ],
+    }
+    first = client.post("/v1/fleet/sync", json=payload)
+    second = client.post("/v1/fleet/sync", json=payload)
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["idempotent_replay"] is True
+    assert len(store.list_all()) == 1
+
+
 # ── State update ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -209,6 +209,37 @@ def test_api_key_middleware_oidc_sets_tenant_from_custom_claim():
     assert resp.json() == {"tenant_id": "tenant-zeta", "role": "analyst"}
 
 
+def test_api_key_middleware_oidc_requires_explicit_role_claim_when_enabled():
+    """Strict OIDC mode should reject tokens that lack a mapped role signal."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+
+    cfg = OIDCConfig(
+        issuer="https://corp.okta.com",
+        audience="agent-bom",
+        require_role_claim=True,
+    )
+    with (
+        patch("agent_bom.api.oidc.OIDCConfig.from_env", return_value=cfg),
+        patch(
+            "agent_bom.api.oidc.verify_oidc_token",
+            return_value={"sub": "u1", "email": "alice@corp.com"},
+        ),
+    ):
+        client = TestClient(test_app)
+        resp = client.get("/v1/test", headers={"Authorization": "Bearer oidc.jwt"})
+
+    assert resp.status_code == 401
+    assert "invalid API key" in resp.json()["detail"]
+
+
 def test_rate_limit_middleware():
     """Should return 429 when rate limit exceeded."""
     from starlette.applications import Starlette

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -27,6 +27,7 @@ import pytest
 from agent_bom.api.oidc import (
     OIDCConfig,
     OIDCError,
+    claims_have_role_signal,
     claims_to_role,
     claims_to_tenant,
     record_oidc_decode_failure,
@@ -105,6 +106,18 @@ def test_oidc_config_require_tenant_claim_from_env():
         assert cfg.require_tenant_claim is True
 
 
+def test_oidc_config_require_role_claim_from_env():
+    with patch.dict(
+        os.environ,
+        {
+            "AGENT_BOM_OIDC_ISSUER": "https://test.okta.com",
+            "AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM": "true",
+        },
+    ):
+        cfg = OIDCConfig.from_env()
+        assert cfg.require_role_claim is True
+
+
 @pytest.fixture(autouse=True)
 def _reset_oidc_metrics():
     reset_oidc_decode_failures()
@@ -137,6 +150,14 @@ def test_claims_analyst_via_groups_array():
 
 def test_claims_viewer_via_unknown_role():
     assert claims_to_role({"agent_bom_role": "readonlyuser"}) == "viewer"
+
+
+def test_claims_have_role_signal_false_for_unknown_role():
+    assert claims_have_role_signal({"agent_bom_role": "readonlyuser"}) is False
+
+
+def test_claims_have_role_signal_true_for_roles_array():
+    assert claims_have_role_signal({"roles": ["admin"]}) is True
 
 
 def test_claims_admin_case_insensitive():
@@ -217,6 +238,18 @@ def test_oidc_config_verify_returns_claims_and_role():
 
     assert claims["email"] == "user@example.com"
     assert role == "analyst"
+
+
+def test_oidc_config_verify_requires_explicit_role_when_enabled():
+    cfg = OIDCConfig(
+        issuer="https://example.com",
+        audience="agent-bom",
+        require_role_claim=True,
+    )
+
+    with patch("agent_bom.api.oidc.verify_oidc_token", return_value={"sub": "user-1", "email": "user@example.com"}):
+        with pytest.raises(OIDCError, match="required role claim"):
+            cfg.verify("valid.jwt.token")
 
 
 def test_oidc_config_resolve_tenant_defaults_when_not_required():

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -183,6 +183,33 @@ def test_proxy_audit_ingest_updates_alerts_and_status():
     proxy_mod._proxy_alerts.clear()
     proxy_mod._proxy_metrics = None
 
+
+def test_proxy_audit_ingest_is_idempotent():
+    import agent_bom.api.routes.proxy as proxy_mod
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+
+    client = TestClient(app)
+    payload = {
+        "source_id": "laptop-1",
+        "session_id": "sess-1",
+        "idempotency_key": "proxy-audit-1",
+        "alerts": [{"type": "runtime_alert", "detector": "credential_leak", "severity": "critical", "message": "AWS key"}],
+        "summary": {"type": "proxy_summary", "total_tool_calls": 7, "total_blocked": 2},
+    }
+    first = client.post("/v1/proxy/audit", json=payload)
+    second = client.post("/v1/proxy/audit", json=payload)
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["idempotent_replay"] is True
+
+    alerts = client.get("/v1/proxy/alerts")
+    assert alerts.json()["count"] == 1
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+
     client = TestClient(app)
     ingest = client.post(
         "/v1/proxy/audit",

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -72,6 +72,12 @@ class TestSanitizeResults:
         assert "source_id" in sanitized
         assert len(sanitized["source_id"]) == 12
 
+    def test_adds_idempotency_key(self):
+        results = {"agents": []}
+        sanitized = sanitize_results(results)
+        assert "idempotency_key" in sanitized
+        assert len(sanitized["idempotency_key"]) >= 32
+
     def test_does_not_mutate_original(self):
         results = {"agents": [{"name": "a", "config_path": "/x"}]}
         sanitize_results(results)


### PR DESCRIPTION
## Summary
- add request idempotency support for fleet sync and proxy audit ingest
- make /v1/fleet/sync accept endpoint push payloads in addition to server-side discovery
- stamp CLI fleet push payloads with an idempotency key and add coverage for replay safety

## Validation
- uv run pytest -q tests/test_api_fleet.py tests/test_api_proxy_scorecard.py tests/test_push.py
- uv run ruff check src/agent_bom/api/idempotency_store.py src/agent_bom/api/models.py src/agent_bom/api/stores.py src/agent_bom/api/routes/fleet.py src/agent_bom/api/routes/proxy.py src/agent_bom/push.py tests/test_api_fleet.py tests/test_api_proxy_scorecard.py tests/test_push.py
- git diff --check