### PR TITLE
Require explicit OIDC role claims in strict mode

### DIFF
--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -12,12 +12,13 @@ Configuration via environment variables::
     AGENT_BOM_OIDC_TENANT_CLAIM = "tenant_id"         # optional JWT claim for tenant
     AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM = "1"         # fail closed when claim absent
     AGENT_BOM_OIDC_REQUIRED_NONCE = "random-nonce"    # optional fail-closed nonce check
+    AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM = "1"           # optional fail-closed role requirement
 
 Role mapping (claim value → agent-bom Role):
 
     "admin"   → Role.ADMIN
     "analyst" → Role.ANALYST
-    any other → Role.VIEWER  (default when claim absent)
+    any other → Role.VIEWER  (default when claim absent unless strict mode enabled)
 
 Install the optional dependency::
 
@@ -250,6 +251,25 @@ def claims_to_role(claims: dict, role_claim: str = "agent_bom_role") -> str:
     return "viewer"
 
 
+def claims_have_role_signal(claims: dict, role_claim: str = "agent_bom_role") -> bool:
+    """Return True when claims include an explicit recognizable role signal."""
+    admin_values = {"admin", "administrator", "superuser"}
+    analyst_values = {"analyst", "security-analyst", "engineer", "developer"}
+
+    role_val = claims.get(role_claim, "")
+    if isinstance(role_val, str) and role_val and role_val.lower() in (admin_values | analyst_values):
+        return True
+
+    for array_claim in ("roles", "groups", "permissions"):
+        values = claims.get(array_claim, [])
+        if isinstance(values, list):
+            lowered = {str(v).lower() for v in values}
+            if lowered & (admin_values | analyst_values):
+                return True
+
+    return False
+
+
 def claims_to_tenant(claims: dict, tenant_claim: str = "tenant_id") -> str | None:
     """Map OIDC JWT claims to a tenant identifier."""
     tenant_val = claims.get(tenant_claim)
@@ -277,6 +297,7 @@ class OIDCConfig:
     - ``AGENT_BOM_OIDC_ROLE_CLAIM`` — JWT claim name for role (default: ``agent_bom_role``)
     - ``AGENT_BOM_OIDC_JWKS_URI`` — Override JWKS URI (optional, auto-discovered if absent)
     - ``AGENT_BOM_OIDC_REQUIRED_NONCE`` — Optional expected ``nonce`` claim for fail-closed checks
+    - ``AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM`` — Fail closed when no explicit mapped role claim is present
     """
 
     def __init__(
@@ -288,6 +309,7 @@ class OIDCConfig:
         tenant_claim: str = "tenant_id",
         require_tenant_claim: Optional[bool] = None,
         required_nonce: Optional[str] = None,
+        require_role_claim: Optional[bool] = None,
     ) -> None:
         self.issuer = issuer or os.environ.get("AGENT_BOM_OIDC_ISSUER", "")
         self.audience = audience or os.environ.get("AGENT_BOM_OIDC_AUDIENCE") or None
@@ -302,6 +324,13 @@ class OIDCConfig:
                 "yes",
             }
         self.require_tenant_claim = require_tenant_claim
+        if require_role_claim is None:
+            require_role_claim = os.environ.get("AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+        self.require_role_claim = require_role_claim
         self.enabled = bool(self.issuer)
 
     def verify(self, token: str) -> tuple[dict, str]:
@@ -315,6 +344,8 @@ class OIDCConfig:
         if not self.audience:
             raise OIDCError("OIDC is configured but AGENT_BOM_OIDC_AUDIENCE is not set")
         claims = verify_oidc_token(token, self.issuer, self.audience, self.jwks_uri, self.required_nonce)
+        if self.require_role_claim and not claims_have_role_signal(claims, self.role_claim):
+            raise OIDCError(f"JWT missing required role claim '{self.role_claim}'")
         role = claims_to_role(claims, self.role_claim)
         return claims, role
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -209,6 +209,37 @@ def test_api_key_middleware_oidc_sets_tenant_from_custom_claim():
     assert resp.json() == {"tenant_id": "tenant-zeta", "role": "analyst"}
 
 
+def test_api_key_middleware_oidc_requires_explicit_role_claim_when_enabled():
+    """Strict OIDC mode should reject tokens that lack a mapped role signal."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+
+    cfg = OIDCConfig(
+        issuer="https://corp.okta.com",
+        audience="agent-bom",
+        require_role_claim=True,
+    )
+    with (
+        patch("agent_bom.api.oidc.OIDCConfig.from_env", return_value=cfg),
+        patch(
+            "agent_bom.api.oidc.verify_oidc_token",
+            return_value={"sub": "u1", "email": "alice@corp.com"},
+        ),
+    ):
+        client = TestClient(test_app)
+        resp = client.get("/v1/test", headers={"Authorization": "Bearer oidc.jwt"})
+
+    assert resp.status_code == 401
+    assert "invalid API key" in resp.json()["detail"]
+
+
 def test_rate_limit_middleware():
     """Should return 429 when rate limit exceeded."""
     from starlette.applications import Starlette

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -27,6 +27,7 @@ import pytest
 from agent_bom.api.oidc import (
     OIDCConfig,
     OIDCError,
+    claims_have_role_signal,
     claims_to_role,
     claims_to_tenant,
     record_oidc_decode_failure,
@@ -105,6 +106,18 @@ def test_oidc_config_require_tenant_claim_from_env():
         assert cfg.require_tenant_claim is True
 
 
+def test_oidc_config_require_role_claim_from_env():
+    with patch.dict(
+        os.environ,
+        {
+            "AGENT_BOM_OIDC_ISSUER": "https://test.okta.com",
+            "AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM": "true",
+        },
+    ):
+        cfg = OIDCConfig.from_env()
+        assert cfg.require_role_claim is True
+
+
 @pytest.fixture(autouse=True)
 def _reset_oidc_metrics():
     reset_oidc_decode_failures()
@@ -137,6 +150,14 @@ def test_claims_analyst_via_groups_array():
 
 def test_claims_viewer_via_unknown_role():
     assert claims_to_role({"agent_bom_role": "readonlyuser"}) == "viewer"
+
+
+def test_claims_have_role_signal_false_for_unknown_role():
+    assert claims_have_role_signal({"agent_bom_role": "readonlyuser"}) is False
+
+
+def test_claims_have_role_signal_true_for_roles_array():
+    assert claims_have_role_signal({"roles": ["admin"]}) is True
 
 
 def test_claims_admin_case_insensitive():
@@ -217,6 +238,18 @@ def test_oidc_config_verify_returns_claims_and_role():
 
     assert claims["email"] == "user@example.com"
     assert role == "analyst"
+
+
+def test_oidc_config_verify_requires_explicit_role_when_enabled():
+    cfg = OIDCConfig(
+        issuer="https://example.com",
+        audience="agent-bom",
+        require_role_claim=True,
+    )
+
+    with patch("agent_bom.api.oidc.verify_oidc_token", return_value={"sub": "user-1", "email": "user@example.com"}):
+        with pytest.raises(OIDCError, match="required role claim"):
+            cfg.verify("valid.jwt.token")
 
 
 def test_oidc_config_resolve_tenant_defaults_when_not_required():


### PR DESCRIPTION
## Summary
- add AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM fail-closed mode for OIDC auth
- deny tokens without a mapped role signal when strict mode is enabled
- add direct OIDC and middleware coverage for the new behavior

## Validation
- uv run pytest -q tests/test_api_oidc.py tests/test_api_hardening.py -x
- uv run ruff check src/agent_bom/api/oidc.py tests/test_api_oidc.py tests/test_api_hardening.py
