### PR TITLE
Add audit export and encrypted backup restore path

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Operator guides:
 - [Packaged API + UI Control Plane](site-docs/deployment/control-plane-helm.md)
 - [Grafana Dashboard](site-docs/deployment/grafana.md)
 - [Performance, Sizing, and Benchmarks](site-docs/deployment/performance-and-sizing.md)
+- [Restore Postgres Backup Script](deploy/ops/restore-postgres-backup.sh)
 
 ## Product views
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Operator guides:
 - [Grafana Dashboard](site-docs/deployment/grafana.md)
 - [Performance, Sizing, and Benchmarks](site-docs/deployment/performance-and-sizing.md)
 - [Restore Postgres Backup Script](deploy/ops/restore-postgres-backup.sh)
+- production backup examples use `REPLACE_ME_BUCKET_REGION` on purpose; set it to your actual S3 bucket region
 
 ## Product views
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Operator guides:
 - [Grafana Dashboard](site-docs/deployment/grafana.md)
 - [Performance, Sizing, and Benchmarks](site-docs/deployment/performance-and-sizing.md)
 - [Restore Postgres Backup Script](deploy/ops/restore-postgres-backup.sh)
-- production backup examples use `REPLACE_ME_BUCKET_REGION` on purpose; set it to your actual S3 bucket region
+- production backup examples use `bucketRegion: REPLACE_ME_BUCKET_REGION` on purpose; set it to your actual object-store bucket region
 
 ## Product views
 

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -94,7 +94,7 @@ controlPlane:
     destination:
       bucket: agent-bom-prod-backups
       prefix: agent-bom/postgres
-      region: us-east-1
+      region: REPLACE_ME_BUCKET_REGION
       encryption:
         enabled: true
         mode: aws:kms

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -95,6 +95,10 @@ controlPlane:
       bucket: agent-bom-prod-backups
       prefix: agent-bom/postgres
       region: us-east-1
+      encryption:
+        enabled: true
+        mode: aws:kms
+        kmsKeyId: alias/agent-bom-backups
     envFrom:
       - secretRef:
           name: agent-bom-control-plane-db

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -94,7 +94,7 @@ controlPlane:
     destination:
       bucket: agent-bom-prod-backups
       prefix: agent-bom/postgres
-      region: REPLACE_ME_BUCKET_REGION
+      bucketRegion: REPLACE_ME_BUCKET_REGION
       encryption:
         enabled: true
         mode: aws:kms

--- a/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
@@ -69,7 +69,7 @@ spec:
                   dump_path="$(cat /backup/latest-path)"
                   test -f "$dump_path"
                   key="{{ trimSuffix "/" .Values.controlPlane.backup.destination.prefix }}/$(basename "$dump_path")"
-                  set -- s3 cp "$dump_path" "s3://{{ .Values.controlPlane.backup.destination.bucket }}/$key" --region "{{ .Values.controlPlane.backup.destination.region }}"
+                  set -- s3 cp "$dump_path" "s3://{{ .Values.controlPlane.backup.destination.bucket }}/$key" --region "{{ default .Values.controlPlane.backup.destination.region .Values.controlPlane.backup.destination.bucketRegion }}"
                   {{- if .Values.controlPlane.backup.destination.endpoint }}
                   set -- "$@" --endpoint-url "{{ .Values.controlPlane.backup.destination.endpoint }}"
                   {{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
@@ -73,6 +73,12 @@ spec:
                   {{- if .Values.controlPlane.backup.destination.endpoint }}
                   set -- "$@" --endpoint-url "{{ .Values.controlPlane.backup.destination.endpoint }}"
                   {{- end }}
+                  {{- if .Values.controlPlane.backup.destination.encryption.enabled }}
+                  set -- "$@" --sse "{{ .Values.controlPlane.backup.destination.encryption.mode }}"
+                  {{- if .Values.controlPlane.backup.destination.encryption.kmsKeyId }}
+                  set -- "$@" --sse-kms-key-id "{{ .Values.controlPlane.backup.destination.encryption.kmsKeyId }}"
+                  {{- end }}
+                  {{- end }}
                   {{- range .Values.controlPlane.backup.destination.extraArgs }}
                   set -- "$@" "{{ . }}"
                   {{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -259,6 +259,7 @@ controlPlane:
     destination:
       bucket: ""
       prefix: "agent-bom/postgres"
+      bucketRegion: ""
       region: us-east-1
       endpoint: ""
       encryption:

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -261,6 +261,10 @@ controlPlane:
       prefix: "agent-bom/postgres"
       region: us-east-1
       endpoint: ""
+      encryption:
+        enabled: true
+        mode: "AES256"
+        kmsKeyId: ""
       extraArgs: []
     retentionDays: 14
     env: []

--- a/deploy/ops/restore-postgres-backup.sh
+++ b/deploy/ops/restore-postgres-backup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <s3-uri> <postgres-url> <aws-region> [local-file]" >&2
+  exit 1
+fi
+
+s3_uri="$1"
+postgres_url="$2"
+aws_region="$3"
+local_file="${4:-/tmp/agent-bom-restore.dump}"
+
+aws s3 cp "$s3_uri" "$local_file" --region "$aws_region"
+pg_restore \
+  --clean \
+  --if-exists \
+  --no-owner \
+  --no-privileges \
+  --dbname "$postgres_url" \
+  "$local_file"

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -168,6 +168,7 @@ You still own:
 - enable `controlPlane.observability.prometheusRule.enabled=true` when the cluster already runs Prometheus Operator
 - enable `controlPlane.observability.grafanaDashboard.enabled=true` when Grafana watches dashboard `ConfigMap`s
 - enable `controlPlane.backup.enabled=true` only after setting a real S3 bucket, prefix, and IRSA-backed upload permissions
+- set `controlPlane.backup.destination.region` to the actual region of your backup bucket; the production example intentionally uses `REPLACE_ME_BUCKET_REGION`
 - keep `controlPlane.backup.destination.encryption.enabled=true`; the default is `AES256`, and production should set `mode=aws:kms` with a dedicated `kmsKeyId`
 - restore drills should use [`deploy/ops/restore-postgres-backup.sh`](../../deploy/ops/restore-postgres-backup.sh):
   `./deploy/ops/restore-postgres-backup.sh s3://bucket/key.dump "$AGENT_BOM_POSTGRES_URL" us-east-1`

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -132,7 +132,7 @@ That example adds:
 - `external-secrets` integration for the control-plane secrets, including split refresh cadence for DB vs auth/HMAC material
 - packaged `PrometheusRule` alerts for API error rate, scanner failures, OIDC decode failures, and proxy audit backlog
 - packaged Grafana dashboard `ConfigMap` for clusters that already watch dashboard config
-- packaged Postgres backup `CronJob` that runs `pg_dump` and uploads to S3 through IRSA
+- packaged Postgres backup `CronJob` that runs `pg_dump` and uploads to S3 through IRSA with SSE or KMS
 - restricted ingress defaults for the chart network policy
 
 ## What you still own
@@ -168,6 +168,9 @@ You still own:
 - enable `controlPlane.observability.prometheusRule.enabled=true` when the cluster already runs Prometheus Operator
 - enable `controlPlane.observability.grafanaDashboard.enabled=true` when Grafana watches dashboard `ConfigMap`s
 - enable `controlPlane.backup.enabled=true` only after setting a real S3 bucket, prefix, and IRSA-backed upload permissions
+- keep `controlPlane.backup.destination.encryption.enabled=true`; the default is `AES256`, and production should set `mode=aws:kms` with a dedicated `kmsKeyId`
+- restore drills should use [`deploy/ops/restore-postgres-backup.sh`](../../deploy/ops/restore-postgres-backup.sh):
+  `./deploy/ops/restore-postgres-backup.sh s3://bucket/key.dump "$AGENT_BOM_POSTGRES_URL" us-east-1`
 - enable PDBs when you are running multi-replica workloads
 
 ## Current boundary

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -168,7 +168,8 @@ You still own:
 - enable `controlPlane.observability.prometheusRule.enabled=true` when the cluster already runs Prometheus Operator
 - enable `controlPlane.observability.grafanaDashboard.enabled=true` when Grafana watches dashboard `ConfigMap`s
 - enable `controlPlane.backup.enabled=true` only after setting a real S3 bucket, prefix, and IRSA-backed upload permissions
-- set `controlPlane.backup.destination.region` to the actual region of your backup bucket; the production example intentionally uses `REPLACE_ME_BUCKET_REGION`
+- set `controlPlane.backup.destination.bucketRegion` to the actual region of your backup bucket; the production example intentionally uses `REPLACE_ME_BUCKET_REGION`
+- `controlPlane.backup.destination.region` remains as a backward-compatible fallback for older values files
 - keep `controlPlane.backup.destination.encryption.enabled=true`; the default is `AES256`, and production should set `mode=aws:kms` with a dedicated `kmsKeyId`
 - restore drills should use [`deploy/ops/restore-postgres-backup.sh`](../../deploy/ops/restore-postgres-backup.sh):
   `./deploy/ops/restore-postgres-backup.sh s3://bucket/key.dump "$AGENT_BOM_POSTGRES_URL" us-east-1`

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -102,7 +102,7 @@ The chart now supports the EKS wiring you actually need:
 | `controlPlane.externalSecrets.secrets[]` | split DB secret cadence from faster OIDC / audit-HMAC rotation |
 | `controlPlane.observability.prometheusRule.*` | package alert rules for API, scanner, OIDC, and proxy backlog |
 | `controlPlane.observability.grafanaDashboard.*` | package the shipped Grafana dashboard as a `ConfigMap` |
-| `controlPlane.backup.*` | package Postgres backup jobs that dump and upload to S3 through IRSA |
+| `controlPlane.backup.*` | package Postgres backup jobs that dump and upload to S3 through IRSA with SSE or KMS |
 | `scanner.extraArgs` | add `--k8s-mcp`, `--enforce`, `--introspect`, or stricter presets |
 | `scanner.env` | inject operator-owned environment like API endpoints or auth context |
 | `scanner.allNamespaces` | scan cluster-wide instead of one namespace |
@@ -181,6 +181,8 @@ all sit under one operator-controlled plane.
 - enable the packaged PrometheusRule and Grafana dashboard when your cluster
   already runs Prometheus Operator and Grafana sidecar discovery
 - enable the packaged backup CronJob only after setting a real S3 destination
+- set `controlPlane.backup.destination.encryption.mode=aws:kms` and a real KMS key for production backups
+- run restore drills with [`deploy/ops/restore-postgres-backup.sh`](../../deploy/ops/restore-postgres-backup.sh) and document RTO/RPO around that exact command path
   and granting `s3:PutObject` via IRSA
 - set a persistent audit HMAC key and require it
 - attach the scanner service account to IRSA instead of static cloud keys

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -181,7 +181,8 @@ all sit under one operator-controlled plane.
 - enable the packaged PrometheusRule and Grafana dashboard when your cluster
   already runs Prometheus Operator and Grafana sidecar discovery
 - enable the packaged backup CronJob only after setting a real S3 destination
-- set `controlPlane.backup.destination.region` to your real bucket region; the production example intentionally leaves a `REPLACE_ME_BUCKET_REGION` placeholder
+- set `controlPlane.backup.destination.bucketRegion` to your real bucket region; the production example intentionally leaves a `REPLACE_ME_BUCKET_REGION` placeholder
+- `controlPlane.backup.destination.region` remains as a backward-compatible fallback for older values files
 - set `controlPlane.backup.destination.encryption.mode=aws:kms` and a real KMS key for production backups
 - run restore drills with [`deploy/ops/restore-postgres-backup.sh`](../../deploy/ops/restore-postgres-backup.sh) and document RTO/RPO around that exact command path
   and granting `s3:PutObject` via IRSA

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -181,6 +181,7 @@ all sit under one operator-controlled plane.
 - enable the packaged PrometheusRule and Grafana dashboard when your cluster
   already runs Prometheus Operator and Grafana sidecar discovery
 - enable the packaged backup CronJob only after setting a real S3 destination
+- set `controlPlane.backup.destination.region` to your real bucket region; the production example intentionally leaves a `REPLACE_ME_BUCKET_REGION` placeholder
 - set `controlPlane.backup.destination.encryption.mode=aws:kms` and a real KMS key for production backups
 - run restore drills with [`deploy/ops/restore-postgres-backup.sh`](../../deploy/ops/restore-postgres-backup.sh) and document RTO/RPO around that exact command path
   and granting `s3:PutObject` via IRSA

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -97,6 +97,11 @@ class AuditEntry:
         }
 
 
+def sign_export_payload(payload: bytes) -> str:
+    """Sign an exported audit payload so downstream consumers can verify it."""
+    return hmac.new(_HMAC_KEY, payload, hashlib.sha256).hexdigest()
+
+
 class AuditLogStore(Protocol):
     """Protocol for audit log persistence."""
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -6,6 +6,7 @@ Endpoints:
     DELETE /v1/auth/keys/{key_id}             revoke API key
     GET    /v1/audit                          audit log entries
     GET    /v1/audit/integrity                verify audit HMAC integrity
+    GET    /v1/audit/export                   export audit evidence packet
     POST   /v1/exceptions                     create vuln exception
     GET    /v1/exceptions                     list exceptions
     GET    /v1/exceptions/{exception_id}      get exception
@@ -24,10 +25,12 @@ Endpoints:
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from agent_bom.api.models import CreateKeyRequest, ExceptionRequest, FalsePositiveRequest, JiraTicketRequest
 from agent_bom.api.stores import _get_exception_store, _get_store, _get_trend_store
@@ -134,6 +137,79 @@ async def audit_integrity(limit: int = 1000) -> dict:
 
     verified, tampered = get_audit_log().verify_integrity(limit=limit)
     return {"verified": verified, "tampered": tampered, "checked": verified + tampered}
+
+
+@router.get("/v1/audit/export", tags=["enterprise"])
+async def export_audit_entries(
+    request: Request,
+    action: str | None = None,
+    resource: str | None = None,
+    since: str | None = None,
+    limit: int = 1000,
+    offset: int = 0,
+    format: str = "json",
+):
+    """Export audit entries as a signed evidence packet."""
+    from agent_bom.api.audit_log import get_audit_log, log_action, sign_export_payload
+
+    fmt = format.lower()
+    if fmt not in {"json", "jsonl"}:
+        raise HTTPException(status_code=400, detail="format must be one of: json, jsonl")
+
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    actor = getattr(request.state, "api_key_name", "") or "system"
+    store = get_audit_log()
+    entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset)
+    verified, tampered = store.verify_integrity(limit=min(limit, 10_000))
+
+    log_action(
+        "audit.export",
+        actor=actor,
+        resource="audit/export",
+        tenant_id=tenant_id,
+        format=fmt,
+        exported=len(entries),
+        action_filter=action,
+        resource_filter=resource,
+    )
+
+    if fmt == "jsonl":
+        lines = [json.dumps(entry.to_dict(), sort_keys=True) for entry in entries]
+        payload = ("\n".join(lines) + ("\n" if lines else "")).encode()
+        return PlainTextResponse(
+            content=payload.decode(),
+            media_type="application/x-ndjson",
+            headers={
+                "Content-Disposition": 'attachment; filename="agent-bom-audit-export.jsonl"',
+                "X-Agent-Bom-Audit-Export-Signature": sign_export_payload(payload),
+            },
+        )
+
+    body = {
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "tenant_id": tenant_id,
+        "filters": {
+            "action": action,
+            "resource": resource,
+            "since": since,
+            "limit": limit,
+            "offset": offset,
+        },
+        "integrity": {
+            "verified": verified,
+            "tampered": tampered,
+            "checked": verified + tampered,
+        },
+        "entries": [entry.to_dict() for entry in entries],
+    }
+    payload = json.dumps(body, sort_keys=True).encode()
+    return JSONResponse(
+        content=body,
+        headers={
+            "Content-Disposition": 'attachment; filename="agent-bom-audit-export.json"',
+            "X-Agent-Bom-Audit-Export-Signature": sign_export_payload(payload),
+        },
+    )
 
 
 # ── Exception / Waiver Management ────────────────────────────────────────────

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 
+from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
 from agent_bom.api.exception_store import InMemoryExceptionStore, VulnException
 from agent_bom.api.models import CreateKeyRequest
@@ -180,3 +182,40 @@ async def test_remove_false_positive_returns_404_for_wrong_tenant(isolated_excep
 
     assert error.value.status_code == 404
     assert isolated_exception_store.get(exc.exception_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_export_audit_entries_returns_signed_json(monkeypatch):
+    store = InMemoryAuditLog()
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/1", details={"packages": 5}))
+    monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
+
+    response = await enterprise.export_audit_entries(_request("tenant-alpha", "alice-admin"))
+
+    payload = json.loads(response.body.decode())
+    assert payload["tenant_id"] == "tenant-alpha"
+    assert payload["entries"][0]["action"] == "scan"
+    assert response.headers["x-agent-bom-audit-export-signature"]
+    assert response.headers["content-disposition"].endswith('agent-bom-audit-export.json"')
+
+
+@pytest.mark.asyncio
+async def test_export_audit_entries_supports_jsonl(monkeypatch):
+    store = InMemoryAuditLog()
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/1"))
+    monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
+
+    response = await enterprise.export_audit_entries(_request("tenant-alpha", "alice-admin"), format="jsonl")
+
+    lines = [line for line in response.body.decode().splitlines() if line]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["resource"] == "job/1"
+    assert response.media_type == "application/x-ndjson"
+
+
+@pytest.mark.asyncio
+async def test_export_audit_entries_rejects_unknown_format():
+    with pytest.raises(HTTPException) as error:
+        await enterprise.export_audit_entries(_request("tenant-alpha"), format="csv")
+
+    assert error.value.status_code == 400

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -329,6 +329,7 @@ def test_helm_control_plane_backup_defaults():
     assert backup["enabled"] is False
     assert backup["schedule"] == "0 3 * * *"
     assert backup["destination"]["prefix"] == "agent-bom/postgres"
+    assert backup["destination"]["bucketRegion"] == ""
     assert backup["destination"]["encryption"]["enabled"] is True
     assert backup["destination"]["encryption"]["mode"] == "AES256"
     assert backup["image"]["dumpRepository"] == "postgres"
@@ -406,7 +407,7 @@ def test_production_values_enable_operator_defaults():
     assert production["controlPlane"]["observability"]["prometheusRule"]["enabled"] is True
     assert production["controlPlane"]["backup"]["enabled"] is True
     assert production["controlPlane"]["backup"]["destination"]["bucket"] == "agent-bom-prod-backups"
-    assert production["controlPlane"]["backup"]["destination"]["region"] == "REPLACE_ME_BUCKET_REGION"
+    assert production["controlPlane"]["backup"]["destination"]["bucketRegion"] == "REPLACE_ME_BUCKET_REGION"
     assert production["controlPlane"]["backup"]["destination"]["encryption"]["enabled"] is True
     assert production["controlPlane"]["backup"]["destination"]["encryption"]["mode"] == "aws:kms"
     assert production["controlPlane"]["backup"]["destination"]["encryption"]["kmsKeyId"] == "alias/agent-bom-backups"

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -11,6 +11,7 @@ K8S_DIR = DEPLOY_DIR / "k8s"
 HELM_DIR = DEPLOY_DIR / "helm" / "agent-bom"
 ENDPOINTS_DIR = DEPLOY_DIR / "endpoints"
 LOADTEST_DIR = DEPLOY_DIR / "loadtest"
+OPS_DIR = DEPLOY_DIR / "ops"
 
 
 # ─── K8s manifest validation ────────────────────────────────────────────────
@@ -142,6 +143,15 @@ def test_loadtest_harness_assets_exist():
     }
     actual = {path.name for path in LOADTEST_DIR.iterdir() if path.is_file()}
     assert expected.issubset(actual)
+
+
+def test_restore_backup_script_exists():
+    """Operators should get a concrete restore path with the packaged backup job."""
+    script = OPS_DIR / "restore-postgres-backup.sh"
+    assert script.exists()
+    body = script.read_text()
+    assert "aws s3 cp" in body
+    assert "pg_restore" in body
 
 
 def test_loadtest_scripts_target_real_endpoints():
@@ -319,6 +329,8 @@ def test_helm_control_plane_backup_defaults():
     assert backup["enabled"] is False
     assert backup["schedule"] == "0 3 * * *"
     assert backup["destination"]["prefix"] == "agent-bom/postgres"
+    assert backup["destination"]["encryption"]["enabled"] is True
+    assert backup["destination"]["encryption"]["mode"] == "AES256"
     assert backup["image"]["dumpRepository"] == "postgres"
     assert backup["image"]["uploadRepository"] == "amazon/aws-cli"
 
@@ -394,6 +406,9 @@ def test_production_values_enable_operator_defaults():
     assert production["controlPlane"]["observability"]["prometheusRule"]["enabled"] is True
     assert production["controlPlane"]["backup"]["enabled"] is True
     assert production["controlPlane"]["backup"]["destination"]["bucket"] == "agent-bom-prod-backups"
+    assert production["controlPlane"]["backup"]["destination"]["encryption"]["enabled"] is True
+    assert production["controlPlane"]["backup"]["destination"]["encryption"]["mode"] == "aws:kms"
+    assert production["controlPlane"]["backup"]["destination"]["encryption"]["kmsKeyId"] == "alias/agent-bom-backups"
     secrets = production["controlPlane"]["externalSecrets"]["secrets"]
     assert {secret["target"]["name"] for secret in secrets} == {
         "agent-bom-control-plane-auth",

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -406,6 +406,7 @@ def test_production_values_enable_operator_defaults():
     assert production["controlPlane"]["observability"]["prometheusRule"]["enabled"] is True
     assert production["controlPlane"]["backup"]["enabled"] is True
     assert production["controlPlane"]["backup"]["destination"]["bucket"] == "agent-bom-prod-backups"
+    assert production["controlPlane"]["backup"]["destination"]["region"] == "REPLACE_ME_BUCKET_REGION"
     assert production["controlPlane"]["backup"]["destination"]["encryption"]["enabled"] is True
     assert production["controlPlane"]["backup"]["destination"]["encryption"]["mode"] == "aws:kms"
     assert production["controlPlane"]["backup"]["destination"]["encryption"]["kmsKeyId"] == "alias/agent-bom-backups"


### PR DESCRIPTION
## Summary
- add a signed audit export endpoint for enterprise evidence packets
- encrypt packaged Postgres backups by default and switch the production example to KMS
- ship a concrete restore script and document the restore drill path

## Validation
- uv run pytest -q tests/test_api_enterprise_tenant.py tests/test_deploy_manifests.py
- uv run ruff check src/agent_bom/api/audit_log.py src/agent_bom/api/routes/enterprise.py tests/test_api_enterprise_tenant.py tests/test_deploy_manifests.py
- uv run mypy src/agent_bom/api/routes/enterprise.py src/agent_bom/api/audit_log.py
- git diff --check