### PR TITLE
Reframe SAST helper-chain findings

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -73,8 +73,8 @@ controlPlane:
         data:
           - secretKey: AGENT_BOM_POSTGRES_URL
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_POSTGRES_URL
+              key: REPLACE_ME_DB_SECRET_PATH
+              property: REPLACE_ME_POSTGRES_URL_PROPERTY
       - nameSuffix: control-plane-auth
         refreshInterval: 5m
         target:
@@ -82,40 +82,40 @@ controlPlane:
         data:
           - secretKey: AGENT_BOM_OIDC_ISSUER
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_OIDC_ISSUER
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_OIDC_ISSUER_PROPERTY
           - secretKey: AGENT_BOM_OIDC_AUDIENCE
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_OIDC_AUDIENCE
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_OIDC_AUDIENCE_PROPERTY
           - secretKey: AGENT_BOM_SAML_IDP_ENTITY_ID
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_SAML_IDP_ENTITY_ID
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SAML_IDP_ENTITY_ID_PROPERTY
           - secretKey: AGENT_BOM_SAML_IDP_SSO_URL
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_SAML_IDP_SSO_URL
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SAML_IDP_SSO_URL_PROPERTY
           - secretKey: AGENT_BOM_SAML_IDP_X509_CERT
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_SAML_IDP_X509_CERT
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SAML_IDP_X509_CERT_PROPERTY
           - secretKey: AGENT_BOM_SAML_SP_ENTITY_ID
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_SAML_SP_ENTITY_ID
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SAML_SP_ENTITY_ID_PROPERTY
           - secretKey: AGENT_BOM_SAML_SP_ACS_URL
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_SAML_SP_ACS_URL
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SAML_SP_ACS_URL_PROPERTY
           - secretKey: AGENT_BOM_AUDIT_HMAC_KEY
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_AUDIT_HMAC_KEY
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_AUDIT_HMAC_KEY_PROPERTY
           - secretKey: AGENT_BOM_REQUIRE_AUDIT_HMAC
             remoteRef:
-              key: /agent-bom/prod/control-plane
-              property: AGENT_BOM_REQUIRE_AUDIT_HMAC
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_REQUIRE_AUDIT_HMAC_PROPERTY
   backup:
     enabled: true
     schedule: "0 3 * * *"

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -8,14 +8,14 @@ Extends the regex-based scanner with semantic analysis:
 - **Credential flow analysis** — tracks env var → agent parameter paths
 - **Framework-specific patterns** — LangChain chains, CrewAI crews, MCP servers, etc.
 - **Call graph extraction** — function-to-function edges for Python entrypoints
-- **Inter-procedural flow findings** — helper-chain reachability to dangerous sinks
+- **Bounded helper-chain findings** — lightweight call-path detection from tool entrypoints to dangerous sinks
 
 Python files use full AST parsing. JS/TS files contribute prompt/tool/guardrail
 signals plus parser-backed import, handler, and call-chain extraction so
 non-Python agent projects participate in the same inventory and flow model.
 
 Compliance mapping:
-- OWASP LLM01 (Prompt Injection) — prompt extraction enables review
+- OWASP LLM01 (Prompt Injection) — prompt inventory and risk review signals
 - OWASP LLM02 (Insecure Output) — guardrail detection validates defenses
 - NIST AI RMF MAP-3.5 — inventories AI components at code level
 - EU AI Act ART-15 — transparency of AI system instructions
@@ -1630,7 +1630,13 @@ def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFindin
 
 
 def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge], list[FlowFinding]]:
-    """Build a lightweight call graph and inter-procedural findings."""
+    """Build a lightweight call graph and bounded helper-chain findings.
+
+    This path is intentionally lightweight: it follows resolved helper-call
+    chains from tool entrypoints to already-detected dangerous sinks, but it
+    does not claim full inter-procedural taint propagation or proof-grade
+    reachability across arbitrary call graphs.
+    """
     by_name: dict[str, list[_FunctionAnalysis]] = {}
     by_module_and_name: dict[tuple[str, str], _FunctionAnalysis] = {}
     for func in functions:
@@ -1681,8 +1687,10 @@ def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge
                 findings.append(
                     FlowFinding(
                         category="interprocedural_dangerous_flow",
-                        title="Tool call chain reaches dangerous sink",
-                        detail=(f"Tool `{func.simple_name}` reaches `{sink_name}` through helper calls in {current.file_path}."),
+                        title="Tool helper chain reaches dangerous sink",
+                        detail=(
+                            f"Tool `{func.simple_name}` reaches `{sink_name}` through a bounded helper-call chain in {current.file_path}."
+                        ),
                         file_path=current.file_path,
                         line_number=line_num,
                         entrypoint=func.simple_name,

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -366,6 +366,13 @@ def test_analyze_project_builds_interprocedural_dangerous_flow(tmp_path: Path):
         finding.category == "interprocedural_dangerous_flow" and finding.entrypoint == "execute" and finding.sink == "subprocess.run"
         for finding in result.flow_findings
     )
+    finding = next(
+        finding
+        for finding in result.flow_findings
+        if finding.category == "interprocedural_dangerous_flow" and finding.entrypoint == "execute" and finding.sink == "subprocess.run"
+    )
+    assert finding.call_path == ["execute", "run_shell", "subprocess.run"]
+    assert "bounded helper-call chain" in finding.detail
 
 
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):


### PR DESCRIPTION
Closes #1481

## Summary
- narrow the AST analyzer contract from broad inter-procedural wording to bounded helper-chain findings
- pin the user-facing contract in tests so future changes do not drift back into overclaiming
- replace concrete-looking secret-manager example paths with operator-owned placeholders in the production EKS example

## Validation
- uv run pytest -q tests/test_ast_analyzer.py tests/test_deploy_manifests.py
- uv run ruff check src/agent_bom/ast_analyzer.py tests/test_ast_analyzer.py tests/test_deploy_manifests.py
- git diff --check