### PR TITLE
Add live Kubernetes posture scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Pick the entrypoint that matches your first job:
 | Turn findings into a fix plan | `agent-bom agents -p . --remediate remediation.md` | Prioritized remediation plan with fix versions and reachable impact |
 | Check a package before install | `agent-bom check flask@2.2.0 --ecosystem pypi` | Machine-readable pre-install verdict |
 | Scan a container image | `agent-bom image nginx:latest` | OS and package CVEs with fixability |
-| Audit IaC or cloud posture | `agent-bom iac Dockerfile k8s/ infra/main.tf` | Misconfigurations and posture findings |
+| Audit IaC or cloud posture | `agent-bom iac Dockerfile k8s/ infra/main.tf` | Misconfigurations, manifest hardening, and optional live cluster posture |
 | Review findings in a persistent graph | `agent-bom serve` | API, dashboard, unified graph, current-state and diff views. Requires `pip install 'agent-bom[ui]'` once. |
 | Inspect live MCP traffic | `agent-bom proxy "<server command>"` | Inline runtime inspection, detector chaining, response/argument review |
 
@@ -85,6 +85,7 @@ agent-bom skills scan .                       # Scan CLAUDE.md, AGENTS.md, .curs
 agent-bom check flask@2.0.0 --ecosystem pypi  # Pre-install CVE gate
 agent-bom image nginx:latest                  # Container image scan
 agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC scan across one or more paths
+agent-bom iac . --k8s-live --k8s-all-namespaces  # Live Kubernetes posture via kubectl
 ```
 
 ## What to do after the first scan

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -18,12 +18,30 @@ Those static manifests are still the scanner/runtime path.
 If you want the packaged API + dashboard control plane, use the Helm chart
 described below.
 
+## Runtime boundary
+
+`agent-bom` now has two distinct Kubernetes security surfaces:
+
+- manifest hardening
+  - `agent-bom iac k8s/`
+  - scans YAML/Helm content in Git or on disk
+- live cluster posture
+  - `agent-bom iac . --k8s-live --k8s-all-namespaces`
+  - inspects runtime state through `kubectl`
+  - covers live pod health, live RBAC drift, and namespace NetworkPolicy coverage
+
+The live path is intentionally scoped. It does not claim full admission-policy,
+service-mesh, or arbitrary controller-state analysis.
+
 ## Quick start
 
 ```bash
 kubectl apply -f deploy/k8s/namespace.yaml
 kubectl apply -f deploy/k8s/rbac.yaml
 kubectl apply -f deploy/k8s/cronjob.yaml
+
+# Inspect live cluster posture through kubectl
+agent-bom iac . --k8s-live --k8s-all-namespaces
 ```
 
 ## Helm chart

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -118,6 +118,10 @@ def fs_cmd(
 @click.option("--fail-on-severity", type=click.Choice(["critical", "high", "medium", "low"]))
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 @click.option("--fixable-only", "fixable_only", is_flag=True, default=False, help="Show only vulnerabilities with available fixes.")
+@click.option("--k8s-live", is_flag=True, help="Inspect live Kubernetes cluster posture via kubectl")
+@click.option("--k8s-namespace", "k8s_live_namespace", default="default", show_default=True, help="Kubernetes namespace for --k8s-live")
+@click.option("--k8s-all-namespaces", "k8s_live_all_namespaces", is_flag=True, help="Inspect all namespaces for --k8s-live")
+@click.option("--k8s-context", "k8s_live_context", default=None, help="kubectl context for --k8s-live")
 def iac_cmd(
     paths: tuple[str, ...],
     output_format: str,
@@ -125,6 +129,10 @@ def iac_cmd(
     fail_on_severity: Optional[str],
     quiet: bool,
     fixable_only: bool,
+    k8s_live: bool,
+    k8s_live_namespace: str,
+    k8s_live_all_namespaces: bool,
+    k8s_live_context: Optional[str],
 ) -> None:
     """Scan infrastructure-as-code files for misconfigurations.
 
@@ -135,6 +143,7 @@ def iac_cmd(
       agent-bom iac Dockerfile
       agent-bom iac Dockerfile k8s/ infra/main.tf
       agent-bom iac . -f sarif -o iac-results.sarif
+      agent-bom iac . --k8s-live --k8s-all-namespaces
     """
     from agent_bom.cli.agents import scan
 
@@ -149,6 +158,10 @@ def iac_cmd(
         fail_on_severity=fail_on_severity,
         quiet=quiet,
         fixable_only=fixable_only,
+        k8s_live=k8s_live,
+        k8s_live_namespace=k8s_live_namespace,
+        k8s_live_all_namespaces=k8s_live_all_namespaces,
+        k8s_live_context=k8s_live_context,
     )
 
 

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -303,6 +303,10 @@ def scan(
     posture: bool = False,
     _iac_only: bool = False,
     _image_only: bool = False,
+    k8s_live: bool = False,
+    k8s_live_namespace: str = "default",
+    k8s_live_all_namespaces: bool = False,
+    k8s_live_context: Optional[str] = None,
 ):
     """Discover agents, extract dependencies, scan for vulnerabilities.
 
@@ -632,26 +636,51 @@ def scan(
     # skip ALL discovery, package extraction, and network calls entirely.
     # This prevents MCP config discovery, lockfile scanning, and registry
     # lookups from running when the user only asked for IaC misconfiguration checks.
-    if _iac_only and iac_paths:
+    if _iac_only and (iac_paths or k8s_live):
         from agent_bom.iac import scan_iac_directory
+        from agent_bom.k8s import K8sDiscoveryError, scan_live_cluster_posture
 
         _iac_ctx = ScanContext(con=con)
         all_iac_findings: list = []
-        con.print(f"\n[bold blue]Scanning {len(iac_paths)} path(s) for IaC misconfigurations...[/bold blue]\n")
-        for _iac_path in iac_paths:
-            _iac_f = scan_iac_directory(_iac_path)
-            all_iac_findings.extend(_iac_f)
-            if _iac_f:
+        if iac_paths:
+            con.print(f"\n[bold blue]Scanning {len(iac_paths)} path(s) for IaC misconfigurations...[/bold blue]\n")
+            for _iac_path in iac_paths:
+                _iac_f = scan_iac_directory(_iac_path)
+                all_iac_findings.extend(_iac_f)
+                if _iac_f:
+                    from collections import Counter as _Counter
+
+                    _sev_counts = _Counter(f.severity for f in _iac_f)
+                    _sev_parts = [
+                        f"[red]{_sev_counts.get('critical', 0)} critical[/red]",
+                        f"[yellow]{_sev_counts.get('high', 0)} high[/yellow]",
+                    ]
+                    con.print(f"  [red]⚠[/red]  {_iac_path}: {len(_iac_f)} finding(s) ({', '.join(_sev_parts)})")
+                else:
+                    con.print(f"  [green]✓[/green] {_iac_path}: no misconfigurations")
+        if k8s_live:
+            con.print("\n[bold blue]Inspecting live Kubernetes cluster posture...[/bold blue]\n")
+            try:
+                _k8s_live_findings = scan_live_cluster_posture(
+                    namespace=k8s_live_namespace,
+                    all_namespaces=k8s_live_all_namespaces,
+                    context=k8s_live_context,
+                )
+            except K8sDiscoveryError as exc:
+                con.print(f"  [red]✗[/red] live cluster scan failed: {exc}")
+                raise SystemExit(1)
+            all_iac_findings.extend(_k8s_live_findings)
+            if _k8s_live_findings:
                 from collections import Counter as _Counter
 
-                _sev_counts = _Counter(f.severity for f in _iac_f)
+                _sev_counts = _Counter(f.severity for f in _k8s_live_findings)
                 _sev_parts = [
                     f"[red]{_sev_counts.get('critical', 0)} critical[/red]",
                     f"[yellow]{_sev_counts.get('high', 0)} high[/yellow]",
                 ]
-                con.print(f"  [red]⚠[/red]  {_iac_path}: {len(_iac_f)} finding(s) ({', '.join(_sev_parts)})")
+                con.print(f"  [red]⚠[/red]  live cluster posture: {len(_k8s_live_findings)} finding(s) ({', '.join(_sev_parts)})")
             else:
-                con.print(f"  [green]✓[/green] {_iac_path}: no misconfigurations")
+                con.print("  [green]✓[/green] live cluster posture: no runtime misconfigurations")
 
         _iac_report = AIBOMReport(agents=[], blast_radii=[])
         _iac_report.iac_findings_data = {

--- a/src/agent_bom/k8s.py
+++ b/src/agent_bom/k8s.py
@@ -1,4 +1,4 @@
-"""Kubernetes pod discovery — extract container image references from a cluster.
+"""Kubernetes live-cluster helpers.
 
 Runs ``kubectl get pods`` to list running containers, then returns their image
 references so the caller can pass them to ``image.scan_image()`` for package
@@ -19,6 +19,8 @@ import shutil
 import subprocess
 from typing import Optional
 
+from agent_bom.iac.models import IaCFinding
+
 
 class K8sDiscoveryError(Exception):
     """Raised when kubectl discovery fails."""
@@ -29,6 +31,39 @@ def _kubectl_available() -> bool:
 
 
 ImageRecord = tuple[str, str, str]  # (image_ref, pod_name, container_name)
+
+
+def _run_kubectl_json(args: list[str], *, context: Optional[str] = None, timeout: int = 60) -> dict:
+    """Run kubectl and parse JSON output."""
+    if not _kubectl_available():
+        raise K8sDiscoveryError(
+            "'kubectl' not found on PATH. Install kubectl and ensure it is configured with access to the target cluster."
+        )
+
+    cmd = ["kubectl", *args]
+    if context:
+        cmd += ["--context", context]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        raise K8sDiscoveryError("kubectl not found")
+    except subprocess.TimeoutExpired:
+        raise K8sDiscoveryError("kubectl timed out — check cluster connectivity")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise K8sDiscoveryError(f"kubectl exited {result.returncode}: {stderr[:300]}")
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise K8sDiscoveryError(f"kubectl produced invalid JSON: {exc}")
 
 
 def discover_images(
@@ -55,44 +90,17 @@ def discover_images(
     Raises:
         K8sDiscoveryError: If kubectl is not available or the API call fails.
     """
-    if not _kubectl_available():
-        raise K8sDiscoveryError(
-            "'kubectl' not found on PATH. Install kubectl and ensure it is configured with access to the target cluster."
-        )
-
-    cmd = ["kubectl", "get", "pods", "-o", "json"]
+    cmd = ["get", "pods", "-o", "json"]
 
     if all_namespaces:
         cmd.append("-A")
     else:
         cmd += ["-n", namespace]
 
-    if context:
-        cmd += ["--context", context]
-
     if label_selector:
         cmd += ["-l", label_selector]
 
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-    except FileNotFoundError:
-        raise K8sDiscoveryError("kubectl not found")
-    except subprocess.TimeoutExpired:
-        raise K8sDiscoveryError("kubectl timed out — check cluster connectivity")
-
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        raise K8sDiscoveryError(f"kubectl exited {result.returncode}: {stderr[:300]}")
-
-    try:
-        data = json.loads(result.stdout)
-    except json.JSONDecodeError as e:
-        raise K8sDiscoveryError(f"kubectl produced invalid JSON: {e}")
+    data = _run_kubectl_json(cmd, context=context, timeout=60)
 
     records: list[ImageRecord] = []
     seen_images: set[str] = set()
@@ -128,23 +136,168 @@ def list_namespaces(context: Optional[str] = None) -> list[str]:
     Raises:
         K8sDiscoveryError: If kubectl is not available or the call fails.
     """
-    if not _kubectl_available():
-        raise K8sDiscoveryError("kubectl not found")
-
-    cmd = ["kubectl", "get", "namespaces", "-o", "json"]
-    if context:
-        cmd += ["--context", context]
-
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        raise K8sDiscoveryError(str(e))
-
-    if result.returncode != 0:
-        raise K8sDiscoveryError(result.stderr.strip()[:200])
-
-    try:
-        data = json.loads(result.stdout)
+        data = _run_kubectl_json(["get", "namespaces", "-o", "json"], context=context, timeout=30)
         return [item["metadata"]["name"] for item in data.get("items", [])]
-    except (json.JSONDecodeError, KeyError):
+    except K8sDiscoveryError as exc:
+        if "invalid JSON" in str(exc):
+            return []
+        raise
+    except KeyError:
         return []
+
+
+def scan_live_cluster_posture(
+    namespace: str = "default",
+    all_namespaces: bool = False,
+    context: Optional[str] = None,
+) -> list[IaCFinding]:
+    """Inspect runtime Kubernetes posture through the live API via kubectl.
+
+    This complements manifest scanning. It does not attempt full policy
+    evaluation across the cluster; it inspects live workload, RBAC, and
+    namespace state that static manifests cannot prove.
+    """
+    ns_args = ["-A"] if all_namespaces else ["-n", namespace]
+    findings: list[IaCFinding] = []
+
+    pods = _run_kubectl_json(["get", "pods", *ns_args, "-o", "json"], context=context, timeout=60)
+    network_policies = _run_kubectl_json(["get", "networkpolicies", *ns_args, "-o", "json"], context=context, timeout=30)
+    cluster_role_bindings = _run_kubectl_json(["get", "clusterrolebindings", "-o", "json"], context=context, timeout=30)
+
+    policy_namespaces = {
+        item.get("metadata", {}).get("namespace", namespace)
+        for item in network_policies.get("items", [])
+        if item.get("metadata", {}).get("namespace")
+    }
+    namespaces_with_pods: set[str] = set()
+
+    for pod in pods.get("items", []):
+        metadata = pod.get("metadata", {})
+        pod_name = metadata.get("name", "unknown")
+        pod_ns = metadata.get("namespace", namespace)
+        namespaces_with_pods.add(pod_ns)
+        pod_ref = f"k8s://{pod_ns}/{pod_name}"
+        spec = pod.get("spec", {}) or {}
+        status = pod.get("status", {}) or {}
+        phase = status.get("phase", "Unknown")
+
+        if phase != "Running":
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-001",
+                    severity="medium",
+                    title="Live pod not running",
+                    message=(
+                        f"Pod '{pod_ns}/{pod_name}' is currently in phase '{phase}'. "
+                        "Investigate runtime drift, crash loops, or image/config rollout health."
+                    ),
+                    file_path=pod_ref,
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
+                )
+            )
+
+        container_statuses = status.get("containerStatuses", []) or []
+        for container_status in container_statuses:
+            waiting = (container_status.get("state", {}) or {}).get("waiting", {}) or {}
+            if waiting.get("reason") == "CrashLoopBackOff":
+                findings.append(
+                    IaCFinding(
+                        rule_id="K8S-LIVE-002",
+                        severity="high",
+                        title="Live pod is crash looping",
+                        message=(
+                            f"Pod '{pod_ns}/{pod_name}' container '{container_status.get('name', 'unknown')}' "
+                            "is in CrashLoopBackOff. Runtime drift or bad rollout is already impacting availability."
+                        ),
+                        file_path=pod_ref,
+                        line_number=1,
+                        category="kubernetes-live",
+                        compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
+                    )
+                )
+            if not container_status.get("ready", False):
+                findings.append(
+                    IaCFinding(
+                        rule_id="K8S-LIVE-003",
+                        severity="medium",
+                        title="Live pod container not ready",
+                        message=(
+                            f"Pod '{pod_ns}/{pod_name}' container '{container_status.get('name', 'unknown')}' "
+                            "is not ready. Live readiness drift may bypass assumptions in static manifests."
+                        ),
+                        file_path=pod_ref,
+                        line_number=1,
+                        category="kubernetes-live",
+                        compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
+                    )
+                )
+
+        if spec.get("automountServiceAccountToken", True):
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-004",
+                    severity="medium",
+                    title="Live pod mounts service-account token",
+                    message=(
+                        f"Pod '{pod_ns}/{pod_name}' is running with service-account token auto-mount enabled. "
+                        "Disable token mounting unless the workload needs Kubernetes API access."
+                    ),
+                    file_path=pod_ref,
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.1.6", "NIST-AC-6"],
+                )
+            )
+
+    for ns in sorted(namespaces_with_pods):
+        if ns not in policy_namespaces:
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-005",
+                    severity="high",
+                    title="Namespace lacks live NetworkPolicy coverage",
+                    message=(
+                        f"Namespace '{ns}' has running pods but no live NetworkPolicy objects. "
+                        "This is a runtime posture gap even if manifests exist elsewhere in Git."
+                    ),
+                    file_path=f"k8s://namespace/{ns}",
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.3.2", "NIST-SC-7"],
+                )
+            )
+
+    for binding in cluster_role_bindings.get("items", []):
+        metadata = binding.get("metadata", {}) or {}
+        role_ref = binding.get("roleRef", {}) or {}
+        if role_ref.get("name") != "cluster-admin":
+            continue
+        subjects = binding.get("subjects", []) or []
+        subject_names = (
+            ", ".join(
+                f"{subject.get('kind', 'Subject')}:{subject.get('namespace', '')}/{subject.get('name', 'unknown')}".strip("/")
+                for subject in subjects
+            )
+            or "unknown subject"
+        )
+        binding_name = metadata.get("name", "unknown")
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-006",
+                severity="critical",
+                title="Live cluster-admin RBAC binding detected",
+                message=(
+                    f"ClusterRoleBinding '{binding_name}' grants cluster-admin to {subject_names}. "
+                    "Review live RBAC drift and replace with least-privilege bindings."
+                ),
+                file_path=f"k8s://clusterrolebinding/{binding_name}",
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-5.1.1", "NIST-AC-6"],
+            )
+        )
+
+    return findings

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -11,7 +11,7 @@ import subprocess
 
 import pytest
 
-from agent_bom.k8s import K8sDiscoveryError, _kubectl_available, discover_images, list_namespaces
+from agent_bom.k8s import K8sDiscoveryError, _kubectl_available, discover_images, list_namespaces, scan_live_cluster_posture
 
 # ─── _kubectl_available ──────────────────────────────────────────────────────
 
@@ -260,3 +260,93 @@ def test_list_namespaces_empty(monkeypatch):
     """list_namespaces returns empty list when no namespaces exist."""
     _mock_kubectl(monkeypatch, {"items": []})
     assert list_namespaces() == []
+
+
+def test_scan_live_cluster_posture_finds_runtime_gaps(monkeypatch):
+    """Live cluster posture scan reports runtime RBAC, pod health, and network gaps."""
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+
+    payloads = {
+        ("get", "pods"): {
+            "items": [
+                {
+                    "metadata": {"name": "api", "namespace": "prod"},
+                    "spec": {"automountServiceAccountToken": True},
+                    "status": {
+                        "phase": "CrashLoopBackOff",
+                        "containerStatuses": [
+                            {
+                                "name": "api",
+                                "ready": False,
+                                "state": {"waiting": {"reason": "CrashLoopBackOff"}},
+                            }
+                        ],
+                    },
+                }
+            ]
+        },
+        ("get", "networkpolicies"): {"items": []},
+        ("get", "clusterrolebindings"): {
+            "items": [
+                {
+                    "metadata": {"name": "admin-binding"},
+                    "roleRef": {"name": "cluster-admin"},
+                    "subjects": [{"kind": "ServiceAccount", "namespace": "prod", "name": "default"}],
+                }
+            ]
+        },
+    }
+
+    def fake_run(cmd, **kwargs):
+        class R:
+            pass
+
+        r = R()
+        r.returncode = 0
+        r.stderr = ""
+        key = tuple(cmd[1:3])
+        r.stdout = json.dumps(payloads[key])
+        return r
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    findings = scan_live_cluster_posture(namespace="prod")
+    rule_ids = {finding.rule_id for finding in findings}
+    assert {"K8S-LIVE-001", "K8S-LIVE-002", "K8S-LIVE-003", "K8S-LIVE-004", "K8S-LIVE-005", "K8S-LIVE-006"} <= rule_ids
+
+
+def test_scan_live_cluster_posture_clean_cluster(monkeypatch):
+    """Live cluster posture scan returns no findings for a healthy constrained cluster."""
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+
+    payloads = {
+        ("get", "pods"): {
+            "items": [
+                {
+                    "metadata": {"name": "api", "namespace": "prod"},
+                    "spec": {"automountServiceAccountToken": False},
+                    "status": {
+                        "phase": "Running",
+                        "containerStatuses": [{"name": "api", "ready": True, "state": {"running": {}}}],
+                    },
+                }
+            ]
+        },
+        ("get", "networkpolicies"): {"items": [{"metadata": {"name": "default-deny", "namespace": "prod"}}]},
+        ("get", "clusterrolebindings"): {"items": []},
+    }
+
+    def fake_run(cmd, **kwargs):
+        class R:
+            pass
+
+        r = R()
+        r.returncode = 0
+        r.stderr = ""
+        key = tuple(cmd[1:3])
+        r.stdout = json.dumps(payloads[key])
+        return r
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert scan_live_cluster_posture(namespace="prod") == []


### PR DESCRIPTION
Closes #1479

Summary:
- add a real live-cluster Kubernetes posture scan via kubectl for runtime RBAC, live network-policy coverage, and pod health
- wire the live scan into the IaC command with explicit k8s-live flags instead of silently broadening manifest claims
- document the boundary between manifest hardening and live cluster posture so product wording matches code

Validation:
- uv run pytest -q tests/test_k8s.py tests/test_deploy_manifests.py
- uv run ruff check src/agent_bom/k8s.py src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/agents/__init__.py tests/test_k8s.py
- git diff --check