### PR TITLE
Tighten prompt injection analyzer signals

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -302,6 +302,10 @@ _JS_TS_UNTRUSTED_DATA_RE = re.compile(
     r"\b(?:user[A-Z_]\w*|user\w*|input|payload|req(?:uest)?\.(?:body|query|params)|ctx\.(?:body|query|params)|process\.env)\b",
     re.IGNORECASE,
 )
+_PROMPT_UNTRUSTED_INPUT_RE = re.compile(
+    r"\b(?:user\w*|input|payload|message|content|query|prompt|instruction|body|request)\b",
+    re.IGNORECASE,
+)
 
 
 # ── AST extraction ───────────────────────────────────────────────────────────
@@ -320,7 +324,34 @@ def _extract_string_value(node: ast.expr) -> str | None:
             else:
                 parts.append("{...}")
         return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _extract_string_value(node.left)
+        right = _extract_string_value(node.right)
+        if left is not None or right is not None:
+            left = left if left is not None else "{...}"
+            right = right if right is not None else "{...}"
+            return f"{left}{right}"
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "format":
+        template = _extract_string_value(node.func.value)
+        if template is not None:
+            return template
     return None
+
+
+def _expr_contains_untrusted_prompt_input(node: ast.AST) -> bool:
+    """Return True when a prompt expression interpolates likely untrusted input."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name) and _PROMPT_UNTRUSTED_INPUT_RE.search(child.id):
+            return True
+        if isinstance(child, ast.Attribute):
+            attr_name = _expr_name(child)
+            if attr_name and _PROMPT_UNTRUSTED_INPUT_RE.search(attr_name):
+                return True
+        if isinstance(child, ast.Call):
+            call_name = _call_name(child.func).lower()
+            if call_name in {"input", "request.get_json", "request.args.get", "request.form.get"}:
+                return True
+    return False
 
 
 def _call_name(node: ast.AST) -> str:
@@ -801,6 +832,8 @@ def _analyze_file(
                     text = _extract_string_value(node.value)
                     if text and len(text) > 10:
                         risk_flags = _check_prompt_risks(text)
+                        if _expr_contains_untrusted_prompt_input(node.value):
+                            risk_flags = [*risk_flags, "untrusted_input_interpolation"]
                         prompts.append(
                             ExtractedPrompt(
                                 text=text[:2000],
@@ -820,6 +853,8 @@ def _analyze_file(
                     text = _extract_string_value(kw.value)
                     if text and len(text) > 10:
                         risk_flags = _check_prompt_risks(text)
+                        if _expr_contains_untrusted_prompt_input(kw.value):
+                            risk_flags = [*risk_flags, "untrusted_input_interpolation"]
                         prompts.append(
                             ExtractedPrompt(
                                 text=text[:2000],

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -263,9 +263,10 @@ def code_cmd(path: str, output_format: str, output_path: Optional[str], quiet: b
     """Analyze source code for AI components — prompts, guardrails, tools.
 
     AST-based analysis of Python AI framework code. Extracts system
-    prompts, detects guardrails, and maps tool signatures. Also reuses the
-    multi-language AI component source scan to surface SDK/model usage across
-    Python, JavaScript/TypeScript, Go, Java, Rust, and Ruby.
+    prompts, flags risky prompt interpolation, detects guardrails, and maps
+    tool signatures. Also reuses the multi-language AI component source scan
+    to surface SDK/model usage across Python, JavaScript/TypeScript, Go,
+    Java, Rust, and Ruby.
 
     \b
     Examples:

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -505,6 +505,17 @@ def test_analyze_project_reports_tainted_prompt_and_sink_flows(tmp_path: Path):
     assert any(finding.category == "tainted_dangerous_sink" and finding.entrypoint == "execute" for finding in result.flow_findings)
 
 
+def test_analyze_project_flags_prompt_interpolation_from_user_input(tmp_path: Path):
+    (tmp_path / "agent.py").write_text(
+        "@tool\ndef execute(user_text):\n    system_prompt = f'Follow this user content: {user_text}'\n    return system_prompt\n"
+    )
+
+    result = analyze_project(tmp_path)
+
+    prompt = next(prompt for prompt in result.prompts if prompt.variable_name == "system_prompt")
+    assert "untrusted_input_interpolation" in prompt.risk_flags
+
+
 def test_analyze_project_reports_tainted_path_access(tmp_path: Path):
     (tmp_path / "agent.py").write_text("@tool\ndef read_any(path):\n    return open(path, 'r').read()\n")
 


### PR DESCRIPTION
Closes #1480

## Summary
- flag prompt definitions that interpolate likely untrusted user input so prompt inventory surfaces injection risk directly
- preserve the existing tainted-LLM flow findings and align the code analysis wording with bounded prompt-risk signals
- pin the intended LLM01 contract with a regression test

## Validation
- uv run pytest -q tests/test_ast_analyzer.py
- uv run ruff check src/agent_bom/ast_analyzer.py src/agent_bom/cli/_focused_commands.py tests/test_ast_analyzer.py
- git diff --check