### PR TITLE
Enforce API key rotation policy and audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Operator guides:
 - [SAML SP Metadata And Login Endpoints](src/agent_bom/api/routes/enterprise.py)
 - production backup examples use `bucketRegion: REPLACE_ME_BUCKET_REGION` on purpose; set it to your actual object-store bucket region
 - self-hosted SSO can use OIDC or SAML; SAML admins use `/v1/auth/saml/metadata`, and the control plane exchanges verified assertions for short-lived API keys at `/v1/auth/saml/login`
+- control-plane API keys now follow an enforced lifetime policy; operators set `AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS` and `AGENT_BOM_API_KEY_MAX_TTL_SECONDS`, and admins can rotate keys in place at `/v1/auth/keys/{key_id}/rotate`
 
 ## Product views
 

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -40,6 +40,7 @@ The API middleware uses ordered route rules. Narrower enterprise routes win over
 |---|---|---|
 | `GET` | `/v1/auth/keys` | `admin` |
 | `POST` | `/v1/auth/keys` | `admin` |
+| `POST` | `/v1/auth/keys/` | `admin` |
 | `DELETE` | `/v1/auth/keys/` | `admin` |
 | `POST` | `/v1/gateway/policies` | `admin` |
 | `PUT` | `/v1/gateway/policies/` | `admin` |
@@ -76,6 +77,9 @@ Implementation source: `src/agent_bom/api/middleware.py`
    - localhost binds are allowed without remote auth
 2. API key enforcement
    - non-loopback binds require `AGENT_BOM_API_KEY` or stored API keys
+   - set `AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS` and `AGENT_BOM_API_KEY_MAX_TTL_SECONDS`
+     to enforce rotation windows on stored keys
+   - rotate stored keys with `POST /v1/auth/keys/{key_id}/rotate`
 3. OIDC bearer enforcement
    - set `AGENT_BOM_OIDC_ISSUER`
    - set `AGENT_BOM_OIDC_AUDIENCE`

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -161,6 +161,9 @@ You still own:
 - use `envFrom` / Secrets for `AGENT_BOM_POSTGRES_URL`, API keys, OIDC issuer,
   audience, optional required nonce, SAML IdP/SP metadata values, and audit
   HMAC settings
+- enforce API key lifetime policy with `AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS`
+  and `AGENT_BOM_API_KEY_MAX_TTL_SECONDS`; admin key replacement uses
+  `POST /v1/auth/keys/{key_id}/rotate` so rotation stays explicit and audited
 - split fast-rotating auth secrets from slower DB config with `controlPlane.externalSecrets.secrets[]`
   so `AGENT_BOM_OIDC_*`, `AGENT_BOM_SAML_*`, and `AGENT_BOM_AUDIT_HMAC_KEY`
   can refresh at `5m`

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -175,6 +175,10 @@ all sit under one operator-controlled plane.
   - [deploy/helm/agent-bom/examples/eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
 - keep the proxy and API internal to your VPC unless exposure is intentional
 - use OIDC or SAML for user access, set `AGENT_BOM_OIDC_AUDIENCE` explicitly when using OIDC, and map roles explicitly
+- enforce API key rotation with:
+  - `AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS`
+  - `AGENT_BOM_API_KEY_MAX_TTL_SECONDS`
+  and rotate admin keys through `POST /v1/auth/keys/{key_id}/rotate`
 - split external secrets by cadence in production:
   - `AGENT_BOM_POSTGRES_URL` at `1h`
   - `AGENT_BOM_OIDC_*`, `AGENT_BOM_SAML_*`, and `AGENT_BOM_AUDIT_HMAC_KEY` at `5m`

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -12,7 +12,7 @@ import os
 import secrets
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Protocol
 
@@ -74,6 +74,52 @@ class ApiKey:
         }
 
 
+@dataclass(frozen=True)
+class ApiKeyPolicy:
+    """Operator-controlled API key lifetime policy."""
+
+    default_ttl_seconds: int = 30 * 24 * 60 * 60
+    max_ttl_seconds: int = 90 * 24 * 60 * 60
+
+
+def get_api_key_policy() -> ApiKeyPolicy:
+    """Load API key lifetime policy from env with safe defaults."""
+    default_ttl = int(os.environ.get("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS", str(30 * 24 * 60 * 60)))
+    max_ttl = int(os.environ.get("AGENT_BOM_API_KEY_MAX_TTL_SECONDS", str(90 * 24 * 60 * 60)))
+    if default_ttl <= 0:
+        raise ValueError("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS must be > 0")
+    if max_ttl <= 0:
+        raise ValueError("AGENT_BOM_API_KEY_MAX_TTL_SECONDS must be > 0")
+    if default_ttl > max_ttl:
+        raise ValueError("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS cannot exceed AGENT_BOM_API_KEY_MAX_TTL_SECONDS")
+    return ApiKeyPolicy(default_ttl_seconds=default_ttl, max_ttl_seconds=max_ttl)
+
+
+def normalize_api_key_expiry(
+    expires_at: str | None,
+    *,
+    now: datetime | None = None,
+    policy: ApiKeyPolicy | None = None,
+) -> str:
+    """Normalize and enforce API key expiry under the configured policy."""
+    active_policy = policy or get_api_key_policy()
+    current = now or datetime.now(timezone.utc)
+    if expires_at:
+        try:
+            parsed = datetime.fromisoformat(expires_at)
+        except ValueError as exc:
+            raise ValueError("expires_at must be a valid ISO-8601 datetime with timezone") from exc
+        if parsed.tzinfo is None:
+            raise ValueError("expires_at must include timezone information")
+        if parsed <= current:
+            raise ValueError("expires_at must be in the future")
+        max_expiry = current + timedelta(seconds=active_policy.max_ttl_seconds)
+        if parsed > max_expiry:
+            raise ValueError(f"expires_at exceeds the maximum allowed API key lifetime ({active_policy.max_ttl_seconds} seconds)")
+        return parsed.isoformat()
+    return (current + timedelta(seconds=active_policy.default_ttl_seconds)).isoformat()
+
+
 def _derive_key(raw_key: str, salt: bytes) -> str:
     """Derive key hash using scrypt KDF (CodeQL-safe, brute-force resistant)."""
     derived = hashlib.scrypt(
@@ -104,6 +150,7 @@ def create_api_key(
     key_hash = _derive_key(raw_key, salt)
     key_id = secrets.token_hex(8)
 
+    normalized_expiry = normalize_api_key_expiry(expires_at)
     api_key = ApiKey(
         key_id=key_id,
         key_hash=key_hash,
@@ -111,7 +158,7 @@ def create_api_key(
         key_prefix=raw_key[:12],
         name=name,
         role=role,
-        expires_at=expires_at,
+        expires_at=normalized_expiry,
         scopes=scopes or [],
         tenant_id=tenant_id,
     )

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -299,6 +299,11 @@ class CreateKeyRequest(BaseModel):
     scopes: list[str] = []
 
 
+class RotateKeyRequest(BaseModel):
+    name: str | None = None
+    expires_at: str | None = None
+
+
 class ExceptionRequest(BaseModel):
     vuln_id: str
     package_name: str

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -2,6 +2,7 @@
 
 Endpoints:
     POST   /v1/auth/keys                      create API key
+    POST   /v1/auth/keys/{key_id}/rotate      rotate API key
     GET    /v1/auth/keys                      list API keys
     DELETE /v1/auth/keys/{key_id}             revoke API key
     GET    /v1/auth/saml/metadata             generate SP metadata for IdP setup
@@ -34,7 +35,14 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
 
-from agent_bom.api.models import CreateKeyRequest, ExceptionRequest, FalsePositiveRequest, JiraTicketRequest, SAMLLoginRequest
+from agent_bom.api.models import (
+    CreateKeyRequest,
+    ExceptionRequest,
+    FalsePositiveRequest,
+    JiraTicketRequest,
+    RotateKeyRequest,
+    SAMLLoginRequest,
+)
 from agent_bom.api.stores import _get_exception_store, _get_store, _get_trend_store
 from agent_bom.security import sanitize_error
 
@@ -59,16 +67,27 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Invalid role: {req.role}. Must be admin, analyst, or viewer")
 
-    raw_key, api_key = create_api_key(
-        name=req.name,
-        role=role,
-        expires_at=req.expires_at,
-        scopes=req.scopes,
-        tenant_id=tenant_id,
-    )
+    try:
+        raw_key, api_key = create_api_key(
+            name=req.name,
+            role=role,
+            expires_at=req.expires_at,
+            scopes=req.scopes,
+            tenant_id=tenant_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     get_key_store().add(api_key)
 
-    log_action("auth.key_created", actor=actor, resource=f"key/{api_key.key_id}", role=req.role)
+    log_action(
+        "auth.key_created",
+        actor=actor,
+        resource=f"key/{api_key.key_id}",
+        role=req.role,
+        tenant_id=tenant_id,
+        expires_at=api_key.expires_at,
+        rotation_policy="enforced",
+    )
 
     return {
         "raw_key": raw_key,
@@ -80,6 +99,65 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
         "created_at": api_key.created_at,
         "expires_at": api_key.expires_at,
         "message": "Store the raw_key securely — it will not be shown again.",
+    }
+
+
+@router.post("/v1/auth/keys/{key_id}/rotate", tags=["enterprise"], status_code=201)
+async def rotate_key(request: Request, key_id: str, req: RotateKeyRequest) -> dict:
+    """Rotate an API key by minting a replacement and revoking the old key."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.auth import create_api_key, get_key_store
+
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    actor = getattr(request.state, "api_key_name", "") or "system"
+    store = get_key_store()
+    current_key = store.get(key_id)
+    if current_key is None or current_key.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail=f"Key {key_id} not found")
+
+    replacement_name = req.name or current_key.name
+    try:
+        raw_key, replacement = create_api_key(
+            name=replacement_name,
+            role=current_key.role,
+            expires_at=req.expires_at,
+            scopes=list(current_key.scopes),
+            tenant_id=current_key.tenant_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    store.add(replacement)
+    store.remove(current_key.key_id)
+    log_action(
+        "auth.key_rotated",
+        actor=actor,
+        resource=f"key/{current_key.key_id}",
+        tenant_id=tenant_id,
+        replacement_key_id=replacement.key_id,
+        previous_expires_at=current_key.expires_at,
+        replacement_expires_at=replacement.expires_at,
+    )
+    log_action(
+        "auth.key_revoked",
+        actor=actor,
+        resource=f"key/{current_key.key_id}",
+        tenant_id=tenant_id,
+        reason="rotated",
+        replacement_key_id=replacement.key_id,
+    )
+
+    return {
+        "raw_key": raw_key,
+        "key_id": replacement.key_id,
+        "replaced_key_id": current_key.key_id,
+        "key_prefix": replacement.key_prefix,
+        "name": replacement.name,
+        "role": replacement.role.value,
+        "tenant_id": replacement.tenant_id,
+        "created_at": replacement.created_at,
+        "expires_at": replacement.expires_at,
+        "message": "Store the raw_key securely — it will not be shown again. The previous key has been revoked.",
     }
 
 

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -11,7 +11,7 @@ from fastapi import HTTPException
 from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
 from agent_bom.api.exception_store import InMemoryExceptionStore, VulnException
-from agent_bom.api.models import CreateKeyRequest
+from agent_bom.api.models import CreateKeyRequest, RotateKeyRequest
 from agent_bom.api.routes import enterprise
 
 
@@ -45,6 +45,7 @@ async def test_create_key_uses_authenticated_tenant(isolated_key_store):
     )
 
     assert created["tenant_id"] == "tenant-alpha"
+    assert created["expires_at"]
     keys = isolated_key_store.list_keys("tenant-alpha")
     assert len(keys) == 1
     assert keys[0].tenant_id == "tenant-alpha"
@@ -70,6 +71,33 @@ async def test_delete_key_returns_404_for_cross_tenant_key(isolated_key_store):
 
     with pytest.raises(HTTPException) as exc:
         await enterprise.delete_key(_request("tenant-alpha"), beta.key_id)
+
+    assert exc.value.status_code == 404
+    assert isolated_key_store.get(beta.key_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_rotate_key_replaces_old_key_and_revokes_previous(isolated_key_store):
+    raw, alpha = create_api_key("alpha", Role.ADMIN, tenant_id="tenant-alpha")
+    isolated_key_store.add(alpha)
+
+    result = await enterprise.rotate_key(_request("tenant-alpha", "alice-admin"), alpha.key_id, RotateKeyRequest())
+
+    assert result["replaced_key_id"] == alpha.key_id
+    assert result["tenant_id"] == "tenant-alpha"
+    assert result["expires_at"]
+    assert isolated_key_store.get(alpha.key_id) is None
+    assert isolated_key_store.verify(raw) is None
+    assert isolated_key_store.verify(result["raw_key"]) is not None
+
+
+@pytest.mark.asyncio
+async def test_rotate_key_returns_404_for_cross_tenant_key(isolated_key_store):
+    _, beta = create_api_key("beta", Role.ADMIN, tenant_id="tenant-beta")
+    isolated_key_store.add(beta)
+
+    with pytest.raises(HTTPException) as exc:
+        await enterprise.rotate_key(_request("tenant-alpha"), beta.key_id, RotateKeyRequest())
 
     assert exc.value.status_code == 404
     assert isolated_key_store.get(beta.key_id) is not None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from agent_bom.api.auth import (
+    ApiKey,
+    ApiKeyPolicy,
     KeyStore,
     Role,
     create_api_key,
     get_key_store,
+    normalize_api_key_expiry,
     set_key_store,
     verify_api_key,
 )
@@ -78,12 +83,12 @@ class TestCreateApiKey:
         _, key = create_api_key("scope-test", Role.ANALYST, scopes=["scan", "vex"])
         assert key.scopes == ["scan", "vex"]
 
-    def test_expires_at_optional(self):
+    def test_expires_at_defaults_under_rotation_policy(self):
         _, key = create_api_key("no-expire", Role.VIEWER)
-        assert key.expires_at is None
+        assert key.expires_at is not None
 
     def test_expires_at_set(self):
-        exp = "2099-12-31T23:59:59+00:00"
+        exp = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
         _, key = create_api_key("expire-test", Role.VIEWER, expires_at=exp)
         assert key.expires_at == exp
 
@@ -106,12 +111,25 @@ class TestVerifyApiKey:
         assert result is None
 
     def test_expired_key_returns_none(self):
-        raw, key = create_api_key("expired", Role.ADMIN, expires_at="2020-01-01T00:00:00+00:00")
+        raw, fresh = create_api_key("expired", Role.ADMIN)
+        key = ApiKey(
+            key_id=fresh.key_id,
+            key_hash=fresh.key_hash,
+            key_salt=fresh.key_salt,
+            key_prefix=fresh.key_prefix,
+            name=fresh.name,
+            role=fresh.role,
+            created_at=fresh.created_at,
+            expires_at="2020-01-01T00:00:00+00:00",
+            scopes=fresh.scopes,
+            tenant_id=fresh.tenant_id,
+        )
         result = verify_api_key(raw, [key])
         assert result is None
 
     def test_not_expired_key_works(self):
-        raw, key = create_api_key("future", Role.ADMIN, expires_at="2099-12-31T23:59:59+00:00")
+        exp = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
+        raw, key = create_api_key("future", Role.ADMIN, expires_at=exp)
         result = verify_api_key(raw, [key])
         assert result is not None
 
@@ -146,16 +164,30 @@ class TestVerifyApiKey:
 
 
 class TestApiKeyExpiry:
-    def test_no_expiry_not_expired(self):
+    def test_default_expiry_not_expired(self):
         _, key = create_api_key("no-exp", Role.VIEWER)
+        assert key.expires_at is not None
         assert not key.is_expired()
 
     def test_past_expiry_is_expired(self):
-        _, key = create_api_key("past", Role.VIEWER, expires_at="2020-01-01T00:00:00+00:00")
+        _, fresh = create_api_key("past", Role.VIEWER)
+        key = ApiKey(
+            key_id=fresh.key_id,
+            key_hash=fresh.key_hash,
+            key_salt=fresh.key_salt,
+            key_prefix=fresh.key_prefix,
+            name=fresh.name,
+            role=fresh.role,
+            created_at=fresh.created_at,
+            expires_at="2020-01-01T00:00:00+00:00",
+            scopes=fresh.scopes,
+            tenant_id=fresh.tenant_id,
+        )
         assert key.is_expired()
 
     def test_future_expiry_not_expired(self):
-        _, key = create_api_key("future", Role.VIEWER, expires_at="2099-12-31T23:59:59+00:00")
+        exp = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
+        _, key = create_api_key("future", Role.VIEWER, expires_at=exp)
         assert not key.is_expired()
 
 
@@ -231,3 +263,28 @@ class TestSingleton:
         assert get_key_store() is new_store
         # Restore
         set_key_store(original)
+
+
+class TestApiKeyRotationPolicy:
+    def test_normalize_expiry_applies_default_ttl(self):
+        now = datetime(2026, 4, 17, 18, 0, tzinfo=timezone.utc)
+        expiry = normalize_api_key_expiry(None, now=now, policy=ApiKeyPolicy(default_ttl_seconds=300, max_ttl_seconds=600))
+        assert expiry == (now + timedelta(seconds=300)).isoformat()
+
+    def test_normalize_expiry_rejects_past(self):
+        now = datetime(2026, 4, 17, 18, 0, tzinfo=timezone.utc)
+        with pytest.raises(ValueError, match="in the future"):
+            normalize_api_key_expiry(
+                "2026-04-17T17:59:00+00:00",
+                now=now,
+                policy=ApiKeyPolicy(default_ttl_seconds=300, max_ttl_seconds=600),
+            )
+
+    def test_normalize_expiry_rejects_over_max(self):
+        now = datetime(2026, 4, 17, 18, 0, tzinfo=timezone.utc)
+        with pytest.raises(ValueError, match="maximum allowed API key lifetime"):
+            normalize_api_key_expiry(
+                "2026-04-17T18:20:01+00:00",
+                now=now,
+                policy=ApiKeyPolicy(default_ttl_seconds=300, max_ttl_seconds=1200),
+            )


### PR DESCRIPTION
## Summary
- enforce default and maximum API key lifetimes with explicit validation
- add a rotate endpoint that revokes the old key and audits the replacement
- document operator-facing rotation policy controls for self-hosted deployments

## Validation
- uv run pytest -q tests/test_auth.py tests/test_api_enterprise_tenant.py tests/test_api_saml.py -x
- uv run ruff check src/agent_bom/api/auth.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/models.py tests/test_auth.py tests/test_api_enterprise_tenant.py
- git diff --check

Closes #1491