### PR TITLE
Complete tenant-scoped rate limiting and Postgres tuning

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -15,6 +15,14 @@ controlPlane:
     env:
       - name: AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT
         value: "1"
+      - name: AGENT_BOM_POSTGRES_POOL_MIN_SIZE
+        value: "5"
+      - name: AGENT_BOM_POSTGRES_POOL_MAX_SIZE
+        value: "20"
+      - name: AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS
+        value: "5"
+      - name: AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS
+        value: "15000"
       - name: AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT
         value: "25"
       - name: AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -170,6 +170,10 @@ You still own:
   while `AGENT_BOM_POSTGRES_URL` stays at `1h`
 - set `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1` for multi-replica production
   control planes so the API refuses to start if the shared limiter backend is unavailable
+- tune Postgres-backed control planes explicitly with
+  `AGENT_BOM_POSTGRES_POOL_MIN_SIZE`, `AGENT_BOM_POSTGRES_POOL_MAX_SIZE`,
+  `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS`, and
+  `AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS`
 - enable `controlPlane.observability.prometheusRule.enabled=true` when the cluster already runs Prometheus Operator
 - enable `controlPlane.observability.grafanaDashboard.enabled=true` when Grafana watches dashboard `ConfigMap`s
 - enable `controlPlane.backup.enabled=true` only after setting a real S3 bucket, prefix, and IRSA-backed upload permissions

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -182,6 +182,11 @@ all sit under one operator-controlled plane.
 - split external secrets by cadence in production:
   - `AGENT_BOM_POSTGRES_URL` at `1h`
   - `AGENT_BOM_OIDC_*`, `AGENT_BOM_SAML_*`, and `AGENT_BOM_AUDIT_HMAC_KEY` at `5m`
+- size the Postgres-backed control plane explicitly:
+  - `AGENT_BOM_POSTGRES_POOL_MIN_SIZE`
+  - `AGENT_BOM_POSTGRES_POOL_MAX_SIZE`
+  - `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS`
+  - `AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS`
 - enable the packaged PrometheusRule and Grafana dashboard when your cluster
   already runs Prometheus Operator and Grafana sidecar discovery
 - enable the packaged backup CronJob only after setting a real S3 destination

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from agent_bom import __version__
+from agent_bom.api.auth import get_key_store
 from agent_bom.api.tracing import configure_otel_tracing, make_request_trace
 
 if TYPE_CHECKING:
@@ -378,7 +379,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Per-IP sliding window rate limiter with bounded memory."""
+    """Tenant-aware sliding window rate limiter with bounded memory."""
 
     def __init__(self, app: ASGIApp, scan_rpm: int = 60, read_rpm: int = 300):
         super().__init__(app)
@@ -397,19 +398,32 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 _logger.warning("Postgres rate limiter unavailable, falling back to in-memory store", exc_info=True)
         return InMemoryRateLimitStore(window_seconds=self._window)
 
+    def _resolve_tenant_scope(self, request: StarletteRequest, raw_key: str) -> str | None:
+        tenant_id = getattr(request.state, "tenant_id", "").strip() or None
+        if tenant_id and tenant_id != "default":
+            return tenant_id
+        if raw_key:
+            try:
+                resolved = get_key_store().verify(raw_key)
+            except Exception:
+                resolved = None
+            if resolved and resolved.tenant_id:
+                return resolved.tenant_id
+        return None
+
     def _bucket_key(self, request: StarletteRequest, is_scan: bool) -> str:
         bucket_type = "scan" if is_scan else "read"
-        tenant_id = getattr(request.state, "tenant_id", "").strip() or None
         auth = request.headers.get("authorization", "")
         raw_key = auth[7:] if auth.startswith("Bearer ") else request.headers.get("x-api-key", "")
-        if raw_key:
+        tenant_scope = self._resolve_tenant_scope(request, raw_key)
+        if tenant_scope:
+            scope = f"tenant:{tenant_scope}"
+        elif raw_key:
             auth_hash = _rate_limit_fingerprint(raw_key)
             scope = f"auth:{auth_hash}"
         else:
             client_ip = request.client.host if request.client else "unknown"
             scope = f"ip:{client_ip}"
-        if tenant_id and tenant_id != "default":
-            scope = f"tenant:{tenant_id}:{scope}"
         return f"{scope}:{bucket_type}"
 
     async def dispatch(self, request: StarletteRequest, call_next):

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -32,6 +32,12 @@ from agent_bom.api.auth import ApiKey, Role, verify_api_key
 from agent_bom.api.exception_store import ExceptionStatus, VulnException
 from agent_bom.api.graph_store import _escape_like_query
 from agent_bom.baseline import TrendPoint
+from agent_bom.config import (
+    POSTGRES_CONNECT_TIMEOUT_SECONDS,
+    POSTGRES_POOL_MAX_SIZE,
+    POSTGRES_POOL_MIN_SIZE,
+    POSTGRES_STATEMENT_TIMEOUT_MS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +81,17 @@ def _get_pool():
         url = os.environ.get("AGENT_BOM_POSTGRES_URL", "")
         if not url:
             raise ValueError("AGENT_BOM_POSTGRES_URL env var is required for PostgreSQL storage.")
-        _pool = psycopg_pool.ConnectionPool(url, min_size=2, max_size=10)
+        min_size = max(1, POSTGRES_POOL_MIN_SIZE)
+        max_size = max(min_size, POSTGRES_POOL_MAX_SIZE)
+        kwargs: dict[str, object] = {}
+        if POSTGRES_CONNECT_TIMEOUT_SECONDS > 0:
+            kwargs["connect_timeout"] = POSTGRES_CONNECT_TIMEOUT_SECONDS
+        _pool = psycopg_pool.ConnectionPool(
+            url,
+            min_size=min_size,
+            max_size=max_size,
+            kwargs=kwargs,
+        )
     return _pool
 
 
@@ -89,6 +105,8 @@ def _apply_tenant_session(conn) -> None:
     """Attach tenant session settings used by Postgres RLS policies."""
     conn.execute("SELECT set_config('app.tenant_id', %s, true)", (_current_tenant.get(),))
     conn.execute("SELECT set_config('app.bypass_rls', %s, true)", ("1" if _bypass_tenant_rls.get() else "0",))
+    if POSTGRES_STATEMENT_TIMEOUT_MS > 0:
+        conn.execute("SELECT set_config('statement_timeout', %s, false)", (str(POSTGRES_STATEMENT_TIMEOUT_MS),))
 
 
 def _ensure_rls_helpers(conn) -> None:

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -207,6 +207,19 @@ API_MAX_FLEET_AGENTS_PER_TENANT = _int("AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENAN
 API_MAX_SCHEDULES_PER_TENANT = _int("AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT", 100)
 
 
+# ── PostgreSQL Control Plane Tuning ──────────────────────────────────────
+# Used by api/postgres_store.py and shared Postgres-backed control-plane
+# services such as the distributed rate limiter.
+#
+# Defaults target multi-replica self-hosted control planes rather than a
+# single local developer process.
+
+POSTGRES_POOL_MIN_SIZE = _int("AGENT_BOM_POSTGRES_POOL_MIN_SIZE", 5)
+POSTGRES_POOL_MAX_SIZE = _int("AGENT_BOM_POSTGRES_POOL_MAX_SIZE", 20)
+POSTGRES_CONNECT_TIMEOUT_SECONDS = _int("AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS", 5)
+POSTGRES_STATEMENT_TIMEOUT_MS = _int("AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS", 15_000)
+
+
 # ── MCP Server Limits ────────────────────────────────────────────────────
 # Used by mcp_server.py for file-size and response-size guards, tool execution
 # governance, and lightweight in-process observability.

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -346,6 +346,35 @@ def test_rate_limit_middleware_scopes_by_auth_credential():
     assert client.get("/v1/test", headers={"X-API-Key": "beta"}).status_code == 200
 
 
+def test_rate_limit_middleware_scopes_api_keys_by_tenant():
+    """Different API keys for the same tenant should share one tenant-wide bucket."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    original_store = get_key_store()
+    store = KeyStore()
+    raw_alpha, alpha = create_api_key("alpha", Role.ADMIN, tenant_id="tenant-alpha")
+    raw_beta, beta = create_api_key("beta", Role.ANALYST, tenant_id="tenant-alpha")
+    store.add(alpha)
+    store.add(beta)
+    set_key_store(store)
+    try:
+        test_app = Starlette(routes=[Route("/v1/test", dummy)])
+        test_app.add_middleware(APIKeyMiddleware, api_key="unused-static-key")
+        test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=2)
+
+        client = TestClient(test_app)
+        assert client.get("/v1/test", headers={"Authorization": f"Bearer {raw_alpha}"}).status_code == 200
+        assert client.get("/v1/test", headers={"Authorization": f"Bearer {raw_beta}"}).status_code == 200
+        assert client.get("/v1/test", headers={"Authorization": f"Bearer {raw_alpha}"}).status_code == 429
+    finally:
+        set_key_store(original_store)
+
+
 def test_in_memory_rate_limit_store_prunes_oldest_entries_instead_of_clearing_all():
     """Overflow should evict oldest buckets, not reset every limiter bucket at once."""
     store = InMemoryRateLimitStore(window_seconds=60)

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -423,6 +423,12 @@ def test_production_values_enable_operator_defaults():
         {"secretRef": {"name": "agent-bom-control-plane-db"}},
         {"secretRef": {"name": "agent-bom-control-plane-auth"}},
     ]
+    env = {entry["name"]: entry["value"] for entry in production["controlPlane"]["api"]["env"]}
+    assert env["AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT"] == "1"
+    assert env["AGENT_BOM_POSTGRES_POOL_MIN_SIZE"] == "5"
+    assert env["AGENT_BOM_POSTGRES_POOL_MAX_SIZE"] == "20"
+    assert env["AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS"] == "5"
+    assert env["AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS"] == "15000"
     assert production["controlPlane"]["podAntiAffinity"]["enabled"] is True
     assert production["controlPlane"]["priorityClass"]["create"] is True
     assert production["topologySpread"]["enabled"] is True

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -4,6 +4,8 @@ Uses a mock psycopg_pool to avoid needing a real PostgreSQL instance.
 """
 
 import json
+import sys
+import types
 
 import pytest
 
@@ -743,6 +745,70 @@ def test_get_pool_missing_psycopg(monkeypatch):
         else:
             sys.modules.pop("psycopg_pool", None)
         reset_pool()
+
+
+def test_get_pool_uses_tuned_pool_sizes_and_connect_timeout(monkeypatch):
+    """Pool creation should honor operator-controlled sizing and connect timeout envs."""
+    from agent_bom.api import postgres_store
+
+    captured: dict[str, object] = {}
+
+    class CapturePool:
+        def __init__(self, url, min_size, max_size, kwargs=None):
+            captured["url"] = url
+            captured["min_size"] = min_size
+            captured["max_size"] = max_size
+            captured["kwargs"] = kwargs or {}
+
+    reset = postgres_store.reset_pool
+    reset()
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://localhost/test")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_POOL_MIN_SIZE", "7")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_POOL_MAX_SIZE", "21")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS", "9")
+    monkeypatch.setattr(
+        postgres_store,
+        "POSTGRES_POOL_MIN_SIZE",
+        7,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        postgres_store,
+        "POSTGRES_POOL_MAX_SIZE",
+        21,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        postgres_store,
+        "POSTGRES_CONNECT_TIMEOUT_SECONDS",
+        9,
+        raising=False,
+    )
+    monkeypatch.setitem(sys.modules, "psycopg_pool", types.SimpleNamespace(ConnectionPool=CapturePool))
+
+    try:
+        postgres_store._get_pool()
+        assert captured == {
+            "url": "postgresql://localhost/test",
+            "min_size": 7,
+            "max_size": 21,
+            "kwargs": {"connect_timeout": 9},
+        }
+    finally:
+        reset()
+
+
+def test_apply_tenant_session_sets_statement_timeout(monkeypatch):
+    """Tenant session setup should apply the configured statement timeout."""
+    from agent_bom.api import postgres_store
+
+    conn = MockConnection()
+    monkeypatch.setattr(postgres_store, "POSTGRES_STATEMENT_TIMEOUT_MS", 12_000, raising=False)
+
+    postgres_store._apply_tenant_session(conn)
+
+    assert any("app.tenant_id" in sql for sql, _ in conn.executed)
+    assert any("statement_timeout" in sql and params == ("12000",) for sql, params in conn.executed)
 
 
 # ─── Server lifespan integration ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- scope shared control-plane rate limiting to tenants when API keys are present, with credential/IP fallback only when tenant identity is unavailable
- make Postgres pool sizing and connect/query timeout behavior operator-configurable with production defaults
- wire the production EKS example and operator docs to the new Postgres tuning envs

## Validation
- uv run pytest -q tests/test_api_hardening.py tests/test_postgres_store.py tests/test_deploy_manifests.py -x
- uv run ruff check src/agent_bom/config.py src/agent_bom/api/middleware.py src/agent_bom/api/postgres_store.py tests/test_api_hardening.py tests/test_postgres_store.py tests/test_deploy_manifests.py
- uv run mypy src/agent_bom/api/middleware.py src/agent_bom/api/postgres_store.py
- git diff --check

Closes #1468