### PR TITLE
Harden proxy audit delivery with circuit breaker and DLQ

### DIFF
--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -43,6 +43,8 @@ ProxyMetrics = _proxy_audit.ProxyMetrics
 ProxyMetricsServer = _proxy_audit.ProxyMetricsServer
 ReplayDetector = _proxy_audit.ReplayDetector
 RotatingAuditLog = _proxy_audit.RotatingAuditLog
+AuditDeliveryController = _proxy_audit.AuditDeliveryController
+AuditSpilloverStore = _proxy_audit.AuditSpilloverStore
 _truncate_args = _proxy_audit._truncate_args
 compute_payload_hash = _proxy_audit.compute_payload_hash
 compute_response_hmac = _proxy_audit.compute_response_hmac
@@ -614,52 +616,52 @@ async def run_proxy(
     audit_buffer_bytes = 0
     audit_lock = asyncio.Lock()
     max_audit_buffer_bytes = max(64 * 1024, int(os.environ.get("AGENT_BOM_PROXY_AUDIT_BUFFER_MAX_BYTES", "1048576")))
+    max_audit_spillover_bytes = max(
+        max_audit_buffer_bytes,
+        int(os.environ.get("AGENT_BOM_PROXY_AUDIT_SPILLOVER_MAX_BYTES", str(max_audit_buffer_bytes * 8))),
+    )
     audit_spill_path = Path(
         os.environ.get(
             "AGENT_BOM_PROXY_AUDIT_SPILLOVER_PATH",
             str(Path(tempfile.gettempdir()) / f"agent-bom-proxy-audit-{control_plane_session_id}.jsonl"),
         )
     )
+    audit_dlq_path = Path(
+        os.environ.get(
+            "AGENT_BOM_PROXY_AUDIT_DLQ_PATH",
+            str(Path(tempfile.gettempdir()) / f"agent-bom-proxy-audit-{control_plane_session_id}.dlq.jsonl"),
+        )
+    )
+    audit_delivery = AuditDeliveryController(
+        base_interval_seconds=max(audit_push_interval, 5),
+        max_backoff_seconds=max(
+            max(audit_push_interval, 5),
+            int(os.environ.get("AGENT_BOM_PROXY_AUDIT_PUSH_BACKOFF_MAX_SECONDS", "300")),
+        ),
+        breaker_failure_threshold=max(
+            1,
+            int(os.environ.get("AGENT_BOM_PROXY_AUDIT_CIRCUIT_BREAKER_THRESHOLD", "3")),
+        ),
+        breaker_cooldown_seconds=max(
+            max(audit_push_interval, 5),
+            int(os.environ.get("AGENT_BOM_PROXY_AUDIT_CIRCUIT_BREAKER_COOLDOWN_SECONDS", "60")),
+        ),
+    )
+    audit_spillover = AuditSpilloverStore(
+        spill_path=audit_spill_path,
+        dlq_path=audit_dlq_path,
+        max_spillover_bytes=max_audit_spillover_bytes,
+    )
 
     def _event_size_bytes(payload: dict) -> int:
         return len(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
 
-    def _spillover_size_bytes() -> int:
-        try:
-            return audit_spill_path.stat().st_size
-        except FileNotFoundError:
-            return 0
-
     def _sync_audit_metrics() -> None:
         metrics.set_audit_buffer_bytes(audit_buffer_bytes)
-        metrics.set_audit_spillover_bytes(_spillover_size_bytes())
-
-    def _append_spillover_locked(events: list[dict]) -> None:
-        if not events:
-            return
-        audit_spill_path.parent.mkdir(parents=True, exist_ok=True)
-        with audit_spill_path.open("a", encoding="utf-8") as handle:
-            for event in events:
-                handle.write(json.dumps(event) + "\n")
-        _sync_audit_metrics()
-
-    def _read_spillover_locked() -> list[dict]:
-        if not audit_spill_path.exists():
-            return []
-        events: list[dict] = []
-        with audit_spill_path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    logger.warning("Skipping malformed proxy audit spillover line from %s", audit_spill_path)
-                    continue
-                if isinstance(payload, dict):
-                    events.append(payload)
-        return events
+        metrics.set_audit_spillover_bytes(audit_spillover.spillover_size_bytes())
+        metrics.set_audit_dlq_bytes(audit_spillover.dlq_size_bytes())
+        metrics.set_audit_push_backoff_seconds(audit_delivery.current_backoff_seconds())
+        metrics.set_audit_circuit_open(audit_delivery.is_circuit_open())
 
     async def _queue_control_plane_alert(alert_payload: dict) -> None:
         nonlocal audit_buffer_bytes
@@ -669,12 +671,19 @@ async def run_proxy(
                 audit_buffer.append(alert_payload)
                 audit_buffer_bytes += event_size
             else:
-                logger.warning(
-                    "Proxy audit buffer exceeded %s bytes; spilling alert backlog to %s",
-                    max_audit_buffer_bytes,
-                    audit_spill_path,
-                )
-                _append_spillover_locked([alert_payload])
+                destination = audit_spillover.append_events([alert_payload])
+                if destination == "dlq":
+                    logger.error(
+                        "Proxy audit spillover exceeded %s bytes; diverting alert backlog to DLQ %s",
+                        max_audit_spillover_bytes,
+                        audit_dlq_path,
+                    )
+                else:
+                    logger.warning(
+                        "Proxy audit buffer exceeded %s bytes; spilling alert backlog to %s",
+                        max_audit_buffer_bytes,
+                        audit_spill_path,
+                    )
             _sync_audit_metrics()
 
     async def _refresh_control_plane_policies(initial: bool = False) -> None:
@@ -705,20 +714,20 @@ async def run_proxy(
             else:
                 rate_tracker._threshold = local_policy_rate_limit or 0
 
-    async def _flush_audit_buffer(summary: dict | None = None) -> None:
+    async def _flush_audit_buffer(summary: dict | None = None) -> bool:
         nonlocal audit_buffer_bytes
         if not control_plane_url:
-            return
+            return True
         async with audit_lock:
             alerts = list(audit_buffer)
             in_memory_bytes = audit_buffer_bytes
-            spillover_alerts = _read_spillover_locked()
+            spillover_alerts = audit_spillover.read_spillover()
             audit_buffer.clear()
             audit_buffer_bytes = 0
             _sync_audit_metrics()
         combined_alerts = spillover_alerts + alerts
         if not combined_alerts and summary is None:
-            return
+            return True
         spillover_had_data = bool(spillover_alerts)
         try:
             await _push_proxy_audit_batch(
@@ -736,10 +745,12 @@ async def run_proxy(
                 audit_buffer[:0] = alerts
                 audit_buffer_bytes += in_memory_bytes
                 _sync_audit_metrics()
+            return False
         else:
-            if spillover_had_data and audit_spill_path.exists():
-                audit_spill_path.unlink()
+            if spillover_had_data:
+                audit_spillover.clear_spillover()
             _sync_audit_metrics()
+            return True
 
     if control_plane_url:
         await _refresh_control_plane_policies(initial=True)
@@ -760,8 +771,15 @@ async def run_proxy(
         if not control_plane_url:
             return
         while True:
-            await asyncio.sleep(max(audit_push_interval, 5))
-            await _flush_audit_buffer()
+            await asyncio.sleep(audit_delivery.current_backoff_seconds())
+            if audit_delivery.is_circuit_open():
+                _sync_audit_metrics()
+                continue
+            if await _flush_audit_buffer():
+                audit_delivery.record_success()
+            else:
+                audit_delivery.record_failure()
+            _sync_audit_metrics()
 
     async def _handle_alerts(alerts, log_f=None):
         """Log alerts and optionally record them + dispatch webhook."""

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -84,8 +84,11 @@ class ProxyMetrics:
     relay_errors: int = 0
     audit_buffer_bytes: int = 0
     audit_spillover_bytes: int = 0
+    audit_dlq_bytes: int = 0
     policy_fetch_failures: int = 0
     audit_push_failures: int = 0
+    audit_push_backoff_seconds: int = 0
+    audit_circuit_open: bool = False
 
     _MAX_LATENCY_ENTRIES = 10_000
 
@@ -106,11 +109,20 @@ class ProxyMetrics:
     def set_audit_spillover_bytes(self, size_bytes: int) -> None:
         self.audit_spillover_bytes = max(0, size_bytes)
 
+    def set_audit_dlq_bytes(self, size_bytes: int) -> None:
+        self.audit_dlq_bytes = max(0, size_bytes)
+
     def record_policy_fetch_failure(self) -> None:
         self.policy_fetch_failures += 1
 
     def record_audit_push_failure(self) -> None:
         self.audit_push_failures += 1
+
+    def set_audit_push_backoff_seconds(self, seconds: int) -> None:
+        self.audit_push_backoff_seconds = max(0, seconds)
+
+    def set_audit_circuit_open(self, is_open: bool) -> None:
+        self.audit_circuit_open = bool(is_open)
 
     def summary(self) -> dict:
         elapsed = time.monotonic() - self.start_time
@@ -144,9 +156,110 @@ class ProxyMetrics:
             "relay_errors": self.relay_errors,
             "audit_buffer_bytes": self.audit_buffer_bytes,
             "audit_spillover_bytes": self.audit_spillover_bytes,
+            "audit_dlq_bytes": self.audit_dlq_bytes,
             "policy_fetch_failures": self.policy_fetch_failures,
             "audit_push_failures": self.audit_push_failures,
+            "audit_push_backoff_seconds": self.audit_push_backoff_seconds,
+            "audit_circuit_open": 1 if self.audit_circuit_open else 0,
         }
+
+
+@dataclass
+class AuditDeliveryController:
+    """Backoff and circuit-breaker state for proxy audit push delivery."""
+
+    base_interval_seconds: int = 10
+    max_backoff_seconds: int = 300
+    breaker_failure_threshold: int = 3
+    breaker_cooldown_seconds: int = 60
+    consecutive_failures: int = 0
+    _next_delay_seconds: int = 10
+    _circuit_open_until: float = 0.0
+
+    def is_circuit_open(self, now: float | None = None) -> bool:
+        now = time.monotonic() if now is None else now
+        return now < self._circuit_open_until
+
+    def current_backoff_seconds(self, now: float | None = None) -> int:
+        now = time.monotonic() if now is None else now
+        if self.is_circuit_open(now):
+            return max(int(self._circuit_open_until - now), 1)
+        return self._next_delay_seconds
+
+    def record_success(self) -> None:
+        self.consecutive_failures = 0
+        self._next_delay_seconds = self.base_interval_seconds
+        self._circuit_open_until = 0.0
+
+    def record_failure(self, now: float | None = None) -> None:
+        now = time.monotonic() if now is None else now
+        self.consecutive_failures += 1
+        if self._next_delay_seconds <= self.base_interval_seconds:
+            self._next_delay_seconds = min(self.base_interval_seconds * 2, self.max_backoff_seconds)
+        else:
+            self._next_delay_seconds = min(self._next_delay_seconds * 2, self.max_backoff_seconds)
+        if self.consecutive_failures >= self.breaker_failure_threshold:
+            self._circuit_open_until = now + self.breaker_cooldown_seconds
+
+
+@dataclass
+class AuditSpilloverStore:
+    """Persist bounded proxy audit overflow to spillover and DLQ files."""
+
+    spill_path: Path
+    dlq_path: Path
+    max_spillover_bytes: int
+
+    def spillover_size_bytes(self) -> int:
+        try:
+            return self.spill_path.stat().st_size
+        except FileNotFoundError:
+            return 0
+
+    def dlq_size_bytes(self) -> int:
+        try:
+            return self.dlq_path.stat().st_size
+        except FileNotFoundError:
+            return 0
+
+    def append_events(self, events: list[dict]) -> str:
+        if not events:
+            return "noop"
+        encoded = [json.dumps(event) for event in events]
+        total_bytes = sum(len((line + "\n").encode("utf-8")) for line in encoded)
+        if self.spillover_size_bytes() + total_bytes <= self.max_spillover_bytes:
+            self._append_lines(self.spill_path, encoded)
+            return "spillover"
+        self._append_lines(self.dlq_path, encoded)
+        return "dlq"
+
+    def read_spillover(self) -> list[dict]:
+        if not self.spill_path.exists():
+            return []
+        events: list[dict] = []
+        with self.spill_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Skipping malformed proxy audit spillover line from %s", self.spill_path)
+                    continue
+                if isinstance(payload, dict):
+                    events.append(payload)
+        return events
+
+    def clear_spillover(self) -> None:
+        if self.spill_path.exists():
+            self.spill_path.unlink()
+
+    def _append_lines(self, path: Path, lines: list[str]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            for line in lines:
+                handle.write(line + "\n")
 
 
 class ProxyMetricsServer:
@@ -211,6 +324,10 @@ class ProxyMetricsServer:
         lines.append("# TYPE agent_bom_proxy_audit_spillover_bytes gauge")
         lines.append(f"agent_bom_proxy_audit_spillover_bytes {summary.get('audit_spillover_bytes', 0)}")
 
+        lines.append("# HELP agent_bom_proxy_audit_dlq_bytes On-disk audit records diverted to the DLQ")
+        lines.append("# TYPE agent_bom_proxy_audit_dlq_bytes gauge")
+        lines.append(f"agent_bom_proxy_audit_dlq_bytes {summary.get('audit_dlq_bytes', 0)}")
+
         lines.append("# HELP agent_bom_proxy_policy_fetch_failures_total Failed policy refresh attempts")
         lines.append("# TYPE agent_bom_proxy_policy_fetch_failures_total counter")
         lines.append(f"agent_bom_proxy_policy_fetch_failures_total {summary.get('policy_fetch_failures', 0)}")
@@ -218,6 +335,14 @@ class ProxyMetricsServer:
         lines.append("# HELP agent_bom_proxy_audit_push_failures_total Failed audit push attempts")
         lines.append("# TYPE agent_bom_proxy_audit_push_failures_total counter")
         lines.append(f"agent_bom_proxy_audit_push_failures_total {summary.get('audit_push_failures', 0)}")
+
+        lines.append("# HELP agent_bom_proxy_audit_push_backoff_seconds Current audit push retry/backoff delay")
+        lines.append("# TYPE agent_bom_proxy_audit_push_backoff_seconds gauge")
+        lines.append(f"agent_bom_proxy_audit_push_backoff_seconds {summary.get('audit_push_backoff_seconds', 0)}")
+
+        lines.append("# HELP agent_bom_proxy_audit_circuit_open Whether the audit push circuit breaker is open")
+        lines.append("# TYPE agent_bom_proxy_audit_circuit_open gauge")
+        lines.append(f"agent_bom_proxy_audit_circuit_open {summary.get('audit_circuit_open', 0)}")
 
         return "\n".join(lines) + "\n"
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import io
 import json
+from pathlib import Path
 
 from agent_bom.proxy import (
+    AuditDeliveryController,
+    AuditSpilloverStore,
     ProxyMetrics,
     ReplayDetector,
     check_policy,
@@ -220,8 +223,11 @@ def test_proxy_metrics_summary():
     assert s["messages_server_to_client"] == 3
     assert s["audit_buffer_bytes"] == 0
     assert s["audit_spillover_bytes"] == 0
+    assert s["audit_dlq_bytes"] == 0
     assert s["policy_fetch_failures"] == 0
     assert s["audit_push_failures"] == 0
+    assert s["audit_push_backoff_seconds"] == 0
+    assert s["audit_circuit_open"] == 0
     assert "ts" in s
     assert "uptime_seconds" in s
 
@@ -241,14 +247,52 @@ def test_proxy_metrics_records_backpressure_and_policy_failures():
     m = ProxyMetrics()
     m.set_audit_buffer_bytes(1024)
     m.set_audit_spillover_bytes(2048)
+    m.set_audit_dlq_bytes(4096)
     m.record_policy_fetch_failure()
     m.record_audit_push_failure()
+    m.set_audit_push_backoff_seconds(30)
+    m.set_audit_circuit_open(True)
 
     s = m.summary()
     assert s["audit_buffer_bytes"] == 1024
     assert s["audit_spillover_bytes"] == 2048
+    assert s["audit_dlq_bytes"] == 4096
     assert s["policy_fetch_failures"] == 1
     assert s["audit_push_failures"] == 1
+    assert s["audit_push_backoff_seconds"] == 30
+    assert s["audit_circuit_open"] == 1
+
+
+def test_audit_delivery_controller_opens_circuit_after_threshold():
+    controller = AuditDeliveryController(
+        base_interval_seconds=10,
+        max_backoff_seconds=60,
+        breaker_failure_threshold=3,
+        breaker_cooldown_seconds=30,
+    )
+    controller.record_failure(now=100.0)
+    assert controller.current_backoff_seconds(now=100.0) == 20
+    assert controller.is_circuit_open(now=100.0) is False
+    controller.record_failure(now=101.0)
+    assert controller.current_backoff_seconds(now=101.0) == 40
+    controller.record_failure(now=102.0)
+    assert controller.is_circuit_open(now=102.0) is True
+    assert controller.current_backoff_seconds(now=102.0) == 30
+    controller.record_success()
+    assert controller.is_circuit_open(now=102.0) is False
+    assert controller.current_backoff_seconds(now=102.0) == 10
+
+
+def test_audit_spillover_store_diverts_to_dlq_when_spillover_full(tmp_path: Path):
+    store = AuditSpilloverStore(
+        spill_path=tmp_path / "spill.jsonl",
+        dlq_path=tmp_path / "audit.dlq.jsonl",
+        max_spillover_bytes=1,
+    )
+    destination = store.append_events([{"event": "first"}])
+    assert destination == "dlq"
+    assert store.spillover_size_bytes() == 0
+    assert store.dlq_size_bytes() > 0
 
 
 # ── CLI proxy --help ─────────────────────────────────────────────────────────

--- a/tests/test_proxy_metrics.py
+++ b/tests/test_proxy_metrics.py
@@ -97,14 +97,20 @@ def test_control_plane_linkage_metrics(server, metrics):
     """Backpressure and refresh failure metrics are exposed for operators."""
     metrics.set_audit_buffer_bytes(512)
     metrics.set_audit_spillover_bytes(2048)
+    metrics.set_audit_dlq_bytes(1024)
     metrics.record_policy_fetch_failure()
     metrics.record_audit_push_failure()
+    metrics.set_audit_push_backoff_seconds(45)
+    metrics.set_audit_circuit_open(True)
     server.port = 9999
     output = server.render_metrics()
     assert "agent_bom_proxy_audit_buffer_bytes 512" in output
     assert "agent_bom_proxy_audit_spillover_bytes 2048" in output
+    assert "agent_bom_proxy_audit_dlq_bytes 1024" in output
     assert "agent_bom_proxy_policy_fetch_failures_total 1" in output
     assert "agent_bom_proxy_audit_push_failures_total 1" in output
+    assert "agent_bom_proxy_audit_push_backoff_seconds 45" in output
+    assert "agent_bom_proxy_audit_circuit_open 1" in output
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add explicit audit delivery backoff and circuit-breaker state for proxy-to-control-plane audit pushes
- bound spillover with a DLQ fallback and publish metrics for backoff, DLQ bytes, and circuit-open state
- lock the resilience contract with focused proxy runtime tests

## Validation
- uv run pytest -q tests/test_proxy.py tests/test_proxy_metrics.py tests/test_cli_runtime.py -x
- uv run ruff check src/agent_bom/proxy.py src/agent_bom/proxy_audit.py tests/test_proxy.py tests/test_proxy_metrics.py
- uv run mypy src/agent_bom/proxy.py src/agent_bom/proxy_audit.py
- git diff --check

Closes #1466