### PR TITLE
Add service-mesh and policy-controller templates for EKS

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml
@@ -1,0 +1,52 @@
+controlPlane:
+  enabled: true
+  serviceMesh:
+    enabled: true
+    provider: istio
+    istio:
+      peerAuthentication:
+        enabled: true
+        mode: STRICT
+      authorizationPolicy:
+        enabled: true
+        allowSameNamespace: true
+        allowedNamespaces:
+          - ingress-nginx
+          - istio-system
+  policyController:
+    enabled: true
+    provider: kyverno
+    kyverno:
+      validationFailureAction: Enforce
+      background: true
+      requireControlPlanePodHardening: true
+  api:
+    env:
+      - name: AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT
+        value: "1"
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: agent-bom.internal.example.com
+
+networkPolicy:
+  enabled: true
+  restrictIngress: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-bom
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+      ports:
+        - protocol: TCP
+          port: 8422
+        - protocol: TCP
+          port: 3000

--- a/deploy/helm/agent-bom/templates/controlplane-istio-authorizationpolicy.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-istio-authorizationpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.serviceMesh.enabled (eq .Values.controlPlane.serviceMesh.provider "istio") .Values.controlPlane.serviceMesh.istio.authorizationPolicy.enabled }}
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "agent-bom.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+  action: ALLOW
+  rules:
+    {{- if .Values.controlPlane.serviceMesh.istio.authorizationPolicy.allowSameNamespace }}
+    - from:
+        - source:
+            namespaces:
+              - {{ .Release.Namespace | quote }}
+    {{- end }}
+    {{- range .Values.controlPlane.serviceMesh.istio.authorizationPolicy.allowedNamespaces }}
+    - from:
+        - source:
+            namespaces:
+              - {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-istio-peerauthentication.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-istio-peerauthentication.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.serviceMesh.enabled (eq .Values.controlPlane.serviceMesh.provider "istio") .Values.controlPlane.serviceMesh.istio.peerAuthentication.enabled }}
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ include "agent-bom.name" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+  mtls:
+    mode: {{ .Values.controlPlane.serviceMesh.istio.peerAuthentication.mode }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-kyverno-policy.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-kyverno-policy.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.policyController.enabled (eq .Values.controlPlane.policyController.provider "kyverno") .Values.controlPlane.policyController.kyverno.requireControlPlanePodHardening }}
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: {{ include "agent-bom.name" . }}-control-plane-hardening
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+spec:
+  validationFailureAction: {{ .Values.controlPlane.policyController.kyverno.validationFailureAction }}
+  background: {{ .Values.controlPlane.policyController.kyverno.background }}
+  rules:
+    - name: require-control-plane-pod-hardening
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      validate:
+        message: agent-bom pods must keep the chart's restricted security contract.
+        pattern:
+          spec:
+            automountServiceAccountToken: false
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            containers:
+              - securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  capabilities:
+                    drop:
+                      - ALL
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -65,6 +65,24 @@ monitor:
 
 controlPlane:
   enabled: false
+  serviceMesh:
+    enabled: false
+    provider: istio
+    istio:
+      peerAuthentication:
+        enabled: true
+        mode: STRICT
+      authorizationPolicy:
+        enabled: true
+        allowSameNamespace: true
+        allowedNamespaces: []
+  policyController:
+    enabled: false
+    provider: kyverno
+    kyverno:
+      validationFailureAction: Audit
+      background: true
+      requireControlPlanePodHardening: true
   observability:
     grafanaDashboard:
       enabled: false

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -135,6 +135,21 @@ That example adds:
 - packaged Postgres backup `CronJob` that runs `pg_dump` and uploads to S3 through IRSA with SSE or KMS
 - restricted ingress defaults for the chart network policy
 
+For clusters that already standardize on a service mesh and policy controller,
+start from:
+
+- [deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml)
+
+That example adds:
+
+- packaged Istio `PeerAuthentication` for strict mTLS on `agent-bom` pods
+- packaged Istio `AuthorizationPolicy` that keeps same-namespace traffic and explicitly whitelisted ingress namespaces
+- packaged namespaced Kyverno `Policy` that enforces the same restricted pod contract already used by the chart
+
+This is intentionally an opt-in hardening layer. It composes with the chart's
+existing `NetworkPolicy`, PSS-restricted pod settings, anti-affinity, and HPA
+defaults instead of replacing them.
+
 ## What you still own
 
 This is a real packaged control plane, but not a magic managed service.
@@ -177,6 +192,9 @@ You still own:
 - enable `controlPlane.observability.prometheusRule.enabled=true` when the cluster already runs Prometheus Operator
 - enable `controlPlane.observability.grafanaDashboard.enabled=true` when Grafana watches dashboard `ConfigMap`s
 - enable `controlPlane.backup.enabled=true` only after setting a real S3 bucket, prefix, and IRSA-backed upload permissions
+- enable `controlPlane.serviceMesh.enabled=true` only when the control-plane namespace is already part of your Istio data plane
+- keep `controlPlane.serviceMesh.istio.authorizationPolicy.allowedNamespaces` explicit; the packaged example allows `ingress-nginx` and `istio-system`, but production should match your real ingress path
+- enable `controlPlane.policyController.enabled=true` only when Kyverno is already installed cluster-wide; the chart packages the namespaced policy, not the controller itself
 - set `controlPlane.backup.destination.bucketRegion` to the actual region of your backup bucket; the production example intentionally uses `REPLACE_ME_BUCKET_REGION`
 - `controlPlane.backup.destination.region` remains as a backward-compatible fallback for older values files
 - keep `controlPlane.backup.destination.encryption.enabled=true`; the default is `AES256`, and production should set `mode=aws:kms` with a dedicated `kmsKeyId`

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -127,6 +127,36 @@ That gives you:
 - runtime surface introspection
 - enforcement checks in the scheduled scan path
 
+## Optional Mesh And Policy Hardening
+
+If your platform baseline already uses Istio and Kyverno, the chart now ships
+an opt-in hardening layer that stays aligned with the current security model
+instead of inventing a second one.
+
+Start from:
+
+- [deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml)
+
+That package adds:
+
+- Istio `PeerAuthentication` with `STRICT` mTLS for `agent-bom` pods
+- Istio `AuthorizationPolicy` with explicit namespace allow-lists for ingress paths
+- a namespaced Kyverno `Policy` that enforces:
+  - `automountServiceAccountToken: false`
+  - `runAsNonRoot`
+  - `seccompProfile: RuntimeDefault`
+  - `allowPrivilegeEscalation: false`
+  - `readOnlyRootFilesystem: true`
+  - `capabilities.drop: [ALL]`
+
+Use it only when:
+
+- the namespace is already part of your Istio mesh
+- ingress traffic really comes from the namespaces you allow
+- Kyverno is already installed cluster-wide
+
+It is additive to the chart's `NetworkPolicy`, not a replacement for it.
+
 ## Policy Enforcement In This Model
 
 `agent-bom` policy enforcement is three separate layers:
@@ -187,6 +217,9 @@ all sit under one operator-controlled plane.
   - `AGENT_BOM_POSTGRES_POOL_MAX_SIZE`
   - `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS`
   - `AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS`
+- when enabling the mesh layer, keep the namespace allow-list explicit:
+  - `controlPlane.serviceMesh.istio.authorizationPolicy.allowedNamespaces`
+  and match it to your actual ingress path instead of assuming `ingress-nginx`
 - enable the packaged PrometheusRule and Grafana dashboard when your cluster
   already runs Prometheus Operator and Grafana sidecar discovery
 - enable the packaged backup CronJob only after setting a real S3 destination

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -237,6 +237,9 @@ def test_helm_templates_exist():
         "controlplane-externalsecret.yaml",
         "controlplane-grafana-dashboard.yaml",
         "controlplane-ingress.yaml",
+        "controlplane-istio-authorizationpolicy.yaml",
+        "controlplane-istio-peerauthentication.yaml",
+        "controlplane-kyverno-policy.yaml",
         "controlplane-pdb.yaml",
         "controlplane-priorityclass.yaml",
         "controlplane-prometheusrule.yaml",
@@ -320,6 +323,24 @@ def test_helm_control_plane_observability_defaults():
     assert observability["prometheusRule"]["enabled"] is False
     assert observability["prometheusRule"]["rules"]["apiErrorRate"]["enabled"] is True
     assert observability["prometheusRule"]["rules"]["proxyAuditBacklog"]["backlogBytesThreshold"] == 10485760
+
+
+def test_helm_control_plane_mesh_and_policy_defaults():
+    """Service-mesh and policy-controller packaging should be explicit and opt-in."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    mesh = doc["controlPlane"]["serviceMesh"]
+    policy = doc["controlPlane"]["policyController"]
+    assert mesh["enabled"] is False
+    assert mesh["provider"] == "istio"
+    assert mesh["istio"]["peerAuthentication"]["enabled"] is True
+    assert mesh["istio"]["peerAuthentication"]["mode"] == "STRICT"
+    assert mesh["istio"]["authorizationPolicy"]["enabled"] is True
+    assert mesh["istio"]["authorizationPolicy"]["allowSameNamespace"] is True
+    assert mesh["istio"]["authorizationPolicy"]["allowedNamespaces"] == []
+    assert policy["enabled"] is False
+    assert policy["provider"] == "kyverno"
+    assert policy["kyverno"]["validationFailureAction"] == "Audit"
+    assert policy["kyverno"]["requireControlPlanePodHardening"] is True
 
 
 def test_helm_control_plane_backup_defaults():
@@ -434,6 +455,24 @@ def test_production_values_enable_operator_defaults():
     assert production["topologySpread"]["enabled"] is True
     assert production["networkPolicy"]["restrictIngress"] is True
     assert "cert-manager.io/cluster-issuer" in production["controlPlane"]["ingress"]["annotations"]
+
+
+def test_mesh_example_enables_istio_and_kyverno_hardening():
+    """Mesh example should wire the chart's Istio and Kyverno packaging coherently."""
+    values = yaml.safe_load((HELM_DIR / "examples" / "eks-istio-kyverno-values.yaml").read_text())
+    mesh = values["controlPlane"]["serviceMesh"]
+    policy = values["controlPlane"]["policyController"]
+    assert values["controlPlane"]["enabled"] is True
+    assert mesh["enabled"] is True
+    assert mesh["provider"] == "istio"
+    assert mesh["istio"]["peerAuthentication"]["mode"] == "STRICT"
+    assert set(mesh["istio"]["authorizationPolicy"]["allowedNamespaces"]) == {"ingress-nginx", "istio-system"}
+    assert policy["enabled"] is True
+    assert policy["provider"] == "kyverno"
+    assert policy["kyverno"]["validationFailureAction"] == "Enforce"
+    ingress_rule = values["networkPolicy"]["ingress"][1]
+    ports = {port["port"] for port in ingress_rule["ports"]}
+    assert ports == {3000, 8422}
 
 
 def test_pilot_and_production_values_narrow_ingress_to_controller_pods_and_ports():


### PR DESCRIPTION
## Summary
- package opt-in Istio hardening templates for strict mTLS and namespace-scoped control-plane access
- add an opt-in Kyverno restricted-pod policy aligned to the chart's existing security contract
- ship an EKS example values file and docs for the additive service-mesh / policy-controller layer

## Validation
- uv run pytest -q tests/test_deploy_manifests.py -x
- git diff --check

Closes #1467