### PR TITLE
Add /v1/auth/debug for auth-method introspection

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -309,6 +309,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             request.state.api_key_name = "static-key"
             request.state.api_key_role = "admin"
             request.state.tenant_id = "default"
+            request.state.auth_method = "static_api_key"
             return await self._call_with_tenant_context(request, call_next)
 
         # OIDC mode: try JWT verification when AGENT_BOM_OIDC_ISSUER is set
@@ -331,6 +332,12 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                     request.state.api_key_name = _claims.get("email") or _claims.get("sub", "oidc-user")
                     request.state.api_key_role = oidc_role
                     request.state.tenant_id = oidc_cfg.resolve_tenant(_claims)
+                    request.state.auth_method = "oidc"
+                    # Short issuer suffix helps operators recognize which IdP
+                    # resolved the token without leaking the full URL to all
+                    # request-scoped log fields.
+                    issuer = str(_claims.get("iss") or "")
+                    request.state.auth_issuer = issuer.rsplit("/", 1)[-1][:64] if issuer else None
                     return await self._call_with_tenant_context(request, call_next)
                 return JSONResponse(
                     status_code=403,
@@ -358,6 +365,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 request.state.api_key_name = api_key.name
                 request.state.api_key_role = api_key.role.value
                 request.state.tenant_id = api_key.tenant_id
+                request.state.api_key_id = api_key.key_id
+                # SAML-minted keys are named "saml:<subject>" — surface that
+                # as a distinct auth method so operators can trace who came
+                # in via which IdP path even after the key has been issued.
+                request.state.auth_method = "saml" if api_key.name.startswith("saml:") else "api_key"
                 return await self._call_with_tenant_context(request, call_next)
 
         return JSONResponse(

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -195,6 +195,46 @@ async def auth_policy() -> dict:
     }
 
 
+@router.get("/v1/auth/debug", tags=["enterprise"])
+async def auth_debug(request: Request) -> dict:
+    """Introspect how the current request was authenticated.
+
+    Surfaces the auth method (``static_api_key`` / ``api_key`` / ``oidc`` /
+    ``saml``), the resolved role + tenant, the request-scoped trace IDs, and
+    the subject recorded for audit purposes. Intended for operator support
+    flows — "why is my request being denied?" — and for client SDKs doing
+    session introspection without issuing a shadow request.
+
+    The response never contains the raw API key or OIDC token. Only
+    non-secret identifying attributes (name, key_id prefix, role, tenant,
+    auth method) so the endpoint is safe to log.
+    """
+    method = getattr(request.state, "auth_method", None)
+    subject = getattr(request.state, "api_key_name", None)
+    role = getattr(request.state, "api_key_role", None)
+    tenant_id = getattr(request.state, "tenant_id", None) or "default"
+    request_id = getattr(request.state, "request_id", None)
+    trace_id = getattr(request.state, "trace_id", None)
+    span_id = getattr(request.state, "span_id", None)
+    issuer = getattr(request.state, "auth_issuer", None)
+    key_id = getattr(request.state, "api_key_id", None)
+    key_id_prefix = key_id[:8] if isinstance(key_id, str) else None
+
+    authenticated = bool(method and role)
+    return {
+        "authenticated": authenticated,
+        "auth_method": method,
+        "subject": subject,
+        "role": role,
+        "tenant_id": tenant_id,
+        "oidc_issuer_suffix": issuer,
+        "api_key_id_prefix": key_id_prefix,
+        "request_id": request_id,
+        "trace_id": trace_id,
+        "span_id": span_id,
+    }
+
+
 @router.delete("/v1/auth/keys/{key_id}", tags=["enterprise"], status_code=204)
 async def delete_key(request: Request, key_id: str) -> None:
     """Revoke an API key."""

--- a/tests/test_api_auth_debug.py
+++ b/tests/test_api_auth_debug.py
@@ -1,0 +1,160 @@
+"""Tests for GET /v1/auth/debug — operator-facing auth introspection.
+
+Covers:
+- unauthenticated request returns a safe zero-state response
+- auth method + role + tenant reflect the middleware-resolved state
+- no raw key / token / hash ever appears in the response
+- request-scoped trace IDs are surfaced so operators can correlate logs
+"""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+
+def _set_state(client: TestClient, **attrs) -> TestClient:
+    """Install a one-shot ASGI middleware that seeds request.state.
+
+    The API's real middleware stack populates these attributes from a valid
+    API key / OIDC token / SAML session. For the debug endpoint contract we
+    only care that given some state, the response shape is stable — so we
+    inject the state directly and exercise the endpoint handler.
+    """
+    # Starlette's TestClient shares the app instance; stacking middlewares
+    # between tests would leak. Instead, monkey-patch the endpoint's
+    # request.state lookups via a scope override.
+    raise NotImplementedError  # sentinel to clarify intent — see direct calls below
+
+
+def test_auth_debug_returns_zero_state_without_auth() -> None:
+    """No middleware has run → every auth attribute reports None."""
+    client = TestClient(app)
+    resp = client.get("/v1/auth/debug")
+    # The endpoint itself is not auth-required; it reports the absence.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["authenticated"] is False
+    assert body["auth_method"] is None
+    assert body["subject"] is None
+    assert body["role"] is None
+    # tenant_id defaults to "default" so clients can always display a value
+    assert body["tenant_id"] == "default"
+
+
+def test_auth_debug_reports_resolved_method_and_role() -> None:
+    """When middleware has set auth state, it surfaces on the debug endpoint."""
+    from agent_bom.api.routes.enterprise import auth_debug
+
+    class _FakeState:
+        auth_method = "api_key"
+        api_key_name = "ci-bot"
+        api_key_role = "analyst"
+        tenant_id = "tenant-alpha"
+        request_id = "req-123"
+        trace_id = "trace-abc"
+        span_id = "span-456"
+        auth_issuer = None
+        api_key_id = "deadbeef01234567"
+
+    class _FakeRequest:
+        state = _FakeState()
+
+    import asyncio
+
+    result = asyncio.run(auth_debug(_FakeRequest()))  # type: ignore[arg-type]
+    assert result == {
+        "authenticated": True,
+        "auth_method": "api_key",
+        "subject": "ci-bot",
+        "role": "analyst",
+        "tenant_id": "tenant-alpha",
+        "oidc_issuer_suffix": None,
+        "api_key_id_prefix": "deadbeef",
+        "request_id": "req-123",
+        "trace_id": "trace-abc",
+        "span_id": "span-456",
+    }
+
+
+def test_auth_debug_never_leaks_raw_key_or_token() -> None:
+    """Even if a wildly-unsafe key somehow lands in state, it must not escape."""
+    from agent_bom.api.routes.enterprise import auth_debug
+
+    secret = "sk-live-super-secret-123456789"
+
+    class _FakeState:
+        auth_method = "oidc"
+        api_key_name = "alice@example.com"
+        api_key_role = "admin"
+        tenant_id = "tenant-alpha"
+        request_id = "r-1"
+        trace_id = "t-1"
+        span_id = "s-1"
+        auth_issuer = "example.com"
+        api_key_id = None
+        # Attributes the endpoint explicitly does not read
+        raw_api_key = secret
+        jwt_token = secret
+        api_key_hash = secret
+
+    class _FakeRequest:
+        state = _FakeState()
+
+    import asyncio
+    import json
+
+    body = asyncio.run(auth_debug(_FakeRequest()))  # type: ignore[arg-type]
+    serialized = json.dumps(body)
+    assert secret not in serialized, "raw key/token must never appear in /v1/auth/debug output"
+
+
+def test_auth_debug_distinguishes_saml_from_api_key() -> None:
+    """Keys minted via /v1/auth/saml/login are reported as auth_method=saml."""
+    from agent_bom.api.routes.enterprise import auth_debug
+
+    class _FakeState:
+        auth_method = "saml"
+        api_key_name = "saml:alice@example.com"
+        api_key_role = "analyst"
+        tenant_id = "tenant-alpha"
+        request_id = "r-1"
+        trace_id = "t-1"
+        span_id = "s-1"
+        auth_issuer = None
+        api_key_id = "cafebabe12345678"
+
+    class _FakeRequest:
+        state = _FakeState()
+
+    import asyncio
+
+    result = asyncio.run(auth_debug(_FakeRequest()))  # type: ignore[arg-type]
+    assert result["auth_method"] == "saml"
+    assert result["subject"].startswith("saml:")
+
+
+def test_auth_debug_key_id_only_exposes_prefix() -> None:
+    """api_key_id_prefix must be 8 chars max to avoid leaking full identifier."""
+    from agent_bom.api.routes.enterprise import auth_debug
+
+    class _FakeState:
+        auth_method = "api_key"
+        api_key_name = "ci-bot"
+        api_key_role = "viewer"
+        tenant_id = "default"
+        request_id = "r-1"
+        trace_id = "t-1"
+        span_id = "s-1"
+        auth_issuer = None
+        api_key_id = "0123456789abcdef0123456789abcdef"
+
+    class _FakeRequest:
+        state = _FakeState()
+
+    import asyncio
+
+    result = asyncio.run(auth_debug(_FakeRequest()))  # type: ignore[arg-type]
+    assert result["api_key_id_prefix"] == "01234567"
+    assert len(result["api_key_id_prefix"]) == 8


### PR DESCRIPTION
## Summary

Closes the small P2 gap flagged in the recent audit: no operator-facing endpoint to introspect how a live request resolved its auth. Until now, the only signal was the per-request audit log line.

## What this adds

### New endpoint — `GET /v1/auth/debug`

```json
{
  "authenticated": true,
  "auth_method": "saml",
  "subject": "saml:alice@example.com",
  "role": "analyst",
  "tenant_id": "tenant-alpha",
  "oidc_issuer_suffix": null,
  "api_key_id_prefix": "cafebabe",
  "request_id": "r-1",
  "trace_id": "t-1",
  "span_id": "s-1"
}
```

- `auth_method` ∈ `static_api_key` / `api_key` / `oidc` / `saml` (or null when unauthenticated)
- SAML-minted keys (named `saml:<subject>`) report `auth_method="saml"` so the audit story stays faithful to the IdP path
- `oidc_issuer_suffix` = last path segment of the `iss` claim, capped at 64 chars (recognizable without leaking full issuer URLs)
- `api_key_id_prefix` = first 8 chars of the key id only (never the full id, never the raw key, never the hash)
- `request_id` / `trace_id` / `span_id` so operators can pivot to observability dashboards

### Middleware plumbing

- new `request.state.auth_method` set at each auth-resolution branch
- new `request.state.auth_issuer` for OIDC
- new `request.state.api_key_id` so the debug endpoint can surface the prefix

## Test plan

- `uv run pytest tests/test_api_auth_debug.py tests/test_auth.py tests/test_api_hardening.py` — 58 passed
- `uv run mypy src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py` — clean
- `uv run ruff check` — clean
- Five focused tests: unauthenticated zero-state, resolved state shape, never-leaks-raw-key invariant, SAML distinction, api_key_id_prefix length invariant