### PR TITLE
Tighten README diagrams + document the visual language

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,35 +142,31 @@ Self-hosted is a first-class path. Employee endpoints push fleet discovery into 
 ```mermaid
 flowchart LR
     subgraph endpoints["Employee endpoints"]
-        cur[Cursor / Claude / VS Code]
-        codex[Codex / Cortex / Continue]
-        agcli[agent-bom agents --push]
-        prx[agent-bom proxy &lt;mcp cmd&gt;]
+        direction TB
+        clients["Cursor · Claude · VS Code<br/>Codex · Cortex · Continue"]
+        push["agent-bom agents --push"]
+        proxy["agent-bom proxy &lt;mcp&gt;"]
+        clients -.-> push
+        clients -.-> proxy
     end
 
-    subgraph eks["Your AWS / EKS cluster"]
-        api[Control-plane API + UI]
-        fleet[Fleet · Mesh · Gateway · Audit]
-        auth[OIDC / SAML / RBAC]
-        pg[(Postgres)]
-        ch[(ClickHouse · optional)]
-        secrets[(External Secrets · KMS)]
-        obs[Prometheus · Grafana · OTel]
-        mcps[Selected MCP workloads<br/>+ proxy sidecars]
-    end
+    cp(["Control plane<br/>API · UI · Fleet · Mesh · Gateway · Audit"])
+    pg[("Postgres")]
+    ch[("ClickHouse<br/>optional")]
+    sec[("External Secrets · KMS")]
+    obs["Prometheus · Grafana · OTel"]
+    workloads["Selected MCP workloads<br/>+ proxy sidecars"]
 
-    cur --> agcli
-    codex --> agcli
-    agcli -->|HTTPS push| api
-    prx -->|policy pull · audit push| api
-    api --- fleet
-    api --- auth
-    api --- pg
-    api -. analytics .- ch
-    api --- secrets
-    api --- obs
-    api --- mcps
+    push -->|HTTPS push| cp
+    proxy -->|policy pull · audit push| cp
+    cp --- pg
+    cp -. analytics .- ch
+    cp --- sec
+    cp --- obs
+    cp --> workloads
 ```
+
+Inside the control plane: **OIDC + SAML SSO** with RBAC, **enforced API-key rotation policy**, **tenant-scoped quotas + rate limits**, **HMAC-chained audit log** with signed export, and **KMS-encrypted Postgres backups** with a verified restore round-trip in CI.
 
 What that gives you:
 
@@ -178,6 +174,23 @@ What that gives you:
 - runtime enforcement for selected MCP workloads in-cluster
 - one control plane for fleet, mesh, findings, gateway policy, and audit
 - no mandatory hosted vendor plane
+
+### How a request flows through the control plane
+
+```mermaid
+flowchart LR
+    REQ([HTTP request]) --> BODY[Body size + read timeout]
+    BODY --> TRACE[Trust headers + W3C trace]
+    TRACE --> AUTH["Auth — API key · OIDC · SAML"]
+    AUTH --> RBAC[RBAC role check]
+    RBAC --> TENANT[Tenant context propagation]
+    TENANT --> QUOTA[Tenant quota + rate limit]
+    QUOTA --> ROUTE[Route handler]
+    ROUTE --> AUDIT[(HMAC audit log)]
+    ROUTE --> STORE[(Postgres / ClickHouse<br/>KMS at rest)]
+```
+
+Every layer is testable on its own; failures emit Prometheus metrics. Operators introspect a live request via `GET /v1/auth/debug` and see rotation status via `GET /v1/auth/policy`.
 
 ```bash
 # control plane in your cluster

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -1,0 +1,63 @@
+# Visual language for agent-bom docs
+
+Three media, used deliberately. Picking the right one keeps the README
+readable, mobile-friendly, and easy to keep in sync with code.
+
+## SVG — for hero visuals + dense product imagery
+
+Use when:
+- the diagram is the *story* of the section (blast-radius, scan pipeline, engine internals, compliance mapping, topology)
+- you need typographic control, color hierarchy, or dense info per pixel
+- it does not change every PR
+
+Files live in `docs/images/`, always shipped as `*-light.svg` + `*-dark.svg`
+with `<picture>`+`prefers-color-scheme` switching. Hand-tuned, no auto-layout.
+
+Current SVG inventory:
+
+| File | What it shows | Where it lives in the README |
+|---|---|---|
+| `logo-{light,dark}.svg` | Brand mark | hero |
+| `blast-radius-{light,dark}.svg` | Package → CVE → MCP → agent → credentials → tools | hero, under tagline |
+| `scan-pipeline-{light,dark}.svg` | 5-stage pipeline (discover → scan → analyze → report → enforce) | "How a scan moves" |
+| `engine-internals-{light,dark}.svg` | Inside the scanner | "How a scan moves" |
+| `topology-{light,dark}.svg` | Focused graph view (start scoped, expand) | "How a scan moves" |
+| `compliance-{light,dark}.svg` | Finding → control → evidence packet | Compliance section |
+| `dashboard-live.png` `mesh-live.png` `remediation-live.png` | Live UI screenshots | Product views |
+| `demo-latest.gif` | Terminal demo (1.04MB after compression) | "Try the demo" |
+
+## Mermaid — for code-true flows that evolve
+
+Use when:
+- the diagram mirrors a piece of code or config that changes (helm templates, middleware stack, deployment topology)
+- editing it as text in a PR is more honest than re-rendering an SVG
+- the layout is naturally **linear or single-radial** (no crossing edges)
+
+Rules to avoid spaghetti:
+1. Pick one direction (`LR` or `TB`), don't mix
+2. Maximum one level of `subgraph` nesting; flatten the rest into siblings
+3. Maximum 4–6 nodes per inner cluster — overflow goes into a paragraph below the diagram, not into the diagram
+4. Edges should radiate from a single hub OR flow linearly — never form a mesh
+5. Drop modifier nodes (logos, decorations) — Mermaid is structure, not decoration
+
+Current Mermaid surface:
+- `## Deploy in your own AWS / EKS` — 3-tier hub-and-spoke (endpoints → control plane → workloads + state + observability)
+- `### How a request flows through the control plane` — linear left-to-right pipeline of middleware classes
+
+## ASCII / monospace — for terminal output only
+
+Use when the block is literally a terminal artifact (CLI output, code snippet,
+config file). Do not use ASCII for architecture diagrams — every drift makes
+it harder to read.
+
+Current ASCII surface:
+- The CVE blast-radius tree at the top of the README — it is what
+  `agent-bom agents --offline` actually prints
+- All `bash` / `yaml` / `json` code blocks — those are commands, not diagrams
+
+## When in doubt
+
+If the diagram is going to be referenced by an enterprise buyer's procurement
+deck, ship SVG. If it's going to drift faster than the next release, ship
+Mermaid. If a junior engineer would type it into a terminal, ship ASCII inside
+a fenced code block.


### PR DESCRIPTION
## Summary

Follow-up to #1499. The deploy-topology Mermaid had a hub with eight nodes plus back-references — rendered as spaghetti on GitHub. This pass restructures the same information into a clean three-tier hub-and-spoke and pushes the inside-the-control-plane detail to a one-paragraph callout.

## What changes

### `## Deploy in your own AWS / EKS`

Before: 8 inner nodes inside a single subgraph, multiple `---` edges back to `api`, criss-crossing arrows.

After: three tiers (endpoints → control plane → state / observability / workloads), single subgraph nesting, edges radiate from the `cp` hub only — no mesh.

### New `### How a request flows through the control plane`

Linear LR Mermaid: Request → Body limit → Trust headers + trace → Auth (API key · OIDC · SAML) → RBAC → Tenant context → Quota + rate limit → Route → HMAC audit log + KMS-encrypted storage.

Linear means no crossing edges by construction. Surfaces the new `/v1/auth/debug` and `/v1/auth/policy` endpoints right where readers will look.

### `docs/VISUAL_LANGUAGE.md`

New doc that names the deliberate three-medium mix and the rules to keep them honest:

- **SVG** — hero visuals + dense product imagery (blast-radius, scan-pipeline, engine-internals, compliance, topology). Hand-tuned, light/dark via `<picture>`.
- **Mermaid** — code-true flows that evolve. Anti-spaghetti rules: one direction, one subgraph nesting level, max 4–6 nodes per cluster, hub-and-spoke or linear (never mesh).
- **ASCII / monospace** — terminal output only (CVE tree, code blocks).

So future PRs know which medium to pick and how to keep it readable.

## Test plan

- [ ] Render the README on github.com/msaad00/agent-bom and confirm both Mermaid blocks paint cleanly with no overlap
- [ ] Mobile reader-mode check on iOS Safari