### PR TITLE
Add /v1/compliance/{framework}/report signed evidence bundle endpoint

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -5,6 +5,7 @@ Endpoints:
     GET  /v1/compliance/narrative            full compliance narrative (all frameworks)
     GET  /v1/compliance/narrative/{framework} single-framework narrative
     GET  /v1/compliance/{framework}          single framework (must be after /narrative)
+    GET  /v1/compliance/{framework}/report   signed evidence bundle for auditors
     GET  /v1/posture                         enterprise posture scorecard
     GET  /v1/posture/counts                  severity counts for nav badges
     GET  /v1/posture/credentials             credential risk ranking
@@ -13,9 +14,12 @@ Endpoints:
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_store
@@ -512,6 +516,254 @@ async def get_compliance_by_framework(request: Request, framework: str) -> dict:
         "summary": {"pass": pass_count, "warning": warn_count, "fail": fail_count},
         "score": round((pass_count / len(controls)) * 100, 1) if controls else 100.0,
     }
+
+
+# ─── Signed evidence bundle ────────────────────────────────────────────────
+
+
+def _parse_iso_or_default(value: str | None, default: datetime) -> datetime:
+    """Parse an ISO-8601 timestamp; fall back to ``default`` on missing/invalid."""
+    if not value:
+        return default
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid timestamp '{value}'. Use ISO-8601 with timezone.",
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _evidence_for_control(
+    control: dict,
+    blast_radii_by_tag: dict[str, list[dict]],
+) -> list[dict]:
+    """Map a control's tags onto the matching blast-radius findings."""
+    seen_finding_ids: set[str] = set()
+    evidence: list[dict] = []
+    for tag in control.get("tags", []) or []:
+        for br in blast_radii_by_tag.get(tag, []):
+            finding_id = br.get("finding_id") or f"{br.get('vulnerability_id', '')}@{br.get('package', '')}"
+            if finding_id in seen_finding_ids:
+                continue
+            seen_finding_ids.add(finding_id)
+            evidence.append(
+                {
+                    "finding_id": finding_id,
+                    "control_tag": tag,
+                    "vulnerability_id": br.get("vulnerability_id"),
+                    "package": br.get("package"),
+                    "severity": br.get("severity"),
+                    "scan_id": br.get("scan_id"),
+                    "fixed_version": br.get("fixed_version"),
+                    "agents_at_risk": br.get("affected_agents") or [],
+                }
+            )
+    return evidence
+
+
+def _index_blast_radii_by_tag(jobs: list) -> dict[str, list[dict]]:
+    """Build a flat tag → list[blast-radius] index across all completed scans."""
+    by_tag: dict[str, list[dict]] = {}
+    for job in jobs:
+        if job.status != JobStatus.DONE or not job.result:
+            continue
+        scan_id = job.result.get("scan_id") or job.job_id
+        for br in job.result.get("blast_radius", []):
+            br_with_scan = {**br, "scan_id": scan_id}
+            for tag_field in (
+                "owasp_tags",
+                "owasp_mcp_tags",
+                "atlas_tags",
+                "nist_ai_rmf_tags",
+                "nist_csf_tags",
+                "iso_27001_tags",
+                "soc2_tags",
+                "cmmc_tags",
+                "fedramp_tags",
+                "owasp_agentic_tags",
+                "eu_ai_act_tags",
+                "cis_tags",
+                "nist_800_53_tags",
+                "pci_dss_tags",
+            ):
+                for tag in br.get(tag_field, []) or []:
+                    by_tag.setdefault(tag, []).append(br_with_scan)
+    return by_tag
+
+
+@router.get("/v1/compliance/{framework}/report", tags=["compliance"], response_model=None)
+async def export_compliance_report(
+    request: Request,
+    framework: str,
+    since: str | None = None,
+    until: str | None = None,
+    format: str = "json",
+) -> JSONResponse | PlainTextResponse:
+    """Export an auditor-ready signed evidence bundle for a single framework.
+
+    The bundle pairs each control with the blast-radius findings that map to
+    its tags, the audit-log entries within the requested time window, and
+    integrity totals from the HMAC-chained log. The response carries an
+    ``X-Agent-Bom-Compliance-Report-Signature`` header — the HMAC-SHA256 of
+    the canonical body — so downstream auditors can verify the bundle did
+    not drift between export and review. The export itself is audit-logged
+    as ``compliance.report_exported`` so re-issued bundles leave a trail.
+
+    Query params:
+      - ``since`` ISO-8601 timestamp (default: now − 30 days)
+      - ``until`` ISO-8601 timestamp (default: now)
+      - ``format`` ``json`` (default) or ``jsonl`` for streaming consumers
+    """
+    fmt = format.lower()
+    if fmt not in {"json", "jsonl"}:
+        raise HTTPException(status_code=400, detail="format must be one of: json, jsonl")
+
+    now = datetime.now(timezone.utc)
+    since_dt = _parse_iso_or_default(since, now - timedelta(days=30))
+    until_dt = _parse_iso_or_default(until, now)
+    if since_dt >= until_dt:
+        raise HTTPException(status_code=400, detail="since must be earlier than until")
+
+    full = await get_compliance(request)
+    framework_map = {
+        "owasp-llm": ("owasp_llm_top10", "OWASP LLM Top 10"),
+        "owasp-mcp": ("owasp_mcp_top10", "OWASP MCP Top 10"),
+        "atlas": ("mitre_atlas", "MITRE ATLAS"),
+        "nist": ("nist_ai_rmf", "NIST AI RMF"),
+        "owasp-agentic": ("owasp_agentic_top10", "OWASP Agentic Top 10"),
+        "eu-ai-act": ("eu_ai_act", "EU AI Act"),
+        "nist-csf": ("nist_csf", "NIST CSF"),
+        "iso-27001": ("iso_27001", "ISO 27001"),
+        "soc2": ("soc2", "SOC 2"),
+        "cis": ("cis_controls", "CIS Controls"),
+        "cmmc": ("cmmc", "CMMC"),
+        "nist-800-53": ("nist_800_53", "NIST 800-53"),
+        "fedramp": ("fedramp", "FedRAMP"),
+        "pci-dss": ("pci_dss", "PCI DSS"),
+    }
+    key_label = framework_map.get(framework.lower())
+    if not key_label:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown framework '{framework}'. Supported: {', '.join(framework_map.keys())}",
+        )
+    framework_key, framework_label = key_label
+    controls = full.get(framework_key, [])
+
+    tenant_id = _tenant_id(request)
+    actor = getattr(request.state, "api_key_name", "") or "system"
+
+    blast_by_tag = _index_blast_radii_by_tag(_tenant_jobs(request))
+
+    from agent_bom.api.audit_log import get_audit_log, log_action, sign_export_payload
+
+    store = get_audit_log()
+    audit_since_iso = since_dt.isoformat()
+    # Cap audit fetch at 10k for export sanity; consumers paginate further via /v1/audit
+    audit_entries = store.list_entries(since=audit_since_iso, limit=10_000)
+    until_iso = until_dt.isoformat()
+    audit_in_window = [
+        e
+        for e in audit_entries
+        if str((e.details or {}).get("tenant_id", "default")) == tenant_id
+        and audit_since_iso <= (e.timestamp or "") <= until_iso
+    ]
+    verified, tampered = store.verify_integrity(limit=min(10_000, len(audit_entries) or 1))
+
+    pass_count = sum(1 for c in controls if c.get("status") == "pass")
+    warn_count = sum(1 for c in controls if c.get("status") == "warning")
+    fail_count = sum(1 for c in controls if c.get("status") == "fail")
+
+    enriched_controls: list[dict] = []
+    total_findings = 0
+    for control in controls:
+        evidence = _evidence_for_control(control, blast_by_tag)
+        total_findings += len(evidence)
+        enriched_controls.append(
+            {
+                "control_id": control.get("control_id") or control.get("id"),
+                "control_name": control.get("name") or control.get("title"),
+                "status": control.get("status", "unknown"),
+                "finding_count": len(evidence),
+                "evidence": evidence,
+            }
+        )
+
+    body = {
+        "schema_version": "v1",
+        "framework": framework,
+        "framework_key": framework_key,
+        "framework_label": framework_label,
+        "tenant_id": tenant_id,
+        "generated_at": now.isoformat(),
+        "scope": {
+            "since": since_dt.isoformat(),
+            "until": until_dt.isoformat(),
+            "control_count": len(controls),
+            "finding_count": total_findings,
+            "audit_event_count": len(audit_in_window),
+        },
+        "summary": {
+            "pass": pass_count,
+            "warning": warn_count,
+            "fail": fail_count,
+            "score": round((pass_count / len(controls)) * 100, 1) if controls else 100.0,
+        },
+        "controls": enriched_controls,
+        "audit_events": [entry.to_dict() for entry in audit_in_window],
+        "audit_log_integrity": {
+            "verified": verified,
+            "tampered": tampered,
+            "checked": verified + tampered,
+        },
+        "signature_algorithm": "HMAC-SHA256",
+    }
+
+    log_action(
+        "compliance.report_exported",
+        actor=actor,
+        resource=f"compliance/{framework_key}",
+        tenant_id=tenant_id,
+        format=fmt,
+        since=since_dt.isoformat(),
+        until=until_dt.isoformat(),
+        control_count=len(controls),
+        finding_count=total_findings,
+        audit_event_count=len(audit_in_window),
+    )
+
+    filename = f"agent-bom-compliance-{framework_key.replace('_', '-')}.{ 'jsonl' if fmt == 'jsonl' else 'json'}"
+
+    if fmt == "jsonl":
+        # jsonl streams one control per line so SIEM and security-lake
+        # consumers can ingest without loading the whole bundle.
+        lines = [json.dumps({"meta": {k: v for k, v in body.items() if k not in {"controls", "audit_events"}}}, sort_keys=True)]
+        for control in body["controls"]:
+            lines.append(json.dumps({"control": control}, sort_keys=True))
+        for entry in body["audit_events"]:
+            lines.append(json.dumps({"audit": entry}, sort_keys=True))
+        payload = ("\n".join(lines) + "\n").encode()
+        return PlainTextResponse(
+            content=payload.decode(),
+            media_type="application/x-ndjson",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "X-Agent-Bom-Compliance-Report-Signature": sign_export_payload(payload),
+            },
+        )
+
+    payload = json.dumps(body, sort_keys=True).encode()
+    return JSONResponse(
+        content=body,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "X-Agent-Bom-Compliance-Report-Signature": sign_export_payload(payload),
+        },
+    )
 
 
 # ─── Posture Scorecard ─────────────────────────────────────────────────────

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -1,0 +1,289 @@
+"""Tests for GET /v1/compliance/{framework}/report — signed evidence bundle.
+
+Locks the auditor-facing contract:
+
+- response carries ``X-Agent-Bom-Compliance-Report-Signature`` matching
+  the HMAC-SHA256 of the canonical JSON body
+- bundle pairs every framework control with the matching blast-radius
+  evidence drawn from the tenant's completed scans
+- audit events are filtered to the requested time window and the authed
+  tenant — never cross-tenant leakage
+- ``compliance.report_exported`` is appended to the audit log with the
+  exporter's actor + tenant + scope so re-issued bundles leave a trail
+- jsonl format streams one control per line for SIEM / security-lake
+- unknown framework, malformed timestamps, and inverted ranges all 4xx
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+from agent_bom.api.audit_log import (
+    AuditEntry,
+    InMemoryAuditLog,
+    set_audit_log,
+)
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.routes import compliance as compliance_routes
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _request(tenant_id: str, actor: str = "ci-bot") -> SimpleNamespace:
+    state = SimpleNamespace(tenant_id=tenant_id, api_key_name=actor)
+    return SimpleNamespace(state=state)
+
+
+def _seed_jobs_with_findings(tenant_id: str = "tenant-alpha") -> list[ScanJob]:
+    """Build two completed scans with blast-radius entries tagged for OWASP LLM and SOC 2."""
+    job_a = ScanJob(
+        job_id="scan-a",
+        tenant_id=tenant_id,
+        status=JobStatus.DONE,
+        created_at=_now_iso(),
+        completed_at=_now_iso(),
+        request=ScanRequest(),
+    )
+    job_a.result = {
+        "scan_id": "scan-a",
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2024-0001",
+                "package": "axios@1.4.0",
+                "severity": "high",
+                "fixed_version": "1.7.4",
+                "owasp_tags": ["LLM01"],
+                "soc2_tags": ["CC6.1"],
+                "affected_agents": ["claude-desktop"],
+            },
+            {
+                "vulnerability_id": "CVE-2024-0002",
+                "package": "certifi@2022.12.7",
+                "severity": "critical",
+                "fixed_version": "2024.7.4",
+                "owasp_tags": ["LLM02"],
+                "affected_agents": ["claude-desktop"],
+            },
+        ],
+    }
+    return [job_a]
+
+
+def _setup_audit_log() -> InMemoryAuditLog:
+    audit = InMemoryAuditLog()
+    audit.append(
+        AuditEntry(
+            entry_id="e1",
+            timestamp=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+            action="auth.key_rotated",
+            actor="ci-bot",
+            resource="key/abc",
+            details={"tenant_id": "tenant-alpha"},
+        )
+    )
+    audit.append(
+        AuditEntry(
+            entry_id="e2",
+            timestamp=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+            action="scan.started",
+            actor="ci-bot",
+            resource="scan/scan-a",
+            details={"tenant_id": "tenant-other"},  # cross-tenant — must NOT appear in tenant-alpha bundle
+        )
+    )
+    set_audit_log(audit)
+    return audit
+
+
+def _patched_get_compliance_returns(payload: dict):
+    return patch.object(compliance_routes, "get_compliance", return_value=payload)
+
+
+# ─── Happy-path JSON ─────────────────────────────────────────────────────────
+
+
+def test_report_json_signature_matches_canonical_body() -> None:
+    audit = _setup_audit_log()
+    jobs = _seed_jobs_with_findings()
+
+    full_payload = {
+        "owasp_llm_top10": [
+            {"control_id": "LLM01", "name": "Prompt Injection", "status": "fail", "tags": ["LLM01"]},
+            {"control_id": "LLM02", "name": "Insecure Output Handling", "status": "warning", "tags": ["LLM02"]},
+            {"control_id": "LLM03", "name": "Training Data Poisoning", "status": "pass", "tags": ["LLM03"]},
+        ]
+    }
+    req = _request("tenant-alpha")
+
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
+        with _patched_get_compliance_returns(full_payload):
+            resp = asyncio.run(
+                compliance_routes.export_compliance_report(req, "owasp-llm")
+            )
+
+    assert isinstance(resp, JSONResponse)
+    body = json.loads(resp.body)
+    assert body["framework_key"] == "owasp_llm_top10"
+    assert body["framework_label"] == "OWASP LLM Top 10"
+    assert body["tenant_id"] == "tenant-alpha"
+    assert body["scope"]["control_count"] == 3
+    assert body["scope"]["finding_count"] == 2
+
+    # Pass/warning/fail summary
+    assert body["summary"]["fail"] == 1
+    assert body["summary"]["warning"] == 1
+    assert body["summary"]["pass"] == 1
+
+    # Evidence wired to the right control
+    by_id = {c["control_id"]: c for c in body["controls"]}
+    assert by_id["LLM01"]["finding_count"] == 1
+    assert by_id["LLM01"]["evidence"][0]["vulnerability_id"] == "CVE-2024-0001"
+    assert by_id["LLM03"]["finding_count"] == 0
+
+    # HMAC signature header matches canonical body
+    sig = resp.headers["X-Agent-Bom-Compliance-Report-Signature"]
+    canonical = json.dumps(body, sort_keys=True).encode()
+    from agent_bom.api.audit_log import _HMAC_KEY  # noqa: PLC0415
+
+    expected = hmac.new(_HMAC_KEY, canonical, hashlib.sha256).hexdigest()
+    assert sig == expected
+
+    # Content-Disposition + filename
+    assert resp.headers["Content-Disposition"].endswith('agent-bom-compliance-owasp-llm-top10.json"')
+
+    # compliance.report_exported emitted with full scope
+    log_entries = list(audit._entries)  # type: ignore[attr-defined]
+    exported_entries = [e for e in log_entries if e.action == "compliance.report_exported"]
+    assert len(exported_entries) == 1
+    exported = exported_entries[0]
+    assert (exported.details or {}).get("tenant_id") == "tenant-alpha"
+    assert exported.actor == "ci-bot"
+
+
+# ─── Tenant isolation ─────────────────────────────────────────────────────────
+
+
+def test_report_audit_events_are_tenant_filtered() -> None:
+    _setup_audit_log()  # has one tenant-alpha and one tenant-other entry
+    jobs = _seed_jobs_with_findings()
+    full_payload = {"owasp_llm_top10": []}
+    req = _request("tenant-alpha")
+
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
+        with _patched_get_compliance_returns(full_payload):
+            resp = asyncio.run(
+                compliance_routes.export_compliance_report(req, "owasp-llm")
+            )
+
+    body = json.loads(resp.body)
+    # Cross-tenant audit entry must not leak into the bundle
+    tenants = {e["details"].get("tenant_id") for e in body["audit_events"]}
+    assert tenants == {"tenant-alpha"}
+    assert all(e["details"].get("tenant_id") != "tenant-other" for e in body["audit_events"])
+
+
+# ─── Format = jsonl ──────────────────────────────────────────────────────────
+
+
+def test_report_jsonl_streams_one_record_per_line() -> None:
+    _setup_audit_log()
+    jobs = _seed_jobs_with_findings()
+    full_payload = {
+        "soc2": [
+            {"control_id": "CC6.1", "name": "Logical Access", "status": "fail", "tags": ["CC6.1"]},
+        ]
+    }
+    req = _request("tenant-alpha")
+
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
+        with _patched_get_compliance_returns(full_payload):
+            resp = asyncio.run(
+                compliance_routes.export_compliance_report(req, "soc2", format="jsonl")
+            )
+
+    assert isinstance(resp, PlainTextResponse)
+    raw = resp.body.decode()
+    lines = [ln for ln in raw.split("\n") if ln]
+    # First line is meta; followed by one control line; followed by the audit entry
+    assert json.loads(lines[0])["meta"]["framework_key"] == "soc2"
+    assert json.loads(lines[1])["control"]["control_id"] == "CC6.1"
+    # The signature is over the canonical jsonl payload, not the json one
+    sig = resp.headers["X-Agent-Bom-Compliance-Report-Signature"]
+    from agent_bom.api.audit_log import _HMAC_KEY  # noqa: PLC0415
+
+    expected = hmac.new(_HMAC_KEY, raw.encode(), hashlib.sha256).hexdigest()
+    assert sig == expected
+
+
+# ─── Bad input ────────────────────────────────────────────────────────────────
+
+
+def test_unknown_framework_returns_400() -> None:
+    _setup_audit_log()
+    req = _request("tenant-alpha")
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
+        with _patched_get_compliance_returns({}):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    compliance_routes.export_compliance_report(req, "made-up-framework")
+                )
+    assert exc.value.status_code == 400
+    assert "Unknown framework" in exc.value.detail
+
+
+def test_invalid_format_returns_400() -> None:
+    _setup_audit_log()
+    req = _request("tenant-alpha")
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
+        with _patched_get_compliance_returns({}):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    compliance_routes.export_compliance_report(req, "fedramp", format="csv")
+                )
+    assert exc.value.status_code == 400
+    assert "format must be" in exc.value.detail
+
+
+def test_malformed_since_returns_400() -> None:
+    _setup_audit_log()
+    req = _request("tenant-alpha")
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
+        with _patched_get_compliance_returns({}):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    compliance_routes.export_compliance_report(req, "fedramp", since="not-a-date")
+                )
+    assert exc.value.status_code == 400
+    assert "Invalid timestamp" in exc.value.detail
+
+
+def test_since_after_until_returns_400() -> None:
+    _setup_audit_log()
+    req = _request("tenant-alpha")
+    later = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    earlier = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
+        with _patched_get_compliance_returns({}):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    compliance_routes.export_compliance_report(
+                        req,
+                        "fedramp",
+                        since=later,
+                        until=earlier,
+                    )
+                )
+    assert exc.value.status_code == 400
+    assert "since must be earlier" in exc.value.detail


### PR DESCRIPTION
## Summary

Closes Phase 1 item 1.2 from the post-#1494 audit plan — the last F500-parity depth item.

Until now, auditors had no machine-readable way to pull a single-framework evidence packet on demand. Operators had to either run the CLI `--compliance-export` job and ship a ZIP out-of-band, or compose the bundle by hand from `/v1/compliance` + `/v1/audit` + per-job blast-radius pulls. This endpoint produces the bundle in one HTTP call, signs it for tamper-evidence, and audit-logs the export.

## What ships

### `GET /v1/compliance/{framework}/report?since=&until=&format=json|jsonl`

The response pairs every framework control with the matching blast-radius findings (drawn from the tenant's completed scans via the existing tag fields — `owasp_tags`, `soc2_tags`, `cmmc_tags`, `fedramp_tags`, `nist_*_tags`, etc.) plus the audit-log entries within the requested time window plus integrity totals from the HMAC-chained log.

```json
{
  "schema_version": "v1",
  "framework": "fedramp",
  "framework_label": "FedRAMP",
  "tenant_id": "tenant-alpha",
  "generated_at": "2026-04-18T...Z",
  "scope": { "since": "...", "until": "...", "control_count": 14, "finding_count": 42, "audit_event_count": 120 },
  "summary": { "pass": 11, "warning": 2, "fail": 1, "score": 78.6 },
  "controls": [
    { "control_id": "AC-2", "control_name": "Account Management", "status": "pass", "finding_count": 0, "evidence": [...] }
  ],
  "audit_events": [...],
  "audit_log_integrity": { "verified": 120, "tampered": 0, "checked": 120 },
  "signature_algorithm": "HMAC-SHA256"
}
```

### Headers

- `X-Agent-Bom-Compliance-Report-Signature` = HMAC-SHA256 of the canonical body
- `Content-Disposition: attachment; filename="agent-bom-compliance-{framework}.{ext}"`

### Format = `jsonl`

Streams `meta` + one `control` per line + one `audit` per line. Signed over the canonical jsonl payload (not the json one) for SIEM / security-lake ingest.

### Audit trail

Every export emits `compliance.report_exported` with exporter actor + tenant + scope (since, until, control_count, finding_count, audit_event_count) so re-issued bundles leave a trail.

### 14 supported frameworks

`cmmc`, `fedramp`, `soc2`, `iso-27001`, `owasp-llm`, `owasp-mcp`, `atlas`, `nist`, `nist-csf`, `nist-800-53`, `owasp-agentic`, `eu-ai-act`, `cis`, `pci-dss`.

## Validation

- `uv run pytest tests/test_compliance_report.py tests/test_compliance.py tests/test_compliance_export.py tests/test_compliance_narrative.py tests/test_audit_chain.py tests/test_api_enterprise_tenant.py tests/test_api_hardening.py` — 87 passed
- `uv run ruff check` — clean
- `uv run mypy src/agent_bom/api/routes/compliance.py` — clean

Tests pin: HMAC signature matches canonical body, evidence wired by tag overlap, audit events tenant-isolated (cross-tenant leak proof), `compliance.report_exported` appended on every export, 4xx on unknown framework / bad format / inverted time range.