### PR TITLE
Update dashboard description for the Risk overview redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ pip install 'agent-bom[ui]' && agent-bom serve                    # API + dashbo
 
 These come from the live product path, using the built-in demo data pushed through the API. See [`docs/CAPTURE.md`](docs/CAPTURE.md) for the canonical capture protocol.
 
-### Dashboard
+### Dashboard — Risk overview
 
-Risk summary, posture, and the highest-value attack paths in one screen.
+The landing page is the **Risk overview**: a letter-grade gauge, the four headline counters (actively exploited · credentials exposed · reachable tools · top attack-path risk), the security-posture grade with sub-scores (policy + controls, open evidence, packages + CVEs, reach + exposure, MCP configuration), the score breakdown for each driver, and the top attack paths with one-click drilldown.
 
 ![agent-bom dashboard](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png)
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -31,9 +31,24 @@ that does not happen again.
 
 | Asset | Page | Required scope | Rationale |
 |---|---|---|---|
-| `dashboard-live.png` | `/dashboard` | All agents | Shows risk overview + top attack paths |
+| `dashboard-live.png` | `/dashboard` (Risk overview) | All agents · scroll showing F-grade gauge, posture sub-scores, score breakdown, top attack paths | Captures the headline counters (actively exploited / credentials exposed / reachable tools / top-path risk), the security-posture grade, and the score breakdown — all in one frame |
 | `mesh-live.png` | `/mesh` | Filter to `claude-desktop` | Has 2 servers, 4 packages, 5+ CVEs — produces a rich graph |
 | `remediation-live.png` | `/remediation` | All frameworks tab | Shows the full prioritized fix list |
+
+### Dashboard layout (current)
+
+The Risk overview redesign (post-#1496 operator UX drilldown) replaced
+the older single-column attack-path layout. The current frame contains:
+
+1. **Header** — `Risk overview` title, scan count + agent count + package count + CVE count
+2. **Top counters** — actively exploited · credentials exposed · reachable tools · top attack-path risk
+3. **F-grade gauge** — 0-100 numeric score with letter grade
+4. **Security posture card** — grade explanation + 6 sub-scores (policy + controls, open evidence × 2, packages + CVEs, reach + exposure, MCP configuration)
+5. **Score breakdown** — per-driver progress bars with one-line evidence
+6. **Top attack paths** — clickable rows linking to the security graph
+
+A capture that misses any of those sections is incomplete. Re-shoot
+with the page scrolled to top so the gauge + posture card both fit.
 
 The `claude-desktop` agent in `src/agent_bom/demo.py` is the one wired
 for the mesh hero shot — it pulls in `axios@1.4.0` (7 CVEs) and


### PR DESCRIPTION
## Summary

The Risk overview landing redesign replaced the older single-column attack-path layout with a gauge + posture card + score breakdown layout. The README description still described the old layout, and `docs/CAPTURE.md` still pointed at "risk summary + top attack paths" without enumerating the new sections — so the next capture pass could easily miss a section.

## What changes

### `## Product views` → `### Dashboard — Risk overview`

Rewrites the description to enumerate the six visible sections:

1. Header with scan / agent / package / CVE counts
2. Top counters — actively exploited · credentials exposed · reachable tools · top attack-path risk
3. F-grade gauge
4. Security posture card with 6 sub-scores
5. Score breakdown per driver
6. Top attack paths

### `docs/CAPTURE.md`

- Updates the per-screenshot scope row for `dashboard-live.png` to call out the F-grade gauge + posture sub-scores + score breakdown explicitly
- Adds a new "Dashboard layout (current)" section enumerating the six sections so the next operator capture cannot miss one
- Catches the "scrolled past the gauge" capture mistake

## Note on the PNG itself

`docs/images/dashboard-live.png` still shows the old layout. Replacing the file requires running `agent-bom serve` against the demo data and capturing in a browser per the protocol in `docs/CAPTURE.md` — which cannot be done from inside a PR-only workflow. This PR ships the description + protocol updates so when an operator does the recapture, the surrounding text is already correct.

## Test plan

- [ ] Render the README and confirm the new dashboard description matches the new product layout
- [ ] Operator: re-capture `dashboard-live.png` per the updated `docs/CAPTURE.md` protocol and merge the resulting binary as a follow-up