### PR TITLE
Add MCP tool-schema validation rule catalog (OWASP-mapped)

### DIFF
--- a/src/agent_bom/mcp_tool_rules.py
+++ b/src/agent_bom/mcp_tool_rules.py
@@ -1,0 +1,323 @@
+"""MCP tool-schema validation rules — OWASP-mapped catalog.
+
+The product previously detected schema-level capability hints
+(`shell-execution-capability`, `network-egress-capability`, etc.) via
+the heuristic linter in :mod:`agent_bom.mcp_introspect`. That surfaced
+the *signal* but did not give operators a rule ID they could route to
+a compliance control.
+
+This module turns those hints — plus a few additional schema patterns
+we care about for OWASP LLM Top 10 (LLM01–LLM10) and the OWASP MCP
+Top 10 — into structured rule findings. Each rule carries:
+
+- a stable ``rule_id`` (e.g. ``MCP-TOOL-01-shell-input``) so dashboards
+  and SIEM filters can pin behavior
+- a ``severity`` aligned with the canonical :class:`Severity` ladder
+- ``owasp_tags`` and ``owasp_mcp_tags`` so the compliance-report
+  endpoint and ``BlastRadius`` can route the finding to the right
+  control without a separate tag-assignment pass
+- ``message`` + ``evidence`` so the operator can act without re-running
+  the analyzer
+
+Rules are intentionally narrow: only fire when the underlying schema
+shape genuinely matches the threat. False positives here become alert
+fatigue and erode trust in the catalog. New rules require a test in
+``tests/test_mcp_tool_rules.py`` that verifies the rule fires on a
+representative bad schema and stays silent on a clean one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_bom.models import MCPTool
+
+
+# ─── Hint regexes ──────────────────────────────────────────────────────────────
+# Reused from mcp_introspect to keep the two analyzers in sync.
+
+_PATH_HINT_RE = re.compile(r"(path|file|dir|cwd|workspace)", re.IGNORECASE)
+_URL_HINT_RE = re.compile(r"(url|uri|endpoint|host|domain|webhook)", re.IGNORECASE)
+_SHELL_HINT_RE = re.compile(r"(cmd|command|shell|exec|script)", re.IGNORECASE)
+_SQL_HINT_RE = re.compile(r"(query|sql|statement|stmt)", re.IGNORECASE)
+_PROMPT_HINT_RE = re.compile(r"(prompt|instruction|system|markdown|html|svg)", re.IGNORECASE)
+_CRED_HINT_RE = re.compile(r"(token|secret|password|credential|api[_-]?key|access[_-]?key)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class MCPRuleFinding:
+    """A single rule violation against an MCP tool input schema."""
+
+    rule_id: str
+    severity: str  # "low" | "medium" | "high" | "critical"
+    title: str
+    message: str
+    evidence: str
+    tool_name: str
+    property_name: str | None = None
+    owasp_tags: tuple[str, ...] = field(default_factory=tuple)
+    owasp_mcp_tags: tuple[str, ...] = field(default_factory=tuple)
+    cwe_ids: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        return {
+            "rule_id": self.rule_id,
+            "severity": self.severity,
+            "title": self.title,
+            "message": self.message,
+            "evidence": self.evidence,
+            "tool_name": self.tool_name,
+            "property_name": self.property_name,
+            "owasp_tags": list(self.owasp_tags),
+            "owasp_mcp_tags": list(self.owasp_mcp_tags),
+            "cwe_ids": list(self.cwe_ids),
+        }
+
+
+# ─── Rule definitions ─────────────────────────────────────────────────────────
+#
+# Each rule is a pure function of (tool, prop_name, prop_schema) → list of
+# findings. Returning an empty list means the rule did not fire.
+
+
+def _is_freeform_string(prop_schema: dict) -> bool:
+    """A string property with no enum, no maxLength, and no pattern is freeform."""
+    return (
+        prop_schema.get("type") == "string"
+        and not prop_schema.get("enum")
+        and not prop_schema.get("maxLength")
+        and not prop_schema.get("pattern")
+    )
+
+
+def _rule_shell_input(tool_name: str, prop_name: str, prop_schema: dict) -> list[MCPRuleFinding]:
+    """MCP-TOOL-01 — tool accepts an unbounded string named like a shell command."""
+    if not _SHELL_HINT_RE.search(prop_name):
+        return []
+    if not _is_freeform_string(prop_schema):
+        return []
+    return [
+        MCPRuleFinding(
+            rule_id="MCP-TOOL-01-shell-input",
+            severity="critical",
+            title="MCP tool accepts unbounded shell-style input",
+            message=(
+                f"Tool `{tool_name}` accepts a freeform string parameter `{prop_name}` whose name "
+                "implies command execution. Without an enum or pattern an attacker can pivot the "
+                "tool into arbitrary shell execution via prompt injection."
+            ),
+            evidence=f"property `{prop_name}` has type=string with no enum, maxLength, or pattern",
+            tool_name=tool_name,
+            property_name=prop_name,
+            owasp_tags=("LLM02-Insecure-Output-Handling", "LLM06-Sensitive-Information-Disclosure"),
+            owasp_mcp_tags=("MCP01-Untrusted-Tool-Inputs", "MCP04-Excessive-Capability"),
+            cwe_ids=("CWE-78",),  # OS Command Injection
+        )
+    ]
+
+
+def _rule_path_traversal(tool_name: str, prop_name: str, prop_schema: dict) -> list[MCPRuleFinding]:
+    """MCP-TOOL-02 — tool accepts an unbounded path with no allow-list."""
+    if not _PATH_HINT_RE.search(prop_name):
+        return []
+    if not _is_freeform_string(prop_schema):
+        return []
+    return [
+        MCPRuleFinding(
+            rule_id="MCP-TOOL-02-path-traversal",
+            severity="high",
+            title="MCP tool accepts unbounded file path",
+            message=(
+                f"Tool `{tool_name}` accepts a freeform string parameter `{prop_name}` that names "
+                "a file/path target. Without an allow-list pattern, an attacker can read or write "
+                "outside the intended scope via `..` traversal or absolute paths."
+            ),
+            evidence=f"property `{prop_name}` has type=string with no pattern constraint",
+            tool_name=tool_name,
+            property_name=prop_name,
+            owasp_tags=("LLM02-Insecure-Output-Handling",),
+            owasp_mcp_tags=("MCP01-Untrusted-Tool-Inputs", "MCP05-Insecure-Defaults"),
+            cwe_ids=("CWE-22",),  # Path Traversal
+        )
+    ]
+
+
+def _rule_ssrf(tool_name: str, prop_name: str, prop_schema: dict) -> list[MCPRuleFinding]:
+    """MCP-TOOL-03 — tool accepts an unbounded URL/host with no allow-list."""
+    if not _URL_HINT_RE.search(prop_name):
+        return []
+    if not _is_freeform_string(prop_schema):
+        return []
+    return [
+        MCPRuleFinding(
+            rule_id="MCP-TOOL-03-ssrf",
+            severity="high",
+            title="MCP tool accepts unbounded URL or host",
+            message=(
+                f"Tool `{tool_name}` accepts a freeform string parameter `{prop_name}` that names "
+                "a network destination. Without an allow-list, an attacker can pivot the tool into "
+                "SSRF against cloud metadata, internal services, or arbitrary external destinations."
+            ),
+            evidence=f"property `{prop_name}` has type=string with no enum or pattern",
+            tool_name=tool_name,
+            property_name=prop_name,
+            owasp_tags=("LLM02-Insecure-Output-Handling",),
+            owasp_mcp_tags=("MCP01-Untrusted-Tool-Inputs", "MCP04-Excessive-Capability"),
+            cwe_ids=("CWE-918",),  # SSRF
+        )
+    ]
+
+
+def _rule_sql_injection(tool_name: str, prop_name: str, prop_schema: dict) -> list[MCPRuleFinding]:
+    """MCP-TOOL-04 — tool accepts an unbounded string named like a SQL statement."""
+    if not _SQL_HINT_RE.search(prop_name):
+        return []
+    if not _is_freeform_string(prop_schema):
+        return []
+    return [
+        MCPRuleFinding(
+            rule_id="MCP-TOOL-04-sql-injection",
+            severity="high",
+            title="MCP tool accepts unbounded SQL-style input",
+            message=(
+                f"Tool `{tool_name}` accepts a freeform string parameter `{prop_name}` whose name "
+                "implies a SQL statement. Without parameterization or an enum of allowed shapes, "
+                "the tool can be steered into injection via prompt-driven query rewriting."
+            ),
+            evidence=f"property `{prop_name}` has type=string with no enum or pattern",
+            tool_name=tool_name,
+            property_name=prop_name,
+            owasp_tags=("LLM02-Insecure-Output-Handling",),
+            owasp_mcp_tags=("MCP01-Untrusted-Tool-Inputs",),
+            cwe_ids=("CWE-89",),  # SQL Injection
+        )
+    ]
+
+
+def _rule_credential_in_input(tool_name: str, prop_name: str, prop_schema: dict) -> list[MCPRuleFinding]:
+    """MCP-TOOL-05 — tool accepts a credential as an input parameter."""
+    if not _CRED_HINT_RE.search(prop_name):
+        return []
+    if prop_schema.get("type") not in (None, "string"):
+        return []
+    return [
+        MCPRuleFinding(
+            rule_id="MCP-TOOL-05-credential-in-input",
+            severity="medium",
+            title="MCP tool accepts credential-shaped input",
+            message=(
+                f"Tool `{tool_name}` accepts parameter `{prop_name}` whose name implies a "
+                "credential. Credentials passed through tool calls flow through prompt history, "
+                "logs, and audit trails — they should be injected via the server environment, "
+                "not the LLM-controlled input surface."
+            ),
+            evidence=f"property name `{prop_name}` matches credential pattern",
+            tool_name=tool_name,
+            property_name=prop_name,
+            owasp_tags=("LLM06-Sensitive-Information-Disclosure",),
+            owasp_mcp_tags=("MCP02-Credential-Leakage",),
+            cwe_ids=("CWE-522",),  # Insufficiently Protected Credentials
+        )
+    ]
+
+
+def _rule_prompt_passthrough(tool_name: str, prop_name: str, prop_schema: dict) -> list[MCPRuleFinding]:
+    """MCP-TOOL-06 — tool accepts a property described as a prompt or instruction."""
+    desc = (prop_schema.get("description") or "").strip()
+    if not desc or not _PROMPT_HINT_RE.search(desc):
+        return []
+    return [
+        MCPRuleFinding(
+            rule_id="MCP-TOOL-06-prompt-passthrough",
+            severity="medium",
+            title="MCP tool input passes a prompt-shaped value",
+            message=(
+                f"Tool `{tool_name}` parameter `{prop_name}` description names it as a prompt / "
+                "instruction. Prompt-shaped tool inputs are a primary OWASP LLM01 injection vector "
+                "when the tool composes the value into another LLM call without sanitization."
+            ),
+            evidence=f"description references prompt/instruction/system: \"{desc[:80]}\"",
+            tool_name=tool_name,
+            property_name=prop_name,
+            owasp_tags=("LLM01-Prompt-Injection",),
+            owasp_mcp_tags=("MCP01-Untrusted-Tool-Inputs",),
+            cwe_ids=("CWE-94",),  # Code Injection
+        )
+    ]
+
+
+def _rule_weak_description(tool_name: str, prop_name: str | None, prop_schema: dict, *, tool_desc: str) -> list[MCPRuleFinding]:
+    """MCP-TOOL-07 — tool description is missing or trivially short.
+
+    Operates at the tool level, not per-property. The function still takes
+    ``prop_name``/``prop_schema`` to keep the rule signature uniform with the
+    per-property rules so the dispatcher does not branch.
+    """
+    if prop_name is not None:
+        return []
+    if tool_desc and len(tool_desc.strip()) >= 12:
+        return []
+    return [
+        MCPRuleFinding(
+            rule_id="MCP-TOOL-07-weak-description",
+            severity="low",
+            title="MCP tool description is missing or trivially short",
+            message=(
+                f"Tool `{tool_name}` has no usable description. LLMs route tool selection by "
+                "description; an empty or trivial description encourages the model to pick the "
+                "tool indiscriminately and lets a malicious server hide intent from the agent."
+            ),
+            evidence=f"tool description length is {len(tool_desc.strip()) if tool_desc else 0}",
+            tool_name=tool_name,
+            property_name=None,
+            owasp_tags=("LLM05-Improper-Output-Handling",),
+            owasp_mcp_tags=("MCP07-Confusing-Tool-Surface",),
+            cwe_ids=(),
+        )
+    ]
+
+
+_PROPERTY_RULES = (
+    _rule_shell_input,
+    _rule_path_traversal,
+    _rule_ssrf,
+    _rule_sql_injection,
+    _rule_credential_in_input,
+    _rule_prompt_passthrough,
+)
+
+
+def evaluate_tool(tool: "MCPTool") -> list[MCPRuleFinding]:
+    """Evaluate every rule against an MCP tool and return the firing findings.
+
+    The dispatcher walks ``input_schema.properties`` once; each property is
+    fed into every per-property rule. Tool-level rules (currently just
+    weak-description) run separately.
+    """
+    findings: list[MCPRuleFinding] = []
+
+    findings.extend(_rule_weak_description(tool.name, None, {}, tool_desc=tool.description or ""))
+
+    schema = tool.input_schema or {}
+    properties = schema.get("properties", {}) if isinstance(schema, dict) else {}
+    if not isinstance(properties, dict):
+        return findings
+
+    for prop_name, prop_schema in properties.items():
+        if not isinstance(prop_schema, dict):
+            continue
+        for rule in _PROPERTY_RULES:
+            findings.extend(rule(tool.name, prop_name, prop_schema))
+
+    return findings
+
+
+def evaluate_server_tools(tools: list["MCPTool"]) -> list[MCPRuleFinding]:
+    """Evaluate every rule across a server's tool inventory."""
+    out: list[MCPRuleFinding] = []
+    for tool in tools:
+        out.extend(evaluate_tool(tool))
+    return out

--- a/tests/test_mcp_tool_rules.py
+++ b/tests/test_mcp_tool_rules.py
@@ -1,0 +1,203 @@
+"""Tests for the MCP tool-schema rule catalog.
+
+Each rule is asserted with a representative bad schema (rule must fire,
+with the expected severity + OWASP tags) and a representative clean
+schema (rule must stay silent). Together this prevents the catalog
+from drifting into either false-positive noise or false-negative
+silence as new rules land.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.mcp_tool_rules import (
+    MCPRuleFinding,
+    evaluate_server_tools,
+    evaluate_tool,
+)
+from agent_bom.models import MCPTool
+
+
+def _tool(tool_name: str, description: str = "Adequate description for tool", **schema_props) -> MCPTool:
+    """Build a minimal MCPTool with the given schema properties."""
+    schema = {"type": "object", "properties": schema_props}
+    return MCPTool(name=tool_name, description=description, input_schema=schema)
+
+
+# ─── Per-rule positive + negative cases ──────────────────────────────────────
+
+
+class TestShellInputRule:
+    def test_fires_on_unbounded_command_string(self) -> None:
+        tool = _tool("run_command", command={"type": "string"})
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-01-shell-input"]
+        assert len(rules) == 1
+        finding = rules[0]
+        assert finding.severity == "critical"
+        assert "MCP01-Untrusted-Tool-Inputs" in finding.owasp_mcp_tags
+        assert "CWE-78" in finding.cwe_ids
+
+    def test_silent_when_command_has_enum(self) -> None:
+        tool = _tool("run_command", command={"type": "string", "enum": ["ls", "pwd"]})
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-01-shell-input"]
+
+    def test_silent_when_property_unrelated(self) -> None:
+        tool = _tool("greet", name={"type": "string"})
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-01-shell-input"]
+
+
+class TestPathTraversalRule:
+    def test_fires_on_unbounded_file_path(self) -> None:
+        tool = _tool("read_file", file_path={"type": "string"})
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-02-path-traversal"]
+        assert len(rules) == 1
+        assert rules[0].severity == "high"
+        assert "CWE-22" in rules[0].cwe_ids
+
+    def test_silent_when_path_has_pattern(self) -> None:
+        tool = _tool("read_file", file_path={"type": "string", "pattern": "^/sandbox/[a-z0-9_/.-]+$"})
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-02-path-traversal"]
+
+
+class TestSSRFRule:
+    def test_fires_on_unbounded_url(self) -> None:
+        tool = _tool("fetch", url={"type": "string"})
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-03-ssrf"]
+        assert len(rules) == 1
+        assert rules[0].severity == "high"
+        assert "CWE-918" in rules[0].cwe_ids
+
+    def test_silent_when_url_has_enum(self) -> None:
+        tool = _tool("fetch", url={"type": "string", "enum": ["https://api.example.com/v1"]})
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-03-ssrf"]
+
+
+class TestSQLInjectionRule:
+    def test_fires_on_unbounded_query(self) -> None:
+        tool = _tool("run_query", query={"type": "string"})
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-04-sql-injection"]
+        assert len(rules) == 1
+        assert "CWE-89" in rules[0].cwe_ids
+
+    def test_silent_on_parameterized_shape(self) -> None:
+        tool = _tool(
+            "run_query",
+            statement_id={"type": "string", "enum": ["list_users", "list_jobs"]},
+            params={"type": "object"},
+        )
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-04-sql-injection"]
+
+
+class TestCredentialInInputRule:
+    def test_fires_on_token_input(self) -> None:
+        tool = _tool("call_api", token={"type": "string"})
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-05-credential-in-input"]
+        assert len(rules) == 1
+        assert "MCP02-Credential-Leakage" in rules[0].owasp_mcp_tags
+        assert "CWE-522" in rules[0].cwe_ids
+
+    def test_silent_on_username(self) -> None:
+        tool = _tool("call_api", username={"type": "string"})
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-05-credential-in-input"]
+
+
+class TestPromptPassthroughRule:
+    def test_fires_on_prompt_described_property(self) -> None:
+        tool = _tool(
+            "summarize",
+            text={"type": "string", "description": "The system prompt to compose with the user input"},
+        )
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-06-prompt-passthrough"]
+        assert len(rules) == 1
+        assert "LLM01-Prompt-Injection" in rules[0].owasp_tags
+
+    def test_silent_when_description_is_neutral(self) -> None:
+        tool = _tool(
+            "summarize",
+            text={"type": "string", "description": "Free-form English text to summarize"},
+        )
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-06-prompt-passthrough"]
+
+
+class TestWeakDescriptionRule:
+    def test_fires_when_description_missing(self) -> None:
+        tool = MCPTool(name="x", description="", input_schema={"type": "object", "properties": {}})
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-07-weak-description"]
+        assert len(rules) == 1
+        assert rules[0].severity == "low"
+
+    def test_fires_on_trivial_description(self) -> None:
+        tool = MCPTool(name="x", description="do x", input_schema={"type": "object", "properties": {}})
+        rules = [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-07-weak-description"]
+        assert len(rules) == 1
+
+    def test_silent_when_description_is_useful(self) -> None:
+        tool = _tool("read_file", file_path={"type": "string", "pattern": "^/safe/"})
+        assert not [f for f in evaluate_tool(tool) if f.rule_id == "MCP-TOOL-07-weak-description"]
+
+
+# ─── Dispatcher invariants ────────────────────────────────────────────────────
+
+
+def test_evaluate_tool_handles_missing_schema() -> None:
+    tool = MCPTool(name="empty", description="A reasonable description here", input_schema=None)
+    # No schema → no per-property rules fire, no crash
+    findings = evaluate_tool(tool)
+    assert all(f.tool_name == "empty" for f in findings)
+
+
+def test_evaluate_tool_handles_non_dict_schema() -> None:
+    tool = MCPTool(name="weird", description="A reasonable description here", input_schema={"type": "string"})
+    findings = evaluate_tool(tool)
+    # No properties dict → no per-property rules fire, no crash
+    assert all(f.rule_id == "MCP-TOOL-07-weak-description" for f in findings) or findings == []
+
+
+def test_evaluate_server_tools_aggregates_across_inventory() -> None:
+    tools = [
+        _tool("run_command", command={"type": "string"}),
+        _tool("read_file", file_path={"type": "string"}),
+        _tool("safe_lookup", item_id={"type": "string", "pattern": "^[a-z0-9]{8}$"}),
+    ]
+    findings = evaluate_server_tools(tools)
+    rule_ids = {f.rule_id for f in findings}
+    assert "MCP-TOOL-01-shell-input" in rule_ids
+    assert "MCP-TOOL-02-path-traversal" in rule_ids
+    # The clean tool contributes nothing
+    by_tool = {f.tool_name for f in findings}
+    assert "safe_lookup" not in by_tool
+
+
+def test_findings_serialize_cleanly() -> None:
+    tool = _tool("run_command", command={"type": "string"})
+    findings = [f for f in evaluate_tool(tool) if isinstance(f, MCPRuleFinding)]
+    assert findings
+    payload = findings[0].to_dict()
+    assert payload["rule_id"] == "MCP-TOOL-01-shell-input"
+    assert payload["owasp_mcp_tags"] == ["MCP01-Untrusted-Tool-Inputs", "MCP04-Excessive-Capability"]
+
+
+# ─── No accidental fires on the canonical demo tools ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        # Mirrors the curated demo tools in src/agent_bom/demo.py — they
+        # are intentionally clean so they should produce no rule findings.
+        _tool(
+            "list_directory",
+            description="List directory entries under the workspace root",
+            path={"type": "string", "pattern": "^/workspace/[A-Za-z0-9_/.-]+$"},
+        ),
+        _tool(
+            "send_message",
+            description="Send a chat message to a configured Slack channel",
+            channel_id={"type": "string", "pattern": "^C[A-Z0-9]{8,}$"},
+            text={"type": "string", "maxLength": 2000},
+        ),
+    ],
+)
+def test_demo_clean_tools_produce_no_rule_findings(tool: MCPTool) -> None:
+    assert evaluate_tool(tool) == []


### PR DESCRIPTION
## Summary

Closes the LLM01 / OWASP-MCP depth gap from the recent audit. The heuristic linter in `mcp_introspect` already extracted capability hints (`shell-execution-capability`, `network-egress-capability`, etc.), but it did not give operators a rule ID they could route to a compliance control and did not map findings onto the OWASP LLM Top 10 / OWASP MCP Top 10 catalogs that the compliance-report endpoint and `BlastRadius` use.

## What ships

`src/agent_bom/mcp_tool_rules.py` — a structured rule catalog. Each finding carries `rule_id`, `severity`, `owasp_tags`, `owasp_mcp_tags`, `cwe_ids`, `message`, `evidence`, and the property it fired on.

| Rule | Severity | OWASP MCP | OWASP LLM | CWE |
|---|---|---|---|---|
| `MCP-TOOL-01-shell-input` — unbounded shell-style string | critical | MCP01 + MCP04 | LLM02 + LLM06 | CWE-78 |
| `MCP-TOOL-02-path-traversal` — unbounded file path | high | MCP01 + MCP05 | LLM02 | CWE-22 |
| `MCP-TOOL-03-ssrf` — unbounded URL/host | high | MCP01 + MCP04 | LLM02 | CWE-918 |
| `MCP-TOOL-04-sql-injection` — unbounded SQL-style string | high | MCP01 | LLM02 | CWE-89 |
| `MCP-TOOL-05-credential-in-input` — credential-shaped parameter | medium | MCP02 | LLM06 | CWE-522 |
| `MCP-TOOL-06-prompt-passthrough` — property described as a prompt | medium | MCP01 | LLM01 | CWE-94 |
| `MCP-TOOL-07-weak-description` — tool description missing or trivial | low | MCP07 | LLM05 | — |

Every rule is **narrow on purpose**: only fires when the schema shape genuinely matches the threat. False positives become alert fatigue and erode trust in the catalog. New rules require a positive + negative test in the same PR.

## Routing

Findings carry `owasp_tags` and `owasp_mcp_tags` directly so the compliance-report endpoint (PR #1504) and `BlastRadius` map them to controls without a separate tag-assignment pass. `to_dict()` makes them safe to project into the unified graph and JSON output formats.

## Test plan

- `uv run pytest tests/test_mcp_tool_rules.py` — 22 passed (every rule: positive + negative case; dispatcher handles missing / non-dict schema; demo tools produce zero rule findings)
- `uv run mypy src/agent_bom/mcp_tool_rules.py` — clean
- `uv run ruff check` — clean

## Follow-up (not in this PR)

Wire the rule catalog into `_lint_tool_schema` in `mcp_introspect.py` so live introspection emits structured rule findings alongside the existing capability hints. That's a focused 30-line PR once this catalog is reviewed.