### PR TITLE
Add bounded depth cap to inter-procedural taint analyzer

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -24,6 +24,7 @@ Compliance mapping:
 from __future__ import annotations
 
 import ast
+import os
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -70,6 +71,28 @@ from agent_bom.ast_signal_utils import (
 from agent_bom.ast_signal_utils import (
     classify_prompt_type as _classify_prompt_type,
 )
+
+
+# Bounded depth for inter-procedural taint propagation. The taint analyzer
+# already follows tainted parameters across helper-call boundaries with
+# per-callsite parameter mapping; this cap pins the "bounded" claim with
+# a concrete number so operators understand exactly how many hops the
+# analyzer commits to following before it stops. Defaults to 4 — three
+# helper hops past the tool entrypoint plus the entrypoint itself —
+# which matches the depth the prior PR (#1488) committed to in writing.
+def _max_taint_depth() -> int:
+    raw = os.environ.get("AGENT_BOM_TAINT_MAX_DEPTH", "").strip()
+    if not raw:
+        return 4
+    try:
+        value = int(raw)
+    except ValueError:
+        return 4
+    # Clamp to a sane operational range. Going deeper than 8 in practice
+    # explodes the visit-set and produces near-duplicate findings; going
+    # below 2 disables the inter-procedural pass entirely.
+    return max(2, min(value, 8))
+
 
 # ── Prompt extraction patterns ───────────────────────────────────────────────
 
@@ -1272,12 +1295,20 @@ def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFindin
             return guarded
         return set()
 
+    max_depth = _max_taint_depth()
+
     def analyze_function(
         func: _FunctionAnalysis,
         tainted_params: set[str],
         call_path: list[str],
         visited: set[tuple[str, tuple[str, ...]]],
     ) -> tuple[list[FlowFinding], bool]:
+        # Bounded inter-procedural traversal: the visit-set already prevents
+        # cycles, but a long fan-out chain could still explode the work
+        # without surfacing a finding the operator can act on. Cap the
+        # call_path length so the analyzer commits to a documented depth.
+        if len(call_path) > max_depth:
+            return [], False
         visit_key = (func.qualified_name, tuple(sorted(tainted_params)))
         if visit_key in visited or func.node is None:
             return [], False
@@ -1699,6 +1730,7 @@ def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge
     findings: list[FlowFinding] = []
     seen_findings: set[tuple[str, str, str, int]] = set()
     function_by_id = {func.qualified_name: func for func in functions}
+    max_depth = _max_taint_depth()
     for func in functions:
         if not func.is_tool:
             continue
@@ -1706,6 +1738,12 @@ def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge
         visited: set[str] = set()
         while queue:
             current_id, path = queue.pop(0)
+            if len(path) > max_depth:
+                # Stop following helper chains past the configured depth so
+                # the bounded claim is honored uniformly across the two
+                # taint surfaces (this BFS + the parameter-level recursion
+                # in _build_taint_findings).
+                continue
             if current_id in visited:
                 continue
             visited.add(current_id)

--- a/tests/test_taint_depth_cap.py
+++ b/tests/test_taint_depth_cap.py
@@ -1,0 +1,156 @@
+"""Tests for the bounded inter-procedural taint depth cap.
+
+The taint analyzer follows tainted parameters through helper-call chains
+with per-callsite parameter mapping. This is real inter-procedural
+propagation, but without an explicit depth cap a long fan-out chain
+can either explode the visit-set or surface noisy near-duplicate
+findings the operator cannot act on.
+
+These tests pin the depth-cap contract:
+
+- ``AGENT_BOM_TAINT_MAX_DEPTH`` env caps the call_path length the
+  analyzer commits to following
+- the cap is clamped to the [2, 8] operational range
+- a chain at the cap surfaces the finding; one step past it does not
+- the cap applies uniformly across the two taint surfaces
+  (``_build_taint_findings`` parameter recursion and ``_build_call_graph``
+  BFS to dangerous sinks)
+- malformed env values fall back to the documented default (4)
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from agent_bom.ast_analyzer import _max_taint_depth, analyze_project
+
+
+def _make_project(tmp_path, source: str) -> str:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "main.py").write_text(textwrap.dedent(source))
+    return str(project)
+
+
+# ─── Env parsing ──────────────────────────────────────────────────────────────
+
+
+def test_default_depth_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_TAINT_MAX_DEPTH", raising=False)
+    assert _max_taint_depth() == 4
+
+
+def test_default_depth_when_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TAINT_MAX_DEPTH", "")
+    assert _max_taint_depth() == 4
+
+
+def test_default_depth_when_malformed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TAINT_MAX_DEPTH", "not-a-number")
+    assert _max_taint_depth() == 4
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0", 2),  # clamped up to floor
+        ("1", 2),  # clamped up to floor
+        ("2", 2),
+        ("3", 3),
+        ("4", 4),
+        ("5", 5),
+        ("8", 8),
+        ("12", 8),  # clamped down to ceiling
+        ("9999", 8),  # clamped down to ceiling
+    ],
+)
+def test_depth_clamped_to_operational_range(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: int
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_TAINT_MAX_DEPTH", value)
+    assert _max_taint_depth() == expected
+
+
+# ─── End-to-end: chain at cap fires, beyond cap does not ─────────────────────
+
+
+def _chain_source(depth: int) -> str:
+    """Build a tool that delegates through ``depth - 1`` helpers to os.system.
+
+    With ``depth=2`` the structure is tool → helper1 → os.system.
+    With ``depth=4`` it is tool → helper1 → helper2 → helper3 → os.system.
+    """
+    helper_definitions: list[str] = []
+    for level in range(1, depth):
+        next_call = f"helper{level + 1}(value)" if level + 1 < depth else "os.system(value)"
+        helper_definitions.append(
+            textwrap.dedent(
+                f"""
+                def helper{level}(value):
+                    {next_call}
+                """
+            ).strip()
+        )
+
+    return (
+        textwrap.dedent(
+            """
+            import os
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("danger-server")
+            """
+        )
+        + "\n\n"
+        + "\n\n".join(helper_definitions)
+        + textwrap.dedent(
+            """
+
+            @mcp.tool()
+            def run(payload: str):
+                helper1(payload)
+            """
+        )
+    )
+
+
+def _has_helper_chain_finding(result, sink: str = "os.system") -> bool:
+    return any(
+        finding.category in {"interprocedural_dangerous_flow", "interprocedural_tainted_sink", "tainted_dangerous_sink"}
+        and sink in (finding.sink or "")
+        for finding in result.flow_findings
+    )
+
+
+def test_chain_within_default_depth_fires(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default cap is 4; a 3-hop chain (tool → h1 → h2 → sink) must surface."""
+    monkeypatch.delenv("AGENT_BOM_TAINT_MAX_DEPTH", raising=False)
+    project = _make_project(tmp_path, _chain_source(depth=3))
+    result = analyze_project(project)
+    assert _has_helper_chain_finding(result), (
+        f"Expected an inter-procedural finding within the default depth (4); "
+        f"got categories={[f.category for f in result.flow_findings]}"
+    )
+
+
+def test_chain_capped_does_not_fire(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cap=2 stops at one helper hop — a 3-hop chain must NOT fire."""
+    monkeypatch.setenv("AGENT_BOM_TAINT_MAX_DEPTH", "2")
+    project = _make_project(tmp_path, _chain_source(depth=3))
+    result = analyze_project(project)
+    # The cap prevents the analyzer from reaching the sink past depth 2
+    assert not _has_helper_chain_finding(result), (
+        f"Expected no inter-procedural finding with cap=2; "
+        f"got categories={[f.category for f in result.flow_findings]}"
+    )
+
+
+def test_raised_cap_extends_traversal(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raising the cap to 6 lets a 4-hop chain through that the default would clip."""
+    project = _make_project(tmp_path, _chain_source(depth=5))
+
+    monkeypatch.setenv("AGENT_BOM_TAINT_MAX_DEPTH", "6")
+    deep_result = analyze_project(project)
+    assert _has_helper_chain_finding(deep_result)


### PR DESCRIPTION
## Summary

Phase 3 scanner-depth item from the recent audit. The taint analyzer in `ast_analyzer.py` already does real inter-procedural propagation — per-callsite parameter mapping, sanitizer awareness, cycle prevention via a `(qualified_name, tainted_params)` visit-set. The "bounded helper-call chain" wording from #1488 was honest about intent, but the codebase had **no concrete depth cap**. A long fan-out chain in a pathological project could explode the visit-set without producing findings an operator can act on.

## What this adds

- `AGENT_BOM_TAINT_MAX_DEPTH` — env knob, default `4` (three helper hops past the tool entrypoint plus the entrypoint itself, matching the depth #1488 committed to in writing)
- Clamped to `[2, 8]` so operators cannot disable the pass entirely or blow up the visit-set
- Applied uniformly across **both** taint surfaces:
  - `_build_taint_findings` parameter-level recursion (`analyze_function`)
  - `_build_call_graph` BFS to dangerous sinks
- Malformed env values fall back to the documented default (no surprise behavior)
- New `_max_taint_depth()` helper so future operators tune one knob, not two constants

## Why this matters

The bounded claim is now a **defensible engineering contract**, not a phrase. Operators can tune the cap via env, dashboards can show "we explored chains up to N hops", and the analyzer's worst-case complexity is now an operator-controlled function instead of a property of the project structure.

## Test plan

- `uv run pytest tests/test_taint_depth_cap.py tests/test_ast_analyzer.py` — 64 passed (15 new + 49 existing)
- `uv run ruff check` — clean
- `uv run mypy src/agent_bom/ast_analyzer.py` — clean
- The 15 new tests cover env parsing for blank / malformed / out-of-range / valid values, plus an end-to-end trio that builds tool → helper → sink chains at varying depths and asserts which fire vs which clip under different cap settings.