### PR TITLE
Document and enforce OCSF boundary (optional SIEM interop)

### DIFF
--- a/docs/OCSF_BOUNDARY.md
+++ b/docs/OCSF_BOUNDARY.md
@@ -1,0 +1,80 @@
+# OCSF boundary
+
+**Principle:** OCSF (Open Cybersecurity Schema Framework) is an **optional
+wire-protocol for SIEM interop**, not agent-bom's internal data model.
+
+## What this means
+
+1. **Core scanning, enrichment, graph, and reporting code does not depend
+   on OCSF.** If the two OCSF modules (`siem/ocsf.py`,
+   `output/ocsf.py`) were deleted tomorrow, every core path still works
+   — cloud scans, CIS benchmarks, CVE enrichment, skill audits,
+   blast-radius graph queries, HTML / JSON / SARIF / CycloneDX
+   reporting. You would lose SIEM push and the MCP tool's OCSF event
+   output; everything else is unchanged.
+2. **Internal schemas are product-shaped, not OCSF-shaped.** Each
+   finding source keeps the dataclass that best models its domain:
+   - `CISCheckResult` — check_id, status, evidence, resource_ids, remediation
+   - `SkillFinding` — category, context, ai_analysis, ai_adjusted_severity
+   - `Finding` (graph) — blast_radius, reachability, kev, epss_percentile
+   - `RuntimeAlert` — alert dict from proxy / MCP tool telemetry
+
+   Forcing these into OCSF would drop fields OCSF does not model
+   (`ai_analysis`, `blast_radius`, `reachability`) and is the wrong
+   direction.
+3. **Per-cloud code stays cloud-native.** AWS API response →
+   `CISCheckResult` directly. Azure / GCP / Snowflake the same. No
+   AWS-→-OCSF-→-internal double hop. OCSF only appears on the way out to
+   a SIEM.
+4. **OCSF emission is one-way, at the wire boundary.** Translators live
+   in `siem/ocsf.py` (SIEM push, Detection Finding, `class_uid=2004`)
+   and `output/ocsf.py` (MCP tool output, Security Finding,
+   `class_uid=2001`). Runtime alerts are the only source currently
+   translated; CIS / skills / CVE findings stay in internal JSON today.
+
+## What is allowed to depend on OCSF
+
+- `siem/` — connector layer, may freely import OCSF.
+- `output/ocsf.py` — OCSF serializer for MCP tool callers.
+- `graph/ocsf.py` — a thin mapping table (`EntityType` → OCSF
+  `category_uid` / `class_uid`) plus `ocsf_type_uid()`. The graph Node
+  dataclass carries the resulting IDs as inert fields (reserved seats
+  for SIEM export). **No core logic branches on these fields.**
+- `graph/severity.py` — `OCSFSeverity` IntEnum (UNKNOWN=0 … CRITICAL=5)
+  used as a stable integer severity scale. Coincidence of convention,
+  not a dependency; would stay even without OCSF.
+
+## What is **not** allowed to depend on OCSF
+
+Anything under `scan`, `enrichment`, `parsers`, `cli`, `cloud`
+(CIS benchmarks and cloud asset models), `skills`, `analyzers`,
+`api`, `dashboard`, `db`, `ingestion` must not import from
+`agent_bom.siem.ocsf` or `agent_bom.output.ocsf`. These modules
+describe product behaviour; OCSF is an export format, not a product
+concept.
+
+**Enforcement:** a reverse-import check can be added to CI (
+`grep -r "from agent_bom.siem.ocsf\|from agent_bom.output.ocsf" src/
+| grep -v "^src/agent_bom/siem/\|^src/agent_bom/output/ocsf.py"`
+should return zero lines).
+
+## When to add a new OCSF translator
+
+Only when a real customer / integration asks. Do **not** pre-emptively
+author:
+
+- CIS → Compliance Finding (`class_uid=2003`)
+- Skill → Security Finding (`class_uid=2001`)
+- CVE / SAST → Vulnerability Finding (`class_uid=2002`)
+- Inbound OCSF-→-internal normalizer
+
+These are legitimate follow-ups if and when a SIEM / XDR / Security
+Lake integration needs them. Until then they are speculative work and
+should stay off the roadmap.
+
+## Why keep OCSF at all
+
+AWS Security Lake, Google Chronicle, and Microsoft Sentinel all
+standardize on OCSF. Dropping it eliminates a real enterprise-buyer
+checkbox for ~130 lines of optional code. Keeping it as an opt-in
+peripheral costs effectively zero and preserves integration upside.

--- a/tests/test_ocsf_boundary.py
+++ b/tests/test_ocsf_boundary.py
@@ -1,0 +1,71 @@
+"""Enforce the OCSF boundary documented in ``docs/OCSF_BOUNDARY.md``.
+
+OCSF is an optional SIEM wire protocol. Core modules
+(scan, enrichment, parsers, cli, cloud, skills, analyzers, api,
+dashboard, db, ingestion) must not import from ``agent_bom.siem.ocsf``
+or ``agent_bom.output.ocsf``. The graph layer is allowed to import
+``agent_bom.graph.ocsf`` because that file is a thin entity→OCSF-id
+mapping table the graph uses as reserved seats for SIEM export;
+nothing in core logic branches on those IDs.
+
+If this test fails, either:
+1. Move the OCSF-using code behind a boundary module (``siem/``,
+   ``output/ocsf.py``), or
+2. Update ``docs/OCSF_BOUNDARY.md`` and ``_ALLOWED_OCSF_CONSUMERS``
+   below with an explicit, reviewed exception.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC_ROOT = _REPO_ROOT / "src" / "agent_bom"
+
+# Files that may import the emission-layer OCSF modules. Everything else
+# under src/agent_bom must not.
+_ALLOWED_OCSF_CONSUMERS = {
+    # siem/ is the SIEM wire boundary — may import freely.
+    "siem/__init__.py",
+    "siem/ocsf.py",
+    "siem/splunk.py",
+    "siem/sentinel.py",
+    "siem/chronicle.py",
+    "siem/security_lake.py",
+    # output/ocsf.py is the MCP tool's OCSF serializer.
+    "output/ocsf.py",
+}
+
+_OCSF_EMISSION_IMPORT = re.compile(
+    r"from\s+agent_bom\.(siem\.ocsf|output\.ocsf)\s+import"
+    r"|import\s+agent_bom\.(siem\.ocsf|output\.ocsf)"
+)
+
+
+def test_no_core_module_imports_ocsf_emission_layer():
+    offenders: list[str] = []
+    for path in _SRC_ROOT.rglob("*.py"):
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+        if rel in _ALLOWED_OCSF_CONSUMERS:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if _OCSF_EMISSION_IMPORT.search(text):
+            offenders.append(rel)
+    assert not offenders, (
+        "OCSF boundary violation — these core modules import the "
+        "OCSF emission layer. See docs/OCSF_BOUNDARY.md:\n  - " + "\n  - ".join(sorted(offenders))
+    )
+
+
+def test_graph_ocsf_map_is_thin_mapping_only():
+    """``graph/ocsf.py`` may stay in core, but must remain a pure
+    mapping table — no SIEM/event construction, no network I/O, no
+    serialization. If this file grows logic, it should move to an
+    emission-layer module."""
+
+    text = (_SRC_ROOT / "graph" / "ocsf.py").read_text(encoding="utf-8")
+    for forbidden in ("import requests", "import urllib", "socket", "json.dumps", "to_ocsf_event"):
+        assert forbidden not in text, (
+            f"graph/ocsf.py must stay a thin mapping — found '{forbidden}'. Move emission logic to siem/ocsf.py or output/ocsf.py."
+        )


### PR DESCRIPTION
## Summary

- Codifies the architectural decision that **OCSF is an optional SIEM interop protocol, not agent-bom's internal data model**.
- Core scanning, enrichment, graph, and reporting code does not depend on OCSF; the two emission modules can be deleted without breaking any product path — only SIEM push is lost.
- Per-cloud ingestion and asset types stay cloud-native. No AWS→OCSF→internal double-hop.

## What's in the PR

- ``docs/OCSF_BOUNDARY.md`` — 1-pager stating which modules may import the OCSF emission layer, which may not, why ``graph/ocsf.py`` is allowed to stay in core (inert mapping table, no core logic branches on its IDs), and when to add a new translator (only on real customer request).
- ``tests/test_ocsf_boundary.py`` — enforces the rule in CI:
  - ``test_no_core_module_imports_ocsf_emission_layer`` — no core module may ``from agent_bom.siem.ocsf import …`` / ``from agent_bom.output.ocsf import …``.
  - ``test_graph_ocsf_map_is_thin_mapping_only`` — ``graph/ocsf.py`` must not grow SIEM / event / serialization / network logic.

**Current codebase already honors the boundary** — both tests pass without any production code change.

## Reverse-import audit (what the test checks)

| File | Imported by | Verdict |
|---|---|---|
| ``siem/ocsf.py`` | Only inside ``siem/`` | Boundary clean |
| ``output/ocsf.py`` | Nothing (called via MCP tool) | Boundary clean |
| ``graph/ocsf.py`` | ``graph/node.py``, ``graph/container.py``, ``graph/__init__.py`` | Allowed — thin mapping, no core branching |

## Test plan

- [x] ``pytest tests/test_ocsf_boundary.py`` — 2/2 pass
- [ ] Review the allow-list in ``_ALLOWED_OCSF_CONSUMERS`` — add or remove siem connector files as they are authored
- [ ] Confirm the arch doc's "when to add a translator" list matches your product intent (today: CIS / skills / CVE explicitly deferred until a SIEM customer asks)