### PR TITLE
Wire CIS remediation through CLI, HTML, and SARIF (#665)

### DIFF
--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -28,6 +28,7 @@ from agent_bom.output import (
     print_blast_radius,
     print_compact_agents,
     print_compact_blast_radius,
+    print_compact_cis_posture,
     print_compact_export_hint,
     print_compact_remediation,
     print_compact_summary,
@@ -196,9 +197,11 @@ def render_output(
 
         if verbose:
             print_remediation_plan(report)
+            print_compact_cis_posture(report, limit=20)
             print_export_hint(report)
         else:
             print_compact_remediation(report)
+            print_compact_cis_posture(report)
             print_compact_export_hint(report)
     elif output_format in ("text", "plain") and not output:
         _print_text(report, blast_radii)

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1830,6 +1830,103 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
     console.print()
 
 
+def _iter_cis_bundles(report: AIBOMReport):
+    """Yield (cloud, bundle_dict) for every populated CIS benchmark bundle."""
+    bundles = [
+        ("aws", getattr(report, "cis_benchmark_data", None)),
+        ("azure", getattr(report, "azure_cis_benchmark_data", None)),
+        ("gcp", getattr(report, "gcp_cis_benchmark_data", None)),
+        ("snowflake", getattr(report, "snowflake_cis_benchmark_data", None)),
+    ]
+    for cloud, bundle in bundles:
+        if bundle and bundle.get("checks"):
+            yield cloud, bundle
+
+
+def print_compact_cis_posture(report: AIBOMReport, limit: int = 5) -> None:
+    """Per-cloud CIS posture with top failing checks + remediation.
+
+    Renders once per cloud that has a populated benchmark. For each
+    cloud:
+      - Header line with pass rate and failed-count (colored by
+        pass-rate band).
+      - Top ``limit`` failed checks, sorted by remediation priority
+        (1 = fix first), each showing: check_id, title, guardrails
+        tags, effort, ``fix_cli`` (when present) or the ``fix_console``
+        path (when ``fix_cli`` is ``None``), and a ``review`` flag when
+        ``requires_human_review`` is true.
+
+    Respects the same compact/one-screen style as
+    ``print_compact_blast_radius`` and ``print_compact_remediation``.
+    """
+
+    bundles = list(_iter_cis_bundles(report))
+    if not bundles:
+        return
+
+    console.print()
+    console.print("  [bold]CIS Benchmark Posture[/bold]")
+
+    for cloud, bundle in bundles:
+        checks = bundle.get("checks") or []
+        failed = [c for c in checks if c.get("status") == "fail"]
+        total_eval = sum(1 for c in checks if c.get("status") in ("pass", "fail"))
+        pass_rate = bundle.get("pass_rate", 0.0)
+
+        band = "green" if pass_rate >= 90 else "yellow" if pass_rate >= 70 else "red"
+        cloud_label = {"aws": "AWS", "azure": "Azure", "gcp": "GCP", "snowflake": "Snowflake"}.get(cloud, cloud)
+        console.print(
+            f"  [bold]{cloud_label}[/bold]  "
+            f"[{band}]{pass_rate:.0f}%[/{band}] pass  "
+            f"[dim]({bundle.get('passed', 0)}/{total_eval} checks, "
+            f"{len(failed)} failed)[/dim]"
+        )
+
+        if not failed:
+            console.print("    [green]✓[/green] [dim]no failed checks[/dim]")
+            continue
+
+        # Sort by remediation priority (1 = fix first), then severity.
+        def _sort_key(c: dict) -> tuple[int, int]:
+            rem = c.get("remediation") or {}
+            priority = rem.get("priority", 3)
+            sev = (c.get("severity") or "").lower()
+            sev_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(sev, 4)
+            return (priority, sev_rank)
+
+        failed_sorted = sorted(failed, key=_sort_key)
+        shown = failed_sorted[:limit]
+        sev_style = {"critical": "red bold", "high": "#e67e22 bold", "medium": "yellow", "low": "dim"}
+
+        for i, check in enumerate(shown, 1):
+            sev = (check.get("severity") or "").lower()
+            style = sev_style.get(sev, "white")
+            rem = check.get("remediation") or {}
+            guardrails = rem.get("guardrails") or []
+            guard_str = " · ".join(guardrails[:3])
+            if len(guardrails) > 3:
+                guard_str += f" · +{len(guardrails) - 3}"
+            review_flag = " [yellow]↺ review[/yellow]" if rem.get("requires_human_review") else ""
+
+            title = (check.get("title") or "").rstrip(".")
+            console.print(
+                f"    [{style}]{i}.[/{style}] [bold]{check.get('check_id', '')}[/bold] "
+                f"{_compact_detail(title, limit=70)}{review_flag}  "
+                f"[dim]P{rem.get('priority', 3)} · {rem.get('effort', 'manual')}[/dim]"
+            )
+            if guard_str:
+                console.print(f"       [dim]{guard_str}[/dim]")
+            if rem.get("fix_cli"):
+                console.print(f"       [cyan]{_compact_detail(rem['fix_cli'], limit=110)}[/cyan]")
+            elif rem.get("fix_console"):
+                console.print(f"       [dim]→ {_compact_detail(rem['fix_console'], limit=110)}[/dim]")
+
+        if len(failed) > limit:
+            console.print(f"    [dim]... {len(failed) - limit} more (use --verbose for full plan)[/dim]")
+
+    console.print()
+
+
 def print_compact_export_hint(report: AIBOMReport) -> None:
     """Single-line summary with key metrics."""
     vuln_color = "red" if report.total_vulnerabilities > 0 else "green"

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -528,6 +528,123 @@ def _ai_inventory_section(report: "AIBOMReport") -> str:
     )
 
 
+_CIS_CLOUD_LABELS = {
+    "aws": ("AWS", "cis_benchmark_data"),
+    "azure": ("Azure", "azure_cis_benchmark_data"),
+    "gcp": ("GCP", "gcp_cis_benchmark_data"),
+    "snowflake": ("Snowflake", "snowflake_cis_benchmark_data"),
+}
+
+
+def _cis_benchmark_section(report: "AIBOMReport") -> str:
+    """Build the CIS benchmark posture section (issue #665).
+
+    Renders one sub-panel per cloud with a CIS benchmark bundle. Each
+    failed check surfaces its structured remediation dict (``fix_cli``,
+    ``fix_console``, ``priority``, ``guardrails``, human-review flag).
+    Returns an empty string when no CIS data is present.
+    """
+
+    panels: list[str] = []
+    for cloud_key, (label, attr) in _CIS_CLOUD_LABELS.items():
+        bundle = getattr(report, attr, None)
+        if not bundle:
+            continue
+        checks = bundle.get("checks") or []
+        if not checks:
+            continue
+        failed = [c for c in checks if c.get("status") == "fail"]
+        evaluated = [c for c in checks if c.get("status") in ("pass", "fail")]
+        pass_rate = bundle.get("pass_rate", 0.0)
+        band_color = "#16a34a" if pass_rate >= 90 else "#eab308" if pass_rate >= 70 else "#ef4444"
+
+        header = (
+            f'<div style="display:flex;align-items:center;gap:18px;margin-bottom:12px">'
+            f'<div style="font-weight:700;color:#f1f5f9;font-size:.95rem">{_esc(label)}</div>'
+            f'<div style="color:{band_color};font-weight:700">{pass_rate:.0f}% pass</div>'
+            f'<div style="color:#64748b;font-size:.78rem">'
+            f"{bundle.get('passed', 0)}/{len(evaluated)} checks &middot; "
+            f'<strong style="color:#f97316">{len(failed)} failed</strong>'
+            f"</div></div>"
+        )
+
+        if not failed:
+            panels.append(
+                f'<div class="panel" style="margin-bottom:16px">{header}<div class="empty-state">&#x2705; No failed CIS checks.</div></div>'
+            )
+            continue
+
+        def _sort_key(c: dict) -> tuple[int, int]:
+            rem = c.get("remediation") or {}
+            priority = rem.get("priority", 3)
+            sev = (c.get("severity") or "").lower()
+            sev_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(sev, 4)
+            return (priority, sev_rank)
+
+        rows = []
+        for check in sorted(failed, key=_sort_key):
+            sev = (check.get("severity") or "").lower()
+            rem = check.get("remediation") or {}
+            fix_cli = rem.get("fix_cli")
+            fix_console = rem.get("fix_console") or ""
+            effort = rem.get("effort") or "manual"
+            priority = rem.get("priority", 3)
+            guardrails = rem.get("guardrails") or []
+            guard_html = "".join(
+                f'<span style="display:inline-block;padding:1px 7px;margin:1px 3px 1px 0;border-radius:4px;background:#1e293b;color:#94a3b8;font-size:.65rem;font-family:monospace">{_esc(g)}</span>'
+                for g in guardrails[:5]
+            )
+            if len(guardrails) > 5:
+                guard_html += f'<span style="color:#475569;font-size:.65rem">+{len(guardrails) - 5}</span>'
+            review_badge = (
+                '<span style="color:#eab308;font-size:.7rem;margin-left:6px">&#8634; review</span>'
+                if rem.get("requires_human_review")
+                else ""
+            )
+
+            fix_cell = ""
+            if fix_cli:
+                fix_cell = f'<code style="color:#67e8f9;font-size:.72rem;white-space:pre-wrap;word-break:break-all">{_esc(fix_cli)}</code>'
+            elif fix_console:
+                fix_cell = f'<span style="color:#94a3b8;font-size:.72rem">&rarr; {_esc(fix_console)}</span>'
+
+            docs_link = ""
+            docs = rem.get("docs") or ""
+            if docs:
+                docs_link = f' &middot; <a href="{_esc(docs)}" target="_blank" rel="noopener" style="font-size:.7rem">docs</a>'
+
+            rows.append(
+                "<tr>"
+                f"<td>{_sev_badge(sev)}</td>"
+                f'<td style="font-family:monospace;color:#f1f5f9;font-weight:600">{_esc(check.get("check_id", ""))}</td>'
+                f'<td style="color:#e2e8f0;font-size:.82rem">{_esc(check.get("title", ""))}{review_badge}</td>'
+                f'<td style="color:#94a3b8;font-size:.75rem">P{priority} &middot; {_esc(effort)}</td>'
+                f"<td>{guard_html}</td>"
+                f"<td>{fix_cell}{docs_link}</td>"
+                "</tr>"
+            )
+
+        table_html = (
+            '<div class="table-wrap"><table class="data-table sortable">'
+            + "<thead><tr>"
+            + "".join(
+                f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>'
+                for i, h in enumerate(["Severity", "Check", "Title", "Priority", "Guardrails", "Remediation"])
+            )
+            + "</tr></thead>"
+            + f"<tbody>{''.join(rows)}</tbody></table></div>"
+        )
+
+        panels.append(f'<div class="panel" style="margin-bottom:16px">{header}{table_html}</div>')
+
+    if not panels:
+        return ""
+
+    return (
+        '<section id="cisbenchmarks"><div class="sec-title">&#x1f6e1;&#xfe0f; CIS Benchmark Posture</div>' + "".join(panels) + "</section>"
+    )
+
+
 def _trust_assessment_section(report: "AIBOMReport") -> str:
     """Build the trust assessment section if data is available."""
     data = getattr(report, "trust_assessment_data", None)
@@ -984,6 +1101,9 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
     # Enforcement section
     enforce_section = _enforcement_section(report)
 
+    # CIS benchmark posture (issue #665 — structured remediation)
+    cis_bench_section = _cis_benchmark_section(report)
+
     # Determine node counts for graph subtitle
     vuln_node_count = len({(br.package.name, br.package.ecosystem) for br in blast_radii})
     graph_note = (
@@ -1236,6 +1356,7 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
     {'<a href="#skillaudit" class="sidebar-link"><span class="link-icon">&#x1f50d;</span> Skill Audit</a>' if skill_section else ""}
     {'<a href="#trust" class="sidebar-link"><span class="link-icon">&#x1f91d;</span> Trust</a>' if trust_section else ""}
     {'<a href="#enforcement" class="sidebar-link"><span class="link-icon">&#x1f512;</span> Enforcement</a>' if enforce_section else ""}
+    {'<a href="#cisbenchmarks" class="sidebar-link"><span class="link-icon">&#x1f6e1;&#xfe0f;</span> CIS Benchmarks</a>' if cis_bench_section else ""}
   </div>
 
   <div class="sidebar-spacer"></div>
@@ -1346,6 +1467,9 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
 
   <!-- Enforcement -->
   {enforce_section}
+
+  <!-- CIS benchmark posture (issue #665) -->
+  {cis_bench_section}
 
   <!-- Attack flow graph (only when vulns exist) -->
   {_attack_flow_section(blast_radii)}

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -269,6 +269,91 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
                 }
             )
 
+    # CIS benchmark findings (AWS / Azure / GCP / Snowflake). Each failed
+    # check emits a SARIF result with the structured remediation dict
+    # (issue #665) in ``properties.remediation`` so GitHub Code Scanning
+    # and downstream SARIF consumers can surface fix guidance per finding.
+    cis_sev_map = {"critical": "error", "high": "error", "medium": "warning", "low": "note", "info": "none"}
+    cis_sev_score = {"critical": "9.0", "high": "7.0", "medium": "4.0", "low": "1.0", "info": "0.0"}
+    for cloud_key, data_attr in (
+        ("aws", "cis_benchmark_data"),
+        ("azure", "azure_cis_benchmark_data"),
+        ("gcp", "gcp_cis_benchmark_data"),
+        ("snowflake", "snowflake_cis_benchmark_data"),
+    ):
+        bundle = getattr(report, data_attr, None)
+        if not bundle:
+            continue
+        for check in bundle.get("checks", []):
+            if check.get("status") != "fail":
+                continue
+            sev = (check.get("severity") or "medium").lower()
+            check_id = check.get("check_id") or "unknown"
+            rule_id = f"cis/{cloud_key}/{check_id}"
+            level = cis_sev_map.get(sev, "warning")
+            remediation = check.get("remediation") or {}
+            title = check.get("title") or rule_id
+            help_uri = remediation.get("docs") or ""
+
+            if rule_id not in seen_rule_ids:
+                seen_rule_ids.add(rule_id)
+                cis_rule: dict = {
+                    "id": rule_id,
+                    "shortDescription": {"text": f"{sev.upper()}: CIS {cloud_key.upper()} {check_id} — {title}"},
+                    "fullDescription": {"text": check.get("recommendation") or title},
+                    "defaultConfiguration": {"level": level},
+                    "properties": {
+                        "security-severity": cis_sev_score.get(sev, "4.0"),
+                        "tags": ["cis", cloud_key, "compliance"],
+                        "cis_section": check.get("cis_section") or "",
+                    },
+                }
+                if help_uri:
+                    cis_rule["helpUri"] = help_uri
+                rules.append(cis_rule)
+
+            # Synthetic fingerprint so repeat runs produce stable IDs.
+            fp_input = f"{rule_id}:{','.join(check.get('resource_ids') or [])}"
+            fingerprint = hashlib.sha256(fp_input.encode()).hexdigest()
+
+            # CIS findings are cloud-control-level, not file-level. Point
+            # at a conventional manifest so GitHub renders the result;
+            # the rich context lives in ``properties``.
+            result_props: dict = {
+                "remediation": remediation,
+                "cis_section": check.get("cis_section") or "",
+                "evidence": check.get("evidence") or "",
+                "resource_ids": check.get("resource_ids") or [],
+            }
+            # Surface the remediation knobs flat for consumers that
+            # can't (or don't want to) read nested dicts.
+            if remediation:
+                result_props["fix_cli"] = remediation.get("fix_cli")
+                result_props["fix_console"] = remediation.get("fix_console") or ""
+                result_props["effort"] = remediation.get("effort") or "manual"
+                result_props["priority"] = remediation.get("priority") or 3
+                result_props["guardrails"] = remediation.get("guardrails") or []
+                result_props["requires_human_review"] = bool(remediation.get("requires_human_review"))
+
+            results.append(
+                {
+                    "ruleId": rule_id,
+                    "level": level,
+                    "kind": "fail",
+                    "message": {"text": f"CIS {cloud_key.upper()} {check_id} failed: {title}"},
+                    "fingerprints": {"agent-bom/v1": fingerprint},
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": f"cis-{cloud_key}-benchmark", "uriBaseId": "%SRCROOT%"},
+                                "region": {"startLine": 1, "startColumn": 1},
+                            },
+                        }
+                    ],
+                    "properties": result_props,
+                }
+            )
+
     return {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
         "version": "2.1.0",

--- a/tests/test_cis_remediation_surfaces.py
+++ b/tests/test_cis_remediation_surfaces.py
@@ -1,0 +1,175 @@
+"""E2E surface tests for #665 remediation field.
+
+Verifies the CIS ``remediation`` dict reaches CLI, HTML report, and
+SARIF output surfaces (JSON already covered by existing output tests).
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from agent_bom.models import AIBOMReport
+from agent_bom.output import print_compact_cis_posture
+from agent_bom.output.html import _cis_benchmark_section
+from agent_bom.output.sarif import to_sarif
+
+
+def _bundle_with_remediation(cloud: str = "aws") -> dict:
+    """Minimal CIS bundle dict matching what ``<cloud>_CISReport.to_dict()``
+    produces, with a failed check carrying a structured remediation
+    dict."""
+    return {
+        "benchmark": f"CIS {cloud.upper()} Foundations",
+        "benchmark_version": "3.0",
+        "account_id": "123456789012" if cloud == "aws" else None,
+        "pass_rate": 75.0,
+        "passed": 3,
+        "failed": 1,
+        "total": 4,
+        "checks": [
+            {
+                "check_id": "1.4",
+                "title": "Ensure no root user account access key exists",
+                "status": "fail",
+                "severity": "high",
+                "evidence": "Root access key present.",
+                "resource_ids": ["root"],
+                "recommendation": "Remove root access keys.",
+                "remediation": {
+                    "why": "Failure indicates: ensure no root user account access key exists.",
+                    "fix_cli": "aws iam delete-access-key --user-name root --access-key-id <ROOT_KEY_ID>",
+                    "fix_console": "AWS Console → IAM → Security credentials (root) → Delete access key",
+                    "effort": "low",
+                    "priority": 1,
+                    "docs": "https://example/docs",
+                    "guardrails": ["identity", "least-privilege", "priv-escalation", "zero-trust"],
+                    "requires_human_review": True,
+                },
+                "cis_section": "1 - Identity and Access Management",
+                "attack_techniques": [],
+            },
+            {
+                "check_id": "1.8",
+                "title": "Password policy",
+                "status": "pass",
+                "severity": "medium",
+                "evidence": "policy configured",
+                "resource_ids": [],
+                "recommendation": "",
+                "remediation": {
+                    "why": "Failure indicates: password policy.",
+                    "fix_cli": None,
+                    "fix_console": "",
+                    "effort": "manual",
+                    "priority": 2,
+                    "docs": "",
+                    "guardrails": [],
+                    "requires_human_review": True,
+                },
+                "cis_section": "1 - Identity and Access Management",
+                "attack_techniques": [],
+            },
+        ],
+    }
+
+
+def _report_with_aws_cis() -> AIBOMReport:
+    report = AIBOMReport(tool_version="0.77.1")
+    report.cis_benchmark_data = _bundle_with_remediation("aws")
+    return report
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+
+def test_cli_compact_cis_posture_renders_remediation():
+    report = _report_with_aws_cis()
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=200)
+
+    # Patch the module-level console with our capture console.
+    import agent_bom.output as output_mod
+
+    original = output_mod.console
+    output_mod.console = con
+    try:
+        print_compact_cis_posture(report)
+    finally:
+        output_mod.console = original
+
+    out = buf.getvalue()
+    assert "CIS Benchmark Posture" in out
+    assert "AWS" in out
+    assert "1.4" in out  # check_id
+    assert "delete-access-key" in out  # fix_cli surfaced
+    assert "priv-escalation" in out or "least-privilege" in out  # guardrails surfaced
+    assert "review" in out  # requires_human_review flag shown
+
+
+def test_cli_compact_cis_posture_silent_without_cis_data():
+    report = AIBOMReport(tool_version="0.77.1")
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=200)
+    import agent_bom.output as output_mod
+
+    original = output_mod.console
+    output_mod.console = con
+    try:
+        print_compact_cis_posture(report)
+    finally:
+        output_mod.console = original
+
+    assert buf.getvalue() == ""
+
+
+# ── HTML ─────────────────────────────────────────────────────────────────
+
+
+def test_html_cis_section_emits_remediation():
+    report = _report_with_aws_cis()
+    html = _cis_benchmark_section(report)
+    assert html, "expected non-empty section when CIS data is present"
+    assert 'id="cisbenchmarks"' in html
+    assert "AWS" in html
+    assert "1.4" in html
+    assert "delete-access-key" in html  # fix_cli
+    assert "priv-escalation" in html or "least-privilege" in html
+    assert "review" in html  # human-review flag rendered
+
+
+def test_html_cis_section_empty_when_no_data():
+    report = AIBOMReport(tool_version="0.77.1")
+    assert _cis_benchmark_section(report) == ""
+
+
+# ── SARIF ────────────────────────────────────────────────────────────────
+
+
+def test_sarif_includes_cis_result_with_remediation_properties():
+    report = _report_with_aws_cis()
+    sarif = to_sarif(report)
+    runs = sarif["runs"][0]
+    rule_ids = {r["id"] for r in runs["tool"]["driver"]["rules"]}
+    assert "cis/aws/1.4" in rule_ids
+
+    cis_results = [r for r in runs["results"] if r["ruleId"] == "cis/aws/1.4"]
+    assert len(cis_results) == 1
+    props = cis_results[0].get("properties", {})
+    # Structured remediation is preserved as a nested dict.
+    assert props["remediation"]["fix_cli"].startswith("aws iam delete-access-key")
+    # Flat convenience keys are also present for SARIF consumers that
+    # don't parse nested dicts.
+    assert props["fix_cli"].startswith("aws iam delete-access-key")
+    assert props["priority"] == 1
+    assert "priv-escalation" in props["guardrails"]
+    assert props["requires_human_review"] is True
+
+
+def test_sarif_skips_passing_cis_checks():
+    report = _report_with_aws_cis()
+    sarif = to_sarif(report)
+    cis_result_ids = {r["ruleId"] for r in sarif["runs"][0]["results"] if r["ruleId"].startswith("cis/")}
+    # 1.8 passed — must not appear as a SARIF result.
+    assert "cis/aws/1.8" not in cis_result_ids


### PR DESCRIPTION
## Summary

Exposes the structured ``remediation`` dict (added in #1512) through every output surface that currently renders — or in the case of CIS, should render — benchmark findings.

- **CLI**: new ``print_compact_cis_posture(report)`` — per-cloud pass rate + top failing checks sorted by remediation priority, with ``fix_cli`` (or ``fix_console`` fallback), guardrail chips, and review flag. Wired into both compact + verbose render paths.
- **HTML**: new ``_cis_benchmark_section`` — sidebar-navigable section, one sub-panel per cloud, per-check table with severity / priority / effort / guardrails / fix_cli (code block) / fix_console / docs link.
- **SARIF**: ``to_sarif`` now emits one result per failed CIS check. Remediation present as nested dict (``properties.remediation``) AND flat convenience keys (``fix_cli``, ``priority``, ``guardrails``, ``requires_human_review``, ``fix_console``, ``effort``).

## Intentionally deferred (tracked as P2 follow-ups)

- #1514 — Dashboard cloud CIS drill-down
- #1515 — ``cis_benchmark`` MCP tool
- #1516 — Columnar DB schema for CIS findings

These are net-new features, not a wire-through of existing surfaces.

## Test plan

- [x] 6 new surface tests (``tests/test_cis_remediation_surfaces.py``) — CLI renders remediation, HTML section emits remediation, SARIF emits CIS results with both nested and flat remediation keys, passing checks are excluded from SARIF output
- [x] 538 existing SARIF + HTML + CIS tests remain green
- [ ] Pull a demo scan with CIS data and confirm the CLI "CIS Benchmark Posture" block and HTML sidebar link render as expected
- [ ] Spot-check a SARIF upload to a GitHub repo and confirm Code Scanning renders the CIS results