### PR TITLE
Wire MCP schema rule findings and harden chart defaults

### DIFF
--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -349,7 +349,7 @@ startupProbe:
 
 networkPolicy:
   enabled: true
-  restrictIngress: false
+  restrictIngress: true
   ingress: []
   allowDns: true
   allowWeb: true

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -82,7 +82,7 @@ helm install agent-bom deploy/helm/agent-bom/ \
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments and Services |
 | `controlPlane.ingress.enabled` | `false` | Add same-origin ingress routing for UI + API |
 | `controlPlane.ui.env` | `NEXT_PUBLIC_API_URL=\"\"` | Blank by default so the browser uses same-origin paths |
-| `networkPolicy.restrictIngress` | `false` | Keep ingress open unless you explicitly provide ingress policy rules |
+| `networkPolicy.restrictIngress` | `true` | Deny ingress by default; add explicit ingress policy rules for allowed callers |
 | `rbac.create` | `true` | Create RBAC resources |
 | `serviceAccount.annotations` | `{}` | Attach provider-specific identity such as AWS IRSA |
 

--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -23,6 +23,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional
 
+from agent_bom.mcp_tool_rules import evaluate_tool
 from agent_bom.models import MCPResource, MCPServer, MCPTool, TransportType
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,7 @@ class ServerIntrospection:
     runtime_resources: list[MCPResource] = field(default_factory=list)
     error: Optional[str] = None
     tool_schema_findings: list[str] = field(default_factory=list)
+    tool_schema_rule_findings: list[dict] = field(default_factory=list)
     resource_findings: list[str] = field(default_factory=list)
     capability_risk_score: float = 0.0
     capability_risk_level: str = "low"
@@ -99,6 +101,7 @@ class ServerIntrospection:
             "resources_added": self.resources_added,
             "resources_removed": self.resources_removed,
             "tool_schema_findings": self.tool_schema_findings,
+            "tool_schema_rule_findings": self.tool_schema_rule_findings,
             "resource_findings": self.resource_findings,
             "has_drift": self.has_drift,
             "capability_risk_score": self.capability_risk_score,
@@ -116,6 +119,7 @@ class ServerIntrospection:
                     "name": t.name,
                     "description": t.description,
                     "schema_findings": t.schema_findings,
+                    "schema_rule_findings": t.schema_rule_findings,
                     "risk_score": t.risk_score,
                 }
                 for t in self.runtime_tools
@@ -378,6 +382,7 @@ async def _query_capabilities(
                 input_schema=getattr(tool, "inputSchema", None),
             )
             runtime_tool.schema_findings = _lint_tool_schema(runtime_tool)
+            runtime_tool.schema_rule_findings = [finding.to_dict() for finding in evaluate_tool(runtime_tool)]
             result.runtime_tools.append(runtime_tool)
         tools_ok = True
     except Exception as exc:
@@ -420,6 +425,7 @@ async def _query_capabilities(
         result.resources_removed = sorted(config_resource_uris - runtime_resource_uris)
 
     result.tool_schema_findings = sorted({finding for tool in result.runtime_tools for finding in tool.schema_findings})
+    result.tool_schema_rule_findings = [finding for tool in result.runtime_tools for finding in tool.schema_rule_findings]
     result.resource_findings = sorted({finding for resource in result.runtime_resources for finding in resource.content_findings})
     result.runtime_fingerprint = _runtime_server_fingerprint(server, result.runtime_tools, result.runtime_resources)
     _apply_runtime_risk(server, result)

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -406,6 +406,7 @@ class MCPTool:
     description: str
     input_schema: Optional[dict] = None
     schema_findings: list[str] = field(default_factory=list)
+    schema_rule_findings: list[dict] = field(default_factory=list)
 
     @property
     def stable_id(self) -> str:

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -307,6 +307,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                         "fingerprint": tool.fingerprint,
                         "description": tool.description,
                         "schema_findings": tool.schema_findings,
+                        "schema_rule_findings": tool.schema_rule_findings,
                         "risk_score": tool.risk_score,
                     }
                 if tool.stable_id not in servers[server.stable_id]["tool_ids"]:
@@ -417,6 +418,10 @@ def _build_mcp_runtime_diff(report: AIBOMReport) -> dict | None:
                         "tool_schema_findings",
                         sorted({finding for tool in server.tools for finding in tool.schema_findings}),
                     ),
+                    "tool_schema_rule_findings": intro.get(
+                        "tool_schema_rule_findings",
+                        [finding for tool in server.tools for finding in tool.schema_rule_findings],
+                    ),
                     "resource_findings": intro.get(
                         "resource_findings",
                         sorted({finding for resource in server.resources for finding in resource.content_findings}),
@@ -516,6 +521,7 @@ def to_json(report: AIBOMReport) -> dict:
                                 "fingerprint": t.fingerprint,
                                 "description": t.description,
                                 "schema_findings": t.schema_findings,
+                                "schema_rule_findings": t.schema_rule_findings,
                                 "risk_score": t.risk_score,
                             }
                             for t in server.tools

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -383,6 +383,7 @@ def test_helm_network_policy_defaults_are_explicit():
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
     policy = doc["networkPolicy"]
     assert policy["enabled"] is True
+    assert policy["restrictIngress"] is True
     assert policy["allowDns"] is True
     assert policy["allowWeb"] is True
     assert policy["webPorts"] == [80, 443]

--- a/tests/test_mcp_introspect.py
+++ b/tests/test_mcp_introspect.py
@@ -220,6 +220,35 @@ def test_server_introspection_to_dict_includes_capability_risk():
     assert payload["tool_risk_profiles"][0]["tool_name"] == "run_command"
 
 
+def test_server_introspection_to_dict_includes_structured_schema_rule_findings():
+    from agent_bom.mcp_introspect import ServerIntrospection
+
+    tool = MCPTool(
+        name="read_file",
+        description="Read a file from the workspace",
+        schema_findings=["read_file.path: filesystem-capability"],
+        schema_rule_findings=[
+            {
+                "rule_id": "mcp.tool.path-input",
+                "severity": "medium",
+                "category": "filesystem",
+                "message": "Tool accepts filesystem paths.",
+            }
+        ],
+    )
+    result = ServerIntrospection(
+        server_name="filesystem",
+        success=True,
+        runtime_tools=[tool],
+        tool_schema_findings=["read_file.path: filesystem-capability"],
+        tool_schema_rule_findings=tool.schema_rule_findings,
+    )
+
+    payload = result.to_dict(include_runtime_objects=True)
+    assert payload["tool_schema_rule_findings"][0]["rule_id"] == "mcp.tool.path-input"
+    assert payload["runtime_tools"][0]["schema_rule_findings"][0]["category"] == "filesystem"
+
+
 def test_enrich_servers_no_duplicate_tools():
     from agent_bom.mcp_introspect import IntrospectionReport, ServerIntrospection, enrich_servers
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.77.0"
+version = "0.77.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes the two concrete post-release audit gaps found on current main.\n\nChanges:\n- wire structured MCP tool-schema rule findings into live introspection outputs alongside existing heuristic schema findings\n- surface structured rule findings in JSON serialization and runtime diff payloads\n- harden Helm chart defaults by setting networkPolicy.restrictIngress=true\n- align Kubernetes deployment docs with the hardened default\n- correct uv.lock package version drift to 0.77.1\n\nValidation:\n- uv run pytest -q tests/test_mcp_introspect.py tests/test_mcp_tool_rules.py tests/test_deploy_manifests.py\n- uv run ruff check src/agent_bom/models.py src/agent_bom/mcp_introspect.py src/agent_bom/output/json_fmt.py tests/test_mcp_introspect.py tests/test_deploy_manifests.py\n- uv run mypy src/agent_bom/models.py src/agent_bom/mcp_introspect.py src/agent_bom/output/json_fmt.py\n- git diff --check