### PR TITLE
ux(cli): polish Fix First output — spacing + $ command prefix

### DIFF
--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1807,6 +1807,7 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
     total = len(fixable)
     title = f"Fix First (top {min(limit, total)} of {total})" if total > limit else f"Fix First ({total})"
     console.print(f"  [bold]{title}[/bold]")
+    console.print()
 
     sev_style = {
         Severity.CRITICAL: "red bold",
@@ -1816,7 +1817,8 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
         Severity.NONE: "white",
     }
 
-    for i, item in enumerate(fixable[:limit], 1):
+    shown = fixable[:limit]
+    for i, item in enumerate(shown, 1):
         style = sev_style.get(item["max_severity"], "white")
         kev = " [red]KEV[/red]" if item["has_kev"] else ""
         reach_parts = [f"{len(item['vulns'])} vuln(s)", f"{len(item['agents'])} agent(s)"]
@@ -1832,11 +1834,14 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
         )
         console.print(f"     [dim]{_compact_detail(item['action'], limit=110)}[/dim]")
         if item.get("command"):
-            console.print(f"     [cyan]{item['command']}[/cyan]")
+            console.print(f"     [cyan]$ {item['command']}[/cyan]")
         if item.get("verify_command"):
-            console.print(f"     [dim]verify:[/dim] [cyan]{item['verify_command']}[/cyan]")
+            console.print(f"     [dim cyan]$ {item['verify_command']}[/dim cyan] [dim](verify)[/dim]")
+        if i < len(shown):
+            console.print()
 
     if total > limit:
+        console.print()
         console.print(f"  [dim]... {total - limit} more (use --verbose for full plan)[/dim]")
     console.print()
 

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -288,6 +288,36 @@ def test_compact_remediation_empty():
     assert output.strip() == ""
 
 
+def test_compact_remediation_command_prefix_and_spacing():
+    """Install + verify commands render with a `$` prefix (copy-this affordance),
+    and numbered items are separated by a blank line for scan-ability."""
+    server = _make_server(env={"GITHUB_TOKEN": "x"}, tools=[{"name": "read_file"}])
+    agent = _make_agent(servers=[server])
+    radii = []
+    for i in range(3):
+        v = _vuln(vid=f"CVE-2024-{i:04d}", severity=Severity.HIGH, fixed="9.9.9", kev=True)
+        p = Package(name=f"pkg-{i}", version="1.0.0", ecosystem="pypi", vulnerabilities=[v])
+        radii.append(_blast(v, p, [agent], [server], creds=["GITHUB_TOKEN"]))
+    report = AIBOMReport(agents=[agent], blast_radii=radii)
+    plain = _plain(_capture(print_compact_remediation, report, limit=3))
+
+    # Install command is prefixed with "$ " to signal a copy-this line.
+    assert "$ pip install 'pkg-0>=9.9.9'" in plain
+    # Verify command is also "$ "-prefixed and annotated as verify.
+    assert "$ agent-bom check pkg-0@9.9.9 --ecosystem pypi" in plain
+    assert "(verify)" in plain
+
+    # Numbered items are separated by a blank line (breathing room).
+    # Strip leading/trailing blank lines, then look for the pattern of a
+    # dedented numbered item preceded by an empty line.
+    lines = plain.splitlines()
+    item_indices = [idx for idx, line in enumerate(lines) if line.lstrip().startswith(("1.", "2.", "3."))]
+    assert len(item_indices) == 3
+    # Items 2 and 3 must each be preceded by a blank line.
+    for idx in item_indices[1:]:
+        assert lines[idx - 1].strip() == "", f"Expected blank line before {lines[idx]!r}"
+
+
 # ── print_compact_export_hint ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Tightens the compact `Fix First` remediation block so numbered items are scannable at a glance and install/verify commands read as copy-this affordances. Pure presentation — no behavioral changes.

## What changed

`src/agent_bom/output/__init__.py` — `print_compact_remediation`:
- Blank line after the "Fix First" title, and between each numbered item, so entries no longer visually run together
- Install command prefixed with `$ ` (cyan) — universal shell-prompt convention signals "copy this line"
- Verify command prefixed with `$ ` (dim cyan) + trailing `(verify)` hint — unambiguous which line is the verification step
- Terminating `... N more` hint preceded by a blank line so it doesn't collide with the last item's verify line

## Visual diff

**Before**
```
  Fix First (top 2 of 3)
  1. openssl 1.0.0 → 3.0.2 KEV  P1 · clears 1 vuln(s), 1 agent(s), 1 credential(s)
     rotate exposed credentials, then upgrade
     pip install 'openssl>=3.0.2'
     verify: agent-bom check openssl@3.0.2 --ecosystem pypi
  2. requests 2.28.0 → 2.31.0 KEV  P1 · clears 1 vuln(s), 1 agent(s)
     upgrade to fix CVE-2024-0001
     pip install 'requests>=2.31.0'
     verify: agent-bom check requests@2.31.0 --ecosystem pypi
```

**After**
```
  Fix First (top 2 of 3)

  1. openssl 1.0.0 → 3.0.2 KEV  P1 · clears 1 vuln(s), 1 agent(s), 1 credential(s)
     rotate exposed credentials, then upgrade
     $ pip install 'openssl>=3.0.2'
     $ agent-bom check openssl@3.0.2 --ecosystem pypi (verify)

  2. requests 2.28.0 → 2.31.0 KEV  P1 · clears 1 vuln(s), 1 agent(s)
     upgrade to fix CVE-2024-0001
     $ pip install 'requests>=2.31.0'
     $ agent-bom check requests@2.31.0 --ecosystem pypi (verify)
```

## Test plan

- [x] `uv run pytest tests/test_compact_output.py` — 15/15 pass (14 existing + 1 new)
- [x] New `test_compact_remediation_command_prefix_and_spacing` locks the polish invariants so regressions are caught: `$ ` prefix on install + verify commands, `(verify)` marker, blank line between numbered items
- [x] `uv run pytest tests/test_cli_polish.py tests/test_cli_remediate.py tests/test_apply_remediation.py` — all pass, no downstream CLI regressions

## Part of v0.78.0 release train

Sibling PRs: #1523 (CHANGELOG backfill + tools.json — merged), PR-C dashboard polish, PR-D site-docs competitor purge, PR-E skills consistency, PR-F oci_parser security (separate review).