### PR TITLE
chore(docs): replace vendor names with generic language in published docs

### DIFF
--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -102,9 +102,8 @@ data:
 
 The external scanner fuzz target covers:
 
-- Trivy JSON ingestion
-- Grype JSON ingestion
-- Syft JSON ingestion
+- CVE-scanner JSON ingestion (common industry formats)
+- container-SBOM JSON ingestion (common industry formats)
 - format auto-detection via `detect_and_parse()`
 
 That keeps the import path for third-party scanner results under the same

--- a/site-docs/architecture/how-agent-bom-works.md
+++ b/site-docs/architecture/how-agent-bom-works.md
@@ -19,7 +19,7 @@ flowchart LR
         B["Imported artifacts
         SBOMs
         inventories
-        Trivy / Grype / Syft JSON"]
+        third-party scanner JSON"]
         C["Pushed ingest
         traces
         runtime events
@@ -82,7 +82,7 @@ flowchart LR
 | Intake mode | What it means | Typical inputs | Best when |
 |---|---|---|---|
 | Direct scan | `agent-bom` reads the target itself | agent configs, projects, lockfiles, images, IaC, read-only cloud APIs | you want local or CI-native discovery |
-| Imported artifact | you hand `agent-bom` an exported file | CycloneDX, SPDX, Trivy, Grype, Syft, inventories | collection already happens elsewhere |
+| Imported artifact | you hand `agent-bom` an exported file | CycloneDX, SPDX, third-party scanner JSON, inventories | collection already happens elsewhere |
 | Pushed ingest | another system sends evidence in | traces, runtime events, audit payloads | runtime telemetry already exists |
 | Read-only integration | `agent-bom` connects to an existing source | cloud accounts, governance systems, analytics backends | you want central review without modifying the source |
 

--- a/site-docs/architecture/supply-chain-and-trust.md
+++ b/site-docs/architecture/supply-chain-and-trust.md
@@ -61,9 +61,8 @@ High-risk ingest surfaces are fuzzed because they accept external data:
 
 The external scanner fuzz target covers:
 
-- Trivy JSON
-- Grype JSON
-- Syft JSON
+- CVE-scanner JSON reports (common industry formats)
+- container-SBOM JSON reports (common industry formats)
 - auto-detection of scanner formats
 
 ## Release trust

--- a/site-docs/features/scanning.md
+++ b/site-docs/features/scanning.md
@@ -36,7 +36,7 @@ Linux paths use `~/.config/` equivalents.
 | [EPSS](https://www.first.org/epss/) | Exploit probability scores (0.0–1.0) |
 | [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | Known exploited vulnerabilities catalog |
 | [GitHub Advisories](https://github.com/advisories) | Supplemental advisory data |
-| [Snyk](https://snyk.io) | Optional enrichment (requires `SNYK_TOKEN`) |
+| Commercial vuln API | Optional enrichment when a vendor API token is configured |
 
 ## Credential exposure detection
 

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -79,7 +79,7 @@ See [CLI Debug Guide](cli-debug.md) for quiet/logging behavior, stdout vs file o
 | Variable | Purpose | Required |
 |----------|---------|----------|
 | `NVD_API_KEY` | Increase NVD rate limit | No |
-| `SNYK_TOKEN` | Snyk enrichment | No |
+| `SNYK_TOKEN` | Optional commercial vuln-API enrichment | No |
 | `AGENT_BOM_CLICKHOUSE_URL` | Analytics storage | No |
 | `AWS_PROFILE` | AWS CIS benchmark | Only for `cis-benchmark --provider aws` |
 | `SNOWFLAKE_ACCOUNT` | Snowflake CIS benchmark | Only for `cis-benchmark --provider snowflake` |


### PR DESCRIPTION
## Summary

Removes competitor-brand references from user-facing documentation per project editorial policy. Docs-only — code-level parser module names and comments stay as-is (they're technical format identifiers, separate scope).

## Changes

| File | Before | After |
|---|---|---|
| `site-docs/features/scanning.md:39` | `[Snyk](https://snyk.io)` row in vuln-sources table | "Commercial vuln API" — feature capability preserved, brand dropped |
| `site-docs/architecture/supply-chain-and-trust.md:64-66` | `Trivy JSON`, `Grype JSON`, `Syft JSON` fuzz-target list | "CVE-scanner JSON (common industry formats)" + "container-SBOM JSON (common industry formats)" |
| `site-docs/architecture/how-agent-bom-works.md:22` | Mermaid node `Trivy / Grype / Syft JSON` | `third-party scanner JSON` |
| `site-docs/architecture/how-agent-bom-works.md:85` | Imported-artifact table row listed vendor names | `third-party scanner JSON` |
| `docs/SUPPLY_CHAIN.md:105-107` | `Trivy JSON ingestion`, `Grype JSON ingestion`, `Syft JSON ingestion` | "CVE-scanner JSON" + "container-SBOM JSON" bullets |
| `site-docs/reference/cli.md:82` | `SNYK_TOKEN` env-var description: "Snyk enrichment" | "Optional commercial vuln-API enrichment" — env-var name itself unchanged (hardcoded in code, separate scope) |

## What stays

- `src/agent_bom/parsers/external_scanners.py` — parser module retains `parse_trivy_json`, `parse_grype_json`, `parse_syft_json` function names and `_TRIVY_ECOSYSTEM_MAP` / `_GRYPE_ECOSYSTEM_MAP` / `_SYFT_ECOSYSTEM_MAP` constants. Those are technical format identifiers; renaming would hurt code readability for engineers maintaining the ingest path.
- `docs/adr/` and `docs/decisions/` — ADRs are historical rationale records documenting *why* alternatives were considered. Renaming them would destroy their educational value. Scope boundary respected.

## Test plan

- [x] Word-boundary grep confirms zero Trivy/Grype/Snyk/Syft mentions across `site-docs/` and `docs/SUPPLY_CHAIN.md`
- [x] All affected files remain valid Markdown / Mermaid
- [x] No code changes — external-scanner ingest paths behave identically

## Part of v0.78.0 release train

Sibling PRs: [#1523](https://github.com/msaad00/agent-bom/pull/1523) CHANGELOG (merged), [#1524](https://github.com/msaad00/agent-bom/pull/1524) CLI polish, [#1525](https://github.com/msaad00/agent-bom/pull/1525) dashboard polish, PR-E skills consistency, PR-F oci_parser hardening.