### PR TITLE
chore(skills): align openclaw SKILL.md with on-disk sub-skills + 36-tool catalog

### DIFF
--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -232,7 +232,7 @@ agent-bom where             # show all discovery paths
 }
 ```
 
-## Sub-Skills (8)
+## Sub-Skills (10)
 
 | Sub-Skill | Purpose | Triggers |
 |-----------|---------|---------|
@@ -243,6 +243,8 @@ agent-bom where             # show all discovery paths
 | [compliance](compliance/SKILL.md) | 14-framework compliance, SBOM generation | "compliance report", "NIST", "SOC 2", "OWASP" |
 | [monitor](monitor/SKILL.md) | Fleet monitoring, trust scores, lifecycle | "fleet", "watch agents", "trust scores" |
 | [analyze](analyze/SKILL.md) | Blast radius, attack paths, context graph | "blast radius", "threat intel", "attack path" |
+| [registry](registry/SKILL.md) | MCP registry lookup, marketplace check, fleet risk scoring, skill trust, SAST | "registry lookup", "marketplace check", "skill trust" |
+| [runtime](runtime/SKILL.md) | Runtime audit-log correlation, context graph analytics, vulnerability trends | "runtime monitoring", "audit correlation", "analytics" |
 | [troubleshoot](troubleshoot/SKILL.md) | Diagnostics, doctor, config validation | "doctor", "debug", "why failing", "validate config" |
 
 ## Tools
@@ -274,6 +276,7 @@ agent-bom where             # show all discovery paths
 | `registry_lookup` | Look up MCP server in 427+ server security metadata registry |
 | `marketplace_check` | Pre-install trust check with registry cross-reference |
 | `fleet_scan` | Batch registry lookup + risk scoring for MCP server inventories |
+| `tool_risk_assessment` | Score live-introspected MCP tool capabilities and server risk (READ/WRITE/EXECUTE/NETWORK classification + dangerous-combination flags) |
 | `skill_scan` | Scan instruction files for package refs, trust, and findings |
 | `skill_verify` | Verify Sigstore provenance for instruction files |
 | `skill_trust` | Assess skill file trust level (5-category analysis) |
@@ -283,6 +286,7 @@ agent-bom where             # show all discovery paths
 | Tool | Description |
 |------|-------------|
 | `context_graph` | Agent context graph with lateral movement analysis |
+| `graph_export` | Export the agent dependency graph (json, graphml, cypher, dot, mermaid) |
 | `analytics_query` | Query vulnerability trends, posture history, and runtime events |
 | `runtime_correlate` | Cross-reference proxy audit JSONL with CVE findings, risk amplification |
 | `vector_db_scan` | Probe Qdrant/Weaviate/Chroma/Milvus for auth and exposure |
@@ -291,6 +295,7 @@ agent-bom where             # show all discovery paths
 ### Specialized Scans
 | Tool | Description |
 |------|-------------|
+| `ai_inventory_scan` | Discover AI/ML components across infrastructure (models, datasets, agents, training jobs) |
 | `dataset_card_scan` | Scan dataset cards for bias, licensing, and provenance issues |
 | `training_pipeline_scan` | Scan training pipeline configs for security risks |
 | `browser_extension_scan` | Scan browser extensions for risky permissions and AI domain access |


### PR DESCRIPTION
## Summary

Closes two drift items surfaced by the pre-release audit. Docs-only — no code changes.

## Drift fixed

### Sub-skill count
- Header said **(8)** while **10** sub-skill directories exist on disk
- Added the missing rows for `registry` and `runtime`
- Reordered so `troubleshoot` stays at the end (diagnostic skill after functional skills)

### Tool catalog parity with the running MCP server

| Tool | Added to section | Reason missing |
|---|---|---|
| `tool_risk_assessment` | Registry & Trust | Landed in code but never added to SKILL.md |
| `graph_export` | Runtime & Analytics | Landed in code but never added to SKILL.md |
| `ai_inventory_scan` | Specialized Scans | Listed in tools.json but orphan — no SKILL.md row described it |

All three tools already exist as `@mcp.tool` decorators in `src/agent_bom/mcp_server.py` / `mcp_server_specialized.py`.

## Verification (automated count)

```
SKILL.md tool count:            36
tools.json tool count:          36
@mcp.tool decorators in code:   36
Set diff either direction:      empty
```

## Scope boundary

This PR covers sub-skill directory enumeration and tool-catalog parity only. Other audit items flagged but out-of-scope for this cohesive commit:

- **Example syntax uniformity across individual sub-skill READMEs** (CLI-style vs function-call-style mix) — deferred to a follow-up so diffs stay reviewable
- **Version bumps in skill frontmatter** (0.77.1 → 0.78.0) — part of the final release-cut PR
- **Credential-handling security.py link pinning** — deferred; linking to `main` is fine for the bundle while we maintain a single canonical source

## Test plan

- [x] Python one-liner confirms SKILL.md ↔ tools.json ↔ code decorator parity (set diff empty both directions)
- [x] Markdown table renders correctly (all 5 "###" tool-section tables parse)
- [x] No behavioral or code changes

## Part of v0.78.0 release train

Siblings: [#1523](https://github.com/msaad00/agent-bom/pull/1523) (merged), [#1524](https://github.com/msaad00/agent-bom/pull/1524), [#1525](https://github.com/msaad00/agent-bom/pull/1525), [#1526](https://github.com/msaad00/agent-bom/pull/1526), PR-F oci_parser security.