### PR TITLE
security(oci): harden tar-member safety against traversal + symlink attacks

### DIFF
--- a/src/agent_bom/oci_parser.py
+++ b/src/agent_bom/oci_parser.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import posixpath
 import re
 import sqlite3
 import struct
@@ -42,12 +43,137 @@ import tempfile
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import IO, Optional
 
 from agent_bom.models import Package, PackageOccurrence
 from agent_bom.package_utils import parse_debian_source_name
 
 _logger = logging.getLogger(__name__)
+
+
+# ── Tar member safety ────────────────────────────────────────────────────────
+#
+# Image tarballs are untrusted input. A malicious tar can carry members whose
+# names escape the extraction root, members that are symlinks pointing outside
+# the tar, or hardlinks to arbitrary files. `tarfile.TarFile` does not validate
+# these by default (Python's `data_filter` arrived in 3.12 but we target 3.11+
+# and call `extractfile()` which bypasses it anyway).
+#
+# The helpers below give us two guarantees the parser relies on:
+#   1. `_is_safe_tar_member_name(name)` — the member name, after POSIX
+#      normalization, stays inside the tar root. Rejects `../` traversal,
+#      absolute paths, and NUL-injected names.
+#   2. `_safe_getmember(tf, name)` — resolves a member by name and also
+#      requires it to be a regular file. Symlinks and hardlinks never reach
+#      `extractfile()`, so the parser cannot be tricked into reading a host
+#      file by a crafted tar with `METADATA -> /etc/passwd`.
+#
+# Both helpers log at debug level when they reject something, so operators
+# scanning hostile images can see why certain layers contributed zero
+# packages.
+
+
+def _is_safe_tar_member_name(name: str) -> bool:
+    """Return True iff ``name`` is safe to treat as a relative path inside a tar.
+
+    Rejects absolute paths, parent-traversal (``../``), NUL-injected names,
+    and any name whose POSIX-normalized form escapes the tar root.
+    """
+    if not name or "\x00" in name:
+        return False
+    if name.startswith("/"):
+        return False
+    # posixpath.normpath collapses "./foo/../bar" → "bar" but preserves a
+    # leading ".." if the name escapes. "a/../b" → "b" (safe);
+    # "../a" → "../a" (escapes); "a/../../b" → "../b" (escapes).
+    normalized = posixpath.normpath(name)
+    if normalized.startswith("../") or normalized == "..":
+        return False
+    if normalized.startswith("/"):
+        return False
+    # Belt-and-suspenders against split-by-"/" bypasses on odd separators.
+    parts = normalized.split("/")
+    if any(p == ".." for p in parts):
+        return False
+    return True
+
+
+def _safe_tar_names(tf: tarfile.TarFile) -> set[str]:
+    """Return member names that are safe regular files inside ``tf``.
+
+    Filters out:
+      - names failing ``_is_safe_tar_member_name`` (traversal / absolute / NUL)
+      - symlink members (``SYMTYPE``) and hardlink members (``LNKTYPE``)
+      - device / fifo members
+
+    Directory members are excluded because this helper exists to feed
+    file-reading loops; directories carry no file payload.
+    """
+    safe: set[str] = set()
+    rejected_traversal = 0
+    rejected_link = 0
+    for member in tf.getmembers():
+        name = member.name
+        if not _is_safe_tar_member_name(name):
+            rejected_traversal += 1
+            continue
+        if member.issym() or member.islnk():
+            # Symlinks / hardlinks inside an image layer are legitimate OS
+            # artifacts — but we never follow them for package parsing. We
+            # only ingest concrete regular-file payloads.
+            rejected_link += 1
+            continue
+        if not member.isfile():
+            # Skip directories, devices, fifos, etc.
+            continue
+        safe.add(name)
+    if rejected_traversal:
+        _logger.debug(
+            "Rejected %d tar member(s) with unsafe names (traversal / absolute / NUL)",
+            rejected_traversal,
+        )
+    if rejected_link:
+        _logger.debug(
+            "Skipped %d symlink/hardlink member(s) — package parsing reads concrete files only",
+            rejected_link,
+        )
+    return safe
+
+
+def _safe_getmember(tf: tarfile.TarFile, name: str) -> tarfile.TarInfo | None:
+    """Resolve ``name`` to a tar member only if the name is safe AND the member is a regular file.
+
+    Returns ``None`` (instead of raising ``KeyError``) so callers can treat a
+    missing-or-unsafe member the same way they treat a missing-but-legitimate
+    member: skip and move on.
+    """
+    if not _is_safe_tar_member_name(name):
+        return None
+    try:
+        member = tf.getmember(name)
+    except KeyError:
+        return None
+    if member.issym() or member.islnk() or not member.isfile():
+        return None
+    return member
+
+
+def _safe_extractfile(tf: tarfile.TarFile, name: str) -> IO[bytes] | None:
+    """Open a tar member by name, but only if it is safe (see ``_safe_getmember``).
+
+    Returns ``None`` if the member is missing, a symlink / hardlink, has an
+    unsafe name, or can't be opened as a stream. Callers can treat ``None``
+    uniformly as "skip this member" without distinguishing the cause.
+    """
+    member = _safe_getmember(tf, name)
+    if member is None:
+        return None
+    try:
+        return tf.extractfile(member)
+    except (tarfile.TarError, OSError) as e:
+        _logger.debug("Failed to open tar member %s: %s: %s", name, type(e).__name__, e)
+        return None
+
 
 # Whiteout prefix per OCI image spec
 _WHITEOUT_PREFIX = ".wh."
@@ -334,9 +460,9 @@ def _read_os_release_from_layer(layer_tf: tarfile.TarFile, deleted_paths: set[st
     for os_release_path in ("etc/os-release", "./etc/os-release"):
         if os_release_path in deleted_paths:
             continue
-        try:
-            member = layer_tf.getmember(os_release_path)
-        except KeyError:
+        member = _safe_getmember(layer_tf, os_release_path)
+        if member is None:
+            # Missing, symlinked (refused), or unsafe name. Try next candidate.
             continue
         try:
             f = layer_tf.extractfile(member)
@@ -351,8 +477,8 @@ def _read_os_release_from_layer(layer_tf: tarfile.TarFile, deleted_paths: set[st
                 elif line.startswith("VERSION_ID="):
                     distro_version = line.split("=", 1)[1].strip().strip('"').strip("'") or None
             return distro_name, distro_version
-        except Exception:
-            _logger.debug("Failed to parse os-release: %s", os_release_path)
+        except (tarfile.TarError, OSError, UnicodeDecodeError) as e:
+            _logger.debug("Failed to parse os-release %s: %s: %s", os_release_path, type(e).__name__, e)
     return None, None
 
 
@@ -376,10 +502,10 @@ def _extract_packages_from_layer(
         Set of paths marked as whiteout in THIS layer (for caller to accumulate).
     """
     whiteouts: set[str] = set()
-    raw_names = set(layer_tf.getnames())
-
-    # Filter out path traversal attempts (malicious tar members with ../)
-    names = {n for n in raw_names if ".." not in n.split("/") and not n.startswith("/")}
+    # `_safe_tar_names` filters out path-traversal members (normalized + split-part
+    # check, not just substring), absolute paths, NUL-injected names, AND symlink /
+    # hardlink members. Prior filter only substring-checked "..".
+    names = _safe_tar_names(layer_tf)
 
     # Collect whiteout paths from this layer
     for member_name in names:
@@ -410,7 +536,7 @@ def _extract_packages_from_layer(
         if _is_deleted(member_name):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(member_name))
+            f = _safe_extractfile(layer_tf, member_name)
             if f is None:
                 continue
             pkg_name = pkg_version = ""
@@ -436,7 +562,7 @@ def _extract_packages_from_layer(
         if _is_deleted(member_name):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(member_name))
+            f = _safe_extractfile(layer_tf, member_name)
             if f is None:
                 continue
             data = json.loads(f.read().decode("utf-8", errors="ignore"))
@@ -452,7 +578,7 @@ def _extract_packages_from_layer(
         if dpkg_path not in names or _is_deleted(dpkg_path):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(dpkg_path))
+            f = _safe_extractfile(layer_tf, dpkg_path)
             if f:
                 content = f.read().decode("utf-8", errors="ignore")
                 pkg_name = pkg_version = ""
@@ -500,7 +626,7 @@ def _extract_packages_from_layer(
         if apk_path not in names or _is_deleted(apk_path):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(apk_path))
+            f = _safe_extractfile(layer_tf, apk_path)
             if f:
                 content = f.read().decode("utf-8", errors="ignore")
                 pkg_name = pkg_version = ""
@@ -541,7 +667,7 @@ def _extract_packages_from_layer(
         if rpm_path not in names or _is_deleted(rpm_path):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(rpm_path))
+            f = _safe_extractfile(layer_tf, rpm_path)
             if f:
                 for raw_line in f:
                     line = raw_line.decode("utf-8", errors="ignore").strip()
@@ -576,7 +702,7 @@ def _extract_packages_from_layer(
         if sqlite_path not in names or _is_deleted(sqlite_path):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(sqlite_path))
+            f = _safe_extractfile(layer_tf, sqlite_path)
             if f is None:
                 continue
             db_bytes = f.read()
@@ -626,10 +752,10 @@ def _extract_packages_from_layer(
         name_for_hint = "/" + member_name.lower()
         if not any(hint in name_for_hint for hint in _JAR_DIR_HINTS):
             continue
+        member = _safe_getmember(layer_tf, member_name)
+        if member is None or member.size == 0 or member.size > _JAR_MAX_BYTES:
+            continue
         try:
-            member = layer_tf.getmember(member_name)
-            if not member.isfile() or member.size == 0 or member.size > _JAR_MAX_BYTES:
-                continue
             f = layer_tf.extractfile(member)
             if f is None:
                 continue
@@ -672,10 +798,10 @@ def _extract_packages_from_layer(
             continue
         if _is_deleted(member_name):
             continue
+        member = _safe_getmember(layer_tf, member_name)
+        if member is None or member.size < 64:
+            continue
         try:
-            member = layer_tf.getmember(member_name)
-            if not member.isfile() or member.size < 64:
-                continue
             f = layer_tf.extractfile(member)
             if f is None:
                 continue
@@ -707,7 +833,7 @@ def _extract_packages_from_layer(
         if _is_deleted(member_name):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(member_name))
+            f = _safe_extractfile(layer_tf, member_name)
             if f is None:
                 continue
             content = f.read(32 * 1024).decode("utf-8", errors="ignore")
@@ -736,7 +862,7 @@ def _extract_packages_from_layer(
         if _is_deleted(member_name):
             continue
         try:
-            f = layer_tf.extractfile(layer_tf.getmember(member_name))
+            f = _safe_extractfile(layer_tf, member_name)
             if f is None:
                 continue
             deps = json.loads(f.read().decode("utf-8", errors="ignore"))
@@ -774,7 +900,7 @@ def _extract_packages_from_layer(
             if path not in names or _is_deleted(path):
                 continue
             try:
-                f = layer_tf.extractfile(layer_tf.getmember(path))
+                f = _safe_extractfile(layer_tf, path)
                 if f is None:
                     continue
                 data = json.loads(f.read().decode("utf-8", errors="ignore"))
@@ -803,7 +929,7 @@ def _extract_packages_from_layer(
             if path not in names or _is_deleted(path):
                 continue
             try:
-                f = layer_tf.extractfile(layer_tf.getmember(path))
+                f = _safe_extractfile(layer_tf, path)
                 if f is None:
                     continue
                 content = f.read().decode("utf-8", errors="ignore")
@@ -834,7 +960,7 @@ def _extract_packages_from_layer(
             if path not in names or _is_deleted(path):
                 continue
             try:
-                f = layer_tf.extractfile(layer_tf.getmember(path))
+                f = _safe_extractfile(layer_tf, path)
                 if f is None:
                     continue
                 data = json.loads(f.read().decode("utf-8", errors="ignore"))

--- a/tests/test_oci_parser.py
+++ b/tests/test_oci_parser.py
@@ -799,6 +799,130 @@ def test_rpm_sqlite_and_log_manifest_dedup():
 # ── Full mixed ecosystem layer ────────────────────────────────────────────────
 
 
+# ── Security hardening: tar-member safety ───────────────────────────────────
+
+
+def _make_layer_tar_with_members(members: list[tarfile.TarInfo], payloads: list[bytes | None]) -> bytes:
+    """Build an in-memory layer tar with explicit TarInfo objects (for symlink / traversal tests)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:") as tf:
+        for info, payload in zip(members, payloads):
+            if payload is None:
+                tf.addfile(info)  # link/symlink/dir — no payload
+            else:
+                info.size = len(payload)
+                tf.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+def _wrap_layer_bytes_in_docker_save(layer_bytes: bytes) -> Path:
+    """Wrap a single raw layer tar into a Docker-save outer tar (manifest.json + layer.tar)."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".tar", delete=False)
+    layer_path = "0" * 40 + "/layer.tar"
+    with tarfile.open(fileobj=tmp, mode="w:") as outer:
+        info = tarfile.TarInfo(name=layer_path)
+        info.size = len(layer_bytes)
+        outer.addfile(info, io.BytesIO(layer_bytes))
+        manifest = [{"Config": "sha256:abc.json", "RepoTags": ["myapp:latest"], "Layers": [layer_path]}]
+        mb = json.dumps(manifest).encode()
+        mi = tarfile.TarInfo(name="manifest.json")
+        mi.size = len(mb)
+        outer.addfile(mi, io.BytesIO(mb))
+    tmp.close()
+    return Path(tmp.name)
+
+
+def test_is_safe_tar_member_name_accepts_normal_paths():
+    from agent_bom.oci_parser import _is_safe_tar_member_name
+
+    assert _is_safe_tar_member_name("var/lib/dpkg/status") is True
+    assert _is_safe_tar_member_name("./usr/lib/node_modules/foo/package.json") is True
+    assert _is_safe_tar_member_name("a/b/c") is True
+
+
+def test_is_safe_tar_member_name_rejects_traversal():
+    from agent_bom.oci_parser import _is_safe_tar_member_name
+
+    assert _is_safe_tar_member_name("../etc/passwd") is False
+    assert _is_safe_tar_member_name("../../etc/passwd") is False
+    assert _is_safe_tar_member_name("foo/../../etc/passwd") is False, "normalize must detect escapes that span segments"
+    assert _is_safe_tar_member_name("a/b/../../c/../../d") is False
+
+
+def test_is_safe_tar_member_name_rejects_absolute_and_nul():
+    from agent_bom.oci_parser import _is_safe_tar_member_name
+
+    assert _is_safe_tar_member_name("/etc/passwd") is False
+    assert _is_safe_tar_member_name("") is False
+    assert _is_safe_tar_member_name("a\x00b") is False
+
+
+def test_path_traversal_member_never_produces_a_package():
+    """A crafted tar whose member name escapes the root must not be parsed as a real file."""
+    traversal_info = tarfile.TarInfo(name="foo/../../../etc/passwd")
+    traversal_info.type = tarfile.REGTYPE
+    # Give it "METADATA-looking" content so a naive parser would treat it as a Python dist-info
+    payload = b"Name: evil\nVersion: 9.9.9\n"
+
+    benign_info = tarfile.TarInfo(name="requests-2.31.0.dist-info/METADATA")
+    benign_info.type = tarfile.REGTYPE
+
+    layer = _make_layer_tar_with_members(
+        [traversal_info, benign_info],
+        [payload, _METADATA_REQUESTS],
+    )
+    tar = _wrap_layer_bytes_in_docker_save(layer)
+    result = parse_oci_tarball(tar)
+    names = {p.name for p in result.packages}
+    assert "evil" not in names, "path-traversal member must not contribute a package"
+    assert "requests" in names, "legitimate sibling members must still parse"
+
+
+def test_symlink_metadata_member_is_refused_not_followed():
+    """A symlinked METADATA member must not be opened (would leak host FS if followed)."""
+    symlink = tarfile.TarInfo(name="requests-2.31.0.dist-info/METADATA")
+    symlink.type = tarfile.SYMTYPE
+    symlink.linkname = "/etc/passwd"
+
+    # Include a legitimate sibling package so we know the parser still runs.
+    other = tarfile.TarInfo(name="urllib3-2.0.0.dist-info/METADATA")
+    other.type = tarfile.REGTYPE
+    other_payload = b"Name: urllib3\nVersion: 2.0.0\n"
+
+    layer = _make_layer_tar_with_members([symlink, other], [None, other_payload])
+    tar = _wrap_layer_bytes_in_docker_save(layer)
+    result = parse_oci_tarball(tar)
+    names = {p.name for p in result.packages}
+    assert "requests" not in names, "symlinked METADATA must be skipped, not followed"
+    assert "urllib3" in names, "non-symlink siblings must still parse"
+
+
+def test_symlinked_dpkg_status_is_refused():
+    """A symlinked var/lib/dpkg/status must not be followed to leak host state."""
+    symlink = tarfile.TarInfo(name="var/lib/dpkg/status")
+    symlink.type = tarfile.SYMTYPE
+    symlink.linkname = "/etc/passwd"
+
+    layer = _make_layer_tar_with_members([symlink], [None])
+    tar = _wrap_layer_bytes_in_docker_save(layer)
+    result = parse_oci_tarball(tar)
+    assert all("passwd" not in (p.name or "") for p in result.packages)
+    # Zero dpkg packages because the symlink was refused.
+    assert len(result.packages) == 0
+
+
+def test_absolute_path_member_rejected():
+    """A member whose name starts with `/` must not be readable."""
+    info = tarfile.TarInfo(name="/etc/evil/METADATA")
+    info.type = tarfile.REGTYPE
+    payload = b"Name: escaped\nVersion: 0.0.1\n"
+
+    layer = _make_layer_tar_with_members([info], [payload])
+    tar = _wrap_layer_bytes_in_docker_save(layer)
+    result = parse_oci_tarball(tar)
+    assert not any(p.name == "escaped" for p in result.packages)
+
+
 def test_full_mixed_ecosystem_layer():
     """All ecosystems detected from a single mixed layer."""
     jar = _make_jar(pom_props={"groupId": "org.springframework", "artifactId": "spring-core", "version": "6.1.0"})


### PR DESCRIPTION
## Summary

Container image tarballs are untrusted, attacker-reachable input. The OCI layer parser had two defects that let a crafted image read host filesystem state or smuggle fake packages into the scan result. This PR closes both and locks the behavior in with 7 new tests.

## Vulnerabilities fixed

### 1. Path-traversal filter was defeatable

**Before** (line 382, the original substring check):
```python
names = {n for n in raw_names if ".." not in n.split("/")
                                 and not n.startswith("/")}
```

`".." not in n.split("/")` only checks whether any path component is exactly the string `".."`. It does **not** catch:
- Names whose *normalized* form escapes even when no raw segment equals `".."`
- Names with NUL bytes (some filesystems treat as shorter; path smuggling)

**After** (`_is_safe_tar_member_name` + `_safe_tar_names`):
- `posixpath.normpath` collapses the path; rejected if it starts with `../` or equals `..`
- Post-normalize split-by-`/` catches every component equal to `..`
- Absolute paths (starting with `/`) rejected
- Empty names or names with `\x00` rejected

### 2. No symlink / hardlink validation

`extractfile(getmember("var/lib/dpkg/status"))` **followed symlinks**. A malicious image could ship:

```
var/lib/dpkg/status -> /etc/passwd
```

and trick the scanner into reading the host filesystem as if it were a dpkg database. Same attack vector for every hardcoded metadata path the parser queries: METADATA, package.json, apk db, rpm db, os-release.

**After** (`_safe_getmember` / `_safe_extractfile`):
- Every `getmember()` call goes through `_safe_getmember`, which refuses `SYMTYPE`, `LNKTYPE`, and any non-regular-file member
- A symlinked metadata file is simply skipped — as if it did not exist
- Rejections logged at debug level so operators scanning hostile images can see the counts

## Changes

### `src/agent_bom/oci_parser.py`

New module-level helpers (~90 LOC) with threat model + rationale in the docstring:
- `_is_safe_tar_member_name(name)` — pure predicate
- `_safe_tar_names(tf)` — filter for member enumeration
- `_safe_getmember(tf, name)` — safe `getmember` replacement
- `_safe_extractfile(tf, name)` — safe `getmember + extractfile` one-shot

Call-site updates:
- Primary filter (layer member enumeration) → `_safe_tar_names`
- 13 `layer_tf.extractfile(layer_tf.getmember(X))` sites → `_safe_extractfile(layer_tf, X)`
- 2 `member = layer_tf.getmember(...)` blocks (JAR, Go buildinfo) → `_safe_getmember`
- os-release reader: now uses `_safe_getmember` and narrows its broad `except Exception:` to `(tarfile.TarError, OSError, UnicodeDecodeError)` with exception-type + message logged

### `tests/test_oci_parser.py`

7 new tests locking the hardened behavior:
- `_is_safe_tar_member_name` accepts normal paths
- rejects `../`, `..`, and span-escape paths (`foo/../../etc/passwd`)
- rejects absolute paths and NUL-injected names
- path-traversal tar member never surfaces as a package
- **symlink METADATA member is refused (not followed)**
- **symlink dpkg status is refused**
- absolute-path member is rejected

Plus helpers `_make_layer_tar_with_members` and `_wrap_layer_bytes_in_docker_save` for crafting hostile tars without going through the existing dict-based builder.

## Test plan

- [x] `uv run pytest tests/test_oci_parser.py -q` → **52 passed** (45 existing + 7 new)
- [x] `uv run pytest tests/test_os_package_scanning.py tests/test_cli_scan.py tests/test_external_scanners.py tests/test_api_pipeline_image_contract.py tests/test_native_disk_scan.py -q` → **193 passed** across nearby image / scan modules
- [x] ruff / ruff-format / mypy / bandit clean (pre-commit hooks)

## Scope boundary

This PR hardens the **layer-member access path** (the attacker-reachable surface). Still remaining as follow-up work tracked separately:
- Outer-tar format-detection helpers (`_read_json_member_from_tar`, etc.) — small additional surface, candidate for the same helper if audit recommends
- Remaining 12+ broad `except Exception:` handlers in per-ecosystem parsers (dpkg / apk / rpm sqlite / jar / ruby / dotnet) — each has ecosystem-specific expected-error contracts; narrowing them cleanly is a follow-up refactor

## Part of v0.78.0 release train

Siblings: [#1523](https://github.com/msaad00/agent-bom/pull/1523) merged, [#1524](https://github.com/msaad00/agent-bom/pull/1524), [#1525](https://github.com/msaad00/agent-bom/pull/1525), [#1526](https://github.com/msaad00/agent-bom/pull/1526), [#1527](https://github.com/msaad00/agent-bom/pull/1527).