### PR TITLE
docs: sharpen self-hosted deployment story

### DIFF
--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -117,7 +117,7 @@ helm install agent-bom deploy/helm/agent-bom \
 
 For the stronger self-hosted operator path, start from:
 
-- [deploy/helm/agent-bom/examples/eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+- [eks-production-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-production-values.yaml)
 - [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
 
 That example adds:
@@ -138,7 +138,7 @@ That example adds:
 For clusters that already standardize on a service mesh and policy controller,
 start from:
 
-- [deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml)
+- [eks-istio-kyverno-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml)
 
 That example adds:
 

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -36,7 +36,7 @@ Leave out unless you need them:
 
 Use the packaged control-plane chart with the focused pilot values file:
 
-- [deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
+- [eks-mcp-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
 
 Install:
 
@@ -66,7 +66,7 @@ specific MCP workloads you want to guard.
 
 Use:
 
-- [deploy/k8s/proxy-sidecar-pilot.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/k8s/proxy-sidecar-pilot.yaml)
+- [proxy-sidecar-pilot.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/k8s/proxy-sidecar-pilot.yaml)
 
 This manifest shows:
 
@@ -119,7 +119,7 @@ alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 ```
 
 If the database was already bootstrapped from
-[deploy/supabase/postgres/init.sql](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/supabase/postgres/init.sql),
+[deploy/supabase/postgres/init.sql](https://github.com/msaad00/agent-bom/blob/main/deploy/supabase/postgres/init.sql),
 stamp the baseline once before future upgrades:
 
 ```bash
@@ -133,7 +133,7 @@ allow ingress from:
 - the `ingress-nginx` namespace
 
 If your ingress controller runs elsewhere, change
-[deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
+[eks-mcp-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
 before install.
 
 ## Recommended secrets and auth

--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -53,10 +53,10 @@ Important boundary:
 
 Shipped templates:
 
-- [deploy/endpoints/agent-bom-fleet-sync.sh](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/agent-bom-fleet-sync.sh)
-- [deploy/endpoints/agent-bom-fleet-sync.service](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/agent-bom-fleet-sync.service)
-- [deploy/endpoints/agent-bom-fleet-sync.timer](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/agent-bom-fleet-sync.timer)
-- [deploy/endpoints/com.agentbom.fleet-sync.plist](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/endpoints/com.agentbom.fleet-sync.plist)
+- [agent-bom-fleet-sync.sh](https://github.com/msaad00/agent-bom/blob/main/deploy/endpoints/agent-bom-fleet-sync.sh)
+- [agent-bom-fleet-sync.service](https://github.com/msaad00/agent-bom/blob/main/deploy/endpoints/agent-bom-fleet-sync.service)
+- [agent-bom-fleet-sync.timer](https://github.com/msaad00/agent-bom/blob/main/deploy/endpoints/agent-bom-fleet-sync.timer)
+- [com.agentbom.fleet-sync.plist](https://github.com/msaad00/agent-bom/blob/main/deploy/endpoints/com.agentbom.fleet-sync.plist)
 
 The wrapper script expects:
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -128,7 +128,7 @@ alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 ```
 
 If a database was already initialized from
-[deploy/supabase/postgres/init.sql](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/supabase/postgres/init.sql),
+[deploy/supabase/postgres/init.sql](https://github.com/msaad00/agent-bom/blob/main/deploy/supabase/postgres/init.sql),
 stamp it once before future changes:
 
 ```bash

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -1,90 +1,129 @@
 # Deployment Overview
 
-`agent-bom` is intentionally deployable in multiple ways. The product contract is
-interoperable and self-hostable:
+Use this page when the question is not "how do I install agent-bom?" but
+"what should I actually deploy in my environment?"
 
-- run it locally as a CLI
-- run it in CI
-- run it in Docker or Kubernetes
-- expose it as an MCP server
-- self-host the API + dashboard
-- pair the control plane with Postgres / Supabase, ClickHouse, or Snowflake where
-  parity is explicitly documented
+`agent-bom` is intentionally split into deployable surfaces instead of forcing
+one monolithic control plane:
 
-That gives users real choices instead of locking the product to one control
-plane or one hosting provider.
+- scan jobs for discovery and vulnerability analysis
+- fleet sync for persisted endpoint and collector inventory
+- proxy/runtime enforcement for selected live MCP traffic
+- gateway policy management in the control plane
+- API + UI for central review, audit, remediation, and graph visibility
+- MCP server mode when you want `agent-bom` itself exposed as tools
 
-## Runtime Surfaces
+## Best Self-Hosted Path
 
-| Surface | Best for | Command / entrypoint |
-|---|---|---|
-| **CLI** | local scans, endpoint runs, CI jobs | `pip install agent-bom` then `agent-bom agents` |
-| **GitHub Action** | PR and release gates | `uses: msaad00/agent-bom@v0.77.1` |
-| **Docker** | isolated scans and reproducible runners | `docker run ghcr.io/msaad00/agent-bom agents` |
-| **API + dashboard** | team and enterprise self-hosting | `agent-bom serve` |
-| **REST API only** | platform integration without bundled UI | `agent-bom api` |
-| **MCP server** | Claude Desktop, Claude Code, Codex, Cursor, Windsurf, Smithery-style remote use | `agent-bom mcp server` |
-| **Runtime proxy** | live MCP traffic inspection and policy enforcement | `agent-bom proxy` |
-| **Shield SDK** | in-process protection inside an app or service | `from agent_bom.shield import Shield` |
+If you want the best current self-hosted rollout in your own infrastructure,
+start with this shape:
 
-## Hosting and Storage Choices
+1. Deploy the packaged API + UI control plane with Postgres.
+2. Add scheduled scan jobs for cluster, container, and MCP discovery.
+3. Add endpoint fleet sync for developer laptops and workstations.
+4. Add `agent-bom proxy` only to the MCP workloads that need inline runtime
+   enforcement.
+5. Use the gateway surface to manage policy centrally, then let proxies pull
+   those policies and push audit events back.
 
-| Choice | What it means today | Best for |
-|---|---|---|
-| **Local laptop / workstation** | local CLI or `agent-bom serve` with SQLite | individuals, demos, endpoint audit |
-| **Self-hosted VM / container** | `agent-bom api` or `agent-bom serve` behind your ingress/auth | teams and platform operators |
-| **Docker Compose / container platforms** | containerized API, proxy, or MCP server | repeatable deployment without vendor lock-in |
-| **Kubernetes / Helm** | cluster deployment for scanner, proxy, optional runtime monitor, and packaged API + UI control plane | larger team and enterprise rollout |
-| **Postgres / Supabase** | primary transactional control plane | full API/UI and tenant-aware persistence |
-| **ClickHouse** | analytics and event-scale persistence | trends, runtime event analytics, OLAP |
-| **Snowflake** | warehouse-native governance and selected control-plane paths | governance/activity workflows and Snowflake-native operators |
+That gives you one operator story without pretending every workload needs the
+same runtime path.
 
-## Important Boundary
+```mermaid
+flowchart LR
+    subgraph Sources["What you deploy around agent-bom"]
+      CI["CI / one-off scans"]
+      Endpoints["Developer laptops and workstations"]
+      Cluster["EKS workloads and MCP services"]
+      Proxies["Selected proxy sidecars"]
+    end
 
-`Snowflake` is a supported backend and governance surface, not the default full
-application hosting contract.
+    subgraph ControlPlane["agent-bom in your infra"]
+      API["API + UI"]
+      Fleet["Fleet inventory"]
+      Gateway["Gateway policies"]
+      Findings["Findings / graph / remediation"]
+      PG["Postgres"]
+      CH["ClickHouse optional"]
+    end
 
-Today the honest story is:
+    CI -->|scan output| API
+    Endpoints -->|/v1/fleet/sync| Fleet
+    Cluster -->|scheduled discovery + scans| Findings
+    Proxies -->|policy pull + audit push| Gateway
+    API --> PG
+    API --> CH
+    Fleet --> API
+    Gateway --> API
+    Findings --> API
+```
 
-- `Postgres` / `Supabase`: primary control-plane backend
-- `ClickHouse`: analytics add-on
-- `Snowflake`: warehouse/governance/native-data option with explicit parity limits
+## Which Service Does What
 
-For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).
+| Surface | Deploy it when | What it owns | What it is not |
+|---|---|---|---|
+| **Scan** | you need discovery, CVE analysis, Kubernetes inventory, CI gates, or scheduled audits | package, container, IaC, MCP, cloud, and cluster scanning | a live enforcement layer |
+| **Fleet** | you want laptops, workstations, or other collectors to persist inventory into one control plane | endpoint and collector push into `/v1/fleet/sync`, review in `/fleet` | an always-on endpoint agent or MDM product |
+| **Proxy / runtime** | you need inline MCP inspection or policy enforcement on live tool traffic | `agent-bom proxy`, audit push, selected blocks/warns, local or sidecar enforcement | a generic shared network gateway for every workload |
+| **Gateway** | you want central policy authoring and evaluation | `/gateway`, `/v1/gateway/policies`, policy pull for proxies | a replacement for the proxy itself |
+| **API + UI** | you want one operator control plane | findings, graph, remediation, fleet review, audit, policy management | a hosted vendor control plane |
+| **MCP server** | you want `agent-bom` exposed as tools to assistants or remote clients | `agent-bom mcp server` tool surface | the same thing as the runtime proxy |
 
-## Deployment Selection
+## Recommended Deployment Choices
 
 | Need | Recommended path |
 |---|---|
 | Run one scan locally | CLI |
-| Sync employee laptops into the same control plane | endpoint fleet `agent-bom agents --push-url .../v1/fleet/sync` |
-| Gate pull requests | GitHub Action |
-| Keep the runtime isolated | Docker |
-| Self-host UI + API for a team | `agent-bom serve` + `Postgres` / `Supabase` |
-| Run a focused MCP / agents / fleet pilot on EKS | Helm control plane + scanner CronJob + selected proxy sidecars |
-| Run a production-shaped self-hosted control plane on EKS | Helm control plane + production values example + Postgres + external-secrets |
-| Integrate with internal platforms | `agent-bom api` |
-| Expose agent-bom as a tool server | `agent-bom mcp server` |
-| Add runtime enforcement | `agent-bom proxy` |
-| Add analytics at scale | `ClickHouse` alongside the control plane |
-| Use warehouse-native governance data | `Snowflake` with explicit parity limits |
+| Gate pull requests and releases | GitHub Action |
+| Keep runtime isolated for a single job | Docker |
+| Self-host the operator plane for a team | API + UI + Postgres |
+| Deploy in your own AWS / EKS | Helm control plane + scheduled scan jobs + selected proxy sidecars |
+| Bring developer endpoints into the same plane | Fleet sync |
+| Add live MCP enforcement | Proxy + gateway policy pull |
+| Expose agent-bom as a tool server | MCP server |
+| Add event-scale analytics | ClickHouse alongside the control plane |
+| Use warehouse-native governance workflows | Snowflake with explicit backend parity limits |
 
-## Canonical Pilot
+## What Operators See After Deploy
 
-If you want the deployment shape we actively defend with enterprise pilot
-buyers, use the consolidated guide:
+The deployment story should end in usable operator surfaces, not just pods and
+YAML.
 
-- [Enterprise MCP / Endpoint Fleet Pilot](enterprise-pilot.md)
+**Risk overview**
+
+![agent-bom dashboard](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png)
+
+**Fleet and graph visibility**
+
+![agent-bom agent mesh](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png)
+
+**Remediation workflow**
+
+![agent-bom remediation view](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png)
+
+## Start Here
+
+- [Your Own AWS / EKS](own-infra-eks.md)
+- [Enterprise MCP / Endpoint Pilot](enterprise-pilot.md)
 - [Endpoint Fleet](endpoint-fleet.md)
 - [Focused EKS MCP Pilot](eks-mcp-pilot.md)
 - [Packaged API + UI Control Plane](control-plane-helm.md)
 - [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
+- [Backend Parity](backend-parity.md)
 
-## Available on
+## Hosting and Storage Boundaries
 
-- [PyPI](https://pypi.org/project/agent-bom/)
-- [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom)
-- [GHCR](https://github.com/msaad00/agent-bom/pkgs/container/agent-bom)
-- [GitHub Marketplace](https://github.com/marketplace/actions/agent-bom-ai-supply-chain-security-scan)
-- [Smithery](https://smithery.ai/server/agent-bom/agent-bom)
-- [Glama](https://glama.ai)
+`agent-bom` is deployable in multiple honest ways:
+
+- **Local laptop / workstation**: CLI or `agent-bom serve` with SQLite
+- **Self-hosted VM / container**: `agent-bom api` or `agent-bom serve` behind
+  your ingress and auth
+- **Docker Compose / container platforms**: packaged API, proxy, or MCP server
+- **Kubernetes / Helm**: control plane, scanner, optional runtime monitor, and
+  operator surfaces
+- **Postgres / Supabase**: primary transactional backend
+- **ClickHouse**: analytics add-on
+- **Snowflake**: warehouse-native governance surface with explicit parity
+  limits, not the default full hosting contract
+
+For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -1,112 +1,157 @@
 # Deploy In Your Own AWS / EKS Infrastructure
 
 This is the self-hosted path for teams that want `agent-bom` inside their own
-AWS account, VPC, EKS cluster, and databases.
+AWS account, VPC, EKS cluster, IAM boundary, and databases.
 
-If you want the narrower pilot shape for MCP discovery, fleet, mesh, gateway
-policy, and selected runtime enforcement, start with
-[Focused EKS MCP Pilot](eks-mcp-pilot.md).
+Use this path when you want one operator-controlled system for:
 
-It is a good fit when you want:
+- scheduled scans and discovery
+- endpoint fleet inventory
+- selected live MCP proxy enforcement
+- central gateway policy management
+- API, UI, findings, graph, and remediation in your own infra
 
-- your API, audit logs, and findings in your own infrastructure
-- inline MCP policy enforcement in your own runtime path
-- Kubernetes and cloud discovery under your own IAM and network controls
-- no dependency on a vendor-hosted control plane
+If you want the narrower pilot shape first, start with
+[Focused EKS MCP Pilot](eks-mcp-pilot.md). If you want the broader rollout that
+also covers developer endpoints, pair this page with
+[Endpoint Fleet](endpoint-fleet.md).
 
-## What Is Real Today
+## Best-In-Class EKS Shape
 
-`agent-bom` already ships the building blocks for this model:
-
-- control-plane containers:
-  - [`deploy/docker-compose.platform.yml`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/docker-compose.platform.yml)
-- runtime proxy sidecar:
-  - [`deploy/docker-compose.runtime.yml`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/docker-compose.runtime.yml)
-  - [`deploy/k8s/sidecar-example.yaml`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/k8s/sidecar-example.yaml)
-- Helm chart for scanner, runtime-monitoring, and packaged API/UI control-plane surfaces:
-  - [`deploy/helm/agent-bom`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom)
-- Postgres-backed control-plane path:
-  - [`deploy/supabase/postgres/init.sql`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/supabase/postgres/init.sql)
-- ClickHouse analytics path:
-  - [`deploy/supabase/clickhouse/init.sql`](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/supabase/clickhouse/init.sql)
-
-Important boundary:
-
-- the Helm chart now packages the API + UI control plane
-- Postgres, ClickHouse, secrets, ingress-controller specifics, and autoscaling
-  policy are still operator-owned
-- this is now a real self-host packaging path, not just a container-and-docs story
-
-## Reference Shape
+The best current EKS rollout is not "put everything behind one service." It is
+a split between a control plane and the discovery/enforcement paths around it.
 
 ```mermaid
 flowchart LR
-    A[MCP clients in your VPC] --> B[agent-bom proxy]
-    B --> C[MCP servers]
-    D[Scheduled scans and discovery] --> E[agent-bom API and UI]
-    E --> F[(Postgres)]
-    E --> G[(ClickHouse optional)]
-    H[Okta or other OIDC or SAML IdP] --> E
+    subgraph Workloads["Your workloads"]
+      Endpoints["Developer endpoints"]
+      Cron["Scanner CronJob"]
+      MCP["Selected MCP workloads"]
+      Sidecars["agent-bom proxy sidecars"]
+    end
+
+    subgraph ControlPlane["agent-bom control plane"]
+      API["API + UI"]
+      Fleet["Fleet"]
+      Gateway["Gateway policies"]
+      Findings["Findings / graph / remediation"]
+    end
+
+    subgraph Data["Operator-owned data plane"]
+      PG["Postgres"]
+      CH["ClickHouse optional"]
+      Secrets["Secrets / IRSA / ingress / OIDC"]
+    end
+
+    Endpoints -->|fleet sync| Fleet
+    Cron -->|scheduled scans| Findings
+    MCP --> Sidecars
+    Sidecars -->|policy pull + audit push| Gateway
+    API --> PG
+    API --> CH
+    API --> Secrets
+    Fleet --> API
+    Gateway --> API
+    Findings --> API
 ```
 
-## What Stays In Your Infra
+## Which Agent-BOM Surface Runs Where
 
-For this deployment model, these surfaces stay inside your environment unless
-you explicitly wire external destinations:
+| Surface | Where it runs | Why you deploy it |
+|---|---|---|
+| **API + UI** | in-cluster or on self-hosted compute behind your ingress | one operator plane for findings, graph, fleet, audit, gateway, and remediation |
+| **Scan** | CronJob, CI runner, or one-off job | Kubernetes, container, package, MCP, cloud, and inventory scanning |
+| **Fleet** | pushed into the control plane from endpoints or collectors | persisted workstation and collector inventory in `/fleet` |
+| **Proxy / runtime** | only next to the MCP workloads you want inline enforcement on | live JSON-RPC inspection, allow/warn/deny, audit push |
+| **Gateway** | central control plane API + UI | store and manage policies that proxies evaluate and pull |
+| **MCP server** | wherever you expose `agent-bom` itself as a tool server | assistant-facing tool access, separate from the proxy path |
+
+The important boundary is that `agent-bom proxy` is the inline runtime path,
+while the gateway is the central policy surface. One does not replace the
+other.
+
+## What Stays In Your Infrastructure
+
+For this model, the sensitive operator surfaces stay inside your environment
+unless you explicitly wire external destinations:
 
 - API and dashboard traffic
+- fleet inventory
 - proxy audit logs
-- Postgres and ClickHouse persistence
-- Kubernetes discovery through your service account / IRSA role
+- Postgres and optional ClickHouse
+- Kubernetes discovery through your service account and IRSA role
 - cloud discovery through your own IAM credentials
+- OIDC, API-key, audit-HMAC, and ingress policy
 
 Potential egress still depends on operator choice:
 
-- vulnerability and threat-intel refresh
+- vulnerability database refresh
 - enrichment lookups
-- explicit exports such as SARIF upload, webhooks, or OTLP
+- explicit exports such as SARIF upload, OTLP, SIEM, or webhooks
 
-If you need a tighter posture, run with local databases, explicit outbound
-policy, and only the integrations you intend to allow.
+## What You Actually Deploy
 
-## Recommended EKS Topology
+These are the maintained building blocks for this model:
 
-Use two layers:
+- control plane:
+  [deploy/helm/agent-bom](https://github.com/msaad00/agent-bom/tree/main/deploy/helm/agent-bom)
+- Compose references:
+  [deploy/docker-compose.platform.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.platform.yml)
+  and
+  [deploy/docker-compose.runtime.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.runtime.yml)
+- sidecar examples:
+  [deploy/k8s/sidecar-example.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/k8s/sidecar-example.yaml)
+  and
+  [deploy/k8s/proxy-sidecar-pilot.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/k8s/proxy-sidecar-pilot.yaml)
+- Postgres bootstrap:
+  [deploy/supabase/postgres/init.sql](https://github.com/msaad00/agent-bom/blob/main/deploy/supabase/postgres/init.sql)
+- ClickHouse bootstrap:
+  [deploy/supabase/clickhouse/init.sql](https://github.com/msaad00/agent-bom/blob/main/deploy/supabase/clickhouse/init.sql)
+- production values example:
+  [eks-production-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+- focused pilot values example:
+  [eks-mcp-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
 
-1. control plane
-- enable `controlPlane.enabled=true` in Helm
-- back the API with `Postgres`
-- add `ClickHouse` only if you want event-scale analytics
-- use the packaged same-origin ingress unless you have a reason to split hosts
+## Recommended Topology
 
-2. dataplane and discovery
-- run `agent-bom proxy` beside or in front of MCP servers
-- run the scanner CronJob for scheduled discovery and scan jobs
-- use a dedicated Kubernetes service account with IRSA for discovery scope
+Use two layers.
 
-## Helm Chart Knobs That Matter
+### 1. Control plane
 
-The chart now supports the EKS wiring you actually need:
+- enable the packaged API + UI control plane
+- back it with Postgres
+- add ClickHouse only when you want event-scale analytics
+- keep ingress same-origin unless you have a concrete reason to split hosts
+- use OIDC or SAML for user access
+
+### 2. Discovery and enforcement
+
+- run scheduled scan jobs for Kubernetes, MCP, package, and cloud discovery
+- use fleet sync for laptops and workstations
+- run `agent-bom proxy` only beside the MCP workloads that need inline
+  runtime enforcement
+- let proxies pull gateway policy from the control plane and push audit back
+
+That keeps scan, fleet, runtime enforcement, and gateway policy aligned
+without pretending every workload needs the same enforcement model.
+
+## Helm Knobs That Matter
 
 | Value | Why it matters |
 |---|---|
-| `controlPlane.enabled` | package the API + dashboard in-cluster |
-| `controlPlane.ingress.enabled` | route `/` to UI and `/v1`, `/health`, `/docs`, `/ws` to API |
-| `controlPlane.api.envFrom` | load Postgres URL, API key, OIDC issuer/audience, optional required nonce, SAML IdP/SP values, and audit settings from Secrets |
-| `controlPlane.ui.env` | keep `NEXT_PUBLIC_API_URL=\"\"` for same-origin or set a full API URL for cross-origin |
-| `serviceAccount.annotations` | attach an IRSA role to the scanner service account |
-| `controlPlane.api.autoscaling.*` | autoscale the API deployment with HPA |
-| `controlPlane.ui.autoscaling.*` | autoscale the UI deployment with HPA |
-| `topologySpread.*` | spread API and UI replicas across zones and nodes |
-| `controlPlane.externalSecrets.*` | map control-plane env vars from external-secrets |
-| `controlPlane.externalSecrets.secrets[]` | split DB secret cadence from faster OIDC/SAML/audit-HMAC rotation |
-| `controlPlane.observability.prometheusRule.*` | package alert rules for API, scanner, OIDC, and proxy backlog |
-| `controlPlane.observability.grafanaDashboard.*` | package the shipped Grafana dashboard as a `ConfigMap` |
-| `controlPlane.backup.*` | package Postgres backup jobs that dump and upload to S3 through IRSA with SSE or KMS |
-| `scanner.extraArgs` | add `--k8s-mcp`, `--enforce`, `--introspect`, or stricter presets |
-| `scanner.env` | inject operator-owned environment like API endpoints or auth context |
-| `scanner.allNamespaces` | scan cluster-wide instead of one namespace |
-| `rbac.create` | create cluster read access for discovery |
+| `controlPlane.enabled` | packages the API + dashboard in-cluster |
+| `controlPlane.ingress.enabled` | routes `/` to UI and `/v1`, `/health`, `/docs`, `/ws` to API |
+| `controlPlane.api.envFrom` | loads Postgres URL, auth settings, audit HMAC, and other control-plane secrets |
+| `controlPlane.ui.env` | keeps same-origin routing honest with `NEXT_PUBLIC_API_URL=\"\"` or sets an explicit API URL |
+| `serviceAccount.annotations` | attaches IRSA to the scanner service account |
+| `scanner.extraArgs` | enables `--k8s-mcp`, `--introspect`, `--enforce`, and other operator choices |
+| `scanner.allNamespaces` | expands cluster scan scope |
+| `controlPlane.api.autoscaling.*` | autoscales the API deployment |
+| `controlPlane.ui.autoscaling.*` | autoscales the UI deployment |
+| `topologySpread.*` | spreads API and UI pods across zones and nodes |
+| `controlPlane.externalSecrets.*` | maps secrets from your external-secrets provider |
+| `controlPlane.observability.prometheusRule.*` | packages alerts for API, scanner, OIDC, and proxy backlog |
+| `controlPlane.backup.*` | packages the Postgres backup job when you are ready to wire S3 and KMS |
 
 Example:
 
@@ -117,141 +162,77 @@ helm install agent-bom deploy/helm/agent-bom \
   --set controlPlane.ingress.enabled=true \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/agent-bom-discovery \
   --set scanner.allNamespaces=true \
-  --set-json 'scanner.extraArgs=["--k8s-mcp","--k8s-all-namespaces","--enforce","--introspect","--preset","enterprise"]'
+  --set-json 'scanner.extraArgs=["--k8s-mcp","--k8s-all-namespaces","--introspect","--enforce","--preset","enterprise"]'
 ```
 
 That gives you:
 
-- Kubernetes image discovery
-- Kubernetes MCP server discovery
-- runtime surface introspection
-- enforcement checks in the scheduled scan path
+- packaged API + UI
+- cluster-wide discovery
+- MCP-oriented scheduled scans
+- a clean bridge to selected proxy sidecars and gateway policy
 
-## Optional Mesh And Policy Hardening
+## Runtime, Proxy, Gateway, Scan, and Fleet Together
 
-If your platform baseline already uses Istio and Kyverno, the chart now ships
-an opt-in hardening layer that stays aligned with the current security model
-instead of inventing a second one.
+This is the most common source of confusion in self-hosted rollouts:
 
-Start from:
+- **Scan** finds and analyzes what is deployed.
+- **Fleet** persists endpoint and collector inventory into the control plane.
+- **Proxy / runtime** inspects and enforces live MCP traffic for selected
+  workloads.
+- **Gateway** stores and serves the policies that proxies use.
+- **API + UI** is where operators review all of the above together.
 
-- [deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml)
+The rollout order should normally be:
 
-That package adds:
-
-- Istio `PeerAuthentication` with `STRICT` mTLS for `agent-bom` pods
-- Istio `AuthorizationPolicy` with explicit namespace allow-lists for ingress paths
-- a namespaced Kyverno `Policy` that enforces:
-  - `automountServiceAccountToken: false`
-  - `runAsNonRoot`
-  - `seccompProfile: RuntimeDefault`
-  - `allowPrivilegeEscalation: false`
-  - `readOnlyRootFilesystem: true`
-  - `capabilities.drop: [ALL]`
-
-Use it only when:
-
-- the namespace is already part of your Istio mesh
-- ingress traffic really comes from the namespaces you allow
-- Kyverno is already installed cluster-wide
-
-It is additive to the chart's `NetworkPolicy`, not a replacement for it.
-
-## Policy Enforcement In This Model
-
-`agent-bom` policy enforcement is three separate layers:
-
-1. stored policy model
-- policies live in the control plane and are managed through the gateway API
-
-2. inline proxy enforcement
-- each MCP call is evaluated before relay
-- allow, warn, or deny happens on the wire
-
-3. scan-time enforcement
-- introspection, description drift, undeclared tool drift, dangerous capability
-  combinations, and CVE-aware checks run during scheduled scans
-
-That means the same self-hosted deployment can:
-
-- block risky live MCP calls
-- discover unknown or unverified servers
-- persist findings for later review
-
-## Discovery In This Model
-
-For EKS, the relevant discovery surfaces are:
-
-- Kubernetes image discovery via `--k8s`
-- Kubernetes MCP discovery via `--k8s-mcp`
-- config and registry matching
-- optional cloud and Snowflake discovery through your own credentials
-
-That combination is what makes the EKS deployment useful for platform teams:
-
-- inventory
-- policy enforcement
-- scanning
-- graph correlation
-
-all sit under one operator-controlled plane.
+1. control plane
+2. scheduled scan jobs
+3. fleet sync
+4. selected proxy sidecars
+5. stricter gateway-backed enforcement
 
 ## Recommended Production Defaults
 
-- use `Postgres`, not SQLite, for the control plane
-- use Alembic as the migration path for long-lived Postgres control planes
-- start from the production values example when you want HPA, cert-manager,
-  topology spread, and external-secrets wiring:
-  - [deploy/helm/agent-bom/examples/eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+- use Postgres, not SQLite, for the control plane
+- use Alembic for long-lived Postgres-backed deployments
 - keep the proxy and API internal to your VPC unless exposure is intentional
-- use OIDC or SAML for user access, set `AGENT_BOM_OIDC_AUDIENCE` explicitly when using OIDC, and map roles explicitly
-- enforce API key rotation with:
-  - `AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS`
-  - `AGENT_BOM_API_KEY_MAX_TTL_SECONDS`
-  and rotate admin keys through `POST /v1/auth/keys/{key_id}/rotate`
-- split external secrets by cadence in production:
-  - `AGENT_BOM_POSTGRES_URL` at `1h`
-  - `AGENT_BOM_OIDC_*`, `AGENT_BOM_SAML_*`, and `AGENT_BOM_AUDIT_HMAC_KEY` at `5m`
-- size the Postgres-backed control plane explicitly:
-  - `AGENT_BOM_POSTGRES_POOL_MIN_SIZE`
-  - `AGENT_BOM_POSTGRES_POOL_MAX_SIZE`
-  - `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS`
-  - `AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS`
-- when enabling the mesh layer, keep the namespace allow-list explicit:
-  - `controlPlane.serviceMesh.istio.authorizationPolicy.allowedNamespaces`
-  and match it to your actual ingress path instead of assuming `ingress-nginx`
-- enable the packaged PrometheusRule and Grafana dashboard when your cluster
-  already runs Prometheus Operator and Grafana sidecar discovery
-- enable the packaged backup CronJob only after setting a real S3 destination
-- set `controlPlane.backup.destination.bucketRegion` to your real bucket region; the production example intentionally leaves a `REPLACE_ME_BUCKET_REGION` placeholder
-- `controlPlane.backup.destination.region` remains as a backward-compatible fallback for older values files
-- set `controlPlane.backup.destination.encryption.mode=aws:kms` and a real KMS key for production backups
-- run restore drills with [`deploy/ops/restore-postgres-backup.sh`](../../deploy/ops/restore-postgres-backup.sh) and document RTO/RPO around that exact command path
-- publish `GET /v1/auth/saml/metadata` to your IdP admins if you choose SAML, and keep `POST /v1/auth/saml/login` on the same internal ingress as the API
-  and granting `s3:PutObject` via IRSA
-- set a persistent audit HMAC key and require it
-- attach the scanner service account to IRSA instead of static cloud keys
-- start with audit-only policies where rollout risk is unclear, then move to deny
+- attach discovery jobs to IRSA instead of static cloud keys
+- set a persistent `AGENT_BOM_AUDIT_HMAC_KEY` and require it for proxy audit
+  sign-off
+- split external secrets by rotation cadence
+- enable the packaged PrometheusRule and Grafana dashboard only when your
+  cluster already runs Prometheus Operator and Grafana sidecar discovery
+- wire backup destinations explicitly before enabling the packaged backup CronJob
+- use topology spread for multi-AZ EKS
+- start with audit-only policy outcomes where rollout risk is unclear, then
+  move to deny
 
-## What Still Needs Your Own Manifests
+Run database migrations explicitly:
 
-This path is self-hostable today, but not every enterprise primitive is encoded
- in the Helm chart yet.
+```bash
+alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+```
+
+If the database was previously bootstrapped from `init.sql`, stamp the baseline
+once before future upgrades:
+
+```bash
+alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
+```
+
+## What You Still Own
+
+This is a real self-hosted packaging path, but not every enterprise primitive
+is abstracted into the chart.
 
 You still own:
 
 - Postgres, optional ClickHouse, and secret storage
-- HPA, topology, and failover settings for your own workloads
-- Secrets Manager / IRSA / ingress-controller wiring
-- operator runbooks and load testing
+- ingress controller, cert-manager, and network perimeter specifics
+- HPA, failover, and operator runbooks
+- platform-specific logging and SIEM wiring
+- workload-by-workload decisions about where proxy sidecars belong
 
-For the UI specifically, the container now reads `NEXT_PUBLIC_API_URL` at
-startup. That means:
-
-- set a full internal or external API URL when you want cross-origin calls
-- set `NEXT_PUBLIC_API_URL=` for same-origin ingress and route `/v1/*`,
-  `/health`, and `/ws/*` to the API service in your ingress/controller
-
-That is now a stronger no-lock-in story. The repo packages the control plane,
-proxy surface, and scanner/discovery knobs without forcing you into a hosted
-vendor plane.
+For the narrower rollout, see [Focused EKS MCP Pilot](eks-mcp-pilot.md). For
+the packaged control plane details, see
+[Packaged API + UI Control Plane](control-plane-helm.md).

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -59,7 +59,7 @@ backend and Helm values before running your own load tests.
 
 Start from the packaged production example:
 
-- [eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+- [eks-production-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-production-values.yaml)
 
 That example already enables:
 
@@ -71,7 +71,7 @@ That example already enables:
 
 ### API
 
-Current chart defaults in [values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/values.yaml):
+Current chart defaults in [values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/values.yaml):
 
 - replicas: `2`
 - requests: `100m` CPU / `256Mi` memory
@@ -178,7 +178,7 @@ These are enforced on:
 The packaged production example already shows how to inject these through
  `controlPlane.api.env` in:
 
-- [eks-production-values.yaml](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/helm/agent-bom/examples/eks-production-values.yaml)
+- [eks-production-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-production-values.yaml)
 
 Recommended starting posture:
 
@@ -191,9 +191,9 @@ Recommended starting posture:
 
 The repo now ships a small benchmark harness under:
 
-- [deploy/loadtest/README.md](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/loadtest/README.md)
-- [k6-control-plane-api.js](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/loadtest/k6-control-plane-api.js)
-- [k6-proxy-audit.js](/Users/mohamedsaad/Desktop/Agent-Bom/deploy/loadtest/k6-proxy-audit.js)
+- [deploy/loadtest/README.md](https://github.com/msaad00/agent-bom/blob/main/deploy/loadtest/README.md)
+- [k6-control-plane-api.js](https://github.com/msaad00/agent-bom/blob/main/deploy/loadtest/k6-control-plane-api.js)
+- [k6-proxy-audit.js](https://github.com/msaad00/agent-bom/blob/main/deploy/loadtest/k6-proxy-audit.js)
 
 Use that harness to validate:
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -44,13 +44,24 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | **SBOM** | CycloneDX 1.6, SPDX 3.0 output |
 | **Cloud** | AWS, Snowflake, Azure, GCP CIS benchmarks |
 
-## Deployment options
+## Deploy In Your Infra
 
-| Mode | Command |
+`agent-bom` is not limited to one hosting model. The clean self-hosted story is:
+
+- **control plane**: API + UI + Postgres
+- **scan**: CI jobs, scheduled CronJobs, or one-off discovery runs
+- **fleet**: endpoint and collector inventory pushed into one control plane
+- **runtime**: selected `agent-bom proxy` sidecars or local proxy wrappers
+- **gateway**: central policy management for those proxy paths
+
+| Need | Recommended path |
 |---|---|
-| CLI | `pip install agent-bom` |
-| MCP server | `agent-bom mcp server` |
-| Docker | `docker run ghcr.io/msaad00/agent-bom agents` |
-| GitHub Action | `uses: msaad00/agent-bom@v0.77.1` |
-| Kubernetes | Helm chart + CronJob + DaemonSet |
-| Remote SSE | Self-host or use hosted endpoint |
+| local scan or CI gate | CLI or GitHub Action |
+| self-hosted operator plane | API + UI + Postgres |
+| your own AWS / EKS rollout | Helm control plane + scheduled scan jobs + selected proxy sidecars |
+| developer workstation inventory | fleet sync |
+| live MCP enforcement | proxy + gateway |
+| assistant-facing tool server | `agent-bom mcp server` |
+
+[Deployment Overview](deployment/overview.md){ .md-button .md-button--primary }
+[Your Own AWS / EKS](deployment/own-infra-eks.md){ .md-button }


### PR DESCRIPTION
## Summary
- rewrite the deployment overview around concrete self-hosted surfaces: scan, fleet, proxy/runtime, gateway, API/UI, and MCP server
- rewrite the AWS/EKS guide into a clearer control-plane plus discovery/enforcement blueprint
- surface the self-hosted deployment path on the docs home page
- remove absolute local filesystem links from the touched deployment docs and normalize them to GitHub links

## Verification
- searched touched deployment docs for stale /Users/... absolute paths

## Notes
- local mkdocs build could not be completed in this environment because the installed MkDocs stack is incompatible with Material here and mkdocstrings is missing