### PR TITLE
fix: speed up demo scan path and polish check output

### DIFF
--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -15,4 +15,4 @@ Set PlaybackSpeed 1.35
 # Hero flow — render_demo.sh handles TERM=xterm-256color for Rich colors
 Type "bash scripts/render_demo.sh"
 Enter
-Sleep 18s
+Sleep 9s

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -171,6 +171,10 @@ def _check_result_payload(
     }
 
 
+def _format_vulnerability_count(count: int) -> str:
+    return f"{count} vulnerability found" if count == 1 else f"{count} vulnerabilities found"
+
+
 def _resolve_check_ecosystems(name: str, version: str, ecosystem: Optional[str], detected_eco: str) -> list[str]:
     """Return the ecosystems that `check` should scan."""
     if ecosystem:
@@ -514,7 +518,8 @@ def check(
 
         from agent_bom.cwe_impact import classify_cwe_impact
 
-        table = Table(title=f"{name}@{version} — {len(vulns)} vulnerability/ies found")
+        vuln_count_text = _format_vulnerability_count(len(vulns))
+        table = Table(title=f"{name}@{version} — {vuln_count_text}")
         table.add_column("Sev", width=10, no_wrap=True)
         table.add_column("ID", width=20, no_wrap=True)
         table.add_column("Impact", width=14, no_wrap=True)
@@ -572,7 +577,7 @@ def check(
                     version=version,
                     ecosystems=ecosystems,
                     verdict="unsafe",
-                    message=f"{len(vulns)} vulnerability/ies found in {name}@{version}; reported without failing due to --exit-zero.",
+                    message=f"{_format_vulnerability_count(len(vulns))} in {name}@{version}; reported without failing due to --exit-zero.",
                     exit_code=0,
                     vulnerabilities=vulns,
                     warnings=scan_warnings,
@@ -582,9 +587,11 @@ def check(
             )
             sys.exit(0)
         if quiet:
-            click.echo(f"{name}@{version}: {len(vulns)} vulnerability/ies found (exit-zero)")
+            click.echo(f"{name}@{version}: {_format_vulnerability_count(len(vulns))} (exit-zero)")
         else:
-            console.print(f"  [yellow]⚠ {len(vulns)} vulnerability/ies found — reported without failing due to --exit-zero.[/yellow]\n")
+            console.print(
+                f"  [yellow]⚠ {_format_vulnerability_count(len(vulns))} — reported without failing due to --exit-zero.[/yellow]\n"
+            )
         sys.exit(0)
 
     if structured_output:
@@ -594,7 +601,7 @@ def check(
                 version=version,
                 ecosystems=ecosystems,
                 verdict="unsafe",
-                message=f"{len(vulns)} vulnerability/ies found in {name}@{version}.",
+                message=f"{_format_vulnerability_count(len(vulns))} in {name}@{version}.",
                 exit_code=1,
                 vulnerabilities=vulns,
                 warnings=scan_warnings,
@@ -604,9 +611,9 @@ def check(
         sys.exit(1)
 
     if quiet:
-        click.echo(f"{name}@{version}: {len(vulns)} vulnerability/ies found")
+        click.echo(f"{name}@{version}: {_format_vulnerability_count(len(vulns))}")
     else:
-        console.print(f"  [red]✗ {len(vulns)} vulnerability/ies found — do not install without review.[/red]\n")
+        console.print(f"  [red]✗ {_format_vulnerability_count(len(vulns))} — do not install without review.[/red]\n")
     sys.exit(1)
 
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -522,10 +522,13 @@ def _scan_packages_local_db(packages: list[Package]) -> tuple[int, set[str]]:
         from agent_bom.db.schema import init_db, open_existing_db_readonly
 
         try:
-            conn = init_db(DB_PATH)
+            # Scans only need read access. Prefer the existing DB in read-only
+            # mode so the hot path avoids init-time integrity work and extra
+            # writable-open overhead on large catalogs.
+            conn = open_existing_db_readonly(DB_PATH) if DB_PATH.exists() else init_db(DB_PATH)
         except Exception as exc:
-            _logger.debug("Writable local DB open failed, retrying read-only: %s", exc)
-            conn = open_existing_db_readonly(DB_PATH)
+            _logger.debug("Primary local DB open failed, retrying writable init: %s", exc)
+            conn = init_db(DB_PATH)
     except Exception as exc:
         _logger.warning("Local DB unavailable: %s", exc)
         record_scan_warning("local vulnerability DB unavailable")

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -163,7 +163,32 @@ def test_check_quiet_suppresses_scan_chatter(monkeypatch):
     assert result.exit_code == 1
     assert "scanner noise" not in result.output
     assert "Checking flask@2.2.0" not in result.output
-    assert "1 vulnerability/ies found" in result.output
+    assert "1 vulnerability found" in result.output
+
+
+def test_check_pluralizes_vulnerability_count(monkeypatch):
+    _patch_check_scan(
+        monkeypatch,
+        [
+            Vulnerability(
+                id="CVE-2023-30861",
+                summary="Session cookie disclosure",
+                severity=Severity.HIGH,
+                fixed_version="2.3.2",
+            ),
+            Vulnerability(
+                id="CVE-2024-00002",
+                summary="Second issue",
+                severity=Severity.MEDIUM,
+                fixed_version="2.3.3",
+            ),
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["check", "flask@2.2.0", "--ecosystem", "pypi", "--quiet"])
+
+    assert result.exit_code == 1
+    assert "2 vulnerabilities found" in result.output
 
 
 def test_check_json_output_is_machine_readable(monkeypatch):

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -134,6 +134,32 @@ def test_scan_packages_local_db_falls_back_to_readonly_open():
     conn.close.assert_called_once()
 
 
+def test_scan_packages_local_db_prefers_readonly_open_for_existing_db(tmp_path):
+    """Existing DBs should open read-only on the scan hot path."""
+    from agent_bom.scanners import _scan_packages_local_db
+
+    pkg = _make_pkg()
+    db_file = tmp_path / "scan.db"
+    db_file.write_text("placeholder", encoding="utf-8")
+    conn = MagicMock()
+
+    with (
+        patch("agent_bom.db.schema.db_freshness_days", return_value=1),
+        patch("agent_bom.db.schema.DB_PATH", db_file),
+        patch("agent_bom.db.schema.open_existing_db_readonly", return_value=conn) as mock_open_ro,
+        patch("agent_bom.db.schema.init_db") as mock_init_db,
+        patch("agent_bom.db.lookup.package_in_db", return_value=False),
+        patch("agent_bom.db.lookup_package", return_value=[]),
+    ):
+        count, covered = _scan_packages_local_db([pkg])
+
+    assert count == 0
+    assert covered == set()
+    mock_open_ro.assert_called_once_with(db_file)
+    mock_init_db.assert_not_called()
+    conn.close.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # _scan_packages_local_db — DB has findings
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- open the local vulnerability DB read-only on the scan hot path when it already exists
- tighten the demo tape sleep to match the faster render path
- replace the awkward vulnerability wording in agent-bom check

## Verification
- python -m pytest tests/test_local_db_scan.py tests/test_cli_check.py -q
- manual timing of bash scripts/render_demo.sh after the scanner change (~6.1s locally)

## Notes
- split from the deployment/docs refresh work to keep PR scope tight