### PR TITLE
fix: restore inventory schema validation path

### DIFF
--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -76,6 +76,35 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
     print_agent_tree(report)
 
 
+def _inventory_schema_path() -> Path | None:
+    """Return the inventory schema path from the repo or installed package."""
+    candidate_paths = [
+        Path(__file__).parent.parent.parent / "config" / "schemas" / "inventory.schema.json",
+        Path(__file__).parent.parent.parent / "schemas" / "inventory.schema.json",
+    ]
+
+    for candidate in candidate_paths:
+        if candidate.exists():
+            return candidate
+
+    try:
+        import importlib.resources
+
+        package_root = Path(str(importlib.resources.files("agent_bom")))
+    except Exception:
+        return None
+
+    fallback_paths = [
+        package_root / ".." / ".." / "config" / "schemas" / "inventory.schema.json",
+        package_root / ".." / ".." / "schemas" / "inventory.schema.json",
+    ]
+    for candidate in fallback_paths:
+        resolved = candidate.resolve()
+        if resolved.exists():
+            return resolved
+    return None
+
+
 @click.command()
 @click.argument("inventory_file", type=click.Path(exists=True))
 def validate(inventory_file: str):
@@ -94,17 +123,7 @@ def validate(inventory_file: str):
         console.print("[red]jsonschema not installed. Run: pip install jsonschema[/red]")
         sys.exit(1)
 
-    _initial_schema = Path(__file__).parent.parent.parent / "schemas" / "inventory.schema.json"
-    schema_path: Path | None = _initial_schema
-    if not _initial_schema.exists():
-        # Fallback: look relative to installed package
-        import importlib.resources
-
-        try:
-            schema_path = Path(str(importlib.resources.files("agent_bom"))) / ".." / ".." / "schemas" / "inventory.schema.json"
-        except Exception:
-            schema_path = None
-
+    schema_path = _inventory_schema_path()
     if not schema_path or not schema_path.exists():
         console.print("[red]Schema file not found. Run from the agent-bom repo root.[/red]")
         sys.exit(1)

--- a/tests/test_cli_inventory.py
+++ b/tests/test_cli_inventory.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
-from agent_bom.cli._inventory import completions_cmd, inventory, validate, where
+from agent_bom.cli._inventory import _inventory_schema_path, completions_cmd, inventory, validate, where
 
 # ---------------------------------------------------------------------------
 # inventory
@@ -90,19 +88,21 @@ def test_inventory_security_blocked():
 
 def test_validate_valid_file(tmp_path):
     runner = CliRunner()
-    # Create a minimal valid inventory
-    data = {"agents": [], "generated_at": "2025-01-01T00:00:00Z", "version": "0.1"}
+    data = {
+        "schema_version": "1",
+        "generated_at": "2025-01-01T00:00:00Z",
+        "agents": [{"name": "demo-agent", "agent_type": "custom", "mcp_servers": []}],
+    }
     inv_file = tmp_path / "inv.json"
     inv_file.write_text(json.dumps(data))
 
-    # Need the schema file to exist
-    schema_path = Path(__file__).parent.parent / "schemas" / "inventory.schema.json"
-    if not schema_path.exists():
-        pytest.skip("Schema file not found")
+    schema_path = _inventory_schema_path()
+    assert schema_path is not None
+    assert schema_path.exists()
 
     result = runner.invoke(validate, [str(inv_file)])
-    # Will succeed if schema allows empty agents, fail otherwise — just test it runs
-    assert result.exit_code in (0, 1)
+    assert result.exit_code == 0
+    assert "Valid" in result.output
 
 
 def test_validate_invalid_json(tmp_path):
@@ -110,13 +110,19 @@ def test_validate_invalid_json(tmp_path):
     inv_file = tmp_path / "bad.json"
     inv_file.write_text("not json {{{")
 
-    # Need the schema file to exist
-    schema_path = Path(__file__).parent.parent / "schemas" / "inventory.schema.json"
-    if not schema_path.exists():
-        pytest.skip("Schema file not found")
+    schema_path = _inventory_schema_path()
+    assert schema_path is not None
+    assert schema_path.exists()
 
     result = runner.invoke(validate, [str(inv_file)])
     assert result.exit_code == 1
+
+
+def test_inventory_schema_path_points_to_repo_schema():
+    schema_path = _inventory_schema_path()
+    assert schema_path is not None
+    assert schema_path.name == "inventory.schema.json"
+    assert "config/schemas" in schema_path.as_posix()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- point inventory validation at the checked-in schema under config/schemas
- keep a fallback for the legacy schemas path so older layouts still resolve
- stop skipping CLI coverage when the schema lookup breaks and assert a real valid inventory passes

## Testing
- python -m pytest tests/test_cli_inventory.py -q