### PR TITLE
fix: enforce end-to-end inventory and graph contracts

### DIFF
--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 # ─── Enums ─────────────────────────────────────────────────────────────────
 
@@ -35,7 +35,7 @@ class ScanRequest(BaseModel):
     inventory: str | None = None
     """Path to agents.json inventory file."""
 
-    images: list[str] = []
+    images: list[str] = Field(default_factory=list)
     """Docker image references to scan (e.g. ['myapp:latest', 'redis:7'])."""
 
     k8s: bool = False
@@ -44,16 +44,16 @@ class ScanRequest(BaseModel):
     k8s_namespace: str | None = None
     """Kubernetes namespace (None = all)."""
 
-    tf_dirs: list[str] = []
+    tf_dirs: list[str] = Field(default_factory=list)
     """Terraform directories to scan."""
 
     gha_path: str | None = None
     """Path to a Git repo to scan GitHub Actions workflows."""
 
-    agent_projects: list[str] = []
+    agent_projects: list[str] = Field(default_factory=list)
     """Python project directories using AI agent frameworks."""
 
-    jupyter_dirs: list[str] = []
+    jupyter_dirs: list[str] = Field(default_factory=list)
     """Directories to scan for Jupyter notebooks (.ipynb) with AI library usage."""
 
     sbom: str | None = None
@@ -62,10 +62,10 @@ class ScanRequest(BaseModel):
     enrich: bool = False
     """Enrich with NVD CVSS, EPSS, and CISA KEV data."""
 
-    connectors: list[str] = []
+    connectors: list[str] = Field(default_factory=list)
     """SaaS connectors to discover from (e.g. ['jira', 'servicenow', 'slack'])."""
 
-    filesystem_paths: list[str] = []
+    filesystem_paths: list[str] = Field(default_factory=list)
     """Filesystem directories or tar archives to scan via Syft."""
 
     format: str = "json"
@@ -77,16 +77,16 @@ class ScanRequest(BaseModel):
     dynamic_max_depth: int = 4
     """Max directory depth for dynamic discovery."""
 
-    scope_agents: list[str] = []
+    scope_agents: list[str] = Field(default_factory=list)
     """Filter discovered agents by name (glob patterns, e.g. ['claude-*', 'cursor'])."""
 
-    scope_servers: list[str] = []
+    scope_servers: list[str] = Field(default_factory=list)
     """Filter discovered MCP servers by name (glob patterns)."""
 
-    exclude_agents: list[str] = []
+    exclude_agents: list[str] = Field(default_factory=list)
     """Exclude agents matching these name patterns."""
 
-    exclude_servers: list[str] = []
+    exclude_servers: list[str] = Field(default_factory=list)
     """Exclude MCP servers matching these name patterns."""
 
     min_severity: str | None = None
@@ -103,11 +103,11 @@ class ScanJob(BaseModel):
     started_at: str | None = None
     completed_at: str | None = None
     request: ScanRequest
-    progress: list[str] = []
+    progress: list[str] = Field(default_factory=list)
     result: dict[str, Any] | None = None
     error: str | None = None
 
-    model_config = {"arbitrary_types_allowed": True}
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 # ─── Meta Models ───────────────────────────────────────────────────────────
@@ -180,10 +180,10 @@ class PolicyCreate(BaseModel):
     name: str
     description: str = ""
     mode: str = "audit"
-    rules: list[dict] = []
-    bound_agents: list[str] = []
-    bound_agent_types: list[str] = []
-    bound_environments: list[str] = []
+    rules: list[dict[str, Any]] = Field(default_factory=list)
+    bound_agents: list[str] = Field(default_factory=list)
+    bound_agent_types: list[str] = Field(default_factory=list)
+    bound_environments: list[str] = Field(default_factory=list)
     enabled: bool = True
 
 
@@ -191,7 +191,7 @@ class PolicyUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
     mode: str | None = None
-    rules: list[dict] | None = None
+    rules: list[dict[str, Any]] | None = None
     bound_agents: list[str] | None = None
     bound_agent_types: list[str] | None = None
     bound_environments: list[str] | None = None
@@ -201,15 +201,15 @@ class PolicyUpdate(BaseModel):
 class EvaluateRequest(BaseModel):
     agent_name: str = ""
     tool_name: str
-    arguments: dict = {}
+    arguments: dict[str, Any] = Field(default_factory=dict)
 
 
 class ProxyAuditIngestRequest(BaseModel):
     source_id: str = ""
     session_id: str = ""
     idempotency_key: str = ""
-    alerts: list[dict] = []
-    summary: dict | None = None
+    alerts: list[dict[str, Any]] = Field(default_factory=list)
+    summary: dict[str, Any] | None = None
 
 
 class SAMLLoginRequest(BaseModel):
@@ -244,20 +244,20 @@ class BrowserExtensionsRequest(BaseModel):
 class ModelProvenanceRequest(BaseModel):
     """Request body for POST /v1/scan/model-provenance."""
 
-    hf_models: list[str] = []
+    hf_models: list[str] = Field(default_factory=list)
     """HuggingFace model IDs to check (e.g. ['meta-llama/Llama-2-7b-hf'])."""
 
-    ollama_models: list[str] = []
+    ollama_models: list[str] = Field(default_factory=list)
     """Ollama model names to check (e.g. ['llama2', 'codellama'])."""
 
 
 class PromptScanRequest(BaseModel):
     """Request body for POST /v1/scan/prompt-scan."""
 
-    directories: list[str] = []
+    directories: list[str] = Field(default_factory=list)
     """Directories to scan for prompt files (.prompt, prompt.yaml, etc.)."""
 
-    files: list[str] = []
+    files: list[str] = Field(default_factory=list)
     """Specific prompt files to scan."""
 
 
@@ -279,15 +279,15 @@ class PushPayload(BaseModel):
 
     source_id: str = ""
     idempotency_key: str = ""
-    agents: list = []
-    blast_radii: list = []
-    warnings: list = []
+    agents: list[dict[str, Any]] = Field(default_factory=list)
+    blast_radii: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[dict[str, Any] | str] = Field(default_factory=list)
 
 
 class ScheduleCreate(BaseModel):
     name: str
     cron_expression: str
-    scan_config: dict = {}
+    scan_config: dict[str, Any] = Field(default_factory=dict)
     enabled: bool = True
     tenant_id: str = "default"
 
@@ -296,7 +296,7 @@ class CreateKeyRequest(BaseModel):
     name: str
     role: str = "viewer"
     expires_at: str | None = None
-    scopes: list[str] = []
+    scopes: list[str] = Field(default_factory=list)
 
 
 class RotateKeyRequest(BaseModel):
@@ -320,7 +320,7 @@ class JiraTicketRequest(BaseModel):
     jira_url: str
     email: str
     project_key: str
-    finding: dict
+    finding: dict[str, Any]
 
 
 class FalsePositiveRequest(BaseModel):

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -153,12 +153,12 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
         existing_by_name = {agent.name: agent for agent in store.list_by_tenant(tenant_id)}
         new_names = {str(agent.get("name", "unknown-agent")) for agent in payload_agents} - set(existing_by_name)
         enforce_fleet_agents_quota(tenant_id, attempted=len(new_names))
-        for agent in payload_agents:
-            name = agent.get("name", "unknown-agent")
+        for payload_agent in payload_agents:
+            name = payload_agent.get("name", "unknown-agent")
             existing = existing_by_name.get(name)
-            server_count, pkg_count, cred_count, vuln_count = _payload_counts(agent)
-            score = float(agent.get("trust_score", 0.0) or 0.0)
-            factors = dict(agent.get("trust_factors", {}) or {})
+            server_count, pkg_count, cred_count, vuln_count = _payload_counts(payload_agent)
+            score = float(payload_agent.get("trust_score", 0.0) or 0.0)
+            factors = dict(payload_agent.get("trust_factors", {}) or {})
             if existing:
                 existing.server_count = server_count
                 existing.package_count = pkg_count
@@ -169,14 +169,14 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
                 existing.last_discovery = now
                 existing.updated_at = now
                 existing.config_path = ""
-                existing.agent_type = str(agent.get("agent_type", existing.agent_type))
+                existing.agent_type = str(payload_agent.get("agent_type", existing.agent_type))
                 store.put(existing)
                 updated_count += 1
             else:
                 fleet_agent = FleetAgent(
                     agent_id=str(uuid.uuid4()),
                     name=name,
-                    agent_type=str(agent.get("agent_type", "unknown")),
+                    agent_type=str(payload_agent.get("agent_type", "unknown")),
                     config_path="",
                     lifecycle_state=FleetLifecycleState.DISCOVERED,
                     trust_score=score,
@@ -198,10 +198,10 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
         discovered_names = {agent.name for agent in discovered}
         new_names = discovered_names - set(existing_by_name)
         enforce_fleet_agents_quota(tenant_id, attempted=len(new_names))
-        for agent in discovered:
-            existing = existing_by_name.get(agent.name)
-            server_count, pkg_count, cred_count, vuln_count = _server_counts(agent)
-            score, factors = compute_trust_score(agent)
+        for discovered_agent in discovered:
+            existing = existing_by_name.get(discovered_agent.name)
+            server_count, pkg_count, cred_count, vuln_count = _server_counts(discovered_agent)
+            score, factors = compute_trust_score(discovered_agent)
 
             if existing:
                 existing.server_count = server_count
@@ -212,15 +212,19 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
                 existing.trust_factors = factors
                 existing.last_discovery = now
                 existing.updated_at = now
-                existing.config_path = agent.config_path or ""
+                existing.config_path = discovered_agent.config_path or ""
                 store.put(existing)
                 updated_count += 1
             else:
                 fleet_agent = FleetAgent(
                     agent_id=str(uuid.uuid4()),
-                    name=agent.name,
-                    agent_type=agent.agent_type.value if hasattr(agent.agent_type, "value") else str(agent.agent_type),
-                    config_path=agent.config_path or "",
+                    name=discovered_agent.name,
+                    agent_type=(
+                        discovered_agent.agent_type.value
+                        if hasattr(discovered_agent.agent_type, "value")
+                        else str(discovered_agent.agent_type)
+                    ),
+                    config_path=discovered_agent.config_path or "",
                     lifecycle_state=FleetLifecycleState.DISCOVERED,
                     trust_score=score,
                     trust_factors=factors,

--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -12,6 +12,7 @@ from rich.console import Console
 
 from agent_bom.cli._common import _make_console
 from agent_bom.discovery import discover_all
+from agent_bom.inventory import _inventory_schema_path, _inventory_validator
 from agent_bom.models import AIBOMReport
 from agent_bom.output import print_agent_tree, print_summary
 from agent_bom.parsers import extract_packages
@@ -76,35 +77,6 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
     print_agent_tree(report)
 
 
-def _inventory_schema_path() -> Path | None:
-    """Return the inventory schema path from the repo or installed package."""
-    candidate_paths = [
-        Path(__file__).parent.parent.parent / "config" / "schemas" / "inventory.schema.json",
-        Path(__file__).parent.parent.parent / "schemas" / "inventory.schema.json",
-    ]
-
-    for candidate in candidate_paths:
-        if candidate.exists():
-            return candidate
-
-    try:
-        import importlib.resources
-
-        package_root = Path(str(importlib.resources.files("agent_bom")))
-    except Exception:
-        return None
-
-    fallback_paths = [
-        package_root / ".." / ".." / "config" / "schemas" / "inventory.schema.json",
-        package_root / ".." / ".." / "schemas" / "inventory.schema.json",
-    ]
-    for candidate in fallback_paths:
-        resolved = candidate.resolve()
-        if resolved.exists():
-            return resolved
-    return None
-
-
 @click.command()
 @click.argument("inventory_file", type=click.Path(exists=True))
 def validate(inventory_file: str):
@@ -117,19 +89,10 @@ def validate(inventory_file: str):
     """
     console = Console()
 
-    try:
-        import jsonschema
-    except ImportError:
-        console.print("[red]jsonschema not installed. Run: pip install jsonschema[/red]")
-        sys.exit(1)
-
     schema_path = _inventory_schema_path()
     if not schema_path or not schema_path.exists():
         console.print("[red]Schema file not found. Run from the agent-bom repo root.[/red]")
         sys.exit(1)
-
-    with open(schema_path) as f:
-        schema = json.load(f)
 
     with open(inventory_file) as f:
         try:
@@ -138,7 +101,11 @@ def validate(inventory_file: str):
             console.print(f"[red]JSON parse error: {e}[/red]")
             sys.exit(1)
 
-    validator = jsonschema.Draft202012Validator(schema)
+    try:
+        validator = _inventory_validator()
+    except ImportError:
+        console.print("[red]jsonschema not installed. Run: pip install jsonschema[/red]")
+        sys.exit(1)
     errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
 
     if not errors:

--- a/src/agent_bom/inventory.py
+++ b/src/agent_bom/inventory.py
@@ -35,6 +35,9 @@ import json
 import logging
 import sys
 from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +46,75 @@ _CSV_REQUIRED_COLUMNS = frozenset({"name", "version", "ecosystem"})
 
 # Size guard to prevent OOM on malicious/huge inputs.
 _MAX_INVENTORY_SIZE = 100 * 1024 * 1024  # 100 MB
+_ECOSYSTEM_ALIASES = {
+    "pip": "pypi",
+    "python": "pypi",
+    "node": "npm",
+    "golang": "go",
+    "crates": "cargo",
+    "dotnet": "nuget",
+}
+
+
+def _inventory_schema_path() -> Path | None:
+    """Return the checked-in inventory schema path."""
+    candidate_paths = [
+        Path(__file__).parent.parent.parent / "config" / "schemas" / "inventory.schema.json",
+        Path(__file__).parent.parent.parent / "schemas" / "inventory.schema.json",
+    ]
+    for candidate in candidate_paths:
+        if candidate.exists():
+            return candidate
+
+    try:
+        import importlib.resources
+
+        package_root = Path(str(importlib.resources.files("agent_bom")))
+    except Exception:
+        return None
+
+    fallback_paths = [
+        package_root / ".." / ".." / "config" / "schemas" / "inventory.schema.json",
+        package_root / ".." / ".." / "schemas" / "inventory.schema.json",
+    ]
+    for candidate in fallback_paths:
+        resolved = candidate.resolve()
+        if resolved.exists():
+            return resolved
+    return None
+
+
+@lru_cache(maxsize=1)
+def _inventory_validator():
+    """Build and cache the inventory JSON Schema validator."""
+    import jsonschema
+
+    schema_path = _inventory_schema_path()
+    if not schema_path or not schema_path.exists():
+        raise RuntimeError("Inventory schema file not found")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _validate_inventory_payload(data: Any) -> dict[str, Any]:
+    """Validate an inventory payload against the canonical schema."""
+    if not isinstance(data, dict):
+        raise ValueError("Inventory JSON root must be an object with an 'agents' array")
+
+    errors = sorted(_inventory_validator().iter_errors(data), key=lambda e: list(e.path))
+    if errors:
+        first = errors[0]
+        path = " -> ".join(str(part) for part in first.path) or "(root)"
+        raise ValueError(f"Inventory schema validation failed at {path}: {first.message}")
+    return data
+
+
+def _normalize_inventory_ecosystem(ecosystem: str) -> str:
+    """Map common feed aliases into the canonical inventory schema vocabulary."""
+    normalized = ecosystem.strip().lower()
+    if not normalized:
+        return "unknown"
+    return _ECOSYSTEM_ALIASES.get(normalized, normalized)
 
 
 def load_inventory(source: str) -> dict:
@@ -62,8 +134,6 @@ def load_inventory(source: str) -> dict:
     """
     if source == "-":
         return _load_from_stdin()
-
-    from pathlib import Path
 
     path = Path(source)
     if not path.exists():
@@ -91,7 +161,7 @@ def _load_from_stdin() -> dict:
 
     fmt = _detect_format(content)
     if fmt == "json":
-        return json.loads(content)
+        return _validate_inventory_payload(json.loads(content))
 
     return _load_csv_inventory(io.StringIO(content))
 
@@ -106,7 +176,7 @@ def _detect_format(content: str) -> str:
 
 def _load_json_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
     """Parse JSON inventory from a file-like object."""
-    return json.load(fp)
+    return _validate_inventory_payload(json.load(fp))
 
 
 def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
@@ -150,14 +220,14 @@ def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
         for row in rows:
             name = (row.get(col_name) or "").strip()
             version = (row.get(col_version) or "").strip()
-            ecosystem = (row.get(col_ecosystem) or "").strip()
+            ecosystem = _normalize_inventory_ecosystem((row.get(col_ecosystem) or "").strip())
             if not name or not version:
                 continue
             packages.append(
                 {
                     "name": name,
                     "version": version,
-                    "ecosystem": ecosystem or "unknown",
+                    "ecosystem": ecosystem,
                 }
             )
             # Parse semicolon-separated env key names (values always redacted)
@@ -187,4 +257,4 @@ def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
     if not agents_by_name:
         raise ValueError("CSV produced no valid inventory entries (check name/version columns)")
 
-    return {"agents": list(agents_by_name.values())}
+    return _validate_inventory_payload({"agents": list(agents_by_name.values())})

--- a/tests/test_graph_schema_ui_parity.py
+++ b/tests/test_graph_schema_ui_parity.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from agent_bom.graph import FINDING_ENTITY_TYPES, EntityType, GraphLayout, RelationshipType
+from agent_bom.graph.container import GraphFilterOptions
+from agent_bom.graph.severity import SEVERITY_RANK, SEVERITY_RISK_SCORE, SEVERITY_TO_OCSF, OCSFSeverity
+
+ROOT = Path(__file__).resolve().parent.parent
+TS_GRAPH_SCHEMA = ROOT / "ui" / "lib" / "graph-schema.ts"
+TS_SOURCE = TS_GRAPH_SCHEMA.read_text(encoding="utf-8")
+
+
+def _block_after(marker: str, opener: str, closer: str) -> str:
+    start = TS_SOURCE.index(marker)
+    open_idx = TS_SOURCE.index(opener, start)
+    depth = 0
+    for idx in range(open_idx, len(TS_SOURCE)):
+        char = TS_SOURCE[idx]
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return TS_SOURCE[open_idx + 1 : idx]
+    raise AssertionError(f"Could not parse block for {marker}")
+
+
+def _ts_enum_values(name: str) -> set[str]:
+    body = _block_after(f"export enum {name}", "{", "}")
+    return {value for _key, value in re.findall(r"(\w+)\s*=\s*\"([^\"]+)\"", body)}
+
+
+def _ts_enum_mapping(name: str) -> dict[str, int]:
+    body = _block_after(f"export enum {name}", "{", "}")
+    return {key: int(value) for key, value in re.findall(r"(\w+)\s*=\s*(\d+)", body)}
+
+
+def _ts_object_mapping(name: str, *, enum_refs: dict[str, int] | None = None) -> dict[str, int | float]:
+    body = _block_after(f"export const {name}", "{", "}")
+    mapping: dict[str, int | float] = {}
+    for raw_key, raw_value in re.findall(r"^\s*([A-Za-z_]+):\s*([^,\n]+)", body, re.MULTILINE):
+        value = raw_value.strip()
+        if enum_refs and value.startswith("OCSFSeverity."):
+            mapping[raw_key] = enum_refs[value.split(".", 1)[1]]
+        elif re.fullmatch(r"\d+", value):
+            mapping[raw_key] = int(value)
+        elif re.fullmatch(r"\d+\.\d+", value):
+            mapping[raw_key] = float(value)
+    return mapping
+
+
+def _ts_default_filters(enum_refs: dict[str, str]) -> dict[str, object]:
+    function_start = TS_SOURCE.index("export function defaultFilters()")
+    return_start = TS_SOURCE.index("return {", function_start)
+    open_idx = TS_SOURCE.index("{", return_start)
+    depth = 0
+    close_idx = open_idx
+    for idx in range(open_idx, len(TS_SOURCE)):
+        char = TS_SOURCE[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                close_idx = idx
+                break
+    body = TS_SOURCE[open_idx + 1 : close_idx]
+    defaults: dict[str, object] = {}
+    for raw_key, raw_value in re.findall(r"^\s*([A-Za-z]+):\s*([^,\n]+)", body, re.MULTILINE):
+        value = raw_value.strip()
+        if value in {"false", "true"}:
+            defaults[raw_key] = value == "true"
+        elif value == '""':
+            defaults[raw_key] = ""
+        elif value == "new Set()":
+            defaults[raw_key] = set()
+        elif re.fullmatch(r"\d+", value):
+            defaults[raw_key] = int(value)
+        elif value.startswith("GraphLayout."):
+            defaults[raw_key] = enum_refs[value.split(".", 1)[1]]
+    return defaults
+
+
+def test_ui_entity_types_match_python_graph_schema():
+    assert _ts_enum_values("EntityType") == {entity.value for entity in EntityType}
+
+
+def test_ui_relationship_types_match_python_graph_schema():
+    assert _ts_enum_values("RelationshipType") == {relationship.value for relationship in RelationshipType}
+
+
+def test_ui_graph_layouts_match_python_graph_schema():
+    assert _ts_enum_values("GraphLayout") == {layout.value for layout in GraphLayout}
+
+
+def test_ui_severity_constants_match_python_graph_schema():
+    ts_ocsf = _ts_enum_mapping("OCSFSeverity")
+    assert ts_ocsf == {severity.name: int(severity.value) for severity in OCSFSeverity}
+    assert _ts_object_mapping("SEVERITY_TO_OCSF", enum_refs=ts_ocsf) == {key: int(value) for key, value in SEVERITY_TO_OCSF.items()}
+    assert _ts_object_mapping("SEVERITY_RANK") == SEVERITY_RANK
+    assert _ts_object_mapping("SEVERITY_RISK_SCORE") == SEVERITY_RISK_SCORE
+
+
+def test_ui_finding_entity_types_match_python_graph_schema():
+    body = _block_after("export const FINDING_ENTITY_TYPES", "[", "]")
+    ts_findings = {match.split(".", 1)[1].strip() for match in re.findall(r"EntityType\.\w+", body)}
+    assert ts_findings == {entity.name for entity in FINDING_ENTITY_TYPES}
+
+
+def test_ui_default_filters_match_python_graph_schema():
+    layout_block = _block_after("export enum GraphLayout", "{", "}")
+    ts_layout_names = {name: value for name, value in re.findall(r"(\w+)\s*=\s*\"([^\"]+)\"", layout_block)}
+    defaults = GraphFilterOptions()
+    assert _ts_default_filters(ts_layout_names) == {
+        "maxDepth": defaults.max_depth,
+        "maxHops": defaults.max_hops,
+        "minSeverity": defaults.min_severity,
+        "entityTypes": set(),
+        "relationshipTypes": set(),
+        "staticOnly": defaults.static_only,
+        "dynamicOnly": defaults.dynamic_only,
+        "includeIds": set(),
+        "excludeIds": set(),
+        "layout": defaults.layout,
+    }

--- a/tests/test_hardening_phase2.py
+++ b/tests/test_hardening_phase2.py
@@ -394,6 +394,7 @@ class TestInventoryCSV:
         agent = result["agents"][0]
         assert agent["name"] == "inventory-agent"
         assert agent["mcp_servers"][0]["name"] == "inventory-server"
+        assert agent["mcp_servers"][0]["packages"][0]["ecosystem"] == "pypi"
 
     def test_env_keys_parsed(self):
         from agent_bom.inventory import _load_csv_inventory
@@ -455,6 +456,16 @@ class TestInventoryJSON:
         result = load_inventory(str(json_file))
         assert result == data
 
+    def test_invalid_json_schema_rejected(self, tmp_path):
+        from agent_bom.inventory import load_inventory
+
+        data = {"agents": [{}]}
+        json_file = tmp_path / "inventory.json"
+        json_file.write_text(json.dumps(data))
+
+        with pytest.raises(ValueError, match="Inventory schema validation failed"):
+            load_inventory(str(json_file))
+
     def test_csv_file_detected_by_extension(self, tmp_path):
         from agent_bom.inventory import load_inventory
 
@@ -500,4 +511,11 @@ class TestInventoryStdin:
 
         with patch("sys.stdin", io.StringIO("   ")):
             with pytest.raises(ValueError, match="Empty input"):
+                _load_from_stdin()
+
+    def test_stdin_invalid_schema_raises(self):
+        from agent_bom.inventory import _load_from_stdin
+
+        with patch("sys.stdin", io.StringIO(json.dumps({"agents": [{}]}))):
+            with pytest.raises(ValueError, match="Inventory schema validation failed"):
                 _load_from_stdin()


### PR DESCRIPTION
## Summary
- validate inventory payloads on the actual ingest path and normalize common ecosystem aliases into the canonical schema vocabulary
- reuse the shared inventory schema resolver in the CLI validator and cache the schema validator for repeated scans
- add Python to TypeScript graph schema parity tests so UI graph enums, severities, finding sets, and default filters cannot silently drift
- tighten API model boundary hygiene with typed dict/list fields and default_factory defaults

## Testing
- python -m pytest tests/test_hardening_phase2.py tests/test_cli_inventory.py tests/test_graph_schema_ui_parity.py tests/test_api_scan_types.py tests/test_graph_schema.py tests/test_graph_api.py -q