### PR TITLE
ci: skip pages deploy during tag releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,12 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
   workflow_call:
+    inputs:
+      deploy:
+        description: 'Deploy built docs to GitHub Pages'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -43,6 +49,7 @@ jobs:
           path: site
 
   deploy:
+    if: ${{ inputs.deploy }}
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
     needs: version-guard
     permissions:
       contents: read
-      pages: write
-      id-token: write
     uses: ./.github/workflows/docs.yml
+    with:
+      deploy: false
 
   build:
     name: Build distribution


### PR DESCRIPTION
## Summary
- add a reusable docs workflow input so callers can build docs without deploying Pages
- keep normal `main` docs deploy behavior unchanged
- make tag releases rebuild docs strictly but skip the Pages deploy leg that GitHub blocks for tags

## Why
`v0.78.1` proved the docs content is fixed, but the release workflow still fails because the reusable docs workflow attempts a `github-pages` environment deploy from the tag ref. The `main` push already deploys docs successfully, so tag releases only need a strict docs build check.

## Verification
- workflow YAML parses cleanly
- `main` docs deploy remains separate and green
