### PR TITLE
polish: tighten dashboard captures and demo UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,18 +135,29 @@ Self-hosted is a first-class path. `agent-bom` is designed to run inside the
 customer's own AWS account, VPC, EKS cluster, IAM boundary, databases, and SSO
 stack.
 
-The deployable surfaces are intentionally split:
+The promoted self-hosted rollout today is a scoped operator stack, not a
+monolith. Most teams start with four product surfaces plus one operator plane:
 
 - **scan**: discovery, inventory, CVE, image, IaC, Kubernetes, and cloud analysis
 - **fleet**: endpoint and collector inventory pushed into the control plane
 - **proxy / runtime**: inline MCP enforcement near selected workloads
 - **gateway**: central policy management for those runtime paths
-- **API + UI**: findings, graph, remediation, audit, and operator workflows
+- **API + UI**: the operator plane for findings, graph, remediation, audit, and policy workflows
 
 That gives one shared graph and policy model without forcing one runtime
 monolith. By default, findings, fleet data, audit logs, graph state, and
 remediation outputs stay in your infrastructure; optional egress is operator
 controlled for DB refresh, enrichment, SIEM, OTLP, and webhooks.
+
+The recommended EKS shape is:
+
+- stateless API + UI deployments behind your ingress
+- Postgres for transactional state and graph metadata
+- optional ClickHouse only when audit and analytics volume justifies it
+- scheduled scan jobs for cluster, image, and discovery work
+- endpoint fleet sync for laptops and collectors
+- selected `agent-bom proxy` sidecars or local wrappers for the MCP workloads that need inline enforcement
+- gateway-backed policy pull so runtime controls stay centralized without hairpinning all traffic through one shared chokepoint
 
 ### 1. External flow — where the data comes from
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -20,6 +20,10 @@ that does not happen again.
    AGENT_BOM_DB=/tmp/agent-bom-capture.db agent-bom serve
    ```
 
+   Use the packaged UI path for captures. Do not shoot screenshots from the
+   Next.js dev server, or you risk the transient `Compiling...` badge showing
+   up in published assets.
+
 4. Generate the bundled demo report offline, then push that exact payload to
    the API so the stored job matches the terminal demo and does not pull in
    local workstation discovery:
@@ -35,7 +39,7 @@ that does not happen again.
 
 | Asset | Page | Required scope | Rationale |
 |---|---|---|---|
-| `dashboard-live.png` | `/dashboard` (Risk overview) | All agents · scroll showing F-grade gauge, posture sub-scores, score breakdown, top attack paths | Captures the headline counters (actively exploited / credentials exposed / reachable tools / top-path risk), the security-posture grade, and the score breakdown — all in one frame |
+| `dashboard-live.png` | `/dashboard?capture=1` (Risk overview) | All agents · scroll showing F-grade gauge, posture sub-scores, score breakdown, top attack paths, and KPI section header | Capture mode expands every nav section for the screenshot while leaving the default product navigation behavior unchanged |
 | `mesh-live.png` | `/mesh` | Filter to `cursor` | Has 2 servers, 8 packages, 10+ CVEs, and richer tool + credential traversal than the smaller `claude-desktop` slice |
 | `remediation-live.png` | `/remediation` | All frameworks tab | Shows the full prioritized fix list |
 
@@ -49,7 +53,8 @@ the older single-column attack-path layout. The current frame contains:
 3. **F-grade gauge** — 0-100 numeric score with letter grade
 4. **Security posture card** — grade explanation + 6 sub-scores (policy + controls, open evidence × 2, packages + CVEs, reach + exposure, MCP configuration)
 5. **Score breakdown** — per-driver progress bars with one-line evidence
-6. **Top attack paths** — clickable rows linking to the security graph
+6. **Top attack paths** — visible collapsible header plus clickable rows linking to the security graph
+7. **Exposure KPIs** — visible collapsible header above the KPI tiles below the attack-path list
 
 A capture that misses any of those sections is incomplete. Re-shoot
 with the page scrolled to top so the gauge + posture card both fit.

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -6,13 +6,13 @@ Output docs/images/demo-latest.gif
 Set Shell "bash"
 Set FontSize 20
 Set Width 1280
-Set Height 980
+Set Height 1120
 Set Theme "Dracula"
 Set Padding 20
-Set TypingSpeed 30ms
-Set PlaybackSpeed 1.35
+Set TypingSpeed 34ms
+Set PlaybackSpeed 1.0
 
 # Hero flow — render_demo.sh handles TERM=xterm-256color for Rich colors
 Type "bash scripts/render_demo.sh"
 Enter
-Sleep 9s
+Sleep 15s

--- a/scripts/render_demo.sh
+++ b/scripts/render_demo.sh
@@ -19,22 +19,29 @@ export AGENT_BOM_LOG_LEVEL=error
 # Clear screen for clean recording
 printf '\033[H\033[2J'
 
-run_step() {
-  local visible="$1"
-  shift
+print_section() {
+  local label="$1"
+  printf '\033[38;5;151m━━ %s ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n' "$label"
+}
 
+run_step() {
+  local label="$1"
+  local visible="$2"
+  shift 2
+
+  print_section "$label"
   printf '\033[1;36m$ %s\033[0m\n' "$visible"
   if ! "$@" 2>&1; then
     true
   fi
   printf '\n'
-  sleep 1
+  sleep 2
 }
 
 # ── Demo: blast radius → quick package gate ──
 
 # 1. Full agent scan — blast radius, severity, remediation
-run_step "agent-bom agents --demo --offline" agent-bom agents --demo --offline
+run_step "Blast-radius scan" "agent-bom agents --demo --offline" agent-bom agents --demo --offline
 
 # 2. Pre-install CVE gate
-run_step "agent-bom check pillow@9.0.0" agent-bom check pillow@9.0.0 --ecosystem pypi --quiet
+run_step "Package verification" "agent-bom check pillow@9.0.0 --ecosystem pypi" agent-bom check pillow@9.0.0 --ecosystem pypi

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -1806,7 +1806,8 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
     console.print()
     total = len(fixable)
     title = f"Fix First (top {min(limit, total)} of {total})" if total > limit else f"Fix First ({total})"
-    console.print(f"  [bold]{title}[/bold]")
+    console.print(Rule(f"[bold]{title}[/bold]", style="dim"))
+    console.print("  [dim]Each item shows the impact radius, the primary action, and a verification command.[/dim]")
     console.print()
 
     sev_style = {
@@ -1828,15 +1829,16 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
             reach_parts.append(f"{len(item['tools'])} tool(s)")
         reach = ", ".join(reach_parts)
         console.print(
-            f"  [{style}]{i}.[/{style}] [bold]{item['package']}[/bold] "
-            f"[dim]{item['current']}[/dim] → [green]{item['fix']}[/green]{kev}  "
-            f"[dim]{item['priority']} · clears {reach}[/dim]"
+            f"  [{style}]{i}.[/{style}] [bold]{item['package']}[/bold] [dim]{item['current']}[/dim] → [green]{item['fix']}[/green]{kev}"
         )
-        console.print(f"     [dim]{_compact_detail(item['action'], limit=110)}[/dim]")
+        console.print(f"     [bold]Priority:[/bold] {item['priority']} [dim]· clears {reach}[/dim]")
+        console.print(f"     [bold]Action:[/bold] [dim]{_compact_detail(item['action'], limit=96)}[/dim]")
         if item.get("command"):
-            console.print(f"     [cyan]$ {item['command']}[/cyan]")
+            console.print(f"     [bold cyan]Install:[/bold cyan] [cyan]$ {item['command']}[/cyan]")
         if item.get("verify_command"):
-            console.print(f"     [dim cyan]$ {item['verify_command']}[/dim cyan] [dim](verify)[/dim]")
+            console.print(
+                f"     [bold dim cyan]Verify:[/bold dim cyan] [dim cyan]$ {item['verify_command']}[/dim cyan] [dim](verify)[/dim]"
+            )
         if i < len(shown):
             console.print()
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -818,7 +818,8 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
     # when the DB is populated via `agent-bom db update`.
     local_count, db_covered = _scan_packages_local_db(scannable)
     if local_count:
-        console.print(f"  [green]✓[/green] Local DB: {local_count} vulnerability/vulnerabilities found (offline)")
+        local_label = "vulnerability found" if local_count == 1 else "vulnerabilities found"
+        console.print(f"  [green]✓[/green] Local DB: {local_count} {local_label} (offline)")
 
     # Only call OSV for packages not already covered by the local DB
     def _db_key(p: Package) -> str:

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -584,19 +584,33 @@ export default function Dashboard() {
         )}
       </section>
 
-      {/* Top Attack Paths — collapsible so the list doesn't force endless scroll */}
       {(!isLoading) && allBlast.length > 0 && (
-        <details open className="group/attack">
-          <summary className="flex cursor-pointer list-none items-center gap-2 mb-3 select-none">
-            <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/attack:rotate-90" />
-            <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest">
-              Top Attack Paths
-            </h2>
-            <span className="ml-2 rounded-full bg-zinc-800/80 px-2 py-0.5 font-mono text-[10px] text-zinc-400">
-              {Math.min(allBlast.length, 5)}
+        <details open className="group/attack rounded-[28px] border border-zinc-800/90 bg-zinc-950/70 p-4 shadow-[0_24px_80px_-48px_rgba(16,185,129,0.28)]">
+          <summary className="flex cursor-pointer list-none items-start justify-between gap-4 select-none">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-emerald-500/20 bg-emerald-500/10 text-emerald-300">
+                <GitBranch className="h-4 w-4" />
+              </div>
+              <div>
+                <div className="flex items-center gap-2">
+                  <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/attack:rotate-90" />
+                  <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-widest">
+                    Top Attack Paths
+                  </h2>
+                  <span className="rounded-full border border-zinc-800 bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400">
+                    {Math.min(allBlast.length, 5)} shown
+                  </span>
+                </div>
+                <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-500">
+                  Collapse this list when you want a tighter landing view. Open any path card to jump straight into the focused security graph drilldown.
+                </p>
+              </div>
+            </div>
+            <span className="hidden rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-300 md:inline-flex">
+              Clickable drilldowns
             </span>
           </summary>
-          <div className="space-y-2">
+          <div className="mt-4 space-y-2">
             {[...allBlast]
               .sort((a, b) => (b.risk_score ?? b.blast_score) - (a.risk_score ?? a.blast_score))
               .slice(0, 5)
@@ -625,15 +639,29 @@ export default function Dashboard() {
         </details>
       )}
 
-      {/* Scan metrics — collapsible */}
-      <details open className="group/metrics">
-        <summary className="flex cursor-pointer list-none items-center gap-2 mb-3 select-none">
-          <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/metrics:rotate-90" />
-          <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest">
-            Scan metrics
-          </h2>
+      <details open className="group/metrics rounded-[28px] border border-zinc-800/90 bg-zinc-950/70 p-4 shadow-[0_24px_80px_-48px_rgba(59,130,246,0.24)]">
+        <summary className="flex cursor-pointer list-none items-start justify-between gap-4 select-none">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-sky-500/20 bg-sky-500/10 text-sky-300">
+              <Layers className="h-4 w-4" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/metrics:rotate-90" />
+                <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-widest">
+                  Exposure KPIs
+                </h2>
+              </div>
+              <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-500">
+                Coverage and backlog snapshot for the current scan set: total scans, agents, packages, unique CVEs, and critical findings.
+              </p>
+            </div>
+          </div>
+          <span className="hidden rounded-full border border-zinc-800 bg-zinc-900/90 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-zinc-400 md:inline-flex">
+            5 tiles
+          </span>
         </summary>
-        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+        <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-5">
           <StatCard icon={Layers} label="Total scans" value={summaryReady ? String(effectiveRecentJobs.length) : "—"} color="zinc" href="/jobs" />
           <StatCard icon={Server} label="Agents" value={agentsReady ? String(effectiveAgentCount) : "—"} color="blue" href="/agents" />
           <StatCard icon={Package} label="Packages" value={summaryReady ? String(detailsReady ? totalPackages : (summaryStats?.total_packages ?? 0)) : "—"} color="orange" href="/findings" />

--- a/ui/components/attack-path-card.tsx
+++ b/ui/components/attack-path-card.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
-import { Bot, Bug, ChevronRight, KeyRound, Package, Server } from "lucide-react";
+import { ArrowRight, Bot, Bug, ChevronRight, KeyRound, Package, Server } from "lucide-react";
 
 interface AttackPathNode {
   type: "cve" | "package" | "server" | "agent" | "credential";
@@ -76,8 +76,17 @@ export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCa
         })}
       </div>
       {href && (
-        <div className="mt-3 text-xs font-medium text-emerald-500">
-          Open focused security graph
+        <div className="mt-4 flex items-center justify-between border-t border-[color:var(--border-subtle)] pt-3">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Drilldown</p>
+            <p className="mt-1 text-xs font-medium text-emerald-500 transition-colors group-hover:text-emerald-400">
+              Open focused security graph
+            </p>
+          </div>
+          <div className="flex items-center gap-1 text-xs font-medium text-[color:var(--text-secondary)] transition-colors group-hover:text-[color:var(--foreground)]">
+            Inspect path
+            <ArrowRight className="h-3.5 w-3.5" />
+          </div>
         </div>
       )}
     </>

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -119,6 +119,8 @@ const NAV_GROUPS: NavGroup[] = [
   },
 ];
 
+const ALL_GROUP_LABELS = NAV_GROUPS.map((group) => group.label);
+
 // ─── Risk counts for badges ─────────────────────────────────────────────────
 
 interface RiskCounts {
@@ -138,10 +140,11 @@ const MCP_ONLY_PAGES = new Set(["/agents", "/fleet", "/mesh", "/context"]);
 
 export function Nav() {
   const path = usePathname();
+  const [captureMode, setCaptureMode] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
-    () => new Set([activeGroupForPath(path)])
+    () => new Set(captureMode ? ALL_GROUP_LABELS : [activeGroupForPath(path)])
   );
   const [counts, setCounts] = useState<RiskCounts | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -157,12 +160,20 @@ export function Nav() {
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
+      const capture = new URLSearchParams(window.location.search).get("capture") === "1";
+      setCaptureMode(capture);
+      if (capture) {
+        setCollapsed(false);
+        setExpandedGroups(new Set(ALL_GROUP_LABELS));
+        setSearchOpen(false);
+        return;
+      }
       if (!collapsed) {
         setExpandedGroups(new Set([activeGroupForPath(path)]));
       }
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [collapsed, path]);
+  }, [captureMode, collapsed, path]);
 
   // Sync main content padding with sidebar collapsed state
   useEffect(() => {
@@ -192,13 +203,16 @@ export function Nav() {
   }, []);
 
   const toggleGroup = useCallback((label: string) => {
+    if (captureMode) {
+      return;
+    }
     setExpandedGroups((prev) => {
       if (prev.has(label) && prev.size === 1) {
         return new Set();
       }
       return new Set([label]);
     });
-  }, []);
+  }, [captureMode]);
 
   const isDimmed = (href: string): boolean => {
     if (!counts || (counts.scan_count ?? 0) === 0) return false;
@@ -287,7 +301,7 @@ export function Nav() {
       {/* Navigation Groups */}
       <nav className="flex-1 overflow-y-auto px-2 py-2 space-y-2 scrollbar-thin">
         {filteredGroups.map((group) => {
-          const isExpanded = expandedGroups.has(group.label);
+          const isExpanded = captureMode || expandedGroups.has(group.label);
           const GroupIcon = group.icon;
           const hasActiveChild = group.links.some(
             (l) => (l.href === "/" ? path === "/" : path.startsWith(l.href))
@@ -297,7 +311,12 @@ export function Nav() {
             <div key={group.label} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
               {/* Group Header */}
               <button
-                onClick={() => collapsed ? setCollapsed(false) : toggleGroup(group.label)}
+                onClick={() => {
+                  if (captureMode) {
+                    return;
+                  }
+                  collapsed ? setCollapsed(false) : toggleGroup(group.label);
+                }}
                 className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-xl text-xs font-medium transition-colors border-l-2 ${
                   hasActiveChild
                     ? "text-[color:var(--foreground)] bg-[color:var(--surface-elevated)]"

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+let mockedPathname = '/'
+
 // Mock next/link so it renders a plain anchor
 vi.mock('next/link', () => ({
   default: ({ href, children, ...rest }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
@@ -10,7 +12,7 @@ vi.mock('next/link', () => ({
 
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/',
+  usePathname: () => mockedPathname,
 }))
 
 // Mock the API so the component doesn't make real network calls
@@ -37,6 +39,8 @@ import { Nav } from '@/components/nav'
 
 describe('Nav', () => {
   beforeEach(() => {
+    mockedPathname = '/'
+    window.history.replaceState({}, '', '/')
     vi.clearAllMocks()
   })
 
@@ -192,5 +196,22 @@ describe('Nav', () => {
         }
       })
     }
+  })
+
+  it('expands every nav group in capture mode for screenshots', async () => {
+    window.history.replaceState({}, '', '/?capture=1')
+    render(<Nav />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Choose source mode, run scans, and review findings')).toBeInTheDocument()
+      expect(screen.getByText('Trace blast radius and graph relationships')).toBeInTheDocument()
+      expect(screen.getByText('Proxy, policy, and runtime enforcement surfaces')).toBeInTheDocument()
+      expect(screen.getByText('Evidence, remediation, governance, and activity')).toBeInTheDocument()
+    })
+
+    expect(screen.getAllByRole('link', { name: /dashboard/i }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /new scan/i }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /proxy/i }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /remediation/i }).length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## What changed
- added a screenshot-only `capture=1` mode so dashboard captures show all nav groups expanded without changing default runtime behavior
- strengthened the Risk overview layout with clearer collapsible headers for Top Attack Paths and Exposure KPIs, plus stronger attack-path drilldown affordances
- cleaned up compact remediation and demo output so the terminal GIF is slower, sectioned, and shows the actual package-check CVE table instead of quiet output
- tightened the self-hosted README and capture docs around the promoted EKS rollout: scan, fleet/runtime, proxy, gateway, and the operator plane
- fixed the local DB status grammar in package scan output so release media does not show `vulnerability/vulnerabilities`

## Why
The current screenshots and terminal demo flatten important sections, hide the full navigation structure, and read too much like dev-state artifacts instead of polished release assets. This pass makes the dashboard and CLI media path presentable while keeping the product behavior honest.

## Impact
- release screenshots can be re-shot from the packaged UI with `/dashboard?capture=1`
- dashboard attack-path and KPI sections are clearer in-product and in captures
- terminal demo output is easier to read during the GIF playback
- README now leads with the scoped self-hosted deployment story we actually want to promote

## Validation
- `python -m pytest tests/test_compact_output.py -q`
- `npm run test:run -- tests/nav.test.tsx`
- `npm run build` (in `ui/`)
- `bash scripts/render_demo.sh` smoke run
