### PR TITLE
fix: close compliance audit gaps

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -48,15 +48,29 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Check Smithery configuration
+        id: smithery_config
+        env:
+          SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
+        run: |
+          if [ -z "${SMITHERY_MCP_URL:-}" ]; then
+            echo "::notice::SMITHERY_MCP_URL not configured — skipping Smithery publish"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${SMITHERY_API_TOKEN:-}" ]; then
+            echo "::notice::SMITHERY_API_TOKEN not configured — skipping Smithery publish"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
       - name: Validate Smithery public endpoint
+        if: steps.smithery_config.outputs.enabled == 'true'
         env:
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
         run: |
-          if [ -z "$SMITHERY_MCP_URL" ]; then
-            echo "::error::SMITHERY_MCP_URL not set — Smithery must publish a separate public MCP surface, not the protected Railway endpoint"
-            exit 1
-          fi
-
           RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
             --base-url "$SMITHERY_MCP_URL" \
             --attempts 3 \
@@ -78,16 +92,12 @@ jobs:
           echo "Smithery public endpoint tool count: ${PUBLIC_TOOLS}"
 
       - name: Publish to Smithery
+        if: steps.smithery_config.outputs.enabled == 'true'
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          if [ -z "$SMITHERY_API_TOKEN" ]; then
-            echo "::error::SMITHERY_API_TOKEN not set — cannot publish to Smithery"
-            exit 1
-          fi
-
           QUALIFIED_NAME="agent-bom%2Fagent-bom"
           MCP_URL="${SMITHERY_MCP_URL}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,15 @@ ui/.next/
 .coverage
 .claude/worktrees/
 AUDIT_*.md
+ui/.claude/
+# macOS / iCloud duplicate conflict files — keep them out of git even if they
+# appear locally in a synced working tree.
+README [0-9].md
+docs/CAPTURE [0-9].md
+docs/images/* [0-9].png
+docs/images/* [0-9].gif
+docs/images/* [0-9].svg
+src/agent_bom/**/* [0-9].py
+tests/**/* [0-9].py
+deploy/helm/agent-bom/**/* [0-9].yaml
+.github/workflows/* [0-9].yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Work targeting the next minor release. Tracking toward `0.78.1`.
 ### Added
 - **MCP tool-schema validation rule catalog** (#1507) — OWASP-mapped rules classify MCP tool definitions for risky capability combinations, over-broad permissions, and schema gaps; findings wired into live introspection output (#1519)
 - **Graded exploit likelihood signal** (#1518, closes #486) — blast-radius scoring fuses EPSS and CISA KEV into a single `exploit_likelihood` tier so triage reflects in-the-wild exploitation risk, not just theoretical severity
-- **Signed compliance evidence bundle** — new `/v1/compliance/{framework}/report` endpoint (#1504) returns cosign-signed, replay-protected evidence (#1509) for auditor hand-off
+- **Signed compliance evidence bundle** — new `/v1/compliance/{framework}/report` endpoint (#1504) returns HMAC-signed, replay-protected evidence (#1509) for auditor hand-off
 - **Structured CIS remediation field** (#1512, #1517) — CIS benchmark findings now carry a first-class `remediation` object surfaced through CLI, HTML, and SARIF outputs
 - **OCSF interop boundary** (#1513) — optional SIEM export is scoped as a boundary concern (not core data model); ownership and schema lifecycle documented
 - **Auth-method introspection** — `/v1/auth/debug` endpoint (#1502) reports which auth method resolved a request, easing operator debugging in mixed-auth deployments
@@ -306,7 +306,7 @@ Work targeting the next minor release. Tracking toward `0.78.1`.
 ### Added
 - **Dashboard UX** — posture grade (A-F) hero, top 5 attack path cards, security graph page with interactive React Flow, insight layer toggle (risk/credentials/default), 14-framework compliance heatmap
 - **Remediation page** — priority table sorted by blast radius impact, Jira ticket creation per finding, compliance impact summary, severity/framework filters, JSON export
-- **Compliance narratives** — `GET /v1/compliance/narrative` generates auditor-ready text per framework with control-level detail and remediation-compliance bridge
+- **Compliance narratives** — `GET /v1/compliance/narrative` generates review-ready text per framework with control-level detail and remediation-compliance bridge
 - **`--posture` flag** — 5-line workstation posture summary for solo developers
 - **`--fixable-only` flag** — show only vulnerabilities with available fixes
 - **`agent-bom doctor`** — preflight diagnostic (Python, DB, network, Docker, MCP configs, API keys)

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -67,7 +67,7 @@ docker run --rm agentbom/agent-bom:latest cloud aws
 docker run --rm agentbom/agent-bom:latest doctor
 ```
 
-## Why Teams Use It
+## What it scans
 
 - Blast radius from package to server to agent to credentials and tools
 - AI-native coverage across agents, MCP, runtime, containers, cloud, IaC, and GPU surfaces
@@ -84,7 +84,7 @@ docker run --rm agentbom/agent-bom:latest doctor
 
 ![agent-bom focused graph](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png)
 
-## Coverage At A Glance
+## Key features
 
 - **Agents + MCP** — clients, servers, tools, transports, trust posture
 - **Skills + instructions** — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `skills/*`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ After the first scan:
 
 ```bash
 agent-bom agents -p . --remediate remediation.md                  # fix-first plan
-agent-bom agents -p . --compliance-export fedramp -o evidence.zip # auditor-ready bundle
+agent-bom agents -p . --compliance-export fedramp -o evidence.zip # tamper-evident evidence bundle
 pip install 'agent-bom[ui]' && agent-bom serve                    # API + dashboard
 ```
 
@@ -235,7 +235,7 @@ Every layer is testable on its own; failures emit Prometheus metrics. Operators 
 
 ### 4. What you get, and how to install it
 
-Inside the control plane: **OIDC + SAML SSO** with RBAC, **enforced API-key rotation policy**, **tenant-scoped quotas + rate limits**, **HMAC-chained audit log** with signed export, **KMS-encrypted Postgres backups** with a verified restore round-trip in CI, and **signed compliance evidence bundles** (`/v1/compliance/{framework}/report` — nonce + expiry inside the signature).
+Inside the control plane: **OIDC + SAML SSO** with RBAC, **enforced API-key rotation policy**, **tenant-scoped quotas + rate limits**, **HMAC-chained audit log** with signed export, **KMS-encrypted Postgres backups** with a verified restore round-trip in CI, and **tamper-evident compliance evidence bundles** (`/v1/compliance/{framework}/report` — nonce + expiry inside the HMAC envelope).
 
 <details>
 <summary><b>Helm install + fleet sync + local proxy</b></summary>
@@ -277,7 +277,7 @@ Full trust model: [SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) · [
 
 ## Compliance
 
-Bundled mappings for FedRAMP, CMMC, NIST AI RMF, ISO 27001, SOC 2, OWASP LLM Top-10, MITRE ATLAS, and EU AI Act. Export auditor-ready evidence packets in one command.
+Bundled mappings for FedRAMP, CMMC, NIST AI RMF, ISO 27001, SOC 2, OWASP LLM Top-10, MITRE ATLAS, and EU AI Act. Export tamper-evident evidence packets in one command.
 
 <p align="center">
   <picture>
@@ -336,7 +336,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
     fail-on-kev: true
 ```
 
-Container image gate, IaC gate, air-gapped CI, MCP scan, and the SARIF / SBOM examples are documented in [site-docs/getting-started/ci-cd.md](site-docs/getting-started/ci-cd.md).
+Container image gate, IaC gate, air-gapped CI, MCP scan, and the SARIF / SBOM examples are documented in [site-docs/getting-started/quickstart.md](site-docs/getting-started/quickstart.md).
 
 </details>
 

--- a/docs/skills/cloud-security-audit.md
+++ b/docs/skills/cloud-security-audit.md
@@ -309,7 +309,7 @@ This closes the loop: the same warehouse that sourced the departed employee data
 - **Remediation velocity** — time from termination to IAM cleanup
 - **Coverage gaps** — departed employees whose IAM was missed
 - **Posture trend** — orphaned IAM count over time
-- **Compliance evidence** — auditor-ready logs of every action taken
+- **Compliance evidence** — review-ready logs of every action taken
 
 ```sql
 -- Snowflake: remediation dashboard query

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -265,6 +265,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
     # Ordered route rules so narrower enterprise paths win over broad prefixes.
     _ROLE_RULES: tuple[tuple[str, str, str], ...] = (
+        ("GET", "/v1/compliance", "viewer"),
+        ("GET", "/v1/posture", "viewer"),
         ("GET", "/v1/auth/keys", "admin"),
         ("POST", "/v1/auth/keys", "admin"),
         ("DELETE", "/v1/auth/keys/", "admin"),

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -158,6 +158,73 @@ class HealthResponse(BaseModel):
     storage: StorageHealth
 
 
+class ComplianceEvidenceItem(BaseModel):
+    finding_id: str
+    control_tag: str
+    vulnerability_id: str | None = None
+    package: str | None = None
+    severity: str | None = None
+    scan_id: str | None = None
+    fixed_version: str | None = None
+    agents_at_risk: list[str] = Field(default_factory=list)
+
+
+class ComplianceReportControl(BaseModel):
+    control_id: str | None = None
+    control_name: str | None = None
+    status: str = "unknown"
+    finding_count: int = 0
+    evidence: list[ComplianceEvidenceItem] = Field(default_factory=list)
+
+
+class ComplianceReportScope(BaseModel):
+    since: str
+    until: str
+    control_count: int = 0
+    finding_count: int = 0
+    audit_event_count: int = 0
+
+
+class ComplianceReportSummary(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    passed: int = Field(alias="pass")
+    warning: int = 0
+    fail: int = 0
+    score: float = 100.0
+
+
+class ComplianceAuditIntegrity(BaseModel):
+    verified: int = 0
+    tampered: int = 0
+    checked: int = 0
+
+
+class ComplianceThreatModel(BaseModel):
+    integrity: str
+    confidentiality: str
+    replay: str
+    non_repudiation: str
+
+
+class ComplianceReportBundle(BaseModel):
+    schema_version: str = "v1"
+    framework: str
+    framework_key: str
+    framework_label: str
+    tenant_id: str
+    generated_at: str
+    expires_at: str
+    nonce: str
+    scope: ComplianceReportScope
+    summary: ComplianceReportSummary
+    controls: list[ComplianceReportControl] = Field(default_factory=list)
+    audit_events: list[dict[str, Any]] = Field(default_factory=list)
+    audit_log_integrity: ComplianceAuditIntegrity
+    signature_algorithm: str
+    threat_model: ComplianceThreatModel
+
+
 # ─── Fleet Models ──────────────────────────────────────────────────────────
 
 

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -18,19 +18,25 @@ import json
 import os
 import secrets
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
 
-from agent_bom.api.models import JobStatus
+from agent_bom.api.models import ComplianceReportBundle, JobStatus
 from agent_bom.api.stores import _get_store
+from agent_bom.rbac import require_authenticated_permission
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport
     from agent_bom.output.compliance_narrative import ComplianceNarrative
 
-router = APIRouter()
+
+def _dep(permission: str) -> Any:
+    return cast(Any, require_authenticated_permission(permission))
+
+
+router = APIRouter(dependencies=[_dep("read")])
 
 
 def _tenant_id(request: Request) -> str:
@@ -112,7 +118,9 @@ async def get_compliance(request: Request) -> dict:
             controls.append(
                 {
                     id_key: code,
+                    "control_id": code,
                     "name": name,
+                    "tags": [code],
                     "findings": findings,
                     "status": status,
                     "severity_breakdown": sev_breakdown,
@@ -412,7 +420,7 @@ def _narrative_to_dict(narrative: "ComplianceNarrative") -> dict:
 
 @router.get("/v1/compliance/narrative", tags=["compliance"])
 async def get_compliance_narrative(request: Request) -> dict:
-    """Generate an auditor-ready compliance narrative from all completed scans.
+    """Generate a review-ready compliance narrative from all completed scans.
 
     Produces human-readable stories for all 11 supported frameworks, a
     cross-framework executive summary, and a remediation-compliance bridge
@@ -546,7 +554,11 @@ def _evidence_for_control(
     """Map a control's tags onto the matching blast-radius findings."""
     seen_finding_ids: set[str] = set()
     evidence: list[dict] = []
-    for tag in control.get("tags", []) or []:
+    tags = list(control.get("tags", []) or [])
+    fallback_tag = control.get("control_id") or control.get("code") or control.get("id")
+    if fallback_tag and fallback_tag not in tags:
+        tags.append(str(fallback_tag))
+    for tag in tags:
         for br in blast_radii_by_tag.get(tag, []):
             finding_id = br.get("finding_id") or f"{br.get('vulnerability_id', '')}@{br.get('package', '')}"
             if finding_id in seen_finding_ids:
@@ -597,7 +609,19 @@ def _index_blast_radii_by_tag(jobs: list) -> dict[str, list[dict]]:
     return by_tag
 
 
-@router.get("/v1/compliance/{framework}/report", tags=["compliance"], response_model=None)
+def _verify_audit_entries(entries: list) -> tuple[int, int]:
+    """Verify only the entries included in the exported bundle."""
+    verified = 0
+    tampered = 0
+    for entry in entries:
+        if entry.verify():
+            verified += 1
+        else:
+            tampered += 1
+    return verified, tampered
+
+
+@router.get("/v1/compliance/{framework}/report", tags=["compliance"], response_model=ComplianceReportBundle)
 async def export_compliance_report(
     request: Request,
     framework: str,
@@ -605,7 +629,7 @@ async def export_compliance_report(
     until: str | None = None,
     format: str = "json",
 ) -> JSONResponse | PlainTextResponse:
-    """Export an auditor-ready signed evidence bundle for a single framework.
+    """Export a tamper-evident signed evidence bundle for a single framework.
 
     The bundle pairs each control with the blast-radius findings that map to
     its tags, the audit-log entries within the requested time window, and
@@ -688,10 +712,9 @@ async def export_compliance_report(
     audit_in_window = [
         e
         for e in audit_entries
-        if str((e.details or {}).get("tenant_id", "default")) == tenant_id
-        and audit_since_iso <= (e.timestamp or "") <= until_iso
+        if str((e.details or {}).get("tenant_id", "")) == tenant_id and audit_since_iso <= (e.timestamp or "") <= until_iso
     ]
-    verified, tampered = store.verify_integrity(limit=min(10_000, len(audit_entries) or 1))
+    verified, tampered = _verify_audit_entries(audit_in_window)
 
     pass_count = sum(1 for c in controls if c.get("status") == "pass")
     warn_count = sum(1 for c in controls if c.get("status") == "warning")
@@ -748,7 +771,7 @@ async def export_compliance_report(
         "audit_log_integrity": {
             "verified": verified,
             "tampered": tampered,
-            "checked": verified + tampered,
+            "checked": len(audit_in_window),
         },
         "signature_algorithm": "HMAC-SHA256",
         "threat_model": {
@@ -789,7 +812,7 @@ async def export_compliance_report(
         expires_at=expires_at.isoformat(),
     )
 
-    filename = f"agent-bom-compliance-{framework_key.replace('_', '-')}.{ 'jsonl' if fmt == 'jsonl' else 'json'}"
+    filename = f"agent-bom-compliance-{framework_key.replace('_', '-')}.{'jsonl' if fmt == 'jsonl' else 'json'}"
 
     if fmt == "jsonl":
         # jsonl streams one control per line so SIEM and security-lake

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -1,4 +1,4 @@
-"""Compliance narrative generator — auditor-ready stories from scan data.
+"""Compliance narrative generator — review-ready stories from scan data.
 
 Produces human-readable compliance narratives from AIBOMReport data without
 requiring an LLM.  Uses template strings and structured data from blast_radius
@@ -123,7 +123,7 @@ class RemediationImpact:
 
 @dataclass
 class ComplianceNarrative:
-    """Full auditor-ready compliance story from a scan."""
+    """Full review-ready compliance story from a scan."""
 
     executive_summary: str
     framework_narratives: list[FrameworkNarrative]
@@ -642,7 +642,7 @@ def generate_compliance_narrative(
     report: "AIBOMReport",
     framework: str | None = None,
 ) -> ComplianceNarrative:
-    """Generate auditor-ready compliance narrative from scan results.
+    """Generate review-ready compliance narrative from scan results.
 
     Args:
         report: The AIBOMReport to analyse.

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -19,6 +19,8 @@ import threading
 from enum import Enum
 from typing import Callable
 
+from fastapi import HTTPException, Request
+
 logger = logging.getLogger(__name__)
 
 
@@ -153,3 +155,69 @@ def require_permission(action: str) -> Callable:
         return role
 
     return Depends(_check)
+
+
+def require_authenticated_permission(action: str) -> Callable:
+    """FastAPI dependency that requires authenticated enterprise access.
+
+    Unlike ``require_permission()``, this helper does not silently fall back to
+    the default viewer role for unauthenticated requests. It accepts either:
+
+    - a request already authenticated by APIKeyMiddleware / OIDC / SAML, or
+    - a trusted reverse proxy injecting ``X-Agent-Bom-Role`` plus
+      ``X-Agent-Bom-Tenant-ID``.
+    """
+    from fastapi import Depends, Header, HTTPException
+
+    async def _check(
+        request: Request,
+        x_role: str | None = Header(None, alias="X-Agent-Bom-Role"),
+        x_tenant_id: str | None = Header(None, alias="X-Agent-Bom-Tenant-ID"),
+    ) -> Role:
+        state_role = getattr(request.state, "api_key_role", None)
+        if state_role:
+            try:
+                role = Role(str(state_role).lower())
+            except ValueError as exc:
+                raise HTTPException(status_code=403, detail=f"Invalid authenticated role '{state_role}'") from exc
+            if not getattr(request.state, "tenant_id", None):
+                request.state.tenant_id = "default"
+            return _authorize(role, action)
+
+        if not x_role:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    "Authentication required — provide an authenticated API key/token "
+                    "or trusted proxy headers (X-Agent-Bom-Role + X-Agent-Bom-Tenant-ID)"
+                ),
+            )
+
+        try:
+            role = Role(x_role.lower())
+        except ValueError as exc:
+            raise HTTPException(status_code=403, detail=f"Invalid proxy role '{x_role}'") from exc
+
+        if not x_tenant_id:
+            raise HTTPException(
+                status_code=401,
+                detail="Authentication required — trusted proxy requests must include X-Agent-Bom-Tenant-ID",
+            )
+
+        request.state.api_key_role = role.value
+        request.state.tenant_id = x_tenant_id
+        request.state.api_key_name = getattr(request.state, "api_key_name", None) or "proxy-header"
+        request.state.auth_method = getattr(request.state, "auth_method", None) or "proxy_header"
+        return _authorize(role, action)
+
+    return Depends(_check)
+
+
+def _authorize(role: Role, action: str) -> Role:
+    """Validate that a resolved role can perform an action."""
+    if not check_permission(role, action):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role '{role.value}' does not have '{action}' permission",
+        )
+    return role

--- a/tests/test_api_compliance_auth.py
+++ b/tests/test_api_compliance_auth.py
@@ -1,0 +1,59 @@
+"""Defense-in-depth auth tests for compliance and posture routes."""
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+
+def test_posture_requires_authenticated_context() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/posture")
+    assert resp.status_code == 401
+    assert "Authentication required" in resp.json()["detail"]
+
+
+def test_posture_accepts_trusted_proxy_headers() -> None:
+    client = TestClient(app)
+    resp = client.get(
+        "/v1/posture",
+        headers={
+            "X-Agent-Bom-Role": "viewer",
+            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["grade"] == "N/A"
+
+
+def test_posture_proxy_auth_requires_tenant_header() -> None:
+    client = TestClient(app)
+    resp = client.get(
+        "/v1/posture",
+        headers={
+            "X-Agent-Bom-Role": "viewer",
+        },
+    )
+    assert resp.status_code == 401
+    assert "X-Agent-Bom-Tenant-ID" in resp.json()["detail"]
+
+
+def test_compliance_export_requires_authenticated_context() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/compliance")
+    assert resp.status_code == 401
+    assert "Authentication required" in resp.json()["detail"]
+
+
+def test_compliance_export_accepts_trusted_proxy_headers() -> None:
+    client = TestClient(app)
+    resp = client.get(
+        "/v1/compliance/owasp-llm/report",
+        headers={
+            "X-Agent-Bom-Role": "viewer",
+            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["framework"] == "owasp-llm"
+    assert body["tenant_id"] == "tenant-alpha"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -337,3 +337,7 @@ def test_openapi_schema_available():
     assert "openapi" in body
     assert "paths" in body
     assert body["info"]["title"] == "agent-bom API"
+    compliance_report = body["paths"]["/v1/compliance/{framework}/report"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert compliance_report["$ref"].endswith("/ComplianceReportBundle")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -7,6 +7,11 @@ from starlette.testclient import TestClient
 from agent_bom.api.server import JobStatus, _get_store, app
 from agent_bom.api.store import InMemoryJobStore
 
+_AUTH_HEADERS = {
+    "X-Agent-Bom-Role": "viewer",
+    "X-Agent-Bom-Tenant-ID": "default",
+}
+
 
 def _clear_jobs():
     """Reset the job store to a fresh in-memory store."""
@@ -41,7 +46,7 @@ def test_compliance_no_scans():
     """With no completed scans, all controls pass and score is 100%."""
     _clear_jobs()
     client = TestClient(app)
-    resp = client.get("/v1/compliance")
+    resp = client.get("/v1/compliance", headers=_AUTH_HEADERS)
     assert resp.status_code == 200
     data = resp.json()
     assert data["overall_score"] == 100.0
@@ -72,7 +77,7 @@ def test_compliance_with_findings():
         ]
     )
     client = TestClient(app)
-    resp = client.get("/v1/compliance")
+    resp = client.get("/v1/compliance", headers=_AUTH_HEADERS)
     data = resp.json()
 
     assert data["scan_count"] == 1
@@ -110,7 +115,7 @@ def test_compliance_severity_breakdown():
         ]
     )
     client = TestClient(app)
-    data = client.get("/v1/compliance").json()
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
 
     lmm04 = next(c for c in data["owasp_llm_top10"] if c["code"] == "LLM04")
     assert lmm04["status"] == "fail"
@@ -137,7 +142,7 @@ def test_compliance_warning_status():
         ]
     )
     client = TestClient(app)
-    data = client.get("/v1/compliance").json()
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
 
     lmm05 = next(c for c in data["owasp_llm_top10"] if c["code"] == "LLM05")
     assert lmm05["status"] == "warning"
@@ -150,7 +155,7 @@ def test_compliance_owasp_catalog_complete():
     """All 10 OWASP LLM Top 10 controls are present."""
     _clear_jobs()
     client = TestClient(app)
-    data = client.get("/v1/compliance").json()
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
     codes = {c["code"] for c in data["owasp_llm_top10"]}
     assert codes == {f"LLM{str(i).zfill(2)}" for i in range(1, 11)}
     _clear_jobs()
@@ -160,7 +165,7 @@ def test_compliance_atlas_catalog_complete():
     """MITRE ATLAS catalog is fully populated (74 entries as of March 2026)."""
     _clear_jobs()
     client = TestClient(app)
-    data = client.get("/v1/compliance").json()
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
     assert len(data["mitre_atlas"]) >= 50
     _clear_jobs()
 
@@ -169,7 +174,7 @@ def test_compliance_nist_catalog_complete():
     """All 14 NIST AI RMF subcategories are present."""
     _clear_jobs()
     client = TestClient(app)
-    data = client.get("/v1/compliance").json()
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
     assert len(data["nist_ai_rmf"]) == 14
     _clear_jobs()
 
@@ -191,7 +196,7 @@ def test_compliance_summary_counts():
         ]
     )
     client = TestClient(app)
-    data = client.get("/v1/compliance").json()
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
 
     s = data["summary"]
     # Verify OWASP: 1 fail (LLM05), 9 pass

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -129,9 +129,7 @@ def test_report_json_signature_matches_canonical_body() -> None:
 
     with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
         with _patched_get_compliance_returns(full_payload):
-            resp = asyncio.run(
-                compliance_routes.export_compliance_report(req, "owasp-llm")
-            )
+            resp = asyncio.run(compliance_routes.export_compliance_report(req, "owasp-llm"))
 
     assert isinstance(resp, JSONResponse)
     body = json.loads(resp.body)
@@ -173,6 +171,27 @@ def test_report_json_signature_matches_canonical_body() -> None:
     # Nonce from the body is recorded in the audit trail for forensic correlation
     assert (exported.details or {}).get("nonce") == body["nonce"]
     assert (exported.details or {}).get("expires_at") == body["expires_at"]
+
+
+def test_real_compliance_export_wires_control_tags_and_non_empty_evidence() -> None:
+    """Exercise the real producer path instead of patching in synthetic tags."""
+    _setup_audit_log()
+    jobs = _seed_jobs_with_findings()
+    req = _request("tenant-alpha")
+
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
+        posture = asyncio.run(compliance_routes.get_compliance(req))
+        resp = asyncio.run(compliance_routes.export_compliance_report(req, "owasp-llm"))
+
+    controls = posture["owasp_llm_top10"]
+    llm01 = next(c for c in controls if c["control_id"] == "LLM01")
+    assert llm01["tags"] == ["LLM01"]
+
+    body = json.loads(resp.body)
+    exported = {c["control_id"]: c for c in body["controls"]}
+    assert exported["LLM01"]["finding_count"] == 1
+    assert exported["LLM01"]["evidence"][0]["control_tag"] == "LLM01"
+    assert exported["LLM01"]["evidence"][0]["vulnerability_id"] == "CVE-2024-0001"
 
 
 # ─── Replay-protection envelope ──────────────────────────────────────────────
@@ -247,22 +266,32 @@ def test_threat_model_block_documents_guarantees() -> None:
 
 
 def test_report_audit_events_are_tenant_filtered() -> None:
-    _setup_audit_log()  # has one tenant-alpha and one tenant-other entry
+    audit = _setup_audit_log()  # has one tenant-alpha and one tenant-other entry
+    audit.append(
+        AuditEntry(
+            entry_id="e3",
+            timestamp=(datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(),
+            action="scan.completed",
+            actor="system",
+            resource="scan/scan-a",
+            details={},  # missing tenant_id must NOT leak into default tenant exports
+        )
+    )
     jobs = _seed_jobs_with_findings()
     full_payload = {"owasp_llm_top10": []}
     req = _request("tenant-alpha")
 
     with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
         with _patched_get_compliance_returns(full_payload):
-            resp = asyncio.run(
-                compliance_routes.export_compliance_report(req, "owasp-llm")
-            )
+            resp = asyncio.run(compliance_routes.export_compliance_report(req, "owasp-llm"))
 
     body = json.loads(resp.body)
     # Cross-tenant audit entry must not leak into the bundle
     tenants = {e["details"].get("tenant_id") for e in body["audit_events"]}
     assert tenants == {"tenant-alpha"}
     assert all(e["details"].get("tenant_id") != "tenant-other" for e in body["audit_events"])
+    assert len(body["audit_events"]) == 1
+    assert body["audit_log_integrity"]["checked"] == 1
 
 
 # ─── Format = jsonl ──────────────────────────────────────────────────────────
@@ -280,9 +309,7 @@ def test_report_jsonl_streams_one_record_per_line() -> None:
 
     with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
         with _patched_get_compliance_returns(full_payload):
-            resp = asyncio.run(
-                compliance_routes.export_compliance_report(req, "soc2", format="jsonl")
-            )
+            resp = asyncio.run(compliance_routes.export_compliance_report(req, "soc2", format="jsonl"))
 
     assert isinstance(resp, PlainTextResponse)
     raw = resp.body.decode()
@@ -307,9 +334,7 @@ def test_unknown_framework_returns_400() -> None:
     with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
         with _patched_get_compliance_returns({}):
             with pytest.raises(HTTPException) as exc:
-                asyncio.run(
-                    compliance_routes.export_compliance_report(req, "made-up-framework")
-                )
+                asyncio.run(compliance_routes.export_compliance_report(req, "made-up-framework"))
     assert exc.value.status_code == 400
     assert "Unknown framework" in exc.value.detail
 
@@ -320,9 +345,7 @@ def test_invalid_format_returns_400() -> None:
     with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
         with _patched_get_compliance_returns({}):
             with pytest.raises(HTTPException) as exc:
-                asyncio.run(
-                    compliance_routes.export_compliance_report(req, "fedramp", format="csv")
-                )
+                asyncio.run(compliance_routes.export_compliance_report(req, "fedramp", format="csv"))
     assert exc.value.status_code == 400
     assert "format must be" in exc.value.detail
 
@@ -333,9 +356,7 @@ def test_malformed_since_returns_400() -> None:
     with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
         with _patched_get_compliance_returns({}):
             with pytest.raises(HTTPException) as exc:
-                asyncio.run(
-                    compliance_routes.export_compliance_report(req, "fedramp", since="not-a-date")
-                )
+                asyncio.run(compliance_routes.export_compliance_report(req, "fedramp", since="not-a-date"))
     assert exc.value.status_code == 400
     assert "Invalid timestamp" in exc.value.detail
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3908,7 +3908,10 @@ def test_api_posture_counts_empty():
     from agent_bom.api.server import app
 
     client = TestClient(app)
-    resp = client.get("/v1/posture/counts")
+    resp = client.get(
+        "/v1/posture/counts",
+        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "default"},
+    )
     assert resp.status_code == 200
     body = resp.json()
     assert "critical" in body
@@ -3955,7 +3958,10 @@ def test_api_posture_counts_with_data():
         },
     )
     _get_store().put(job)
-    resp = client.get("/v1/posture/counts")
+    resp = client.get(
+        "/v1/posture/counts",
+        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "default"},
+    )
     assert resp.status_code == 200
     body = resp.json()
     assert body["critical"] >= 1


### PR DESCRIPTION
## What changed

This closes the Claude audit P0/P1 gaps on the enterprise/compliance surface.

- fix compliance evidence bundles so real exports include evidence instead of empty arrays
- require authenticated context on compliance and posture routes, while still allowing trusted proxy header injection for enterprise ingress patterns
- tighten tenant filtering for exported audit events so missing tenant markers do not leak into the default tenant bundle
- add an explicit OpenAPI response model for compliance evidence exports
- align product wording away from overstated "auditor-ready" claims where the implementation is HMAC tamper-evidence rather than asymmetric non-repudiation
- make Smithery registry publish skip cleanly when required repo configuration is absent instead of failing the whole publish workflow red
- add ignore guardrails for macOS/iCloud duplicate conflict files so they do not get committed accidentally

## Why it changed

Claude's audit was directionally right on the highest-risk issues:

- evidence export logic was wired incorrectly in production
- the enterprise compliance/posture surface needed defense-in-depth auth instead of relying only on global middleware configuration
- tenant filtering on exported audit evidence was too loose
- registry publishing and docs wording were overstating readiness in a few places

This PR closes those gaps end to end instead of patching only the symptoms.

## Impact

- compliance exports now return real control evidence from real scan data
- posture and compliance endpoints fail closed without authenticated context
- tenant-scoped exports no longer pull audit entries that omitted tenant metadata
- OpenAPI now documents the compliance bundle schema
- publish-to-registries no longer goes red purely because Smithery env vars are unset
- repo hygiene is safer against duplicate conflict files in synced working trees

## Validation

- `PYTHONPATH=src python -m pytest tests/test_compliance.py tests/test_compliance_report.py tests/test_api_compliance_auth.py tests/test_api_endpoints.py tests/test_core.py tests/test_deployment.py -q`
- `python scripts/check_release_consistency.py`
- pre-commit hooks via commit path (`ruff`, `ruff-format`, `mypy`, `bandit`, etc.)
