### PR TITLE
fix: wrap remaining p0/p1 audit gaps

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -206,6 +206,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install ClawHub CLI
+        run: |
+          npm install -g clawhub@latest
+          clawhub --version
+
       - name: Publish to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
@@ -217,51 +222,30 @@ jobs:
           fi
 
           echo "Publishing agent-bom v${VERSION} to ClawHub..."
+          clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 
-          # Direct API publish — bypasses clawhub CLI v0.7.0 acceptLicenseTerms bug.
-          # API: POST /api/v1/skills with multipart form: payload JSON + file blobs.
           _publish_skill() {
             local DIR="$1" SLUG="$2" FATAL="${3:-true}"
             local DISPLAY_NAME="${4:-$SLUG}"
 
-            # Build file list (text files only, skip hidden/binary)
-            local CURL_ARGS=()
-            local FILE_COUNT=0
-            while IFS= read -r -d '' FILE; do
-              REL_PATH="${FILE#${DIR}/}"
-              CURL_ARGS+=(-F "files=@${FILE};filename=${REL_PATH};type=text/plain")
-              FILE_COUNT=$((FILE_COUNT + 1))
-            done < <(find "${DIR}" -maxdepth 2 -type f \( -name "*.md" -o -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.txt" \) -print0)
-
-            if [ "$FILE_COUNT" -eq 0 ]; then
+            if [ ! -d "$DIR" ]; then
               echo "::warning::No files found in ${DIR} — skipping"
               return 0
             fi
 
-            local PAYLOAD
-            PAYLOAD=$(cat <<EOJSON
-          {"slug":"${SLUG}","displayName":"${DISPLAY_NAME}","version":"${VERSION}","changelog":"Release v${VERSION}","tags":["latest"],"acceptLicenseTerms":true}
-          EOJSON
-            )
-
             for ATTEMPT in 1 2 3; do
               echo "ClawHub ${SLUG} attempt ${ATTEMPT}/3..."
-              HTTP_CODE=$(curl -s -o /tmp/clawhub_resp.json -w "%{http_code}" \
-                --connect-timeout 15 --max-time 120 \
-                -X POST "https://clawhub.ai/api/v1/skills" \
-                -H "Authorization: Bearer ${CLAWHUB_TOKEN}" \
-                -H "Accept: application/json" \
-                -F "payload=${PAYLOAD}" \
-                "${CURL_ARGS[@]}")
-              if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
-                echo "ClawHub ${SLUG} v${VERSION} published (HTTP ${HTTP_CODE})"
+              if clawhub publish "$DIR" \
+                --slug "$SLUG" \
+                --name "$DISPLAY_NAME" \
+                --version "$VERSION" \
+                --changelog "Release v${VERSION}" \
+                --tags latest; then
+                echo "ClawHub ${SLUG} v${VERSION} published"
                 return 0
               else
-                echo "ClawHub ${SLUG} failed (HTTP ${HTTP_CODE})"
-                jq -r '.error // .message // "unknown error"' /tmp/clawhub_resp.json 2>/dev/null || echo "(non-JSON response)"
-                if [ "$HTTP_CODE" -eq 429 ] && [ "$ATTEMPT" -lt 3 ]; then
-                  sleep $((ATTEMPT * 15))
-                elif [ "$ATTEMPT" -lt 3 ]; then
+                echo "ClawHub ${SLUG} publish failed"
+                if [ "$ATTEMPT" -lt 3 ]; then
                   sleep $((ATTEMPT * 10))
                 fi
               fi

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -2,20 +2,23 @@
 
 **Open security scanner for AI supply chain — agents, MCP servers, packages, containers, cloud, GPU, and runtime.**
 
-Package risk is only the start. What matters is what it can reach.
+Every CVE in your AI stack is a credential leak waiting to happen. `agent-bom`
+follows the chain end-to-end and tells you which fix collapses it first.
 
-agent-bom helps developers, security teams, and enterprises discover AI agents and MCP environments, map CVEs into real blast radius, scan packages, container images, Kubernetes, IaC, and cloud AI infrastructure, and protect MCP traffic at runtime.
+Blast radius is the core idea:
+
+```text
+CVE -> package -> MCP server -> agent -> credentials -> tools
+```
+
+This container is the quickest way to run the same scanner, runtime surfaces,
+and self-hosted operator path described in the main repository README.
 
 References:
 
+- GitHub README: https://github.com/msaad00/agent-bom/blob/main/README.md
 - Product brief: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_BRIEF.md
 - Verified metrics: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_METRICS.md
-
-## Who It Is For
-
-- **Developers:** scan your workstation, repos, MCP servers, and AI tools
-- **Security teams:** map package risk into agents, credentials, and reachable tools
-- **Enterprises:** add runtime protection, policy, and compliance evidence
 
 ## Quick Start
 
@@ -43,7 +46,7 @@ docker run --rm agentbom/agent-bom:latest check flask@2.0.0
 docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom:latest agents -p /workspace
 ```
 
-**Export AI BOM (CycloneDX 1.6 / SPDX 3.0)**
+**Export AI BOM (CycloneDX / SPDX)**
 
 ```bash
 docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom:latest agents -p /workspace -f cyclonedx -o /workspace/ai-bom.json
@@ -55,51 +58,64 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom:latest agents -p /work
 docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom:latest iac /workspace
 ```
 
-**Cloud AI and infra inventory**
-
-```bash
-docker run --rm agentbom/agent-bom:latest cloud aws
-```
-
-**Preflight health check**
-
-```bash
-docker run --rm agentbom/agent-bom:latest doctor
-```
-
-## What it scans
+## What You Get
 
 - Blast radius from package to server to agent to credentials and tools
-- AI-native coverage across agents, MCP, runtime, containers, cloud, IaC, and GPU surfaces
+- AI-native coverage across agents, MCP, runtime, containers, cloud, IaC, and GPU
 - One operator path across CLI, CI, API, dashboard, remediation, and MCP tools
-- Runtime MCP protection plus broader review and evidence exports
+- Runtime MCP protection plus broader review and tamper-evident evidence exports
 
-## Product views
+## Product Surfaces
 
-### Dashboard
+The promoted self-hosted rollout is a scoped operator stack, not one forced
+runtime monolith. Teams typically deploy only the surfaces they need:
+
+- **scan**: discovery, inventory, CVE, image, IaC, Kubernetes, and cloud analysis
+- **fleet**: endpoint and collector inventory pushed into the control plane
+- **proxy / runtime**: inline MCP enforcement near selected workloads
+- **gateway**: central policy management for those runtime paths
+- **API + UI**: the operator plane for findings, graph, remediation, audit, and policy workflows
+
+## Deploy In Your Own Infra
+
+`agent-bom` is designed to run inside your own AWS account, VPC, EKS cluster,
+IAM boundary, databases, and SSO stack.
+
+Recommended shape:
+
+- stateless API + UI deployments behind your ingress
+- Postgres for transactional state and graph metadata
+- optional ClickHouse only when audit and analytics volume justifies it
+- scheduled scan jobs for cluster, image, and discovery work
+- endpoint fleet sync for laptops and collectors
+- selected `agent-bom proxy` sidecars or local wrappers for the MCP workloads that need inline enforcement
+- gateway-backed policy pull so runtime controls stay centralized without hairpinning all traffic through one shared chokepoint
+
+Everything stays in your infrastructure by default; optional egress for DB
+refresh, enrichment, SIEM, OTLP, and webhooks is operator-controlled.
+
+## Security Posture
+
+- HTTPS for every external hop
+- private in-cluster traffic or service-mesh mTLS for internal hops
+- auth on every non-loopback control-plane surface
+- RBAC and tenant scoping on sensitive routes
+- rate limiting, audit trails, and signed release artifacts
+- HMAC-backed tamper evidence for exported bundles
+
+## Dashboard Views
+
+Dashboard overview:
 
 ![agent-bom dashboard overview](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png)
 
-### Focused graph
+Attack paths and exposure:
+
+![agent-bom dashboard attack paths and exposure](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-paths-live.png)
+
+Focused graph:
 
 ![agent-bom focused graph](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png)
-
-## Key features
-
-- **Agents + MCP** — clients, servers, tools, transports, trust posture
-- **Skills + instructions** — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `skills/*`
-- **Supply chain** — package ecosystems, blast radius, dependency confusion, SBOM formats
-- **Containers + IaC + cloud** — OCI images, Docker, Kubernetes, Terraform, Helm, cloud AI posture
-- **Runtime + trust** — MCP proxy, runtime protection engine, capability risk, compliance mapping
-
-## Deployment Guidance
-
-| Environment | Recommendation |
-|-------------|----------------|
-| Developer laptop | `pip install agent-bom` is fine; read-only and no listener by default |
-| CI/CD | `docker run --rm agentbom/agent-bom` for isolated scans and easy gating |
-| Enterprise fleet | run `agent-bom serve` in a dedicated container or namespace with RBAC |
-| Air-gapped | pre-sync the DB and run with `--offline` |
 
 ## Tags
 
@@ -110,8 +126,7 @@ docker run --rm agentbom/agent-bom:latest doctor
 
 ## Links
 
-- [GitHub](https://github.com/msaad00/agent-bom)
-- [PyPI](https://pypi.org/project/agent-bom/)
-- [GitHub Action](https://github.com/marketplace/actions/agent-bom)
-- [Discord](https://discord.gg/3YmYPqKZh5)
-- [Discussions](https://github.com/msaad00/agent-bom/discussions)
+- GitHub: https://github.com/msaad00/agent-bom
+- PyPI: https://pypi.org/project/agent-bom/
+- Docs: https://msaad00.github.io/agent-bom/
+- GitHub Action: https://github.com/marketplace/actions/agent-bom

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -94,11 +94,14 @@ but is not part of the public ClawHub release surface.
 
 ```bash
 npm install -g clawhub@latest
-clawhub login --token "$CLAWHUB_TOKEN"
+clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
   --version "0.78.1"
 ```
+
+Release automation uses the same official `clawhub` CLI flow, not a custom
+multipart API shim, so local publishing and CI stay aligned.
 
 ### Verification
 

--- a/src/agent_bom/ai_components/scanner.py
+++ b/src/agent_bom/ai_components/scanner.py
@@ -9,7 +9,7 @@ Usage::
 
     report = scan_source("/path/to/project")
     for comp in report.components:
-        print(f"{comp.component_type.value}: {comp.name} in {comp.file_path}:{comp.line_number}")
+        summary = f"{comp.component_type.value}: {comp.name} in {comp.file_path}:{comp.line_number}"
 """
 
 from __future__ import annotations

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -411,7 +411,8 @@ def display_json(log: AuditLog) -> int:
         else None,
         "alert_details": [{"severity": a.severity, "detector": a.detector, "tool": a.tool, "message": a.message} for a in log.alerts],
     }
-    print(json.dumps(out, indent=2))
+    sys.stdout.write(json.dumps(out, indent=2))
+    sys.stdout.write("\n")
     blocked = out["blocked"]
     errors = out["relay_errors"]
     return 1 if (blocked or errors) else 0
@@ -434,7 +435,7 @@ def replay(
     """Parse and display an audit log. Returns exit code (0 = clean, 1 = issues)."""
     path = Path(log_path)
     if not path.exists():
-        print(f"Error: audit log not found: {log_path}", file=sys.stderr)
+        sys.stderr.write(f"Error: audit log not found: {log_path}\n")
         return 2
 
     log = parse_audit_log(path)

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -30,6 +30,7 @@ from agent_bom.cli.agents._context import ScanContext
 from agent_bom.cli.agents._discovery import run_local_discovery
 from agent_bom.cli.agents._output import _format_text, render_output
 from agent_bom.cli.agents._post import compute_exit_code, run_integrations
+from agent_bom.cli.agents._preflight import emit_dry_run_plan, run_iac_only_scan
 from agent_bom.cli.options import scan_options
 from agent_bom.discovery import discover_all
 from agent_bom.models import AIBOMReport
@@ -486,119 +487,46 @@ def scan(
 
     # ── Dry-run: show access plan without scanning ────────────────────────────
     if dry_run:
-        con.print("\n[bold cyan]🔍 Dry-run — access plan (no files read, no queries made)[/bold cyan]\n")
-        reads = []
-        if inventory:
-            reads.append(f"  [green]Would read:[/green]   {inventory}")
-        if project:
-            reads.append(f"  [green]Would read:[/green]   {project}  (agent configs)")
-        if config_dir:
-            reads.append(f"  [green]Would read:[/green]   {config_dir}  (config directory)")
-        if not reads:
-            from agent_bom.discovery import get_all_discovery_paths
-
-            for client, path in get_all_discovery_paths():
-                reads.append(f"  [green]Would read:[/green]   {path}  ({client})")
-        for cp in code_paths:
-            reads.append(f"  [green]Would scan:[/green]   {cp}  (SAST via semgrep)")
-        for aip in ai_inventory_paths:
-            reads.append(f"  [green]Would scan:[/green]   {aip}  (AI component source scan)")
-        for tf_dir in tf_dirs:
-            reads.append(f"  [green]Would read:[/green]   {tf_dir}  (Terraform .tf files)")
-        for ap in agent_projects:
-            reads.append(f"  [green]Would read:[/green]   {ap}  (Python agent project)")
-        for jdir in jupyter_dirs:
-            reads.append(f"  [green]Would read:[/green]   {jdir}  (Jupyter notebooks *.ipynb)")
-        for mdir in model_dirs:
-            reads.append(f"  [green]Would read:[/green]   {mdir}  (ML model files .gguf, .safetensors, .onnx, .pt, etc.)")
-        for ddir in dataset_dirs:
-            reads.append(f"  [green]Would read:[/green]   {ddir}  (dataset cards: dataset_info.json, README.md, .dvc)")
-        for tdir in training_dirs:
-            reads.append(f"  [green]Would read:[/green]   {tdir}  (training pipelines: MLflow, Kubeflow, W&B)")
-        if gha_path:
-            reads.append(f"  [green]Would read:[/green]   {gha_path}/.github/workflows/  (GitHub Actions)")
-        for sp in skill_paths:
-            reads.append(f"  [green]Would read:[/green]   {sp}  (skill/instruction file)")
-        if no_skill:
-            reads.append("  [dim]Skill scanning:[/dim]   disabled (--no-skill)")
-        elif not skill_paths:
-            reads.append("  [green]Would discover:[/green] skill files (CLAUDE.md, .cursorrules, etc.)")
-        if skill_only:
-            reads.append("  [bold cyan]Mode:[/bold cyan]           skill-only (skipping agent/package/CVE scanning)")
-        for img in images:
-            reads.append(f"  [green]Would scan:[/green]   docker image {img}  (via grype → syft → docker)")
-        if aws:
-            reads.append(f"  [green]Would query:[/green]  AWS Bedrock/Lambda/ECS APIs ({aws_region or 'default region'})")
-            if aws_include_lambda:
-                reads.append(f"  [green]Would query:[/green]  AWS Lambda ListFunctions API ({aws_region or 'default region'})")
-            if aws_include_eks:
-                reads.append("  [green]Would query:[/green]  AWS EKS ListClusters + kubectl pod discovery")
-            if aws_include_step_functions:
-                reads.append("  [green]Would query:[/green]  AWS Step Functions ListStateMachines API")
-            if aws_include_ec2:
-                reads.append("  [green]Would query:[/green]  AWS EC2 DescribeInstances API (tag-filtered)")
-        if azure_flag:
-            reads.append("  [green]Would query:[/green]  Azure AI Foundry/Container Apps APIs")
-        if gcp_flag:
-            reads.append(f"  [green]Would query:[/green]  GCP Vertex AI/Cloud Run APIs ({gcp_project or 'default project'})")
-        if databricks_flag:
-            reads.append("  [green]Would query:[/green]  Databricks Clusters/Libraries APIs")
-        if snowflake_flag:
-            reads.append("  [green]Would query:[/green]  Snowflake Cortex Agents/MCP Servers/Search/Snowpark/Streamlit APIs")
-        if coreweave_flag:
-            reads.append(
-                "  [green]Would query:[/green]  CoreWeave VirtualServer/InferenceService CRDs, GPU pods, InfiniBand jobs via kubectl"
-            )
-        if nebius_flag:
-            reads.append("  [green]Would query:[/green]  Nebius K8s/Container APIs")
-        if hf_flag:
-            reads.append("  [green]Would query:[/green]  Hugging Face Hub Models/Spaces/Endpoints APIs")
-        if wandb_flag:
-            reads.append("  [green]Would query:[/green]  W&B Runs/Artifacts/Model Registry APIs")
-        if mlflow_flag:
-            reads.append("  [green]Would query:[/green]  MLflow Tracking Server (models, experiments)")
-        if openai_flag:
-            reads.append("  [green]Would query:[/green]  OpenAI Assistants/Fine-tuning APIs")
-        if ollama_flag:
-            _host = ollama_host or "http://localhost:11434"
-            reads.append(f"  [green]Would query:[/green]  Ollama API ({_host}/api/tags) + ~/.ollama/models manifests")
-        if mcp_registry_flag:
-            reads.append(
-                "  [green]Would query:[/green]  https://registry.modelcontextprotocol.io/v0/servers  (Official MCP Registry, no auth)"
-            )
-        if snyk_flag:
-            reads.append("  [green]Would query:[/green]  https://api.snyk.io/rest/  (Snyk vulnerability enrichment)")
-        for line in reads:
-            con.print(line)
-        con.print()
-        con.print("  [dim]Would query:[/dim]  https://api.osv.dev/v1/querybatch  (batch CVE lookup, no auth required)")
-        if enrich:
-            con.print("  [dim]Would query:[/dim]  https://services.nvd.nist.gov/rest/json/cves/2.0  (CVSS v4)")
-            con.print("  [dim]Would query:[/dim]  https://api.first.org/data/v1/epss  (exploit probability)")
-            con.print("  [dim]Would query:[/dim]  https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json")
-        con.print()
-
-        # ── Data audit: exactly what gets extracted and sent ──────────────
-        con.print("[bold cyan]📋 Data Audit — what is extracted and transmitted[/bold cyan]\n")
-        con.print("  [bold]Extracted from config files:[/bold]")
-        con.print('    • Server names (e.g. "filesystem", "github")')
-        con.print('    • Commands and arguments (e.g. "npx @modelcontextprotocol/server-filesystem")')
-        con.print('    • Environment variable [bold]NAMES only[/bold] (e.g. "OPENAI_API_KEY")')
-        con.print("    • [dim]Values are NEVER read, stored, or logged[/dim]")
-        con.print()
-        con.print("  [bold]Sent to vulnerability APIs:[/bold]")
-        con.print('    • Package name + version only (e.g. "express@4.17.1")')
-        con.print("    • [dim]No file paths, config contents, env var values, hostnames, or IP addresses[/dim]")
-        con.print()
-        con.print("  [bold]Credential detection (name-only pattern matching):[/bold]")
-        con.print("    • Flagged patterns: *KEY*, *TOKEN*, *SECRET*, *PASSWORD*, *CREDENTIAL*, *AUTH*")
-        con.print("    • Excluded: PATH, HOME, LANG, SHELL, USER, TERM, EDITOR")
-        con.print("    • [dim]Detection is purely on env var names — values are never accessed[/dim]")
-        con.print()
-        con.print("  [bold green]✓ agent-bom is read-only.[/bold green] It never writes to configs or executes MCP servers.")
-        con.print("  [bold green]✓ Credential values are never read.[/bold green] Only env var names appear in reports.")
-        con.print(
-            "  See [link=https://github.com/msaad00/agent-bom/blob/main/PERMISSIONS.md]PERMISSIONS.md[/link] for the full trust contract."
+        emit_dry_run_plan(
+            con,
+            inventory=inventory,
+            project=project,
+            config_dir=config_dir,
+            code_paths=code_paths,
+            ai_inventory_paths=ai_inventory_paths,
+            tf_dirs=tf_dirs,
+            agent_projects=agent_projects,
+            jupyter_dirs=jupyter_dirs,
+            model_dirs=model_dirs,
+            dataset_dirs=dataset_dirs,
+            training_dirs=training_dirs,
+            gha_path=gha_path,
+            skill_paths=skill_paths,
+            no_skill=no_skill,
+            skill_only=skill_only,
+            images=images,
+            aws=aws,
+            aws_region=aws_region,
+            aws_include_lambda=aws_include_lambda,
+            aws_include_eks=aws_include_eks,
+            aws_include_step_functions=aws_include_step_functions,
+            aws_include_ec2=aws_include_ec2,
+            azure_flag=azure_flag,
+            gcp_flag=gcp_flag,
+            gcp_project=gcp_project,
+            databricks_flag=databricks_flag,
+            snowflake_flag=snowflake_flag,
+            coreweave_flag=coreweave_flag,
+            nebius_flag=nebius_flag,
+            hf_flag=hf_flag,
+            wandb_flag=wandb_flag,
+            mlflow_flag=mlflow_flag,
+            openai_flag=openai_flag,
+            ollama_flag=ollama_flag,
+            ollama_host=ollama_host,
+            mcp_registry_flag=mcp_registry_flag,
+            snyk_flag=snyk_flag,
+            enrich=enrich,
         )
         return
 
@@ -637,114 +565,30 @@ def scan(
     # This prevents MCP config discovery, lockfile scanning, and registry
     # lookups from running when the user only asked for IaC misconfiguration checks.
     if _iac_only and (iac_paths or k8s_live):
-        from agent_bom.iac import scan_iac_directory
-        from agent_bom.k8s import K8sDiscoveryError, scan_live_cluster_posture
-
-        _iac_ctx = ScanContext(con=con)
-        all_iac_findings: list = []
-        if iac_paths:
-            con.print(f"\n[bold blue]Scanning {len(iac_paths)} path(s) for IaC misconfigurations...[/bold blue]\n")
-            for _iac_path in iac_paths:
-                _iac_f = scan_iac_directory(_iac_path)
-                all_iac_findings.extend(_iac_f)
-                if _iac_f:
-                    from collections import Counter as _Counter
-
-                    _sev_counts = _Counter(f.severity for f in _iac_f)
-                    _sev_parts = [
-                        f"[red]{_sev_counts.get('critical', 0)} critical[/red]",
-                        f"[yellow]{_sev_counts.get('high', 0)} high[/yellow]",
-                    ]
-                    con.print(f"  [red]⚠[/red]  {_iac_path}: {len(_iac_f)} finding(s) ({', '.join(_sev_parts)})")
-                else:
-                    con.print(f"  [green]✓[/green] {_iac_path}: no misconfigurations")
-        if k8s_live:
-            con.print("\n[bold blue]Inspecting live Kubernetes cluster posture...[/bold blue]\n")
-            try:
-                _k8s_live_findings = scan_live_cluster_posture(
-                    namespace=k8s_live_namespace,
-                    all_namespaces=k8s_live_all_namespaces,
-                    context=k8s_live_context,
-                )
-            except K8sDiscoveryError as exc:
-                con.print(f"  [red]✗[/red] live cluster scan failed: {exc}")
-                raise SystemExit(1)
-            all_iac_findings.extend(_k8s_live_findings)
-            if _k8s_live_findings:
-                from collections import Counter as _Counter
-
-                _sev_counts = _Counter(f.severity for f in _k8s_live_findings)
-                _sev_parts = [
-                    f"[red]{_sev_counts.get('critical', 0)} critical[/red]",
-                    f"[yellow]{_sev_counts.get('high', 0)} high[/yellow]",
-                ]
-                con.print(f"  [red]⚠[/red]  live cluster posture: {len(_k8s_live_findings)} finding(s) ({', '.join(_sev_parts)})")
-            else:
-                con.print("  [green]✓[/green] live cluster posture: no runtime misconfigurations")
-
-        _iac_report = AIBOMReport(agents=[], blast_radii=[])
-        _iac_report.iac_findings_data = {
-            "total": len(all_iac_findings),
-            "findings": [
-                {
-                    "rule_id": f.rule_id,
-                    "severity": f.severity,
-                    "title": f.title,
-                    "message": f.message,
-                    "file_path": f.file_path,
-                    "line_number": f.line_number,
-                    "category": f.category,
-                    "compliance": f.compliance,
-                    "attack_techniques": f.attack_techniques,
-                    "remediation": f.remediation,
-                }
-                for f in all_iac_findings
-            ],
-        }
-        _iac_ctx.report = _iac_report
-        _iac_ctx.iac_findings_data = _iac_report.iac_findings_data
-
-        # Output
-        if output_format == "json" or output:
-            import json as _json
-
-            _out_data = _json.dumps(_iac_report.iac_findings_data, indent=2)
-            if output and output != "-":
-                from pathlib import Path as _Path
-
-                _Path(output).write_text(_out_data)
-                con.print(f"\n[green]IaC report written[/green] → {output}")
-            else:
-                import click as _click
-
-                _click.echo(_out_data)
-        elif output_format != "console":
-            # For SARIF, CycloneDX, etc — use the standard render pipeline
-            render_output(
-                _iac_ctx,
-                output=output,
-                output_format=output_format,
-                no_tree=no_tree,
-                quiet=quiet,
-                no_color=no_color,
-                open_report=open_report,
-                compliance_export=compliance_export,
-                mermaid_mode=mermaid_mode,
-                push_gateway=push_gateway,
-                otel_endpoint=otel_endpoint,
-                baseline=baseline,
-                delta_mode=delta_mode,
-                verbose=verbose,
-                exclude_unfixable=exclude_unfixable,
-                fixable_only=fixable_only,
-            )
-
-        # Exit code based on findings severity
-        if fail_on_severity and all_iac_findings:
-            _sev_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-            _threshold = _sev_order.get(fail_on_severity, 99)
-            if any(_sev_order.get(f.severity, 99) <= _threshold for f in all_iac_findings):
-                sys.exit(1)
+        run_iac_only_scan(
+            con=con,
+            iac_paths=iac_paths,
+            k8s_live=k8s_live,
+            k8s_live_namespace=k8s_live_namespace,
+            k8s_live_all_namespaces=k8s_live_all_namespaces,
+            k8s_live_context=k8s_live_context,
+            output=output,
+            output_format=output_format,
+            no_tree=no_tree,
+            quiet=quiet,
+            no_color=no_color,
+            open_report=open_report,
+            compliance_export=compliance_export,
+            mermaid_mode=mermaid_mode,
+            push_gateway=push_gateway,
+            otel_endpoint=otel_endpoint,
+            baseline=baseline,
+            delta_mode=delta_mode,
+            verbose=verbose,
+            exclude_unfixable=exclude_unfixable,
+            fixable_only=fixable_only,
+            fail_on_severity=fail_on_severity,
+        )
         return
 
     # Create shared context object

--- a/src/agent_bom/cli/agents/_preflight.py
+++ b/src/agent_bom/cli/agents/_preflight.py
@@ -1,0 +1,304 @@
+"""Preflight helpers extracted from the main scan command.
+
+These helpers keep the public ``agent_bom.cli.agents`` interface stable while
+pulling the high-branching preflight stages out of the main command body:
+
+- dry-run access/data audit rendering
+- IaC-only fast path execution
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+
+from agent_bom.cli.agents._context import ScanContext
+from agent_bom.cli.agents._output import render_output
+from agent_bom.models import AIBOMReport
+
+
+def emit_dry_run_plan(
+    con: Any,
+    *,
+    inventory: str | None,
+    project: str | None,
+    config_dir: str | None,
+    code_paths: tuple,
+    ai_inventory_paths: tuple,
+    tf_dirs: tuple,
+    agent_projects: tuple,
+    jupyter_dirs: tuple,
+    model_dirs: tuple,
+    dataset_dirs: tuple,
+    training_dirs: tuple,
+    gha_path: str | None,
+    skill_paths: tuple,
+    no_skill: bool,
+    skill_only: bool,
+    images: tuple,
+    aws: bool,
+    aws_region: str | None,
+    aws_include_lambda: bool,
+    aws_include_eks: bool,
+    aws_include_step_functions: bool,
+    aws_include_ec2: bool,
+    azure_flag: bool,
+    gcp_flag: bool,
+    gcp_project: str | None,
+    databricks_flag: bool,
+    snowflake_flag: bool,
+    coreweave_flag: bool,
+    nebius_flag: bool,
+    hf_flag: bool,
+    wandb_flag: bool,
+    mlflow_flag: bool,
+    openai_flag: bool,
+    ollama_flag: bool,
+    ollama_host: str | None,
+    mcp_registry_flag: bool,
+    snyk_flag: bool,
+    enrich: bool,
+) -> None:
+    """Render the dry-run access plan and data-audit block."""
+    from agent_bom.discovery import get_all_discovery_paths
+
+    con.print("\n[bold cyan]🔍 Dry-run — access plan (no files read, no queries made)[/bold cyan]\n")
+    reads: list[str] = []
+    if inventory:
+        reads.append(f"  [green]Would read:[/green]   {inventory}")
+    if project:
+        reads.append(f"  [green]Would read:[/green]   {project}  (agent configs)")
+    if config_dir:
+        reads.append(f"  [green]Would read:[/green]   {config_dir}  (config directory)")
+    if not reads:
+        for client, path in get_all_discovery_paths():
+            reads.append(f"  [green]Would read:[/green]   {path}  ({client})")
+    for cp in code_paths:
+        reads.append(f"  [green]Would scan:[/green]   {cp}  (SAST via semgrep)")
+    for aip in ai_inventory_paths:
+        reads.append(f"  [green]Would scan:[/green]   {aip}  (AI component source scan)")
+    for tf_dir in tf_dirs:
+        reads.append(f"  [green]Would read:[/green]   {tf_dir}  (Terraform .tf files)")
+    for ap in agent_projects:
+        reads.append(f"  [green]Would read:[/green]   {ap}  (Python agent project)")
+    for jdir in jupyter_dirs:
+        reads.append(f"  [green]Would read:[/green]   {jdir}  (Jupyter notebooks *.ipynb)")
+    for mdir in model_dirs:
+        reads.append(f"  [green]Would read:[/green]   {mdir}  (ML model files .gguf, .safetensors, .onnx, .pt, etc.)")
+    for ddir in dataset_dirs:
+        reads.append(f"  [green]Would read:[/green]   {ddir}  (dataset cards: dataset_info.json, README.md, .dvc)")
+    for tdir in training_dirs:
+        reads.append(f"  [green]Would read:[/green]   {tdir}  (training pipelines: MLflow, Kubeflow, W&B)")
+    if gha_path:
+        reads.append(f"  [green]Would read:[/green]   {gha_path}/.github/workflows/  (GitHub Actions)")
+    for sp in skill_paths:
+        reads.append(f"  [green]Would read:[/green]   {sp}  (skill/instruction file)")
+    if no_skill:
+        reads.append("  [dim]Skill scanning:[/dim]   disabled (--no-skill)")
+    elif not skill_paths:
+        reads.append("  [green]Would discover:[/green] skill files (CLAUDE.md, .cursorrules, etc.)")
+    if skill_only:
+        reads.append("  [bold cyan]Mode:[/bold cyan]           skill-only (skipping agent/package/CVE scanning)")
+    for img in images:
+        reads.append(f"  [green]Would scan:[/green]   docker image {img}  (via grype → syft → docker)")
+    if aws:
+        reads.append(f"  [green]Would query:[/green]  AWS Bedrock/Lambda/ECS APIs ({aws_region or 'default region'})")
+        if aws_include_lambda:
+            reads.append(f"  [green]Would query:[/green]  AWS Lambda ListFunctions API ({aws_region or 'default region'})")
+        if aws_include_eks:
+            reads.append("  [green]Would query:[/green]  AWS EKS ListClusters + kubectl pod discovery")
+        if aws_include_step_functions:
+            reads.append("  [green]Would query:[/green]  AWS Step Functions ListStateMachines API")
+        if aws_include_ec2:
+            reads.append("  [green]Would query:[/green]  AWS EC2 DescribeInstances API (tag-filtered)")
+    if azure_flag:
+        reads.append("  [green]Would query:[/green]  Azure AI Foundry/Container Apps APIs")
+    if gcp_flag:
+        reads.append(f"  [green]Would query:[/green]  GCP Vertex AI/Cloud Run APIs ({gcp_project or 'default project'})")
+    if databricks_flag:
+        reads.append("  [green]Would query:[/green]  Databricks Clusters/Libraries APIs")
+    if snowflake_flag:
+        reads.append("  [green]Would query:[/green]  Snowflake Cortex Agents/MCP Servers/Search/Snowpark/Streamlit APIs")
+    if coreweave_flag:
+        reads.append("  [green]Would query:[/green]  CoreWeave VirtualServer/InferenceService CRDs, GPU pods, InfiniBand jobs via kubectl")
+    if nebius_flag:
+        reads.append("  [green]Would query:[/green]  Nebius K8s/Container APIs")
+    if hf_flag:
+        reads.append("  [green]Would query:[/green]  Hugging Face Hub Models/Spaces/Endpoints APIs")
+    if wandb_flag:
+        reads.append("  [green]Would query:[/green]  W&B Runs/Artifacts/Model Registry APIs")
+    if mlflow_flag:
+        reads.append("  [green]Would query:[/green]  MLflow Tracking Server (models, experiments)")
+    if openai_flag:
+        reads.append("  [green]Would query:[/green]  OpenAI Assistants/Fine-tuning APIs")
+    if ollama_flag:
+        host = ollama_host or "http://localhost:11434"
+        reads.append(f"  [green]Would query:[/green]  Ollama API ({host}/api/tags) + ~/.ollama/models manifests")
+    if mcp_registry_flag:
+        reads.append("  [green]Would query:[/green]  https://registry.modelcontextprotocol.io/v0/servers  (Official MCP Registry, no auth)")
+    if snyk_flag:
+        reads.append("  [green]Would query:[/green]  https://api.snyk.io/rest/  (Snyk vulnerability enrichment)")
+    for line in reads:
+        con.print(line)
+    con.print()
+    con.print("  [dim]Would query:[/dim]  https://api.osv.dev/v1/querybatch  (batch CVE lookup, no auth required)")
+    if enrich:
+        con.print("  [dim]Would query:[/dim]  https://services.nvd.nist.gov/rest/json/cves/2.0  (CVSS v4)")
+        con.print("  [dim]Would query:[/dim]  https://api.first.org/data/v1/epss  (exploit probability)")
+        con.print("  [dim]Would query:[/dim]  https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json")
+    con.print()
+
+    con.print("[bold cyan]📋 Data Audit — what is extracted and transmitted[/bold cyan]\n")
+    con.print("  [bold]Extracted from config files:[/bold]")
+    con.print('    • Server names (e.g. "filesystem", "github")')
+    con.print('    • Commands and arguments (e.g. "npx @modelcontextprotocol/server-filesystem")')
+    con.print('    • Environment variable [bold]NAMES only[/bold] (e.g. "OPENAI_API_KEY")')
+    con.print("    • [dim]Values are NEVER read, stored, or logged[/dim]")
+    con.print()
+    con.print("  [bold]Sent to vulnerability APIs:[/bold]")
+    con.print('    • Package name + version only (e.g. "express@4.17.1")')
+    con.print("    • [dim]No file paths, config contents, env var values, hostnames, or IP addresses[/dim]")
+    con.print()
+    con.print("  [bold]Credential detection (name-only pattern matching):[/bold]")
+    con.print("    • Flagged patterns: *KEY*, *TOKEN*, *SECRET*, *PASSWORD*, *CREDENTIAL*, *AUTH*")
+    con.print("    • Excluded: PATH, HOME, LANG, SHELL, USER, TERM, EDITOR")
+    con.print("    • [dim]Detection is purely on env var names — values are never accessed[/dim]")
+    con.print()
+    con.print("  [bold green]✓ agent-bom is read-only.[/bold green] It never writes to configs or executes MCP servers.")
+    con.print("  [bold green]✓ Credential values are never read.[/bold green] Only env var names appear in reports.")
+    con.print(
+        "  See [link=https://github.com/msaad00/agent-bom/blob/main/PERMISSIONS.md]PERMISSIONS.md[/link] for the full trust contract."
+    )
+
+
+def run_iac_only_scan(
+    *,
+    con: Any,
+    iac_paths: tuple,
+    k8s_live: bool,
+    k8s_live_namespace: str,
+    k8s_live_all_namespaces: bool,
+    k8s_live_context: str | None,
+    output: str | None,
+    output_format: str,
+    no_tree: bool,
+    quiet: bool,
+    no_color: bool,
+    open_report: bool,
+    compliance_export: str | None,
+    mermaid_mode: str,
+    push_gateway: str | None,
+    otel_endpoint: str | None,
+    baseline: str | None,
+    delta_mode: bool,
+    verbose: bool,
+    exclude_unfixable: bool,
+    fixable_only: bool,
+    fail_on_severity: str | None,
+) -> None:
+    """Execute the dedicated IaC-only scan path and exit from the main command."""
+    from agent_bom.iac import scan_iac_directory
+    from agent_bom.k8s import K8sDiscoveryError, scan_live_cluster_posture
+
+    iac_ctx = ScanContext(con=con)
+    all_iac_findings: list = []
+
+    if iac_paths:
+        con.print(f"\n[bold blue]Scanning {len(iac_paths)} path(s) for IaC misconfigurations...[/bold blue]\n")
+        for iac_path in iac_paths:
+            iac_findings = scan_iac_directory(iac_path)
+            all_iac_findings.extend(iac_findings)
+            if iac_findings:
+                from collections import Counter
+
+                severity_counts = Counter(f.severity for f in iac_findings)
+                severity_parts = [
+                    f"[red]{severity_counts.get('critical', 0)} critical[/red]",
+                    f"[yellow]{severity_counts.get('high', 0)} high[/yellow]",
+                ]
+                con.print(f"  [red]⚠[/red]  {iac_path}: {len(iac_findings)} finding(s) ({', '.join(severity_parts)})")
+            else:
+                con.print(f"  [green]✓[/green] {iac_path}: no misconfigurations")
+
+    if k8s_live:
+        con.print("\n[bold blue]Inspecting live Kubernetes cluster posture...[/bold blue]\n")
+        try:
+            k8s_live_findings = scan_live_cluster_posture(
+                namespace=k8s_live_namespace,
+                all_namespaces=k8s_live_all_namespaces,
+                context=k8s_live_context,
+            )
+        except K8sDiscoveryError as exc:
+            con.print(f"  [red]✗[/red] live cluster scan failed: {exc}")
+            raise SystemExit(1) from exc
+        all_iac_findings.extend(k8s_live_findings)
+        if k8s_live_findings:
+            from collections import Counter
+
+            severity_counts = Counter(f.severity for f in k8s_live_findings)
+            severity_parts = [
+                f"[red]{severity_counts.get('critical', 0)} critical[/red]",
+                f"[yellow]{severity_counts.get('high', 0)} high[/yellow]",
+            ]
+            con.print(f"  [red]⚠[/red]  live cluster posture: {len(k8s_live_findings)} finding(s) ({', '.join(severity_parts)})")
+        else:
+            con.print("  [green]✓[/green] live cluster posture: no runtime misconfigurations")
+
+    iac_report = AIBOMReport(agents=[], blast_radii=[])
+    iac_report.iac_findings_data = {
+        "total": len(all_iac_findings),
+        "findings": [
+            {
+                "rule_id": finding.rule_id,
+                "severity": finding.severity,
+                "title": finding.title,
+                "message": finding.message,
+                "file_path": finding.file_path,
+                "line_number": finding.line_number,
+                "category": finding.category,
+                "compliance": finding.compliance,
+                "attack_techniques": finding.attack_techniques,
+                "remediation": finding.remediation,
+            }
+            for finding in all_iac_findings
+        ],
+    }
+    iac_ctx.report = iac_report
+    iac_ctx.iac_findings_data = iac_report.iac_findings_data
+
+    if output_format == "json" or output:
+        out_data = json.dumps(iac_report.iac_findings_data, indent=2)
+        if output and output != "-":
+            Path(output).write_text(out_data)
+            con.print(f"\n[green]IaC report written[/green] → {output}")
+        else:
+            click.echo(out_data)
+    elif output_format != "console":
+        render_output(
+            iac_ctx,
+            output=output,
+            output_format=output_format,
+            no_tree=no_tree,
+            quiet=quiet,
+            no_color=no_color,
+            open_report=open_report,
+            compliance_export=compliance_export,
+            mermaid_mode=mermaid_mode,
+            push_gateway=push_gateway,
+            otel_endpoint=otel_endpoint,
+            baseline=baseline,
+            delta_mode=delta_mode,
+            verbose=verbose,
+            exclude_unfixable=exclude_unfixable,
+            fixable_only=fixable_only,
+        )
+
+    if fail_on_severity and all_iac_findings:
+        severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+        threshold = severity_order.get(fail_on_severity, 99)
+        if any(severity_order.get(finding.severity, 99) <= threshold for finding in all_iac_findings):
+            sys.exit(1)

--- a/src/agent_bom/deployment_probe.py
+++ b/src/agent_bom/deployment_probe.py
@@ -75,10 +75,7 @@ def fetch_health(
                 break
             sleep_seconds = max(backoff_seconds, 0.0) * attempt
             if sleep_seconds:
-                print(
-                    f"Attempt {attempt}/{attempts} failed for {health_url}: {exc}. Retrying in {sleep_seconds:.0f}s...",
-                    file=sys.stderr,
-                )
+                sys.stderr.write(f"Attempt {attempt}/{attempts} failed for {health_url}: {exc}. Retrying in {sleep_seconds:.0f}s...\n")
                 time.sleep(sleep_seconds)
 
     raise RuntimeError(f"unable to fetch MCP health from {health_url}: {last_error}")
@@ -129,7 +126,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.resolve_only:
-            print(resolve_health_url(args.base_url))
+            sys.stdout.write(f"{resolve_health_url(args.base_url)}\n")
             return 0
 
         _, payload = fetch_health(
@@ -144,7 +141,7 @@ def main(argv: list[str] | None = None) -> int:
             forbid_auth_required=args.forbid_auth_required,
         )
     except (RuntimeError, ValueError) as exc:
-        print(str(exc), file=sys.stderr)
+        sys.stderr.write(f"{exc}\n")
         return 1
 
     json.dump(payload, sys.stdout, separators=(",", ":"))

--- a/src/agent_bom/guard.py
+++ b/src/agent_bom/guard.py
@@ -236,25 +236,25 @@ def run_guarded_install(
     result = guard_install_sync(tool, args, min_severity=min_severity, allow_risky=allow_risky)
 
     if not result.install_allowed:
-        print(f"\n  BLOCKED — {result.packages_blocked} package(s) have critical/high vulnerabilities:", file=sys.stderr)
+        sys.stderr.write(f"\n  BLOCKED — {result.packages_blocked} package(s) have critical/high vulnerabilities:\n")
         for pkg in result.blocked:
             vulns_str = ", ".join(v["id"] for v in pkg.get("vulns", [])[:5])
-            print(f"    {pkg['name']}: {pkg['vuln_count']} CVEs ({vulns_str})", file=sys.stderr)
-        print("\n  Use --allow-risky to install anyway, or fix the vulnerabilities first.", file=sys.stderr)
+            sys.stderr.write(f"    {pkg['name']}: {pkg['vuln_count']} CVEs ({vulns_str})\n")
+        sys.stderr.write("\n  Use --allow-risky to install anyway, or fix the vulnerabilities first.\n")
         return 1
 
     if result.packages_blocked > 0 and allow_risky:
-        print(f"\n  WARNING — installing {result.packages_blocked} package(s) with known vulnerabilities", file=sys.stderr)
+        sys.stderr.write(f"\n  WARNING — installing {result.packages_blocked} package(s) with known vulnerabilities\n")
         for pkg in result.blocked:
-            print(f"    {pkg['name']}: {pkg['vuln_count']} CVEs", file=sys.stderr)
+            sys.stderr.write(f"    {pkg['name']}: {pkg['vuln_count']} CVEs\n")
 
     if result.packages_checked > 0:
-        print(f"  {result.packages_clean}/{result.packages_checked} packages clean", file=sys.stderr)
+        sys.stderr.write(f"  {result.packages_clean}/{result.packages_checked} packages clean\n")
 
     # Execute the real install command
     real_cmd = _find_real_tool(tool)
     if not real_cmd:
-        print(f"  ERROR: Could not find real '{tool}' binary", file=sys.stderr)
+        sys.stderr.write(f"  ERROR: Could not find real '{tool}' binary\n")
         return 1
 
     full_cmd = [real_cmd] + args

--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -13,7 +13,7 @@ Categories:
 Usage:
     from agent_bom.parsers.trust_assessment import assess_trust
     result = assess_trust(scan_result, audit_result)
-    print(result.verdict, result.confidence)
+    verdict = (result.verdict, result.confidence)
 """
 
 from __future__ import annotations

--- a/src/agent_bom/red_team.py
+++ b/src/agent_bom/red_team.py
@@ -8,7 +8,7 @@ Usage::
 
     from agent_bom.red_team import run_red_team
     report = run_red_team()
-    print(f"Detected: {report['detected']}/{report['total']}")
+    summary = f"Detected: {report['detected']}/{report['total']}"
 
 Categories:
 - Prompt injection (role override, jailbreak, delimiter attacks)

--- a/src/agent_bom/registry_enrichment.py
+++ b/src/agent_bom/registry_enrichment.py
@@ -12,7 +12,7 @@ Usage::
 
     from agent_bom.registry_enrichment import enrich_registry
     stats = enrich_registry()  # updates mcp_registry.json in-place
-    print(f"Enriched {stats['total']} servers from {stats['sources']} sources")
+    summary = f"Enriched {stats['total']} servers from {stats['sources']} sources"
 """
 
 from __future__ import annotations

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -13,7 +13,7 @@ Usage::
 
     findings = scan_secrets("/path/to/project")
     for f in findings:
-        print(f"{f['file']}:{f['line']} [{f['severity']}] {f['type']}")
+        line = f"{f['file']}:{f['line']} [{f['severity']}] {f['type']}"
 
 Compliance:
 - OWASP LLM01 — hardcoded credentials enable account takeover

--- a/src/agent_bom/shield.py
+++ b/src/agent_bom/shield.py
@@ -9,7 +9,7 @@ Use as a Python middleware in any AI agent pipeline:
     # Check tool calls before execution
     alerts = shield.check_tool_call("read_file", {"path": "/etc/passwd"})
     if alerts:
-        print(f"Blocked: {alerts[0]['message']}")
+        raise RuntimeError(alerts[0]["message"])
 
     # Check and redact tool responses
     alerts = shield.check_response("read_file", response_text)

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -27,14 +27,19 @@ from unittest.mock import patch
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse, PlainTextResponse
+from starlette.testclient import TestClient
 
 from agent_bom.api.audit_log import (
     AuditEntry,
     InMemoryAuditLog,
+    get_audit_log,
     set_audit_log,
 )
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.routes import compliance as compliance_routes
+from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store, set_job_store
 
 
 def _now_iso() -> str:
@@ -192,6 +197,45 @@ def test_real_compliance_export_wires_control_tags_and_non_empty_evidence() -> N
     assert exported["LLM01"]["finding_count"] == 1
     assert exported["LLM01"]["evidence"][0]["control_tag"] == "LLM01"
     assert exported["LLM01"]["evidence"][0]["vulnerability_id"] == "CVE-2024-0001"
+
+
+def test_compliance_report_route_exports_real_evidence_end_to_end() -> None:
+    """Exercise the real FastAPI route with real auth, store, and audit wiring."""
+    original_store = _get_store()
+    original_audit_log = get_audit_log()
+    audit = _setup_audit_log()
+    store = InMemoryJobStore()
+    set_job_store(store)
+    try:
+        for job in _seed_jobs_with_findings():
+            store.put(job)
+
+        client = TestClient(app)
+        resp = client.get(
+            "/v1/compliance/owasp-llm/report",
+            headers={
+                "X-Agent-Bom-Role": "viewer",
+                "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+            },
+        )
+        assert resp.status_code == 200
+
+        body = resp.json()
+        assert body["tenant_id"] == "tenant-alpha"
+        assert body["scope"]["finding_count"] == 2
+        llm01 = next(control for control in body["controls"] if control["control_id"] == "LLM01")
+        assert llm01["finding_count"] == 1
+        assert llm01["evidence"]
+        assert llm01["evidence"][0]["control_tag"] == "LLM01"
+        assert llm01["evidence"][0]["scan_id"] == "scan-a"
+        assert llm01["evidence"][0]["vulnerability_id"] == "CVE-2024-0001"
+        assert {entry["details"]["tenant_id"] for entry in body["audit_events"]} == {"tenant-alpha"}
+
+        log_entries = list(audit._entries)  # type: ignore[attr-defined]
+        assert any(entry.action == "compliance.report_exported" for entry in log_entries)
+    finally:
+        set_job_store(original_store)
+        set_audit_log(original_audit_log)
 
 
 # ─── Replay-protection envelope ──────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- replace the brittle ClawHub multipart publish step with the official `clawhub` CLI flow used in local docs, which should clear the remaining `Publish to Registries` failure on main
- add a real FastAPI integration test for `/v1/compliance/{framework}/report` so the evidence bundle path is exercised end to end with tenant auth, a real job store, and a real audit log
- align `DOCKER_HUB_README.md` with the main README's product and self-hosted deployment story instead of presenting a materially different pitch
- extract the scan command preflight stages into `src/agent_bom/cli/agents/_preflight.py` and remove the remaining bare `print()` calls in `src/agent_bom` so the CLI monolith/logging debt is materially reduced

## Why it changed
Claude's follow-up audit left four substantive items open after `#1541`:
- the registry publish workflow still failed on ClawHub
- the compliance report tests were still too mock-heavy to catch route-level regressions
- Docker Hub users still saw a different product story than GitHub users
- the CLI monolith / print debt still needed a real implementation pass rather than a paper issue close

## Impact
- registry publishing should now follow the same supported ClawHub path operators use manually
- compliance export coverage now guards the tenant-scoped, authenticated route instead of only direct helper calls
- Docker Hub now markets the same scan / fleet / proxy / gateway / self-hosted deployment story as the main README
- `src/agent_bom/cli/agents/__init__.py` is smaller and the remaining bare `print()` calls in `src/agent_bom` are gone

## Validation
- `python -m pytest tests/test_compliance_report.py tests/test_api_compliance_auth.py -q`
- `python -m pytest tests/test_core.py::test_dry_run_exits_zero tests/test_core.py::test_cli_dry_run_shows_data_audit tests/test_no_skill_flag_dry_run tests/test_skill_only_flag_dry_run tests/test_cloud.py::test_dry_run_lists_aws_apis tests/test_cloud.py::test_dry_run_lists_ollama -q`
- `python -m pytest tests/test_guard_cov.py tests/test_deployment_probe.py tests/test_audit_replay.py tests/test_cli_runtime.py::test_audit_replay_cmd_json -q`
- `python scripts/check_release_consistency.py`
- `pre-commit run --files .github/workflows/publish-registries.yml DOCKER_HUB_README.md docs/PUBLISHING.md src/agent_bom/ai_components/scanner.py src/agent_bom/audit_replay.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_preflight.py src/agent_bom/deployment_probe.py src/agent_bom/guard.py src/agent_bom/parsers/trust_assessment.py src/agent_bom/red_team.py src/agent_bom/registry_enrichment.py src/agent_bom/secret_scanner.py src/agent_bom/shield.py tests/test_compliance_report.py`
