### PR TITLE
fix(ci): replace clawhub --version probe with --help

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -209,7 +209,11 @@ jobs:
       - name: Install ClawHub CLI
         run: |
           npm install -g clawhub@latest
-          clawhub --version
+          # `clawhub --version` is not a supported option on the current CLI, so
+          # use --help as a binary-present probe instead. `npm install -g` already
+          # exits non-zero on install failure; this just confirms the command is
+          # on PATH before the publish step runs.
+          clawhub --help > /dev/null
 
       - name: Publish to ClawHub
         env:


### PR DESCRIPTION
## Summary
- The ClawHub publish step added in #1543 calls `clawhub --version`, which is not a supported option on the current CLI and fails with `error: unknown option '--version'`.
- Publish to Registries has been red on `main` since that PR (run 24639074586, 24638248038). Tracked by #1537.
- Replace the probe with `clawhub --help > /dev/null` — `npm install -g` already exits non-zero on install failure, so this only needs to confirm the binary is on PATH before the publish step runs.

## Test plan
- [ ] Re-run Publish to Registries on `main` after merge; confirm ClawHub install step passes
- [ ] Close #1537 once the next run is green