### PR TITLE
test(compliance): end-to-end evidence-bundle guard + local dupe cleanup

### DIFF
--- a/tests/test_api_compliance_auth.py
+++ b/tests/test_api_compliance_auth.py
@@ -1,8 +1,13 @@
 """Defense-in-depth auth tests for compliance and posture routes."""
 
+from datetime import datetime, timezone
+
 from starlette.testclient import TestClient
 
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import set_job_store
 
 
 def test_posture_requires_authenticated_context() -> None:
@@ -57,3 +62,57 @@ def test_compliance_export_accepts_trusted_proxy_headers() -> None:
     body = resp.json()
     assert body["framework"] == "owasp-llm"
     assert body["tenant_id"] == "tenant-alpha"
+
+
+def test_compliance_export_end_to_end_returns_real_evidence() -> None:
+    """Full stack: seed a real ScanJob, hit the FastAPI route, verify evidence wires.
+
+    Guards against the regression where `_build_controls` and `_evidence_for_control`
+    disagree on the control dict shape (code vs tags) — a bug that can only be caught
+    by exercising the real producer path through the real router, not by mocking
+    `get_compliance`.
+    """
+    store = InMemoryJobStore()
+    now = datetime.now(timezone.utc).isoformat()
+    job = ScanJob(
+        job_id="e2e-scan",
+        tenant_id="tenant-alpha",
+        status=JobStatus.DONE,
+        created_at=now,
+        completed_at=now,
+        request=ScanRequest(),
+    )
+    job.result = {
+        "scan_id": "e2e-scan",
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2024-9999",
+                "package": "axios@1.4.0",
+                "severity": "high",
+                "fixed_version": "1.7.4",
+                "owasp_tags": ["LLM01"],
+                "affected_agents": ["claude-desktop"],
+            }
+        ],
+    }
+    store.put(job)
+    set_job_store(store)
+    try:
+        client = TestClient(app)
+        resp = client.get(
+            "/v1/compliance/owasp-llm/report",
+            headers={
+                "X-Agent-Bom-Role": "viewer",
+                "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        exported = {c["control_id"]: c for c in body["controls"]}
+        assert exported["LLM01"]["finding_count"] == 1
+        assert exported["LLM01"]["control_id"] == "LLM01"
+        assert exported["LLM01"]["evidence"][0]["vulnerability_id"] == "CVE-2024-9999"
+        assert exported["LLM01"]["evidence"][0]["control_tag"] == "LLM01"
+        assert resp.headers.get("X-Agent-Bom-Compliance-Report-Signature")
+    finally:
+        set_job_store(InMemoryJobStore())


### PR DESCRIPTION
## Summary
Follows up the audit closed in #1541 / #1543 with two items left on Claude's list:

1. **Real integration test for the evidence bundle.** `test_compliance_export_end_to_end_returns_real_evidence` seeds a real `ScanJob` with tagged blast-radius data into `InMemoryJobStore`, hits `/v1/compliance/owasp-llm/report` via `TestClient`, and asserts `finding_count`, `control_id`, and `evidence[*].vulnerability_id` all populate. The existing tests patch `get_compliance` and `_tenant_jobs` separately, so the control-dict shape drift (`code` vs `tags`) that caused empty bundles in production was not caught at route level — this test is a regression guard for exactly that.
2. **Local macOS duplicate cleanup.** `.gitignore` rules for `* 2.py` / `* 3.md` etc. already landed in #1541; this cleans the 52 duplicate files that had accumulated in the working tree (README, src/agent_bom/api/{middleware,server,config,push,routes/enterprise} 2.py, .github/workflows/backup-restore 2.yml, helm templates, tests, docs, docs/images, mypy cache). No tracked files changed — purely local hygiene — so this PR carries only the test change.

## Test plan
- [x] `python -m pytest tests/test_api_compliance_auth.py -x -q` — 6 passed
- [ ] Full suite in CI