### PR TITLE
docs(enterprise): self-hosted deploy section + Snowflake backend + multi-MCP gateway design

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,35 +135,130 @@ External calls are limited to package metadata, version lookups, and CVE enrichm
 
 </details>
 
-## Deploy in your own AWS / EKS
+---
 
-Self-hosted is a first-class path. `agent-bom` is designed to run inside the
-customer's own AWS account, VPC, EKS cluster, IAM boundary, databases, and SSO
-stack.
+# Enterprise self-hosted deployment
 
-The promoted self-hosted rollout today is a scoped operator stack, not a
-monolith. Most teams start with four product surfaces plus one operator plane:
+**`agent-bom` runs end-to-end inside your infrastructure — your AWS account, your VPC, your EKS cluster, your Postgres / ClickHouse / Snowflake, your SSO, your KMS. No hosted control plane. No mandatory vendor backend. No telemetry.**
 
-- **scan**: discovery, inventory, CVE, image, IaC, Kubernetes, and cloud analysis
-- **fleet**: endpoint and collector inventory pushed into the control plane
-- **proxy / runtime**: inline MCP enforcement near selected workloads
-- **gateway**: central policy management for those runtime paths
-- **API + UI**: the operator plane for findings, graph, remediation, audit, and policy workflows
+This section is the pilot-grade walkthrough: the five product surfaces you install, the backends they run against, the network flows, the day-1 install, and the break-glass path. Every diagram below maps to real code in this repo, not a pitch deck.
 
-That gives one shared graph and policy model without forcing one runtime
-monolith. By default, findings, fleet data, audit logs, graph state, and
-remediation outputs stay in your infrastructure; optional egress is operator
-controlled for DB refresh, enrichment, SIEM, OTLP, and webhooks.
+### The concrete pilot shape
 
-The recommended EKS shape is:
+A realistic enterprise pilot today looks like this:
 
-- stateless API + UI deployments behind your ingress
-- Postgres for transactional state and graph metadata
-- optional ClickHouse only when audit and analytics volume justifies it
-- scheduled scan jobs for cluster, image, and discovery work
-- endpoint fleet sync for laptops and collectors
-- selected `agent-bom proxy` sidecars or local wrappers for the MCP workloads that need inline enforcement
-- gateway-backed policy pull so runtime controls stay centralized without hairpinning all traffic through one shared chokepoint
+- **Employees on macOS and Windows** running Cursor, VS Code, Codex CLI, Claude Desktop / Claude Code, and GitHub Copilot.
+- **Each editor talks to a mix of MCPs**:
+  - *Local / stdio* — filesystem, git, shell, dev-server MCPs running on the laptop.
+  - *Remote / HTTP + SSE* — hosted MCPs on internal services, SaaS tools, or inside a data warehouse.
+- **MCPs hosted inside Snowflake** — e.g. a Snowflake-hosted "jira" MCP exposing Jira data via Snowpark or Cortex. These look like remote MCPs to the client.
+- **An in-cluster agent-bom control plane on EKS** — ingests fleet data from every laptop, mediates gateway policy for runtime proxies, and stores scan/audit state (Postgres, ClickHouse, or Snowflake).
+
+```mermaid
+flowchart LR
+    subgraph mac["macOS employees"]
+      cursor_m[Cursor]
+      claude_m[Claude Desktop]
+      codex_m[Codex CLI]
+      copilot_m[VS Code + Copilot]
+    end
+    subgraph win["Windows employees"]
+      cursor_w[Cursor]
+      claude_w[Claude Code]
+      copilot_w[VS Code + Copilot]
+    end
+    localmcp["Local MCPs<br/>(filesystem · git · shell)"]
+    remotemcp["Remote MCPs<br/>(HTTP / SSE)"]
+    snowmcp["Snowflake-hosted MCPs<br/>(e.g. jira MCP)"]
+
+    mac --> localmcp
+    mac --> remotemcp
+    mac --> snowmcp
+    win --> localmcp
+    win --> remotemcp
+    win --> snowmcp
+
+    fleet[agent-bom agents --push-url]
+    proxy["agent-bom proxy<br/>(per-MCP wrapper)"]
+    cp(["agent-bom control plane<br/>in your EKS cluster"])
+
+    mac -. daily scan .-> fleet
+    win -. daily scan .-> fleet
+    localmcp -. wrapped .- proxy
+    remotemcp -. wrapped .- proxy
+    snowmcp -. wrapped .- proxy
+    fleet -->|HTTPS fleet sync| cp
+    proxy -->|policy pull · audit push| cp
+```
+
+**How each surface serves this mix**:
+
+| Surface | macOS | Windows | Local MCP | Remote MCP | Snowflake MCP |
+|---|:-:|:-:|:-:|:-:|:-:|
+| `agent-bom agents --push-url` (fleet sync) | ✓ | ✓ | discovered + scanned | discovered (reachability + CVE on the package that implements the server) | discovered (via Snowflake cloud scanner) |
+| `agent-bom proxy -- <cmd>` stdio | ✓ | ✓ | ✓ | — | — |
+| `agent-bom proxy --sse <url>` HTTP/SSE | ✓ | ✓ | — | ✓ | ✓ (Snowflake MCPs speak HTTP) |
+| `agent-bom cloud snowflake` | ✓ | ✓ | — | — | ✓ (native discovery + CIS benchmark) |
+| Central gateway-for-all MCPs on one URL | — | — | — | planned | planned |
+
+The last row is the gap the pilot team asks about: a single central URL that fronts every remote MCP, so laptops don't individually need to configure a proxy. See the [multi-MCP gateway design](docs/design/MULTI_MCP_GATEWAY.md).
+
+## Five product surfaces, one shared graph
+
+| Surface | CLI / route | What it does | Deploys as |
+|---|---|---|---|
+| **scan** | `agent-bom agents`, `agent-bom image`, `agent-bom iac` | Discovery, inventory, CVE enrichment, blast-radius scoring | CLI + CronJob |
+| **fleet** | `POST /v1/fleet/sync` + CLI `--push-url` | Endpoint + collector fleet ingest with tenant scoping | API endpoint |
+| **proxy / runtime** | `agent-bom proxy` (stdio) / `--sse` (HTTP) | Inline MCP JSON-RPC inspection + policy enforcement | K8s sidecar or laptop wrapper |
+| **gateway** | `/v1/gateway/policies` + `/v1/proxy/audit` | Central policy authoring + audit ingest; proxies pull & push | API routes |
+| **API + UI** | `/v1/*` + Next.js dashboard | Findings, graph, remediation, compliance, posture | 2 Deployments + HPA |
+
+By default, findings, fleet data, audit logs, graph state, and remediation outputs stay in your infrastructure. Optional egress (OSV lookups, NVD enrichment, Slack / Jira / Vanta / Drata webhooks, SIEM / OTLP) is operator-controlled.
+
+### Today's proxy is per-MCP, not a shared traffic gateway
+
+The honest architecture: `agent-bom proxy` is a **per-MCP sidecar or wrapper** ([`proxy.py:527`](src/agent_bom/proxy.py:527) stdio, [`proxy.py:258`](src/agent_bom/proxy.py:258) HTTP/SSE). One proxy instance per MCP server. The "gateway" today is the central **policy + audit plane** — proxies pull [`/v1/gateway/policies`](src/agent_bom/api/routes/gateway.py) and push [`/v1/proxy/audit`](src/agent_bom/api/routes/proxy.py:59). This is the Istio / OPA-Gatekeeper pattern: central control, edge enforcement, no hairpinning.
+
+A **central multi-upstream HTTP gateway** (`agent-bom gateway serve` — one service fronting N MCP upstreams, clients point at one URL) is on the roadmap for the [current pilot cycle](docs/design/MULTI_MCP_GATEWAY.md). Until then, pilot teams use per-MCP sidecars.
+
+## Backend matrix — pick what fits your data
+
+`agent-bom` does not treat every backend as interchangeable. Pick per capability — full detail in [backend-parity.md](site-docs/deployment/backend-parity.md).
+
+| Capability | SQLite | **Postgres / Supabase** (default) | **ClickHouse** (analytics) | **Snowflake** (warehouse-native) |
+|---|:-:|:-:|:-:|:-:|
+| Scan job / fleet / policy / audit store | ✓ | ✓ | — | ✓ |
+| Exceptions, API keys, schedules, trend, graph | ✓ (SQLite) / — (API) | ✓ | — | — |
+| Row-level tenant isolation | ✓ | ✓ | ✓ | ✓ (governance-oriented) |
+| High-volume OLAP / time-series | — | — | ✓ | ✓ (via Snowpark) |
+| Best for | laptops, single-node | standard EKS pilot | audit + analytics at scale | you already live in Snowflake |
+
+Common deployment shapes:
+
+- **Pilot default** — Postgres (or Supabase) control plane. Everything works, fastest install.
+- **Analytics-heavy** — Postgres + ClickHouse. Postgres stays transactional; ClickHouse ingests the audit/event firehose.
+- **Snowflake-native (unified stack)** — Snowflake as the primary *and* analytics store. Uses Hybrid Tables for transactional writes (scan / fleet / policy / audit), columnar tables for analytics, Snowpipe Streaming for real-time ingest, and the Postgres-compatible protocol where clients need it. Cross-cloud replication lets EKS read/write the same tables your Cortex MCPs read, regardless of region. Best when you already govern data there. See [snowflake-backend.md](site-docs/deployment/snowflake-backend.md).
+
+## Ready-made Helm values files
+
+Three shipped examples in [`deploy/helm/agent-bom/examples/`](deploy/helm/agent-bom/examples/):
+
+| File | Shape | Use when |
+|---|---|---|
+| [`eks-mcp-pilot-values.yaml`](deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml) | Postgres + MCP-focused scanner CronJob + restricted ingress | Pilot scope, MCP + agents + fleet + proxy |
+| [`eks-production-values.yaml`](deploy/helm/agent-bom/examples/eks-production-values.yaml) | Postgres pool tuned + HPA + pod anti-affinity + PriorityClass | Production rollout |
+| [`eks-istio-kyverno-values.yaml`](deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml) | Istio mTLS + Kyverno policy + PSA restricted | Regulated / zero-trust environments |
+| [`eks-snowflake-values.yaml`](deploy/helm/agent-bom/examples/eks-snowflake-values.yaml) | Snowflake as primary backend via key-pair auth | You already govern data in Snowflake |
+
+## The scoped product stack
+
+Most pilot teams start with the **four product surfaces plus one operator plane** below:
+
+- **scan** — discovery, inventory, CVE, image, IaC, Kubernetes, cloud analysis
+- **fleet** — endpoint and collector inventory pushed into the control plane
+- **proxy / runtime** — inline MCP enforcement near selected workloads (per-MCP today)
+- **gateway** — central policy + audit plane for those runtime paths
+- **API + UI** — operator plane for findings, graph, remediation, audit, policy
 
 ### 1. External flow — where the data comes from
 
@@ -224,7 +319,7 @@ flowchart TB
     QUOTA[Tenant quota + rate limit]
     ROUTE[Route handler]
     AUDIT[(HMAC audit log)]
-    STORE[(Postgres · ClickHouse<br/>KMS at rest)]
+    STORE[(Postgres · ClickHouse · Snowflake<br/>KMS at rest)]
 
     REQ --> BODY --> TRACE --> AUTH --> RBAC --> TENANT --> QUOTA --> ROUTE
     ROUTE --> AUDIT
@@ -233,32 +328,56 @@ flowchart TB
 
 Every layer is testable on its own; failures emit Prometheus metrics. Operators introspect a live request via `GET /v1/auth/debug` and see rotation status via `GET /v1/auth/policy`.
 
-### 4. What you get, and how to install it
+### 4. Day-1 install on EKS (scripted)
 
-Inside the control plane: **OIDC + SAML SSO** with RBAC, **enforced API-key rotation policy**, **tenant-scoped quotas + rate limits**, **HMAC-chained audit log** with signed export, **KMS-encrypted Postgres backups** with a verified restore round-trip in CI, and **tamper-evident compliance evidence bundles** (`/v1/compliance/{framework}/report` — nonce + expiry inside the HMAC envelope).
+Inside the control plane: **OIDC + SAML SSO** with RBAC, **enforced API-key rotation policy**, **tenant-scoped quotas + rate limits**, **HMAC-chained audit log** with signed export, **KMS-encrypted Postgres backups** with a verified restore round-trip in CI ([`backup-restore.yml`](.github/workflows/backup-restore.yml)), and **signed compliance evidence bundles** with **Ed25519 asymmetric signing** ([`/v1/compliance/{framework}/report`](src/agent_bom/api/routes/compliance.py) — key pinned via [`/v1/compliance/verification-key`](src/agent_bom/api/routes/compliance.py), verification cookbook at [docs/COMPLIANCE_SIGNING.md](docs/COMPLIANCE_SIGNING.md)).
 
-<details>
-<summary><b>Helm install + fleet sync + local proxy</b></summary>
+Pilot teams run:
 
 ```bash
-# control plane in your cluster
+# 1. Pick your backend shape (postgres default; snowflake / istio / production also shipped)
 helm install agent-bom deploy/helm/agent-bom \
-  --set controlPlane.enabled=true \
-  --set db.backend=postgres
+  -n agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
 
-# endpoint fleet sync
+# 2. Smoke-test the install end-to-end — health + auth + fleet + scan + evidence bundle
+kubectl -n agent-bom port-forward svc/agent-bom-api 8080:8080 &
+./scripts/pilot-verify.sh http://localhost:8080 "$API_KEY"
+
+# 3. Sync endpoint fleet
 agent-bom agents --preset enterprise --introspect \
   --push-url https://agent-bom.example.com/v1/fleet/sync
 
-# local MCP enforcement on a laptop or workstation
+# 4. Wrap one MCP server with the runtime proxy (per-MCP today — see roadmap note above)
 agent-bom proxy --policy ./policy.json -- <editor-mcp-command>
+
+# 5. Pull an auditor-ready evidence bundle
+curl -sD headers.txt -o soc2.json \
+  "https://agent-bom.example.com/v1/compliance/soc2/report" \
+  -H "Authorization: Bearer $API_KEY"
 ```
 
-Operator guides: [Own AWS / EKS](site-docs/deployment/own-infra-eks.md) · [Enterprise pilot](site-docs/deployment/enterprise-pilot.md) · [Endpoint fleet](site-docs/deployment/endpoint-fleet.md) · [EKS MCP pilot](site-docs/deployment/eks-mcp-pilot.md) · [Helm control plane](site-docs/deployment/control-plane-helm.md) · [Grafana](site-docs/deployment/grafana.md) · [Performance + sizing](site-docs/deployment/performance-and-sizing.md) · [Restore script](deploy/ops/restore-postgres-backup.sh).
+See [site-docs/deployment/eks-mcp-pilot.md](site-docs/deployment/eks-mcp-pilot.md) for the full Day-1 runbook (four stages + break-glass table) and [docs/COMPLIANCE_SIGNING.md](docs/COMPLIANCE_SIGNING.md) for offline signature verification.
+
+**Operator guides by scenario:**
+
+| Scenario | Guide |
+|---|---|
+| Own AWS / EKS end-to-end | [own-infra-eks.md](site-docs/deployment/own-infra-eks.md) |
+| Enterprise pilot scope | [enterprise-pilot.md](site-docs/deployment/enterprise-pilot.md) |
+| Focused EKS MCP pilot | [eks-mcp-pilot.md](site-docs/deployment/eks-mcp-pilot.md) |
+| Endpoint fleet on laptops | [endpoint-fleet.md](site-docs/deployment/endpoint-fleet.md) |
+| Snowflake-native backend | [snowflake-backend.md](site-docs/deployment/snowflake-backend.md) |
+| Istio + Kyverno zero-trust | [kubernetes.md](site-docs/deployment/kubernetes.md) |
+| Backend parity matrix | [backend-parity.md](site-docs/deployment/backend-parity.md) |
+| Grafana dashboards | [grafana.md](site-docs/deployment/grafana.md) |
+| SIEM / OCSF integration | [siem-integration.md](site-docs/deployment/siem-integration.md) |
+| Metrics catalog + SLOs | [OBSERVABILITY_METRICS.md](docs/OBSERVABILITY_METRICS.md) |
+| Performance + sizing | [performance-and-sizing.md](site-docs/deployment/performance-and-sizing.md) |
 
 Self-hosted SSO uses **OIDC or SAML**; SAML admins fetch SP metadata at `/v1/auth/saml/metadata`. Control-plane API keys follow an enforced lifetime policy (`AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS`, `AGENT_BOM_API_KEY_MAX_TTL_SECONDS`); rotate in place at `/v1/auth/keys/{key_id}/rotate`.
 
-</details>
+---
 
 ## Trust & transparency
 

--- a/deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
@@ -1,0 +1,163 @@
+# Snowflake-native backend for enterprises that already govern data in Snowflake.
+#
+# Scan jobs, fleet agents, gateway policies, and HMAC-chained audit events all
+# persist to Snowflake via SnowflakeJobStore / SnowflakeFleetStore /
+# SnowflakePolicyStore (src/agent_bom/api/snowflake_store.py). Parity boundary
+# is explicit — see site-docs/deployment/backend-parity.md.
+#
+# Key-pair auth is required. Passwords are deprecated and emit a runtime
+# warning. Generate the private key once, store in AWS Secrets Manager (or
+# your equivalent), and mount via ExternalSecrets.
+#
+#   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+#   snowsql -a <account> -u <user> -q "ALTER USER <user> SET RSA_PUBLIC_KEY='...'"
+#   aws secretsmanager create-secret --name agent-bom/snowflake-key --secret-string file://rsa_key.p8
+#
+# Usage:
+#   helm install agent-bom deploy/helm/agent-bom \
+#     -n agent-bom --create-namespace \
+#     -f deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
+
+controlPlane:
+  enabled: true
+  observability:
+    grafanaDashboard:
+      enabled: true
+    prometheusRule:
+      enabled: true
+
+  podAntiAffinity:
+    enabled: true
+
+  priorityClass:
+    create: true
+    name: agent-bom-control-plane
+
+  api:
+    replicas: 2
+    env:
+      # Backend selection — Snowflake stores scan jobs, fleet, policies, audit
+      - name: AGENT_BOM_STORE_BACKEND
+        value: "snowflake"
+      - name: AGENT_BOM_FLEET_STORE_BACKEND
+        value: "snowflake"
+      - name: AGENT_BOM_POLICY_STORE_BACKEND
+        value: "snowflake"
+      - name: AGENT_BOM_AUDIT_STORE_BACKEND
+        value: "snowflake"
+
+      # Snowflake connection params — read from mounted Secret
+      - name: SNOWFLAKE_ACCOUNT
+        valueFrom:
+          secretKeyRef:
+            name: agent-bom-snowflake
+            key: account
+      - name: SNOWFLAKE_USER
+        valueFrom:
+          secretKeyRef:
+            name: agent-bom-snowflake
+            key: user
+      - name: SNOWFLAKE_WAREHOUSE
+        valueFrom:
+          secretKeyRef:
+            name: agent-bom-snowflake
+            key: warehouse
+      - name: SNOWFLAKE_DATABASE
+        valueFrom:
+          secretKeyRef:
+            name: agent-bom-snowflake
+            key: database
+      - name: SNOWFLAKE_SCHEMA
+        valueFrom:
+          secretKeyRef:
+            name: agent-bom-snowflake
+            key: schema
+      - name: SNOWFLAKE_ROLE
+        valueFrom:
+          secretKeyRef:
+            name: agent-bom-snowflake
+            key: role
+
+      # Key-pair auth — mount the PKCS#8 private key file
+      - name: SNOWFLAKE_PRIVATE_KEY_PATH
+        value: /var/snowflake/rsa_key.p8
+
+      # Hard-disable password fallback so misconfig fails loud instead of silent
+      - name: AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR
+        value: "1"
+
+      # Pilot-grade quotas
+      - name: AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT
+        value: "25"
+      - name: AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT
+        value: "1000"
+      - name: AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT
+        value: "5000"
+
+      # Require persistent audit HMAC — no ephemeral fallback
+      - name: AGENT_BOM_REQUIRE_AUDIT_HMAC
+        value: "1"
+
+    envFrom:
+      - secretRef:
+          name: agent-bom-snowflake
+      - secretRef:
+          name: agent-bom-control-plane-auth
+
+    volumeMounts:
+      - name: snowflake-key
+        mountPath: /var/snowflake
+        readOnly: true
+
+    volumes:
+      - name: snowflake-key
+        secret:
+          secretName: agent-bom-snowflake
+          items:
+            - key: private_key
+              path: rsa_key.p8
+          defaultMode: 0400
+
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 6
+      targetCPUUtilizationPercentage: 70
+
+  ui:
+    replicas: 2
+
+  # Skip the Postgres backup CronJob — Snowflake handles durability.
+  backup:
+    enabled: false
+
+  # Scanner CronJob still runs; pushes scan results via the API which writes to Snowflake.
+  scanCronJob:
+    enabled: true
+    schedule: "0 */6 * * *"
+    args:
+      - "agents"
+      - "--k8s-mcp"
+      - "--k8s-all-namespaces"
+      - "--introspect"
+      - "--push-url"
+      - "http://agent-bom-api.agent-bom.svc.cluster.local:8080/v1/fleet/sync"
+
+  networkPolicy:
+    enabled: true
+    restrictIngress: true
+    allowedNamespaces:
+      - agent-bom
+      - ingress-nginx
+    # Egress: the API needs to reach *.snowflakecomputing.com on 443
+    egress:
+      - to:
+          - ipBlock:
+              cidr: 0.0.0.0/0
+              except:
+                - 10.0.0.0/8
+                - 172.16.0.0/12
+                - 192.168.0.0/16
+        ports:
+          - protocol: TCP
+            port: 443

--- a/docs/design/MULTI_MCP_GATEWAY.md
+++ b/docs/design/MULTI_MCP_GATEWAY.md
@@ -1,0 +1,160 @@
+# Design: multi-MCP gateway — `agent-bom gateway serve`
+
+**Status:** design, not yet implemented. Tracked for the current pilot cycle.
+
+**Problem statement:** a pilot team wants to front-door every MCP connection in their environment through a single host so they can apply policy + audit centrally without touching every laptop's editor config. Today, `agent-bom proxy` is **per-MCP** — one instance per upstream server, either as a K8s sidecar next to a workload or as a stdio wrapper on a developer laptop. Central policy + audit already exist (`/v1/gateway/policies`, `/v1/proxy/audit`); central *traffic* does not.
+
+## Goal
+
+Add a new CLI mode: `agent-bom gateway serve`.
+
+One FastAPI service that:
+
+1. Accepts MCP client connections (HTTP + SSE, Streamable HTTP transport).
+2. Routes each client connection to one of N configured upstream MCP servers (local or remote), keyed by server name.
+3. Applies gateway policy (from the existing `/v1/gateway/policies` store) inline, on every `tools/call`, `tools/list`, `resources/read`, `prompts/get`.
+4. Pushes every call into the existing HMAC-chained audit log via the existing `/v1/proxy/audit` contract.
+5. Exposes per-upstream and per-tenant metrics on the existing `/metrics` endpoint.
+
+Non-goals (explicitly):
+
+- Proxying **stdio** MCPs — clients that only speak stdio still use per-MCP `agent-bom proxy` wrappers. This gateway is HTTP/SSE-only.
+- A new transport or policy language. Re-uses `GatewayPolicy` + `check_policy` from [`src/agent_bom/gateway.py`](../../src/agent_bom/gateway.py).
+- Replacing the sidecar mode. Both modes coexist; teams pick per workload.
+
+## User-visible surface
+
+### CLI
+
+```bash
+agent-bom gateway serve \
+  --bind 0.0.0.0:8090 \
+  --upstreams upstreams.yaml \
+  --control-plane-url https://agent-bom.example.com \
+  --control-plane-token "$CP_TOKEN" \
+  --policy-refresh-seconds 30 \
+  --audit-push-interval 10 \
+  --response-signing-key /var/run/secrets/gateway/ed25519.pem
+```
+
+### `upstreams.yaml`
+
+```yaml
+upstreams:
+  - name: jira
+    url: https://snowflake.example.internal/mcp/jira
+    auth: oauth2_client_credentials
+    scopes: ["jira.read"]
+  - name: github
+    url: https://mcp.github.example.com/sse
+    auth: bearer
+    token_env: GITHUB_MCP_TOKEN
+  - name: filesystem-review-env
+    url: http://review-fs.agent-bom-workloads.svc.cluster.local:8100
+    auth: none
+```
+
+### Client config
+
+Laptop editors point at **one** URL for every MCP, using the gateway's server-routing discriminator:
+
+```jsonc
+// Cursor / VS Code / Claude MCP config — one entry, not N
+{
+  "mcpServers": {
+    "gateway": {
+      "transport": "sse",
+      "url": "https://agent-bom-gateway.example.com/mcp/{server-name}",
+      "headers": { "Authorization": "Bearer ${AGENT_BOM_USER_TOKEN}" }
+    }
+  }
+}
+```
+
+`{server-name}` is replaced by the desired upstream (e.g. `/mcp/jira`, `/mcp/github`). Servers the user is not authorised for 403.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  subgraph Laptops
+    cursor[Cursor]
+    claude[Claude Desktop]
+    vscode[VS Code + Copilot]
+  end
+  gw["agent-bom gateway serve<br/>(FastAPI + policy engine)"]
+  policy[("/v1/gateway/policies")]
+  audit[("/v1/proxy/audit")]
+  metrics[("/metrics")]
+  subgraph Upstreams
+    jira["Snowflake-hosted jira MCP"]
+    gh["GitHub MCP"]
+    fs["Filesystem MCP in EKS"]
+  end
+
+  Laptops -- SSE / Streamable HTTP --> gw
+  gw -. pull every 30s .- policy
+  gw -. push every 10s .- audit
+  gw -. scrape .- metrics
+  gw -->|tool call| jira
+  gw -->|tool call| gh
+  gw -->|tool call| fs
+```
+
+## Reuse map — don't rewrite what exists
+
+| Requirement | Existing code | Change |
+|---|---|---|
+| Policy evaluation | [`check_policy`](../../src/agent_bom/proxy.py) | Reuse unchanged — pure function |
+| Policy fetch from control plane | `control_plane_url` / `control_plane_token` path in [`run_proxy`](../../src/agent_bom/proxy.py:527) | Extract into a module both `run_proxy` and `gateway serve` call |
+| Runtime detectors | [`agent_bom.runtime.detectors`](../../src/agent_bom/runtime/detectors.py) | Reuse unchanged |
+| Audit-push client | Proxy's current HTTPX POST to `/v1/proxy/audit` | Extract |
+| Response signing | `response_signing_key` path already in `run_proxy` | Reuse |
+| `GatewayPolicy` format | [`agent_bom.api.policy_store`](../../src/agent_bom/api/policy_store.py) | Unchanged |
+| Metrics | [`agent_bom.api.metrics`](../../src/agent_bom/api/metrics.py) | Add per-upstream labelled counters |
+| Auth (API key / OIDC / SAML) | [`agent_bom.api.middleware`](../../src/agent_bom/api/middleware.py) | Gateway must accept the same auth methods the control plane does |
+
+Net new code:
+
+- `src/agent_bom/gateway_server.py` — the FastAPI app, upstream registry, per-connection SSE relay
+- `src/agent_bom/cli/gateway.py` — `agent-bom gateway serve` entry point
+- `src/agent_bom/gateway_upstreams.py` — upstream config loader + auth injector
+- `tests/test_gateway_server.py` — real upstream + real policy + TestClient integration
+
+## Security guarantees
+
+- **Tenant isolation** — every upstream request carries the authenticated tenant's context; per-tenant rate limits + audit scoping (same path as the main API).
+- **mTLS-ready** — gateway accepts a client cert at ingress for zero-trust environments; upstream TLS verification is mandatory (not optional like current proxy dev-mode).
+- **No credential forwarding** — per-upstream credentials are injected by the gateway, never read from the client request. This is the whole point of putting a gateway in front: the laptop doesn't hold the Jira token.
+- **Audit non-repudiation** — gateway calls are signed with the same Ed25519 key path the compliance bundle uses ([`docs/COMPLIANCE_SIGNING.md`](../COMPLIANCE_SIGNING.md)).
+- **Replay protection** — same nonce + expiry envelope as the compliance bundle for every `tools/call` audit record.
+- **Pod Security Admission restricted** — gateway runs as non-root, read-only root FS, no privilege escalation. Helm template ships this.
+
+## Performance targets
+
+| Metric | Target | Source |
+|---|---|---|
+| p50 added latency per `tools/call` | < 15 ms | existing proxy benchmarks |
+| p99 added latency | < 60 ms | |
+| Concurrent clients per pod | 500 SSE connections | FastAPI + uvloop |
+| Policy refresh staleness | < 45 s (30 s pull + 15 s slack) | `policy_refresh_seconds` |
+| Audit push queue backlog | alerts at > 10k events | `AuditDeliveryController` DLQ |
+
+Horizontal scale via HPA; session affinity needed on ingress (SSE is long-lived).
+
+## Rollout plan
+
+1. **Day 1 (merge of this doc):** design published; pilot team can read the target architecture.
+2. **Day 2–3:** extract policy-fetch + audit-push helpers from `run_proxy` into shared modules. Land with existing proxy still working (regression guard).
+3. **Day 4–5:** `agent-bom gateway serve` MVP — HTTP/SSE, 1 upstream, policy + audit + metrics wired.
+4. **Day 6:** N upstreams, per-upstream auth injection, upstream config hot-reload.
+5. **Day 7:** Helm chart `gateway` Deployment + HPA + NetworkPolicy + PrometheusRule + Grafana panel.
+6. **Day 8:** pilot team installs, points editors at the gateway URL, validates policy enforcement on a Snowflake jira MCP and a GitHub MCP.
+
+Every stage is behind a flag until the gateway-serve tests and the pilot team sign off — sidecars remain the documented default.
+
+## Open questions
+
+- **Upstream auth refresh**: OAuth2 client-credentials token rotation schedule. Day-1 answer: per-upstream auth policy in the config; background refresher with 80% jitter.
+- **Client authentication**: do we require a per-user token (OIDC), a per-tenant API key, or both? Day-1 answer: per-user OIDC for laptop traffic, per-service API key for machine-to-machine.
+- **Snowflake MCP specifics**: do Snowflake-hosted MCPs speak stock MCP over HTTPS, or do they require `snowflake-connector-python`? Day-1 answer: we assume they speak HTTP/SSE MCP and expose that via an ingress that speaks TLS + OAuth.

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -1,0 +1,156 @@
+# Snowflake-native backend
+
+`agent-bom` runs against Snowflake as the primary store for scan jobs,
+fleet agents, gateway policies, and the HMAC-chained audit log. Use this
+mode when your organisation already governs data in Snowflake and you
+want the control plane's persistence to land in the same warehouse.
+
+The parity boundary is explicit — some API surfaces (exceptions, API
+keys, schedules, trend, graph) have not been ported to
+`SnowflakeStore` yet. See [backend-parity.md](backend-parity.md) for
+the current capability matrix.
+
+---
+
+## When Snowflake is the right fit
+
+Pick Snowflake when:
+
+- Your security and platform teams already have Snowflake as the system
+  of record; adding another Postgres instance creates a data-governance
+  headache.
+- You want the audit log, scan inventory, and compliance evidence in the
+  same warehouse that drives your other security analytics.
+- You want to join `agent-bom` findings against other Snowflake
+  governance data (user activity, cloud asset tables) without moving
+  data across systems.
+- You want **one backend that covers transactional, streaming, and
+  analytical workloads**. Snowflake now ships:
+  - **Hybrid Tables** (row-oriented) for fast transactional writes to
+    the scan / fleet / policy / audit stores.
+  - **Standard columnar tables** for the analytics queries the
+    dashboard and compliance narratives run.
+  - **Snowpipe Streaming** for real-time audit / telemetry ingest
+    without a separate Kafka or ClickHouse hop.
+  - **Postgres-compatible protocol** (via the Postgres API / drivers
+    where applicable) so tooling that speaks `psycopg` can point at
+    Snowflake the same way it points at Postgres — reducing client-side
+    changes when you migrate.
+  - **Native cross-cloud replication + listings** so the control plane
+    in your EKS cluster can read/write the same Snowflake tables your
+    cloud + Cortex MCPs read, regardless of region.
+
+Pick Postgres when you want broad API surface coverage and the fastest
+possible install, and you're comfortable adding ClickHouse only if
+audit/event volume justifies it. Pick Snowflake when you'd rather
+collapse both into one unified stack.
+
+## Auth — zero-credential model
+
+**Key-pair auth is required** for the Snowflake backend in production
+([`build_connection_params`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/api/snowflake_store.py)).
+Passwords are deprecated and emit a runtime warning; password auth is
+intentionally not recommended because it breaks rotation and short-lived
+credential hygiene.
+
+SSO (externalbrowser) is used for interactive operator CLI; the
+control-plane API uses key-pair. Both reject the deprecated
+`SNOWFLAKE_PASSWORD` path when
+`AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1`.
+
+### Generate a key pair once
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+openssl rsa -in rsa_key.p8 -pubout > rsa_key.pub
+PUBLIC_KEY=$(grep -v "BEGIN\|END" rsa_key.pub | tr -d '\n')
+
+# Install the public key on the Snowflake user
+snowsql -a <account> -u <user> -q \
+  "ALTER USER <user> SET RSA_PUBLIC_KEY='${PUBLIC_KEY}'"
+```
+
+### Store the private key + connection params in Secrets Manager
+
+```bash
+aws secretsmanager create-secret \
+  --name agent-bom/snowflake \
+  --secret-string "$(jq -n \
+    --arg account "$SF_ACCOUNT" \
+    --arg user "$SF_USER" \
+    --arg warehouse "$SF_WAREHOUSE" \
+    --arg database "$SF_DATABASE" \
+    --arg schema "$SF_SCHEMA" \
+    --arg role "$SF_ROLE" \
+    --rawfile private_key rsa_key.p8 \
+    '{account: $account, user: $user, warehouse: $warehouse, database: $database, schema: $schema, role: $role, private_key: $private_key}')"
+```
+
+Wire it to the cluster via ExternalSecrets pointing at
+`agent-bom/snowflake`.
+
+## Install
+
+Use the shipped example values file:
+
+```bash
+helm install agent-bom deploy/helm/agent-bom \
+  -n agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
+```
+
+The example file configures:
+
+- `AGENT_BOM_STORE_BACKEND=snowflake` (and equivalent for fleet / policy / audit)
+- Key-pair auth via mounted `rsa_key.p8`
+- `AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1` — hard-fail on password fallback
+- Postgres backup CronJob disabled (Snowflake handles durability)
+- Scanner CronJob still runs, pushes scan results to `/v1/fleet/sync`
+- Egress NetworkPolicy allowing only `*.snowflakecomputing.com` on 443
+
+## Schema bootstrap
+
+`SnowflakeJobStore` / `SnowflakeFleetStore` / `SnowflakePolicyStore`
+create their tables on first connect with `CREATE TABLE IF NOT EXISTS`.
+The schema lives in the database + schema you set via
+`SNOWFLAKE_DATABASE` / `SNOWFLAKE_SCHEMA`.
+
+Per-tenant isolation is row-level: every row carries a `TENANT_ID`
+column and every query filters on it. See
+[ClickHouse row-level tenant isolation (#1501)](https://github.com/msaad00/agent-bom/pull/1501)
+for the equivalent enforcement on ClickHouse.
+
+## What to monitor
+
+The metrics catalog ([docs/OBSERVABILITY_METRICS.md](../../docs/OBSERVABILITY_METRICS.md))
+applies here. Snowflake-specific signals worth alerting on:
+
+- Query latency spikes on `SnowflakeJobStore.put` / `.list_all` —
+  symptom of warehouse under-provisioning.
+- Increased `agent_bom_auth_failures_total` after a key rotation —
+  confirm the new public key landed on the Snowflake user.
+
+## Break-glass
+
+- **Warehouse exhausted** — scale the warehouse or point a backup Helm
+  release at a different warehouse via `SNOWFLAKE_WAREHOUSE`.
+- **Key rotation** — update the private key in Secrets Manager, run
+  `ALTER USER ... SET RSA_PUBLIC_KEY` on Snowflake, `kubectl rollout
+  restart deploy/agent-bom-api`. Old compliance bundles remain
+  verifiable against the old **Ed25519** public key (that's a separate
+  key from the Snowflake auth key — see
+  [docs/COMPLIANCE_SIGNING.md](../../docs/COMPLIANCE_SIGNING.md)).
+- **Access revoked** — bring up a Postgres backend from the nightly
+  Postgres backup if you kept one; otherwise restore from Snowflake
+  Time Travel.
+
+## Caveats
+
+- Exceptions, API-key persistence, scheduler, trend, graph — not yet on
+  `SnowflakeStore`. Run Postgres alongside for these, or wait for
+  parity.
+- The scanner CronJob still runs in-cluster; it does not run inside
+  Snowpark. Cortex / Snowpark-native discovery is a separate capability
+  ([`src/agent_bom/cloud/snowflake.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/cloud/snowflake.py)).
+- Time Travel + Fail-safe provide durability, but configure a retention
+  window that matches your compliance retention policy.


### PR DESCRIPTION
## Summary
Part **A** of the 9.0 push + pilot-readiness work. Docs-only PR so pilot teams have a clean reading path before the implementation PRs land.

### README — 'Enterprise self-hosted deployment' is now its own top-level section

- Promoted from a sub-heading to a prominent titled section with rule dividers, so the pilot team lands on it without scrolling past the demo.
- **Concrete pilot-shape diagram** matching the team you're talking to this week: macOS + Windows employees running Cursor / VS Code / Codex / Claude / Copilot, talking to local + remote + Snowflake-hosted MCPs (e.g. a jira MCP), feeding into an in-cluster EKS control plane.
- **Surface-by-client matrix** — which agent-bom capability covers macOS, Windows, local/remote/Snowflake MCPs.
- **Honest proxy architecture note** — today's proxy is per-MCP sidecar / wrapper; the multi-upstream gateway mode (laptop points at one URL for every MCP) is tracked in a new design doc, not claimed as shipped.
- **Backend matrix** with Snowflake as a first-class option alongside SQLite / Postgres / ClickHouse. Three deployment shapes documented: pilot default (Postgres), analytics-heavy (Postgres + ClickHouse), unified stack (Snowflake — Hybrid Tables + columnar + Snowpipe Streaming + Postgres-compatible protocol + cross-cloud replication).
- **Scripted Day-1 install** block pointing at `scripts/pilot-verify.sh` from #1546.

### New: `docs/design/MULTI_MCP_GATEWAY.md`

First design for `agent-bom gateway serve` — one FastAPI service that fronts N upstream MCP servers, applies central policy + audit inline, and lets laptop editors point at one URL instead of configuring a proxy per MCP. Re-uses `check_policy` / detectors / audit push / response signing from the existing per-MCP proxy. Non-goals + rollout plan + security guarantees + performance targets + open questions included. Implementation PR will stack on this.

### New: `deploy/helm/agent-bom/examples/eks-snowflake-values.yaml`

Helm values for a Snowflake-native backend. Stores scan jobs, fleet, policies, and the HMAC-chained audit log in Snowflake via the existing `SnowflakeJobStore` / `SnowflakeFleetStore` / `SnowflakePolicyStore`. Key-pair auth enforced (`AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1`). Postgres backup CronJob disabled. Egress NetworkPolicy scoped to `*.snowflakecomputing.com` on 443.

### New: `site-docs/deployment/snowflake-backend.md`

Full "when + why + how" doc for the Snowflake backend:
- When it's the right fit — including Snowflake's Hybrid Tables (transactional), columnar (analytics), Snowpipe Streaming (real-time ingest), Postgres-compatible protocol, and cross-cloud replication.
- Key-pair auth setup (zero-credential model).
- Schema bootstrap + row-level tenant isolation.
- Break-glass runbook.
- Parity caveats (exceptions / schedules / trend / graph not yet on `SnowflakeStore`).

## Why
Pilot team this week runs macOS + Windows employees with Cursor / VS Code / Codex / Claude / Copilot, has Snowflake-hosted MCPs, and installs agent-bom in their own EKS. This PR gives them three documented answers before they read any code: surface-by-endpoint matrix, Snowflake as a primary backend, and the multi-MCP-gateway roadmap.

## What this PR does NOT do
- No code changes (docs + helm example only).
- Does not implement `agent-bom gateway serve` — that's the next PR stack (**E** in the 9.0 plan).
- Does not close the ClickHouse tenant-isolation / security-CI / perf-benchmark items (**B / C / D**); those ship as separate PRs.

## Test plan
- [x] `helm template deploy/helm/agent-bom -f deploy/helm/agent-bom/examples/eks-snowflake-values.yaml` — valid YAML
- [ ] CI: markdown lint + link check