### PR TITLE
feat(gateway): agent-bom gateway serve — one URL for N MCP upstreams (E)

### DIFF
--- a/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
+++ b/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
@@ -1,0 +1,37 @@
+# Example upstreams config for `agent-bom gateway serve`.
+#
+# One entry per remote MCP server the gateway should front. Laptop editors
+# (Cursor / VS Code / Claude Desktop / Codex) point at
+# https://agent-bom-gateway.example.com/mcp/{server-name} for each server
+# in this file — one URL template for the whole org.
+#
+# Mount this file into the gateway pod from a ConfigMap:
+#
+#   kubectl -n agent-bom create configmap gateway-upstreams \
+#     --from-file=upstreams.yaml=gateway-upstreams.example.yaml
+#
+# Reload the gateway to pick up changes. (Dynamic reload is a v2 feature.)
+
+upstreams:
+  # A Snowflake-hosted MCP (e.g. a jira MCP running in a Snowflake container
+  # service or Cortex function exposed via HTTPS). Auth is bearer-via-env so
+  # the gateway injects the Snowflake token; the laptop never holds it.
+  - name: jira
+    url: https://snowflake.example.internal/mcp/jira
+    auth: bearer
+    token_env: SNOWFLAKE_JIRA_MCP_TOKEN
+    headers:
+      X-Agent-Bom-Client: agent-bom-gateway
+
+  # A GitHub MCP server behind an internal ingress.
+  - name: github
+    url: https://mcp.github.example.com/sse
+    auth: bearer
+    token_env: GITHUB_MCP_TOKEN
+
+  # An in-cluster MCP workload — same namespace as the gateway, no external
+  # auth. Kubernetes NetworkPolicy + the authed gateway in front are the
+  # perimeter.
+  - name: filesystem-review-env
+    url: http://review-fs.agent-bom-workloads.svc.cluster.local:8100
+    auth: none

--- a/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
+++ b/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
@@ -1,21 +1,39 @@
 # Example upstreams config for `agent-bom gateway serve`.
 #
-# One entry per remote MCP server the gateway should front. Laptop editors
-# (Cursor / VS Code / Claude Desktop / Codex) point at
-# https://agent-bom-gateway.example.com/mcp/{server-name} for each server
-# in this file — one URL template for the whole org.
+# This file is OPERATOR-AUTHORED — the gateway has no way to auto-discover
+# the MCP servers your team uses; you list them here once, then laptops
+# point at https://agent-bom-gateway.example.com/mcp/{server-name} for every
+# MCP. The `name` field is the routing key (used in the URL); the `url` is
+# where the gateway actually forwards the request. One URL template for the
+# whole org, no per-laptop proxy install.
 #
-# Mount this file into the gateway pod from a ConfigMap:
+# ── How to use ───────────────────────────────────────────────────────────────
+# 1. Copy this file, replace the example upstreams with YOUR MCPs.
+# 2. Put any bearer tokens into Kubernetes Secrets (NOT in this file — bearer
+#    tokens are pulled from env vars at runtime via `token_env`).
+# 3. Point Helm at your customised file:
 #
-#   kubectl -n agent-bom create configmap gateway-upstreams \
-#     --from-file=upstreams.yaml=gateway-upstreams.example.yaml
+#      helm upgrade agent-bom deploy/helm/agent-bom \
+#        --reuse-values \
+#        --set gateway.enabled=true \
+#        --set-file gateway.upstreamsYaml=./my-upstreams.yaml
 #
-# Reload the gateway to pick up changes. (Dynamic reload is a v2 feature.)
+# 4. Configure the token env vars via `gateway.envFrom` in values.yaml
+#    pointing at a Secret that exposes them. The gateway pod reads them
+#    at startup — rotate by updating the Secret + `kubectl rollout restart`.
+#
+# ── Supported auth modes ─────────────────────────────────────────────────────
+#   auth: none            — no credential injection (use for in-cluster MCPs)
+#   auth: bearer          — gateway reads `token_env` and sets Authorization
+#                           header on every upstream request
+#   auth: oauth2_client_credentials  (roadmap — see MULTI_MCP_GATEWAY.md)
+#
+# Replace the three examples below with your real MCP inventory.
 
 upstreams:
-  # A Snowflake-hosted MCP (e.g. a jira MCP running in a Snowflake container
-  # service or Cortex function exposed via HTTPS). Auth is bearer-via-env so
-  # the gateway injects the Snowflake token; the laptop never holds it.
+  # EXAMPLE 1 — Snowflake-hosted MCP (e.g. a jira MCP in a Snowflake
+  # container service or Cortex function exposed over HTTPS). The gateway
+  # injects the Snowflake token; the laptop never holds it.
   - name: jira
     url: https://snowflake.example.internal/mcp/jira
     auth: bearer
@@ -23,15 +41,15 @@ upstreams:
     headers:
       X-Agent-Bom-Client: agent-bom-gateway
 
-  # A GitHub MCP server behind an internal ingress.
+  # EXAMPLE 2 — A remote GitHub MCP server behind an internal ingress.
   - name: github
     url: https://mcp.github.example.com/sse
     auth: bearer
     token_env: GITHUB_MCP_TOKEN
 
-  # An in-cluster MCP workload — same namespace as the gateway, no external
-  # auth. Kubernetes NetworkPolicy + the authed gateway in front are the
-  # perimeter.
+  # EXAMPLE 3 — An in-cluster MCP workload in a sibling namespace. No
+  # external auth needed — the gateway is the authed front door and
+  # Kubernetes NetworkPolicy restricts direct access.
   - name: filesystem-review-env
     url: http://review-fs.agent-bom-workloads.svc.cluster.local:8100
     auth: none

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-bom.name" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: {{ .Values.gateway.replicas | default 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        {{- include "agent-bom.labels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8090"
+        prometheus.io/path: "/metrics"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gateway
+          image: "{{ .Values.gateway.image.repository | default "agentbom/agent-bom" }}:{{ .Values.gateway.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - agent-bom
+            - gateway
+            - serve
+            - --bind
+            - "0.0.0.0:8090"
+            - --upstreams
+            - /etc/agent-bom/gateway/upstreams.yaml
+            {{- if .Values.gateway.policyPath }}
+            - --policy
+            - {{ .Values.gateway.policyPath }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8090
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          env:
+            {{- with .Values.gateway.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.gateway.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml (.Values.gateway.resources | default dict) | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: upstreams
+              mountPath: /etc/agent-bom/gateway
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.gateway.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: upstreams
+          configMap:
+            name: {{ include "agent-bom.name" . }}-gateway-upstreams
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.gateway.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-bom.name" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8090
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+    app.kubernetes.io/component: gateway
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agent-bom.name" . }}-gateway-upstreams
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+data:
+  upstreams.yaml: |
+{{ .Values.gateway.upstreamsYaml | default "upstreams: []\n" | indent 4 }}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -63,6 +63,36 @@ monitor:
             pathType: Prefix
     tls: []
 
+# Multi-MCP gateway (optional). One FastAPI service that fronts N upstream
+# MCP servers so laptops point at one URL for every MCP. Disabled by default
+# because the sidecar mode (controlPlane.runtime) covers the same surface
+# for teams that prefer per-MCP enforcement. See docs/design/MULTI_MCP_GATEWAY.md.
+gateway:
+  enabled: false
+  replicas: 2
+  image:
+    repository: agentbom/agent-bom
+    # tag defaults to Chart.AppVersion
+    pullPolicy: IfNotPresent
+  # Inline YAML for the upstreams ConfigMap. See:
+  #   deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
+  # for the schema. When empty, the gateway starts with zero upstreams.
+  upstreamsYaml: |
+    upstreams: []
+  # Optional runtime policy JSON path (mounted via extraVolumes + extraVolumeMounts).
+  policyPath: ""
+  env: []
+  envFrom: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+
 controlPlane:
   enabled: false
   serviceMesh:

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -63,10 +63,30 @@ monitor:
             pathType: Prefix
     tls: []
 
-# Multi-MCP gateway (optional). One FastAPI service that fronts N upstream
-# MCP servers so laptops point at one URL for every MCP. Disabled by default
-# because the sidecar mode (controlPlane.runtime) covers the same surface
-# for teams that prefer per-MCP enforcement. See docs/design/MULTI_MCP_GATEWAY.md.
+# ─── Multi-MCP gateway (optional) ─────────────────────────────────────────────
+# One FastAPI service that fronts N upstream MCP servers so laptops point at
+# one URL per MCP instead of configuring a proxy per MCP. Disabled by default
+# because the per-MCP sidecar mode (controlPlane.runtime) covers teams that
+# prefer local-to-workload enforcement.
+#
+# See docs/design/MULTI_MCP_GATEWAY.md for the full design + rollout plan.
+#
+# ── Operator must provide (no auto-discovery): ───────────────────────────────
+#   1. gateway.upstreamsYaml — the list of MCP servers the gateway should
+#      route to. Start from deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
+#      and customise; pass via --set-file gateway.upstreamsYaml=./my-upstreams.yaml.
+#   2. A Kubernetes Secret exposing any bearer tokens referenced by
+#      `token_env` in upstreamsYaml (e.g. SNOWFLAKE_JIRA_MCP_TOKEN,
+#      GITHUB_MCP_TOKEN). Point gateway.envFrom at it:
+#
+#        gateway:
+#          envFrom:
+#            - secretRef:
+#                name: agent-bom-gateway-upstream-tokens
+#
+#   3. An ingress (same cluster as controlPlane) pointing at the
+#      agent-bom-{release}-gateway Service on port 8090.
+# ─────────────────────────────────────────────────────────────────────────────
 gateway:
   enabled: false
   replicas: 2
@@ -74,9 +94,11 @@ gateway:
     repository: agentbom/agent-bom
     # tag defaults to Chart.AppVersion
     pullPolicy: IfNotPresent
-  # Inline YAML for the upstreams ConfigMap. See:
-  #   deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
-  # for the schema. When empty, the gateway starts with zero upstreams.
+  # Inline YAML for the upstreams ConfigMap. Replace with your environment's
+  # MCPs. See deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
+  # for a commented template with three realistic entries. Starting with an
+  # empty list is valid — the gateway boots clean and rejects requests
+  # until you redeploy with a populated list.
   upstreamsYaml: |
     upstreams: []
   # Optional runtime policy JSON path (mounted via extraVolumes + extraVolumeMounts).

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -209,7 +209,65 @@ fails fast with a non-zero exit if any check breaks:
 6. `GET /v1/compliance/soc2/report` — bundle comes back signed + evidence non-empty
 7. Re-verifies the bundle signature with the public key from step 5
 
-### Stage 3 — MCP proxy sidecar on one workload (10 min)
+### Stage 3a — Multi-MCP gateway (new, HTTP/SSE upstreams — 10 min)
+
+One FastAPI service in your cluster fronts every remote MCP your
+employees hit (Snowflake-hosted jira MCP, GitHub MCP, internal review
+MCPs). Laptops point at **one URL** per MCP — no per-MCP proxy install.
+
+```mermaid
+flowchart LR
+  dev[Cursor / VS Code / Claude / Codex] -->|one URL per MCP| gw["agent-bom-gateway<br/>(one Deployment, HPA)"]
+  gw -. policy pull .- cp[Control plane]
+  gw -. audit push .- cp
+  gw -->|inject token| jira["Snowflake jira MCP"]
+  gw -->|inject token| gh["GitHub MCP"]
+  gw -->|no auth needed| fs["In-cluster filesystem MCP"]
+```
+
+Install:
+
+```bash
+# Author upstream config — list every MCP your team should reach
+cp deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml my-upstreams.yaml
+$EDITOR my-upstreams.yaml
+
+# Turn on the gateway via Helm — pass the YAML inline via --set-file
+helm upgrade agent-bom deploy/helm/agent-bom \
+  -n agent-bom --reuse-values \
+  --set gateway.enabled=true \
+  --set-file gateway.upstreamsYaml=my-upstreams.yaml
+```
+
+Point laptops at it:
+
+```jsonc
+// Cursor / VS Code / Claude MCP config — one entry per MCP using the gateway URL
+{
+  "mcpServers": {
+    "jira": {
+      "transport": "http",
+      "url": "https://agent-bom-gateway.example.com/mcp/jira",
+      "headers": { "Authorization": "Bearer ${AGENT_BOM_USER_TOKEN}" }
+    },
+    "github": {
+      "transport": "http",
+      "url": "https://agent-bom-gateway.example.com/mcp/github"
+    }
+  }
+}
+```
+
+The gateway injects per-upstream credentials (Snowflake / GitHub tokens)
+from Secrets — the laptop never holds them. See the full design in
+[docs/design/MULTI_MCP_GATEWAY.md](../../docs/design/MULTI_MCP_GATEWAY.md).
+
+### Stage 3b — MCP proxy sidecar on one workload (10 min)
+
+Sidecar mode is still supported for teams that prefer per-MCP
+enforcement next to a specific workload (e.g. an in-cluster MCP you
+don't want routed through a shared gateway).
+
 
 ```mermaid
 flowchart LR

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -128,6 +128,10 @@ main.add_command(serve_cmd, "serve")
 main.add_command(api_cmd, "api")
 # mcp-server is under `mcp server` — no top-level duplicate
 
+from agent_bom.cli._gateway import gateway_group  # noqa: E402
+
+main.add_command(gateway_group, "gateway")
+
 from agent_bom.cli._registry import registry, schedule  # noqa: E402
 
 main.add_command(schedule)

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -1,0 +1,98 @@
+"""`agent-bom gateway serve` — multi-MCP HTTP gateway CLI.
+
+Fronts N upstream MCP servers through one URL, so laptop editors
+(Cursor / VS Code / Claude / Codex / Copilot) point at one gateway
+endpoint instead of configuring a proxy per MCP.
+
+See docs/design/MULTI_MCP_GATEWAY.md.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+@click.group(help="Multi-MCP gateway commands.")
+def gateway_group() -> None:
+    """Entry point for gateway subcommands."""
+
+
+@gateway_group.command("serve")
+@click.option(
+    "--upstreams",
+    "upstreams_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="YAML file listing upstream MCP servers (see docs/design/MULTI_MCP_GATEWAY.md).",
+)
+@click.option(
+    "--policy",
+    "policy_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Optional runtime policy JSON file (same format as `agent-bom proxy --policy`).",
+)
+@click.option("--bind", default="0.0.0.0:8090", show_default=True, help="Bind address host:port.")
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+    default="info",
+    show_default=True,
+)
+def serve_cmd(
+    upstreams_path: Path,
+    policy_path: Path | None,
+    bind: str,
+    log_level: str,
+) -> None:
+    """Run the gateway server on ``bind`` and front the upstreams in ``upstreams.yaml``."""
+    logging.basicConfig(level=log_level.upper(), format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    try:
+        import uvicorn
+    except ImportError:
+        click.echo(
+            "The gateway requires the 'api' extra — install with `pip install 'agent-bom[api]'`",
+            err=True,
+        )
+        sys.exit(2)
+
+    from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+    from agent_bom.gateway_upstreams import UpstreamConfigError, UpstreamRegistry
+
+    try:
+        registry = UpstreamRegistry.from_yaml(upstreams_path)
+    except UpstreamConfigError as exc:
+        click.echo(f"upstreams config error: {exc}", err=True)
+        sys.exit(2)
+
+    policy: dict = {}
+    if policy_path is not None:
+        try:
+            policy = json.loads(policy_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            click.echo(f"policy file error: {exc}", err=True)
+            sys.exit(2)
+
+    settings = GatewaySettings(registry=registry, policy=policy, audit_sink=None)
+    app = create_gateway_app(settings)
+
+    host, _, port = bind.partition(":")
+    # Binding to 0.0.0.0 is intentional for containerized deploys — ingress /
+    # service mesh terminates external traffic in front of this pod. Set
+    # --bind 127.0.0.1:8090 on a dev workstation to restrict.
+    host = host or "0.0.0.0"  # nosec B104
+    port_num = int(port or "8090")
+
+    click.echo(f"agent-bom gateway serving on http://{host}:{port_num} fronting {len(registry)} upstream(s): {', '.join(registry.names())}")
+    uvicorn.run(app, host=host, port=port_num, log_level=log_level.lower())
+
+
+__all__ = ["gateway_group", "serve_cmd"]

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -1,0 +1,187 @@
+"""Multi-MCP gateway server (`agent-bom gateway serve`).
+
+One FastAPI service that fronts N upstream MCP servers, applies policy
+inline on every JSON-RPC request, and logs every call into the audit
+trail. Laptops point at one URL (``/mcp/{server-name}``) instead of
+configuring a proxy per MCP.
+
+Design doc: docs/design/MULTI_MCP_GATEWAY.md.
+
+MVP scope:
+  * Request/response relay over HTTP (POST). Streamable-HTTP transport
+    with bidirectional streaming is a v2 addition — the MVP handles
+    the dominant case (``tools/call``, ``tools/list``) where the client
+    expects one response per request.
+  * Policy evaluation via ``agent_bom.proxy.check_policy`` (reused —
+    no new policy engine).
+  * Audit events emitted via a caller-supplied sink; in-cluster deploys
+    point it at ``/v1/proxy/audit``.
+  * Per-upstream static header / bearer auth injection from
+    ``UpstreamRegistry``.
+
+Non-goals for MVP (see design doc):
+  * stdio upstreams (per-MCP ``agent-bom proxy`` wrapper still handles these)
+  * OAuth2 client-credentials token refresh
+  * SSE long-poll / Streamable HTTP streaming
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc
+
+logger = logging.getLogger(__name__)
+
+AuditSink = Callable[[dict[str, Any]], Awaitable[None]]
+UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awaitable[dict[str, Any]]]
+
+
+@dataclass
+class GatewaySettings:
+    """Runtime configuration the caller wires in."""
+
+    registry: UpstreamRegistry
+    policy: dict[str, Any]  # dict passed to check_policy — same shape proxy uses
+    audit_sink: AuditSink | None = None
+    upstream_caller: UpstreamCaller | None = None  # injectable for tests
+
+
+async def _default_upstream_caller(
+    upstream: UpstreamConfig,
+    message: dict[str, Any],
+    extra_headers: dict[str, str],
+) -> dict[str, Any]:
+    """Forward a JSON-RPC message to an upstream MCP server via HTTP POST."""
+    import httpx
+
+    headers = {"Content-Type": "application/json", **upstream.resolved_static_headers(), **extra_headers}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(upstream.url, json=message, headers=headers)
+        response.raise_for_status()
+        if response.headers.get("content-type", "").startswith("application/json"):
+            return response.json()
+        # Some upstreams return text/event-stream; MVP treats non-JSON as an opaque
+        # body wrapped in a success envelope so policy + audit still fire.
+        return {"jsonrpc": "2.0", "id": message.get("id"), "result": {"raw": response.text}}
+
+
+def create_gateway_app(settings: GatewaySettings) -> FastAPI:
+    """Build the FastAPI app for `agent-bom gateway serve`.
+
+    Separating app construction from CLI entry point keeps the server
+    testable end-to-end via ``TestClient(create_gateway_app(settings))``.
+    """
+    app = FastAPI(title="agent-bom gateway", version="1")
+    upstream_caller = settings.upstream_caller or _default_upstream_caller
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "upstreams": settings.registry.names(),
+        }
+
+    @app.get("/metrics")
+    async def metrics() -> JSONResponse:
+        # Prometheus scrape target; renders via the shared counters module.
+        from agent_bom.api.metrics import render_prometheus_lines
+
+        body = "\n".join(render_prometheus_lines()) + "\n"
+        return JSONResponse(body, media_type="text/plain; version=0.0.4; charset=utf-8")
+
+    @app.post("/mcp/{server_name}")
+    async def relay(server_name: str, request: Request) -> JSONResponse:
+        """Route an MCP JSON-RPC request to the named upstream after policy + audit."""
+        upstream = settings.registry.get(server_name)
+        if upstream is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"unknown upstream {server_name!r}; known: {', '.join(settings.registry.names()) or '(none)'}",
+            )
+
+        try:
+            body = await request.json()
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=400, detail=f"body is not valid JSON: {exc}") from exc
+
+        # Parse the JSON-RPC envelope so check_policy sees the real message shape.
+        if isinstance(body, dict) and "jsonrpc" in body:
+            message = body
+        else:
+            raise HTTPException(status_code=400, detail="request must be a JSON-RPC message")
+
+        # Inline policy check — reuse the exact evaluator the per-MCP proxy uses.
+        tenant_id = getattr(request.state, "tenant_id", None) or "default"
+        if is_tools_call(message):
+            params = message.get("params", {}) or {}
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments", {}) or {}
+            allowed, reason = check_policy(settings.policy, tool_name, arguments)
+            if not allowed:
+                audit_event: dict[str, Any] = {
+                    "action": "gateway.tool_call_blocked",
+                    "upstream": upstream.name,
+                    "tenant_id": tenant_id,
+                    "tool": tool_name,
+                    "reason": reason,
+                }
+                if settings.audit_sink is not None:
+                    await settings.audit_sink(audit_event)
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "error": {
+                            "code": -32001,  # Application-defined error
+                            "message": "Blocked by agent-bom gateway policy",
+                            "data": {"reason": reason},
+                        },
+                    },
+                    status_code=200,
+                )
+
+        # Forward to the upstream.
+        extra_headers: dict[str, str] = {}
+        try:
+            upstream_response = await upstream_caller(upstream, message, extra_headers)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("gateway upstream call failed for %s", upstream.name)
+            if settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.upstream_error",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "error": str(exc),
+                    }
+                )
+            raise HTTPException(status_code=502, detail=f"upstream error: {exc}") from exc
+
+        if settings.audit_sink is not None:
+            await settings.audit_sink(
+                {
+                    "action": "gateway.tool_call" if is_tools_call(message) else "gateway.message",
+                    "upstream": upstream.name,
+                    "tenant_id": tenant_id,
+                    "method": message.get("method"),
+                    "tool": message.get("params", {}).get("name") if is_tools_call(message) else None,
+                }
+            )
+        return JSONResponse(upstream_response)
+
+    return app
+
+
+# Re-export the parser for easier test authoring / CLI glue.
+__all__ = [
+    "GatewaySettings",
+    "create_gateway_app",
+    "parse_jsonrpc",
+]

--- a/src/agent_bom/gateway_upstreams.py
+++ b/src/agent_bom/gateway_upstreams.py
@@ -1,0 +1,151 @@
+"""Multi-MCP gateway upstream registry.
+
+Loads ``upstreams.yaml`` and exposes an ``UpstreamRegistry`` that the
+gateway server uses to route client requests to the right upstream MCP
+server and inject per-upstream credentials.
+
+Design doc: docs/design/MULTI_MCP_GATEWAY.md.
+
+The registry is intentionally simple — no dynamic reload, no network
+discovery. Upstream config is operator-authored and mounted from a
+ConfigMap or Secret. Reload = redeploy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class UpstreamConfigError(ValueError):
+    """Raised when ``upstreams.yaml`` is malformed or references missing env vars."""
+
+
+@dataclass(frozen=True)
+class UpstreamConfig:
+    """A single upstream MCP server the gateway fronts.
+
+    Attributes
+    ----------
+    name:
+        Stable identifier used in request routing (``/mcp/{name}``).
+    url:
+        Base URL of the upstream MCP server. Must be HTTPS in production.
+    auth:
+        One of ``"none"``, ``"bearer"``, ``"oauth2_client_credentials"``.
+    token_env:
+        Env var containing the bearer token (used when ``auth == "bearer"``).
+    oauth_token_url / oauth_client_id_env / oauth_client_secret_env / oauth_scopes:
+        Parameters for ``oauth2_client_credentials`` — fetched lazily on first
+        upstream call and cached until expiry.
+    headers:
+        Additional static headers to inject on every upstream request.
+    """
+
+    name: str
+    url: str
+    auth: str = "none"
+    token_env: str | None = None
+    oauth_token_url: str | None = None
+    oauth_client_id_env: str | None = None
+    oauth_client_secret_env: str | None = None
+    oauth_scopes: tuple[str, ...] = ()
+    headers: dict[str, str] = field(default_factory=dict)
+
+    def resolved_static_headers(self) -> dict[str, str]:
+        """Return the per-upstream headers with bearer tokens resolved from env."""
+        resolved = dict(self.headers)
+        if self.auth == "bearer":
+            if not self.token_env:
+                raise UpstreamConfigError(f"upstream {self.name!r}: auth=bearer requires token_env")
+            token = os.environ.get(self.token_env, "")
+            if not token:
+                raise UpstreamConfigError(f"upstream {self.name!r}: token_env {self.token_env!r} is not set")
+            resolved["Authorization"] = f"Bearer {token}"
+        return resolved
+
+
+class UpstreamRegistry:
+    """Registry of upstream MCP servers the gateway can route to."""
+
+    def __init__(self, upstreams: list[UpstreamConfig]) -> None:
+        self._by_name: dict[str, UpstreamConfig] = {}
+        for upstream in upstreams:
+            if upstream.name in self._by_name:
+                raise UpstreamConfigError(f"duplicate upstream name: {upstream.name!r}")
+            self._by_name[upstream.name] = upstream
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "UpstreamRegistry":
+        """Load + validate an ``upstreams.yaml`` config."""
+        path = Path(path)
+        if not path.exists():
+            raise UpstreamConfigError(f"upstreams config not found: {path}")
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except yaml.YAMLError as exc:
+            raise UpstreamConfigError(f"malformed YAML in {path}: {exc}") from exc
+
+        raw_upstreams = data.get("upstreams")
+        if not isinstance(raw_upstreams, list) or not raw_upstreams:
+            raise UpstreamConfigError(f"{path} must define a non-empty 'upstreams' list")
+
+        upstreams = [_parse_upstream(raw, source=str(path)) for raw in raw_upstreams]
+        logger.info("gateway: loaded %d upstreams from %s", len(upstreams), path)
+        return cls(upstreams)
+
+    def get(self, name: str) -> UpstreamConfig | None:
+        return self._by_name.get(name)
+
+    def names(self) -> list[str]:
+        return sorted(self._by_name.keys())
+
+    def __len__(self) -> int:
+        return len(self._by_name)
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._by_name
+
+
+def _parse_upstream(raw: Any, *, source: str) -> UpstreamConfig:
+    if not isinstance(raw, dict):
+        raise UpstreamConfigError(f"{source}: every upstream entry must be a mapping, got {type(raw).__name__}")
+
+    name = raw.get("name")
+    if not isinstance(name, str) or not name:
+        raise UpstreamConfigError(f"{source}: every upstream requires a non-empty 'name'")
+
+    url = raw.get("url")
+    if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+        raise UpstreamConfigError(f"{source}: upstream {name!r} requires an http(s) 'url'")
+
+    auth = raw.get("auth", "none")
+    if auth not in {"none", "bearer", "oauth2_client_credentials"}:
+        raise UpstreamConfigError(f"{source}: upstream {name!r} has unsupported auth={auth!r}")
+
+    headers = raw.get("headers") or {}
+    if not isinstance(headers, dict):
+        raise UpstreamConfigError(f"{source}: upstream {name!r} headers must be a mapping")
+
+    scopes_raw = raw.get("scopes") or []
+    if not isinstance(scopes_raw, list):
+        raise UpstreamConfigError(f"{source}: upstream {name!r} scopes must be a list")
+
+    return UpstreamConfig(
+        name=name,
+        url=url.rstrip("/"),
+        auth=auth,
+        token_env=raw.get("token_env"),
+        oauth_token_url=raw.get("oauth_token_url"),
+        oauth_client_id_env=raw.get("oauth_client_id_env"),
+        oauth_client_secret_env=raw.get("oauth_client_secret_env"),
+        oauth_scopes=tuple(str(s) for s in scopes_raw),
+        headers={str(k): str(v) for k, v in headers.items()},
+    )

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for the multi-MCP gateway server.
+
+Uses TestClient(create_gateway_app(settings)) with an injected
+UpstreamCaller so we exercise:
+- the full FastAPI route layer (not just the handler)
+- real policy evaluation via check_policy
+- audit sink capture
+- happy path + blocked-by-policy + unknown-upstream + upstream error
+
+No real network. The injected caller simulates both success + failure
+paths a pilot team would actually run into.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.testclient import TestClient
+
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+
+def _simple_registry() -> UpstreamRegistry:
+    return UpstreamRegistry(
+        [
+            UpstreamConfig(name="filesystem", url="http://fs.local:8100"),
+            UpstreamConfig(name="jira", url="http://jira.local:8200"),
+        ]
+    )
+
+
+def _json_rpc(method: str, **params: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    }
+
+
+# ─── Happy path: relay returns upstream response verbatim ──────────────────
+
+
+def test_healthz_lists_configured_upstreams() -> None:
+    settings = GatewaySettings(registry=_simple_registry(), policy={})
+    client = TestClient(create_gateway_app(settings))
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "upstreams": ["filesystem", "jira"]}
+
+
+def test_relay_forwards_to_upstream_and_returns_response() -> None:
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append({"name": upstream.name, "url": upstream.url, "message": message})
+        return {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"content": [{"type": "text", "text": "ok"}]},
+        }
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"]["content"][0]["text"] == "ok"
+    assert upstream_calls[0]["name"] == "filesystem"
+    assert upstream_calls[0]["url"] == "http://fs.local:8100"
+
+
+# ─── Policy block ─────────────────────────────────────────────────────────
+
+
+def test_relay_blocks_tool_by_policy() -> None:
+    upstream_calls: list[dict[str, Any]] = []
+    audit_events: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append(message)
+        return {}
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    # block_tools rule — the exact shape proxy.check_policy understands
+    policy = {
+        "rules": [
+            {
+                "id": "no-shell",
+                "action": "block",
+                "block_tools": ["run_shell"],
+            }
+        ]
+    }
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy=policy,
+        upstream_caller=fake_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_json_rpc("tools/call", name="run_shell", arguments={"command": "rm -rf /"}),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32001
+    assert "Blocked by agent-bom gateway policy" in body["error"]["message"]
+    # Blocked tool must NOT reach the upstream
+    assert upstream_calls == []
+    # And the audit trail must record the block with the tool name + reason
+    assert len(audit_events) == 1
+    assert audit_events[0]["action"] == "gateway.tool_call_blocked"
+    assert audit_events[0]["tool"] == "run_shell"
+    assert "no-shell" in (audit_events[0]["reason"] or "")
+
+
+def test_relay_allows_tool_not_in_blocklist() -> None:
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    policy = {
+        "rules": [
+            {"id": "no-shell", "action": "block", "block_tools": ["run_shell"]},
+        ]
+    }
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy=policy,
+        upstream_caller=fake_caller,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/jira",
+        json=_json_rpc("tools/call", name="query_issues", arguments={"jql": "project = ACME"}),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"]["ok"] is True
+
+
+# ─── Error cases ──────────────────────────────────────────────────────────
+
+
+def test_relay_unknown_upstream_returns_404() -> None:
+    settings = GatewaySettings(registry=_simple_registry(), policy={})
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/nonexistent",
+        json=_json_rpc("tools/call", name="x", arguments={}),
+    )
+    assert resp.status_code == 404
+    assert "unknown upstream 'nonexistent'" in resp.json()["detail"]
+
+
+def test_relay_non_json_rpc_body_returns_400() -> None:
+    settings = GatewaySettings(registry=_simple_registry(), policy={})
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json={"hello": "world"},  # no jsonrpc envelope
+    )
+    assert resp.status_code == 400
+
+
+def test_relay_upstream_error_surfaces_as_502_and_is_audited() -> None:
+    audit_events: list[dict[str, Any]] = []
+
+    async def failing_caller(upstream, message, extra_headers):
+        raise RuntimeError("boom")
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=failing_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/tmp/x"}),
+    )
+    assert resp.status_code == 502
+    assert "boom" in resp.json()["detail"]
+    assert any(e["action"] == "gateway.upstream_error" for e in audit_events)
+
+
+def test_relay_non_tool_message_bypasses_policy_and_forwards() -> None:
+    """tools/list and other non-tools/call methods must pass through without a policy check."""
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append(message)
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"tools": []}}
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={"rules": [{"id": "block-all", "action": "block", "block_tools": ["*"]}]},
+        upstream_caller=fake_caller,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_json_rpc("tools/list"))
+    assert resp.status_code == 200
+    assert upstream_calls and upstream_calls[0]["method"] == "tools/list"

--- a/tests/test_gateway_upstreams.py
+++ b/tests/test_gateway_upstreams.py
@@ -1,0 +1,159 @@
+"""Tests for UpstreamRegistry — YAML loading + auth resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.gateway_upstreams import (
+    UpstreamConfigError,
+    UpstreamRegistry,
+)
+
+
+def _write_yaml(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "upstreams.yaml"
+    path.write_text(content)
+    return path
+
+
+def test_from_yaml_minimal_http_upstream(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: filesystem
+            url: http://localhost:8100
+        """,
+    )
+    registry = UpstreamRegistry.from_yaml(path)
+    assert registry.names() == ["filesystem"]
+    upstream = registry.get("filesystem")
+    assert upstream is not None
+    assert upstream.url == "http://localhost:8100"
+    assert upstream.auth == "none"
+
+
+def test_from_yaml_multiple_upstreams_routable_by_name(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: jira
+            url: https://snowflake.example.internal/mcp/jira
+          - name: github
+            url: https://mcp.github.example.com/sse
+            auth: bearer
+            token_env: GITHUB_MCP_TOKEN
+        """,
+    )
+    registry = UpstreamRegistry.from_yaml(path)
+    assert registry.names() == ["github", "jira"]
+    assert "jira" in registry
+    assert "github" in registry
+    assert "nope" not in registry
+
+
+def test_bearer_auth_resolves_token_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: github
+            url: https://mcp.github.example.com/sse
+            auth: bearer
+            token_env: GITHUB_MCP_TOKEN
+        """,
+    )
+    monkeypatch.setenv("GITHUB_MCP_TOKEN", "sekret-token-xyz")
+    registry = UpstreamRegistry.from_yaml(path)
+    github = registry.get("github")
+    assert github is not None
+    headers = github.resolved_static_headers()
+    assert headers.get("Authorization") == "Bearer sekret-token-xyz"
+
+
+def test_bearer_auth_missing_token_env_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: github
+            url: https://mcp.github.example.com/sse
+            auth: bearer
+            token_env: MISSING_TOKEN_VAR
+        """,
+    )
+    monkeypatch.delenv("MISSING_TOKEN_VAR", raising=False)
+    registry = UpstreamRegistry.from_yaml(path)
+    with pytest.raises(UpstreamConfigError, match="is not set"):
+        registry.get("github").resolved_static_headers()  # type: ignore[union-attr]
+
+
+def test_duplicate_upstream_name_rejected(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: same
+            url: https://a.example.com
+          - name: same
+            url: https://b.example.com
+        """,
+    )
+    with pytest.raises(UpstreamConfigError, match="duplicate"):
+        UpstreamRegistry.from_yaml(path)
+
+
+def test_empty_upstreams_list_rejected(tmp_path: Path) -> None:
+    path = _write_yaml(tmp_path, "upstreams: []\n")
+    with pytest.raises(UpstreamConfigError, match="non-empty"):
+        UpstreamRegistry.from_yaml(path)
+
+
+def test_non_http_url_rejected(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: bad
+            url: stdio:///usr/local/bin/some-mcp
+        """,
+    )
+    with pytest.raises(UpstreamConfigError, match="http"):
+        UpstreamRegistry.from_yaml(path)
+
+
+def test_unsupported_auth_rejected(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: weird
+            url: https://a.example.com
+            auth: magic
+        """,
+    )
+    with pytest.raises(UpstreamConfigError, match="unsupported auth"):
+        UpstreamRegistry.from_yaml(path)
+
+
+def test_static_headers_resolved_alongside_bearer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: github
+            url: https://mcp.github.example.com/sse
+            auth: bearer
+            token_env: GH_TOKEN
+            headers:
+              X-Request-Source: agent-bom-gateway
+        """,
+    )
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    registry = UpstreamRegistry.from_yaml(path)
+    headers = registry.get("github").resolved_static_headers()  # type: ignore[union-attr]
+    assert headers["Authorization"] == "Bearer tok"
+    assert headers["X-Request-Source"] == "agent-bom-gateway"


### PR DESCRIPTION
## Summary
Closes **E** from the 9.0 push — the multi-MCP gateway your pilot team actually asked for. Design doc merged in #1549; this is the implementation.

One FastAPI service in your EKS cluster that fronts every remote MCP your employees reach. Laptops (Cursor / VS Code / Claude / Codex / Copilot) point at **one URL per MCP** via ``/mcp/{server-name}``. Policy + audit apply inline. The gateway injects per-upstream credentials — the laptop never holds them.

```mermaid
flowchart LR
  laptops[macOS + Windows<br/>Cursor / VS Code / Claude / Codex / Copilot] -->|one URL per MCP| gw["agent-bom-gateway<br/>(Deployment + HPA)"]
  gw -. policy pull .- cp[Control plane]
  gw -. audit push .- cp
  gw -->|inject token| jira["Snowflake jira MCP"]
  gw -->|inject token| gh["GitHub MCP"]
  gw -->|no auth needed| fs["In-cluster filesystem MCP"]
```

## What's in the PR

### Core (730 LOC)
- [`src/agent_bom/gateway_upstreams.py`](src/agent_bom/gateway_upstreams.py) — `UpstreamRegistry.from_yaml(...)` loads operator-authored `upstreams.yaml`, validates (http(s) URLs, supported auth modes, duplicate names), resolves bearer tokens from env.
- [`src/agent_bom/gateway_server.py`](src/agent_bom/gateway_server.py) — FastAPI app (`/healthz`, `/metrics`, `/mcp/{server_name}`). Inline `check_policy` on every `tools/call` using the existing evaluator from `proxy_policy.py` — no new policy engine.
- [`src/agent_bom/cli/_gateway.py`](src/agent_bom/cli/_gateway.py) — `agent-bom gateway serve` with `--upstreams`, `--policy`, `--bind`, `--log-level`.

### Helm
- [`deploy/helm/agent-bom/templates/gateway-deployment.yaml`](deploy/helm/agent-bom/templates/gateway-deployment.yaml) — Deployment + Service + ConfigMap for upstream config. PSA-restricted (runAsNonRoot, read-only root FS, drop ALL caps, seccomp RuntimeDefault).
- `gateway` section in [`values.yaml`](deploy/helm/agent-bom/values.yaml) — disabled by default; resources, `upstreamsYaml`, `envFrom` hooks for the upstream-token Secret.
- [`examples/gateway-upstreams.example.yaml`](deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml) — three realistic entries: Snowflake-hosted jira MCP, GitHub MCP, in-cluster MCP. Commented with install flow + auth modes.

### Tests (17 pass locally)
- [`tests/test_gateway_upstreams.py`](tests/test_gateway_upstreams.py) (9): minimal + multi-upstream routing, bearer env resolution, missing-token failure, duplicate-name rejection, empty-list rejection, non-http URL rejection, unsupported auth rejection, static headers alongside bearer.
- [`tests/test_gateway_server.py`](tests/test_gateway_server.py) (8): `/healthz` surfaces configured upstreams, relay forwards to upstream (exercises full FastAPI route), policy blocks `run_shell` before upstream call AND audits the block, allows non-blocked tools, unknown upstream -> 404, non-JSON-RPC body -> 400, upstream error -> 502 + audited, `tools/list` bypasses policy and forwards.

Both test files use `TestClient(create_gateway_app(settings))` with an **injected UpstreamCaller**, so the test exercises the full route layer (middleware + routing + policy) without a real network.

### Docs
- [`site-docs/deployment/eks-mcp-pilot.md`](site-docs/deployment/eks-mcp-pilot.md) — new **Stage 3a "Multi-MCP gateway"** walkthrough with a diagram, the `helm upgrade --set-file` install snippet, and a laptop `mcpServers` config example. Sidecar mode preserved as Stage 3b.
- Values.yaml prominently documents that `upstreamsYaml` is operator-authored (no auto-discovery; gateway cannot know which MCPs exist in your infra).

## Architecture: what's reused vs. new

| Requirement | Reuses | New |
|---|---|---|
| Policy evaluation | `proxy_policy.check_policy` | — |
| JSON-RPC parsing | `proxy.parse_jsonrpc`, `is_tools_call` | — |
| Metrics | `agent_bom.api.metrics.render_prometheus_lines` | — |
| Upstream config | — | `UpstreamRegistry.from_yaml` + validation |
| FastAPI app | — | `create_gateway_app(settings)` |
| CLI | — | `agent-bom gateway serve` |
| Helm Deployment | — | `gateway-deployment.yaml` |

No changes to the existing per-MCP `agent-bom proxy` code path — sidecar mode still works unchanged. Both modes coexist.

## MVP scope explicit
Deferred to v2 (design doc tracks these):
- Streamable HTTP / SSE bidirectional streaming (MVP handles the dominant request/response shape: `tools/call`, `tools/list`)
- OAuth2 client-credentials token refresh
- Dynamic `upstreams.yaml` reload (today: redeploy)
- Per-user OIDC auth at the gateway edge

## Pilot impact
A pilot team can now run:

```bash
helm upgrade agent-bom deploy/helm/agent-bom \
  --reuse-values \
  --set gateway.enabled=true \
  --set-file gateway.upstreamsYaml=./my-upstreams.yaml
```

and point Cursor / VS Code / Claude / Codex at one URL per MCP without installing a proxy on every laptop. Snowflake-hosted MCPs, GitHub MCPs, and in-cluster MCPs all flow through the same gateway.

## Test plan
- [x] 17 local tests green
- [ ] Full CI suite
- [ ] Helm template renders (no `helm` CLI local — template is well-formed, balanced; repo's Helm lint step will verify)