### PR TITLE
feat(gateway): fleet-driven discovery + real OAuth2 + gateway metrics (no scaff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ A realistic enterprise pilot today looks like this:
 - **Each editor talks to a mix of MCPs**:
   - *Local / stdio* — filesystem, git, shell, dev-server MCPs running on the laptop.
   - *Remote / HTTP + SSE* — hosted MCPs on internal services, SaaS tools, or inside a data warehouse.
-- **MCPs hosted inside Snowflake** — e.g. a Snowflake-hosted "jira" MCP exposing Jira data via Snowpark or Cortex. These look like remote MCPs to the client.
+- **SaaS MCPs** — e.g. a Jira MCP, GitHub MCP, or similar published by the SaaS vendor or a third party. Speak HTTP/SSE over the network.
+- **Snowflake-hosted MCPs** — an MCP running as a Snowflake container service or Cortex function (separate from the SaaS MCPs above). Typically authenticated via OAuth2 client-credentials against your Snowflake IdP.
 - **An in-cluster agent-bom control plane on EKS** — ingests fleet data from every laptop, mediates gateway policy for runtime proxies, and stores scan/audit state (Postgres, ClickHouse, or Snowflake).
 
 ```mermaid
@@ -169,13 +170,16 @@ flowchart LR
     end
     localmcp["Local MCPs<br/>(filesystem · git · shell)"]
     remotemcp["Remote MCPs<br/>(HTTP / SSE)"]
-    snowmcp["Snowflake-hosted MCPs<br/>(e.g. jira MCP)"]
+    saasmcp["SaaS MCPs<br/>(e.g. Jira MCP, GitHub MCP)"]
+    snowmcp["Snowflake-hosted MCPs<br/>(Cortex / container services)"]
 
     mac --> localmcp
     mac --> remotemcp
+    mac --> saasmcp
     mac --> snowmcp
     win --> localmcp
     win --> remotemcp
+    win --> saasmcp
     win --> snowmcp
 
     fleet[agent-bom agents --push-url]
@@ -186,6 +190,7 @@ flowchart LR
     win -. daily scan .-> fleet
     localmcp -. wrapped .- proxy
     remotemcp -. wrapped .- proxy
+    saasmcp -. wrapped .- proxy
     snowmcp -. wrapped .- proxy
     fleet -->|HTTPS fleet sync| cp
     proxy -->|policy pull · audit push| cp
@@ -193,15 +198,15 @@ flowchart LR
 
 **How each surface serves this mix**:
 
-| Surface | macOS | Windows | Local MCP | Remote MCP | Snowflake MCP |
+| Surface | macOS | Windows | Local MCP | SaaS MCP | Snowflake MCP |
 |---|:-:|:-:|:-:|:-:|:-:|
 | `agent-bom agents --push-url` (fleet sync) | ✓ | ✓ | discovered + scanned | discovered (reachability + CVE on the package that implements the server) | discovered (via Snowflake cloud scanner) |
 | `agent-bom proxy -- <cmd>` stdio | ✓ | ✓ | ✓ | — | — |
-| `agent-bom proxy --sse <url>` HTTP/SSE | ✓ | ✓ | — | ✓ | ✓ (Snowflake MCPs speak HTTP) |
+| `agent-bom proxy --sse <url>` HTTP/SSE | ✓ | ✓ | — | ✓ | ✓ (when exposed over HTTP/SSE) |
 | `agent-bom cloud snowflake` | ✓ | ✓ | — | — | ✓ (native discovery + CIS benchmark) |
-| Central gateway-for-all MCPs on one URL | — | — | — | planned | planned |
+| `agent-bom gateway serve` — one URL for all MCPs | ✓ | ✓ | — | ✓ (bearer auth) | ✓ (OAuth2 client-credentials) |
 
-The last row is the gap the pilot team asks about: a single central URL that fronts every remote MCP, so laptops don't individually need to configure a proxy. See the [multi-MCP gateway design](docs/design/MULTI_MCP_GATEWAY.md).
+The last row closes the gap that pilot teams ask about: a single central URL that fronts every remote MCP, so laptops don't individually need to configure a proxy. See the [multi-MCP gateway design](docs/design/MULTI_MCP_GATEWAY.md) and the [Stage 3a gateway install walkthrough](site-docs/deployment/eks-mcp-pilot.md).
 
 ## Five product surfaces, one shared graph
 

--- a/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
+++ b/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
@@ -31,23 +31,33 @@
 # Replace the three examples below with your real MCP inventory.
 
 upstreams:
-  # EXAMPLE 1 — Snowflake-hosted MCP (e.g. a jira MCP in a Snowflake
-  # container service or Cortex function exposed over HTTPS). The gateway
-  # injects the Snowflake token; the laptop never holds it.
+  # EXAMPLE 1 — A SaaS MCP (e.g. a Jira MCP published by Atlassian or a
+  # vendor) behind an internal ingress. The gateway injects the bearer
+  # token from a Secret; the laptop never holds it.
   - name: jira
-    url: https://snowflake.example.internal/mcp/jira
+    url: https://mcp.jira.example.com/sse
     auth: bearer
-    token_env: SNOWFLAKE_JIRA_MCP_TOKEN
-    headers:
-      X-Agent-Bom-Client: agent-bom-gateway
+    token_env: JIRA_MCP_TOKEN
 
-  # EXAMPLE 2 — A remote GitHub MCP server behind an internal ingress.
+  # EXAMPLE 2 — A Snowflake-hosted MCP (e.g. a data-query MCP running as
+  # a Snowflake container service or Cortex function). Uses OAuth2
+  # client-credentials so the gateway fetches + rotates tokens against
+  # Snowflake's IdP automatically.
+  - name: snowflake
+    url: https://snowflake.example.internal/mcp/cortex
+    auth: oauth2_client_credentials
+    oauth_token_url: https://snowflake.example.internal/oauth/token
+    oauth_client_id_env: SNOWFLAKE_OAUTH_CLIENT_ID
+    oauth_client_secret_env: SNOWFLAKE_OAUTH_CLIENT_SECRET
+    scopes: ["mcp.read", "mcp.write"]
+
+  # EXAMPLE 3 — A remote GitHub MCP server behind an internal ingress.
   - name: github
     url: https://mcp.github.example.com/sse
     auth: bearer
     token_env: GITHUB_MCP_TOKEN
 
-  # EXAMPLE 3 — An in-cluster MCP workload in a sibling namespace. No
+  # EXAMPLE 4 — An in-cluster MCP workload in a sibling namespace. No
   # external auth needed — the gateway is the authed front door and
   # Kubernetes NetworkPolicy restricts direct access.
   - name: filesystem-review-env

--- a/docs/design/MULTI_MCP_GATEWAY.md
+++ b/docs/design/MULTI_MCP_GATEWAY.md
@@ -4,6 +4,12 @@
 
 **Problem statement:** a pilot team wants to front-door every MCP connection in their environment through a single host so they can apply policy + audit centrally without touching every laptop's editor config. Today, `agent-bom proxy` is **per-MCP** — one instance per upstream server, either as a K8s sidecar next to a workload or as a stdio wrapper on a developer laptop. Central policy + audit already exist (`/v1/gateway/policies`, `/v1/proxy/audit`); central *traffic* does not.
 
+**Concrete pilot mix the gateway must cover:**
+- SaaS MCPs (Jira, GitHub, etc.) — bearer-token auth, remote HTTPS.
+- Snowflake-hosted MCPs (Cortex functions / container services) — OAuth2 client-credentials against the Snowflake IdP.
+- In-cluster MCPs running alongside the gateway — no external auth; NetworkPolicy is the perimeter.
+- stdio-only local MCPs — out of scope for this gateway; keep using `agent-bom proxy` per-MCP wrappers.
+
 ## Goal
 
 Add a new CLI mode: `agent-bom gateway serve`.
@@ -87,8 +93,9 @@ flowchart LR
   audit[("/v1/proxy/audit")]
   metrics[("/metrics")]
   subgraph Upstreams
-    jira["Snowflake-hosted jira MCP"]
-    gh["GitHub MCP"]
+    jira["Jira MCP (SaaS)"]
+    gh["GitHub MCP (SaaS)"]
+    snow["Snowflake MCP (Cortex / container service)"]
     fs["Filesystem MCP in EKS"]
   end
 
@@ -98,6 +105,7 @@ flowchart LR
   gw -. scrape .- metrics
   gw -->|tool call| jira
   gw -->|tool call| gh
+  gw -->|tool call| snow
   gw -->|tool call| fs
 ```
 
@@ -149,7 +157,7 @@ Horizontal scale via HPA; session affinity needed on ingress (SSE is long-lived)
 3. **Day 4–5:** `agent-bom gateway serve` MVP — HTTP/SSE, 1 upstream, policy + audit + metrics wired.
 4. **Day 6:** N upstreams, per-upstream auth injection, upstream config hot-reload.
 5. **Day 7:** Helm chart `gateway` Deployment + HPA + NetworkPolicy + PrometheusRule + Grafana panel.
-6. **Day 8:** pilot team installs, points editors at the gateway URL, validates policy enforcement on a Snowflake jira MCP and a GitHub MCP.
+6. **Day 8:** pilot team installs, points editors at the gateway URL, validates policy enforcement on a SaaS MCP (Jira or GitHub) and a Snowflake-hosted MCP (Cortex function).
 
 Every stage is behind a flag until the gateway-serve tests and the pilot team sign off — sidecars remain the documented default.
 
@@ -157,4 +165,4 @@ Every stage is behind a flag until the gateway-serve tests and the pilot team si
 
 - **Upstream auth refresh**: OAuth2 client-credentials token rotation schedule. Day-1 answer: per-upstream auth policy in the config; background refresher with 80% jitter.
 - **Client authentication**: do we require a per-user token (OIDC), a per-tenant API key, or both? Day-1 answer: per-user OIDC for laptop traffic, per-service API key for machine-to-machine.
-- **Snowflake MCP specifics**: do Snowflake-hosted MCPs speak stock MCP over HTTPS, or do they require `snowflake-connector-python`? Day-1 answer: we assume they speak HTTP/SSE MCP and expose that via an ingress that speaks TLS + OAuth.
+- **Snowflake-hosted MCP specifics**: Snowflake MCPs today expose HTTP/SSE endpoints via Cortex functions or container services, authenticated against the Snowflake IdP. We assume stock MCP over HTTPS and support OAuth2 client-credentials at the gateway — the `snowflake` example in `gateway-upstreams.example.yaml` is the shape.

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -212,16 +212,18 @@ fails fast with a non-zero exit if any check breaks:
 ### Stage 3a — Multi-MCP gateway (new, HTTP/SSE upstreams — 10 min)
 
 One FastAPI service in your cluster fronts every remote MCP your
-employees hit (Snowflake-hosted jira MCP, GitHub MCP, internal review
-MCPs). Laptops point at **one URL** per MCP — no per-MCP proxy install.
+employees hit (SaaS MCPs like Jira or GitHub, Snowflake-hosted MCPs
+running as Cortex functions or container services, in-cluster MCPs).
+Laptops point at **one URL** per MCP — no per-MCP proxy install.
 
 ```mermaid
 flowchart LR
   dev[Cursor / VS Code / Claude / Codex] -->|one URL per MCP| gw["agent-bom-gateway<br/>(one Deployment, HPA)"]
   gw -. policy pull .- cp[Control plane]
   gw -. audit push .- cp
-  gw -->|inject token| jira["Snowflake jira MCP"]
-  gw -->|inject token| gh["GitHub MCP"]
+  gw -->|inject bearer| jira["Jira MCP<br/>(SaaS)"]
+  gw -->|inject bearer| gh["GitHub MCP<br/>(SaaS)"]
+  gw -->|OAuth2 client-creds| snow["Snowflake MCP<br/>(Cortex / container service)"]
   gw -->|no auth needed| fs["In-cluster filesystem MCP"]
 ```
 

--- a/src/agent_bom/api/metrics.py
+++ b/src/agent_bom/api/metrics.py
@@ -39,6 +39,7 @@ _rate_limit_hits = _LabelledCounter()  # labelled by bucket name (global, tenant
 _compliance_exports = _LabelledCounter()  # labelled by algorithm (Ed25519, HMAC-SHA256)
 _compliance_export_bytes = _LabelledCounter()  # labelled by framework key
 _scan_completions = _LabelledCounter()  # labelled by status (done, failed, cancelled)
+_gateway_relays = _LabelledCounter()  # labelled by "<upstream>|<outcome>"
 
 
 def record_auth_failure(reason: str) -> None:
@@ -60,6 +61,17 @@ def record_compliance_export(algorithm: str, framework_key: str, byte_count: int
 def record_scan_completion(status: str) -> None:
     """Record a scan outcome (done, failed, cancelled)."""
     _scan_completions.inc(status)
+
+
+def record_gateway_relay(upstream: str, outcome: str) -> None:
+    """Record a gateway relay event.
+
+    ``upstream`` is the routing name (e.g. "jira"); ``outcome`` is one of
+    ``forwarded``, ``blocked``, ``upstream_error``. Labelled as
+    ``upstream|outcome`` in the Prometheus output so operators can
+    rate() by either dimension.
+    """
+    _gateway_relays.inc(f"{upstream}|{outcome}")
 
 
 def render_prometheus_lines() -> list[str]:
@@ -106,6 +118,15 @@ def render_prometheus_lines() -> list[str]:
     for status, count in sorted(scans.items()):
         lines.append(f'agent_bom_scan_completions_total{{status="{status}"}} {count}')
 
+    relays = _gateway_relays.snapshot()
+    lines.append("# HELP agent_bom_gateway_relays_total Multi-MCP gateway relay events by upstream and outcome")
+    lines.append("# TYPE agent_bom_gateway_relays_total counter")
+    if not relays:
+        lines.append('agent_bom_gateway_relays_total{upstream="none",outcome="none"} 0')
+    for label, count in sorted(relays.items()):
+        upstream, _, outcome = label.partition("|")
+        lines.append(f'agent_bom_gateway_relays_total{{upstream="{upstream}",outcome="{outcome}"}} {count}')
+
     return lines
 
 
@@ -117,6 +138,7 @@ def reset_for_tests() -> None:
         _compliance_exports,
         _compliance_export_bytes,
         _scan_completions,
+        _gateway_relays,
     ):
         with counter._lock:  # noqa: SLF001
             counter._values.clear()  # noqa: SLF001

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -9,6 +9,7 @@ Endpoints:
     POST   /v1/gateway/evaluate              dry-run policy evaluation
     GET    /v1/gateway/audit                 policy audit log
     GET    /v1/gateway/stats                 gateway statistics
+    GET    /v1/gateway/upstreams/discovered  MCP upstreams discovered across the fleet
 """
 
 from __future__ import annotations
@@ -22,9 +23,9 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
-from agent_bom.api.models import EvaluateRequest, PolicyCreate, PolicyUpdate
-from agent_bom.api.stores import _get_policy_store
-from agent_bom.rbac import require_permission
+from agent_bom.api.models import EvaluateRequest, JobStatus, PolicyCreate, PolicyUpdate
+from agent_bom.api.stores import _get_policy_store, _get_store
+from agent_bom.rbac import require_authenticated_permission, require_permission
 
 if TYPE_CHECKING:
     from agent_bom.api.policy_store import GatewayPolicy
@@ -222,6 +223,86 @@ async def list_gateway_audit(
         tenant_id=tenant_id,
     )
     return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
+
+
+@router.get(
+    "/v1/gateway/upstreams/discovered",
+    tags=["gateway"],
+    dependencies=[cast(Any, require_authenticated_permission("read"))],
+)
+async def discovered_upstreams(request: Request) -> dict:
+    """Return the remote MCP servers discovered across the tenant's fleet.
+
+    Aggregates every MCP server surfaced by the fleet-scan path (pushed
+    via ``/v1/fleet/sync`` or returned from in-cluster scans) that has a
+    real HTTP(S) URL — i.e. something a multi-MCP gateway can actually
+    front. stdio servers are excluded because they only make sense as a
+    per-workload sidecar / wrapper (``agent-bom proxy -- <cmd>``).
+
+    Response shape matches the ``upstreams.yaml`` the gateway consumes,
+    so a gateway pod can pull this endpoint at startup and every N
+    seconds to auto-populate its registry without the operator hand-
+    editing YAML. Auth / bearer-token wiring is still operator-supplied
+    via `gateway.envFrom` because tokens live in Secrets, not scan data.
+
+    Shape::
+
+        {
+          "generated_at": "2026-04-20T00:00:00Z",
+          "tenant_id": "...",
+          "source": "fleet_scan_aggregate",
+          "upstreams": [
+            {"name": "jira", "url": "https://...", "transport": "sse",
+             "auth": "none", "source_agents": ["agent-a", ...]},
+            ...
+          ]
+        }
+
+    The ``auth`` field is always ``"none"`` from discovery — discovery can
+    see the URL but not the credential. The gateway operator decides per
+    upstream whether to switch it to ``bearer`` + ``token_env`` when
+    merging with their authored overrides.
+    """
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    jobs = _get_store().list_all(tenant_id=tenant_id)
+
+    # name -> merged upstream record
+    by_name: dict[str, dict[str, Any]] = {}
+    for job in jobs:
+        if job.status != JobStatus.DONE or not job.result:
+            continue
+        agents = job.result.get("agents") or []
+        for agent in agents:
+            agent_name = agent.get("name") or agent.get("agent_name") or ""
+            for server in agent.get("servers") or []:
+                url = server.get("url") or ""
+                if not url.startswith(("http://", "https://")):
+                    # Skip stdio MCPs — they're per-workload sidecar territory.
+                    continue
+                name = server.get("name") or ""
+                if not name:
+                    continue
+                transport = server.get("transport") or "http"
+                record = by_name.setdefault(
+                    name,
+                    {
+                        "name": name,
+                        "url": url,
+                        "transport": transport,
+                        "auth": "none",
+                        "source_agents": [],
+                    },
+                )
+                # First URL wins; record every distinct agent that reports it.
+                if agent_name and agent_name not in record["source_agents"]:
+                    record["source_agents"].append(agent_name)
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "tenant_id": tenant_id,
+        "source": "fleet_scan_aggregate",
+        "upstreams": sorted(by_name.values(), key=lambda r: r["name"]),
+    }
 
 
 @router.get("/v1/gateway/stats", tags=["gateway"], dependencies=[_dep("audit_read")])

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -29,8 +29,31 @@ def gateway_group() -> None:
     "--upstreams",
     "upstreams_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
-    required=True,
-    help="YAML file listing upstream MCP servers (see docs/design/MULTI_MCP_GATEWAY.md).",
+    default=None,
+    help=(
+        "YAML file listing upstream MCP servers (see "
+        "docs/design/MULTI_MCP_GATEWAY.md). When --from-control-plane is also "
+        "set, entries here overlay on top of discovered upstreams — use to "
+        "attach bearer-token auth to a discovered upstream."
+    ),
+)
+@click.option(
+    "--from-control-plane",
+    "control_plane_url",
+    default=None,
+    help=(
+        "Pull auto-discovered upstreams from this agent-bom control plane URL "
+        "(hits /v1/gateway/upstreams/discovered). Fleet scans surface remote "
+        "HTTP/SSE MCPs into this endpoint — the gateway registers whatever the "
+        "fleet has discovered, so pilot teams don't start from a blank YAML."
+    ),
+)
+@click.option(
+    "--control-plane-token",
+    "control_plane_token",
+    envvar="AGENT_BOM_CONTROL_PLANE_TOKEN",
+    default=None,
+    help="Bearer token for the control plane API key (or set AGENT_BOM_CONTROL_PLANE_TOKEN).",
 )
 @click.option(
     "--policy",
@@ -47,13 +70,28 @@ def gateway_group() -> None:
     show_default=True,
 )
 def serve_cmd(
-    upstreams_path: Path,
+    upstreams_path: Path | None,
+    control_plane_url: str | None,
+    control_plane_token: str | None,
     policy_path: Path | None,
     bind: str,
     log_level: str,
 ) -> None:
-    """Run the gateway server on ``bind`` and front the upstreams in ``upstreams.yaml``."""
+    """Run the gateway server on ``bind``.
+
+    Upstreams come from (a) ``--from-control-plane`` auto-discovery, (b)
+    a local ``--upstreams`` YAML, or both (YAML overlays on top of
+    discovery). Must provide at least one — an empty gateway serves
+    nothing.
+    """
     logging.basicConfig(level=log_level.upper(), format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    if upstreams_path is None and control_plane_url is None:
+        click.echo(
+            "error: pass --upstreams or --from-control-plane (or both). See `agent-bom gateway serve --help`.",
+            err=True,
+        )
+        sys.exit(2)
 
     try:
         import uvicorn
@@ -65,13 +103,35 @@ def serve_cmd(
         sys.exit(2)
 
     from agent_bom.gateway_server import GatewaySettings, create_gateway_app
-    from agent_bom.gateway_upstreams import UpstreamConfigError, UpstreamRegistry
+    from agent_bom.gateway_upstreams import (
+        UpstreamConfigError,
+        UpstreamRegistry,
+        fetch_discovered_upstreams,
+    )
 
-    try:
-        registry = UpstreamRegistry.from_yaml(upstreams_path)
-    except UpstreamConfigError as exc:
-        click.echo(f"upstreams config error: {exc}", err=True)
-        sys.exit(2)
+    registry: UpstreamRegistry | None = None
+
+    if control_plane_url is not None:
+        try:
+            payload = fetch_discovered_upstreams(control_plane_url, token=control_plane_token)
+            discovered = UpstreamRegistry.from_discovery_response(payload)
+            click.echo(f"discovered {len(discovered)} upstream(s) from {control_plane_url}: {', '.join(discovered.names()) or '(none)'}")
+            registry = discovered
+        except Exception as exc:  # noqa: BLE001 — network/DNS/permission all surface here
+            click.echo(f"control-plane discovery failed: {exc}", err=True)
+            if upstreams_path is None:
+                sys.exit(2)
+            click.echo("continuing with local --upstreams only", err=True)
+
+    if upstreams_path is not None:
+        try:
+            local = UpstreamRegistry.from_yaml(upstreams_path)
+        except UpstreamConfigError as exc:
+            click.echo(f"upstreams config error: {exc}", err=True)
+            sys.exit(2)
+        registry = local if registry is None else registry.merged_with(local)
+
+    assert registry is not None  # guarded above
 
     policy: dict = {}
     if policy_path is not None:

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -34,6 +34,7 @@ from typing import Any, Awaitable, Callable
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from agent_bom.api.metrics import record_gateway_relay
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc
 
@@ -58,10 +59,16 @@ async def _default_upstream_caller(
     message: dict[str, Any],
     extra_headers: dict[str, str],
 ) -> dict[str, Any]:
-    """Forward a JSON-RPC message to an upstream MCP server via HTTP POST."""
+    """Forward a JSON-RPC message to an upstream MCP server via HTTP POST.
+
+    Resolves per-upstream auth (bearer + OAuth2 client-credentials) via
+    ``upstream.resolve_auth_headers`` so OAuth tokens are fetched + cached
+    correctly instead of failing at send time.
+    """
     import httpx
 
-    headers = {"Content-Type": "application/json", **upstream.resolved_static_headers(), **extra_headers}
+    auth_headers = await upstream.resolve_auth_headers()
+    headers = {"Content-Type": "application/json", **auth_headers, **extra_headers}
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(upstream.url, json=message, headers=headers)
         response.raise_for_status()
@@ -125,6 +132,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             arguments = params.get("arguments", {}) or {}
             allowed, reason = check_policy(settings.policy, tool_name, arguments)
             if not allowed:
+                record_gateway_relay(upstream.name, "blocked")
                 audit_event: dict[str, Any] = {
                     "action": "gateway.tool_call_blocked",
                     "upstream": upstream.name,
@@ -153,6 +161,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             upstream_response = await upstream_caller(upstream, message, extra_headers)
         except Exception as exc:  # noqa: BLE001
             logger.exception("gateway upstream call failed for %s", upstream.name)
+            record_gateway_relay(upstream.name, "upstream_error")
             if settings.audit_sink is not None:
                 await settings.audit_sink(
                     {
@@ -164,6 +173,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 )
             raise HTTPException(status_code=502, detail=f"upstream error: {exc}") from exc
 
+        record_gateway_relay(upstream.name, "forwarded")
         if settings.audit_sink is not None:
             await settings.audit_sink(
                 {

--- a/src/agent_bom/gateway_upstreams.py
+++ b/src/agent_bom/gateway_upstreams.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -28,6 +30,38 @@ class UpstreamConfigError(ValueError):
     """Raised when ``upstreams.yaml`` is malformed or references missing env vars."""
 
 
+SUPPORTED_AUTH_MODES: tuple[str, ...] = ("none", "bearer", "oauth2_client_credentials")
+
+
+# Process-wide cache for OAuth2 client-credentials access tokens. Keyed by
+# ``(token_url, client_id, scopes)`` so two upstreams pointing at the same
+# IdP with the same credentials share a token.
+_oauth_cache_lock = threading.Lock()
+_oauth_cache: dict[tuple[str, str, tuple[str, ...]], tuple[str, float]] = {}
+
+
+def _cached_oauth_token(key: tuple[str, str, tuple[str, ...]]) -> str | None:
+    with _oauth_cache_lock:
+        entry = _oauth_cache.get(key)
+        if entry is None:
+            return None
+        token, expires_at = entry
+        if expires_at - 60.0 <= time.time():
+            return None  # expire early so we refresh before the token actually dies
+        return token
+
+
+def _store_oauth_token(key: tuple[str, str, tuple[str, ...]], token: str, expires_in: int) -> None:
+    with _oauth_cache_lock:
+        _oauth_cache[key] = (token, time.time() + max(30, expires_in))
+
+
+def reset_oauth_cache_for_tests() -> None:
+    """Drop the process-wide OAuth2 token cache — test-only entry point."""
+    with _oauth_cache_lock:
+        _oauth_cache.clear()
+
+
 @dataclass(frozen=True)
 class UpstreamConfig:
     """A single upstream MCP server the gateway fronts.
@@ -39,12 +73,13 @@ class UpstreamConfig:
     url:
         Base URL of the upstream MCP server. Must be HTTPS in production.
     auth:
-        One of ``"none"``, ``"bearer"``, ``"oauth2_client_credentials"``.
+        One of ``SUPPORTED_AUTH_MODES`` — ``none``, ``bearer``, or
+        ``oauth2_client_credentials``.
     token_env:
         Env var containing the bearer token (used when ``auth == "bearer"``).
     oauth_token_url / oauth_client_id_env / oauth_client_secret_env / oauth_scopes:
-        Parameters for ``oauth2_client_credentials`` — fetched lazily on first
-        upstream call and cached until expiry.
+        OAuth2 client-credentials parameters. Tokens are fetched on first
+        use and cached until ~60 s before expiry.
     headers:
         Additional static headers to inject on every upstream request.
     """
@@ -60,7 +95,12 @@ class UpstreamConfig:
     headers: dict[str, str] = field(default_factory=dict)
 
     def resolved_static_headers(self) -> dict[str, str]:
-        """Return the per-upstream headers with bearer tokens resolved from env."""
+        """Return the per-upstream static headers with bearer tokens resolved from env.
+
+        OAuth2 client-credentials tokens are NOT included here because they
+        require a network fetch + refresh loop — use ``resolve_auth_headers``
+        for those (async, token-cache-aware).
+        """
         resolved = dict(self.headers)
         if self.auth == "bearer":
             if not self.token_env:
@@ -70,6 +110,65 @@ class UpstreamConfig:
                 raise UpstreamConfigError(f"upstream {self.name!r}: token_env {self.token_env!r} is not set")
             resolved["Authorization"] = f"Bearer {token}"
         return resolved
+
+    async def resolve_auth_headers(self) -> dict[str, str]:
+        """Return the full per-request header set, fetching OAuth2 tokens if needed."""
+        headers = self.resolved_static_headers()
+        if self.auth == "oauth2_client_credentials":
+            headers["Authorization"] = f"Bearer {await self._fetch_oauth2_token()}"
+        return headers
+
+    async def _fetch_oauth2_token(self) -> str:
+        if not self.oauth_token_url:
+            raise UpstreamConfigError(f"upstream {self.name!r}: auth=oauth2_client_credentials requires oauth_token_url")
+        if not self.oauth_client_id_env or not self.oauth_client_secret_env:
+            raise UpstreamConfigError(
+                f"upstream {self.name!r}: auth=oauth2_client_credentials requires oauth_client_id_env and oauth_client_secret_env"
+            )
+        client_id = os.environ.get(self.oauth_client_id_env, "")
+        client_secret = os.environ.get(self.oauth_client_secret_env, "")
+        if not client_id or not client_secret:
+            raise UpstreamConfigError(
+                f"upstream {self.name!r}: OAuth2 client credentials env vars "
+                f"({self.oauth_client_id_env}, {self.oauth_client_secret_env}) are not set"
+            )
+
+        cache_key = (self.oauth_token_url, client_id, self.oauth_scopes)
+        cached = _cached_oauth_token(cache_key)
+        if cached is not None:
+            return cached
+
+        import httpx
+
+        form: dict[str, str] = {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+        if self.oauth_scopes:
+            form["scope"] = " ".join(self.oauth_scopes)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                self.oauth_token_url,
+                data=form,
+                headers={"Accept": "application/json"},
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise UpstreamConfigError(f"upstream {self.name!r}: OAuth2 token endpoint {self.oauth_token_url!r} returned no access_token")
+        expires_in = int(payload.get("expires_in") or 3600)
+        _store_oauth_token(cache_key, access_token, expires_in)
+        logger.info(
+            "gateway: fetched OAuth2 access token for upstream=%s token_url=%s (expires_in=%ds)",
+            self.name,
+            self.oauth_token_url,
+            expires_in,
+        )
+        return access_token
 
 
 class UpstreamRegistry:
@@ -101,6 +200,36 @@ class UpstreamRegistry:
         logger.info("gateway: loaded %d upstreams from %s", len(upstreams), path)
         return cls(upstreams)
 
+    @classmethod
+    def from_discovery_response(cls, payload: dict[str, Any]) -> "UpstreamRegistry":
+        """Build a registry from a ``/v1/gateway/upstreams/discovered`` response.
+
+        The control plane returns upstreams with ``auth: none`` because
+        discovery sees URLs but not credentials. Operators who need bearer
+        tokens layer them on via their local ``upstreams.yaml`` overlay
+        (see ``merge_with_overlay``).
+        """
+        raw_upstreams = payload.get("upstreams") or []
+        if not isinstance(raw_upstreams, list):
+            raise UpstreamConfigError("discovery response must contain an 'upstreams' list")
+        upstreams = [_parse_upstream(raw, source="control-plane discovery") for raw in raw_upstreams]
+        logger.info("gateway: loaded %d upstreams from control-plane discovery", len(upstreams))
+        return cls(upstreams)
+
+    def merged_with(self, overlay: "UpstreamRegistry") -> "UpstreamRegistry":
+        """Merge another registry on top of this one — overlay wins per name.
+
+        Used when the gateway pulls auto-discovered upstreams from the
+        control plane AND the operator wants to override a subset (typically
+        to attach bearer-token auth to an upstream discovery can't infer).
+        """
+        merged: dict[str, UpstreamConfig] = dict(self._by_name)
+        for name, upstream in overlay._by_name.items():
+            merged[name] = upstream
+        new = UpstreamRegistry.__new__(UpstreamRegistry)
+        new._by_name = merged
+        return new
+
     def get(self, name: str) -> UpstreamConfig | None:
         return self._by_name.get(name)
 
@@ -112,6 +241,34 @@ class UpstreamRegistry:
 
     def __contains__(self, name: object) -> bool:
         return isinstance(name, str) and name in self._by_name
+
+
+def fetch_discovered_upstreams(
+    control_plane_url: str,
+    *,
+    token: str | None = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Pull auto-discovered upstreams from an agent-bom control plane.
+
+    Returns the JSON body of ``GET /v1/gateway/upstreams/discovered``.
+    Callers typically wrap this in ``UpstreamRegistry.from_discovery_response``.
+
+    Kept dependency-light (httpx is already a core dep) so the gateway
+    startup path doesn't pull extra packages.
+    """
+    import httpx
+
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = httpx.get(
+        control_plane_url.rstrip("/") + "/v1/gateway/upstreams/discovered",
+        headers=headers,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
 
 
 def _parse_upstream(raw: Any, *, source: str) -> UpstreamConfig:
@@ -127,8 +284,10 @@ def _parse_upstream(raw: Any, *, source: str) -> UpstreamConfig:
         raise UpstreamConfigError(f"{source}: upstream {name!r} requires an http(s) 'url'")
 
     auth = raw.get("auth", "none")
-    if auth not in {"none", "bearer", "oauth2_client_credentials"}:
-        raise UpstreamConfigError(f"{source}: upstream {name!r} has unsupported auth={auth!r}")
+    if auth not in SUPPORTED_AUTH_MODES:
+        raise UpstreamConfigError(
+            f"{source}: upstream {name!r} has unsupported auth={auth!r} — supported: {', '.join(SUPPORTED_AUTH_MODES)}"
+        )
 
     headers = raw.get("headers") or {}
     if not isinstance(headers, dict):

--- a/tests/test_gateway_upstream_discovery_route.py
+++ b/tests/test_gateway_upstream_discovery_route.py
@@ -1,0 +1,154 @@
+"""Integration test for GET /v1/gateway/upstreams/discovered.
+
+The gateway auto-discovery path — pilot teams don't hand-author a blank
+upstreams.yaml; they let fleet scans surface remote MCPs and the gateway
+pulls them from this endpoint. This test seeds real ScanJob results
+with mixed local (stdio) + remote (HTTP/SSE) MCPs and verifies that:
+
+- Only HTTP/SSE servers come back (stdio excluded — those are per-MCP
+  sidecar territory).
+- Each discovered upstream reports the agents that surfaced it.
+- Tenant scoping holds — tenant-alpha never sees tenant-beta's
+  discoveries.
+- auth is always 'none' from discovery (credentials live in Secrets,
+  not scan data — operators overlay via upstreams.yaml).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as _stores
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import set_job_store
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _seed_scan_with_servers(store: InMemoryJobStore, tenant: str, agent_name: str, servers: list[dict]) -> None:
+    job = ScanJob(
+        job_id=f"{tenant}-{agent_name}-scan",
+        tenant_id=tenant,
+        status=JobStatus.DONE,
+        created_at=_now(),
+        completed_at=_now(),
+        request=ScanRequest(),
+    )
+    job.result = {
+        "scan_id": f"{tenant}-{agent_name}-scan",
+        "agents": [{"name": agent_name, "servers": servers}],
+    }
+    store.put(job)
+
+
+@pytest.fixture
+def fleet_seeded():
+    """Seed two tenants with a mix of local + remote MCPs across multiple agents."""
+    store = InMemoryJobStore()
+
+    # Tenant alpha — two different agents both surface the same remote jira MCP,
+    # plus a stdio filesystem MCP on one agent. Only jira should come through.
+    _seed_scan_with_servers(
+        store,
+        "tenant-alpha",
+        agent_name="mac-laptop-1",
+        servers=[
+            {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "transport": "sse"},
+            {"name": "filesystem", "url": None, "transport": "stdio"},  # stdio — excluded
+        ],
+    )
+    _seed_scan_with_servers(
+        store,
+        "tenant-alpha",
+        agent_name="windows-laptop-3",
+        servers=[
+            {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "transport": "sse"},
+            {"name": "github", "url": "https://mcp.github.example.com/sse", "transport": "sse"},
+        ],
+    )
+
+    # Tenant beta — different MCPs that must NOT leak into alpha.
+    _seed_scan_with_servers(
+        store,
+        "tenant-beta",
+        agent_name="tenant-beta-laptop",
+        servers=[
+            {"name": "beta-only-jira", "url": "https://beta.example.com/mcp", "transport": "http"},
+        ],
+    )
+
+    prev = _stores._store
+    set_job_store(store)
+    try:
+        yield
+    finally:
+        _stores._store = prev
+
+
+def _client_for(tenant: str) -> TestClient:
+    c = TestClient(app)
+    c.headers.update(
+        {
+            "X-Agent-Bom-Role": "admin",
+            "X-Agent-Bom-Tenant-ID": tenant,
+        }
+    )
+    return c
+
+
+def test_discovered_upstreams_returns_remote_mcps_only(fleet_seeded) -> None:
+    resp = _client_for("tenant-alpha").get("/v1/gateway/upstreams/discovered")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tenant_id"] == "tenant-alpha"
+    assert body["source"] == "fleet_scan_aggregate"
+    names = [u["name"] for u in body["upstreams"]]
+    assert sorted(names) == ["github", "jira"]  # filesystem (stdio) excluded
+    for u in body["upstreams"]:
+        assert u["url"].startswith(("http://", "https://"))
+        assert u["auth"] == "none"
+
+
+def test_discovered_upstreams_aggregates_source_agents(fleet_seeded) -> None:
+    """A remote MCP used by multiple laptops lists every agent that reported it."""
+    resp = _client_for("tenant-alpha").get("/v1/gateway/upstreams/discovered")
+    jira = next(u for u in resp.json()["upstreams"] if u["name"] == "jira")
+    assert sorted(jira["source_agents"]) == ["mac-laptop-1", "windows-laptop-3"]
+
+
+def test_discovered_upstreams_is_tenant_scoped(fleet_seeded) -> None:
+    """Tenant alpha must never see tenant beta's discoveries."""
+    alpha = _client_for("tenant-alpha").get("/v1/gateway/upstreams/discovered").json()
+    beta = _client_for("tenant-beta").get("/v1/gateway/upstreams/discovered").json()
+
+    alpha_names = {u["name"] for u in alpha["upstreams"]}
+    beta_names = {u["name"] for u in beta["upstreams"]}
+    assert alpha_names == {"jira", "github"}
+    assert beta_names == {"beta-only-jira"}
+    assert alpha_names & beta_names == set(), "discovery endpoint leaks across tenants"
+
+
+def test_discovered_upstreams_returns_empty_when_fleet_has_no_remote_mcps() -> None:
+    """A tenant whose fleet only has stdio MCPs gets an empty upstream list (no error)."""
+    store = InMemoryJobStore()
+    _seed_scan_with_servers(
+        store,
+        "tenant-stdio-only",
+        agent_name="laptop",
+        servers=[{"name": "filesystem", "url": None, "transport": "stdio"}],
+    )
+    prev = _stores._store
+    set_job_store(store)
+    try:
+        resp = _client_for("tenant-stdio-only").get("/v1/gateway/upstreams/discovered")
+        assert resp.status_code == 200
+        assert resp.json()["upstreams"] == []
+    finally:
+        _stores._store = prev

--- a/tests/test_gateway_upstreams.py
+++ b/tests/test_gateway_upstreams.py
@@ -1,4 +1,4 @@
-"""Tests for UpstreamRegistry — YAML loading + auth resolution."""
+"""Tests for UpstreamRegistry — YAML loading + auth resolution + discovery."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from agent_bom.gateway_upstreams import (
+    UpstreamConfig,
     UpstreamConfigError,
     UpstreamRegistry,
 )
@@ -157,3 +158,225 @@ def test_static_headers_resolved_alongside_bearer(tmp_path: Path, monkeypatch: p
     headers = registry.get("github").resolved_static_headers()  # type: ignore[union-attr]
     assert headers["Authorization"] == "Bearer tok"
     assert headers["X-Request-Source"] == "agent-bom-gateway"
+
+
+# ─── from_discovery_response + merged_with (fleet-driven auto-discovery) ───
+
+
+def test_from_discovery_response_builds_registry_with_none_auth() -> None:
+    """Discovery payload mirrors the control plane's /v1/gateway/upstreams/discovered shape."""
+    payload = {
+        "generated_at": "2026-04-20T00:00:00Z",
+        "tenant_id": "pilot-acme",
+        "source": "fleet_scan_aggregate",
+        "upstreams": [
+            {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "auth": "none"},
+            {"name": "github", "url": "https://mcp.github.example.com/sse", "auth": "none"},
+        ],
+    }
+    registry = UpstreamRegistry.from_discovery_response(payload)
+    assert registry.names() == ["github", "jira"]
+    assert registry.get("jira").auth == "none"  # type: ignore[union-attr]
+    # Discovery doesn't know bearer tokens — operator overlays them
+    assert registry.get("jira").token_env is None  # type: ignore[union-attr]
+
+
+def test_from_discovery_response_accepts_empty_upstreams_cleanly() -> None:
+    """An empty discovery response produces an empty registry — no error.
+
+    Pilot teams with fleet scans pending may see this briefly; the gateway
+    should boot cleanly and serve zero upstreams, not crash.
+    """
+    registry = UpstreamRegistry.from_discovery_response({"upstreams": []})
+    assert registry.names() == []
+
+
+def test_from_discovery_response_rejects_non_list_upstreams() -> None:
+    with pytest.raises(UpstreamConfigError, match="upstreams"):
+        UpstreamRegistry.from_discovery_response({"upstreams": "not a list"})
+
+
+def test_merged_with_overlay_adds_auth_to_discovered_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The key scenario: discovery finds jira at a URL; operator overlays bearer auth."""
+    discovered = UpstreamRegistry.from_discovery_response(
+        {
+            "upstreams": [
+                {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "auth": "none"},
+            ]
+        }
+    )
+
+    operator_overlay = UpstreamRegistry(
+        [
+            UpstreamConfig(
+                name="jira",
+                url="https://snowflake.example.internal/mcp/jira",
+                auth="bearer",
+                token_env="SNOWFLAKE_JIRA_MCP_TOKEN",
+            )
+        ]
+    )
+
+    merged = discovered.merged_with(operator_overlay)
+    assert merged.names() == ["jira"]
+    jira = merged.get("jira")
+    assert jira is not None
+    assert jira.auth == "bearer"
+    assert jira.token_env == "SNOWFLAKE_JIRA_MCP_TOKEN"
+
+    # Resolving headers now works because the overlay wired the env var name.
+    monkeypatch.setenv("SNOWFLAKE_JIRA_MCP_TOKEN", "sf-token")
+    headers = jira.resolved_static_headers()
+    assert headers["Authorization"] == "Bearer sf-token"
+
+
+def test_merged_with_overlay_adds_new_upstreams_not_in_discovery() -> None:
+    """Operator can add upstreams discovery doesn't know about (yet)."""
+    discovered = UpstreamRegistry.from_discovery_response({"upstreams": [{"name": "jira", "url": "https://a.example.com", "auth": "none"}]})
+    overlay = UpstreamRegistry([UpstreamConfig(name="custom-internal", url="http://custom.svc.cluster.local:8000")])
+    merged = discovered.merged_with(overlay)
+    assert sorted(merged.names()) == ["custom-internal", "jira"]
+
+
+# ─── OAuth2 client-credentials ─────────────────────────────────────────────
+
+
+def test_oauth2_fetches_token_and_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two resolve calls must share the cached token instead of double-fetching."""
+    import asyncio
+
+    import httpx
+
+    from agent_bom.gateway_upstreams import reset_oauth_cache_for_tests
+
+    reset_oauth_cache_for_tests()
+
+    fetch_count = {"n": 0}
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return {"access_token": "oauth-tok-123", "expires_in": 3600, "token_type": "Bearer"}
+
+    class _FakeAsyncClient:
+        def __init__(self, *_, **__):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            fetch_count["n"] += 1
+            return _FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setenv("SF_CLIENT_ID", "cid")
+    monkeypatch.setenv("SF_CLIENT_SECRET", "csec")
+
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: jira-snowflake
+            url: https://snowflake.example.com/mcp/jira
+            auth: oauth2_client_credentials
+            oauth_token_url: https://snowflake.example.com/oauth/token
+            oauth_client_id_env: SF_CLIENT_ID
+            oauth_client_secret_env: SF_CLIENT_SECRET
+            scopes: ["jira.read", "jira.write"]
+        """,
+    )
+    registry = UpstreamRegistry.from_yaml(path)
+    upstream = registry.get("jira-snowflake")
+    assert upstream is not None
+
+    headers_a = asyncio.run(upstream.resolve_auth_headers())
+    headers_b = asyncio.run(upstream.resolve_auth_headers())
+    assert headers_a["Authorization"] == "Bearer oauth-tok-123"
+    assert headers_b["Authorization"] == "Bearer oauth-tok-123"
+    assert fetch_count["n"] == 1, "token must be cached across resolve calls within expiry"
+
+
+def test_oauth2_missing_env_vars_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from agent_bom.gateway_upstreams import reset_oauth_cache_for_tests
+
+    reset_oauth_cache_for_tests()
+    monkeypatch.delenv("SF_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SF_CLIENT_SECRET", raising=False)
+
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: jira-snowflake
+            url: https://snowflake.example.com/mcp/jira
+            auth: oauth2_client_credentials
+            oauth_token_url: https://snowflake.example.com/oauth/token
+            oauth_client_id_env: SF_CLIENT_ID
+            oauth_client_secret_env: SF_CLIENT_SECRET
+        """,
+    )
+    registry = UpstreamRegistry.from_yaml(path)
+    upstream = registry.get("jira-snowflake")
+    assert upstream is not None
+    with pytest.raises(UpstreamConfigError, match="not set"):
+        asyncio.run(upstream.resolve_auth_headers())
+
+
+def test_oauth2_missing_required_fields_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from agent_bom.gateway_upstreams import reset_oauth_cache_for_tests
+
+    reset_oauth_cache_for_tests()
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: jira-broken
+            url: https://snowflake.example.com/mcp/jira
+            auth: oauth2_client_credentials
+            # no oauth_token_url / env names
+        """,
+    )
+    registry = UpstreamRegistry.from_yaml(path)
+    upstream = registry.get("jira-broken")
+    assert upstream is not None
+    with pytest.raises(UpstreamConfigError, match="requires oauth_token_url"):
+        asyncio.run(upstream.resolve_auth_headers())
+
+
+def test_fetch_discovered_upstreams_hits_expected_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unit-level check that the client hits /v1/gateway/upstreams/discovered with the bearer."""
+    from agent_bom.gateway_upstreams import fetch_discovered_upstreams
+
+    captured = {}
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return {"upstreams": []}
+
+    def fake_get(url, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers or {}
+        captured["timeout"] = timeout
+        return _FakeResponse()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    result = fetch_discovered_upstreams("https://agent-bom.example.com/", token="abc")
+    assert captured["url"] == "https://agent-bom.example.com/v1/gateway/upstreams/discovered"
+    assert captured["headers"]["Authorization"] == "Bearer abc"
+    assert captured["timeout"] == 10.0
+    assert result == {"upstreams": []}


### PR DESCRIPTION
## Summary
Follow-up to #1551. Closes the 'no scaffolding, all wired' audit round on the multi-MCP gateway.

### 1. Auto-discovery from fleet inventory — no blank YAML
agent-bom fleet scans already surface every remote MCP a laptop is using. Wire the gateway to that existing inventory so pilot teams don't hand-author a list of MCPs the control plane already knows about.

- `GET /v1/gateway/upstreams/discovered` (new) — aggregates HTTP/SSE MCP servers across the tenant's completed scan jobs. stdio servers excluded (those stay per-MCP sidecar territory). Source-agent provenance included.
- `UpstreamRegistry.from_discovery_response(payload)` + `.merged_with(overlay)` — parse + overlay so operators can attach bearer tokens on top of discovered URLs.
- `fetch_discovered_upstreams(control_plane_url, token=...)` — httpx client the gateway calls at startup.
- CLI: `agent-bom gateway serve --from-control-plane URL` (+ `--control-plane-token` or `AGENT_BOM_CONTROL_PLANE_TOKEN` env). Either `--upstreams`, `--from-control-plane`, or both.

### 2. Real OAuth2 client-credentials — not scaffold
Previously `auth: oauth2_client_credentials` was a validator string with zero implementation. Now real:
- `UpstreamConfig.resolve_auth_headers()` async fetches tokens via `client_credentials` grant, caches until ~60s before expiry.
- Process-wide cache keyed by `(token_url, client_id, scopes)` so multiple upstreams at the same IdP share tokens.
- Fields: `oauth_token_url`, `oauth_client_id_env`, `oauth_client_secret_env`, `oauth_scopes`.
- Default upstream caller uses `resolve_auth_headers()` so OAuth2 tokens hit the wire on every request.
- 3 new OAuth2 tests (fetch+cache, missing env, missing config).

### 3. Gateway metrics actually wired
`/metrics` rendered the shared counters but the gateway never recorded anything. Now:
- `record_gateway_relay(upstream, outcome)` — outcomes: `forwarded`, `blocked`, `upstream_error`.
- `gateway_server.py` calls it on every relay path.
- Exposed as `agent_bom_gateway_relays_total{upstream,outcome}`.

### 4. Terminology fix
De-conflated "Snowflake jira MCP" — you called out Jira MCP and Snowflake MCP as two separate MCP types. Docs + example config updated:
- Jira MCP (SaaS) — bearer-token auth
- Snowflake MCP (Cortex / container service) — OAuth2 client-creds
- GitHub MCP (SaaS) — bearer-token auth
- In-cluster MCP — no external auth

## Tests — 30 pass locally
- `tests/test_gateway_upstreams.py`: 18 tests (bearer, OAuth2×3, discovery×2, overlay×2, fetch client)
- `tests/test_gateway_server.py`: 8 route-level TestClient
- `tests/test_gateway_upstream_discovery_route.py` (new): 4 tests seeding real ScanJob results with mixed stdio + HTTP/SSE — stdio exclusion, source-agent aggregation, tenant isolation, empty-fleet handling

## Pilot impact — end-to-end flow wired
1. Employees run `agent-bom agents --push-url https://agent-bom.example.com/v1/fleet/sync` on their macOS + Windows laptops.
2. Control plane's discovered-upstreams endpoint aggregates every remote HTTP/SSE MCP the fleet saw (Jira, GitHub, Snowflake Cortex, in-cluster).
3. Gateway starts with `--from-control-plane https://agent-bom.example.com` + `--upstreams overlay.yaml` — overlay provides bearer/OAuth2 auth for each discovered upstream.
4. Laptops point editors (Cursor, VS Code, Claude, Codex) at one gateway URL per MCP.
5. Gateway applies `check_policy` inline, fetches OAuth2 tokens for Snowflake upstreams, records relay metrics, pushes audit events.

No scaffolds, all wired.

## Test plan
- [x] 30 tests green
- [x] bandit + mypy + ruff pre-commit pass
- [ ] Full CI suite