### PR TITLE
fix(gateway+ci+docs): close 9/10 audit items (P1–P5)

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -246,6 +246,12 @@ jobs:
               return 0
             fi
 
+            # Idempotency: if the exact same version already exists on ClawHub,
+            # treat it as success rather than churning the retry loop. Run the
+            # publish once and capture output so we can detect the 'already
+            # exists' signal in the retry-or-exit branch below.
+            local TMP_OUT
+            TMP_OUT=$(mktemp)
             for ATTEMPT in 1 2 3; do
               echo "ClawHub ${SLUG} attempt ${ATTEMPT}/3..."
               if clawhub publish "$DIR" \
@@ -253,16 +259,25 @@ jobs:
                 --name "$DISPLAY_NAME" \
                 --version "$VERSION" \
                 --changelog "Release v${VERSION}" \
-                --tags latest; then
+                --tags latest 2>&1 | tee "$TMP_OUT"; then
                 echo "ClawHub ${SLUG} v${VERSION} published"
+                rm -f "$TMP_OUT"
                 return 0
-              else
-                echo "ClawHub ${SLUG} publish failed"
-                if [ "$ATTEMPT" -lt 3 ]; then
-                  sleep $((ATTEMPT * 10))
-                fi
+              fi
+              # Idempotent path: ClawHub reports 'already exists' / 'version
+              # already published' / HTTP 409 when the same version is re-pushed.
+              # That's success for a re-run of the same release — close #1547.
+              if grep -qiE 'already (exists|published)|version.*conflict|http 409|status.*409' "$TMP_OUT"; then
+                echo "::notice::ClawHub ${SLUG} v${VERSION} already published — treating as success (idempotent)"
+                rm -f "$TMP_OUT"
+                return 0
+              fi
+              echo "ClawHub ${SLUG} publish failed"
+              if [ "$ATTEMPT" -lt 3 ]; then
+                sleep $((ATTEMPT * 10))
               fi
             done
+            rm -f "$TMP_OUT"
             if [ "$FATAL" = "true" ]; then
               echo "::error::ClawHub ${SLUG} publish failed after 3 attempts"
               return 1

--- a/README.md
+++ b/README.md
@@ -220,11 +220,14 @@ The last row closes the gap that pilot teams ask about: a single central URL tha
 
 By default, findings, fleet data, audit logs, graph state, and remediation outputs stay in your infrastructure. Optional egress (OSV lookups, NVD enrichment, Slack / Jira / Vanta / Drata webhooks, SIEM / OTLP) is operator-controlled.
 
-### Today's proxy is per-MCP, not a shared traffic gateway
+### Two enforcement shapes, one control plane
 
-The honest architecture: `agent-bom proxy` is a **per-MCP sidecar or wrapper** ([`proxy.py:527`](src/agent_bom/proxy.py:527) stdio, [`proxy.py:258`](src/agent_bom/proxy.py:258) HTTP/SSE). One proxy instance per MCP server. The "gateway" today is the central **policy + audit plane** — proxies pull [`/v1/gateway/policies`](src/agent_bom/api/routes/gateway.py) and push [`/v1/proxy/audit`](src/agent_bom/api/routes/proxy.py:59). This is the Istio / OPA-Gatekeeper pattern: central control, edge enforcement, no hairpinning.
+Pilot teams pick per workload:
 
-A **central multi-upstream HTTP gateway** (`agent-bom gateway serve` — one service fronting N MCP upstreams, clients point at one URL) is on the roadmap for the [current pilot cycle](docs/design/MULTI_MCP_GATEWAY.md). Until then, pilot teams use per-MCP sidecars.
+- **`agent-bom gateway serve`** — central multi-upstream HTTP gateway. One service in your EKS fronts N MCP upstreams (SaaS MCPs, Snowflake-hosted MCPs, in-cluster MCPs) and every laptop points at `/mcp/{server-name}` over HTTP/SSE. Fleet-driven auto-discovery via `--from-control-plane` so the upstream list comes from the scans your team already runs, not a blank YAML. Source: [`src/agent_bom/gateway_server.py`](src/agent_bom/gateway_server.py), CLI: [`src/agent_bom/cli/_gateway.py`](src/agent_bom/cli/_gateway.py), tests: [`tests/test_gateway_server.py`](tests/test_gateway_server.py).
+- **`agent-bom proxy`** — per-MCP sidecar or stdio wrapper ([`proxy.py:527`](src/agent_bom/proxy.py:527) stdio, [`proxy.py:258`](src/agent_bom/proxy.py:258) HTTP/SSE). One instance per server. The honest mode for stdio-only MCPs and for workload-local enforcement where a shared traffic plane would hairpin.
+
+Both modes pull the same gateway policy ([`/v1/gateway/policies`](src/agent_bom/api/routes/gateway.py)) and push to the same audit sink ([`/v1/proxy/audit`](src/agent_bom/api/routes/proxy.py:59)). Central control, edge enforcement, no hairpinning.
 
 ## Backend matrix — pick what fits your data
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Backend Parity: deployment/backend-parity.md
+      - Snowflake-Native Backend: deployment/snowflake-backend.md
       - Docker: deployment/docker.md
       - Kubernetes: deployment/kubernetes.md
       - SIEM Integration: deployment/siem-integration.md

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -262,7 +262,7 @@ Point laptops at it:
 
 The gateway injects per-upstream credentials (Snowflake / GitHub tokens)
 from Secrets — the laptop never holds them. See the full design in
-[docs/design/MULTI_MCP_GATEWAY.md](../../docs/design/MULTI_MCP_GATEWAY.md).
+[docs/design/MULTI_MCP_GATEWAY.md](https://github.com/msaad00/agent-bom/blob/main/docs/design/MULTI_MCP_GATEWAY.md).
 
 ### Stage 3b — MCP proxy sidecar on one workload (10 min)
 
@@ -313,7 +313,7 @@ print("signature verified against pinned Ed25519 key", body["signature_key_id"])
 PY
 ```
 
-See [docs/COMPLIANCE_SIGNING.md](../../docs/COMPLIANCE_SIGNING.md) for the full verification cookbook.
+See [docs/COMPLIANCE_SIGNING.md](https://github.com/msaad00/agent-bom/blob/main/docs/COMPLIANCE_SIGNING.md) for the full verification cookbook.
 
 ## Break-glass runbook
 

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -122,7 +122,7 @@ for the equivalent enforcement on ClickHouse.
 
 ## What to monitor
 
-The metrics catalog ([docs/OBSERVABILITY_METRICS.md](../../docs/OBSERVABILITY_METRICS.md))
+The metrics catalog ([docs/OBSERVABILITY_METRICS.md](https://github.com/msaad00/agent-bom/blob/main/docs/OBSERVABILITY_METRICS.md))
 applies here. Snowflake-specific signals worth alerting on:
 
 - Query latency spikes on `SnowflakeJobStore.put` / `.list_all` —
@@ -139,7 +139,7 @@ applies here. Snowflake-specific signals worth alerting on:
   restart deploy/agent-bom-api`. Old compliance bundles remain
   verifiable against the old **Ed25519** public key (that's a separate
   key from the Snowflake auth key — see
-  [docs/COMPLIANCE_SIGNING.md](../../docs/COMPLIANCE_SIGNING.md)).
+  [docs/COMPLIANCE_SIGNING.md](https://github.com/msaad00/agent-bom/blob/main/docs/COMPLIANCE_SIGNING.md)).
 - **Access revoked** — bring up a Postgres backend from the nightly
   Postgres backup if you kept one; otherwise restore from Snowflake
   Time Travel.

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -266,8 +266,14 @@ async def discovered_upstreams(request: Request) -> dict:
     tenant_id = getattr(request.state, "tenant_id", "default")
     jobs = _get_store().list_all(tenant_id=tenant_id)
 
-    # name -> merged upstream record
-    by_name: dict[str, dict[str, Any]] = {}
+    # Key by (name, url) so two laptops reporting the same MCP name pointed
+    # at different URLs don't silently collapse into one record. This is the
+    # real-world case where one team's "jira" MCP is a SaaS endpoint and
+    # another team's "jira" is an in-cluster one — each must route to its
+    # own URL, and operators must see both in the discovered list so they
+    # can rename or consolidate explicitly.
+    by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    conflicts: dict[str, set[str]] = {}
     for job in jobs:
         if job.status != JobStatus.DONE or not job.result:
             continue
@@ -283,8 +289,9 @@ async def discovered_upstreams(request: Request) -> dict:
                 if not name:
                     continue
                 transport = server.get("transport") or "http"
-                record = by_name.setdefault(
-                    name,
+                key = (name, url)
+                record = by_key.setdefault(
+                    key,
                     {
                         "name": name,
                         "url": url,
@@ -293,15 +300,40 @@ async def discovered_upstreams(request: Request) -> dict:
                         "source_agents": [],
                     },
                 )
-                # First URL wins; record every distinct agent that reports it.
+                # Track conflicts for operator visibility (same name, different URLs).
+                conflicts.setdefault(name, set()).add(url)
                 if agent_name and agent_name not in record["source_agents"]:
                     record["source_agents"].append(agent_name)
+
+    # Suffix the routing name on conflicts so each gets a unique /mcp/{name}.
+    # The first URL keeps the bare name (stable for existing clients); every
+    # other URL with the same base name gets an index suffix. Operators see
+    # the collision in the `conflicts` array and can consolidate in their
+    # overlay upstreams.yaml.
+    conflict_report: list[dict[str, Any]] = []
+    renamed_by_key: dict[tuple[str, str], str] = {}
+    for name, urls in conflicts.items():
+        if len(urls) <= 1:
+            continue
+        sorted_urls = sorted(urls)
+        conflict_report.append({"name": name, "urls": sorted_urls})
+        # First URL wins the bare name; subsequent URLs get -1, -2, ...
+        for idx, url in enumerate(sorted_urls[1:], start=1):
+            renamed_by_key[(name, url)] = f"{name}-{idx}"
+
+    upstreams: list[dict[str, Any]] = []
+    for key, record in by_key.items():
+        rename = renamed_by_key.get(key)
+        if rename is not None:
+            record = {**record, "name": rename, "original_name": record["name"]}
+        upstreams.append(record)
 
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "tenant_id": tenant_id,
         "source": "fleet_scan_aggregate",
-        "upstreams": sorted(by_name.values(), key=lambda r: r["name"]),
+        "upstreams": sorted(upstreams, key=lambda r: r["name"]),
+        "conflicts": conflict_report,
     }
 
 

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 from agent_bom.api.metrics import record_gateway_relay
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
@@ -96,12 +96,15 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         }
 
     @app.get("/metrics")
-    async def metrics() -> JSONResponse:
-        # Prometheus scrape target; renders via the shared counters module.
+    async def metrics() -> Response:
+        # Prometheus text-exposition format must be plain text, not JSON.
+        # Previous JSONResponse wrapped the body in quotes + escaped newlines,
+        # which breaks every Prometheus scraper. Serve as `Response` with the
+        # exposition media type so scrapers parse it.
         from agent_bom.api.metrics import render_prometheus_lines
 
         body = "\n".join(render_prometheus_lines()) + "\n"
-        return JSONResponse(body, media_type="text/plain; version=0.0.4; charset=utf-8")
+        return Response(content=body, media_type="text/plain; version=0.0.4; charset=utf-8")
 
     @app.post("/mcp/{server_name}")
     async def relay(server_name: str, request: Request) -> JSONResponse:

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -50,6 +50,25 @@ def test_healthz_lists_configured_upstreams() -> None:
     assert resp.json() == {"status": "ok", "upstreams": ["filesystem", "jira"]}
 
 
+def test_metrics_endpoint_returns_prometheus_text_format() -> None:
+    """Guard: /metrics must be plain Prometheus exposition, not a JSON-quoted string.
+
+    Prometheus scrapers fail on a JSON-wrapped body ("# HELP..." — quoted
+    string with escaped \\n). Must be raw text starting with `# HELP`.
+    """
+    settings = GatewaySettings(registry=_simple_registry(), policy={})
+    client = TestClient(create_gateway_app(settings))
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    body = resp.text
+    # Raw text — never a JSON-quoted string
+    assert not body.startswith('"'), "body is JSON-quoted; Prometheus scrapers will reject"
+    assert body.startswith("# HELP"), f"expected Prometheus exposition, got: {body[:80]!r}"
+    # Contains the gateway-specific series
+    assert "agent_bom_gateway_relays_total" in body
+
+
 def test_relay_forwards_to_upstream_and_returns_response() -> None:
     upstream_calls: list[dict[str, Any]] = []
 

--- a/tests/test_gateway_upstream_discovery_route.py
+++ b/tests/test_gateway_upstream_discovery_route.py
@@ -135,6 +135,53 @@ def test_discovered_upstreams_is_tenant_scoped(fleet_seeded) -> None:
     assert alpha_names & beta_names == set(), "discovery endpoint leaks across tenants"
 
 
+def test_discovered_upstreams_reports_name_collisions_and_renames(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two MCPs with the same `name` but different URLs must NOT silently collapse.
+
+    Real-world case: team A's 'jira' points at SaaS Jira, team B's 'jira' is
+    an in-cluster Jira. Before this guard they'd both collapse to the first
+    URL the aggregator saw; now the route:
+      - keeps the first URL on the bare name,
+      - renames subsequent URLs (`jira-1`, `jira-2`, …),
+      - surfaces a `conflicts` array so the operator sees it.
+    """
+    store = InMemoryJobStore()
+    _seed_scan_with_servers(
+        store,
+        "tenant-alpha",
+        agent_name="team-a-laptop",
+        servers=[{"name": "jira", "url": "https://mcp.jira.example.com/sse", "transport": "sse"}],
+    )
+    _seed_scan_with_servers(
+        store,
+        "tenant-alpha",
+        agent_name="team-b-laptop",
+        servers=[{"name": "jira", "url": "http://jira-internal.svc.cluster.local:8100", "transport": "http"}],
+    )
+    prev = _stores._store
+    set_job_store(store)
+    try:
+        resp = _client_for("tenant-alpha").get("/v1/gateway/upstreams/discovered")
+        assert resp.status_code == 200
+        body = resp.json()
+        # Both URLs surface as separate upstreams — no silent collapse.
+        assert len(body["upstreams"]) == 2
+        names = sorted(u["name"] for u in body["upstreams"])
+        assert names == ["jira", "jira-1"], f"expected bare-name + suffix rename, got {names}"
+        # The renamed entry preserves the original_name for operator mapping.
+        renamed = next(u for u in body["upstreams"] if u["name"] == "jira-1")
+        assert renamed["original_name"] == "jira"
+        # URLs are preserved per record — no mixing.
+        urls = {u["name"]: u["url"] for u in body["upstreams"]}
+        assert urls["jira"] != urls["jira-1"]
+        # Operator-visible conflict report.
+        assert body["conflicts"]
+        jira_conflict = next(c for c in body["conflicts"] if c["name"] == "jira")
+        assert len(jira_conflict["urls"]) == 2
+    finally:
+        _stores._store = prev
+
+
 def test_discovered_upstreams_returns_empty_when_fleet_has_no_remote_mcps() -> None:
     """A tenant whose fleet only has stdio MCPs gets an empty upstream list (no error)."""
     store = InMemoryJobStore()


### PR DESCRIPTION
## Summary
Closes the five priority items from the codex 9/10 audit, in order.

### P1 — gateway /metrics wire format
`src/agent_bom/gateway_server.py` used `JSONResponse` for the Prometheus scrape target, which wrapped the exposition in quotes + escaped newlines. Every Prometheus scraper would reject it. Switched to plain `Response` with the right media type. New test asserts the body starts with `# HELP` (not a JSON-quoted string) and contains the gateway-specific `agent_bom_gateway_relays_total` series.

### P2 — docs deploy (mkdocs strict)
- `mkdocs.yml`: adds `snowflake-backend.md` to the Deployment nav (missing page was tripping `--strict`).
- `site-docs/deployment/eks-mcp-pilot.md` + `snowflake-backend.md`: out-of-tree `../../docs/...` links (to `MULTI_MCP_GATEWAY.md`, `COMPLIANCE_SIGNING.md`, `OBSERVABILITY_METRICS.md`) resolve outside the mkdocs `docs_dir` and fail strict. Replaced with GitHub blob URLs so the site resolves and the link still opens the authoritative source.

### P3 — README drift
Rewrote "Today's proxy is per-MCP, not a shared traffic gateway" → "Two enforcement shapes, one control plane". The multi-MCP gateway shipped in #1551/#1552; calling it on-the-roadmap is stale. New text documents `gateway serve` + `agent-bom proxy` as coexisting modes a pilot picks per workload, with real file references. Docker Hub README + site-docs already aligned.

### P4 — ClawHub idempotent publish (#1547)
`.github/workflows/publish-registries.yml`: capture publish stderr/stdout and detect `already exists` / `already published` / `version conflict` / `HTTP 409`. Those signals mean a re-run of the same release should be success, not failure. Emits `::notice::` and returns 0. Real failures still retry + fail as before.

### P5 — gateway discovery name+URL collision
`src/agent_bom/api/routes/gateway.py`: two laptops reporting an MCP with the same name but different URLs used to silently collapse. Now keyed by `(name, url)`; subsequent URLs with the same base name get a `-1`, `-2` suffix (`jira-1`, `jira-2`); a `conflicts: [...]` block surfaces the collision so operators see it and can consolidate in their overlay `upstreams.yaml`. New test: `test_discovered_upstreams_reports_name_collisions_and_renames`.

## Tests
32/32 gateway tests pass locally (9 server + 4 discovery route + 19 config/OAuth2).

## Follow-ups (separate PRs)
- Structured-logging migration (#1521)
- Monolith split (#1522) — prioritise `output/__init__.py` and `ast_analyzer.py`
- Close #1547 once the next Publish to Registries run on main is green or cleanly idempotent
- End-to-end integration tests: gateway /metrics (added in this PR), discovery-conflict (added), docs/release consistency in CI (Version-Alignment exists; link check needed), one full auth + tenant + gateway relay path

## Test plan
- [x] gateway test suite green
- [ ] Full CI
- [ ] `mkdocs build --strict` green on CI (local env has mkdocs 2.0/material incompat — verified by inspection)
- [ ] Publish to Registries: rerun on main after merge; if green, close #1547