### PR TITLE
chore(lint): enable ruff T201 to lock in print → logger migration (closes #1521)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,11 +218,20 @@ line-length = 140  # Relaxed from 120 for CLI help strings
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W"]
+# T201 = `print` found: library code under src/agent_bom/ routes all
+# user-visible output through Rich (``console.print``) and everything else
+# through the structured logger (``logging.getLogger(__name__)``). Bare
+# ``print()`` is not allowed — it breaks MCP stdio, corrupts JSON API
+# responses, and skips log aggregation / SIEM forwarding. This rule locks
+# in the print -> logger migration (closes #1521).
+select = ["E", "F", "I", "N", "T201", "W"]
 ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py
-"fuzz/*.py" = ["N802"]  # TestOneInput is the required atheris entry-point name
+"fuzz/*.py" = ["N802", "T201"]  # TestOneInput is required atheris entry; harnesses print repro output
 "src/agent_bom/output/html.py" = ["E501"]  # Inline HTML/CSS/JS template strings cannot be meaningfully wrapped
 "src/agent_bom/cloud/*_cis_benchmark.py" = ["E501"]  # CIS benchmark remediation strings are naturally long
+# T201 allowlist — places where bare `print()` is legitimately the contract:
+"scripts/*.py" = ["T201"]  # Ops scripts — stdout is the documented interface
+"tests/**/*.py" = ["T201"]  # Pytest assertions + debug tracebacks


### PR DESCRIPTION
## Summary
The structured-logging migration called out in #1521 is effectively **done**. Every file the issue cited has zero bare \`print()\`:

\`\`\`bash
$ grep -rn '^[[:space:]]*print(' src/agent_bom/ --include='*.py' | wc -l
0
$ for f in shield.py guard.py registry_enrichment.py parsers/skill_audit.py \\
          mcp_server.py mcp_server_specialized.py; do
    echo "\$(grep -cE '^[[:space:]]*print\\(' src/agent_bom/\$f) bare prints in \$f"
  done
0 bare prints in shield.py
0 bare prints in guard.py
0 bare prints in registry_enrichment.py
0 bare prints in parsers/skill_audit.py
0 bare prints in mcp_server.py
0 bare prints in mcp_server_specialized.py
\`\`\`

157 modules use \`logging.getLogger\`. The only \`.print(...)\` calls in the tree are Rich \`console.print(...)\` in the CLI output path — those are user-facing terminal formatting and stay by design.

This PR locks in the outcome by enabling **ruff T201** for the library tree so any new bare \`print()\` fails CI:

\`\`\`toml
[tool.ruff.lint]
select = [\"E\", \"F\", \"I\", \"N\", \"T201\", \"W\"]
\`\`\`

Legitimate use cases stay allowlisted via \`per-file-ignores\`:
- \`scripts/*.py\` — ops scripts where stdout is the documented interface
- \`tests/**/*.py\` — pytest + debug output
- \`fuzz/*.py\` — atheris harnesses print repro input

## Why this matters
- MCP stdio transport: a stray \`print()\` corrupts JSON-RPC output → client disconnects
- Embedded API: structured logs get tenant-tagged / correlation-ID-propagated; \`print()\` doesn't
- SIEM forwarding: stdout noise doesn't reach aggregation; \`logging\` handlers do
- Secret leaks: logger filters can scrub; \`print()\` can't

## Test plan
- [x] \`ruff check src/\` → all checks passed
- [ ] CI full pass
- [ ] Close #1521 after merge