### PR TITLE
fix: harden tenant-scoped audit chains

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sqlite3
 import threading
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Protocol
@@ -71,9 +72,19 @@ class AuditEntry:
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
+    def _canonical_details_json(self) -> str:
+        return json.dumps(self.details or {}, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+    def _legacy_hmac(self) -> str:
+        payload = f"{self.prev_signature}|{self.entry_id}|{self.timestamp}|{self.action}|{self.actor}|{self.resource}"
+        return hmac.new(_HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
+
     def compute_hmac(self) -> str:
         """Compute HMAC-SHA256 signature for tamper detection (chain-hashed)."""
-        payload = f"{self.prev_signature}|{self.entry_id}|{self.timestamp}|{self.action}|{self.actor}|{self.resource}"
+        payload = (
+            f"{self.prev_signature}|{self.entry_id}|{self.timestamp}|"
+            f"{self.action}|{self.actor}|{self.resource}|{self._canonical_details_json()}"
+        )
         return hmac.new(_HMAC_KEY, payload.encode(), hashlib.sha256).hexdigest()
 
     def sign(self) -> None:
@@ -82,7 +93,9 @@ class AuditEntry:
 
     def verify(self) -> bool:
         """Verify HMAC signature."""
-        return hmac.compare_digest(self.hmac_signature, self.compute_hmac())
+        return hmac.compare_digest(self.hmac_signature, self.compute_hmac()) or hmac.compare_digest(
+            self.hmac_signature, self._legacy_hmac()
+        )
 
     def to_dict(self) -> dict:
         return {
@@ -113,9 +126,14 @@ class AuditLogStore(Protocol):
         since: str | None = None,
         limit: int = 100,
         offset: int = 0,
+        tenant_id: str | None = None,
     ) -> list[AuditEntry]: ...
-    def count(self, action: str | None = None) -> int: ...
-    def verify_integrity(self, limit: int = 1000) -> tuple[int, int]: ...
+    def count(self, action: str | None = None, tenant_id: str | None = None) -> int: ...
+    def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]: ...
+
+
+def _entry_tenant(entry: AuditEntry) -> str:
+    return str((entry.details or {}).get("tenant_id") or "default")
 
 
 class InMemoryAuditLog:
@@ -126,12 +144,13 @@ class InMemoryAuditLog:
     def __init__(self) -> None:
         self._entries: list[AuditEntry] = []
         self._lock = threading.Lock()
-        self._last_sig = ""
+        self._last_sig_by_tenant: dict[str, str] = defaultdict(str)
 
     def append(self, entry: AuditEntry) -> None:
-        entry.prev_signature = self._last_sig
+        tenant_id = _entry_tenant(entry)
+        entry.prev_signature = self._last_sig_by_tenant[tenant_id]
         entry.sign()
-        self._last_sig = entry.hmac_signature
+        self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
         with self._lock:
             self._entries.append(entry)
             if len(self._entries) > self._MAX_ENTRIES:
@@ -144,9 +163,12 @@ class InMemoryAuditLog:
         since: str | None = None,
         limit: int = 100,
         offset: int = 0,
+        tenant_id: str | None = None,
     ) -> list[AuditEntry]:
         with self._lock:
             filtered = self._entries
+            if tenant_id is not None:
+                filtered = [e for e in filtered if str((e.details or {}).get("tenant_id", "")) == tenant_id]
             if action:
                 filtered = [e for e in filtered if e.action == action]
             if resource:
@@ -157,16 +179,18 @@ class InMemoryAuditLog:
             filtered = list(reversed(filtered))
             return filtered[offset : offset + limit]
 
-    def count(self, action: str | None = None) -> int:
+    def count(self, action: str | None = None, tenant_id: str | None = None) -> int:
         with self._lock:
+            entries = self._entries
+            if tenant_id is not None:
+                entries = [e for e in entries if str((e.details or {}).get("tenant_id", "")) == tenant_id]
             if action:
-                return sum(1 for e in self._entries if e.action == action)
-            return len(self._entries)
+                return sum(1 for e in entries if e.action == action)
+            return len(entries)
 
-    def verify_integrity(self, limit: int = 1000) -> tuple[int, int]:
+    def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
         """Verify chain-hashed HMAC signatures. Returns (verified_count, tampered_count)."""
-        with self._lock:
-            entries = self._entries[-limit:]
+        entries = list(reversed(self.list_entries(limit=limit, tenant_id=tenant_id)))
         verified = 0
         tampered = 0
         prev_sig = entries[0].prev_signature if entries else ""
@@ -185,7 +209,7 @@ class SQLiteAuditLog:
     def __init__(self, db_path: str = "agent_bom_audit.db") -> None:
         self._db_path = db_path
         self._local = threading.local()
-        self._last_sig = ""
+        self._last_sig_by_tenant: dict[str, str] = defaultdict(str)
         self._init_db()
         if os.path.exists(self._db_path):
             os.chmod(self._db_path, 0o600)
@@ -213,10 +237,27 @@ class SQLiteAuditLog:
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_log(resource)")
         self._conn.commit()
 
+    def _latest_signature_for_tenant(self, tenant_id: str) -> str:
+        row = self._conn.execute(
+            """
+            SELECT hmac_signature
+            FROM audit_log
+            WHERE json_extract(details, '$.tenant_id') = ?
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """,
+            (tenant_id,),
+        ).fetchone()
+        return row[0] if row else ""
+
     def append(self, entry: AuditEntry) -> None:
-        entry.prev_signature = self._last_sig
+        tenant_id = _entry_tenant(entry)
+        prev_sig = self._last_sig_by_tenant.get(tenant_id)
+        if prev_sig is None or prev_sig == "":
+            prev_sig = self._latest_signature_for_tenant(tenant_id)
+        entry.prev_signature = prev_sig
         entry.sign()
-        self._last_sig = entry.hmac_signature
+        self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
         self._conn.execute(
             "INSERT INTO audit_log"
             " (entry_id, timestamp, action, actor, resource,"
@@ -242,9 +283,13 @@ class SQLiteAuditLog:
         since: str | None = None,
         limit: int = 100,
         offset: int = 0,
+        tenant_id: str | None = None,
     ) -> list[AuditEntry]:
         clauses = []
         params: list = []
+        if tenant_id is not None:
+            clauses.append("json_extract(details, '$.tenant_id') = ?")
+            params.append(tenant_id)
         if action:
             clauses.append("action = ?")
             params.append(action)
@@ -277,16 +322,22 @@ class SQLiteAuditLog:
             for r in rows
         ]
 
-    def count(self, action: str | None = None) -> int:
+    def count(self, action: str | None = None, tenant_id: str | None = None) -> int:
+        clauses = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("json_extract(details, '$.tenant_id') = ?")
+            params.append(tenant_id)
         if action:
-            row = self._conn.execute("SELECT COUNT(*) FROM audit_log WHERE action = ?", (action,)).fetchone()
-        else:
-            row = self._conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()
+            clauses.append("action = ?")
+            params.append(action)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        row = self._conn.execute(f"SELECT COUNT(*) FROM audit_log{where}", params).fetchone()  # nosec B608
         return row[0] if row else 0
 
-    def verify_integrity(self, limit: int = 1000) -> tuple[int, int]:
+    def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
         """Verify chain-hashed HMAC signatures. Returns (verified_count, tampered_count)."""
-        entries = self.list_entries(limit=limit)
+        entries = self.list_entries(limit=limit, tenant_id=tenant_id)
         # list_entries returns most-recent-first; reverse for chronological chain verification
         entries = list(reversed(entries))
         verified = 0
@@ -325,6 +376,21 @@ def get_audit_log() -> AuditLogStore:
     return _audit_log
 
 
+def _default_tenant_id(details: dict[str, object]) -> str:
+    tenant = details.get("tenant_id")
+    if tenant not in (None, ""):
+        return str(tenant)
+    try:
+        from agent_bom.api.postgres_store import _current_tenant
+
+        current = _current_tenant.get()
+        if current:
+            return str(current)
+    except Exception:
+        logger.debug("Audit tenant fallback unavailable", exc_info=True)
+    return "default"
+
+
 def set_audit_log(store: AuditLogStore) -> None:
     global _audit_log
     with _audit_lock:
@@ -333,7 +399,9 @@ def set_audit_log(store: AuditLogStore) -> None:
 
 def log_action(action: str, actor: str = "system", resource: str = "", **details: object) -> None:
     """Convenience: append an audit entry."""
-    entry = AuditEntry(action=action, actor=actor, resource=resource, details=dict(details))
+    audit_details = dict(details)
+    audit_details["tenant_id"] = _default_tenant_id(audit_details)
+    entry = AuditEntry(action=action, actor=actor, resource=resource, details=audit_details)
     get_audit_log().append(entry)
     try:
         from agent_bom.api.stores import _get_analytics_store
@@ -345,7 +413,7 @@ def log_action(action: str, actor: str = "system", resource: str = "", **details
                 "action": entry.action,
                 "actor": entry.actor,
                 "resource": entry.resource,
-                "tenant_id": str(details.get("tenant_id", "default") or "default"),
+                "tenant_id": str(entry.details.get("tenant_id", "default") or "default"),
             }
         )
     except Exception:

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -961,9 +961,8 @@ class PostgresAuditLog:
 
     def __init__(self, pool=None) -> None:
         self._pool = pool or _get_pool()
-        self._last_sig = ""
+        self._last_sig_by_tenant: dict[str, str] = {}
         self._init_tables()
-        self._prime_last_sig()
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
@@ -987,15 +986,22 @@ class PostgresAuditLog:
             _ensure_tenant_rls(conn, "audit_log", "team_id")
             conn.commit()
 
-    def _prime_last_sig(self) -> None:
-        with _tenant_connection(self._pool) as conn:
-            row = conn.execute("SELECT hmac_signature FROM audit_log ORDER BY timestamp DESC LIMIT 1").fetchone()
-            self._last_sig = row[0] if row else ""
+    def _latest_signature_for_tenant(self, tenant_id: str) -> str:
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                "SELECT hmac_signature FROM audit_log WHERE team_id = %s ORDER BY timestamp DESC LIMIT 1",
+                (tenant_id,),
+            ).fetchone()
+        return row[0] if row else ""
 
     def append(self, entry: AuditEntry) -> None:
-        entry.prev_signature = self._last_sig
+        tenant_id = str((entry.details or {}).get("tenant_id") or _current_tenant.get())
+        prev_sig = self._last_sig_by_tenant.get(tenant_id)
+        if not prev_sig:
+            prev_sig = self._latest_signature_for_tenant(tenant_id)
+        entry.prev_signature = prev_sig
         entry.sign()
-        self._last_sig = entry.hmac_signature
+        self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
         with _tenant_connection(self._pool) as conn:
             conn.execute(
                 """INSERT INTO audit_log
@@ -1007,7 +1013,7 @@ class PostgresAuditLog:
                     entry.action,
                     entry.actor,
                     entry.resource,
-                    _current_tenant.get(),
+                    tenant_id,
                     json.dumps(entry.details),
                     entry.prev_signature,
                     entry.hmac_signature,
@@ -1022,9 +1028,13 @@ class PostgresAuditLog:
         since: str | None = None,
         limit: int = 100,
         offset: int = 0,
+        tenant_id: str | None = None,
     ) -> list[AuditEntry]:
         clauses: list[str] = []
         params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("team_id = %s")
+            params.append(tenant_id)
         if action:
             clauses.append("action = %s")
             params.append(action)
@@ -1056,18 +1066,24 @@ class PostgresAuditLog:
             for row in rows
         ]
 
-    def count(self, action: str | None = None) -> int:
+    def count(self, action: str | None = None, tenant_id: str | None = None) -> int:
         sql = "SELECT COUNT(*) FROM audit_log"
-        params: tuple[object, ...] = ()
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("team_id = %s")
+            params.append(tenant_id)
         if action:
-            sql += " WHERE action = %s"
-            params = (action,)
+            clauses.append("action = %s")
+            params.append(action)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
         with _tenant_connection(self._pool) as conn:
-            row = conn.execute(sql, params).fetchone()
+            row = conn.execute(sql, tuple(params)).fetchone()
         return row[0] if row else 0
 
-    def verify_integrity(self, limit: int = 1000) -> tuple[int, int]:
-        entries = list(reversed(self.list_entries(limit=limit)))
+    def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
+        entries = list(reversed(self.list_entries(limit=limit, tenant_id=tenant_id)))
         verified = 0
         tampered = 0
         prev_sig = entries[0].prev_signature if entries else ""

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -747,13 +747,9 @@ async def export_compliance_report(
     store = get_audit_log()
     audit_since_iso = since_dt.isoformat()
     # Cap audit fetch at 10k for export sanity; consumers paginate further via /v1/audit
-    audit_entries = store.list_entries(since=audit_since_iso, limit=10_000)
+    audit_entries = store.list_entries(since=audit_since_iso, limit=10_000, tenant_id=tenant_id)
     until_iso = until_dt.isoformat()
-    audit_in_window = [
-        e
-        for e in audit_entries
-        if str((e.details or {}).get("tenant_id", "")) == tenant_id and audit_since_iso <= (e.timestamp or "") <= until_iso
-    ]
+    audit_in_window = [e for e in audit_entries if audit_since_iso <= (e.timestamp or "") <= until_iso]
     verified, tampered = _verify_audit_entries(audit_in_window)
 
     pass_count = sum(1 for c in controls if c.get("status") == "pass")

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -249,7 +249,7 @@ async def delete_key(request: Request, key_id: str) -> None:
         raise HTTPException(status_code=404, detail=f"Key {key_id} not found")
     store.remove(key_id)
 
-    log_action("auth.key_revoked", actor=actor, resource=f"key/{key_id}")
+    log_action("auth.key_revoked", actor=actor, resource=f"key/{key_id}", tenant_id=tenant_id)
 
 
 @router.get("/v1/auth/saml/metadata", tags=["enterprise"])
@@ -311,6 +311,7 @@ async def saml_login(req: SAMLLoginRequest) -> dict:
 
 @router.get("/v1/audit", tags=["enterprise"])
 async def list_audit_entries(
+    request: Request,
     action: str | None = None,
     resource: str | None = None,
     since: str | None = None,
@@ -320,20 +321,22 @@ async def list_audit_entries(
     """List audit log entries with optional filters."""
     from agent_bom.api.audit_log import get_audit_log
 
+    tenant_id = getattr(request.state, "tenant_id", "default")
     store = get_audit_log()
-    entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset)
+    entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset, tenant_id=tenant_id)
     return {
         "entries": [e.to_dict() for e in entries],
-        "total": store.count(action=action),
+        "total": store.count(action=action, tenant_id=tenant_id),
     }
 
 
 @router.get("/v1/audit/integrity", tags=["enterprise"])
-async def audit_integrity(limit: int = 1000) -> dict:
+async def audit_integrity(request: Request, limit: int = 1000) -> dict:
     """Verify HMAC integrity of audit log entries."""
     from agent_bom.api.audit_log import get_audit_log
 
-    verified, tampered = get_audit_log().verify_integrity(limit=limit)
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    verified, tampered = get_audit_log().verify_integrity(limit=limit, tenant_id=tenant_id)
     return {"verified": verified, "tampered": tampered, "checked": verified + tampered}
 
 
@@ -357,8 +360,8 @@ async def export_audit_entries(
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = get_audit_log()
-    entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset)
-    verified, tampered = store.verify_integrity(limit=min(limit, 10_000))
+    entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset, tenant_id=tenant_id)
+    verified, tampered = store.verify_integrity(limit=min(limit, 10_000), tenant_id=tenant_id)
 
     log_action(
         "audit.export",
@@ -431,7 +434,12 @@ async def create_exception(request: Request, req: ExceptionRequest) -> dict:
     )
     _get_exception_store().put(exc)
     log_action(
-        "exception_create", actor=req.requested_by, resource=f"exception/{exc.exception_id}", vuln_id=req.vuln_id, package=req.package_name
+        "exception_create",
+        actor=req.requested_by,
+        resource=f"exception/{exc.exception_id}",
+        tenant_id=tenant_id,
+        vuln_id=req.vuln_id,
+        package=req.package_name,
     )
     return exc.to_dict()
 
@@ -472,7 +480,7 @@ async def approve_exception(request: Request, exception_id: str, approved_by: st
     exc.approved_by = actor
     exc.approved_at = datetime.now(timezone.utc).isoformat()
     store.put(exc)
-    log_action("exception_approve", actor=actor, resource=f"exception/{exception_id}")
+    log_action("exception_approve", actor=actor, resource=f"exception/{exception_id}", tenant_id=tenant_id)
     return exc.to_dict()
 
 
@@ -491,7 +499,7 @@ async def revoke_exception(request: Request, exception_id: str, revoked_by: str 
     exc.status = ExceptionStatus.REVOKED
     exc.revoked_at = datetime.now(timezone.utc).isoformat()
     store.put(exc)
-    log_action("exception_revoke", actor=actor, resource=f"exception/{exception_id}")
+    log_action("exception_revoke", actor=actor, resource=f"exception/{exception_id}", tenant_id=tenant_id)
     return exc.to_dict()
 
 
@@ -587,6 +595,7 @@ async def test_siem_connection(siem_type: str = "", url: str = "", token: str = 
 
 @router.post("/v1/findings/jira", tags=["enterprise"], status_code=201)
 async def create_jira_ticket_route(
+    request: Request,
     req: JiraTicketRequest,
     jira_api_token: str | None = Header(default=None, alias="X-Jira-Api-Token"),
 ) -> dict:
@@ -619,9 +628,11 @@ async def create_jira_ticket_route(
     if not ticket_key:
         raise HTTPException(status_code=502, detail="Jira API returned no ticket key")
 
+    tenant_id = getattr(request.state, "tenant_id", "default")
     log_action(
         "findings.jira_ticket_created",
         resource=f"jira/{ticket_key}",
+        tenant_id=tenant_id,
         vuln_id=req.finding.get("vulnerability_id", ""),
         package=req.finding.get("package", ""),
     )
@@ -652,6 +663,7 @@ async def mark_false_positive(request: Request, req: FalsePositiveRequest) -> di
         "findings.false_positive_marked",
         actor=req.marked_by,
         resource=f"fp/{exc.exception_id}",
+        tenant_id=tenant_id,
         vuln_id=req.vulnerability_id,
         package=req.package,
     )
@@ -702,4 +714,4 @@ async def remove_false_positive(request: Request, fp_id: str) -> None:
     ok = store.delete(fp_id)
     if not ok:
         raise HTTPException(status_code=404, detail=f"False positive {fp_id} not found")
-    log_action("findings.false_positive_removed", resource=f"fp/{fp_id}")
+    log_action("findings.false_positive_removed", resource=f"fp/{fp_id}", tenant_id=tenant_id)

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -76,6 +76,7 @@ async def create_gateway_policy(body: PolicyCreate, request: Request):
         )
     now = datetime.now(timezone.utc).isoformat()
     rules = [GatewayRule(**r) for r in body.rules]
+    tenant_id = getattr(request.state, "tenant_id", "default")
     policy = GatewayPolicy(
         policy_id=str(uuid.uuid4()),
         name=body.name,
@@ -88,7 +89,7 @@ async def create_gateway_policy(body: PolicyCreate, request: Request):
         enabled=body.enabled,
         created_at=now,
         updated_at=now,
-        tenant_id=getattr(request.state, "tenant_id", "default"),
+        tenant_id=tenant_id,
     )
     _get_policy_store().put_policy(policy)
     actor = getattr(request.state, "api_key_name", "unknown")
@@ -96,6 +97,7 @@ async def create_gateway_policy(body: PolicyCreate, request: Request):
         "gateway.policy_created",
         actor=actor,
         resource=f"gateway-policy/{policy.policy_id}",
+        tenant_id=tenant_id,
         name=policy.name,
         mode=policy.mode.value,
         enabled=policy.enabled,
@@ -154,6 +156,7 @@ async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Req
         "gateway.policy_updated",
         actor=actor,
         resource=f"gateway-policy/{policy.policy_id}",
+        tenant_id=tenant_id,
         name=policy.name,
         changed_fields=changed_fields,
         enabled=policy.enabled,
@@ -179,6 +182,7 @@ async def delete_gateway_policy(policy_id: str, request: Request):
         "gateway.policy_deleted",
         actor=actor,
         resource=f"gateway-policy/{policy_id}",
+        tenant_id=tenant_id,
         name=policy.name,
         mode=policy.mode.value,
         rule_count=len(policy.rules),

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -87,6 +87,7 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         "proxy.audit_ingested",
         actor=actor,
         resource=f"proxy/{source_id}",
+        tenant_id=tenant_id,
         session_id=session_id,
         alert_count=len(body.alerts),
         has_summary=body.summary is not None,
@@ -549,10 +550,12 @@ async def break_glass(request: Request, session_id: str = "default", reason: str
     try:
         from agent_bom.api.audit_log import log_action
 
+        tenant_id = getattr(request.state, "tenant_id", "default")
         log_action(
             "break_glass",
             actor=role,
             resource=f"shield/{session_id}",
+            tenant_id=tenant_id,
             reason=reason,
             was_blocked=was_blocked,
         )

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -39,6 +39,7 @@ def _raise_quota_exceeded(
         "tenant.quota_exceeded",
         actor=f"tenant:{tenant_id}",
         resource=f"tenant/{tenant_id}",
+        tenant_id=tenant_id,
         quota_name=quota_name,
         limit=limit,
         current=current,

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -158,7 +158,7 @@ async def test_create_jira_ticket_requires_header_token(monkeypatch):
     )
 
     with pytest.raises(HTTPException) as error:
-        await enterprise.create_jira_ticket_route(req, jira_api_token=None)
+        await enterprise.create_jira_ticket_route(_request("tenant-alpha"), req, jira_api_token=None)
 
     assert error.value.status_code == 400
     assert "X-Jira-Api-Token" in error.value.detail
@@ -188,7 +188,7 @@ async def test_create_jira_ticket_uses_header_token(monkeypatch):
 
     monkeypatch.setattr("agent_bom.integrations.jira.create_jira_ticket", fake_create_jira_ticket)
 
-    result = await enterprise.create_jira_ticket_route(req, jira_api_token="token-abc")
+    result = await enterprise.create_jira_ticket_route(_request("tenant-alpha"), req, jira_api_token="token-abc")
 
     assert result == {"ticket_key": "SEC-42", "status": "created"}
     assert captured["api_token"] == "token-abc"
@@ -215,14 +215,17 @@ async def test_remove_false_positive_returns_404_for_wrong_tenant(isolated_excep
 @pytest.mark.asyncio
 async def test_export_audit_entries_returns_signed_json(monkeypatch):
     store = InMemoryAuditLog()
-    store.append(AuditEntry(action="scan", actor="alice", resource="job/1", details={"packages": 5}))
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/1", details={"packages": 5, "tenant_id": "tenant-alpha"}))
+    store.append(AuditEntry(action="scan", actor="bob", resource="job/2", details={"packages": 7, "tenant_id": "tenant-beta"}))
     monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
 
     response = await enterprise.export_audit_entries(_request("tenant-alpha", "alice-admin"))
 
     payload = json.loads(response.body.decode())
     assert payload["tenant_id"] == "tenant-alpha"
+    assert len(payload["entries"]) == 1
     assert payload["entries"][0]["action"] == "scan"
+    assert payload["entries"][0]["details"]["tenant_id"] == "tenant-alpha"
     assert response.headers["x-agent-bom-audit-export-signature"]
     assert response.headers["content-disposition"].endswith('agent-bom-audit-export.json"')
 
@@ -230,7 +233,8 @@ async def test_export_audit_entries_returns_signed_json(monkeypatch):
 @pytest.mark.asyncio
 async def test_export_audit_entries_supports_jsonl(monkeypatch):
     store = InMemoryAuditLog()
-    store.append(AuditEntry(action="scan", actor="alice", resource="job/1"))
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/1", details={"tenant_id": "tenant-alpha"}))
+    store.append(AuditEntry(action="scan", actor="bob", resource="job/2", details={"tenant_id": "tenant-beta"}))
     monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
 
     response = await enterprise.export_audit_entries(_request("tenant-alpha", "alice-admin"), format="jsonl")
@@ -239,6 +243,21 @@ async def test_export_audit_entries_supports_jsonl(monkeypatch):
     assert len(lines) == 1
     assert json.loads(lines[0])["resource"] == "job/1"
     assert response.media_type == "application/x-ndjson"
+
+
+@pytest.mark.asyncio
+async def test_list_audit_entries_and_integrity_are_tenant_scoped(monkeypatch):
+    store = InMemoryAuditLog()
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/alpha", details={"tenant_id": "tenant-alpha"}))
+    store.append(AuditEntry(action="scan", actor="bob", resource="job/beta", details={"tenant_id": "tenant-beta"}))
+    monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
+
+    listed = await enterprise.list_audit_entries(_request("tenant-alpha"))
+    integrity = await enterprise.audit_integrity(_request("tenant-alpha"))
+
+    assert listed["total"] == 1
+    assert [entry["resource"] for entry in listed["entries"]] == ["job/alpha"]
+    assert integrity == {"verified": 1, "tampered": 0, "checked": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -21,3 +21,14 @@ def test_chain_hash_detects_tamper():
     log._entries[0].resource = "tampered"
     verified, tampered = log.verify_integrity()
     assert tampered > 0
+
+
+def test_chain_hash_detects_details_tamper():
+    log = InMemoryAuditLog()
+    log.append(AuditEntry(action="scan", actor="test", resource="pkg-a", details={"tenant_id": "tenant-alpha", "severity": "high"}))
+    log.append(AuditEntry(action="scan", actor="test", resource="pkg-b", details={"tenant_id": "tenant-alpha"}))
+
+    log._entries[0].details["severity"] = "critical"
+
+    verified, tampered = log.verify_integrity()
+    assert tampered > 0

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -324,6 +324,39 @@ def test_report_audit_events_are_tenant_filtered() -> None:
     assert body["audit_log_integrity"]["checked"] == 1
 
 
+def test_report_fetches_audit_entries_with_tenant_scope(monkeypatch) -> None:
+    _setup_audit_log()
+    jobs = _seed_jobs_with_findings()
+    req = _request("tenant-alpha")
+
+    class RecordingAuditStore(InMemoryAuditLog):
+        def __init__(self) -> None:
+            super().__init__()
+            self.captured_tenant_id: str | None = None
+
+        def list_entries(self, *args, tenant_id: str | None = None, **kwargs):  # type: ignore[override]
+            self.captured_tenant_id = tenant_id
+            return super().list_entries(*args, tenant_id=tenant_id, **kwargs)
+
+    store = RecordingAuditStore()
+    store.append(
+        AuditEntry(
+            entry_id="e1",
+            timestamp=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+            action="auth.key_rotated",
+            actor="ci-bot",
+            resource="key/abc",
+            details={"tenant_id": "tenant-alpha"},
+        )
+    )
+    monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
+
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=jobs):
+        asyncio.run(compliance_routes.export_compliance_report(req, "owasp-llm"))
+
+    assert store.captured_tenant_id == "tenant-alpha"
+
+
 # ─── Format = jsonl ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_enterprise_gaps.py
+++ b/tests/test_enterprise_gaps.py
@@ -188,7 +188,7 @@ class TestAuditLog:
         log_action("scan", actor="admin", resource="job/test", packages=42)
         entries = store.list_entries()
         assert len(entries) == 1
-        assert entries[0].details == {"packages": 42}
+        assert entries[0].details == {"packages": 42, "tenant_id": "default"}
 
     def test_audit_bounded_size(self):
         from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog


### PR DESCRIPTION
## Summary\n- scope enterprise audit routes to the authenticated tenant\n- include audit entry details in the HMAC chain while preserving legacy verification\n- propagate tenant context through gateway/proxy/quota audit events and tenant-scope compliance audit fetches\n- add regression tests for details tamper detection and tenant-scoped audit export/integrity\n\n## Verification\n- pytest -q tests/test_audit_chain.py tests/test_api_enterprise_tenant.py\n- pytest -q tests/test_api_compliance_auth.py tests/test_compliance_report.py tests/test_gateway_auth_tenant_e2e.py tests/test_gateway_server.py tests/test_gateway_upstream_discovery_route.py tests/test_api_cross_tenant_matrix.py tests/test_cross_tenant_leakage.py\n- python scripts/check_release_consistency.py