### PR TITLE
feat: align deployment context and self-hosted rollout story

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,88 +141,89 @@ External calls are limited to package metadata, version lookups, and CVE enrichm
 
 **`agent-bom` runs end-to-end inside your infrastructure — your AWS account, your VPC, your EKS cluster, your Postgres / ClickHouse / Snowflake, your SSO, your KMS. No hosted control plane. No mandatory vendor backend. No telemetry.**
 
-This section is the pilot-grade walkthrough: the five product surfaces you install, the backends they run against, the network flows, the day-1 install, and the break-glass path. Every diagram below maps to real code in this repo, not a pitch deck.
+This section is deployment-first: what runs in your infrastructure, what the
+data path looks like, which stores hold state, and how a focused pilot narrows
+that same architecture without inventing a different product. The detailed
+rollout runbooks live under [`site-docs/deployment/`](site-docs/deployment/).
 
-### The concrete pilot shape
+### Default self-hosted deployment shape
 
-A realistic enterprise pilot today looks like this:
+`agent-bom` is easiest to reason about as three layers:
 
-- **Employees on macOS and Windows** running Cursor, VS Code, Codex CLI, Claude Desktop / Claude Code, and GitHub Copilot.
-- **Each editor talks to a mix of MCPs**:
-  - *Local / stdio* — filesystem, git, shell, dev-server MCPs running on the laptop.
-  - *Remote / HTTP + SSE* — hosted MCPs on internal services, SaaS tools, or inside a data warehouse.
-- **SaaS MCPs** — e.g. a Jira MCP, GitHub MCP, or similar published by the SaaS vendor or a third party. Speak HTTP/SSE over the network.
-- **Snowflake-hosted MCPs** — an MCP running as a Snowflake container service or Cortex function (separate from the SaaS MCPs above). Typically authenticated via OAuth2 client-credentials against your Snowflake IdP.
-- **An in-cluster agent-bom control plane on EKS** — ingests fleet data from every laptop, mediates gateway policy for runtime proxies, and stores scan/audit state (Postgres, ClickHouse, or Snowflake).
+- **entry points**: local CLI scans, GitHub Action CI/CD gates, endpoint fleet
+  sync, proxy sidecars/wrappers, and an optional central gateway
+- **operator plane**: the self-hosted API + UI, scan/fleet/gateway/compliance
+  routes, and job orchestration in your EKS cluster or self-managed compute
+- **data plane**: Postgres/Supabase for transactional state, with ClickHouse or
+  Snowflake added only when your deployment actually needs them
 
 ```mermaid
 flowchart LR
-    subgraph mac["macOS employees"]
-      cursor_m[Cursor]
-      claude_m[Claude Desktop]
-      codex_m[Codex CLI]
-      copilot_m[VS Code + Copilot]
-    end
-    subgraph win["Windows employees"]
-      cursor_w[Cursor]
-      claude_w[Claude Code]
-      copilot_w[VS Code + Copilot]
+    subgraph entry["Entry points in your environment"]
+      cli["CLI scans<br/>agents · image · iac"]
+      gha["GitHub Action<br/>CI/CD gate + SARIF"]
+      fleet["Endpoint fleet<br/>--push-url sync"]
+      proxy["Proxy / sidecar<br/>stdio or HTTP/SSE"]
+      gateway["Central gateway<br/>agent-bom gateway serve"]
     end
 
-    localmcp["Local MCPs<br/>(stdio · filesystem, git, shell)"]
-    saasmcp["SaaS MCPs<br/>(HTTP/SSE · Jira MCP, GitHub MCP)"]
-    snowmcp["Snowflake-hosted MCPs<br/>(HTTPS · Cortex / container services)"]
-    eksmcp["In-cluster MCPs<br/>(K8s workloads)"]
+    subgraph targets["Targets under review"]
+      local["Local repos + stdio MCPs"]
+      remote["Remote MCPs + SaaS + cluster workloads"]
+    end
 
-    fleet["agent-bom agents --push-url<br/>(daily fleet sync)"]
-    gw["agent-bom gateway serve<br/>(one URL · fronts N remote MCPs)"]
-    px["agent-bom proxy -- &lt;cmd&gt;<br/>(per-MCP stdio wrapper)"]
-    sidecar["agent-bom proxy<br/>(K8s sidecar for an MCP workload)"]
-    cp(["agent-bom control plane<br/>in your EKS cluster"])
+    subgraph control["Self-hosted operator plane"]
+      api["API + UI<br/>findings · graph · remediation"]
+      routes["Fleet / policy / compliance routes<br/>tenant-scoped API"]
+      jobs["Scan jobs + ingest workers"]
+    end
 
-    mac -. daily scan .-> fleet
-    win -. daily scan .-> fleet
-    fleet -->|HTTPS fleet sync| cp
+    subgraph data["Your data stores"]
+      pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
+      ch["ClickHouse (optional)<br/>analytics + long-retention events"]
+      snow["Snowflake (optional)<br/>warehouse-native deployment"]
+    end
 
-    mac -->|stdio| px
-    win -->|stdio| px
-    px --> localmcp
-
-    mac -->|HTTP/SSE| gw
-    win -->|HTTP/SSE| gw
-    gw -->|bearer| saasmcp
-    gw -->|OAuth2 client-creds| snowmcp
-    gw --> eksmcp
-
-    eksmcp -.- sidecar
-
-    px -. policy pull · audit push .- cp
-    gw -. policy pull · audit push .- cp
-    sidecar -. policy pull · audit push .- cp
+    cli --> local
+    gha --> local
+    fleet --> jobs
+    proxy --> remote
+    gateway --> remote
+    proxy --> routes
+    gateway --> routes
+    jobs --> api
+    routes --> api
+    api --> pg
+    api -. optional analytics .-> ch
+    api -. optional warehouse path .-> snow
 ```
 
-**How each surface serves this mix:**
+This is the architecture. A **pilot** is just a narrower rollout profile over
+the same surfaces and stores.
 
-| Surface | macOS | Windows | Local MCP (stdio) | SaaS MCP (HTTP/SSE) | Snowflake MCP |
-|---|:-:|:-:|:-:|:-:|:-:|
-| `agent-bom agents --push-url` (fleet sync) | ✓ | ✓ | discovered + scanned | discovered (reachability + CVE on the package that implements the server) | discovered (via Snowflake cloud scanner) |
-| `agent-bom proxy -- <cmd>` stdio | ✓ | ✓ | ✓ | n/a | n/a |
-| `agent-bom proxy --sse <url>` HTTP/SSE | ✓ | ✓ | n/a | ✓ | ✓ (when exposed over HTTP/SSE) |
-| `agent-bom cloud snowflake` | ✓ | ✓ | n/a | n/a | ✓ (native discovery + CIS benchmark) |
-| `agent-bom gateway serve` — one URL for all MCPs | ✓ | ✓ | n/a | ✓ (bearer auth) | ✓ (OAuth2 client-credentials) |
+### Rollout profiles
 
-**Legend:** `✓` = this surface handles this case today; `n/a` = not applicable by design (e.g. stdio MCPs can't be fronted by an HTTP gateway, and HTTP MCPs don't need a stdio wrapper). Every `n/a` is because a different row in this same table already covers it, not because the feature is missing.
+| Profile | Turn on first | Keep optional until needed |
+|---|---|---|
+| **Local + CI/CD gate** | CLI scans + GitHub Action + HTML/SARIF output | fleet, proxy, gateway, ClickHouse |
+| **Focused pilot** | scan + fleet + proxy + API/UI | ClickHouse, Snowflake, full gateway rollout |
+| **Standard self-hosted** | scan + fleet + proxy + gateway + API/UI | ClickHouse |
+| **Regulated / zero-trust** | standard self-hosted + Istio/Kyverno/ExternalSecret | Snowflake |
 
-The gateway row closes the gap pilot teams ask about: a single central URL in your EKS that fronts every remote MCP, so laptops don't individually need to configure a proxy. See the [multi-MCP gateway design](docs/design/MULTI_MCP_GATEWAY.md) and the [Stage 3a gateway install walkthrough](site-docs/deployment/eks-mcp-pilot.md).
+The gateway closes the biggest deployment gap for remote MCP usage: one central
+URL in your EKS fronts N remote MCP upstreams, so laptops do not each need
+their own proxy config. See the [multi-MCP gateway design](docs/design/MULTI_MCP_GATEWAY.md)
+and the [focused EKS rollout](site-docs/deployment/eks-mcp-pilot.md).
 
-## Five product surfaces, one shared graph
+## Core surfaces and entry points, one shared graph
 
-| Surface | CLI / route | What it does | Deploys as |
+| Surface | CLI / route | What it does | Runs as |
 |---|---|---|---|
 | **scan** | `agent-bom agents`, `agent-bom image`, `agent-bom iac` | Discovery, inventory, CVE enrichment, blast-radius scoring | CLI + CronJob |
+| **CI/CD gate** | GitHub Action `uses: msaad00/agent-bom@v0.78.1` | Pull-request and release gating, SARIF, policy-driven exits | GitHub Actions runner |
 | **fleet** | `POST /v1/fleet/sync` + CLI `--push-url` | Endpoint + collector fleet ingest with tenant scoping | API endpoint |
 | **proxy / runtime** | `agent-bom proxy` (stdio) / `--sse` (HTTP) | Inline MCP JSON-RPC inspection + policy enforcement | K8s sidecar or laptop wrapper |
-| **gateway** | `/v1/gateway/policies` + `/v1/proxy/audit` | Central policy authoring + audit ingest; proxies pull & push | API routes |
+| **gateway** | `agent-bom gateway serve`, `/v1/gateway/policies`, `/v1/proxy/audit` | Central HTTP traffic plane plus shared policy/audit plane | Service + API routes |
 | **API + UI** | `/v1/*` + Next.js dashboard | Findings, graph, remediation, compliance, posture | 2 Deployments + HPA |
 
 By default, findings, fleet data, audit logs, graph state, and remediation outputs stay in your infrastructure. Optional egress (OSV lookups, NVD enrichment, Slack / Jira / Vanta / Drata webhooks, SIEM / OTLP) is operator-controlled.
@@ -270,10 +271,12 @@ Three shipped examples in [`deploy/helm/agent-bom/examples/`](deploy/helm/agent-
 
 ## The scoped product stack
 
-Most pilot teams start with the five product surfaces below. Every one of them
-maps to code in this repo and ships in the Helm chart today.
+Most self-hosted teams start with the surfaces below. The focused pilot simply
+turns on a narrower subset first; it does not use a different architecture.
+Every one of them maps to code in this repo and ships today.
 
 - **scan** — discovery, inventory, CVE, image, IaC, Kubernetes, cloud analysis ([`src/agent_bom/cli/agents/`](src/agent_bom/cli/agents/))
+- **CI/CD gate** — GitHub Action packaging of the scan surface for pull-request and release workflows with SARIF output
 - **fleet** — endpoint + collector inventory pushed into the control plane ([`POST /v1/fleet/sync`](src/agent_bom/api/routes/fleet.py))
 - **proxy / runtime** — per-MCP sidecar or stdio wrapper — the honest mode for stdio MCPs and workload-local enforcement ([`src/agent_bom/proxy.py`](src/agent_bom/proxy.py))
 - **gateway** — two things, same namespace:

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -171,6 +171,107 @@ CREATE INDEX IF NOT EXISTS idx_schedules_due
 CREATE INDEX IF NOT EXISTS idx_schedules_tenant_due
     ON scan_schedules(tenant_id, enabled, next_run);
 
+-- ── Tables: Unified Graph Persistence ───────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS graph_nodes (
+    id              TEXT NOT NULL,
+    entity_type     TEXT NOT NULL,
+    label           TEXT NOT NULL,
+    category_uid    INTEGER DEFAULT 0,
+    class_uid       INTEGER DEFAULT 0,
+    type_uid        INTEGER DEFAULT 0,
+    status          TEXT DEFAULT 'active',
+    risk_score      DOUBLE PRECISION DEFAULT 0.0,
+    severity        TEXT DEFAULT '',
+    severity_id     INTEGER DEFAULT 0,
+    first_seen      TEXT NOT NULL,
+    last_seen       TEXT NOT NULL,
+    attributes      JSONB DEFAULT '{}'::jsonb,
+    compliance_tags JSONB DEFAULT '[]'::jsonb,
+    data_sources    JSONB DEFAULT '[]'::jsonb,
+    dimensions      JSONB DEFAULT '{}'::jsonb,
+    scan_id         TEXT NOT NULL,
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
+    PRIMARY KEY (id, scan_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_entity_type ON graph_nodes(entity_type);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan ON graph_nodes(tenant_id, scan_id);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan_order
+    ON graph_nodes(tenant_id, scan_id, severity_id DESC, risk_score DESC, label);
+
+CREATE TABLE IF NOT EXISTS graph_edges (
+    source_id    TEXT NOT NULL,
+    target_id    TEXT NOT NULL,
+    relationship TEXT NOT NULL,
+    direction    TEXT DEFAULT 'directed',
+    weight       DOUBLE PRECISION DEFAULT 1.0,
+    traversable  INTEGER DEFAULT 1,
+    first_seen   TEXT NOT NULL,
+    last_seen    TEXT NOT NULL,
+    evidence     JSONB DEFAULT '{}'::jsonb,
+    activity_id  INTEGER DEFAULT 1,
+    scan_id      TEXT NOT NULL,
+    tenant_id    TEXT NOT NULL DEFAULT 'default',
+    PRIMARY KEY (source_id, target_id, relationship, scan_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan ON graph_edges(tenant_id, scan_id);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id);
+
+CREATE TABLE IF NOT EXISTS graph_snapshots (
+    scan_id      TEXT NOT NULL,
+    tenant_id    TEXT NOT NULL DEFAULT 'default',
+    created_at   TEXT NOT NULL,
+    node_count   INTEGER DEFAULT 0,
+    edge_count   INTEGER DEFAULT 0,
+    risk_summary JSONB DEFAULT '{}'::jsonb,
+    PRIMARY KEY (scan_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pg_graph_snapshots_recent ON graph_snapshots(tenant_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS attack_paths (
+    source_node         TEXT NOT NULL,
+    target_node         TEXT NOT NULL,
+    hop_count           INTEGER DEFAULT 0,
+    composite_risk      DOUBLE PRECISION DEFAULT 0.0,
+    path_nodes          JSONB DEFAULT '[]'::jsonb,
+    path_edges          JSONB DEFAULT '[]'::jsonb,
+    credential_exposure JSONB DEFAULT '[]'::jsonb,
+    vuln_ids            JSONB DEFAULT '[]'::jsonb,
+    scan_id             TEXT NOT NULL,
+    tenant_id           TEXT NOT NULL DEFAULT 'default',
+    computed_at         TEXT NOT NULL,
+    PRIMARY KEY (source_node, target_node, scan_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan ON attack_paths(tenant_id, scan_id);
+CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan_risk ON attack_paths(tenant_id, scan_id, composite_risk DESC);
+
+CREATE TABLE IF NOT EXISTS interaction_risks (
+    pattern           TEXT NOT NULL,
+    agents            TEXT NOT NULL,
+    risk_score        DOUBLE PRECISION DEFAULT 0.0,
+    description       TEXT DEFAULT '',
+    owasp_agentic_tag TEXT DEFAULT NULL,
+    scan_id           TEXT NOT NULL,
+    tenant_id         TEXT NOT NULL DEFAULT 'default',
+    PRIMARY KEY (pattern, agents, scan_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pg_interaction_risks_scan ON interaction_risks(tenant_id, scan_id);
+
+CREATE TABLE IF NOT EXISTS graph_filter_presets (
+    name        TEXT NOT NULL,
+    tenant_id   TEXT NOT NULL DEFAULT 'default',
+    description TEXT DEFAULT '',
+    filters     JSONB NOT NULL,
+    created_at  TEXT NOT NULL,
+    PRIMARY KEY (name, tenant_id)
+);
+
 -- ── Tables: OSV Scan Cache ────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS osv_cache (
@@ -532,6 +633,114 @@ BEGIN
 END
 $$;
 
+ALTER TABLE graph_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graph_nodes FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'graph_nodes'
+          AND policyname = 'graph_nodes_tenant_isolation'
+    ) THEN
+        CREATE POLICY graph_nodes_tenant_isolation ON graph_nodes
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE graph_edges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graph_edges FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'graph_edges'
+          AND policyname = 'graph_edges_tenant_isolation'
+    ) THEN
+        CREATE POLICY graph_edges_tenant_isolation ON graph_edges
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE graph_snapshots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graph_snapshots FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'graph_snapshots'
+          AND policyname = 'graph_snapshots_tenant_isolation'
+    ) THEN
+        CREATE POLICY graph_snapshots_tenant_isolation ON graph_snapshots
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE attack_paths ENABLE ROW LEVEL SECURITY;
+ALTER TABLE attack_paths FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'attack_paths'
+          AND policyname = 'attack_paths_tenant_isolation'
+    ) THEN
+        CREATE POLICY attack_paths_tenant_isolation ON attack_paths
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE interaction_risks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE interaction_risks FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'interaction_risks'
+          AND policyname = 'interaction_risks_tenant_isolation'
+    ) THEN
+        CREATE POLICY interaction_risks_tenant_isolation ON interaction_risks
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE graph_filter_presets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graph_filter_presets FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'graph_filter_presets'
+          AND policyname = 'graph_filter_presets_tenant_isolation'
+    ) THEN
+        CREATE POLICY graph_filter_presets_tenant_isolation ON graph_filter_presets
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
 ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY;
 ALTER TABLE api_keys FORCE ROW LEVEL SECURITY;
 
@@ -719,7 +928,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_bom_re
 --
 --  Connection: AGENT_BOM_POSTGRES_URL=postgresql://agent_bom_app:<pw>@<host>:5432/agent_bom
 --
---  Schema (15 tables):
+--  Schema (21+ tables):
 --   teams              — multi-tenant team registry (FK root)
 --   scan_jobs          — async scan job lifecycle + full result JSONB
 --   findings           — normalized vulnerability findings (per scan, per CVE)
@@ -734,4 +943,10 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_bom_re
 --   audit_log          — signed API/security audit trail
 --   trend_history      — persisted posture/vulnerability history
 --   scan_schedules     — recurring scan cron configuration
+--   graph_nodes        — per-scan graph entities with severity/risk ordering
+--   graph_edges        — per-scan traversable relationships
+--   graph_snapshots    — graph snapshot summary + recency cursor
+--   attack_paths       — persisted fix-first attack-path projections
+--   interaction_risks  — agent interaction / toxic-combo risk overlays
+--   graph_filter_presets — tenant-scoped saved graph filters
 --   osv_cache          — OSV vulnerability API response cache

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -192,6 +192,7 @@ completed scan jobs, fleet inventory, and gateway policy/audit stores.
 | `has_local_scan` | direct/local scan evidence exists | `scan_sources` + MCP/agent context |
 | `has_fleet_ingest` | governed fleet inventory exists | fleet store |
 | `has_cluster_scan` | cluster/GPU/K8s evidence exists | `scan_sources` + fleet agent environment |
+| `has_ci_cd_scan` | CI/CD workflow scanning exists | `scan_sources` (`github_actions`) |
 | `has_mesh` | mesh/topology views are meaningful | fleet + MCP/agent/runtime evidence |
 | `has_gateway` | central gateway policy plane is configured | policy store |
 | `has_proxy` | proxy/runtime enforcement evidence exists | policy audit + runtime signals |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -179,6 +179,44 @@ Warehouse-native deployment for governance-heavy customers. Mirrors
 Postgres tables with Snowflake-specific column types. Not yet at full
 control-plane parity — see roadmap for the gap list.
 
+### Deployment-context posture contract — `GET /v1/posture/counts`
+
+This endpoint is the lightweight capability contract used by the UI to
+adapt navigation and deployment-specific surfaces without fetching full
+scan payloads. It must be derived from **tenant-scoped state only**:
+completed scan jobs, fleet inventory, and gateway policy/audit stores.
+
+| Field | Meaning | Source |
+|---|---|---|
+| `deployment_mode` | `local`, `fleet`, `cluster`, or `hybrid` | derived from the booleans below |
+| `has_local_scan` | direct/local scan evidence exists | `scan_sources` + MCP/agent context |
+| `has_fleet_ingest` | governed fleet inventory exists | fleet store |
+| `has_cluster_scan` | cluster/GPU/K8s evidence exists | `scan_sources` + fleet agent environment |
+| `has_mesh` | mesh/topology views are meaningful | fleet + MCP/agent/runtime evidence |
+| `has_gateway` | central gateway policy plane is configured | policy store |
+| `has_proxy` | proxy/runtime enforcement evidence exists | policy audit + runtime signals |
+| `has_traces` | trace/timeline views are meaningful | runtime correlation/session graph |
+| `has_registry` | image/SBOM/registry-oriented scans exist | `scan_sources` |
+
+If a new scan mode or deployment surface is added, update this table in
+the same PR as the route and nav change.
+
+### Graph/cache hot-path indexes
+
+The Postgres graph and cache backends are tuned for the query shapes
+the UI and API actually execute:
+
+| Table | Query shape | Required indexes |
+|---|---|---|
+| `graph_nodes` | tenant + snapshot search ordered by severity/risk | `idx_pg_graph_nodes_scan`, `idx_pg_graph_nodes_scan_order` |
+| `graph_edges` | neighbor expansion by source/target in one snapshot | `idx_pg_graph_edges_scan`, `idx_pg_graph_edges_scan_source`, `idx_pg_graph_edges_scan_target` |
+| `attack_paths` | fix-first path lists ordered by composite risk | `idx_pg_attack_paths_scan`, `idx_pg_attack_paths_scan_risk` |
+| `graph_snapshots` | latest/previous snapshot lookup | `idx_pg_graph_snapshots_recent` |
+| `osv_cache` | TTL cleanup and expiry sweeps | `idx_cache_age` |
+
+Any new backend should preserve these access patterns or document the
+replacement plan explicitly.
+
 ---
 
 ## 5. Output formats (`src/agent_bom/output/`)

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -10,6 +10,17 @@ Package risk is only the start. `agent-bom` follows what it can reach across MCP
 
 Current repo-derived counts live in [PRODUCT_METRICS.md](PRODUCT_METRICS.md). This brief intentionally keeps volatile metrics out of the main narrative.
 
+## Deployment truth
+
+The product should be framed deployment-first:
+
+- **self-hosted operator plane** in the customer's own infrastructure
+- **entry points** through CLI, GitHub Action, fleet ingest, proxy, and gateway
+- **pilot** as a narrower rollout profile of the same architecture, not a separate product shape
+
+That keeps the repo story aligned with the actual code: one shared graph, one
+policy model, multiple entry points, no mandatory hosted control plane.
+
 ## Durable thesis
 
 - Agent security is not just software composition analysis. It is context across packages, MCP servers, agent configuration, credentials, tools, and runtime behavior.
@@ -66,7 +77,7 @@ The product is broader than MCP alone. It includes cloud posture, container scan
 - a serious open-source product with a clear path to `1.0`
 - unusually complete for an open tool in agent and MCP security
 - complementary to traditional package and container scanners today, while differentiated by blast radius, runtime, and MCP-aware analysis
-- deployable across local development, CI, and authenticated remote service environments
+- deployable across local development, CI/CD gates, and authenticated self-hosted operator environments
 
 That means public repo copy should emphasize real shipped surfaces, not just aspirations.
 

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -1209,6 +1209,12 @@ class PostgresGraphStore:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan ON graph_nodes(tenant_id, scan_id)")
             conn.execute(
                 """
+                CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan_order
+                ON graph_nodes(tenant_id, scan_id, severity_id DESC, risk_score DESC, label)
+                """
+            )
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS graph_edges (
                     source_id TEXT NOT NULL,
                     target_id TEXT NOT NULL,
@@ -1227,6 +1233,8 @@ class PostgresGraphStore:
                 """
             )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan ON graph_edges(tenant_id, scan_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id)")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS graph_snapshots (
@@ -1260,6 +1268,9 @@ class PostgresGraphStore:
                 """
             )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan ON attack_paths(tenant_id, scan_id)")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan_risk ON attack_paths(tenant_id, scan_id, composite_risk DESC)"
+            )
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS interaction_risks (
@@ -1805,6 +1816,7 @@ class PostgresScanCache:
                     cached_at  REAL NOT NULL
                 )
             """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_cache_age ON osv_cache(cached_at)")
             conn.commit()
 
     def get(self, ecosystem: str, name: str, version: str) -> list[dict] | None:

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -39,6 +39,7 @@ def _dep(permission: str) -> Any:
 router = APIRouter(dependencies=[_dep("read")])
 
 _CLUSTER_SCAN_SOURCES = {"gpu_infra", "k8s"}
+_CI_CD_SCAN_SOURCES = {"github_actions"}
 _REGISTRY_SCAN_SOURCES = {"external_scan", "image", "sbom"}
 _LOCAL_SCAN_SOURCES = {
     "agent_discovery",
@@ -47,7 +48,6 @@ _LOCAL_SCAN_SOURCES = {
     "dataset_cards",
     "external_scan",
     "filesystem",
-    "github_actions",
     "image",
     "jupyter",
     "sbom",
@@ -100,8 +100,12 @@ def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, A
     has_cluster_scan = bool(scan_sources & _CLUSTER_SCAN_SOURCES) or any(
         str(getattr(agent, "environment", "") or "").strip().lower() in _CLUSTER_ENVIRONMENTS for agent in fleet_agents
     )
+    has_ci_cd_scan = bool(scan_sources & _CI_CD_SCAN_SOURCES)
     has_local_scan = (
-        bool(scan_sources & _LOCAL_SCAN_SOURCES) or has_agent_context or has_mcp_context or (scan_count > 0 and not has_cluster_scan)
+        bool(scan_sources & _LOCAL_SCAN_SOURCES)
+        or has_agent_context
+        or has_mcp_context
+        or (scan_count > 0 and not has_cluster_scan and not has_ci_cd_scan)
     )
     has_registry = bool(scan_sources & _REGISTRY_SCAN_SOURCES)
 
@@ -132,6 +136,7 @@ def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, A
         "has_local_scan": has_local_scan,
         "has_fleet_ingest": has_fleet_ingest,
         "has_cluster_scan": has_cluster_scan,
+        "has_ci_cd_scan": has_ci_cd_scan,
         "has_mesh": has_mesh,
         "has_gateway": has_gateway,
         "has_proxy": has_proxy,

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from agent_bom.api.models import ComplianceReportBundle, JobStatus
-from agent_bom.api.stores import _get_store
+from agent_bom.api.stores import _get_fleet_store, _get_policy_store, _get_store
 from agent_bom.rbac import require_authenticated_permission
 
 if TYPE_CHECKING:
@@ -38,6 +38,25 @@ def _dep(permission: str) -> Any:
 
 router = APIRouter(dependencies=[_dep("read")])
 
+_CLUSTER_SCAN_SOURCES = {"gpu_infra", "k8s"}
+_REGISTRY_SCAN_SOURCES = {"external_scan", "image", "sbom"}
+_LOCAL_SCAN_SOURCES = {
+    "agent_discovery",
+    "ast_analysis",
+    "browser_extensions",
+    "dataset_cards",
+    "external_scan",
+    "filesystem",
+    "github_actions",
+    "image",
+    "jupyter",
+    "sbom",
+    "secret_scan",
+    "terraform",
+    "training_pipelines",
+}
+_CLUSTER_ENVIRONMENTS = {"aks", "cluster", "eks", "gke", "k8s", "kubernetes"}
+
 
 def _tenant_id(request: Request) -> str:
     return getattr(request.state, "tenant_id", "default")
@@ -45,6 +64,84 @@ def _tenant_id(request: Request) -> str:
 
 def _tenant_jobs(request: Request) -> list:
     return _get_store().list_all(tenant_id=_tenant_id(request))
+
+
+def _result_has_runtime_signals(result: dict[str, Any]) -> bool:
+    return bool(
+        result.get("runtime_correlation")
+        or result.get("runtime_session_graph")
+        or result.get("introspection")
+        or result.get("introspection_data")
+        or result.get("health_check")
+        or result.get("health_check_data")
+    )
+
+
+def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, Any]:
+    tenant_id = _tenant_id(request)
+    scan_sources: set[str] = set()
+    has_mcp_context = False
+    has_agent_context = False
+    has_runtime_signals = False
+    scan_count = 0
+
+    for job in jobs:
+        if job.status != JobStatus.DONE or not job.result:
+            continue
+        scan_count += 1
+        result = cast(dict[str, Any], job.result)
+        has_mcp_context = has_mcp_context or bool(result.get("has_mcp_context"))
+        has_agent_context = has_agent_context or bool(result.get("has_agent_context"))
+        scan_sources.update(str(src) for src in result.get("scan_sources", []) if src)
+        has_runtime_signals = has_runtime_signals or _result_has_runtime_signals(result)
+
+    fleet_agents = _get_fleet_store().list_by_tenant(tenant_id)
+    has_fleet_ingest = len(fleet_agents) > 0
+    has_cluster_scan = bool(scan_sources & _CLUSTER_SCAN_SOURCES) or any(
+        str(getattr(agent, "environment", "") or "").strip().lower() in _CLUSTER_ENVIRONMENTS for agent in fleet_agents
+    )
+    has_local_scan = (
+        bool(scan_sources & _LOCAL_SCAN_SOURCES) or has_agent_context or has_mcp_context or (scan_count > 0 and not has_cluster_scan)
+    )
+    has_registry = bool(scan_sources & _REGISTRY_SCAN_SOURCES)
+
+    policy_store = _get_policy_store()
+    policies = policy_store.list_policies(tenant_id=tenant_id)
+    policy_audit = policy_store.list_audit_entries(limit=1, tenant_id=tenant_id)
+    has_gateway = bool(policies)
+    has_proxy = bool(policy_audit) or has_runtime_signals
+    has_traces = bool(policy_audit) or has_runtime_signals
+    has_mesh = (
+        has_fleet_ingest
+        or bool(scan_count and has_agent_context and has_mcp_context)
+        or bool(has_runtime_signals and (has_agent_context or has_fleet_ingest))
+    )
+
+    active_modes = sum((has_local_scan, has_fleet_ingest, has_cluster_scan))
+    if active_modes > 1:
+        deployment_mode = "hybrid"
+    elif has_cluster_scan:
+        deployment_mode = "cluster"
+    elif has_fleet_ingest:
+        deployment_mode = "fleet"
+    else:
+        deployment_mode = "local"
+
+    return {
+        "deployment_mode": deployment_mode,
+        "has_local_scan": has_local_scan,
+        "has_fleet_ingest": has_fleet_ingest,
+        "has_cluster_scan": has_cluster_scan,
+        "has_mesh": has_mesh,
+        "has_gateway": has_gateway,
+        "has_proxy": has_proxy,
+        "has_traces": has_traces,
+        "has_registry": has_registry,
+        "has_mcp_context": has_mcp_context,
+        "has_agent_context": has_agent_context,
+        "scan_sources": sorted(scan_sources),
+        "scan_count": scan_count,
+    }
 
 
 @router.get("/v1/compliance", tags=["compliance"])
@@ -975,23 +1072,11 @@ async def get_posture_counts(request: Request) -> dict:
         "compound_issues": 0,
     }
     seen_ids: set[str] = set()
-    has_mcp_context = False
-    has_agent_context = False
-    all_scan_sources: set[str] = set()
-    scan_count = 0
+    tenant_jobs = _tenant_jobs(request)
 
-    for job in _tenant_jobs(request):
+    for job in tenant_jobs:
         if job.status != JobStatus.DONE or not job.result:
             continue
-        scan_count += 1
-
-        # Aggregate context metadata from scan results
-        if job.result.get("has_mcp_context"):
-            has_mcp_context = True
-        if job.result.get("has_agent_context"):
-            has_agent_context = True
-        for src in job.result.get("scan_sources", []):
-            all_scan_sources.add(src)
 
         blast_list = job.result.get("blast_radius", [])
         for b in blast_list:
@@ -1011,10 +1096,7 @@ async def get_posture_counts(request: Request) -> dict:
             elif (b.get("epss_score") or 0) >= 0.3 and (b.get("cvss_score") or 0) >= 7:
                 counts["compound_issues"] += 1
 
-    counts["has_mcp_context"] = has_mcp_context
-    counts["has_agent_context"] = has_agent_context
-    counts["scan_sources"] = sorted(all_scan_sources)
-    counts["scan_count"] = scan_count
+    counts.update(_derive_deployment_context(request, tenant_jobs))
     return counts
 
 

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -724,7 +724,7 @@ async def test_posture_counts_include_deployment_context_by_tenant():
             ],
             "has_mcp_context": True,
             "has_agent_context": True,
-            "scan_sources": ["agent_discovery", "k8s", "sbom"],
+            "scan_sources": ["agent_discovery", "github_actions", "k8s", "sbom"],
             "runtime_session_graph": {"node_count": 3, "edge_count": 2},
         },
     )
@@ -769,6 +769,7 @@ async def test_posture_counts_include_deployment_context_by_tenant():
     assert counts["has_local_scan"] is True
     assert counts["has_fleet_ingest"] is True
     assert counts["has_cluster_scan"] is True
+    assert counts["has_ci_cd_scan"] is True
     assert counts["has_gateway"] is True
     assert counts["has_proxy"] is True
     assert counts["has_traces"] is True

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -14,6 +14,7 @@ from agent_bom.api import tenant_quota as tenant_quota_module
 from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState, InMemoryFleetStore
 from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.models import FleetAgentUpdate, JobStatus, PushPayload, ScanJob, ScanRequest, ScheduleCreate, StateUpdate
+from agent_bom.api.policy_store import GatewayPolicy, InMemoryPolicyStore
 from agent_bom.api.routes import compliance as compliance_routes
 from agent_bom.api.routes import discovery as discovery_routes
 from agent_bom.api.routes import fleet as fleet_routes
@@ -22,7 +23,7 @@ from agent_bom.api.routes import scan as scan_routes
 from agent_bom.api.routes import schedules as schedule_routes
 from agent_bom.api.schedule_store import InMemoryScheduleStore, ScanSchedule
 from agent_bom.api.store import InMemoryJobStore, SQLiteJobStore
-from agent_bom.api.stores import _jobs, set_fleet_store, set_graph_store, set_job_store, set_schedule_store
+from agent_bom.api.stores import _jobs, set_fleet_store, set_graph_store, set_job_store, set_policy_store, set_schedule_store
 
 
 def _now() -> str:
@@ -692,3 +693,84 @@ async def test_discovery_and_traces_are_tenant_scoped():
     # Trace analytics ingest must carry the authed tenant through to
     # ClickHouse so cross-tenant queries cannot see each other's events.
     assert analytics.event_tenants[0] == req.state.tenant_id
+
+
+@pytest.mark.asyncio
+async def test_posture_counts_include_deployment_context_by_tenant():
+    job_store = InMemoryJobStore()
+    fleet_store = InMemoryFleetStore()
+    policy_store = InMemoryPolicyStore()
+    set_job_store(job_store)
+    set_fleet_store(fleet_store)
+    set_policy_store(policy_store)
+
+    alpha_job = ScanJob(
+        job_id="job-alpha-context",
+        tenant_id="tenant-alpha",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        completed_at=_now(),
+        request=ScanRequest(),
+        result={
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-alpha",
+                    "severity": "critical",
+                    "package": "alpha@1.0.0",
+                    "cisa_kev": True,
+                    "reachable_tools": ["exec"],
+                    "affected_agents": ["alpha-agent"],
+                }
+            ],
+            "has_mcp_context": True,
+            "has_agent_context": True,
+            "scan_sources": ["agent_discovery", "k8s", "sbom"],
+            "runtime_session_graph": {"node_count": 3, "edge_count": 2},
+        },
+    )
+    beta_job = ScanJob(
+        job_id="job-beta-context",
+        tenant_id="tenant-beta",
+        status=JobStatus.DONE,
+        created_at=_now(),
+        completed_at=_now(),
+        request=ScanRequest(),
+        result={
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-beta",
+                    "severity": "high",
+                    "package": "beta@1.0.0",
+                    "affected_agents": ["beta-agent"],
+                }
+            ],
+            "scan_sources": ["sbom"],
+        },
+    )
+    job_store.put(alpha_job)
+    job_store.put(beta_job)
+
+    alpha_fleet = _fleet_agent("alpha-fleet-1", "tenant-alpha", "alpha-agent")
+    alpha_fleet.environment = "eks"
+    fleet_store.put(alpha_fleet)
+    policy_store.put_policy(
+        GatewayPolicy(
+            policy_id="policy-alpha",
+            name="alpha-gateway",
+            tenant_id="tenant-alpha",
+            bound_agents=["alpha-agent"],
+        )
+    )
+
+    counts = await compliance_routes.get_posture_counts(_request("tenant-alpha"))
+
+    assert counts["critical"] == 1
+    assert counts["deployment_mode"] == "hybrid"
+    assert counts["has_local_scan"] is True
+    assert counts["has_fleet_ingest"] is True
+    assert counts["has_cluster_scan"] is True
+    assert counts["has_gateway"] is True
+    assert counts["has_proxy"] is True
+    assert counts["has_traces"] is True
+    assert counts["has_registry"] is True
+    assert counts["scan_count"] == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3907,10 +3907,11 @@ def test_api_posture_counts_empty():
 
     from agent_bom.api.server import app
 
+    tenant_id = "counts-empty"
     client = TestClient(app)
     resp = client.get(
         "/v1/posture/counts",
-        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "default"},
+        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": tenant_id},
     )
     assert resp.status_code == 200
     body = resp.json()
@@ -3923,6 +3924,7 @@ def test_api_posture_counts_empty():
     assert body["has_local_scan"] is False
     assert body["has_fleet_ingest"] is False
     assert body["has_cluster_scan"] is False
+    assert body["has_ci_cd_scan"] is False
 
 
 def test_api_posture_counts_with_data():
@@ -3932,9 +3934,11 @@ def test_api_posture_counts_with_data():
 
     from agent_bom.api.server import JobStatus, ScanJob, ScanRequest, _get_store, app
 
+    tenant_id = "counts-with-data"
     client = TestClient(app)
     job = ScanJob(
         job_id="counts-test-001",
+        tenant_id=tenant_id,
         status=JobStatus.DONE,
         created_at="2026-01-01T00:00:00Z",
         request=ScanRequest(),
@@ -3961,14 +3965,14 @@ def test_api_posture_counts_with_data():
             ],
             "has_mcp_context": True,
             "has_agent_context": True,
-            "scan_sources": ["agent_discovery", "sbom"],
+            "scan_sources": ["agent_discovery", "github_actions", "sbom"],
             "runtime_session_graph": {"node_count": 2, "edge_count": 1},
         },
     )
     _get_store().put(job)
     resp = client.get(
         "/v1/posture/counts",
-        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "default"},
+        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": tenant_id},
     )
     assert resp.status_code == 200
     body = resp.json()
@@ -3979,6 +3983,41 @@ def test_api_posture_counts_with_data():
     assert body["total"] >= 2
     assert body["deployment_mode"] == "local"
     assert body["has_local_scan"] is True
+    assert body["has_ci_cd_scan"] is True
     assert body["has_registry"] is True
     assert body["has_proxy"] is True
     assert body["has_traces"] is True
+
+
+def test_api_posture_counts_ci_cd_only_is_not_treated_as_local_runtime():
+    """GitHub Actions scans should surface CI/CD context without implying local runtime deployment."""
+    pytest.importorskip("fastapi", reason="fastapi not installed")
+    from fastapi.testclient import TestClient
+
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest, _get_store, app
+
+    tenant_id = "counts-ci-only"
+    client = TestClient(app)
+    job = ScanJob(
+        job_id="counts-test-ci-001",
+        tenant_id=tenant_id,
+        status=JobStatus.DONE,
+        created_at="2026-01-02T00:00:00Z",
+        request=ScanRequest(),
+        result={
+            "blast_radius": [],
+            "scan_sources": ["github_actions"],
+        },
+    )
+    _get_store().put(job)
+    resp = client.get(
+        "/v1/posture/counts",
+        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": tenant_id},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deployment_mode"] == "local"
+    assert body["has_ci_cd_scan"] is True
+    assert body["has_local_scan"] is False
+    assert body["has_fleet_ingest"] is False
+    assert body["has_cluster_scan"] is False

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3919,6 +3919,10 @@ def test_api_posture_counts_empty():
     assert "kev" in body
     assert "compound_issues" in body
     assert isinstance(body["total"], int)
+    assert body["deployment_mode"] == "local"
+    assert body["has_local_scan"] is False
+    assert body["has_fleet_ingest"] is False
+    assert body["has_cluster_scan"] is False
 
 
 def test_api_posture_counts_with_data():
@@ -3954,7 +3958,11 @@ def test_api_posture_counts_with_data():
                     "reachable_tools": [],
                     "exposed_credentials": [],
                 },
-            ]
+            ],
+            "has_mcp_context": True,
+            "has_agent_context": True,
+            "scan_sources": ["agent_discovery", "sbom"],
+            "runtime_session_graph": {"node_count": 2, "edge_count": 1},
         },
     )
     _get_store().put(job)
@@ -3969,3 +3977,8 @@ def test_api_posture_counts_with_data():
     assert body["kev"] >= 1
     assert body["compound_issues"] >= 1  # KEV + reachable_tools
     assert body["total"] >= 2
+    assert body["deployment_mode"] == "local"
+    assert body["has_local_scan"] is True
+    assert body["has_registry"] is True
+    assert body["has_proxy"] is True
+    assert body["has_traces"] is True

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -125,10 +125,12 @@ def test_remaining_tenant_tables_have_rls():
 
 
 def test_schema_summary_comment_is_current():
-    assert "--  Schema (15 tables):" in SQL
+    assert "--  Schema (21+ tables):" in SQL
     assert "--   api_rate_limits    — shared API rate-limiter buckets" in SQL
     assert "--   audit_log          — signed API/security audit trail" in SQL
     assert "--   trend_history      — persisted posture/vulnerability history" in SQL
+    assert "--   attack_paths       — persisted fix-first attack-path projections" in SQL
+    assert "--   graph_filter_presets — tenant-scoped saved graph filters" in SQL
 
 
 def test_api_rate_limits_table_exists():

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -936,6 +936,18 @@ def test_scan_cache_init(mock_pool):
 
     cache = PostgresScanCache(pool=mock_pool)
     assert cache is not None
+    assert any("idx_cache_age" in sql for sql, _ in mock_pool._conn.executed)
+
+
+def test_graph_store_init_adds_query_indexes(mock_pool):
+    from agent_bom.api.postgres_store import PostgresGraphStore
+
+    store = PostgresGraphStore(pool=mock_pool)
+    assert store is not None
+    assert any("idx_pg_graph_nodes_scan_order" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_graph_edges_scan_source" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_graph_edges_scan_target" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_attack_paths_scan_risk" in sql for sql, _ in mock_pool._conn.executed)
 
 
 def test_scan_cache_put_get(mock_pool):

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -142,6 +142,7 @@ function hasDeploymentSignals(counts: RiskCounts | null): boolean {
       counts.has_local_scan ||
       counts.has_fleet_ingest ||
       counts.has_cluster_scan ||
+      counts.has_ci_cd_scan ||
       counts.has_mesh ||
       counts.has_gateway ||
       counts.has_proxy ||

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -28,7 +28,7 @@ import {
   LayoutDashboard,
   Wrench,
 } from "lucide-react";
-import { api } from "@/lib/api";
+import { api, type PostureCountsResponse } from "@/lib/api";
 import { BrandMark } from "@/components/brand-mark";
 import { ThemeToggle } from "@/components/theme-toggle";
 
@@ -123,18 +123,39 @@ const ALL_GROUP_LABELS = NAV_GROUPS.map((group) => group.label);
 
 // ─── Risk counts for badges ─────────────────────────────────────────────────
 
-interface RiskCounts {
-  critical: number;
-  high: number;
-  kev: number;
-  compound_issues: number;
-  has_mcp_context?: boolean;
-  has_agent_context?: boolean;
-  scan_sources?: string[];
-  scan_count?: number;
+type RiskCounts = PostureCountsResponse;
+
+const CAPABILITY_LINKS: Partial<Record<string, keyof RiskCounts>> = {
+  "/agents": "has_local_scan",
+  "/fleet": "has_fleet_ingest",
+  "/mesh": "has_mesh",
+  "/context": "has_mcp_context",
+  "/proxy": "has_proxy",
+  "/gateway": "has_gateway",
+  "/traces": "has_traces",
+};
+
+function hasDeploymentSignals(counts: RiskCounts | null): boolean {
+  if (!counts) return false;
+  return Boolean(
+    (counts.scan_count ?? 0) > 0 ||
+      counts.has_local_scan ||
+      counts.has_fleet_ingest ||
+      counts.has_cluster_scan ||
+      counts.has_mesh ||
+      counts.has_gateway ||
+      counts.has_proxy ||
+      counts.has_traces ||
+      counts.has_registry
+  );
 }
 
-const MCP_ONLY_PAGES = new Set(["/agents", "/fleet", "/mesh", "/context"]);
+function isLinkVisible(href: string, counts: RiskCounts | null): boolean {
+  if (!hasDeploymentSignals(counts)) return true;
+  const capability = CAPABILITY_LINKS[href];
+  if (!capability) return true;
+  return Boolean(counts?.[capability]);
+}
 
 // ─── Sidebar Component ──────────────────────────────────────────────────────
 
@@ -214,12 +235,6 @@ export function Nav() {
     });
   }, [captureMode]);
 
-  const isDimmed = (href: string): boolean => {
-    if (!counts || (counts.scan_count ?? 0) === 0) return false;
-    if (MCP_ONLY_PAGES.has(href) && !counts.has_mcp_context) return true;
-    return false;
-  };
-
   // Keyboard shortcut: Cmd/Ctrl+K for search, Cmd/Ctrl+B for sidebar
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -243,6 +258,17 @@ export function Nav() {
         links: g.links.filter((l) => l.label.toLowerCase().includes(searchQuery.toLowerCase())),
       })).filter((g) => g.links.length > 0)
     : NAV_GROUPS;
+
+  const navGroups = filteredGroups
+    .map((group) => {
+      if (searchQuery) {
+        return { ...group, visibleLinks: group.links, hiddenLinks: [] as NavLink[] };
+      }
+      const visibleLinks = group.links.filter((link) => isLinkVisible(link.href, counts));
+      const hiddenLinks = group.links.filter((link) => !isLinkVisible(link.href, counts));
+      return { ...group, visibleLinks, hiddenLinks };
+    })
+    .filter((group) => group.visibleLinks.length > 0 || group.hiddenLinks.length > 0);
 
   const sidebarContent = (
     <>
@@ -300,10 +326,10 @@ export function Nav() {
 
       {/* Navigation Groups */}
       <nav className="flex-1 overflow-y-auto px-2 py-2 space-y-2 scrollbar-thin">
-        {filteredGroups.map((group) => {
+        {navGroups.map((group) => {
           const isExpanded = captureMode || expandedGroups.has(group.label);
           const GroupIcon = group.icon;
-          const hasActiveChild = group.links.some(
+          const hasActiveChild = [...group.visibleLinks, ...group.hiddenLinks].some(
             (l) => (l.href === "/" ? path === "/" : path.startsWith(l.href))
           );
 
@@ -337,7 +363,7 @@ export function Nav() {
                       </span>
                     </div>
                     <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-1.5 py-0.5 text-[9px] font-mono text-[color:var(--text-tertiary)]">
-                      {group.links.length}
+                      {group.visibleLinks.length}
                     </span>
                     {isExpanded ? (
                       <ChevronDown className="w-3 h-3 text-[color:var(--text-tertiary)]" />
@@ -354,14 +380,13 @@ export function Nav() {
                   <p className="px-3 pb-1 text-[11px] leading-5 text-[color:var(--text-tertiary)]">
                     {group.description}
                   </p>
-                  {group.links.map(({ href, label, icon: Icon }) => {
+                  {group.visibleLinks.map(({ href, label, icon: Icon }) => {
                     const active =
                       href === "/"
                         ? path === "/"
                         : href === "/findings"
                         ? path.startsWith("/findings") || path.startsWith("/vulns")
                         : path.startsWith(href);
-                    const dimmed = isDimmed(href);
                     const isVulns = href === "/findings";
 
                     return (
@@ -371,8 +396,6 @@ export function Nav() {
                         className={`flex items-center gap-2.5 px-3 py-1.5 rounded-lg text-[13px] font-medium transition-all group relative ${
                           active
                             ? "border-l-2 ml-0 pl-2.5"
-                            : dimmed
-                            ? "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-muted)]"
                             : "text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] hover:bg-[color:var(--surface-muted)]"
                         }`}
                         style={active ? {
@@ -380,10 +403,9 @@ export function Nav() {
                           borderLeftColor: group.accent,
                           backgroundColor: `${group.accent}10`,
                         } : undefined}
-                        title={dimmed ? "No MCP servers detected" : undefined}
                       >
                         <Icon
-                          className={`w-3.5 h-3.5 shrink-0 ${!active && (dimmed ? "opacity-40" : "text-[color:var(--text-tertiary)] group-hover:text-[color:var(--text-secondary)]")}`}
+                          className={`w-3.5 h-3.5 shrink-0 ${!active && "text-[color:var(--text-tertiary)] group-hover:text-[color:var(--text-secondary)]"}`}
                           style={active ? { color: group.accent } : undefined}
                         />
                         <span className="truncate">{label}</span>
@@ -404,13 +426,33 @@ export function Nav() {
                       </Link>
                     );
                   })}
+                  {group.hiddenLinks.length > 0 && (
+                    <details className="mt-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2">
+                      <summary className="cursor-pointer list-none text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">
+                        Unused capabilities ({group.hiddenLinks.length})
+                      </summary>
+                      <div className="mt-2 space-y-0.5">
+                        {group.hiddenLinks.map(({ href, label, icon: Icon }) => (
+                          <Link
+                            key={href}
+                            href={href}
+                            className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-[12px] text-[color:var(--text-tertiary)] transition-colors hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--text-secondary)]"
+                            title="Hidden until this deployment mode is detected"
+                          >
+                            <Icon className="h-3.5 w-3.5 shrink-0 opacity-60" />
+                            <span className="truncate">{label}</span>
+                          </Link>
+                        ))}
+                      </div>
+                    </details>
+                  )}
                 </div>
               )}
 
               {/* Collapsed: just show icons as tooltips */}
               {collapsed && (
                 <div className="space-y-0.5 mt-0.5">
-                  {group.links.map(({ href, label, icon: Icon }) => {
+                  {group.visibleLinks.map(({ href, label, icon: Icon }) => {
                     const active = href === "/" ? path === "/" : path.startsWith(href);
                     return (
                       <Link

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -150,6 +150,7 @@ export interface PostureCountsResponse {
   has_local_scan?: boolean;
   has_fleet_ingest?: boolean;
   has_cluster_scan?: boolean;
+  has_ci_cd_scan?: boolean;
   has_mesh?: boolean;
   has_gateway?: boolean;
   has_proxy?: boolean;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -134,6 +134,31 @@ export interface GraphSearchResponse {
   pagination: GraphPagination;
 }
 
+export type DeploymentMode = "local" | "fleet" | "cluster" | "hybrid";
+
+export interface PostureCountsResponse {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  total: number;
+  kev: number;
+  compound_issues: number;
+  deployment_mode?: DeploymentMode;
+  has_mcp_context?: boolean;
+  has_agent_context?: boolean;
+  has_local_scan?: boolean;
+  has_fleet_ingest?: boolean;
+  has_cluster_scan?: boolean;
+  has_mesh?: boolean;
+  has_gateway?: boolean;
+  has_proxy?: boolean;
+  has_traces?: boolean;
+  has_registry?: boolean;
+  scan_sources?: string[];
+  scan_count?: number;
+}
+
 export interface RemediationItem {
   package: string;
   ecosystem: string;
@@ -919,20 +944,7 @@ export const api = {
   getPosture: () => get<PostureResponse>("/v1/posture"),
 
   /** Lightweight aggregate counts + scan context for nav badges */
-  getPostureCounts: () =>
-    get<{
-      critical: number;
-      high: number;
-      medium: number;
-      low: number;
-      total: number;
-      kev: number;
-      compound_issues: number;
-      has_mcp_context?: boolean;
-      has_agent_context?: boolean;
-      scan_sources?: string[];
-      scan_count?: number;
-    }>("/v1/posture/counts"),
+  getPostureCounts: () => get<PostureCountsResponse>("/v1/posture/counts"),
 
   /** Compliance posture across all completed scans */
   getCompliance: () => get<ComplianceResponse>("/v1/compliance"),

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@/lib/api', () => ({
       has_local_scan: false,
       has_fleet_ingest: false,
       has_cluster_scan: false,
+      has_ci_cd_scan: false,
       has_mesh: false,
       has_gateway: false,
       has_proxy: false,
@@ -240,6 +241,7 @@ describe('Nav', () => {
       has_local_scan: true,
       has_fleet_ingest: false,
       has_cluster_scan: false,
+      has_ci_cd_scan: false,
       has_mesh: false,
       has_gateway: false,
       has_proxy: false,
@@ -277,6 +279,7 @@ describe('Nav', () => {
       has_local_scan: true,
       has_fleet_ingest: true,
       has_cluster_scan: true,
+      has_ci_cd_scan: false,
       has_mesh: true,
       has_gateway: true,
       has_proxy: true,
@@ -295,5 +298,42 @@ describe('Nav', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /govern/i }))
     expect(screen.getAllByRole('link', { name: /^traces$/i }).some((link) => link.getAttribute('href') === '/traces')).toBe(true)
+  })
+
+  it('keeps CI-only scans from masquerading as workstation deployment context', async () => {
+    const { api } = await import('@/lib/api')
+    vi.mocked(api.getPostureCounts).mockResolvedValueOnce({
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      total: 1,
+      kev: 0,
+      compound_issues: 0,
+      deployment_mode: 'local',
+      has_mcp_context: false,
+      has_agent_context: false,
+      has_local_scan: false,
+      has_fleet_ingest: false,
+      has_cluster_scan: false,
+      has_ci_cd_scan: true,
+      has_mesh: false,
+      has_gateway: false,
+      has_proxy: false,
+      has_traces: false,
+      has_registry: false,
+      scan_sources: ['github_actions'],
+      scan_count: 1,
+    })
+
+    render(<Nav />)
+
+    await waitFor(() => {
+      expect(document.querySelector('summary')).toBeTruthy()
+    })
+
+    const agentsLink = screen.getByRole('link', { name: /^agents$/i })
+    expect(agentsLink).toHaveAttribute('href', '/agents')
+    expect(agentsLink).toHaveAttribute('title', 'Hidden until this deployment mode is detected')
   })
 })

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -26,8 +26,17 @@ vi.mock('@/lib/api', () => ({
       total: 0,
       kev: 0,
       compound_issues: 0,
+      deployment_mode: 'local',
       has_mcp_context: false,
       has_agent_context: false,
+      has_local_scan: false,
+      has_fleet_ingest: false,
+      has_cluster_scan: false,
+      has_mesh: false,
+      has_gateway: false,
+      has_proxy: false,
+      has_traces: false,
+      has_registry: false,
       scan_sources: [],
       scan_count: 0,
     }),
@@ -213,5 +222,78 @@ describe('Nav', () => {
     expect(screen.getAllByRole('link', { name: /new scan/i }).length).toBeGreaterThan(0)
     expect(screen.getAllByRole('link', { name: /proxy/i }).length).toBeGreaterThan(0)
     expect(screen.getAllByRole('link', { name: /remediation/i }).length).toBeGreaterThan(0)
+  })
+
+  it('moves inactive deployment surfaces into Unused capabilities', async () => {
+    const { api } = await import('@/lib/api')
+    vi.mocked(api.getPostureCounts).mockResolvedValueOnce({
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      total: 1,
+      kev: 0,
+      compound_issues: 0,
+      deployment_mode: 'local',
+      has_mcp_context: true,
+      has_agent_context: true,
+      has_local_scan: true,
+      has_fleet_ingest: false,
+      has_cluster_scan: false,
+      has_mesh: false,
+      has_gateway: false,
+      has_proxy: false,
+      has_traces: false,
+      has_registry: true,
+      scan_sources: ['agent_discovery', 'sbom'],
+      scan_count: 1,
+    })
+
+    render(<Nav />)
+
+    await waitFor(() => {
+      expect(document.querySelector('summary')).toBeTruthy()
+    })
+
+    expect(document.querySelector('summary')?.textContent).toContain('Unused capabilities')
+    const fleetLink = screen.getByRole('link', { name: /^fleet$/i })
+    expect(fleetLink).toHaveAttribute('href', '/fleet')
+    expect(fleetLink).toHaveAttribute('title', 'Hidden until this deployment mode is detected')
+  })
+
+  it('keeps gateway and traces visible for hybrid deployments', async () => {
+    const { api } = await import('@/lib/api')
+    vi.mocked(api.getPostureCounts).mockResolvedValueOnce({
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      total: 4,
+      kev: 0,
+      compound_issues: 0,
+      deployment_mode: 'hybrid',
+      has_mcp_context: true,
+      has_agent_context: true,
+      has_local_scan: true,
+      has_fleet_ingest: true,
+      has_cluster_scan: true,
+      has_mesh: true,
+      has_gateway: true,
+      has_proxy: true,
+      has_traces: true,
+      has_registry: true,
+      scan_sources: ['agent_discovery', 'k8s', 'sbom'],
+      scan_count: 3,
+    })
+
+    render(<Nav />)
+
+    fireEvent.click(screen.getByRole('button', { name: /protect/i }))
+    await waitFor(() => {
+      expect(screen.getAllByRole('link', { name: /^gateway$/i }).some((link) => link.getAttribute('href') === '/gateway')).toBe(true)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /govern/i }))
+    expect(screen.getAllByRole('link', { name: /^traces$/i }).some((link) => link.getAttribute('href') === '/traces')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- simplify the README deployment section into a deployment-first architecture and rollout-profile story instead of a dense pilot-only network map
- expose CI/CD scan context separately in `/v1/posture/counts` so GitHub Actions workflow scans do not masquerade as workstation deployment state
- document the new posture contract in `docs/DATA_MODEL.md` and align the product brief with the current self-hosted packaging story
- add regression coverage for CI-only posture counts and nav behavior

## Verification
- `python -m pytest -q tests/test_core.py -k "posture_counts"`
- `python -m pytest -q tests/test_api_tenant_isolation.py -k "deployment_context_by_tenant"`
- `npm run test:run -- tests/nav.test.tsx`
- `python scripts/check_release_consistency.py`