### PR TITLE
fix: make tenant-scoped stores query natively

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -143,11 +143,11 @@ list/put plus session-scoped `app.current_tenant` for RLS.
 
 | Table | Source dataclass | Notes |
 |---|---|---|
-| `scan_jobs` | `ScanJob` (api/models.py) | `tenant_id` PK component |
+| `scan_jobs` | `ScanJob` (api/models.py) | global `job_id` PK + tenant column (`team_id` / `tenant_id`) |
 | `fleet_agents` | `FleetAgent` (api/fleet_store.py) | trust score + lifecycle state |
 | `api_keys` | `ApiKey` (api/auth.py) | scrypt hashes, expiry, role, tenant |
 | `exceptions` | `Exception` (api/exceptions.py) | suppression workflow |
-| `gateway_policies` + `policy_audit_log` | `GatewayPolicy` | RBAC-gated mutations |
+| `gateway_policies` + `policy_audit_log` | `GatewayPolicy` | RBAC-gated mutations, tenant-native reads |
 | `scan_schedules` | `ScanSchedule` (api/schedule_store.py) | cron-driven |
 | `audit_log` | `AuditEntry` (api/audit_log.py) | HMAC-chained, tamper-evident |
 | `trend_history` | aggregated severity counts | for `/v1/trends` |

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -245,11 +245,17 @@ class PostgresScheduleStore:
             conn.commit()
             return cursor.rowcount > 0
 
-    def list_all(self) -> list:
+    def list_all(self, tenant_id: str | None = None) -> list:
         from .schedule_store import ScanSchedule
 
         with _tenant_connection(self._pool) as conn:
-            rows = conn.execute("SELECT data FROM scan_schedules ORDER BY schedule_id").fetchall()
+            if tenant_id is None:
+                rows = conn.execute("SELECT data FROM scan_schedules ORDER BY schedule_id").fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT data FROM scan_schedules WHERE tenant_id = %s ORDER BY schedule_id",
+                    (tenant_id,),
+                ).fetchall()
             return [ScanSchedule.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_due(self, now_iso: str) -> list:

--- a/src/agent_bom/api/routes/schedules.py
+++ b/src/agent_bom/api/routes/schedules.py
@@ -54,7 +54,7 @@ async def create_schedule(request: Request, body: ScheduleCreate) -> dict:
 async def list_schedules(request: Request) -> list[dict]:
     """List all scan schedules."""
     tenant_id = getattr(request.state, "tenant_id", "default")
-    return [s.model_dump() for s in _get_schedule_store().list_all() if s.tenant_id == tenant_id]
+    return [s.model_dump() for s in _get_schedule_store().list_all(tenant_id=tenant_id)]
 
 
 @router.get("/v1/schedules/{schedule_id}", tags=["schedules"])

--- a/src/agent_bom/api/schedule_store.py
+++ b/src/agent_bom/api/schedule_store.py
@@ -34,7 +34,7 @@ class ScheduleStore(Protocol):
     def put(self, schedule: ScanSchedule) -> None: ...
     def get(self, schedule_id: str) -> ScanSchedule | None: ...
     def delete(self, schedule_id: str) -> bool: ...
-    def list_all(self) -> list[ScanSchedule]: ...
+    def list_all(self, tenant_id: str | None = None) -> list[ScanSchedule]: ...
     def list_due(self, now_iso: str) -> list[ScanSchedule]: ...
 
 
@@ -56,8 +56,11 @@ class InMemoryScheduleStore:
             return True
         return False
 
-    def list_all(self) -> list[ScanSchedule]:
-        return list(self._schedules.values())
+    def list_all(self, tenant_id: str | None = None) -> list[ScanSchedule]:
+        schedules = list(self._schedules.values())
+        if tenant_id is None:
+            return schedules
+        return [schedule for schedule in schedules if schedule.tenant_id == tenant_id]
 
     def list_due(self, now_iso: str) -> list[ScanSchedule]:
         """Return enabled schedules where next_run <= now."""
@@ -85,17 +88,22 @@ class SQLiteScheduleStore:
                 schedule_id TEXT PRIMARY KEY,
                 enabled INTEGER DEFAULT 1,
                 next_run TEXT,
+                tenant_id TEXT NOT NULL DEFAULT 'default',
                 data TEXT NOT NULL
             )
         """)
+        cols = {r[1] for r in self._conn.execute("PRAGMA table_info(schedules)").fetchall()}
+        if "tenant_id" not in cols:
+            self._conn.execute("ALTER TABLE schedules ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_sched_due ON schedules(enabled, next_run)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_sched_tenant_due ON schedules(tenant_id, enabled, next_run)")
         self._conn.commit()
 
     def put(self, schedule: ScanSchedule) -> None:
         self._conn.execute(
-            """INSERT OR REPLACE INTO schedules (schedule_id, enabled, next_run, data)
-               VALUES (?, ?, ?, ?)""",
-            (schedule.schedule_id, int(schedule.enabled), schedule.next_run, schedule.model_dump_json()),
+            """INSERT OR REPLACE INTO schedules (schedule_id, enabled, next_run, tenant_id, data)
+               VALUES (?, ?, ?, ?, ?)""",
+            (schedule.schedule_id, int(schedule.enabled), schedule.next_run, schedule.tenant_id, schedule.model_dump_json()),
         )
         self._conn.commit()
 
@@ -110,8 +118,14 @@ class SQLiteScheduleStore:
         self._conn.commit()
         return cursor.rowcount > 0
 
-    def list_all(self) -> list[ScanSchedule]:
-        rows = self._conn.execute("SELECT data FROM schedules ORDER BY schedule_id").fetchall()
+    def list_all(self, tenant_id: str | None = None) -> list[ScanSchedule]:
+        if tenant_id is None:
+            rows = self._conn.execute("SELECT data FROM schedules ORDER BY schedule_id").fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT data FROM schedules WHERE tenant_id = ? ORDER BY schedule_id",
+                (tenant_id,),
+            ).fetchall()
         return [ScanSchedule.model_validate_json(r[0]) for r in rows]
 
     def list_due(self, now_iso: str) -> list[ScanSchedule]:

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -365,6 +365,7 @@ class SnowflakePolicyStore:
                     mode VARCHAR NOT NULL,
                     enabled BOOLEAN NOT NULL DEFAULT TRUE,
                     updated_at TIMESTAMP_TZ,
+                    tenant_id VARCHAR NOT NULL DEFAULT 'default',
                     data VARIANT NOT NULL
                 )
             """)
@@ -375,9 +376,12 @@ class SnowflakePolicyStore:
                     agent_name VARCHAR,
                     action_taken VARCHAR,
                     timestamp TIMESTAMP_TZ,
+                    tenant_id VARCHAR NOT NULL DEFAULT 'default',
                     data VARIANT NOT NULL
                 )
             """)
+            cur.execute("ALTER TABLE gateway_policies ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+            cur.execute("ALTER TABLE policy_audit_log ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
 
     # ── policies ──
 
@@ -388,22 +392,24 @@ class SnowflakePolicyStore:
                    ON t.policy_id = s.policy_id
                    WHEN MATCHED THEN UPDATE SET
                      name = %s, mode = %s, enabled = %s,
-                     updated_at = %s, data = PARSE_JSON(%s)
+                     updated_at = %s, tenant_id = %s, data = PARSE_JSON(%s)
                    WHEN NOT MATCHED THEN INSERT
-                     (policy_id, name, mode, enabled, updated_at, data)
-                     VALUES (%s, %s, %s, %s, %s, PARSE_JSON(%s))""",
+                     (policy_id, name, mode, enabled, updated_at, tenant_id, data)
+                     VALUES (%s, %s, %s, %s, %s, %s, PARSE_JSON(%s))""",
                 (
                     policy.policy_id,
                     policy.name,
                     policy.mode.value,
                     policy.enabled,
                     policy.updated_at,
+                    policy.tenant_id,
                     policy.model_dump_json(),
                     policy.policy_id,
                     policy.name,
                     policy.mode.value,
                     policy.enabled,
                     policy.updated_at,
+                    policy.tenant_id,
                     policy.model_dump_json(),
                 ),
             )
@@ -411,17 +417,14 @@ class SnowflakePolicyStore:
     def get_policy(self, policy_id: str, tenant_id: str | None = None) -> GatewayPolicy | None:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute(
-                "SELECT data FROM gateway_policies WHERE policy_id = %s",
-                (policy_id,),
-            )
+            if tenant_id is None:
+                cur.execute("SELECT data FROM gateway_policies WHERE policy_id = %s", (policy_id,))
+            else:
+                cur.execute("SELECT data FROM gateway_policies WHERE policy_id = %s AND tenant_id = %s", (policy_id, tenant_id))
             row = cur.fetchone()
             if row is None:
                 return None
-            policy = GatewayPolicy.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
-            if tenant_id is not None and policy.tenant_id != tenant_id:
-                return None
-            return policy
+            return GatewayPolicy.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
 
     def delete_policy(self, policy_id: str, tenant_id: str | None = None) -> bool:
         if tenant_id is not None and self.get_policy(policy_id, tenant_id=tenant_id) is None:
@@ -437,10 +440,11 @@ class SnowflakePolicyStore:
     def list_policies(self, tenant_id: str | None = None) -> list[GatewayPolicy]:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT data FROM gateway_policies ORDER BY name")
+            if tenant_id is None:
+                cur.execute("SELECT data FROM gateway_policies ORDER BY name")
+            else:
+                cur.execute("SELECT data FROM gateway_policies WHERE tenant_id = %s ORDER BY name", (tenant_id,))
             policies = [GatewayPolicy.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
-            if tenant_id is not None:
-                policies = [p for p in policies if p.tenant_id == tenant_id]
             return policies
 
     def get_policies_for_agent(
@@ -468,14 +472,15 @@ class SnowflakePolicyStore:
         with self._connect() as conn:
             conn.cursor().execute(
                 """INSERT INTO policy_audit_log
-                   (entry_id, policy_id, agent_name, action_taken, timestamp, data)
-                   VALUES (%s, %s, %s, %s, %s, PARSE_JSON(%s))""",
+                   (entry_id, policy_id, agent_name, action_taken, timestamp, tenant_id, data)
+                   VALUES (%s, %s, %s, %s, %s, %s, PARSE_JSON(%s))""",
                 (
                     entry.entry_id,
                     entry.policy_id,
                     entry.agent_name,
                     entry.action_taken,
                     entry.timestamp,
+                    entry.tenant_id,
                     entry.model_dump_json(),
                 ),
             )
@@ -490,6 +495,9 @@ class SnowflakePolicyStore:
         with self._connect() as conn:
             sql = "SELECT data FROM policy_audit_log WHERE 1=1"
             params: list = []
+            if tenant_id is not None:
+                sql += " AND tenant_id = %s"
+                params.append(tenant_id)
             if policy_id:
                 sql += " AND policy_id = %s"
                 params.append(policy_id)
@@ -500,7 +508,4 @@ class SnowflakePolicyStore:
             params.append(limit)
             cur = conn.cursor()
             cur.execute(sql, params)
-            entries = [PolicyAuditEntry.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
-            if tenant_id is not None:
-                entries = [e for e in entries if e.tenant_id == tenant_id]
-            return entries
+            return [PolicyAuditEntry.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -103,7 +103,7 @@ def enforce_schedule_quota(tenant_id: str, attempted: int = 1) -> None:
     limit = API_MAX_SCHEDULES_PER_TENANT
     if limit <= 0 or attempted <= 0:
         return
-    current = len([schedule for schedule in _get_schedule_store().list_all() if schedule.tenant_id == tenant_id])
+    current = len(_get_schedule_store().list_all(tenant_id=tenant_id))
     if current + attempted > limit:
         _raise_quota_exceeded(
             tenant_id=tenant_id,

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -145,6 +145,14 @@ async def test_schedule_routes_are_tenant_scoped():
     assert exc.value.status_code == 404
 
 
+def test_schedule_store_list_all_accepts_tenant_scope():
+    store = InMemoryScheduleStore()
+    store.put(_schedule("sched-alpha", "tenant-alpha"))
+    store.put(_schedule("sched-beta", "tenant-beta"))
+
+    assert [s.schedule_id for s in store.list_all(tenant_id="tenant-alpha")] == ["sched-alpha"]
+
+
 @pytest.mark.asyncio
 async def test_schedule_create_uses_authenticated_tenant():
     store = InMemoryScheduleStore()

--- a/tests/test_audit_round2.py
+++ b/tests/test_audit_round2.py
@@ -149,6 +149,7 @@ def test_sqlite_schedule_store_has_index():
         conn = sqlite3.connect(tmp.name)
         indexes = [r[1] for r in conn.execute("PRAGMA index_list('schedules')").fetchall()]
         assert "idx_sched_due" in indexes
+        assert "idx_sched_tenant_due" in indexes
         conn.close()
 
 

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -460,6 +460,7 @@ class TestSnowflakePolicyStore:
             policy_id=policy_id,
             name=name,
             updated_at=datetime.now(timezone.utc).isoformat(),
+            tenant_id="tenant-alpha",
         )
 
     def _make_audit_entry(self, entry_id="e1"):
@@ -475,6 +476,7 @@ class TestSnowflakePolicyStore:
             action_taken="blocked",
             reason="matched rule",
             timestamp=datetime.now(timezone.utc).isoformat(),
+            tenant_id="tenant-alpha",
         )
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
@@ -538,6 +540,15 @@ class TestSnowflakePolicyStore:
         assert len(result) == 2
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_list_policies_tenant_filter_is_pushed_into_sql(self, mock_connect):
+        conn = _mock_connection()
+        mock_connect.return_value = conn
+        store = self._make_store()
+        store.list_policies(tenant_id="tenant-alpha")
+        sql_calls = [str(c) for c in conn.cursor().execute.call_args_list if "gateway_policies" in str(c) and "SELECT" in str(c)]
+        assert any("tenant_id = %s" in call for call in sql_calls)
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_get_policies_for_agent_filters(self, mock_connect):
         from agent_bom.api.policy_store import GatewayPolicy
 
@@ -595,11 +606,12 @@ class TestSnowflakePolicyStore:
         conn = _mock_connection()
         mock_connect.return_value = conn
         store = self._make_store()
-        store.list_audit_entries(policy_id="p1", agent_name="test-agent", limit=50)
+        store.list_audit_entries(policy_id="p1", agent_name="test-agent", tenant_id="tenant-alpha", limit=50)
         calls = conn.cursor().execute.call_args_list
         # Check that the SQL includes both filter clauses
         sql_calls = [str(c) for c in calls if "policy_audit_log" in str(c) and "SELECT" in str(c)]
         assert len(sql_calls) > 0
+        assert any("tenant_id = %s" in call for call in sql_calls)
 
 
 # ─── Server lifespan auto-detection ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- push schedule reads and quota accounting down into store-native tenant queries instead of broad reads plus Python filtering
- add native tenant columns and tenant-filtered reads for Snowflake gateway policy and policy audit tables
- document the current control-plane tenant column reality in the data model atlas and cover the new parity expectations in tests

## Verification
- pytest -q tests/test_api_tenant_isolation.py -k schedule
- pytest -q tests/test_snowflake_stores.py -k 'policy or list_summary'
- pytest -q tests/test_audit_round2.py -k schedule_store_has_index
- python scripts/check_release_consistency.py
- pre-commit run --files docs/DATA_MODEL.md src/agent_bom/api/postgres_policy.py src/agent_bom/api/routes/schedules.py src/agent_bom/api/schedule_store.py src/agent_bom/api/snowflake_store.py src/agent_bom/api/tenant_quota.py tests/test_api_tenant_isolation.py tests/test_audit_round2.py tests/test_snowflake_stores.py