### PR TITLE
fix: preserve session and trace context in analytics

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -414,6 +414,9 @@ def log_action(action: str, actor: str = "system", resource: str = "", **details
                 "actor": entry.actor,
                 "resource": entry.resource,
                 "tenant_id": str(entry.details.get("tenant_id", "default") or "default"),
+                "session_id": str(entry.details.get("session_id", "") or ""),
+                "trace_id": str(entry.details.get("trace_id", "") or ""),
+                "request_id": str(entry.details.get("request_id", "") or ""),
             }
         )
     except Exception:

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -22,10 +22,31 @@ import queue
 import re
 import threading
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 _CLICKHOUSE_SAFE_STRING_RE = re.compile(r"[\x20-\x7E]+")
+
+
+def _coerce_clickhouse_timestamp(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    candidate = str(value).strip()
+    if not candidate:
+        return None
+    try:
+        dt = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError:
+        return candidate
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
 # ------------------------------------------------------------------
@@ -277,6 +298,7 @@ class ClickHouseAnalyticsStore:
     def _event_row(self, event: dict, *, tenant_id: str = "default") -> dict[str, Any]:
         return {
             "event_id": event.get("event_id", str(uuid.uuid4())),
+            "event_timestamp": _coerce_clickhouse_timestamp(event.get("event_timestamp") or event.get("timestamp") or event.get("ts")),
             "tenant_id": str(event.get("tenant_id") or tenant_id or "default"),
             "event_type": event.get("event_type", event.get("type", "")),
             "detector": event.get("detector", ""),
@@ -284,6 +306,10 @@ class ClickHouseAnalyticsStore:
             "tool_name": event.get("tool_name", event.get("tool", "")),
             "message": event.get("message", ""),
             "agent_name": event.get("agent_name", ""),
+            "session_id": str(event.get("session_id", "") or ""),
+            "trace_id": str(event.get("trace_id", "") or ""),
+            "request_id": str(event.get("request_id", "") or ""),
+            "source_id": str(event.get("source_id", "") or ""),
         }
 
     def record_posture(self, agent_name: str, snapshot: dict, *, tenant_id: str = "default") -> None:
@@ -352,12 +378,15 @@ class ClickHouseAnalyticsStore:
 
     def _audit_row(self, event: dict) -> dict[str, Any]:
         return {
-            "event_timestamp": event.get("timestamp"),
+            "event_timestamp": _coerce_clickhouse_timestamp(event.get("event_timestamp") or event.get("timestamp")),
             "entry_id": event.get("entry_id", str(uuid.uuid4())),
             "action": event.get("action", ""),
             "actor": event.get("actor", ""),
             "resource": event.get("resource", ""),
             "tenant_id": event.get("tenant_id", "default"),
+            "session_id": str(event.get("session_id", "") or ""),
+            "trace_id": str(event.get("trace_id", "") or ""),
+            "request_id": str(event.get("request_id", "") or ""),
         }
 
     # -- reads ---------------------------------------------------------
@@ -599,24 +628,16 @@ class BufferedAnalyticsStore:
         for kind, payload in drained:
             if kind == "scan":
                 scan_id, agent_name, vulns, tenant_id = payload
-                scan_rows.extend(
-                    self._store._scan_rows(str(scan_id), str(agent_name), list(vulns), tenant_id=str(tenant_id))
-                )
+                scan_rows.extend(self._store._scan_rows(str(scan_id), str(agent_name), list(vulns), tenant_id=str(tenant_id)))
             elif kind == "event":
                 event, tenant_id = payload
                 event_rows.append(self._store._event_row(dict(event), tenant_id=str(tenant_id)))
             elif kind == "event_batch":
                 events, tenant_id = payload
-                event_rows.extend(
-                    self._store._event_row(dict(event), tenant_id=str(tenant_id))
-                    for event in events
-                    if event
-                )
+                event_rows.extend(self._store._event_row(dict(event), tenant_id=str(tenant_id)) for event in events if event)
             elif kind == "posture":
                 agent_name, snapshot, tenant_id = payload
-                posture_rows.append(
-                    self._store._posture_row(str(agent_name), dict(snapshot), tenant_id=str(tenant_id))
-                )
+                posture_rows.append(self._store._posture_row(str(agent_name), dict(snapshot), tenant_id=str(tenant_id)))
             elif kind == "metadata":
                 metadata, tenant_id = payload
                 metadata_rows.append(self._store._metadata_row(dict(metadata), tenant_id=str(tenant_id)))
@@ -625,9 +646,7 @@ class BufferedAnalyticsStore:
                 fleet_rows.append(self._store._fleet_row(dict(snapshot)))
             elif kind == "compliance":
                 control, tenant_id = payload
-                compliance_rows.append(
-                    self._store._compliance_row(dict(control), tenant_id=str(tenant_id))
-                )
+                compliance_rows.append(self._store._compliance_row(dict(control), tenant_id=str(tenant_id)))
             elif kind == "audit":
                 (event,) = payload
                 audit_rows.append(self._store._audit_row(dict(event)))

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -60,11 +60,15 @@ def push_proxy_metrics(metrics: dict) -> None:
 async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) -> dict:
     """Ingest alerts and summary from an external proxy process."""
     from agent_bom.api.audit_log import log_action
+    from agent_bom.api.stores import _get_analytics_store
 
     actor = getattr(request.state, "api_key_name", "") or "proxy-client"
     tenant_id = getattr(request.state, "tenant_id", "default")
+    request_id = getattr(request.state, "request_id", "") or ""
+    trace_id = getattr(request.state, "trace_id", "") or ""
     source_id = body.source_id or "unknown"
     session_id = body.session_id or "default"
+    analytics_events: list[dict] = []
     if body.idempotency_key:
         cached = _get_idempotency_store().get("/v1/proxy/audit", tenant_id, source_id, body.idempotency_key)
         if cached is not None:
@@ -75,13 +79,40 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         enriched = dict(alert)
         enriched.setdefault("source_id", source_id)
         enriched.setdefault("session_id", session_id)
+        enriched.setdefault("request_id", request_id)
+        enriched.setdefault("trace_id", trace_id)
         push_proxy_alert(enriched)
+        analytics_events.append(
+            {
+                "event_id": enriched.get("event_id", ""),
+                "event_timestamp": enriched.get("timestamp") or enriched.get("ts"),
+                "tenant_id": tenant_id,
+                "event_type": enriched.get("event_type", enriched.get("type", "runtime_alert")),
+                "detector": enriched.get("detector", ""),
+                "severity": enriched.get("severity", "INFO"),
+                "tool_name": enriched.get("tool_name", enriched.get("tool", "")),
+                "message": enriched.get("message", ""),
+                "agent_name": enriched.get("agent_name", ""),
+                "session_id": enriched.get("session_id", ""),
+                "trace_id": enriched.get("trace_id", ""),
+                "request_id": enriched.get("request_id", ""),
+                "source_id": enriched.get("source_id", ""),
+            }
+        )
 
     if body.summary:
         summary = dict(body.summary)
         summary.setdefault("source_id", source_id)
         summary.setdefault("session_id", session_id)
+        summary.setdefault("request_id", request_id)
+        summary.setdefault("trace_id", trace_id)
         push_proxy_metrics(summary)
+
+    if analytics_events:
+        try:
+            _get_analytics_store().record_events(analytics_events, tenant_id=tenant_id)
+        except Exception:
+            pass
 
     log_action(
         "proxy.audit_ingested",
@@ -89,6 +120,8 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         resource=f"proxy/{source_id}",
         tenant_id=tenant_id,
         session_id=session_id,
+        request_id=request_id,
+        trace_id=trace_id,
         alert_count=len(body.alerts),
         has_summary=body.summary is not None,
     )

--- a/src/agent_bom/cloud/clickhouse.py
+++ b/src/agent_bom/cloud/clickhouse.py
@@ -118,7 +118,7 @@ class ClickHouseClient:
                 # modern ClickHouse. Older clusters may return a transient
                 # error on repeat runs; log and continue so ensure_tables
                 # stays safe to call on every process start.
-                logger.debug("ClickHouse migration skipped (%s): %s", exc, migration.split('\n', 1)[0])
+                logger.debug("ClickHouse migration skipped (%s): %s", exc, migration.split("\n", 1)[0])
         logger.info("ClickHouse analytics tables ensured in database '%s'", self.database)
 
 
@@ -158,7 +158,11 @@ CREATE TABLE IF NOT EXISTS runtime_events (
     severity LowCardinality(String),
     tool_name String,
     message String,
-    agent_name String
+    agent_name String,
+    session_id String DEFAULT '',
+    trace_id String DEFAULT '',
+    request_id String DEFAULT '',
+    source_id String DEFAULT ''
 ) ENGINE = MergeTree()
 ORDER BY (event_timestamp, event_type, agent_name)
 PARTITION BY toYYYYMM(event_timestamp)""",
@@ -240,7 +244,10 @@ CREATE TABLE IF NOT EXISTS audit_events (
     action LowCardinality(String),
     actor String,
     resource String,
-    tenant_id String
+    tenant_id String,
+    session_id String DEFAULT '',
+    trace_id String DEFAULT '',
+    request_id String DEFAULT ''
 ) ENGINE = MergeTree()
 ORDER BY (event_timestamp, tenant_id, action)
 PARTITION BY toYYYYMM(event_timestamp)
@@ -255,7 +262,14 @@ TTL event_timestamp + INTERVAL 2 YEAR""",
 _TABLE_MIGRATIONS: list[str] = [
     "ALTER TABLE vulnerability_scans ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default'",
     "ALTER TABLE runtime_events ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default'",
+    "ALTER TABLE runtime_events ADD COLUMN IF NOT EXISTS session_id String DEFAULT ''",
+    "ALTER TABLE runtime_events ADD COLUMN IF NOT EXISTS trace_id String DEFAULT ''",
+    "ALTER TABLE runtime_events ADD COLUMN IF NOT EXISTS request_id String DEFAULT ''",
+    "ALTER TABLE runtime_events ADD COLUMN IF NOT EXISTS source_id String DEFAULT ''",
     "ALTER TABLE posture_scores ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default'",
     "ALTER TABLE scan_metadata ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default'",
     "ALTER TABLE compliance_controls ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default'",
+    "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS session_id String DEFAULT ''",
+    "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS trace_id String DEFAULT ''",
+    "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS request_id String DEFAULT ''",
 ]

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -6,7 +6,9 @@ import json
 import os
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import (
@@ -186,6 +188,50 @@ def test_proxy_audit_ingest_updates_alerts_and_status():
 
 def test_proxy_audit_ingest_is_idempotent():
     import agent_bom.api.routes.proxy as proxy_mod
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+
+
+@pytest.mark.asyncio
+async def test_proxy_audit_ingest_records_analytics_with_session_trace_context(monkeypatch):
+    import agent_bom.api.routes.proxy as proxy_mod
+    from agent_bom.api.models import ProxyAuditIngestRequest
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+
+    class _Analytics:
+        def __init__(self):
+            self.events = []
+            self.tenants = []
+
+        def record_events(self, events, *, tenant_id="default"):
+            self.events.extend(events)
+            self.tenants.append(tenant_id)
+
+    analytics = _Analytics()
+    monkeypatch.setattr("agent_bom.api.stores._get_analytics_store", lambda: analytics)
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            api_key_name="tenant-analyst",
+            tenant_id="tenant-alpha",
+            request_id="req-1",
+            trace_id="0123456789abcdef0123456789abcdef",
+        )
+    )
+    payload = ProxyAuditIngestRequest(
+        source_id="laptop-1",
+        session_id="sess-1",
+        alerts=[{"type": "runtime_alert", "detector": "credential_leak", "severity": "critical", "message": "AWS key"}],
+    )
+    resp = await proxy_mod.ingest_proxy_audit(request, payload)
+    assert resp["ingested"] is True
+    assert analytics.tenants == ["tenant-alpha"]
+    assert analytics.events[0]["session_id"] == "sess-1"
+    assert analytics.events[0]["source_id"] == "laptop-1"
+    assert analytics.events[0]["request_id"] == "req-1"
+    assert analytics.events[0]["trace_id"] == "0123456789abcdef0123456789abcdef"
 
     proxy_mod._proxy_alerts.clear()
     proxy_mod._proxy_metrics = None

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -329,6 +329,52 @@ class TestClickHouseAnalyticsStore:
         assert len(inserted["rows"]) == 2
         assert inserted["rows"][0]["event_type"] == "vulnerable_tool_call"
 
+    def test_audit_and_runtime_rows_preserve_correlation_fields(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        inserted: list[tuple[str, list[dict]]] = []
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                inserted.append((table, rows))
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_event(
+                {
+                    "event_type": "runtime_alert",
+                    "session_id": "sess-1",
+                    "trace_id": "trace-1",
+                    "request_id": "req-1",
+                    "source_id": "proxy-a",
+                    "timestamp": "2026-04-20T12:00:01Z",
+                },
+                tenant_id="tenant-alpha",
+            )
+            store.record_audit_event(
+                {
+                    "action": "proxy.audit_ingested",
+                    "tenant_id": "tenant-alpha",
+                    "session_id": "sess-1",
+                    "trace_id": "trace-1",
+                    "request_id": "req-1",
+                    "timestamp": "2026-04-20T12:00:02Z",
+                }
+            )
+
+        runtime_row = next(rows[0] for table, rows in inserted if table == "runtime_events")
+        audit_row = next(rows[0] for table, rows in inserted if table == "audit_events")
+        assert runtime_row["session_id"] == "sess-1"
+        assert runtime_row["trace_id"] == "trace-1"
+        assert runtime_row["request_id"] == "req-1"
+        assert runtime_row["source_id"] == "proxy-a"
+        assert audit_row["session_id"] == "sess-1"
+        assert audit_row["trace_id"] == "trace-1"
+        assert audit_row["request_id"] == "req-1"
+
 
 def test_clickhouse_escape_strips_control_chars_and_quotes():
     from agent_bom.api.clickhouse_store import _escape

--- a/tests/test_clickhouse_tenant_isolation.py
+++ b/tests/test_clickhouse_tenant_isolation.py
@@ -77,10 +77,25 @@ class TestWritesCarryTenantId:
 
     def test_record_event(self) -> None:
         store, cap = _make_store()
-        store.record_event({"event_type": "tool_call", "severity": "HIGH"}, tenant_id="tenant-b")
+        store.record_event(
+            {
+                "event_type": "tool_call",
+                "severity": "HIGH",
+                "session_id": "sess-1",
+                "trace_id": "trace-1",
+                "request_id": "req-1",
+                "source_id": "proxy-a",
+                "timestamp": "2026-04-20T12:00:01Z",
+            },
+            tenant_id="tenant-b",
+        )
         table, rows = cap.inserts[0]
         assert table == "runtime_events"
         assert rows[0]["tenant_id"] == "tenant-b"
+        assert rows[0]["session_id"] == "sess-1"
+        assert rows[0]["trace_id"] == "trace-1"
+        assert rows[0]["request_id"] == "req-1"
+        assert rows[0]["source_id"] == "proxy-a"
 
     def test_record_events_batch(self) -> None:
         store, cap = _make_store()
@@ -145,17 +160,13 @@ class TestReadsApplyTenantFilter:
             ("query_compliance_heatmap", {"days": 30}, "compliance_controls"),
         ],
     )
-    def test_tenant_predicate_present(
-        self, method: str, kwargs: dict[str, Any], expected_table: str
-    ) -> None:
+    def test_tenant_predicate_present(self, method: str, kwargs: dict[str, Any], expected_table: str) -> None:
         store, cap = _make_store()
         getattr(store, method)(tenant_id="tenant-a", **kwargs)
         assert cap.queries, f"{method} must issue a query"
         query = cap.queries[0]
         assert expected_table in query, f"{method} must read from {expected_table}"
-        assert "tenant_id = 'tenant-a'" in query, (
-            f"{method} must include tenant predicate; actual:\n{query}"
-        )
+        assert "tenant_id = 'tenant-a'" in query, f"{method} must include tenant predicate; actual:\n{query}"
 
     @pytest.mark.parametrize(
         "method,kwargs",
@@ -173,9 +184,7 @@ class TestReadsApplyTenantFilter:
         store, cap = _make_store()
         getattr(store, method)(**kwargs)
         query = cap.queries[0]
-        assert "tenant_id =" not in query, (
-            f"{method} without tenant_id must not inject a tenant predicate; actual:\n{query}"
-        )
+        assert "tenant_id =" not in query, f"{method} without tenant_id must not inject a tenant predicate; actual:\n{query}"
 
     def test_tenant_id_is_escaped(self) -> None:
         """Tenant identifiers that contain SQL metacharacters must not break queries."""
@@ -245,8 +254,7 @@ class TestMigrationCoverage:
         }
         for table in required:
             assert any(
-                migration.startswith(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS tenant_id")
-                for migration in _TABLE_MIGRATIONS
+                migration.startswith(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS tenant_id") for migration in _TABLE_MIGRATIONS
             ), f"Missing ALTER migration for table '{table}'"
 
     def test_ensure_tables_runs_migrations(self) -> None:


### PR DESCRIPTION
## Summary
- persist proxy-ingested runtime alerts into analytics instead of only the in-process rings and audit log
- extend ClickHouse runtime and audit event rows with session, trace, request, source, and event timestamp correlation fields
- carry those correlation fields through audit analytics sync and cover the contract with proxy and ClickHouse regression tests

## Verification
- pytest -q tests/test_api_proxy_scorecard.py tests/test_clickhouse.py tests/test_clickhouse_tenant_isolation.py
- python scripts/check_release_consistency.py
- pre-commit run --files src/agent_bom/api/audit_log.py src/agent_bom/api/clickhouse_store.py src/agent_bom/api/routes/proxy.py src/agent_bom/cloud/clickhouse.py tests/test_api_proxy_scorecard.py tests/test_clickhouse.py tests/test_clickhouse_tenant_isolation.py