### PR TITLE
fix: tenant-scope baseline compare and trends

### DIFF
--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -201,13 +201,20 @@ class PostgresTrendStore:
             )
             conn.commit()
 
-    def get_history(self, limit: int = 30) -> list[TrendPoint]:
-        with _tenant_connection(self._pool) as conn:
-            rows = conn.execute(
-                "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade "
-                "FROM trend_history ORDER BY timestamp DESC LIMIT %s",
-                (limit,),
-            ).fetchall()
+    def get_history(self, limit: int = 30, tenant_id: str | None = None) -> list[TrendPoint]:
+        token = None
+        if tenant_id is not None:
+            token = _current_tenant.set(tenant_id)
+        try:
+            with _tenant_connection(self._pool) as conn:
+                rows = conn.execute(
+                    "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade "
+                    "FROM trend_history ORDER BY timestamp DESC LIMIT %s",
+                    (limit,),
+                ).fetchall()
+        finally:
+            if token is not None:
+                _current_tenant.reset(token)
         return [
             TrendPoint(
                 timestamp=row[0],
@@ -218,6 +225,7 @@ class PostgresTrendStore:
                 low=row[5],
                 posture_score=row[6],
                 posture_grade=row[7],
+                tenant_id=tenant_id or _current_tenant.get(),
             )
             for row in rows
         ]

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -520,13 +520,20 @@ async def delete_exception(request: Request, exception_id: str) -> None:
 
 
 @router.post("/v1/baseline/compare", tags=["enterprise"])
-async def compare_baseline(previous_job_id: str = "", current_job_id: str = "") -> dict:
+async def compare_baseline(request: Request, previous_job_id: str = "", current_job_id: str = "") -> dict:
     """Compare two scan results to show new, resolved, and persistent vulnerabilities."""
+    from agent_bom.api.audit_log import log_action
     from agent_bom.baseline import compare_reports
 
     store = _get_store()
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    actor = getattr(request.state, "api_key_name", "") or "system"
     prev_job = store.get(previous_job_id) if previous_job_id else None
     curr_job = store.get(current_job_id) if current_job_id else None
+    if previous_job_id and (prev_job is None or prev_job.tenant_id != tenant_id):
+        raise HTTPException(status_code=404, detail="Previous job not found")
+    if current_job_id and (curr_job is None or curr_job.tenant_id != tenant_id):
+        raise HTTPException(status_code=404, detail="Current job not found")
 
     prev_report = prev_job.result if prev_job and prev_job.result else {}
     curr_report = curr_job.result if curr_job and curr_job.result else {}
@@ -535,13 +542,26 @@ async def compare_baseline(previous_job_id: str = "", current_job_id: str = "") 
         raise HTTPException(status_code=404, detail="At least one valid job_id required")
 
     diff = compare_reports(prev_report, curr_report)
+    log_action(
+        "baseline.compare",
+        actor=actor,
+        resource="baseline/compare",
+        tenant_id=tenant_id,
+        previous_job_id=previous_job_id,
+        current_job_id=current_job_id,
+    )
     return diff.to_dict()
 
 
 @router.get("/v1/trends", tags=["enterprise"])
-async def get_trends(limit: int = 30) -> dict:
+async def get_trends(request: Request, limit: int = 30) -> dict:
     """Get historical trend data — posture score and vuln counts over time."""
-    history = _get_trend_store().get_history(limit=limit)
+    from agent_bom.api.audit_log import log_action
+
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    actor = getattr(request.state, "api_key_name", "") or "system"
+    history = _get_trend_store().get_history(limit=limit, tenant_id=tenant_id)
+    log_action("trends.view", actor=actor, resource="trends", tenant_id=tenant_id, limit=limit)
     return {
         "data_points": [p.to_dict() for p in history],
         "count": len(history),

--- a/src/agent_bom/baseline.py
+++ b/src/agent_bom/baseline.py
@@ -134,6 +134,7 @@ class TrendPoint:
     low: int
     posture_score: float
     posture_grade: str
+    tenant_id: str = "default"
 
     def to_dict(self) -> dict:
         return {
@@ -152,7 +153,7 @@ class TrendStore(Protocol):
     """Protocol for trend data persistence."""
 
     def record(self, point: TrendPoint) -> None: ...
-    def get_history(self, limit: int = 30) -> list[TrendPoint]: ...
+    def get_history(self, limit: int = 30, tenant_id: str | None = None) -> list[TrendPoint]: ...
 
 
 class InMemoryTrendStore:
@@ -168,9 +169,12 @@ class InMemoryTrendStore:
             if len(self._points) > self._MAX_POINTS:
                 self._points = self._points[-self._MAX_POINTS :]
 
-    def get_history(self, limit: int = 30) -> list[TrendPoint]:
+    def get_history(self, limit: int = 30, tenant_id: str | None = None) -> list[TrendPoint]:
         with self._lock:
-            return list(reversed(self._points[-limit:]))
+            points = self._points
+            if tenant_id is not None:
+                points = [point for point in points if point.tenant_id == tenant_id]
+            return list(reversed(points[-limit:]))
 
 
 class SQLiteTrendStore:
@@ -190,6 +194,7 @@ class SQLiteTrendStore:
         self._conn.execute("""CREATE TABLE IF NOT EXISTS trend_history (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             timestamp TEXT NOT NULL,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             total_vulns INTEGER NOT NULL,
             critical INTEGER NOT NULL DEFAULT 0,
             high INTEGER NOT NULL DEFAULT 0,
@@ -199,14 +204,19 @@ class SQLiteTrendStore:
             posture_grade TEXT NOT NULL DEFAULT ''
         )""")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_trend_ts ON trend_history(timestamp)")
+        cols = {row[1] for row in self._conn.execute("PRAGMA table_info(trend_history)").fetchall()}
+        if "tenant_id" not in cols:
+            self._conn.execute("ALTER TABLE trend_history ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_trend_tenant_ts ON trend_history(tenant_id, timestamp)")
         self._conn.commit()
 
     def record(self, point: TrendPoint) -> None:
         self._conn.execute(
-            "INSERT INTO trend_history (timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO trend_history (timestamp, tenant_id, total_vulns, critical, high, medium, low, posture_score, posture_grade) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 point.timestamp,
+                point.tenant_id,
                 point.total_vulns,
                 point.critical,
                 point.high,
@@ -218,15 +228,30 @@ class SQLiteTrendStore:
         )
         self._conn.commit()
 
-    def get_history(self, limit: int = 30) -> list[TrendPoint]:
-        rows = self._conn.execute(
-            "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade "
-            "FROM trend_history ORDER BY timestamp DESC LIMIT ?",
-            (limit,),
-        ).fetchall()
+    def get_history(self, limit: int = 30, tenant_id: str | None = None) -> list[TrendPoint]:
+        if tenant_id is None:
+            rows = self._conn.execute(
+                "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade, tenant_id "
+                "FROM trend_history ORDER BY timestamp DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT timestamp, total_vulns, critical, high, medium, low, posture_score, posture_grade, tenant_id "
+                "FROM trend_history WHERE tenant_id = ? ORDER BY timestamp DESC LIMIT ?",
+                (tenant_id, limit),
+            ).fetchall()
         return [
             TrendPoint(
-                timestamp=r[0], total_vulns=r[1], critical=r[2], high=r[3], medium=r[4], low=r[5], posture_score=r[6], posture_grade=r[7]
+                timestamp=r[0],
+                total_vulns=r[1],
+                critical=r[2],
+                high=r[3],
+                medium=r[4],
+                low=r[5],
+                posture_score=r[6],
+                posture_grade=r[7],
+                tenant_id=r[8] if len(r) > 8 else "default",
             )
             for r in rows
         ]

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -11,12 +11,37 @@ from fastapi import HTTPException
 from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
 from agent_bom.api.exception_store import InMemoryExceptionStore, VulnException
-from agent_bom.api.models import CreateKeyRequest, RotateKeyRequest
+from agent_bom.api.models import CreateKeyRequest, JobStatus, RotateKeyRequest, ScanJob, ScanRequest
 from agent_bom.api.routes import enterprise
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store, _get_trend_store, set_job_store, set_trend_store
+from agent_bom.baseline import InMemoryTrendStore, TrendPoint
 
 
 def _request(tenant_id: str, api_key_name: str = "tenant-admin") -> SimpleNamespace:
     return SimpleNamespace(state=SimpleNamespace(tenant_id=tenant_id, api_key_name=api_key_name))
+
+
+@pytest.fixture
+def isolated_job_store():
+    original = _get_store()
+    store = InMemoryJobStore()
+    set_job_store(store)
+    try:
+        yield store
+    finally:
+        set_job_store(original)
+
+
+@pytest.fixture
+def isolated_trend_store():
+    original = _get_trend_store()
+    store = InMemoryTrendStore()
+    set_trend_store(store)
+    try:
+        yield store
+    finally:
+        set_trend_store(original)
 
 
 @pytest.fixture
@@ -266,3 +291,70 @@ async def test_export_audit_entries_rejects_unknown_format():
         await enterprise.export_audit_entries(_request("tenant-alpha"), format="csv")
 
     assert error.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_compare_baseline_is_tenant_scoped(isolated_job_store):
+    alpha_job = ScanJob(
+        job_id="job-alpha",
+        tenant_id="tenant-alpha",
+        status=JobStatus.DONE,
+        created_at="2026-04-20T00:00:00Z",
+        completed_at="2026-04-20T00:01:00Z",
+        request=ScanRequest(),
+        result={"blast_radius": [{"vulnerability_id": "CVE-alpha", "package": "alpha@1.0.0", "severity": "high"}]},
+    )
+    beta_job = ScanJob(
+        job_id="job-beta",
+        tenant_id="tenant-beta",
+        status=JobStatus.DONE,
+        created_at="2026-04-20T00:00:00Z",
+        completed_at="2026-04-20T00:01:00Z",
+        request=ScanRequest(),
+        result={"blast_radius": [{"vulnerability_id": "CVE-beta", "package": "beta@1.0.0", "severity": "critical"}]},
+    )
+    isolated_job_store.put(alpha_job)
+    isolated_job_store.put(beta_job)
+
+    diff = await enterprise.compare_baseline(_request("tenant-alpha"), previous_job_id="job-alpha")
+    assert diff["persistent_count"] == 0
+    assert diff["resolved_count"] == 1
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.compare_baseline(_request("tenant-alpha"), previous_job_id="job-beta")
+
+    assert error.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_trends_is_tenant_scoped(isolated_trend_store):
+    isolated_trend_store.record(
+        TrendPoint(
+            timestamp="2026-04-20T00:00:00Z",
+            total_vulns=5,
+            critical=1,
+            high=2,
+            medium=1,
+            low=1,
+            posture_score=72.0,
+            posture_grade="C",
+            tenant_id="tenant-alpha",
+        )
+    )
+    isolated_trend_store.record(
+        TrendPoint(
+            timestamp="2026-04-20T01:00:00Z",
+            total_vulns=1,
+            critical=0,
+            high=1,
+            medium=0,
+            low=0,
+            posture_score=91.0,
+            posture_grade="A",
+            tenant_id="tenant-beta",
+        )
+    )
+
+    result = await enterprise.get_trends(_request("tenant-alpha"), limit=30)
+    assert result["count"] == 1
+    assert result["data_points"][0]["total_vulns"] == 5

--- a/tests/test_enterprise_gaps.py
+++ b/tests/test_enterprise_gaps.py
@@ -417,6 +417,8 @@ class TestTrendAnalysis:
         assert len(history) == 3
         # Most recent first
         assert history[0].timestamp == "2026-03-05"
+        assert len(store.get_history(limit=10, tenant_id="default")) == 5
+        assert store.get_history(limit=10, tenant_id="tenant-beta") == []
 
     def test_sqlite_trend_store(self, tmp_path):
         from agent_bom.baseline import SQLiteTrendStore, TrendPoint
@@ -435,9 +437,28 @@ class TestTrendAnalysis:
                 posture_grade="B",
             )
         )
+        store.record(
+            TrendPoint(
+                timestamp="2026-03-02T00:00:00",
+                total_vulns=3,
+                critical=0,
+                high=1,
+                medium=1,
+                low=1,
+                posture_score=92.0,
+                posture_grade="A",
+                tenant_id="tenant-beta",
+            )
+        )
         history = store.get_history()
-        assert len(history) == 1
-        assert history[0].total_vulns == 10
+        assert len(history) == 2
+        assert [point.total_vulns for point in history] == [3, 10]
+        alpha = store.get_history(tenant_id="default")
+        beta = store.get_history(tenant_id="tenant-beta")
+        assert len(alpha) == 1
+        assert len(beta) == 1
+        assert alpha[0].total_vulns == 10
+        assert beta[0].total_vulns == 3
 
     def test_trend_point_to_dict(self):
         from agent_bom.baseline import TrendPoint


### PR DESCRIPTION
## Summary
- scope `/v1/baseline/compare` to the authenticated tenant instead of comparing arbitrary scan jobs across tenants
- scope `/v1/trends` natively by tenant across in-memory, SQLite, and Postgres trend stores
- add regression coverage for tenant-scoped baseline compare and tenant-filtered trend history in enterprise routes and store tests

## Verification
- `pytest -q tests/test_api_enterprise_tenant.py tests/test_enterprise_gaps.py tests/test_postgres_store.py -k "baseline or trend or tenant or audit"`
- `python scripts/check_release_consistency.py`
