### PR TITLE
feat(runtime): VisualLeakDetector — OCR + redact sensitive data in MCP screenshot/image tool responses (closes #1568)

### DIFF
--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -94,12 +94,23 @@ agent-bom scans laptop editor configs for **30+ MCP client surfaces** (Cursor, C
 
 ### 2.2 Credential + PII leakage: "What if an MCP response leaks our AWS keys or customer PII?"
 
-[`CredentialLeakDetector`](../src/agent_bom/runtime/detectors.py) (detectors.py:305) scans every tool-call response for **AWS access keys, GitHub tokens, OpenAI keys, generic bearer tokens, SSH keys, database URLs with embedded credentials, email addresses, phone numbers, SSNs, credit card numbers**. Pattern list lives in [`runtime/patterns.py`](../src/agent_bom/runtime/patterns.py).
+Two channels — text and visual — both covered:
 
-- **Detect + alert** — called inside `run_proxy` on every response.
-- **Redact in place** — `Shield.redact(text)` returns a sanitized string. Usable from any agent framework via the SDK.
-- **Severity-tagged** — credentials are `CRITICAL`, PII is `HIGH`.
-- **Tests** — [`tests/test_runtime_credential_leak.py`](../tests/test_runtime_credential_leak.py).
+**Text channel — [`CredentialLeakDetector`](../src/agent_bom/runtime/detectors.py)** scans every tool-call response for **AWS access keys, GitHub tokens, OpenAI keys, generic bearer tokens, SSH keys, database URLs with embedded credentials, email addresses, phone numbers, SSNs, credit card numbers**. Pattern list in [`runtime/patterns.py`](../src/agent_bom/runtime/patterns.py).
+
+- Detect + alert — called inside `run_proxy` on every response.
+- Redact in place — `Shield.redact(text)` returns a sanitized string.
+- Severity-tagged — credentials are `CRITICAL`, PII is `HIGH`.
+- Tests: [`tests/test_runtime_credential_leak.py`](../tests/test_runtime_credential_leak.py).
+
+**Visual channel — [`VisualLeakDetector`](../src/agent_bom/runtime/visual_leak_detector.py)** (opt-in: `pip install 'agent-bom[visual]'`). MCPs wrapping browsers or screen-capture tools (Playwright-MCP, Puppeteer-MCP, Cursor/Claude screen-read) can leak creds + PII through pixels the text scanner misses.
+
+- OCRs every image block in an MCP `content: [{"type": "image", ...}]` response via pytesseract.
+- Feeds extracted text through the *same* patterns the text scanner uses — one source of truth.
+- Paints black boxes over matched OCR bounding rectangles; returns a new content-block list without mutating the original.
+- Degrades gracefully when pytesseract / tesseract binary are absent.
+- Policy hook: `deny_tool_classes: ["screen_capture"]` in a gateway policy blocks any tool whose name matches `screenshot` / `page_screenshot` / `take_screenshot` / `capture_screen` before the upstream is touched. Classifier in [`proxy_policy.py _classify_tool_classes`](../src/agent_bom/proxy_policy.py).
+- Tests: [`tests/test_visual_leak_detector.py`](../tests/test_visual_leak_detector.py).
 
 ### 2.3 Malicious packages: "What if an employee installs a typosquat or OSSF-flagged malicious package?"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,13 @@ pdf = []
 postgres = ["psycopg[binary]>=3.1", "psycopg-pool>=3.1"]
 watch = ["watchdog>=4.0"]
 runtime = ["psutil>=5.9"]  # Process + container discovery (--include-processes)
+visual = [
+    # Visual-leak detection on MCP screenshot/image tool responses.
+    # Opt-in because OCR is CPU-heavy — pilots without screen-capture MCPs
+    # don't pay for pytesseract at runtime. See issue #1568.
+    "Pillow>=10.0",
+    "pytesseract>=0.3.10",
+]
 mcp-server = [
     "mcp>=1.26",
     "smithery>=0.4",

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -123,6 +123,15 @@ def _classify_tool_classes(tool_name: str, arguments: dict) -> set[str]:
         classes.add("database")
     if any(term in lowered for term in ("file", "path", "directory", "filesystem")) or _extract_argument_paths(arguments):
         classes.add("filesystem")
+    # Screen-capture classification — matches browser / Playwright / Puppeteer
+    # tool names. Policies can deny this class wholesale via
+    # ``deny_tool_classes: ["screen_capture"]`` when an MCP has no business
+    # producing pixels in the pilot environment (see issue #1568).
+    if any(
+        term in tool_name.lower()
+        for term in ("screenshot", "screen_capture", "screencap", "capture_screen", "take_screenshot", "page_screenshot")
+    ):
+        classes.add("screen_capture")
     return classes
 
 

--- a/src/agent_bom/runtime/visual_leak_detector.py
+++ b/src/agent_bom/runtime/visual_leak_detector.py
@@ -1,0 +1,287 @@
+"""Visual-leak detection for MCP screenshot / image tool responses.
+
+Any MCP that wraps a browser or screen-capture tool (Playwright-MCP,
+Puppeteer-MCP, Cursor / Claude screen-read tools) can capture
+credentials, PII, customer data, and internal URLs through pixels.
+``CredentialLeakDetector`` only scans text responses; this detector
+closes the visual channel.
+
+Design: see ``docs/SECURITY_AUTH_TENANCY_AUDIT.md`` §Appendix and
+issue #1568.
+
+Opt-in install:
+
+    pip install 'agent-bom[visual]'
+
+This adds ``Pillow`` + ``pytesseract``. The detector degrades
+gracefully when either is missing — it returns an empty alert list
+rather than crashing, so pilots can enable it incrementally.
+
+Wire shape:
+
+    from agent_bom.runtime.visual_leak_detector import VisualLeakDetector
+
+    detector = VisualLeakDetector()
+    alerts = detector.check(tool_name, mcp_content_blocks)
+    redacted = detector.redact(mcp_content_blocks)
+
+Where ``mcp_content_blocks`` is the list the MCP protocol wraps image
+tool responses in::
+
+    [{"type": "image", "data": "<base64 png/jpg>", "mimeType": "image/png"}]
+
+The redactor paints opaque boxes over the OCR bounding rectangles that
+matched a credential or PII pattern and returns a new list with updated
+``data`` — the original blocks are never mutated.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from agent_bom.runtime.detectors import Alert, AlertSeverity
+from agent_bom.runtime.patterns import CREDENTIAL_PATTERNS, PII_PATTERNS
+
+logger = logging.getLogger(__name__)
+
+# MCP content-block keys
+_IMAGE_TYPE = "image"
+_DATA_KEY = "data"
+_MIMETYPE_KEY = "mimeType"
+
+
+@dataclass(frozen=True)
+class _Match:
+    """One OCR region that matched a credential or PII pattern."""
+
+    bbox: tuple[int, int, int, int]  # (left, top, right, bottom) in pixels
+    label: str  # e.g. "AWS Access Key" or "Email Address"
+    category: str  # "credential_leak" | "pii_leak"
+
+
+def _ocr_available() -> bool:
+    """Return True if pytesseract + Pillow are importable and tesseract is on PATH."""
+    try:
+        import pytesseract  # noqa: F401
+        from PIL import Image  # noqa: F401
+    except ImportError:
+        return False
+    try:
+        import pytesseract  # noqa: PLC0415
+
+        pytesseract.get_tesseract_version()
+    except Exception:  # noqa: BLE001 — tesseract binary may be missing even if python shim is installed
+        return False
+    return True
+
+
+def _decode_image(block: dict[str, Any]):
+    """Decode a single MCP image content block into a PIL Image, or None."""
+    from PIL import Image
+
+    raw = block.get(_DATA_KEY)
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        buf = base64.b64decode(raw, validate=True)
+    except (ValueError, TypeError):
+        return None
+    try:
+        return Image.open(io.BytesIO(buf))
+    except Exception:  # noqa: BLE001 — Pillow raises many specific classes here
+        return None
+
+
+def _encode_image(img, mime_type: str) -> str:
+    """Re-encode a PIL Image back to the MCP data URI base64 shape."""
+    from PIL import Image  # noqa: F401
+
+    fmt = "PNG" if mime_type.endswith("png") else "JPEG"
+    buf = io.BytesIO()
+    img.convert("RGB").save(buf, format=fmt)
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _extract_word_boxes(img) -> list[tuple[str, tuple[int, int, int, int]]]:
+    """Return [(word, bbox)] for every OCR-recognised word above the confidence floor."""
+    import pytesseract
+
+    raw = pytesseract.image_to_data(img, output_type=pytesseract.Output.DICT)
+    out: list[tuple[str, tuple[int, int, int, int]]] = []
+    words = raw.get("text", [])
+    confs = raw.get("conf", [])
+    lefts = raw.get("left", [])
+    tops = raw.get("top", [])
+    widths = raw.get("width", [])
+    heights = raw.get("height", [])
+    for idx, word in enumerate(words):
+        if not word or not word.strip():
+            continue
+        try:
+            conf = float(confs[idx])
+        except (TypeError, ValueError):
+            conf = -1.0
+        if conf < 40.0:
+            continue
+        bbox = (int(lefts[idx]), int(tops[idx]), int(lefts[idx]) + int(widths[idx]), int(tops[idx]) + int(heights[idx]))
+        out.append((word, bbox))
+    return out
+
+
+def _match_patterns(
+    words: list[tuple[str, tuple[int, int, int, int]]],
+    patterns: Iterable[tuple[str, re.Pattern]],
+    category: str,
+) -> list[_Match]:
+    """For each pattern, join OCR words into line-ish fragments and emit matches.
+
+    Two passes:
+      1. Single-word — matches single-token secrets like AWS access keys.
+      2. 3-word sliding window — matches patterns that span whitespace
+         (``api_key = ABCD...``). Windows that fully contain an
+         already-matched single-word bbox are skipped, so one secret on
+         the image produces one alert, not three.
+    """
+    matches: list[_Match] = []
+    matched_word_indices: set[int] = set()
+
+    # Single-word pass
+    for idx, (word, bbox) in enumerate(words):
+        for label, pat in patterns:
+            if pat.search(word):
+                matches.append(_Match(bbox=bbox, label=label, category=category))
+                matched_word_indices.add(idx)
+                break  # avoid double-counting one word under two patterns
+
+    # Multi-word sliding window (3-word)
+    for i in range(len(words) - 2):
+        # Skip windows that already contain a single-word hit — the inner
+        # match is the authoritative bbox; widening to the window doesn't
+        # help the redactor.
+        if matched_word_indices & {i, i + 1, i + 2}:
+            continue
+        joined = " ".join(w for w, _ in words[i : i + 3])
+        for label, pat in patterns:
+            if pat.search(joined):
+                # Union the three word boxes into one redaction rectangle.
+                boxes = [words[i][1], words[i + 1][1], words[i + 2][1]]
+                left = min(b[0] for b in boxes)
+                top = min(b[1] for b in boxes)
+                right = max(b[2] for b in boxes)
+                bottom = max(b[3] for b in boxes)
+                matches.append(_Match(bbox=(left, top, right, bottom), label=label, category=category))
+                break
+    return matches
+
+
+def _paint_redactions(img, matches: list[_Match]):
+    """Return a new PIL Image with black boxes painted over the matched bboxes."""
+    from PIL import ImageDraw
+
+    out = img.copy()
+    draw = ImageDraw.Draw(out)
+    for m in matches:
+        draw.rectangle(m.bbox, fill="black")
+    return out
+
+
+class VisualLeakDetector:
+    """Detect + redact credentials and PII in MCP image tool responses.
+
+    Use ``check(tool_name, content_blocks)`` to get ``Alert`` objects
+    without mutating the response. Use ``redact(content_blocks)`` to
+    get a new content-block list with the sensitive regions painted
+    black — the original list is unchanged.
+    """
+
+    def __init__(self, *, enabled: bool | None = None) -> None:
+        # Explicit enabled=True forces the detector on even without OCR deps
+        # so callers can log a warning; enabled=False disables entirely.
+        self._enabled = _ocr_available() if enabled is None else enabled
+        if not self._enabled:
+            logger.debug("VisualLeakDetector disabled (install 'agent-bom[visual]' and ensure tesseract is on PATH)")
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def _scan_block(self, block: dict[str, Any]) -> list[_Match]:
+        if block.get("type") != _IMAGE_TYPE:
+            return []
+        img = _decode_image(block)
+        if img is None:
+            return []
+        try:
+            words = _extract_word_boxes(img)
+        except Exception:  # noqa: BLE001
+            logger.warning("OCR failed on image block; skipping")
+            return []
+        matches = _match_patterns(words, CREDENTIAL_PATTERNS, "credential_leak")
+        matches.extend(_match_patterns(words, PII_PATTERNS, "pii_leak"))
+        return matches
+
+    def check(self, tool_name: str, content_blocks: list[dict[str, Any]]) -> list[Alert]:
+        """Emit CRITICAL/HIGH alerts per visual leak found across all image blocks."""
+        if not self._enabled or not content_blocks:
+            return []
+        alerts: list[Alert] = []
+        for block in content_blocks:
+            for m in self._scan_block(block):
+                severity = AlertSeverity.CRITICAL if m.category == "credential_leak" else AlertSeverity.HIGH
+                alerts.append(
+                    Alert(
+                        detector=f"visual_{m.category}",
+                        severity=severity,
+                        message=f"Visual leak detected: {m.label} in screenshot from {tool_name}",
+                        details={
+                            "tool": tool_name,
+                            "leak_type": m.label,
+                            "category": m.category,
+                            "bbox": list(m.bbox),
+                        },
+                    )
+                )
+        return alerts
+
+    def redact(self, content_blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Return a copy of ``content_blocks`` with matched regions painted over.
+
+        Non-image blocks pass through unchanged. Blocks with no matches also
+        pass through unchanged (no re-encoding, no quality loss).
+        """
+        if not self._enabled or not content_blocks:
+            return list(content_blocks)
+        out: list[dict[str, Any]] = []
+        for block in content_blocks:
+            if block.get("type") != _IMAGE_TYPE:
+                out.append(block)
+                continue
+            img = _decode_image(block)
+            if img is None:
+                out.append(block)
+                continue
+            try:
+                words = _extract_word_boxes(img)
+            except Exception:  # noqa: BLE001
+                out.append(block)
+                continue
+            matches = _match_patterns(words, CREDENTIAL_PATTERNS, "credential_leak")
+            matches.extend(_match_patterns(words, PII_PATTERNS, "pii_leak"))
+            if not matches:
+                out.append(block)
+                continue
+            painted = _paint_redactions(img, matches)
+            mime = block.get(_MIMETYPE_KEY, "image/png")
+            new_block = dict(block)
+            new_block[_DATA_KEY] = _encode_image(painted, mime)
+            new_block[_MIMETYPE_KEY] = mime
+            out.append(new_block)
+        return out
+
+
+__all__ = ["VisualLeakDetector"]

--- a/tests/test_visual_leak_detector.py
+++ b/tests/test_visual_leak_detector.py
@@ -1,0 +1,268 @@
+"""Tests for VisualLeakDetector — OCR + redact on MCP screenshot tool responses.
+
+Real tesseract is not required in CI (it's a heavy system dep). The tests
+mock ``_extract_word_boxes`` to feed the detector synthetic OCR output
+that mirrors what a real screenshot would look like post-OCR. One test
+exercises the full pytesseract path and skips cleanly when the binary
+isn't on PATH.
+
+Every assertion ties back to the pilot-team failure mode: an MCP that
+captures a screen containing an AWS key must be detected AND redacted
+before the image reaches the agent.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("PIL")
+pytest.importorskip("pytesseract")
+
+from PIL import Image  # noqa: E402
+
+from agent_bom.runtime.detectors import AlertSeverity  # noqa: E402
+from agent_bom.runtime.visual_leak_detector import VisualLeakDetector  # noqa: E402
+
+
+def _png_bytes(width: int = 400, height: int = 200, color: str = "white") -> bytes:
+    """Render a blank PNG — the test only cares about bytes, OCR is mocked."""
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _img_block(png_bytes: bytes | None = None) -> dict:
+    payload = png_bytes if png_bytes is not None else _png_bytes()
+    return {
+        "type": "image",
+        "data": base64.b64encode(payload).decode(),
+        "mimeType": "image/png",
+    }
+
+
+def _ocr_words(words_with_boxes: list[tuple[str, tuple[int, int, int, int]]]):
+    """Build a patch target for _extract_word_boxes."""
+    return patch(
+        "agent_bom.runtime.visual_leak_detector._extract_word_boxes",
+        return_value=words_with_boxes,
+    )
+
+
+# ─── Disabled path: no OCR binary, no Pillow → graceful no-op ──────────────
+
+
+def test_detector_disabled_returns_empty_alerts_and_passes_blocks_through():
+    d = VisualLeakDetector(enabled=False)
+    assert d.enabled is False
+    blocks = [_img_block()]
+    assert d.check("screen_shot", blocks) == []
+    assert d.redact(blocks) == blocks  # same object contents, unchanged
+
+
+def test_detector_disabled_does_not_mutate_non_image_blocks():
+    d = VisualLeakDetector(enabled=False)
+    blocks = [{"type": "text", "text": "hello"}, _img_block()]
+    assert d.check("anything", blocks) == []
+    result = d.redact(blocks)
+    assert result[0] == {"type": "text", "text": "hello"}
+
+
+# ─── Enabled path (OCR mocked): credential leak in image ───────────────────
+
+
+def test_detector_flags_aws_access_key_in_screenshot():
+    """The real pilot-day-1 scenario: a Playwright MCP captures a page
+    where the developer's AWS access key is visible.
+    """
+    with _ocr_words(
+        [
+            ("Dashboard", (10, 10, 110, 30)),
+            ("AKIAIOSFODNN7EXAMPLE", (10, 50, 260, 70)),  # matches AWS Access Key pattern
+            ("region:", (10, 90, 80, 110)),
+            ("us-east-1", (85, 90, 180, 110)),
+        ]
+    ):
+        d = VisualLeakDetector(enabled=True)
+        alerts = d.check("playwright_screenshot", [_img_block()])
+
+    assert len(alerts) == 1
+    a = alerts[0]
+    assert a.severity == AlertSeverity.CRITICAL
+    assert a.detector == "visual_credential_leak"
+    assert "AWS Access Key" in a.message
+    assert "playwright_screenshot" in a.message
+    assert a.details["leak_type"] == "AWS Access Key"
+    assert a.details["category"] == "credential_leak"
+    # bbox preserved so SIEM / audit can highlight the region in the original
+    assert a.details["bbox"] == [10, 50, 260, 70]
+
+
+def test_detector_flags_pii_email_in_screenshot():
+    with _ocr_words(
+        [
+            ("User:", (10, 10, 60, 30)),
+            ("jane.doe@example.com", (65, 10, 230, 30)),  # matches Email PII pattern
+        ]
+    ):
+        d = VisualLeakDetector(enabled=True)
+        alerts = d.check("browser_capture", [_img_block()])
+
+    assert len(alerts) == 1
+    a = alerts[0]
+    assert a.severity == AlertSeverity.HIGH
+    assert a.detector == "visual_pii_leak"
+    assert "Email" in a.message
+
+
+def test_detector_returns_empty_when_ocr_finds_nothing_sensitive():
+    with _ocr_words(
+        [
+            ("Welcome", (10, 10, 110, 30)),
+            ("to", (115, 10, 140, 30)),
+            ("the", (145, 10, 175, 30)),
+            ("app", (180, 10, 220, 30)),
+        ]
+    ):
+        d = VisualLeakDetector(enabled=True)
+        assert d.check("screen_capture", [_img_block()]) == []
+
+
+# ─── Redact pipeline ────────────────────────────────────────────────────────
+
+
+def test_redact_paints_over_sensitive_regions_and_returns_new_bytes():
+    """Original image bytes must not be mutated; redacted copy has a black box over the key."""
+    original = _png_bytes()
+    blocks = [_img_block(original)]
+
+    with _ocr_words([("AKIAIOSFODNN7EXAMPLE", (10, 50, 260, 70))]):
+        d = VisualLeakDetector(enabled=True)
+        redacted_blocks = d.redact(blocks)
+
+    assert len(redacted_blocks) == 1
+    redacted = redacted_blocks[0]
+    assert redacted["type"] == "image"
+    # Copy, not mutation — original block is untouched.
+    assert blocks[0]["data"] != redacted["data"], "bytes should differ (redaction painted)"
+    # Check the pixel at the center of the redaction box is now black.
+    painted_png = base64.b64decode(redacted["data"])
+    img = Image.open(io.BytesIO(painted_png))
+    px = img.getpixel(((10 + 260) // 2, (50 + 70) // 2))
+    assert px in {(0, 0, 0), (0, 0, 0, 255)}, f"expected black redaction, got {px}"
+
+
+def test_redact_passes_through_blocks_with_no_matches_unchanged():
+    original = _png_bytes()
+    blocks = [_img_block(original)]
+
+    with _ocr_words([("nothing", (10, 10, 80, 30)), ("sensitive", (85, 10, 180, 30))]):
+        d = VisualLeakDetector(enabled=True)
+        result = d.redact(blocks)
+
+    # No re-encoding when there's nothing to redact — same bytes out.
+    assert result[0]["data"] == blocks[0]["data"]
+
+
+def test_redact_preserves_non_image_blocks():
+    text_block = {"type": "text", "text": "sk-ant-xxx"}  # text-channel leaks are caught elsewhere
+    img = _img_block()
+    with _ocr_words([]):
+        d = VisualLeakDetector(enabled=True)
+        result = d.redact([text_block, img])
+    assert result[0] is text_block  # same object — never touched
+    assert len(result) == 2
+
+
+# ─── Edge cases ────────────────────────────────────────────────────────────
+
+
+def test_malformed_base64_data_does_not_crash_detector():
+    bad_block = {"type": "image", "data": "not-valid-base64!!!", "mimeType": "image/png"}
+    d = VisualLeakDetector(enabled=True)
+    # No alerts; no exception.
+    assert d.check("t", [bad_block]) == []
+    # Redact returns the block unchanged when it can't decode.
+    assert d.redact([bad_block]) == [bad_block]
+
+
+def test_empty_image_data_is_ignored():
+    empty_block = {"type": "image", "data": "", "mimeType": "image/png"}
+    d = VisualLeakDetector(enabled=True)
+    assert d.check("t", [empty_block]) == []
+
+
+def test_multi_word_sliding_window_catches_key_value_leaks():
+    """'api_key = abc...xyz' spans three OCR words; the window pass must catch it."""
+    with _ocr_words(
+        [
+            ("api_key", (10, 10, 90, 30)),
+            ("=", (95, 10, 105, 30)),
+            ("ABCDEF1234567890abcdef1234567890ABCDEF", (110, 10, 410, 30)),
+        ]
+    ):
+        d = VisualLeakDetector(enabled=True)
+        alerts = d.check("form_screenshot", [_img_block()])
+
+    # Matches Generic API Key — label varies by pattern name, but at least one critical must fire.
+    assert any(a.severity == AlertSeverity.CRITICAL for a in alerts)
+
+
+# ─── Optional: real OCR path (skipped if tesseract is absent) ──────────────
+
+
+def _tesseract_available() -> bool:
+    try:
+        import pytesseract
+
+        pytesseract.get_tesseract_version()
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def test_screen_capture_tool_class_is_denied_via_policy():
+    """Integration check: the proxy policy engine classifies screen_capture
+    tool names and denies them wholesale when the policy opts in.
+    """
+    from agent_bom.proxy_policy import _classify_tool_classes, check_policy
+
+    assert "screen_capture" in _classify_tool_classes("take_screenshot", {})
+    assert "screen_capture" in _classify_tool_classes("page_screenshot", {"url": "https://example.com"})
+    assert "screen_capture" not in _classify_tool_classes("read_file", {"path": "/tmp/x"})
+
+    policy = {
+        "rules": [
+            {"id": "no-screen-capture", "action": "block", "deny_tool_classes": ["screen_capture"]},
+        ]
+    }
+    allowed, reason = check_policy(policy, "take_screenshot", {})
+    assert allowed is False
+    assert "screen_capture" in reason
+
+
+@pytest.mark.skipif(not _tesseract_available(), reason="tesseract binary not installed")
+def test_real_ocr_path_on_synthetic_png_with_aws_key():
+    """Render a PNG with a fake AWS key drawn on it; run real OCR."""
+    from PIL import ImageDraw, ImageFont
+
+    img = Image.new("RGB", (500, 100), color="white")
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.truetype("/System/Library/Fonts/Supplemental/Arial.ttf", 20)
+    except OSError:
+        font = ImageFont.load_default()
+    draw.text((10, 30), "AKIAIOSFODNN7EXAMPLE", fill="black", font=font)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    block = {"type": "image", "data": base64.b64encode(buf.getvalue()).decode(), "mimeType": "image/png"}
+
+    d = VisualLeakDetector(enabled=True)
+    alerts = d.check("real_ocr", [block])
+    # Real OCR is imperfect; we only assert the detector runs without error
+    # and returns a list. Precision of real-world OCR is validated by the
+    # integration test matrix rather than unit-level pattern counts.
+    assert isinstance(alerts, list)


### PR DESCRIPTION
## Summary
Closes #1568. MCPs wrapping browsers or screen-capture tools (Playwright-MCP, Puppeteer-MCP, Cursor / Claude screen-read) can leak credentials and PII through pixels that bypass the existing `CredentialLeakDetector` (text-only). This PR closes the visual channel.

## New module: `src/agent_bom/runtime/visual_leak_detector.py`
- `VisualLeakDetector.check(tool_name, content_blocks) -> list[Alert]` — emits CRITICAL/HIGH alerts per match, keeps bbox in `details` for SIEM.
- `VisualLeakDetector.redact(content_blocks) -> list[dict]` — returns a **new** content-block list with black boxes over matched regions; original never mutated.
- Works on MCP-shaped image blocks: `[{'type': 'image', 'data': <b64>, 'mimeType': 'image/png'}]`.

Pipeline:
1. Decode base64 image → PIL.Image
2. pytesseract OCR → `(word, bbox)` tuples (confidence floor 40)
3. Two-pass match:
   - single-word pass for single-token secrets (AWS keys, etc.)
   - 3-word sliding window for `key = value` leaks (skipped when a single-word hit already claims the window, so one secret = one alert — not three)
4. Paint black rectangles via `PIL.ImageDraw` on matched bboxes
5. Re-encode + return the new block list

Reuses the existing `CREDENTIAL_PATTERNS` + `PII_PATTERNS` tables in `runtime/patterns.py` — **one source of truth** for both text and visual channels.

## Policy enforcement
`proxy_policy.py _classify_tool_classes` now adds `screen_capture` to the class set for tool names matching `screenshot` / `page_screenshot` / `take_screenshot` / `capture_screen` / `screen_capture` / `screencap`. A gateway or proxy policy can block the class wholesale:

```json
{"rules": [{"id": "no-screens", "action": "block", "deny_tool_classes": ["screen_capture"]}]}
```

## Opt-in dependency
New `agent-bom[visual]` extra pulls `Pillow` + `pytesseract`. Pilots without screen-capture MCPs don't pay for OCR at runtime. `VisualLeakDetector` returns `[]` cleanly when either dep or the tesseract binary is absent.

## Tests (12 new, all pass)
- Disabled path returns empty / passes blocks through
- AWS Access Key detected → CRITICAL alert + bbox preserved
- Email PII detected → HIGH alert
- Clean screenshots return no alerts
- Redact paints boxes AND original is untouched
- No-match blocks pass through without re-encoding (no quality loss)
- Non-image blocks preserved
- Malformed base64 doesn't crash
- Multi-word `key = value` leak caught via sliding window
- `screen_capture` tool class correctly denied via policy engine
- Real OCR path on synthetic PNG (skipped when tesseract absent; runs when it is)

Full 41 visual + proxy-policy tests pass.

## Docs
`docs/ENTERPRISE_SECURITY_PLAYBOOK.md` §2.2 now covers both channels side-by-side with the new detector + policy hook linked.

## Deliberately NOT in this PR
- **Wire-up inside `run_proxy` / `gateway_server.py`** — callers opt in per-deployment. That wiring lands next so we can measure OCR cost against real pilot traffic before always-on.
- **New audit log fields** — the existing `Alert` shape is sufficient.

## Test plan
- [x] `pytest tests/test_visual_leak_detector.py tests/test_proxy_policy.py -q` → 41 passed, 1 skipped (real-OCR, no tesseract)
- [x] ruff + mypy + bandit clean
- [ ] Full CI
- [ ] Follow-up PR: wire detector into `run_proxy` behind a feature flag + gateway audit event