### PR TITLE
fix: scope auth policy to admin role

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -267,6 +267,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     _ROLE_RULES: tuple[tuple[str, str, str], ...] = (
         ("GET", "/v1/compliance", "viewer"),
         ("GET", "/v1/posture", "viewer"),
+        ("GET", "/v1/auth/debug", "viewer"),
+        ("GET", "/v1/auth/policy", "admin"),
         ("GET", "/v1/auth/keys", "admin"),
         ("POST", "/v1/auth/keys", "admin"),
         ("DELETE", "/v1/auth/keys/", "admin"),

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -14,7 +14,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api import server as _server_mod
-from agent_bom.api.middleware import get_rate_limit_key_status
+from agent_bom.api.middleware import APIKeyMiddleware, get_rate_limit_key_status
 from agent_bom.api.server import app
 
 # ─── Rate-limit key status ────────────────────────────────────────────────────
@@ -124,6 +124,12 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "default_ttl_seconds" in body["api_key"]
     assert "max_ttl_seconds" in body["api_key"]
     assert body["rate_limit_key"]["status"] in {"ok", "ephemeral", "unknown_age", "rotation_due", "max_age_exceeded"}
+
+
+def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
+    middleware = APIKeyMiddleware(app, api_key="static-secret")
+    assert middleware._required_role("GET", "/v1/auth/policy") == "admin"
+    assert middleware._required_role("GET", "/v1/auth/debug") == "viewer"
 
 
 # ─── /readyz drain behavior ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make `GET /v1/auth/policy` explicitly admin-only in the API middleware RBAC map
- keep `GET /v1/auth/debug` explicitly viewer-readable for authenticated session introspection
- add a regression test so these auth support surfaces cannot silently drift via fallback role behavior

## Verification
- `pytest -q tests/test_api_operator_policy.py tests/test_api_auth_debug.py tests/test_api_hardening.py -k "auth_policy or auth_debug or required_role"`
- `python scripts/check_release_consistency.py`
- `pre-commit run --files src/agent_bom/api/middleware.py tests/test_api_operator_policy.py`
