### PR TITLE
fix: add retry jitter and narrow ignore parse errors

### DIFF
--- a/src/agent_bom/http_client.py
+++ b/src/agent_bom/http_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 import time
 from typing import Any, Optional
 
@@ -86,6 +87,13 @@ def _safe_url(url: str) -> str:  # noqa: PLW0108
         return "<redacted-url>"
 
 
+def _jittered_wait(wait: float) -> float:
+    """Apply small positive jitter so concurrent clients do not back off in lockstep."""
+    if wait <= 0:
+        return 0.0
+    return min(wait + random.uniform(0.0, wait * 0.1), MAX_BACKOFF)
+
+
 def create_client(timeout: float | None = None, max_redirects: int = 5) -> httpx.AsyncClient:
     """Create an httpx.AsyncClient with connection-level retries.
 
@@ -162,6 +170,7 @@ async def request_with_retry(
                     wait = backoff
             else:
                 wait = backoff
+            wait = _jittered_wait(wait)
 
             if attempt < max_retries:
                 logger.info(
@@ -185,14 +194,15 @@ async def request_with_retry(
 
         except httpx.TimeoutException:
             if attempt < max_retries:
+                wait = _jittered_wait(backoff)
                 logger.info(
                     "Timeout on %s — retry %d/%d in %.1fs",
                     log_url,
                     attempt + 1,
                     max_retries,
-                    backoff,
+                    wait,
                 )
-                await asyncio.sleep(backoff)
+                await asyncio.sleep(wait)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             else:
                 logger.warning("Timeout on %s — exhausted %d retries", log_url, max_retries)
@@ -201,15 +211,16 @@ async def request_with_retry(
         except httpx.HTTPError as e:
             safe_err = _sanitize_for_log(e)
             if attempt < max_retries:
+                wait = _jittered_wait(backoff)
                 logger.info(
                     "HTTP error on %s: %s — retry %d/%d in %.1fs",
                     log_url,
                     safe_err,
                     attempt + 1,
                     max_retries,
-                    backoff,
+                    wait,
                 )
-                await asyncio.sleep(backoff)
+                await asyncio.sleep(wait)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             else:
                 logger.warning("HTTP error on %s: %s — exhausted %d retries", log_url, safe_err, max_retries)

--- a/src/agent_bom/ignores.py
+++ b/src/agent_bom/ignores.py
@@ -36,6 +36,7 @@ Fields
 from __future__ import annotations
 
 import fnmatch
+import json
 import logging
 from datetime import date, datetime
 from pathlib import Path
@@ -67,27 +68,29 @@ def load_ignore_file(path: str | Path | None = None) -> list[dict[str, Any]]:
     try:
         with target.open() as fh:
             data = yaml.safe_load(fh) or {}
-        entries = data.get("ignores", [])
-        if not isinstance(entries, list):
-            logger.warning("agent-bom-ignore: 'ignores' must be a list — skipping file")
-            return []
-        return entries
-    except Exception as exc:
+    except (OSError, yaml.YAMLError) as exc:
         logger.warning("agent-bom-ignore: failed to parse %s: %s", target, exc)
         return []
+    if not isinstance(data, dict):
+        logger.warning("agent-bom-ignore: expected mapping at top level — skipping file")
+        return []
+    entries = data.get("ignores", [])
+    if not isinstance(entries, list):
+        logger.warning("agent-bom-ignore: 'ignores' must be a list — skipping file")
+        return []
+    return entries
 
 
 def _parse_minimal_yaml(path: Path) -> list[dict[str, Any]]:
     """Fallback parser for simple ignore files when PyYAML is not installed."""
     try:
-        import json
-
         text = path.read_text()
         # Try JSON as last resort
         if text.strip().startswith("{") or text.strip().startswith("["):
             data = json.loads(text)
             return data.get("ignores", data) if isinstance(data, dict) else data
-    except Exception:
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("agent-bom-ignore: failed to parse %s without PyYAML: %s", path, exc)
         pass
     logger.warning("agent-bom-ignore: PyYAML not installed and file is not JSON — ignore file skipped. Install PyYAML: pip install pyyaml")
     return []

--- a/tests/test_http_client_cov.py
+++ b/tests/test_http_client_cov.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 
 from agent_bom.http_client import (
+    _jittered_wait,
     _safe_url,
     _sanitize_for_log,
     create_client,
@@ -64,6 +66,11 @@ class TestCreateClient:
 
 
 class TestRequestWithRetry:
+    def test_jittered_wait_stays_within_cap(self, monkeypatch):
+        monkeypatch.setattr("agent_bom.http_client.random.uniform", lambda lo, hi: hi)
+        wait = _jittered_wait(10.0)
+        assert wait == 11.0
+
     @pytest.mark.asyncio
     async def test_success_on_first_try(self):
         mock_response = MagicMock()
@@ -150,3 +157,23 @@ class TestRequestWithRetry:
         client.request.side_effect = [mock_429, mock_200]
         result = await request_with_retry(client, "GET", "https://example.com", max_retries=2)
         assert result.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_retry_wait_uses_jitter(self, monkeypatch):
+        mock_429 = MagicMock()
+        mock_429.status_code = 429
+        mock_429.headers = {"Retry-After": "0.1"}
+        mock_200 = MagicMock()
+        mock_200.status_code = 200
+        client = AsyncMock()
+        client.request.side_effect = [mock_429, mock_200]
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        monkeypatch.setattr("agent_bom.http_client.random.uniform", lambda lo, hi: 0.01)
+        monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+        result = await request_with_retry(client, "GET", "https://example.com", max_retries=2)
+        assert result.status_code == 200
+        assert sleep_calls == [0.11]

--- a/tests/test_ignores.py
+++ b/tests/test_ignores.py
@@ -50,6 +50,20 @@ def test_load_ignore_file_yaml(tmp_path):
     assert entries[0]["id"] == "CVE-2024-1111"
 
 
+def test_load_ignore_file_invalid_yaml_returns_empty(tmp_path):
+    pytest.importorskip("yaml")
+    f = tmp_path / ".agent-bom-ignore.yaml"
+    f.write_text("ignores:\n  - id: [unterminated\n")
+    assert load_ignore_file(f) == []
+
+
+def test_load_ignore_file_requires_mapping_top_level(tmp_path):
+    pytest.importorskip("yaml")
+    f = tmp_path / ".agent-bom-ignore.yaml"
+    f.write_text("- id: CVE-2024-1111\n  reason: test\n")
+    assert load_ignore_file(f) == []
+
+
 def test_load_ignore_file_default_name(tmp_path, monkeypatch):
     pytest.importorskip("yaml")
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- add small positive retry jitter in the shared HTTP retry path so concurrent clients do not back off in lockstep
- narrow ignore-file parsing from broad `except Exception` handling to concrete YAML / JSON / IO parse failures
- add regression coverage for jittered waits and malformed ignore-file handling

## Verification
- `pytest -q tests/test_http_client_cov.py tests/test_ignores.py`
- `python scripts/check_release_consistency.py`
- `pre-commit run --files src/agent_bom/http_client.py src/agent_bom/ignores.py tests/test_http_client_cov.py tests/test_ignores.py`
