### PR TITLE
docs: promote otel and clarify policy posture

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -76,6 +76,26 @@ runtime monolith. Teams typically deploy only the surfaces they need:
 - **gateway**: central policy management for those runtime paths
 - **API + UI**: the operator plane for findings, graph, remediation, audit, and policy workflows
 
+## OTEL and Policy
+
+`agent-bom` already supports OpenTelemetry as a real interoperability surface:
+
+- API request tracing with W3C trace context
+- OTLP export for operator telemetry
+- OTEL trace ingest through `/v1/traces`
+- runtime workflows that consume OTEL traces as evidence
+
+Policy is native by default. The shipped gateway and proxy use the repo's JSON
+policy engine, not an embedded OPA/Rego runtime. That is intentional: one
+shared policy model across scan, gateway, proxy, and runtime, without adding an
+extra policy binary to the operator stack.
+
+The right enterprise story is:
+
+- OTEL is first-class today
+- native JSON policy remains the default
+- OPA/Rego is an optional future interoperability path, not the core engine
+
 ## Deploy In Your Own Infra
 
 `agent-bom` is designed to run inside your own AWS account, VPC, EKS cluster,

--- a/README.md
+++ b/README.md
@@ -225,8 +225,26 @@ and the [focused EKS rollout](site-docs/deployment/eks-mcp-pilot.md).
 | **proxy / runtime** | `agent-bom proxy` (stdio) / `--sse` (HTTP) | Inline MCP JSON-RPC inspection + policy enforcement | K8s sidecar or laptop wrapper |
 | **gateway** | `agent-bom gateway serve`, `/v1/gateway/policies`, `/v1/proxy/audit` | Central HTTP traffic plane plus shared policy/audit plane | Service + API routes |
 | **API + UI** | `/v1/*` + Next.js dashboard | Findings, graph, remediation, compliance, posture | 2 Deployments + HPA |
+| **OTEL / observability** | `POST /v1/traces`, `--otel-endpoint`, API tracing | W3C trace context, OTLP export, and OTEL trace ingest for runtime evidence | API route + CLI/runtime hooks |
 
 By default, findings, fleet data, audit logs, graph state, and remediation outputs stay in your infrastructure. Optional egress (OSV lookups, NVD enrichment, Slack / Jira / Vanta / Drata webhooks, SIEM / OTLP) is operator-controlled.
+
+### OTEL is first-class, OPA is optional interop
+
+`agent-bom` already treats OpenTelemetry as a real product surface, not a bolt-on:
+
+- the API preserves W3C `traceparent` context and can export request spans over OTLP/HTTP
+- the CLI can emit OTLP metrics and scan context to your collector with `--otel-endpoint`
+- the control plane can ingest OTEL traces at `POST /v1/traces`
+- runtime protection can consume OTEL traces as evidence, not just emit them
+
+Policy is different. The shipped gateway and proxy use the repo's native JSON policy engine, not OPA/Rego. That is an intentional product choice documented in [ADR-002](docs/adr/002-custom-policy-engine.md): lower operator complexity, no extra OPA binary, and one policy model shared across scan, gateway, proxy, and runtime.
+
+What makes sense today:
+
+- **promote OTEL** as a first-class interoperability path
+- **keep the native policy engine** as the default shipped control plane
+- treat **OPA/Rego** as a future enterprise interop option, such as bundle import/export or an external decision hook, not as a replacement for the current engine
 
 ### Two enforcement shapes, one control plane
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -45,6 +45,12 @@ Blast radius is the product center of gravity. `agent-bom` connects vulnerabilit
 
 `agent-bom` scores trust with evidence, not a black-box label. It combines package and registry posture, capability risk, drift, exposed credentials, and related supply-chain signals. Policy and compliance layers can then act on those findings with clearer context.
 
+The shipped policy path is the repo's native JSON policy engine used by the
+gateway and proxy surfaces. That should stay the default product framing today.
+If enterprise buyers need OPA/Rego, the sensible roadmap is interoperability
+through bundle import/export or an external decision hook, not a rewrite of the
+core policy engine.
+
 The product also protects its own shipped surfaces with the same discipline: signed releases, provenance, daily dependency monitoring, drift checks, and CI guards for the JavaScript surfaces so accidental source-map leaks or stale npm dependencies do not silently ship.
 
 Model and weight security should be described the same way: not just as file detection, but as a supply-chain contract that surfaces risky formats, signature presence, manifest and lineage evidence, provenance checks, and Hub-backed hash verification where available.
@@ -57,6 +63,19 @@ The runtime story has two levels:
 - a broader runtime protection engine used for deeper protection workflows
 
 The wording matters. The proxy and the broader runtime engine are related, but they are not the same path and should not be described as the same detector surface.
+
+### Observability and OTEL
+
+OpenTelemetry should be described as a first-class product capability, not a
+buried add-on. `agent-bom` already:
+
+- preserves W3C trace context across API requests
+- exports operator telemetry over OTLP/HTTP when configured
+- ingests OTEL traces into the control plane
+- uses OTEL traces as runtime evidence, not just as emitted spans
+
+That bidirectional model is a real differentiator and should appear in the main
+product narrative.
 
 ### Skills and instruction files
 


### PR DESCRIPTION
## Summary
- promote OpenTelemetry as a first-class product surface in the README and Docker Hub README
- clarify that the shipped gateway/proxy policy engine is native JSON today, with OPA/Rego positioned as future interoperability rather than the core engine
- update the product brief so OTEL emit + ingest and policy posture match the current code and ADRs

## Verification
- python scripts/check_release_consistency.py