### PR TITLE
fix: harden visual leak scanning and release hygiene

### DIFF
--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -36,6 +36,18 @@ tag index in under 50 ms. You can re-index on every evidence-bundle
 export without caching; caching becomes interesting only above ~200k
 findings.
 
+### OSV fallback accounting — `skipped_non_osv_ecosystems`
+
+The scanner tracks packages that deliberately skip the OSV network path
+because their ecosystem is not OSV-backed (for example MCP registry
+entries and other non-package inventory rows). This counter is not a
+false-negative bucket; it is the expected accounting for inventory
+surfaces that never belonged in the OSV query set.
+
+**Implication for operators:** rising `skipped_non_osv_ecosystems`
+counts usually mean your inventory mix includes more registry or
+non-package metadata, not that vulnerability coverage regressed.
+
 ### Compliance bundle signature — HMAC-SHA256 over canonical JSON
 
 The signing path behind `/v1/compliance/{framework}/report`. Measured

--- a/sdks/shared/generate-patterns.py
+++ b/sdks/shared/generate-patterns.py
@@ -21,6 +21,14 @@ PATTERNS_PY = ROOT / "src" / "agent_bom" / "runtime" / "patterns.py"
 OUTPUT = Path(__file__).resolve().parent / "patterns.json"
 
 
+def _stdout(message: str) -> None:
+    sys.stdout.write(f"{message}\n")
+
+
+def _stderr(message: str) -> None:
+    sys.stderr.write(f"{message}\n")
+
+
 def _flags_str(pattern: re.Pattern) -> str:
     """Convert re flags to portable string representation."""
     parts: list[str] = []
@@ -93,17 +101,17 @@ def main() -> None:
 
     if "--check" in sys.argv:
         if not OUTPUT.exists():
-            print(f"FAIL: {OUTPUT} does not exist — run: python {__file__}")
+            _stderr(f"FAIL: {OUTPUT} does not exist — run: python {__file__}")
             sys.exit(1)
         existing = OUTPUT.read_text()
         if existing != current:
-            print(f"FAIL: {OUTPUT} is stale — regenerate with: python {__file__}")
+            _stderr(f"FAIL: {OUTPUT} is stale — regenerate with: python {__file__}")
             sys.exit(1)
-        print(f"OK: {OUTPUT} is up-to-date")
+        _stdout(f"OK: {OUTPUT} is up-to-date")
         return
 
     OUTPUT.write_text(current)
-    print(
+    _stdout(
         f"Generated {OUTPUT} ({len(data['credential_patterns'])} credential, "
         f"{len(data['dangerous_arg_patterns'])} arg, "
         f"{len(data['response_injection_patterns'])} injection, "

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -50,6 +50,11 @@ UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awai
 _visual_detector_singleton: Any = None
 
 
+def _sanitize_for_log(value: Any) -> str:
+    """Return a single-line representation safe for plain-text logs."""
+    return str(value).replace("\r", "").replace("\n", "")
+
+
 def _get_visual_leak_detector() -> Any:
     global _visual_detector_singleton
     if _visual_detector_singleton is None:
@@ -211,12 +216,17 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 if isinstance(content, list) and content:
                     detector = _get_visual_leak_detector()
                     tool_name_for_scan = message.get("params", {}).get("name", "") if is_tools_call(message) else message.get("method", "")
+                    safe_tool_name_for_log = _sanitize_for_log(tool_name_for_scan)
                     from agent_bom.runtime.visual_leak_detector import run_visual_leak_check, run_visual_leak_redact
 
                     try:
                         alerts = await run_visual_leak_check(detector, tool_name_for_scan, content)
                     except asyncio.TimeoutError:
-                        logger.warning("gateway visual leak scan timed out for upstream=%s tool=%s", upstream.name, tool_name_for_scan)
+                        logger.warning(
+                            "gateway visual leak scan timed out for upstream=%s tool=%s",
+                            upstream.name,
+                            safe_tool_name_for_log,
+                        )
                         alerts = []
                     if alerts:
                         record_gateway_relay(upstream.name, "visual_leak_redacted")
@@ -237,7 +247,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                             logger.warning(
                                 "gateway visual leak redaction timed out for upstream=%s tool=%s",
                                 upstream.name,
-                                tool_name_for_scan,
+                                safe_tool_name_for_log,
                             )
 
         if settings.audit_sink is not None:

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -27,6 +27,7 @@ Non-goals for MVP (see design doc):
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
@@ -210,7 +211,13 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 if isinstance(content, list) and content:
                     detector = _get_visual_leak_detector()
                     tool_name_for_scan = message.get("params", {}).get("name", "") if is_tools_call(message) else message.get("method", "")
-                    alerts = detector.check(tool_name_for_scan, content)
+                    from agent_bom.runtime.visual_leak_detector import run_visual_leak_check, run_visual_leak_redact
+
+                    try:
+                        alerts = await run_visual_leak_check(detector, tool_name_for_scan, content)
+                    except asyncio.TimeoutError:
+                        logger.warning("gateway visual leak scan timed out for upstream=%s tool=%s", upstream.name, tool_name_for_scan)
+                        alerts = []
                     if alerts:
                         record_gateway_relay(upstream.name, "visual_leak_redacted")
                         if settings.audit_sink is not None:
@@ -224,7 +231,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                                     "leak_types": sorted({a.details.get("leak_type", "") for a in alerts}),
                                 }
                             )
-                        result["content"] = detector.redact(content)
+                        try:
+                            result["content"] = await run_visual_leak_redact(detector, content)
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                "gateway visual leak redaction timed out for upstream=%s tool=%s",
+                                upstream.name,
+                                tool_name_for_scan,
+                            )
 
         if settings.audit_sink is not None:
             await settings.audit_sink(

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -147,6 +147,10 @@ def set_gateway_evaluator(fn) -> None:  # noqa: ANN001
     _gateway_evaluator = fn
 
 
+def _sanitize_for_log(value: object) -> str:
+    return str(value).replace("\r", "").replace("\n", "")
+
+
 def _generate_proxy_source_id() -> str:
     hostname = platform.node() or "unknown"
     return hashlib.sha256(hostname.encode()).hexdigest()[:12]
@@ -1161,10 +1165,11 @@ async def run_proxy(
                         vis_tool = ""
                         if vis_id is not None and vis_id in pending_calls:
                             vis_tool = pending_calls[vis_id][0]
+                        safe_vis_tool = _sanitize_for_log(vis_tool or "unknown")
                         try:
                             vis_alerts = await run_visual_leak_check(visual_detector, vis_tool or "unknown", vis_content)
                         except asyncio.TimeoutError:
-                            logger.warning("Visual leak scan timed out for tool=%s", vis_tool or "unknown")
+                            logger.warning("Visual leak scan timed out for tool=%s", safe_vis_tool)
                             vis_alerts = []
                         if vis_alerts:
                             await _handle_alerts(vis_alerts, log_file)
@@ -1172,7 +1177,7 @@ async def run_proxy(
                                 try:
                                     redacted = await run_visual_leak_redact(visual_detector, vis_content)
                                 except asyncio.TimeoutError:
-                                    logger.warning("Visual leak redaction timed out for tool=%s", vis_tool or "unknown")
+                                    logger.warning("Visual leak redaction timed out for tool=%s", safe_vis_tool)
                                 else:
                                     msg["result"]["content"] = redacted
                                     line = (json.dumps(msg) + "\n").encode()

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -1155,17 +1155,27 @@ async def run_proxy(
                     vis_result = msg.get("result")
                     vis_content = vis_result.get("content") if isinstance(vis_result, dict) else None
                     if isinstance(vis_content, list) and vis_content:
+                        from agent_bom.runtime.visual_leak_detector import run_visual_leak_check, run_visual_leak_redact
+
                         vis_id = msg.get("id")
                         vis_tool = ""
                         if vis_id is not None and vis_id in pending_calls:
                             vis_tool = pending_calls[vis_id][0]
-                        vis_alerts = visual_detector.check(vis_tool or "unknown", vis_content)
+                        try:
+                            vis_alerts = await run_visual_leak_check(visual_detector, vis_tool or "unknown", vis_content)
+                        except asyncio.TimeoutError:
+                            logger.warning("Visual leak scan timed out for tool=%s", vis_tool or "unknown")
+                            vis_alerts = []
                         if vis_alerts:
                             await _handle_alerts(vis_alerts, log_file)
                             if not log_only:
-                                redacted = visual_detector.redact(vis_content)
-                                msg["result"]["content"] = redacted
-                                line = (json.dumps(msg) + "\n").encode()
+                                try:
+                                    redacted = await run_visual_leak_redact(visual_detector, vis_content)
+                                except asyncio.TimeoutError:
+                                    logger.warning("Visual leak redaction timed out for tool=%s", vis_tool or "unknown")
+                                else:
+                                    msg["result"]["content"] = redacted
+                                    line = (json.dumps(msg) + "\n").encode()
 
                 # Inline response scanning (PII, secrets, payload vuln)
                 if scan_config.enabled and "result" in msg:

--- a/src/agent_bom/runtime/visual_leak_detector.py
+++ b/src/agent_bom/runtime/visual_leak_detector.py
@@ -37,9 +37,11 @@ matched a credential or PII pattern and returns a new list with updated
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
 import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Iterable
@@ -75,7 +77,7 @@ def _ocr_available() -> bool:
         import pytesseract  # noqa: PLC0415
 
         pytesseract.get_tesseract_version()
-    except Exception:  # noqa: BLE001 — tesseract binary may be missing even if python shim is installed
+    except (FileNotFoundError, OSError, RuntimeError):
         return False
     return True
 
@@ -93,7 +95,7 @@ def _decode_image(block: dict[str, Any]):
         return None
     try:
         return Image.open(io.BytesIO(buf))
-    except Exception:  # noqa: BLE001 — Pillow raises many specific classes here
+    except OSError:
         return None
 
 
@@ -218,7 +220,7 @@ class VisualLeakDetector:
             return []
         try:
             words = _extract_word_boxes(img)
-        except Exception:  # noqa: BLE001
+        except (OSError, RuntimeError, ValueError):
             logger.warning("OCR failed on image block; skipping")
             return []
         matches = _match_patterns(words, CREDENTIAL_PATTERNS, "credential_leak")
@@ -267,7 +269,7 @@ class VisualLeakDetector:
                 continue
             try:
                 words = _extract_word_boxes(img)
-            except Exception:  # noqa: BLE001
+            except (OSError, RuntimeError, ValueError):
                 out.append(block)
                 continue
             matches = _match_patterns(words, CREDENTIAL_PATTERNS, "credential_leak")
@@ -284,4 +286,22 @@ class VisualLeakDetector:
         return out
 
 
-__all__ = ["VisualLeakDetector"]
+def _visual_leak_timeout_seconds() -> float:
+    raw = os.environ.get("AGENT_BOM_VISUAL_LEAK_TIMEOUT_SECONDS", "1.5").strip()
+    try:
+        return max(0.1, float(raw))
+    except ValueError:
+        return 1.5
+
+
+async def run_visual_leak_check(detector: VisualLeakDetector, tool_name: str, content_blocks: list[dict[str, Any]]) -> list[Alert]:
+    timeout = _visual_leak_timeout_seconds()
+    return await asyncio.wait_for(asyncio.to_thread(detector.check, tool_name, content_blocks), timeout=timeout)
+
+
+async def run_visual_leak_redact(detector: VisualLeakDetector, content_blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    timeout = _visual_leak_timeout_seconds()
+    return await asyncio.wait_for(asyncio.to_thread(detector.redact, content_blocks), timeout=timeout)
+
+
+__all__ = ["VisualLeakDetector", "run_visual_leak_check", "run_visual_leak_redact"]

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -13,6 +13,7 @@ paths a pilot team would actually run into.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from starlette.testclient import TestClient
@@ -387,5 +388,47 @@ def test_visual_leak_detection_clean_response_passes_through() -> None:
         assert detector.check_calls, "check must fire when the flag is on"
         assert detector.redact_calls == [], "redact must not fire without alerts"
         assert not any(e["action"] == "gateway.visual_leak_blocked" for e in audit_events)
+    finally:
+        gw._visual_detector_singleton = None
+
+
+def test_visual_leak_detection_timeout_fails_open_without_blocking_response(monkeypatch) -> None:
+    import agent_bom.gateway_server as gw
+
+    class _SlowDetector:
+        enabled = True
+
+        def check(self, tool_name, content_blocks):
+            time.sleep(0.05)
+            return []
+
+        def redact(self, content_blocks):
+            return content_blocks
+
+    detector = _SlowDetector()
+    gw._visual_detector_singleton = detector
+    monkeypatch.setenv("AGENT_BOM_VISUAL_LEAK_TIMEOUT_SECONDS", "0.001")
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"content": [{"type": "image", "data": "CLEAN", "mimeType": "image/png"}]},
+        }
+
+    try:
+        settings = GatewaySettings(
+            registry=_simple_registry(),
+            policy={},
+            upstream_caller=fake_caller,
+            enable_visual_leak_detection=True,
+        )
+        client = TestClient(create_gateway_app(settings))
+        resp = client.post(
+            "/mcp/filesystem",
+            json=_json_rpc("tools/call", name="take_screenshot", arguments={}),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["result"]["content"][0]["data"] == "CLEAN"
     finally:
         gw._visual_detector_singleton = None

--- a/tests/test_visual_leak_detector.py
+++ b/tests/test_visual_leak_detector.py
@@ -195,6 +195,16 @@ def test_empty_image_data_is_ignored():
     assert d.check("t", [empty_block]) == []
 
 
+def test_ocr_runtime_error_is_treated_as_empty_scan():
+    d = VisualLeakDetector(enabled=True)
+    with patch(
+        "agent_bom.runtime.visual_leak_detector._extract_word_boxes",
+        side_effect=RuntimeError("tesseract failed"),
+    ):
+        assert d.check("t", [_img_block()]) == []
+        assert d.redact([_img_block()])[0]["type"] == "image"
+
+
 def test_multi_word_sliding_window_catches_key_value_leaks():
     """'api_key = abc...xyz' spans three OCR words; the window pass must catch it."""
     with _ocr_words(


### PR DESCRIPTION
## Summary
- move gateway and proxy visual-leak OCR work off the async event loop with bounded `asyncio.to_thread` + timeout wrappers
- narrow visual-leak detector OCR exception handling and add regression coverage for OCR runtime failures and timeout behavior
- clean the remaining SDK `print()` calls in `sdks/shared/generate-patterns.py` and document `skipped_non_osv_ecosystems` in the performance guide

## Verification
- `python -m pytest -q tests/test_gateway_server.py tests/test_visual_leak_detector.py tests/test_self_scan.py tests/test_ignores.py`
- `python scripts/check_release_consistency.py`
- `pre-commit run --files src/agent_bom/runtime/visual_leak_detector.py src/agent_bom/gateway_server.py src/agent_bom/proxy.py sdks/shared/generate-patterns.py docs/PERFORMANCE_BENCHMARKS.md tests/test_gateway_server.py tests/test_visual_leak_detector.py`
