### PR TITLE
feat: add component service accounts for gateway and backup

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
@@ -36,7 +36,7 @@ pdb:
 
 serviceAccount:
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-discovery
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
 
 networkPolicy:
   enabled: true

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -127,6 +127,9 @@ controlPlane:
   backup:
     enabled: true
     schedule: "0 3 * * *"
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_BACKUP_ROLE
     destination:
       bucket: agent-bom-prod-backups
       prefix: agent-bom/postgres
@@ -142,6 +145,9 @@ controlPlane:
 scanner:
   enabled: true
   allNamespaces: true
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
   extraArgs:
     - --k8s-mcp
     - --k8s-all-namespaces
@@ -152,7 +158,7 @@ scanner:
 
 serviceAccount:
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-discovery
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
 
 topologySpread:
   enabled: true

--- a/deploy/helm/agent-bom/templates/_helpers.tpl
+++ b/deploy/helm/agent-bom/templates/_helpers.tpl
@@ -27,6 +27,41 @@ Service account name.
 {{- end }}
 
 {{/*
+Gateway service account name.
+*/}}
+{{- define "agent-bom.gatewayServiceAccountName" -}}
+{{- if .Values.gateway.serviceAccount.create }}
+{{- default (printf "%s-gateway" (include "agent-bom.name" .)) .Values.gateway.serviceAccount.name }}
+{{- else }}
+{{- default (include "agent-bom.serviceAccountName" .) .Values.gateway.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Scanner service account name.
+*/}}
+{{- define "agent-bom.scannerServiceAccountName" -}}
+{{- if .Values.scanner.serviceAccount.create }}
+{{- default (printf "%s-scanner" (include "agent-bom.name" .)) .Values.scanner.serviceAccount.name }}
+{{- else }}
+{{- default (include "agent-bom.serviceAccountName" .) .Values.scanner.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Backup service account name.
+*/}}
+{{- define "agent-bom.controlPlaneBackupServiceAccountName" -}}
+{{- if .Values.controlPlane.backup.serviceAccountName }}
+{{- .Values.controlPlane.backup.serviceAccountName }}
+{{- else if .Values.controlPlane.backup.serviceAccount.create }}
+{{- default (printf "%s-backup" (include "agent-bom.name" .)) .Values.controlPlane.backup.serviceAccount.name }}
+{{- else }}
+{{- include "agent-bom.serviceAccountName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Control-plane affinity helper. If the operator provides a full affinity block,
 use it verbatim. Otherwise, optionally emit preferred pod anti-affinity so API
 and UI replicas avoid co-location on the same node.

--- a/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             app.kubernetes.io/component: control-plane-backup
         spec:
           restartPolicy: OnFailure
-          serviceAccountName: {{ default (include "agent-bom.serviceAccountName" .) .Values.controlPlane.backup.serviceAccountName }}
+          serviceAccountName: {{ include "agent-bom.controlPlaneBackupServiceAccountName" . }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
           containers:

--- a/deploy/helm/agent-bom/templates/cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         spec:
-          serviceAccountName: {{ include "agent-bom.serviceAccountName" . }}
+          serviceAccountName: {{ include "agent-bom.scannerServiceAccountName" . }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -24,6 +24,7 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       automountServiceAccountToken: false
+      serviceAccountName: {{ include "agent-bom.gatewayServiceAccountName" . }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001

--- a/deploy/helm/agent-bom/templates/serviceaccount.yaml
+++ b/deploy/helm/agent-bom/templates/serviceaccount.yaml
@@ -11,3 +11,63 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
+{{- if and .Values.gateway.enabled .Values.gateway.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-bom.gatewayServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  {{- $gatewayAnnotations := .Values.gateway.serviceAccount.annotations }}
+  {{- if $gatewayAnnotations }}
+  annotations:
+    {{- toYaml $gatewayAnnotations | nindent 4 }}
+  {{- else if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.scanner.enabled .Values.scanner.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-bom.scannerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scanner
+  {{- $scannerAnnotations := .Values.scanner.serviceAccount.annotations }}
+  {{- if $scannerAnnotations }}
+  annotations:
+    {{- toYaml $scannerAnnotations | nindent 4 }}
+  {{- else if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.backup.enabled (not .Values.controlPlane.backup.serviceAccountName) .Values.controlPlane.backup.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-bom.controlPlaneBackupServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane-backup
+  {{- $backupAnnotations := .Values.controlPlane.backup.serviceAccount.annotations }}
+  {{- if $backupAnnotations }}
+  annotations:
+    {{- toYaml $backupAnnotations | nindent 4 }}
+  {{- else if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -35,6 +35,10 @@ scanner:
   outputFormat: json
   extraArgs: []
   env: []
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
 
@@ -105,6 +109,10 @@ gateway:
   policyPath: ""
   env: []
   envFrom: []
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
   extraVolumes: []
   extraVolumeMounts: []
   resources:
@@ -312,6 +320,10 @@ controlPlane:
     failedJobsHistoryLimit: 3
     suspend: false
     serviceAccountName: ""
+    serviceAccount:
+      create: true
+      name: ""
+      annotations: {}
     image:
       dumpRepository: postgres
       dumpTag: "16-alpine"

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -99,11 +99,16 @@ controlPlane:
 scanner:
   enabled: true
   allNamespaces: true
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
 
 serviceAccount:
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-discovery
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
 ```
+
+The chart supports component-specific service-account overrides for scanner, gateway, and backup jobs. If you omit the component-specific annotations, they inherit the shared `serviceAccount.annotations` block.
 
 Install:
 
@@ -133,6 +138,7 @@ That example adds:
 - packaged `PrometheusRule` alerts for API error rate, scanner failures, OIDC decode failures, and proxy audit backlog
 - packaged Grafana dashboard `ConfigMap` for clusters that already watch dashboard config
 - packaged Postgres backup `CronJob` that runs `pg_dump` and uploads to S3 through IRSA with SSE or KMS
+- dedicated service-account hooks for gateway and backup jobs, inheriting the scanner IRSA annotations unless you override them
 - restricted ingress defaults for the chart network policy
 
 For clusters that already standardize on a service mesh and policy controller,

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -180,7 +180,10 @@ without pretending every workload needs the same enforcement model.
 | `controlPlane.ingress.enabled` | routes `/` to UI and `/v1`, `/health`, `/docs`, `/ws` to API |
 | `controlPlane.api.envFrom` | loads Postgres URL, auth settings, audit HMAC, and other control-plane secrets |
 | `controlPlane.ui.env` | keeps same-origin routing honest with `NEXT_PUBLIC_API_URL=\"\"` or sets an explicit API URL |
-| `serviceAccount.annotations` | attaches IRSA to the scanner service account |
+| `serviceAccount.annotations` | shared IRSA/workload-identity annotations inherited by scanner, gateway, and backup service accounts unless you override them per component |
+| `scanner.serviceAccount.annotations` | attach a distinct IRSA role to the scanner CronJob when cluster discovery should use a different IAM role than the shared runtime SA |
+| `gateway.serviceAccount.annotations` | attach a distinct IRSA role to the gateway when it needs separate cloud access |
+| `controlPlane.backup.serviceAccount.annotations` | attach a distinct IRSA role to the Postgres backup CronJob |
 | `scanner.extraArgs` | enables `--k8s-mcp`, `--introspect`, `--enforce`, and other operator choices |
 | `scanner.allNamespaces` | expands cluster scan scope |
 | `controlPlane.api.autoscaling.*` | autoscales the API deployment |
@@ -197,7 +200,7 @@ helm install agent-bom deploy/helm/agent-bom \
   -n agent-bom --create-namespace \
   --set controlPlane.enabled=true \
   --set controlPlane.ingress.enabled=true \
-  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/agent-bom-discovery \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE \
   --set scanner.allNamespaces=true \
   --set-json 'scanner.extraArgs=["--k8s-mcp","--k8s-all-namespaces","--introspect","--enforce","--preset","enterprise"]'
 ```

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -355,6 +355,26 @@ def test_helm_control_plane_backup_defaults():
     assert backup["destination"]["encryption"]["mode"] == "AES256"
     assert backup["image"]["dumpRepository"] == "postgres"
     assert backup["image"]["uploadRepository"] == "amazon/aws-cli"
+    assert backup["serviceAccount"]["create"] is True
+    assert backup["serviceAccount"]["annotations"] == {}
+
+
+def test_helm_gateway_service_account_defaults():
+    """Gateway service account knobs stay explicit for IRSA-style rollout."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    sa = doc["gateway"]["serviceAccount"]
+    assert sa["create"] is True
+    assert sa["name"] == ""
+    assert sa["annotations"] == {}
+
+
+def test_helm_scanner_service_account_defaults():
+    """Scanner service account knobs stay explicit for IRSA-style rollout."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    sa = doc["scanner"]["serviceAccount"]
+    assert sa["create"] is True
+    assert sa["name"] == ""
+    assert sa["annotations"] == {}
 
 
 def test_helm_monitor_disabled_by_default():


### PR DESCRIPTION
## Summary
- add dedicated Helm service-account hooks for gateway and control-plane backup jobs while keeping the shared scanner service account path intact
- let gateway and backup IRSA annotations inherit the shared service-account annotations by default, with component-level overrides when needed
- replace example AWS account IDs with explicit `REPLACE_ME_*` placeholders so the deployment docs and example values cannot be mistaken for live defaults

## Verification
- `python -m pytest -q tests/test_deploy_manifests.py`
- `python scripts/check_release_consistency.py`
- `pre-commit run --files deploy/helm/agent-bom/examples/eks-production-values.yaml deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml deploy/helm/agent-bom/templates/_helpers.tpl deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml deploy/helm/agent-bom/templates/gateway-deployment.yaml deploy/helm/agent-bom/templates/serviceaccount.yaml deploy/helm/agent-bom/values.yaml site-docs/deployment/control-plane-helm.md site-docs/deployment/own-infra-eks.md tests/test_deploy_manifests.py`