### PR TITLE
fix: harden gateway auth and visual leak readiness

### DIFF
--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -103,6 +103,16 @@ gateway:
     upstreams: []
   # Optional runtime policy JSON path (mounted via extraVolumes + extraVolumeMounts).
   policyPath: ""
+  # Typical deploy-time auth/runtime wiring:
+  #   env:
+  #     - name: AGENT_BOM_GATEWAY_DETECT_VISUAL_LEAKS
+  #       value: "1"
+  #   envFrom:
+  #     - secretRef:
+  #         name: agent-bom-gateway-auth
+  #
+  # Where `agent-bom-gateway-auth` contains:
+  #   AGENT_BOM_GATEWAY_BEARER_TOKEN=<token for incoming gateway clients>
   env: []
   envFrom: []
   extraVolumes: []

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -96,6 +96,8 @@ sequenceDiagram
 - self-hosted API, UI, audit log, and Postgres stay in the company's infra
 - OIDC, API keys, RBAC, and Postgres RLS are the control-plane boundary
 - proxy policy pull and audit push are now real, not cosmetic
+- gateway can now require an incoming bearer/API-key token for remote MCP clients
+- screenshot OCR enforcement now fails closed when explicitly enabled without the visual runtime
 - `AGENT_BOM_AUDIT_HMAC_KEY` is required for pilot sign-off
 - the EKS pilot path assumes Pod Security Admission `restricted`
 - focused pilot values lock ingress down instead of leaving it wide open

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import click
 
+from agent_bom.cli._server import _enforce_remote_mcp_auth_defaults
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,6 +66,31 @@ def gateway_group() -> None:
 )
 @click.option("--bind", default="0.0.0.0:8090", show_default=True, help="Bind address host:port.")
 @click.option(
+    "--bearer-token",
+    envvar="AGENT_BOM_GATEWAY_BEARER_TOKEN",
+    default=None,
+    help="Require incoming bearer/API-key auth for gateway clients.",
+)
+@click.option(
+    "--allow-insecure-no-auth",
+    is_flag=True,
+    default=False,
+    help="Allow unauthenticated non-loopback gateway exposure. Unsafe outside local development.",
+)
+@click.option(
+    "--detect-visual-leaks",
+    is_flag=True,
+    envvar="AGENT_BOM_GATEWAY_DETECT_VISUAL_LEAKS",
+    default=False,
+    help="OCR-scan image tool responses for credentials/PII (requires 'agent-bom[visual]').",
+)
+@click.option(
+    "--allow-visual-leak-best-effort",
+    is_flag=True,
+    default=False,
+    help="Continue startup if visual leak detection is enabled but OCR runtime support is unavailable.",
+)
+@click.option(
     "--log-level",
     type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
     default="info",
@@ -75,6 +102,10 @@ def serve_cmd(
     control_plane_token: str | None,
     policy_path: Path | None,
     bind: str,
+    bearer_token: str | None,
+    allow_insecure_no_auth: bool,
+    detect_visual_leaks: bool,
+    allow_visual_leak_best_effort: bool,
     log_level: str,
 ) -> None:
     """Run the gateway server on ``bind``.
@@ -108,6 +139,7 @@ def serve_cmd(
         UpstreamRegistry,
         fetch_discovered_upstreams,
     )
+    from agent_bom.runtime.visual_leak_detector import require_visual_leak_runtime
 
     registry: UpstreamRegistry | None = None
 
@@ -141,17 +173,39 @@ def serve_cmd(
             click.echo(f"policy file error: {exc}", err=True)
             sys.exit(2)
 
-    settings = GatewaySettings(registry=registry, policy=policy, audit_sink=None)
+    host, _, port = bind.partition(":")
+    host = host or "0.0.0.0"  # nosec B104
+    _enforce_remote_mcp_auth_defaults(host, bearer_token, allow_insecure_no_auth)
+    if detect_visual_leaks and not allow_visual_leak_best_effort:
+        try:
+            require_visual_leak_runtime()
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    settings = GatewaySettings(
+        registry=registry,
+        policy=policy,
+        audit_sink=None,
+        bearer_token=bearer_token,
+        enable_visual_leak_detection=detect_visual_leaks,
+        require_visual_leak_detection_ready=detect_visual_leaks and not allow_visual_leak_best_effort,
+    )
     app = create_gateway_app(settings)
 
-    host, _, port = bind.partition(":")
     # Binding to 0.0.0.0 is intentional for containerized deploys — ingress /
     # service mesh terminates external traffic in front of this pod. Set
     # --bind 127.0.0.1:8090 on a dev workstation to restrict.
-    host = host or "0.0.0.0"  # nosec B104
+    host = host  # nosec B104
     port_num = int(port or "8090")
 
     click.echo(f"agent-bom gateway serving on http://{host}:{port_num} fronting {len(registry)} upstream(s): {', '.join(registry.names())}")
+    if bearer_token:
+        click.echo("Auth: bearer/API-key token required for incoming gateway clients")
+    elif allow_insecure_no_auth:
+        click.echo("Auth: disabled by explicit override (--allow-insecure-no-auth)")
+    if detect_visual_leaks:
+        mode = "best-effort" if allow_visual_leak_best_effort else "required"
+        click.echo(f"Visual leak detection: enabled ({mode})")
     uvicorn.run(app, host=host, port=port_num, log_level=log_level.lower())
 
 

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -72,13 +72,20 @@ class GatewaySettings:
     policy: dict[str, Any]  # dict passed to check_policy — same shape proxy uses
     audit_sink: AuditSink | None = None
     upstream_caller: UpstreamCaller | None = None  # injectable for tests
+    bearer_token: str | None = None
     # Visual-leak detection on image tool responses (closes the screenshot
     # channel that CredentialLeakDetector can't see — #1568). Opt-in
     # because OCR is CPU-heavy; see docs/ENTERPRISE_SECURITY_PLAYBOOK.md §2.2.
-    # Set to True AND install `agent-bom[visual]` to enable. When enabled
-    # but the visual extra is missing, the detector degrades silently
-    # (returns empty alerts, passes images through).
+    # Set to True AND install `agent-bom[visual]` to enable.
     enable_visual_leak_detection: bool = False
+    require_visual_leak_detection_ready: bool = False
+
+
+def _request_has_expected_token(request: Request, expected_token: str) -> bool:
+    auth = request.headers.get("authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[len("Bearer ") :].strip() == expected_token
+    return request.headers.get("x-api-key", "").strip() == expected_token
 
 
 async def _default_upstream_caller(
@@ -112,15 +119,29 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     Separating app construction from CLI entry point keeps the server
     testable end-to-end via ``TestClient(create_gateway_app(settings))``.
     """
+    if settings.enable_visual_leak_detection and settings.require_visual_leak_detection_ready:
+        from agent_bom.runtime.visual_leak_detector import require_visual_leak_runtime
+
+        require_visual_leak_runtime()
+
     app = FastAPI(title="agent-bom gateway", version="1")
     upstream_caller = settings.upstream_caller or _default_upstream_caller
 
     @app.get("/healthz")
     async def healthz() -> dict[str, Any]:
-        return {
+        health: dict[str, Any] = {
             "status": "ok",
             "upstreams": settings.registry.names(),
+            "auth": {"incoming_token_required": bool(settings.bearer_token)},
         }
+        if settings.enable_visual_leak_detection:
+            from agent_bom.runtime.visual_leak_detector import visual_leak_runtime_health
+
+            health["visual_leak_detection"] = {
+                **visual_leak_runtime_health(),
+                "required": settings.require_visual_leak_detection_ready,
+            }
+        return health
 
     @app.get("/metrics")
     async def metrics() -> Response:
@@ -136,6 +157,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     @app.post("/mcp/{server_name}")
     async def relay(server_name: str, request: Request) -> JSONResponse:
         """Route an MCP JSON-RPC request to the named upstream after policy + audit."""
+        if settings.bearer_token and not _request_has_expected_token(request, settings.bearer_token):
+            raise HTTPException(status_code=401, detail="gateway authentication required")
+
         upstream = settings.registry.get(server_name)
         if upstream is None:
             raise HTTPException(
@@ -206,9 +230,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         record_gateway_relay(upstream.name, "forwarded")
 
         # Visual-leak detection on image tool responses. Opt-in because OCR
-        # is CPU-heavy; the detector itself is no-op when its deps are
-        # missing, so enabling without the visual extra installed is safe
-        # (see VisualLeakDetector._ocr_available).
+        # is CPU-heavy; startup can now require the OCR runtime so pilots
+        # fail closed instead of silently skipping the screenshot channel.
         if settings.enable_visual_leak_detection and isinstance(upstream_response, dict):
             result = upstream_response.get("result")
             if isinstance(result, dict):

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -556,8 +556,9 @@ async def run_proxy(
         detect_credentials: Enable credential leak detection in responses.
         detect_visual_leaks: Enable OCR-based credential/PII detection on
             image tool responses (Playwright-MCP, Puppeteer-MCP, screen
-            capture tools — see issue #1568). Requires the ``visual`` extra;
-            degrades to a no-op when OCR deps are missing.
+            capture tools — see issue #1568). Requires the ``visual`` extra
+            and tesseract on PATH; startup now fails closed when requested
+            without the OCR runtime.
         rate_limit_threshold: Max calls per tool per 60s (0 = disabled).
         log_only: Log alerts without blocking (advisory mode).
         alert_webhook: Optional webhook URL for runtime alert notifications.
@@ -610,13 +611,10 @@ async def run_proxy(
     cred_detector = CredentialLeakDetector() if detect_credentials else None
     visual_detector = None
     if detect_visual_leaks:
-        from agent_bom.runtime.visual_leak_detector import VisualLeakDetector
+        from agent_bom.runtime.visual_leak_detector import VisualLeakDetector, require_visual_leak_runtime
 
+        require_visual_leak_runtime()
         visual_detector = VisualLeakDetector()
-        if not visual_detector.enabled:
-            logger.warning(
-                "Visual leak detection requested but OCR deps are missing — install 'agent-bom[visual]' and ensure tesseract is on PATH"
-            )
     local_policy_rate_limit = resolve_rate_limit_threshold(policy) if policy else None
     effective_rate_limit_threshold = rate_limit_threshold or local_policy_rate_limit or 0
     rate_tracker = RateLimitTracker(threshold=max(effective_rate_limit_threshold, 0))

--- a/src/agent_bom/runtime/visual_leak_detector.py
+++ b/src/agent_bom/runtime/visual_leak_detector.py
@@ -82,6 +82,32 @@ def _ocr_available() -> bool:
     return True
 
 
+def visual_leak_runtime_ready() -> bool:
+    """Return True when OCR/image deps are actually available for enforcement."""
+    return _ocr_available()
+
+
+def require_visual_leak_runtime() -> None:
+    """Raise when visual-leak enforcement is requested without OCR runtime support."""
+    if visual_leak_runtime_ready():
+        return
+    raise RuntimeError(
+        "Visual leak detection requires 'agent-bom[visual]' and the tesseract binary on PATH. "
+        "Install the visual extra or disable screenshot OCR enforcement."
+    )
+
+
+def visual_leak_runtime_health() -> dict[str, Any]:
+    """Operator-facing readiness metadata for health endpoints and startup checks."""
+    ready = visual_leak_runtime_ready()
+    return {
+        "enabled": ready,
+        "ready": ready,
+        "mode": "enforcing" if ready else "unavailable",
+        "reason": None if ready else "install agent-bom[visual] and ensure tesseract is on PATH",
+    }
+
+
 def _decode_image(block: dict[str, Any]):
     """Decode a single MCP image content block into a PIL Image, or None."""
     from PIL import Image
@@ -304,4 +330,11 @@ async def run_visual_leak_redact(detector: VisualLeakDetector, content_blocks: l
     return await asyncio.wait_for(asyncio.to_thread(detector.redact, content_blocks), timeout=timeout)
 
 
-__all__ = ["VisualLeakDetector", "run_visual_leak_check", "run_visual_leak_redact"]
+__all__ = [
+    "VisualLeakDetector",
+    "require_visual_leak_runtime",
+    "run_visual_leak_check",
+    "run_visual_leak_redact",
+    "visual_leak_runtime_health",
+    "visual_leak_runtime_ready",
+]

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
+from agent_bom.cli._gateway import serve_cmd as gateway_serve_cmd
 from agent_bom.cli._server import api_cmd, mcp_server_cmd, serve_cmd
 
 # ---------------------------------------------------------------------------
@@ -247,6 +248,44 @@ def test_mcp_server_cmd_stdio_warns_when_bearer_token_is_unused():
 
     assert result.exit_code == 0
     assert "applies only to SSE / Streamable HTTP" in result.output
+
+
+def test_gateway_serve_rejects_unauthenticated_non_loopback_bind(tmp_path):
+    runner = CliRunner()
+    upstreams = tmp_path / "upstreams.yaml"
+    upstreams.write_text("upstreams:\n  - name: jira\n    url: https://jira.example.com/mcp\n")
+
+    result = runner.invoke(gateway_serve_cmd, ["--bind", "0.0.0.0:8090", "--upstreams", str(upstreams)])
+    assert result.exit_code == 1
+    assert "without transport authentication" in result.output
+
+
+def test_gateway_serve_allows_non_loopback_bind_with_bearer_token(tmp_path):
+    runner = CliRunner()
+    upstreams = tmp_path / "upstreams.yaml"
+    upstreams.write_text("upstreams:\n  - name: jira\n    url: https://jira.example.com/mcp\n")
+
+    with patch("uvicorn.run") as mock_run:
+        result = runner.invoke(gateway_serve_cmd, ["--bind", "0.0.0.0:8090", "--upstreams", str(upstreams), "--bearer-token", "gw-token"])
+
+    assert result.exit_code == 0
+    assert "token required" in result.output
+    mock_run.assert_called_once()
+
+
+def test_gateway_serve_requires_visual_runtime_when_enabled(tmp_path):
+    runner = CliRunner()
+    upstreams = tmp_path / "upstreams.yaml"
+    upstreams.write_text("upstreams:\n  - name: jira\n    url: https://jira.example.com/mcp\n")
+
+    with patch("agent_bom.runtime.visual_leak_detector.visual_leak_runtime_ready", return_value=False):
+        result = runner.invoke(
+            gateway_serve_cmd,
+            ["--bind", "127.0.0.1:8090", "--upstreams", str(upstreams), "--detect-visual-leaks"],
+        )
+
+    assert result.exit_code == 1
+    assert "Visual leak detection requires" in result.output
 
 
 def test_mcp_server_cmd_missing_sdk():

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -48,7 +48,34 @@ def test_healthz_lists_configured_upstreams() -> None:
     client = TestClient(create_gateway_app(settings))
     resp = client.get("/healthz")
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ok", "upstreams": ["filesystem", "jira"]}
+    assert resp.json() == {
+        "status": "ok",
+        "upstreams": ["filesystem", "jira"],
+        "auth": {"incoming_token_required": False},
+    }
+
+
+def test_healthz_reports_visual_leak_readiness_when_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "agent_bom.runtime.visual_leak_detector.visual_leak_runtime_health",
+        lambda: {"enabled": True, "ready": True, "mode": "enforcing", "reason": None},
+    )
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        enable_visual_leak_detection=True,
+        require_visual_leak_detection_ready=False,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json()["visual_leak_detection"] == {
+        "enabled": True,
+        "ready": True,
+        "mode": "enforcing",
+        "reason": None,
+        "required": False,
+    }
 
 
 def test_metrics_endpoint_returns_prometheus_text_format() -> None:
@@ -95,6 +122,33 @@ def test_relay_forwards_to_upstream_and_returns_response() -> None:
     assert resp.json()["result"]["content"][0]["text"] == "ok"
     assert upstream_calls[0]["name"] == "filesystem"
     assert upstream_calls[0]["url"] == "http://fs.local:8100"
+
+
+def test_relay_requires_gateway_token_when_configured() -> None:
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+        bearer_token="gw-secret",
+    )
+    client = TestClient(create_gateway_app(settings))
+    denied = client.post(
+        "/mcp/filesystem",
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+    assert denied.status_code == 401
+    assert "authentication required" in denied.json()["detail"]
+
+    allowed = client.post(
+        "/mcp/filesystem",
+        headers={"Authorization": "Bearer gw-secret"},
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+    assert allowed.status_code == 200
+    assert allowed.json()["result"]["ok"] is True
 
 
 # ─── Policy block ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- require explicit incoming auth for non-loopback gateway deployments via the CLI and gateway settings instead of leaving public-edge startup at warn-only behavior
- expose gateway-side visual leak detection as a real operator surface with CLI flags, startup enforcement, and health reporting
- fail closed when visual leak detection is enabled without the required OCR runtime, and reflect that readiness in the gateway health payload

## Verification
- `python -m pytest -q tests/test_gateway_server.py tests/test_cli_server.py tests/test_visual_leak_detector.py`
- `python scripts/check_release_consistency.py`
- `pre-commit run --files src/agent_bom/runtime/visual_leak_detector.py src/agent_bom/gateway_server.py src/agent_bom/cli/_gateway.py src/agent_bom/proxy.py deploy/helm/agent-bom/values.yaml site-docs/deployment/enterprise-pilot.md tests/test_gateway_server.py tests/test_cli_server.py tests/test_visual_leak_detector.py`