### PR TITLE
fix P0 audit gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
           cd ui
           npm ci
 
+      - name: Guard UI lockfile drift
+        run: |
+          cd ui
+          cp package-lock.json /tmp/ui-package-lock.before.json
+          npm install --package-lock-only --ignore-scripts
+          diff -u /tmp/ui-package-lock.before.json package-lock.json
+
       - name: Verify UI toolchain contract
         run: |
           cd ui

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The demo uses a curated sample so the output stays reproducible across releases.
 | Check a package before install | `agent-bom check flask@2.2.0 --ecosystem pypi` | Machine-readable pre-install verdict |
 | Scan a container image | `agent-bom image nginx:latest` | OS and package CVEs with fixability |
 | Audit IaC or cloud posture | `agent-bom iac Dockerfile k8s/ infra/main.tf` | Misconfigurations, manifest hardening, optional live cluster posture |
-| Review findings in a persistent graph | `agent-bom serve` | API, dashboard, unified graph, current-state and diff views |
+| Review findings in a persistent graph | `agent-bom serve` | API plus bundled local UI; Kubernetes uses the separate `agent-bom-ui` image |
 | Inspect live MCP traffic | `agent-bom proxy "<server command>"` | Inline runtime inspection, detector chaining, response/argument review |
 
 ## Quick start
@@ -81,7 +81,7 @@ After the first scan:
 ```bash
 agent-bom agents -p . --remediate remediation.md                  # fix-first plan
 agent-bom agents -p . --compliance-export fedramp -o evidence.zip # tamper-evident evidence bundle
-pip install 'agent-bom[ui]' && agent-bom serve                    # API + dashboard
+pip install 'agent-bom[ui]' && agent-bom serve                    # API + bundled local UI
 ```
 
 ## Product views

--- a/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
@@ -1,0 +1,33 @@
+controlPlane:
+  enabled: true
+  api:
+    replicas: 1
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane
+    env:
+      - name: AGENT_BOM_DB
+        value: /var/lib/agent-bom/control-plane.sqlite
+    extraVolumes:
+      - name: sqlite-data
+        persistentVolumeClaim:
+          claimName: agent-bom-sqlite-pilot
+    extraVolumeMounts:
+      - name: sqlite-data
+        mountPath: /var/lib/agent-bom
+  ui:
+    replicas: 1
+    env:
+      - name: NEXT_PUBLIC_API_URL
+        value: ""
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: agent-bom.internal.example.com
+
+scanner:
+  enabled: false
+
+pdb:
+  enabled: false

--- a/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
@@ -59,6 +59,10 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.controlPlane.api.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.controlPlane.api.resources | nindent 12 }}
           livenessProbe:
@@ -73,6 +77,10 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controlPlane.api.extraVolumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -209,6 +209,8 @@ controlPlane:
       - "8422"
     env: []
     envFrom: []
+    extraVolumes: []
+    extraVolumeMounts: []
     service:
       enabled: true
       type: ClusterIP

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -118,6 +118,44 @@ helm install agent-bom deploy/helm/agent-bom \
   -f values.agent-bom.yaml
 ```
 
+## Single-node SQLite pilot preset
+
+For a fast in-cluster pilot without external Postgres, use the shipped
+single-node preset:
+
+- [eks-control-plane-sqlite-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml)
+
+Create the auth secret and a small PVC first:
+
+```bash
+kubectl create secret generic agent-bom-control-plane \
+  -n agent-bom \
+  --from-literal=AGENT_BOM_API_KEY='replace-me'
+
+kubectl apply -n agent-bom -f - <<'EOF'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agent-bom-sqlite-pilot
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi
+EOF
+```
+
+Then install:
+
+```bash
+helm install agent-bom deploy/helm/agent-bom \
+  -n agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
+```
+
+This preset is intentionally single-node only: one API pod, one UI pod, PVC-backed
+SQLite state, no HPA, no PDB, and no multi-replica availability claims.
+
 ## Production defaults example
 
 For the stronger self-hosted operator path, start from:

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -16,6 +16,11 @@ If you want the narrower pilot shape first, start with
 also covers developer endpoints, pair this page with
 [Endpoint Fleet](endpoint-fleet.md).
 
+If you need the fastest packaged control-plane demo before standing up
+Postgres, there is now a single-node SQLite preset at
+[eks-control-plane-sqlite-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml).
+Use it only for pilots and demos; multi-replica EKS still belongs on Postgres.
+
 ## What This EKS Shape Is Optimized For
 
 This deployment model is built for teams that want:

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
@@ -48,6 +49,7 @@ UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awai
 # visual detector (Pillow/pytesseract). Built on first use when
 # ``enable_visual_leak_detection`` is True.
 _visual_detector_singleton: Any = None
+_visual_detector_lock = threading.Lock()
 
 
 def _sanitize_for_log(value: Any) -> str:
@@ -58,9 +60,11 @@ def _sanitize_for_log(value: Any) -> str:
 def _get_visual_leak_detector() -> Any:
     global _visual_detector_singleton
     if _visual_detector_singleton is None:
-        from agent_bom.runtime.visual_leak_detector import VisualLeakDetector
+        with _visual_detector_lock:
+            if _visual_detector_singleton is None:
+                from agent_bom.runtime.visual_leak_detector import VisualLeakDetector
 
-        _visual_detector_singleton = VisualLeakDetector()
+                _visual_detector_singleton = VisualLeakDetector()
     return _visual_detector_singleton
 
 

--- a/src/agent_bom/runtime/visual_leak_detector.py
+++ b/src/agent_bom/runtime/visual_leak_detector.py
@@ -147,16 +147,19 @@ def _extract_word_boxes(img) -> list[tuple[str, tuple[int, int, int, int]]]:
     tops = raw.get("top", [])
     widths = raw.get("width", [])
     heights = raw.get("height", [])
-    for idx, word in enumerate(words):
+    for word, conf_raw, left, top, width, height in zip(words, confs, lefts, tops, widths, heights, strict=False):
         if not word or not word.strip():
             continue
         try:
-            conf = float(confs[idx])
+            conf = float(conf_raw)
+            bbox = (int(left), int(top), int(left) + int(width), int(top) + int(height))
         except (TypeError, ValueError):
             conf = -1.0
+            bbox = None
         if conf < 40.0:
             continue
-        bbox = (int(lefts[idx]), int(tops[idx]), int(lefts[idx]) + int(widths[idx]), int(tops[idx]) + int(heights[idx]))
+        if bbox is None:
+            continue
         out.append((word, bbox))
     return out
 

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -368,6 +368,14 @@ def test_helm_gateway_service_account_defaults():
     assert sa["annotations"] == {}
 
 
+def test_helm_control_plane_api_extra_volume_defaults():
+    """API deployment exposes opt-in extra volume hooks for SQLite pilot storage."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    api = doc["controlPlane"]["api"]
+    assert api["extraVolumes"] == []
+    assert api["extraVolumeMounts"] == []
+
+
 def test_helm_scanner_service_account_defaults():
     """Scanner service account knobs stay explicit for IRSA-style rollout."""
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
@@ -476,6 +484,22 @@ def test_production_values_enable_operator_defaults():
     assert production["topologySpread"]["enabled"] is True
     assert production["networkPolicy"]["restrictIngress"] is True
     assert "cert-manager.io/cluster-issuer" in production["controlPlane"]["ingress"]["annotations"]
+
+
+def test_helm_single_node_sqlite_pilot_example_is_shipped():
+    """Pilot preset should provide an in-cluster control-plane storage story."""
+    doc = yaml.safe_load((HELM_DIR / "examples" / "eks-control-plane-sqlite-pilot-values.yaml").read_text())
+    assert doc["controlPlane"]["enabled"] is True
+    assert doc["controlPlane"]["api"]["replicas"] == 1
+    assert doc["controlPlane"]["ui"]["replicas"] == 1
+    assert doc["controlPlane"]["api"]["env"][0] == {
+        "name": "AGENT_BOM_DB",
+        "value": "/var/lib/agent-bom/control-plane.sqlite",
+    }
+    assert doc["controlPlane"]["api"]["extraVolumes"][0]["persistentVolumeClaim"]["claimName"] == "agent-bom-sqlite-pilot"
+    assert doc["controlPlane"]["api"]["extraVolumeMounts"][0]["mountPath"] == "/var/lib/agent-bom"
+    assert doc["scanner"]["enabled"] is False
+    assert doc["pdb"]["enabled"] is False
 
 
 def test_mesh_example_enables_istio_and_kyverno_hardening():

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -13,7 +13,9 @@ paths a pilot team would actually run into.
 
 from __future__ import annotations
 
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from starlette.testclient import TestClient
@@ -290,6 +292,30 @@ def test_relay_non_tool_message_bypasses_policy_and_forwards() -> None:
     resp = client.post("/mcp/filesystem", json=_json_rpc("tools/list"))
     assert resp.status_code == 200
     assert upstream_calls and upstream_calls[0]["method"] == "tools/list"
+
+
+def test_visual_detector_singleton_init_is_locked(monkeypatch) -> None:
+    import agent_bom.gateway_server as gw
+
+    created: list[object] = []
+    create_lock = threading.Lock()
+
+    class FakeDetector:
+        def __init__(self) -> None:
+            time.sleep(0.02)
+            with create_lock:
+                created.append(self)
+
+    monkeypatch.setattr("agent_bom.runtime.visual_leak_detector.VisualLeakDetector", FakeDetector)
+    gw._visual_detector_singleton = None
+    try:
+        with ThreadPoolExecutor(max_workers=6) as executor:
+            detectors = list(executor.map(lambda _i: gw._get_visual_leak_detector(), range(6)))
+    finally:
+        gw._visual_detector_singleton = None
+
+    assert len(created) == 1
+    assert all(detector is created[0] for detector in detectors)
 
 
 # ─── Visual-leak detection wire-up ─────────────────────────────────────────

--- a/tests/test_visual_leak_detector.py
+++ b/tests/test_visual_leak_detector.py
@@ -25,7 +25,7 @@ pytest.importorskip("pytesseract")
 from PIL import Image  # noqa: E402
 
 from agent_bom.runtime.detectors import AlertSeverity  # noqa: E402
-from agent_bom.runtime.visual_leak_detector import VisualLeakDetector  # noqa: E402
+from agent_bom.runtime.visual_leak_detector import VisualLeakDetector, _extract_word_boxes  # noqa: E402
 
 
 def _png_bytes(width: int = 400, height: int = 200, color: str = "white") -> bytes:
@@ -203,6 +203,24 @@ def test_ocr_runtime_error_is_treated_as_empty_scan():
     ):
         assert d.check("t", [_img_block()]) == []
         assert d.redact([_img_block()])[0]["type"] == "image"
+
+
+def test_extract_word_boxes_tolerates_mismatched_ocr_arrays():
+    img = Image.new("RGB", (32, 32), color="white")
+    with patch(
+        "pytesseract.image_to_data",
+        return_value={
+            "text": ["AKIAIOSFODNN7EXAMPLE", "ignored"],
+            "conf": ["91"],
+            "left": [5],
+            "top": [6],
+            "width": [20],
+            "height": [8],
+        },
+    ):
+        boxes = _extract_word_boxes(img)
+
+    assert boxes == [("AKIAIOSFODNN7EXAMPLE", (5, 6, 25, 14))]
 
 
 def test_multi_word_sliding_window_catches_key_value_leaks():


### PR DESCRIPTION
## What changed

This PR closes the P0 items from the 2026-04-20 audit that were ready to ship as one release patch.

- fixed the `VisualLeakDetector` singleton race in `gateway_server.py`
- fixed OCR word-box extraction so mismatched pytesseract arrays cannot raise out-of-bounds errors
- corrected README/product wording so `agent-bom serve` is described as API + bundled local UI, while Kubernetes uses the separate `agent-bom-ui` image
- added a UI lockfile drift guard in CI so npm lockfile inconsistencies fail in validation instead of lingering silently
- shipped a single-node Helm SQLite control-plane pilot preset, plus the API volume hooks and docs needed to use it honestly

## Why it changed

The audit called out five release-blocking issues:

1. a concurrent lazy-init race in the visual leak detector
2. an OCR indexing bug
3. dashboard packaging overclaim in docs
4. lack of guardrails around UI lockfile drift
5. no minimal packaged control-plane persistence preset for pilots

This PR addresses those directly without bundling broader P1 work.

## User and operator impact

- gateway screenshot OCR is safer under concurrent load
- malformed OCR output fails safe instead of throwing index errors
- docs now match the actual packaging model
- CI now detects UI lockfile drift deterministically
- operators have a supported single-node in-cluster pilot path without provisioning Postgres first

## Validation

- `uv run pytest tests/test_gateway_server.py tests/test_visual_leak_detector.py tests/test_deploy_manifests.py -q`
- `uv run ruff check src/agent_bom/gateway_server.py src/agent_bom/runtime/visual_leak_detector.py tests/test_gateway_server.py tests/test_visual_leak_detector.py tests/test_deploy_manifests.py`
- `cd ui && npm ci --ignore-scripts && git diff --exit-code -- package-lock.json`
- YAML parse check for `deploy/helm/agent-bom/values.yaml` and `deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml`
