### PR TITLE
harden resolver caches and VEX ingestion

### DIFF
--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import re
+import threading
 from typing import TYPE_CHECKING, Optional
 
 import httpx
@@ -49,14 +50,22 @@ logger = logging.getLogger(__name__)
 
 # Simple in-memory cache: hash(prompt) -> response (bounded)
 _cache: dict[str, str] = {}
+_cache_lock = threading.RLock()
+
+
+def _ai_cache_get(key: str) -> str | None:
+    """Read a cached AI response with synchronization."""
+    with _cache_lock:
+        return _cache.get(key)
 
 
 def _ai_cache_put(key: str, value: str) -> None:
     """Insert into bounded AI response cache."""
-    _cache[key] = value
-    if len(_cache) > _MAX_AI_CACHE:
-        for k in list(_cache.keys())[: len(_cache) - _MAX_AI_CACHE]:
-            del _cache[k]
+    with _cache_lock:
+        _cache[key] = value
+        if len(_cache) > _MAX_AI_CACHE:
+            for k in list(_cache.keys())[: len(_cache) - _MAX_AI_CACHE]:
+                del _cache[k]
 
 
 DEFAULT_MODEL = "openai/gpt-4o-mini"
@@ -173,8 +182,9 @@ async def _call_ollama_direct(prompt: str, model: str, max_tokens: int = 500) ->
     The *model* parameter is the bare model name (e.g. ``llama3.2``).
     """
     key = _cache_key(prompt, f"ollama/{model}")
-    if key in _cache:
-        return _cache[key]
+    cached = _ai_cache_get(key)
+    if cached is not None:
+        return cached
 
     try:
         async with httpx.AsyncClient(timeout=120.0) as client:
@@ -209,8 +219,9 @@ async def _call_ollama_direct(prompt: str, model: str, max_tokens: int = 500) ->
 async def _call_llm_via_litellm(prompt: str, model: str, max_tokens: int = 500) -> Optional[str]:
     """Call LLM via litellm with caching and error handling."""
     key = _cache_key(prompt, model)
-    if key in _cache:
-        return _cache[key]
+    cached = _ai_cache_get(key)
+    if cached is not None:
+        return cached
 
     try:
         from litellm import acompletion
@@ -243,8 +254,9 @@ async def _call_huggingface(
     Requires ``HF_TOKEN`` env var for gated models.
     """
     key = _cache_key(prompt, f"huggingface/{model}")
-    if key in _cache:
-        return _cache[key]
+    cached = _ai_cache_get(key)
+    if cached is not None:
+        return cached
 
     try:
         from huggingface_hub import InferenceClient
@@ -363,9 +375,10 @@ async def _call_ollama_structured(
     Falls back to None on error.
     """
     key = _cache_key(prompt, f"ollama/{model}:structured")
-    if key in _cache:
+    cached = _ai_cache_get(key)
+    if cached is not None:
         try:
-            return schema_cls.model_validate_json(_cache[key])
+            return schema_cls.model_validate_json(cached)
         except (json.JSONDecodeError, ValueError, AttributeError):
             pass
 

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1514,7 +1514,10 @@ def scan(
         from agent_bom.vex import apply_vex, load_vex
         from agent_bom.vex import to_serializable as _vex_to_ser
 
-        _vex_doc = load_vex(vex_path)
+        try:
+            _vex_doc = load_vex(vex_path)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
         _vex_count = apply_vex(report, _vex_doc)
         report.vex_data = _vex_to_ser(_vex_doc)
         if not quiet:

--- a/src/agent_bom/resolver.py
+++ b/src/agent_bom/resolver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from collections import defaultdict
 from typing import Optional
@@ -24,9 +25,12 @@ _RESOLVE_CONCURRENCY = 8
 _NPM_RESOLVE_CONCURRENCY = 3
 _NPM_LATEST_CACHE: dict[str, dict | None] = {}
 _PYPI_INFO_CACHE: dict[str, dict | None] = {}
+_NPM_LATEST_INFLIGHT: dict[str, asyncio.Future[dict | None]] = {}
+_PYPI_INFO_INFLIGHT: dict[str, asyncio.Future[dict | None]] = {}
 _NPM_RATE_LIMIT_UNTIL = 0.0
 _NPM_RATE_LIMIT_HITS = 0
 _NPM_RATE_LIMIT_MAX_COOLDOWN = 20.0
+_RESOLVER_STATE_LOCK = threading.RLock()
 _PERF_TEMPLATE = {
     "registry_cache_hits": 0,
     "registry_cache_misses": 0,
@@ -55,53 +59,71 @@ _PERF_STATS = dict(_PERF_TEMPLATE)
 
 def reset_performance_stats() -> None:
     """Reset per-scan resolver performance counters."""
-    _PERF_STATS.clear()
-    _PERF_STATS.update(_PERF_TEMPLATE)
+    with _RESOLVER_STATE_LOCK:
+        _PERF_STATS.clear()
+        _PERF_STATS.update(_PERF_TEMPLATE)
 
 
 def _bump_perf(key: str, delta: int = 1) -> None:
-    _PERF_STATS[key] = int(_PERF_STATS.get(key, 0)) + delta
+    with _RESOLVER_STATE_LOCK:
+        _PERF_STATS[key] = int(_PERF_STATS.get(key, 0)) + delta
 
 
 def consume_performance_stats() -> dict[str, dict[str, int]]:
     """Return and reset resolver performance counters."""
-    registry_hits = int(_PERF_STATS["registry_cache_hits"])
-    registry_misses = int(_PERF_STATS["registry_cache_misses"])
-    version_candidates = int(_PERF_STATS["version_candidates"])
-    version_reused = int(_PERF_STATS["version_reused_entries"])
-    license_candidates = int(_PERF_STATS["license_candidates"])
-    license_reused = int(_PERF_STATS["license_reused_entries"])
-    supply_candidates = int(_PERF_STATS["supply_chain_candidates"])
-    supply_reused = int(_PERF_STATS["supply_chain_reused_entries"])
+    with _RESOLVER_STATE_LOCK:
+        registry_hits = int(_PERF_STATS["registry_cache_hits"])
+        registry_misses = int(_PERF_STATS["registry_cache_misses"])
+        version_candidates = int(_PERF_STATS["version_candidates"])
+        version_reused = int(_PERF_STATS["version_reused_entries"])
+        license_candidates = int(_PERF_STATS["license_candidates"])
+        license_reused = int(_PERF_STATS["license_reused_entries"])
+        supply_candidates = int(_PERF_STATS["supply_chain_candidates"])
+        supply_reused = int(_PERF_STATS["supply_chain_reused_entries"])
+        registry_network_requests = int(_PERF_STATS["registry_network_requests"])
+        npm_rate_limit_events = int(_PERF_STATS["npm_rate_limit_events"])
+        npm_rate_limit_short_circuits = int(_PERF_STATS["npm_rate_limit_short_circuits"])
+        version_unique_lookups = int(_PERF_STATS["version_unique_lookups"])
+        version_resolved_live = int(_PERF_STATS["version_resolved_live"])
+        version_resolved_fallback = int(_PERF_STATS["version_resolved_fallback"])
+        version_unresolved = int(_PERF_STATS["version_unresolved"])
+        license_unique_lookups = int(_PERF_STATS["license_unique_lookups"])
+        license_enriched = int(_PERF_STATS["license_enriched"])
+        license_deps_dev_lookups = int(_PERF_STATS["license_deps_dev_lookups"])
+        supply_chain_unique_lookups = int(_PERF_STATS["supply_chain_unique_lookups"])
+        supply_chain_enriched = int(_PERF_STATS["supply_chain_enriched"])
+        supply_chain_deps_dev_fallbacks = int(_PERF_STATS["supply_chain_deps_dev_fallbacks"])
+        _PERF_STATS.clear()
+        _PERF_STATS.update(_PERF_TEMPLATE)
     snapshot = {
         "registry_metadata": {
             "cache_hits": registry_hits,
             "cache_misses": registry_misses,
-            "network_requests": int(_PERF_STATS["registry_network_requests"]),
-            "npm_rate_limit_events": int(_PERF_STATS["npm_rate_limit_events"]),
-            "npm_rate_limit_short_circuits": int(_PERF_STATS["npm_rate_limit_short_circuits"]),
+            "network_requests": registry_network_requests,
+            "npm_rate_limit_events": npm_rate_limit_events,
+            "npm_rate_limit_short_circuits": npm_rate_limit_short_circuits,
         },
         "version_resolution": {
             "candidates": version_candidates,
-            "unique_lookups": int(_PERF_STATS["version_unique_lookups"]),
+            "unique_lookups": version_unique_lookups,
             "reused_entries": version_reused,
-            "resolved_live": int(_PERF_STATS["version_resolved_live"]),
-            "resolved_fallback": int(_PERF_STATS["version_resolved_fallback"]),
-            "unresolved": int(_PERF_STATS["version_unresolved"]),
+            "resolved_live": version_resolved_live,
+            "resolved_fallback": version_resolved_fallback,
+            "unresolved": version_unresolved,
         },
         "license_enrichment": {
             "candidates": license_candidates,
-            "unique_lookups": int(_PERF_STATS["license_unique_lookups"]),
+            "unique_lookups": license_unique_lookups,
             "reused_entries": license_reused,
-            "enriched": int(_PERF_STATS["license_enriched"]),
-            "deps_dev_lookups": int(_PERF_STATS["license_deps_dev_lookups"]),
+            "enriched": license_enriched,
+            "deps_dev_lookups": license_deps_dev_lookups,
         },
         "supply_chain_enrichment": {
             "candidates": supply_candidates,
-            "unique_lookups": int(_PERF_STATS["supply_chain_unique_lookups"]),
+            "unique_lookups": supply_chain_unique_lookups,
             "reused_entries": supply_reused,
-            "enriched": int(_PERF_STATS["supply_chain_enriched"]),
-            "deps_dev_fallbacks": int(_PERF_STATS["supply_chain_deps_dev_fallbacks"]),
+            "enriched": supply_chain_enriched,
+            "deps_dev_fallbacks": supply_chain_deps_dev_fallbacks,
         },
     }
     total_registry_lookups = registry_hits + registry_misses
@@ -113,7 +135,6 @@ def consume_performance_stats() -> dict[str, dict[str, int]]:
         snapshot["license_enrichment"]["reuse_rate_pct"] = int(round((license_reused / license_candidates) * 100))
     if supply_candidates:
         snapshot["supply_chain_enrichment"]["reuse_rate_pct"] = int(round((supply_reused / supply_candidates) * 100))
-    reset_performance_stats()
     return snapshot
 
 
@@ -151,7 +172,8 @@ def _copy_resolution_fields(source: Package, target: Package) -> bool:
 
 
 def _npm_rate_limit_active() -> bool:
-    return time.monotonic() < _NPM_RATE_LIMIT_UNTIL
+    with _RESOLVER_STATE_LOCK:
+        return time.monotonic() < _NPM_RATE_LIMIT_UNTIL
 
 
 def _record_npm_rate_limit(response: httpx.Response | None) -> None:
@@ -171,69 +193,119 @@ def _record_npm_rate_limit(response: httpx.Response | None) -> None:
                 wait = min(float(retry_after), _NPM_RATE_LIMIT_MAX_COOLDOWN)
             except ValueError:
                 wait = 5.0
-    _NPM_RATE_LIMIT_HITS += 1
-    _bump_perf("npm_rate_limit_events")
-    _NPM_RATE_LIMIT_UNTIL = max(_NPM_RATE_LIMIT_UNTIL, time.monotonic() + wait)
+    with _RESOLVER_STATE_LOCK:
+        _NPM_RATE_LIMIT_HITS += 1
+        _PERF_STATS["npm_rate_limit_events"] = int(_PERF_STATS.get("npm_rate_limit_events", 0)) + 1
+        _NPM_RATE_LIMIT_UNTIL = max(_NPM_RATE_LIMIT_UNTIL, time.monotonic() + wait)
+
+
+def _npm_rate_limit_hits() -> int:
+    with _RESOLVER_STATE_LOCK:
+        return _NPM_RATE_LIMIT_HITS
 
 
 async def _get_npm_latest_doc(package_name: str, client: httpx.AsyncClient) -> dict | None:
     """Return cached npm `/latest` JSON for a package."""
     cache_key = package_name.lower()
-    if cache_key in _NPM_LATEST_CACHE:
-        _bump_perf("registry_cache_hits")
-        return _NPM_LATEST_CACHE[cache_key]
-    if _npm_rate_limit_active():
-        _bump_perf("npm_rate_limit_short_circuits")
-        return None
-    _bump_perf("registry_cache_misses")
-    _bump_perf("registry_network_requests")
+    owner = False
+    with _RESOLVER_STATE_LOCK:
+        if cache_key in _NPM_LATEST_CACHE:
+            _PERF_STATS["registry_cache_hits"] = int(_PERF_STATS.get("registry_cache_hits", 0)) + 1
+            return _NPM_LATEST_CACHE[cache_key]
+        if time.monotonic() < _NPM_RATE_LIMIT_UNTIL:
+            _PERF_STATS["npm_rate_limit_short_circuits"] = int(_PERF_STATS.get("npm_rate_limit_short_circuits", 0)) + 1
+            return None
+        inflight = _NPM_LATEST_INFLIGHT.get(cache_key)
+        if inflight is None:
+            inflight = asyncio.get_running_loop().create_future()
+            _NPM_LATEST_INFLIGHT[cache_key] = inflight
+            _PERF_STATS["registry_cache_misses"] = int(_PERF_STATS.get("registry_cache_misses", 0)) + 1
+            _PERF_STATS["registry_network_requests"] = int(_PERF_STATS.get("registry_network_requests", 0)) + 1
+            owner = True
+    if not owner:
+        return await inflight
 
     encoded_name = package_name.replace("/", "%2F")
-    response = await request_with_retry(
-        client,
-        "GET",
-        f"{NPM_REGISTRY}/{encoded_name}/latest",
-    )
-    data: dict | None = None
-    if response and response.status_code == 429:
-        _record_npm_rate_limit(response)
-        return None
-    if response and response.status_code == 200:
-        try:
-            parsed = response.json()
-            if isinstance(parsed, dict):
-                data = parsed
-        except ValueError as exc:
-            _logger.debug("Failed to parse npm metadata for %s: %s", package_name, exc)
-    _NPM_LATEST_CACHE[cache_key] = data
-    return data
+    inflight = _NPM_LATEST_INFLIGHT[cache_key]
+    try:
+        response = await request_with_retry(
+            client,
+            "GET",
+            f"{NPM_REGISTRY}/{encoded_name}/latest",
+        )
+        data: dict | None = None
+        if response and response.status_code == 429:
+            _record_npm_rate_limit(response)
+            if not inflight.done():
+                inflight.set_result(None)
+            return None
+        if response and response.status_code == 200:
+            try:
+                parsed = response.json()
+                if isinstance(parsed, dict):
+                    data = parsed
+            except ValueError as exc:
+                _logger.debug("Failed to parse npm metadata for %s: %s", package_name, exc)
+        with _RESOLVER_STATE_LOCK:
+            _NPM_LATEST_CACHE[cache_key] = data
+        if not inflight.done():
+            inflight.set_result(data)
+        return data
+    except Exception as exc:
+        if not inflight.done():
+            inflight.set_exception(exc)
+        raise
+    finally:
+        with _RESOLVER_STATE_LOCK:
+            _NPM_LATEST_INFLIGHT.pop(cache_key, None)
 
 
 async def _get_pypi_info_doc(package_name: str, client: httpx.AsyncClient) -> dict | None:
     """Return cached PyPI `info` JSON for a package."""
     cache_key = package_name.lower()
-    if cache_key in _PYPI_INFO_CACHE:
-        _bump_perf("registry_cache_hits")
-        return _PYPI_INFO_CACHE[cache_key]
-    _bump_perf("registry_cache_misses")
-    _bump_perf("registry_network_requests")
+    owner = False
+    with _RESOLVER_STATE_LOCK:
+        if cache_key in _PYPI_INFO_CACHE:
+            _PERF_STATS["registry_cache_hits"] = int(_PERF_STATS.get("registry_cache_hits", 0)) + 1
+            return _PYPI_INFO_CACHE[cache_key]
+        inflight = _PYPI_INFO_INFLIGHT.get(cache_key)
+        if inflight is None:
+            inflight = asyncio.get_running_loop().create_future()
+            _PYPI_INFO_INFLIGHT[cache_key] = inflight
+            _PERF_STATS["registry_cache_misses"] = int(_PERF_STATS.get("registry_cache_misses", 0)) + 1
+            _PERF_STATS["registry_network_requests"] = int(_PERF_STATS.get("registry_network_requests", 0)) + 1
+            owner = True
+    if not owner:
+        return await inflight
 
-    response = await request_with_retry(
-        client,
-        "GET",
-        f"{PYPI_API}/{package_name}/json",
-    )
-    info: dict | None = None
-    if response and response.status_code == 200:
-        try:
-            parsed = response.json()
-            maybe_info = parsed.get("info", {}) if isinstance(parsed, dict) else {}
-            if isinstance(maybe_info, dict):
-                info = maybe_info
-        except ValueError as exc:
-            _logger.debug("Failed to parse PyPI metadata for %s: %s", package_name, exc)
-    _PYPI_INFO_CACHE[cache_key] = info
-    return info
+    inflight = _PYPI_INFO_INFLIGHT[cache_key]
+    try:
+        response = await request_with_retry(
+            client,
+            "GET",
+            f"{PYPI_API}/{package_name}/json",
+        )
+        info: dict | None = None
+        if response and response.status_code == 200:
+            try:
+                parsed = response.json()
+                maybe_info = parsed.get("info", {}) if isinstance(parsed, dict) else {}
+                if isinstance(maybe_info, dict):
+                    info = maybe_info
+            except ValueError as exc:
+                _logger.debug("Failed to parse PyPI metadata for %s: %s", package_name, exc)
+        with _RESOLVER_STATE_LOCK:
+            _PYPI_INFO_CACHE[cache_key] = info
+        if not inflight.done():
+            inflight.set_result(info)
+        return info
+    except Exception as exc:
+        if not inflight.done():
+            inflight.set_exception(exc)
+        raise
+    finally:
+        with _RESOLVER_STATE_LOCK:
+            _PYPI_INFO_INFLIGHT.pop(cache_key, None)
 
 
 async def resolve_npm_metadata(
@@ -530,7 +602,7 @@ async def resolve_all_versions(
     if not unresolved:
         return 0
     _bump_perf("version_candidates", len(unresolved))
-    npm_rate_limit_hits_before = _NPM_RATE_LIMIT_HITS
+    npm_rate_limit_hits_before = _npm_rate_limit_hits()
     resolved_count = 0
     groups: dict[tuple[str, str], list[Package]] = defaultdict(list)
     for pkg in unresolved:
@@ -635,7 +707,7 @@ async def resolve_all_versions(
                     console.print(
                         f"  [yellow]↺[/yellow] Preserved scan continuity for {fallback_count} package(s) using bundled registry versions"
                     )
-            npm_rate_limit_hits = _NPM_RATE_LIMIT_HITS - npm_rate_limit_hits_before
+            npm_rate_limit_hits = _npm_rate_limit_hits() - npm_rate_limit_hits_before
             if npm_rate_limit_hits and not quiet:
                 console.print(
                     f"  [yellow]⚠[/yellow] npm registry rate-limited during version resolution "

--- a/src/agent_bom/vex.py
+++ b/src/agent_bom/vex.py
@@ -107,8 +107,8 @@ def load_vex(path: str) -> VexDocument:
         status_str = stmt_data.get("status", "under_investigation")
         try:
             status = VexStatus(status_str)
-        except ValueError:
-            status = VexStatus.UNDER_INVESTIGATION
+        except ValueError as exc:
+            raise ValueError(f"Unknown VEX status {status_str!r} in {path}") from exc
 
         justification = None
         just_str = stmt_data.get("justification")

--- a/tests/test_resolver_cov.py
+++ b/tests/test_resolver_cov.py
@@ -11,8 +11,11 @@ import agent_bom.resolver as resolver
 from agent_bom.models import Package
 from agent_bom.resolver import (
     _NPM_LATEST_CACHE,
+    _NPM_LATEST_INFLIGHT,
     _PYPI_INFO_CACHE,
+    _PYPI_INFO_INFLIGHT,
     _get_npm_latest_doc,
+    _get_pypi_info_doc,
     consume_performance_stats,
     enrich_licenses,
     enrich_supply_chain_metadata,
@@ -29,14 +32,18 @@ from agent_bom.resolver import (
 @pytest.fixture(autouse=True)
 def clear_registry_metadata_caches():
     _NPM_LATEST_CACHE.clear()
+    _NPM_LATEST_INFLIGHT.clear()
     _PYPI_INFO_CACHE.clear()
+    _PYPI_INFO_INFLIGHT.clear()
     reset_performance_stats()
 
     resolver._NPM_RATE_LIMIT_UNTIL = 0.0
     resolver._NPM_RATE_LIMIT_HITS = 0
     yield
     _NPM_LATEST_CACHE.clear()
+    _NPM_LATEST_INFLIGHT.clear()
     _PYPI_INFO_CACHE.clear()
+    _PYPI_INFO_INFLIGHT.clear()
     reset_performance_stats()
     resolver._NPM_RATE_LIMIT_UNTIL = 0.0
     resolver._NPM_RATE_LIMIT_HITS = 0
@@ -125,6 +132,48 @@ class TestResolveNpmMetadata:
         assert perf["registry_metadata"]["cache_misses"] == 1
         assert perf["registry_metadata"]["cache_hits"] == 1
         assert perf["registry_metadata"]["network_requests"] == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_npm_latest_requests_share_inflight_lookup(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"version": "1.2.3", "license": "MIT"}
+
+        async def fake_request(*_args, **_kwargs):
+            await asyncio.sleep(0.01)
+            return mock_response
+
+        with patch("agent_bom.resolver.request_with_retry", side_effect=fake_request) as mock_request:
+            client = AsyncMock()
+            first, second = await asyncio.gather(
+                _get_npm_latest_doc("cached", client),
+                _get_npm_latest_doc("cached", client),
+            )
+
+        assert first == {"version": "1.2.3", "license": "MIT"}
+        assert second == first
+        assert mock_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_pypi_info_requests_share_inflight_lookup(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"info": {"version": "2.31.0", "license": "Apache-2.0"}}
+
+        async def fake_request(*_args, **_kwargs):
+            await asyncio.sleep(0.01)
+            return mock_response
+
+        with patch("agent_bom.resolver.request_with_retry", side_effect=fake_request) as mock_request:
+            client = AsyncMock()
+            first, second = await asyncio.gather(
+                _get_pypi_info_doc("requests", client),
+                _get_pypi_info_doc("requests", client),
+            )
+
+        assert first == {"version": "2.31.0", "license": "Apache-2.0"}
+        assert second == first
+        assert mock_request.call_count == 1
 
 
 class TestResolvePypiMetadata:

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from agent_bom.models import (
     Agent,
     AIBOMReport,
@@ -187,12 +189,12 @@ class TestVexLoad:
         assert doc.statements[0].status == VexStatus.AFFECTED
         assert doc.statements[0].action_statement == "Upgrade to 2.0.0"
 
-    def test_load_unknown_status_defaults(self, tmp_path):
+    def test_load_unknown_status_raises(self, tmp_path):
         data = {"statements": [{"vulnerability_id": "CVE-2024-0001", "status": "bogus_status"}]}
         path = tmp_path / "vex.json"
         path.write_text(json.dumps(data))
-        doc = load_vex(str(path))
-        assert doc.statements[0].status == VexStatus.UNDER_INVESTIGATION
+        with pytest.raises(ValueError, match="Unknown VEX status"):
+            load_vex(str(path))
 
     def test_load_unknown_justification_ignored(self, tmp_path):
         data = {


### PR DESCRIPTION
## Summary
- harden resolver registry caches with synchronized state and shared inflight lookups
- synchronize AI enrichment cache access so concurrent scans do not race the in-process cache
- reject unknown VEX statuses at ingestion time and surface the failure as a CLI validation error
- add resolver concurrency regressions and VEX parsing coverage

## Why
The audit called out two real next-sprint correctness issues:
- the npm/PyPI and AI enrichment globals were mutable shared state with no synchronization
- invalid VEX statuses silently downgraded to `under_investigation`, which hides malformed policy input

This change keeps the existing cache behavior but removes duplicate concurrent registry fetches and fails fast on bad VEX data instead of silently rewriting it.

## Impact
- concurrent resolver lookups now share one network request per package key
- AI cache reads and writes are guarded inside the process
- `agent-bom scan --vex ...` now exits with a clear error when the VEX file contains an unknown status

## Validation
- `uv run pytest tests/test_resolver_cov.py tests/test_vex.py tests/test_ai_enrich.py -q`
- `uv run ruff check src/agent_bom/resolver.py src/agent_bom/ai_enrich.py src/agent_bom/vex.py src/agent_bom/cli/agents/__init__.py tests/test_resolver_cov.py tests/test_vex.py`
- pre-commit hooks during commit (`ruff`, `ruff-format`, `mypy`, `bandit`)
