### PR TITLE
tighten release guardrails and operator defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,25 @@ jobs:
           }
           # Scan dashboard deps
           osv-scanner scan --config osv-scanner.toml --lockfile=dashboard/requirements.txt
+          # Scan UI and SDK npm lockfiles with the same OSV gate as uv.lock
+          osv-scanner scan --config osv-scanner.toml --lockfile=ui/package-lock.json 2>&1 | tee /tmp/osv-ui.txt || {
+            FIXABLE=$(grep -E "^\|" /tmp/osv-ui.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
+            if [ -n "$FIXABLE" ]; then
+              echo "::error::osv-scanner found UI lockfile vulnerabilities with available fixes:"
+              echo "$FIXABLE"
+              exit 1
+            fi
+            echo "::warning::osv-scanner found only unfixable UI lockfile CVEs (no upstream fix) — passing"
+          }
+          osv-scanner scan --config osv-scanner.toml --lockfile=sdks/typescript/package-lock.json 2>&1 | tee /tmp/osv-sdk.txt || {
+            FIXABLE=$(grep -E "^\|" /tmp/osv-sdk.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
+            if [ -n "$FIXABLE" ]; then
+              echo "::error::osv-scanner found TypeScript SDK lockfile vulnerabilities with available fixes:"
+              echo "$FIXABLE"
+              exit 1
+            fi
+            echo "::warning::osv-scanner found only unfixable TypeScript SDK lockfile CVEs (no upstream fix) — passing"
+          }
 
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,21 @@ jobs:
           npm ci --ignore-scripts
           npm audit --audit-level=high
 
+      - name: OSV scanner (ui lockfile) — block release on fixable CVEs
+        run: |
+          curl -fsSL -o /usr/local/bin/osv-scanner \
+            https://github.com/google/osv-scanner/releases/download/v2.3.3/osv-scanner_linux_amd64
+          chmod +x /usr/local/bin/osv-scanner
+          osv-scanner scan --config osv-scanner.toml --lockfile=ui/package-lock.json 2>&1 | tee /tmp/osv-ui-release.txt || {
+            FIXABLE=$(grep -E "^\|" /tmp/osv-ui-release.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
+            if [ -n "$FIXABLE" ]; then
+              echo "::error::osv-scanner found UI lockfile vulnerabilities with available fixes:"
+              echo "$FIXABLE"
+              exit 1
+            fi
+            echo "::warning::osv-scanner found only unfixable UI lockfile CVEs (no upstream fix) — passing"
+          }
+
       - name: Self dep scan — block release on critical CVE
         run: |
           mkdir -p sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,8 @@ agent-bom is a **read-only scanner**. It does not modify agent configurations, e
 - API key auth via `AGENT_BOM_API_KEY` env var; OIDC/JWT via `AGENT_BOM_OIDC_ISSUER`
 - WebSocket endpoints require the same auth when `AGENT_BOM_API_KEY` is set
 - JWKS public key caching (1h TTL); RS256/RS384/RS512/ES256/ES384/ES512 supported; `alg: none` rejected
+- Dashboard HTML uses a route-specific CSP. The packaged FastAPI-served UI allows `script-src 'self' 'unsafe-inline'` for the Next.js runtime bootstrap; API JSON routes keep the stricter `default-src 'self'` policy.
+- The standalone Vercel preview config in `ui/vercel.json` is looser and still includes `unsafe-eval` for that hosting path. Treat it as a preview-only constraint, not the recommended self-hosted control-plane policy.
 
 ## Security Testing
 

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -160,6 +160,11 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
 
+monitor:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
 topologySpread:
   enabled: true
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -166,6 +166,7 @@ For the stronger self-hosted operator path, start from:
 That example adds:
 
 - `HPA` for API and UI
+- `ServiceMonitor` enabled in the production preset so `/metrics` is scraped when Prometheus Operator is present
 - `HPA` scale-down stabilization
 - topology spread across zones and nodes
 - preferred pod anti-affinity for API and UI replicas
@@ -234,6 +235,7 @@ You still own:
   `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS`, and
   `AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS`
 - enable `controlPlane.observability.prometheusRule.enabled=true` when the cluster already runs Prometheus Operator
+- keep `monitor.enabled=true` and `monitor.serviceMonitor.enabled=true` in the production preset unless your platform team has a different scrape contract
 - enable `controlPlane.observability.grafanaDashboard.enabled=true` when Grafana watches dashboard `ConfigMap`s
 - enable `controlPlane.backup.enabled=true` only after setting a real S3 bucket, prefix, and IRSA-backed upload permissions
 - enable `controlPlane.serviceMesh.enabled=true` only when the control-plane namespace is already part of your Istio data plane

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -500,6 +500,24 @@ def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def get_rate_limit_runtime_status() -> dict[str, object]:
+    """Report whether API rate limiting is shared across replicas."""
+    postgres_configured = bool(os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip())
+    shared_required = _env_flag("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT")
+    backend = "postgres_shared" if postgres_configured else "inmemory"
+    return {
+        "backend": backend,
+        "postgres_configured": postgres_configured,
+        "shared_required": shared_required,
+        "shared_across_replicas": postgres_configured,
+        "message": (
+            "Rate limiting uses Postgres-backed shared state across replicas."
+            if postgres_configured
+            else ("Rate limiting is process-local and resets on pod restart. Set AGENT_BOM_POSTGRES_URL for shared limiter state.")
+        ),
+    }
+
+
 def _rate_limit_fingerprint_key() -> bytes:
     key = (os.environ.get("AGENT_BOM_RATE_LIMIT_KEY") or os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") or "").strip()
     return key.encode() if key else _RATE_LIMIT_FINGERPRINT_FALLBACK

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -180,10 +180,11 @@ async def auth_policy() -> dict:
     past the configured maximum.
     """
     from agent_bom.api.auth import get_api_key_policy
-    from agent_bom.api.middleware import get_rate_limit_key_status
+    from agent_bom.api.middleware import get_rate_limit_key_status, get_rate_limit_runtime_status
 
     api_policy = get_api_key_policy()
     rl_status = get_rate_limit_key_status()
+    rl_runtime = get_rate_limit_runtime_status()
     return {
         "api_key": {
             "default_ttl_seconds": api_policy.default_ttl_seconds,
@@ -192,6 +193,7 @@ async def auth_policy() -> dict:
             "rotation_endpoint": "/v1/auth/keys/{key_id}/rotate",
         },
         "rate_limit_key": rl_status,
+        "rate_limit_runtime": rl_runtime,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Global test fixtures for shared module state reset."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _reset_resolver_state() -> None:
+    try:
+        import agent_bom.resolver as resolver
+
+        resolver._NPM_LATEST_CACHE.clear()
+        if hasattr(resolver, "_NPM_LATEST_INFLIGHT"):
+            resolver._NPM_LATEST_INFLIGHT.clear()
+        resolver._PYPI_INFO_CACHE.clear()
+        if hasattr(resolver, "_PYPI_INFO_INFLIGHT"):
+            resolver._PYPI_INFO_INFLIGHT.clear()
+        resolver._NPM_RATE_LIMIT_UNTIL = 0.0
+        resolver._NPM_RATE_LIMIT_HITS = 0
+        resolver.reset_performance_stats()
+    except Exception:
+        pass
+
+
+def _reset_registry_state() -> None:
+    try:
+        from agent_bom.mcp_server_helpers import reset_registry_cache_for_tests
+
+        reset_registry_cache_for_tests()
+    except Exception:
+        pass
+
+    try:
+        import agent_bom.parsers as parsers
+
+        parsers._registry_cache = None
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def reset_global_test_state():
+    """Reset process-global caches so test order does not affect outcomes."""
+    _reset_resolver_state()
+    _reset_registry_state()
+    yield
+    _reset_resolver_state()
+    _reset_registry_state()

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -14,7 +14,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api import server as _server_mod
-from agent_bom.api.middleware import APIKeyMiddleware, get_rate_limit_key_status
+from agent_bom.api.middleware import APIKeyMiddleware, get_rate_limit_key_status, get_rate_limit_runtime_status
 from agent_bom.api.server import app
 
 # ─── Rate-limit key status ────────────────────────────────────────────────────
@@ -124,6 +124,21 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "default_ttl_seconds" in body["api_key"]
     assert "max_ttl_seconds" in body["api_key"]
     assert body["rate_limit_key"]["status"] in {"ok", "ephemeral", "unknown_age", "rotation_due", "max_age_exceeded"}
+    assert body["rate_limit_runtime"]["backend"] in {"inmemory", "postgres_shared"}
+    assert "shared_across_replicas" in body["rate_limit_runtime"]
+
+
+def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://example/test")
+    monkeypatch.setenv("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT", "1")
+    status = get_rate_limit_runtime_status()
+    assert status == {
+        "backend": "postgres_shared",
+        "postgres_configured": True,
+        "shared_required": True,
+        "shared_across_replicas": True,
+        "message": "Rate limiting uses Postgres-backed shared state across replicas.",
+    }
 
 
 def test_auth_policy_requires_admin_role_in_api_middleware() -> None:

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -450,6 +450,8 @@ def test_production_values_enable_operator_defaults():
     production = yaml.safe_load((HELM_DIR / "examples" / "eks-production-values.yaml").read_text())
     assert production["controlPlane"]["api"]["autoscaling"]["enabled"] is True
     assert production["controlPlane"]["ui"]["autoscaling"]["enabled"] is True
+    assert production["monitor"]["enabled"] is True
+    assert production["monitor"]["serviceMonitor"]["enabled"] is True
     assert production["controlPlane"]["api"]["autoscaling"]["behavior"]["scaleDown"]["stabilizationWindowSeconds"] == 300
     assert production["controlPlane"]["ui"]["autoscaling"]["behavior"]["scaleDown"]["stabilizationWindowSeconds"] == 300
     assert production["controlPlane"]["externalSecrets"]["enabled"] is True

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,6 +36,9 @@
         "typescript": "^6",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=20 <23"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,9 @@
   "name": "ui",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20 <23"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build --webpack",

--- a/ui/scripts/verify-toolchain.mjs
+++ b/ui/scripts/verify-toolchain.mjs
@@ -27,9 +27,10 @@ const eslintConfigNextDeclared = packageJson.devDependencies?.["eslint-config-ne
 const eslintDeclared = packageJson.devDependencies?.eslint;
 const reactDeclared = packageJson.dependencies?.react;
 const reactDomDeclared = packageJson.dependencies?.["react-dom"];
+const nodeEngines = packageJson.engines?.node;
 
-if (!nextDeclared || !eslintConfigNextDeclared || !eslintDeclared) {
-  fail("UI toolchain contract is incomplete: next, eslint-config-next, and eslint must all be declared.");
+if (!nextDeclared || !eslintConfigNextDeclared || !eslintDeclared || !nodeEngines) {
+  fail("UI toolchain contract is incomplete: next, eslint-config-next, eslint, and engines.node must all be declared.");
 }
 
 if (normalizeVersionRange(nextDeclared) !== normalizeVersionRange(eslintConfigNextDeclared)) {
@@ -59,6 +60,7 @@ if (nextInstalled !== eslintConfigNextInstalled) {
 
 const nextMajor = majorOf(nextInstalled);
 const eslintMajor = majorOf(eslintInstalled);
+const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
 
 // Next.js 16.2.x is currently validated in this repo with ESLint 9.x and 10.x.
 // Keep the allowlist explicit so future major jumps fail closed until the UI
@@ -69,6 +71,10 @@ if (nextMajor === 16 && ![9, 10].includes(eslintMajor)) {
   );
 }
 
+if (!Number.isInteger(nodeMajor) || nodeMajor < 20 || nodeMajor > 22) {
+  fail(`UI runtime must stay within the declared Node range ${nodeEngines}; found Node ${process.versions.node}.`);
+}
+
 console.log(
-  `UI toolchain contract verified: next ${nextInstalled}, eslint-config-next ${eslintConfigNextInstalled}, eslint ${eslintInstalled}.`,
+  `UI toolchain contract verified: next ${nextInstalled}, eslint-config-next ${eslintConfigNextInstalled}, eslint ${eslintInstalled}, node ${process.versions.node}.`,
 );


### PR DESCRIPTION
## Summary
- add CI and release OSV scanning for the UI lockfile alongside the existing npm audit checks
- pin the supported UI Node runtime in `ui/package.json` and enforce it in the toolchain verifier
- expose rate-limit runtime status in `/v1/auth/policy` so operators can see whether limiter state is shared across replicas
- turn on `ServiceMonitor` in the production Helm example and document the intended scrape contract
- document the dashboard CSP exception in `SECURITY.md`
- add an autouse pytest fixture that resets shared resolver and registry globals between tests

## Why
This closes the release-scope guardrail and operator-alignment gaps from the audit without changing product behavior:
- UI lockfile CVEs now have OSV parity with `uv.lock`
- the production preset now matches the documented observability posture
- operators can confirm whether rate limiting is still process-local or Postgres-backed
- test order no longer leaks through shared module globals

## Validation
- `uv run pytest tests/test_api_operator_policy.py tests/test_deploy_manifests.py -q`
- `uv run ruff check src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py tests/test_api_operator_policy.py tests/test_deploy_manifests.py tests/conftest.py`
- `npx -y node@22 scripts/verify-toolchain.mjs` (run from `ui/`)
