### PR TITLE
finish release hardening backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,21 @@ jobs:
           cd ui
           npm run build
 
+      - name: UI bundle budget
+        run: |
+          cd ui
+          npm run bundle:check
+
+      - name: Install Playwright browser
+        run: |
+          cd ui
+          npx playwright install --with-deps chromium
+
+      - name: UI E2E
+        run: |
+          cd ui
+          npm run test:e2e
+
   # 3. Tests
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        id: build-api-image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -147,6 +148,19 @@ jobs:
             org.opencontainers.image.description=Open security scanner for AI supply chain — agents, MCP, packages, containers, cloud, GPU, and runtime.
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign API image
+        run: cosign sign --yes "agentbom/agent-bom@${{ steps.build-api-image.outputs.digest }}"
+
+      - name: Attest API image provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: index.docker.io/agentbom/agent-bom
+          subject-digest: ${{ steps.build-api-image.outputs.digest }}
+          push-to-registry: true
 
       - name: Sync Docker Hub README
         env:
@@ -219,6 +233,156 @@ jobs:
               "https://hub.docker.com/v2/repositories/${REPO}/tags/${tag}" \
               -H "Authorization: Bearer $TOKEN" || true
           done <<< "$ALL_TAGS"
+
+  docker-publish-ui:
+    name: Publish UI image
+    needs: [build, self-scan-gate, container-gate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract version from tag
+        id: meta
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test UI container
+        run: |
+          set -euo pipefail
+          cleanup() {
+            status=$?
+            if [ $status -ne 0 ]; then
+              docker logs agent-bom-ui-smoke || true
+            fi
+            docker stop agent-bom-ui-smoke >/dev/null 2>&1 || true
+            exit $status
+          }
+          docker build -f ui/Dockerfile -t agent-bom-ui:release-test ui
+          docker run -d --rm --name agent-bom-ui-smoke -p 3000:3000 -e NEXT_PUBLIC_API_URL= agent-bom-ui:release-test
+          trap cleanup EXIT
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:3000/ >/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://127.0.0.1:3000/ >/dev/null || {
+            echo "::error::UI container did not become healthy in time"
+            exit 1
+          }
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push UI image
+        id: build-ui-image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ui
+          file: ui/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            NEXT_PUBLIC_API_URL=
+          provenance: true
+          sbom: true
+          tags: |
+            agentbom/agent-bom-ui:${{ steps.meta.outputs.version }}
+            agentbom/agent-bom-ui:latest
+          labels: |
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.title=agent-bom-ui
+            org.opencontainers.image.description=agent-bom control-plane dashboard.
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign UI image
+        run: cosign sign --yes "agentbom/agent-bom-ui@${{ steps.build-ui-image.outputs.digest }}"
+
+      - name: Attest UI image provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: index.docker.io/agentbom/agent-bom-ui
+          subject-digest: ${{ steps.build-ui-image.outputs.digest }}
+          push-to-registry: true
+
+  helm-publish:
+    name: Publish Helm chart to OCI
+    needs: [version-guard, self-scan-gate, container-gate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract version from tag
+        id: meta
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Helm
+        run: |
+          set -euo pipefail
+          curl -fsSL https://get.helm.sh/helm-v3.18.6-linux-amd64.tar.gz -o /tmp/helm.tar.gz
+          tar -xzf /tmp/helm.tar.gz -C /tmp
+          sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          helm version
+
+      - name: Package release chart
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/agent-bom-chart
+          cp -R deploy/helm/agent-bom /tmp/agent-bom-chart
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+
+          version = "${{ steps.meta.outputs.version }}"
+          chart = Path("/tmp/agent-bom-chart/Chart.yaml")
+          text = chart.read_text()
+          text = re.sub(r"^version: .+$", f"version: {version}", text, flags=re.MULTILINE)
+          text = re.sub(r'^appVersion: ".+"$', f'appVersion: "{version}"', text, flags=re.MULTILINE)
+          chart.write_text(text)
+          PY
+          mkdir -p dist/helm
+          helm package /tmp/agent-bom-chart --destination dist/helm
+
+      - name: Login to GHCR OCI registry
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: echo "${GH_TOKEN}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Push chart to OCI registry
+        run: helm push "dist/helm/agent-bom-${{ steps.meta.outputs.version }}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+
+      - name: Attest Helm chart package
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/helm/agent-bom-${{ steps.meta.outputs.version }}.tgz
+
+      - name: Upload Helm chart artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: helm-chart
+          path: dist/helm/agent-bom-${{ steps.meta.outputs.version }}.tgz
 
   container-gate:
     name: Container release gate
@@ -410,7 +574,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     # Only requires PyPI publish — Docker Hub is best-effort (needs external secrets)
-    needs: [pypi-publish, sign, provenance, sbom]
+    needs: [pypi-publish, sign, provenance, sbom, helm-publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -439,6 +603,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: agent-bom-sbom
+          path: dist/
+
+      - name: Download Helm chart artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: helm-chart
           path: dist/
 
       - name: Create or update GitHub Release

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -24,3 +24,9 @@ a5c3a329da9d0f5deed6a6857bcbaeaf3a024f1e:docs/ENTERPRISE_SECURITY_PLAYBOOK.md:ge
 # Historical false positive in a previous version of this file itself, caused
 # by the trap documented above. Retained because gitleaks walks history.
 792b4ad4ff3f877992a678bd533f2dd2dd7854da:.gitleaksignore:generic-api-key:10
+
+# History-only false positives from test fixtures that temporarily used
+# unsigned token-shaped strings before being replaced with generated values.
+e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_hardening.py:jwt:286
+e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:334
+e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360

--- a/README.md
+++ b/README.md
@@ -378,7 +378,8 @@ Pilot teams run:
 
 ```bash
 # 1. Pick your backend shape (postgres default; snowflake / istio / production also shipped)
-helm install agent-bom deploy/helm/agent-bom \
+helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
+  --version 0.79.0 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
 

--- a/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
@@ -38,6 +38,10 @@ spec:
       {{- include "agent-bom.controlPlaneTopologySpreadConstraints" (dict "Values" .Values "component" "api" "Chart" .Chart "Release" .Release) | nindent 6 }}
       {{- include "agent-bom.controlPlaneAffinity" (dict "Values" .Values "component" "api" "Chart" .Chart "Release" .Release) | nindent 6 }}
       containers:
+        {{- $apiReplicaFloor := int .Values.controlPlane.api.replicas }}
+        {{- if and .Values.controlPlane.api.autoscaling.enabled (gt (int .Values.controlPlane.api.autoscaling.minReplicas) $apiReplicaFloor) }}
+        {{- $apiReplicaFloor = int .Values.controlPlane.api.autoscaling.minReplicas }}
+        {{- end }}
         - name: api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -49,8 +53,10 @@ spec:
             - containerPort: {{ .Values.controlPlane.api.port }}
               name: http
               protocol: TCP
-          {{- with .Values.controlPlane.api.env }}
           env:
+            - name: AGENT_BOM_CONTROL_PLANE_REPLICAS
+              value: {{ $apiReplicaFloor | quote }}
+          {{- with .Values.controlPlane.api.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.controlPlane.api.envFrom }}

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -81,12 +81,18 @@ Implementation source: `src/agent_bom/api/middleware.py`
      to enforce rotation windows on stored keys
    - rotate stored keys with `POST /v1/auth/keys/{key_id}/rotate`
 3. OIDC bearer enforcement
-   - set `AGENT_BOM_OIDC_ISSUER`
+   - set `AGENT_BOM_OIDC_ISSUER`, or use `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON` for tenant-bound issuers
    - set `AGENT_BOM_OIDC_AUDIENCE`
    - map roles with `AGENT_BOM_OIDC_ROLE_CLAIM`
    - map tenants with `AGENT_BOM_OIDC_TENANT_CLAIM`
    - fail closed with `AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1`
    - optionally set `AGENT_BOM_OIDC_REQUIRED_NONCE` when your IdP flow includes a nonce claim
+
+Rate limiting also follows an explicit fail-closed contract for scaled control planes:
+
+- single-process / single-replica API: in-memory limiter is allowed
+- multi-replica API or `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1`: PostgreSQL-backed shared limiter is required
+- if shared rate limiting is required and `AGENT_BOM_POSTGRES_URL` is absent or broken, API startup now fails instead of silently falling back to process-local state
 
 Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`
 

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -105,7 +105,7 @@ agent-bom serve --port 8422 --persist jobs.db
 - `POST /v1/fleet/sync` — ingest endpoint scan results
 - `GET /v1/compliance` — 14-framework compliance posture
 
-**Authentication:** localhost binds are allowed for local development. Non-loopback binds fail closed unless you set `AGENT_BOM_API_KEY`, configure `AGENT_BOM_OIDC_ISSUER`, or explicitly pass `--allow-insecure-no-auth`. Rate limiting and CORS controls are built in.
+**Authentication:** localhost binds are allowed for local development. Non-loopback binds fail closed unless you set `AGENT_BOM_API_KEY`, configure `AGENT_BOM_OIDC_ISSUER`, configure `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON`, or explicitly pass `--allow-insecure-no-auth`. Rate limiting and CORS controls are built in.
 
 **Tracing:** every API response includes `X-Request-ID`, `X-Trace-ID`, `X-Span-ID`, and W3C `traceparent`. If your ingress or collector already sends `traceparent`, `tracestate`, or bounded W3C `baggage`, `agent-bom` preserves the upstream trace context and continues the chain. `GET /health` also reports the current tracing contract (`w3c_trace_context`, `w3c_tracestate`, `w3c_baggage`) plus OTLP export state so operators can confirm whether tracing is merely available or actively exported. Set `AGENT_BOM_OTEL_TRACES_ENDPOINT` to export API request spans over OTLP/HTTP, and use `AGENT_BOM_OTEL_TRACES_HEADERS` for collector auth headers when needed.
 
@@ -122,7 +122,30 @@ export AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1        # fail closed if the claim i
 
 That keeps API roles and tenant boundaries aligned with the upstream identity provider instead of silently falling back to a shared tenant when you expect strict isolation.
 
+For tenant-bound issuers, configure one issuer per tenant and do not also set `AGENT_BOM_OIDC_ISSUER`:
+
+```bash
+export AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON='{
+  "tenant-alpha": {
+    "issuer": "https://alpha.okta.example",
+    "audience": "agent-bom",
+    "tenant_claim": "tenant_id",
+    "require_tenant_claim": true
+  },
+  "tenant-beta": {
+    "issuer": "https://beta.okta.example",
+    "audience": "agent-bom",
+    "tenant_claim": "tenant_id",
+    "require_tenant_claim": true
+  }
+}'
+```
+
+At startup, `agent-bom` treats `AGENT_BOM_OIDC_ISSUER` and `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON` as mutually exclusive. Mixed configuration now fails closed instead of silently choosing one mode.
+
 For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated tenant into the database session (`app.tenant_id`) so Postgres row-level security can enforce the same tenant boundary for fleet and schedule data. Internal scheduler work uses an explicit trusted bypass rather than silently reading across tenants.
+
+For horizontally scaled control-plane APIs, shared rate limiting is mandatory. `agent-bom` now fails closed when `AGENT_BOM_CONTROL_PLANE_REPLICAS > 1` (or `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1`) and no PostgreSQL-backed limiter is configured via `AGENT_BOM_POSTGRES_URL`.
 
 **Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, schedules, graph state, and trend history.
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -88,7 +88,7 @@ agent-bom operates in four modes:
 
 | Attack | MITRE | Mitigation |
 |--------|-------|-----------|
-| Unauthorized access | T1078 | Non-loopback binds require API key auth (`AGENT_BOM_API_KEY`) or OIDC/JWT (`AGENT_BOM_OIDC_ISSUER`) unless explicitly overridden |
+| Unauthorized access | T1078 | Non-loopback binds require API key auth (`AGENT_BOM_API_KEY`) or OIDC/JWT (`AGENT_BOM_OIDC_ISSUER` or `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON`) unless explicitly overridden |
 | JWT algorithm confusion | T1550 | JWKS enforces RS/ES algorithms; `alg: none` explicitly rejected |
 | Network exposure | T1190 | Defaults to `127.0.0.1:8422` (localhost-only); non-loopback unauthenticated binds fail closed by default |
 

--- a/docs/adr/006-ui-auth-model.md
+++ b/docs/adr/006-ui-auth-model.md
@@ -1,0 +1,35 @@
+# ADR-006: UI Authentication Model
+
+## Status
+
+Accepted
+
+## Context
+
+The packaged dashboard shipped without a defined browser authentication model. The UI assumed same-origin API access, but it did not propagate bearer credentials, did not gate protected routes, and did not document how enterprise reverse-proxy auth should work.
+
+## Decision
+
+The control-plane UI uses two supported browser auth modes:
+
+1. Recommended for enterprise: same-origin reverse-proxy OIDC or SSO session. The reverse proxy terminates browser auth, keeps the session cookie, and injects trusted `X-Agent-Bom-Role` and `X-Agent-Bom-Tenant-ID` headers to the backend. `AGENT_BOM_TRUST_PROXY_AUTH=1` must be enabled on the API for this mode.
+2. Fallback for local and single-user pilots: a short-lived API key entered into the dashboard and stored only in browser `sessionStorage`. The UI forwards it as `Authorization: Bearer <key>` for HTTP calls and `?token=` for the proxy WebSocket surfaces.
+
+The UI always sends `credentials: "include"` so same-origin proxy sessions work without custom browser configuration. A global auth gate now blocks dashboard routes until one of the supported auth modes succeeds.
+
+## Consequences
+
+### Positive
+
+- The browser auth story is explicit and consistent across backend, runtime config, and UI behavior.
+- Enterprise ingress can use OIDC without exposing raw API keys to end users.
+- Single-user pilots still have a low-friction API-key fallback without persisting secrets beyond the browser session.
+
+### Negative
+
+- Multi-user browser access still depends on an external reverse proxy; the API itself does not mint browser cookies.
+- Proxy-auth mode trusts headers and must only be enabled behind a hardened ingress that strips spoofed client headers.
+
+### Neutral
+
+- The dashboard no longer treats unauthenticated production deployments as undefined behavior; it shows an auth gate instead.

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -67,6 +67,9 @@ runtime model.
 - the discovery service account and IRSA path stay attached to the scanner
 - the API still refuses non-loopback startup without `AGENT_BOM_API_KEY`,
   OIDC, SAML-issued session keys, or an explicit insecure override
+- multi-replica API deployments now require a PostgreSQL-backed shared rate-limit
+  store; the chart exports the replica floor and the API fails closed instead of
+  silently falling back to process-local limits
 - same-origin ingress avoids default CORS sprawl
 - network policy stays enabled, with configurable ingress restrictions
 
@@ -113,7 +116,8 @@ The chart supports component-specific service-account overrides for scanner, gat
 Install:
 
 ```bash
-helm install agent-bom deploy/helm/agent-bom \
+helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
+  --version 0.79.0 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -148,7 +152,8 @@ EOF
 Then install:
 
 ```bash
-helm install agent-bom deploy/helm/agent-bom \
+helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
+  --version 0.79.0 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -29,6 +29,11 @@ from starlette.types import ASGIApp
 
 _logger = logging.getLogger(__name__)
 _RATE_LIMIT_FINGERPRINT_FALLBACK = secrets.token_bytes(32)
+_AUTH_RUNTIME_STATUS: dict[str, object] = {
+    "auth_required": False,
+    "configured_modes": [],
+    "recommended_ui_mode": "no_auth",
+}
 _API_CSP = "default-src 'self'"
 _DASHBOARD_CSP = (
     "default-src 'self'; "
@@ -48,6 +53,44 @@ def _content_security_policy(path: str, content_type: str) -> str:
     if "text/html" in content_type and not path.startswith(("/v1/", "/docs", "/redoc", "/openapi.json")):
         return _DASHBOARD_CSP
     return _API_CSP
+
+
+def configure_auth_runtime(
+    *,
+    api_key_configured: bool,
+    oidc_enabled: bool,
+    trusted_proxy_enabled: bool,
+) -> None:
+    """Track the active auth modes for operator/UI introspection surfaces."""
+    configured_modes: list[str] = []
+    if trusted_proxy_enabled:
+        configured_modes.append("trusted_proxy")
+    if oidc_enabled:
+        configured_modes.append("oidc_bearer")
+    if api_key_configured:
+        configured_modes.append("api_key")
+
+    recommended_ui_mode = "no_auth"
+    if trusted_proxy_enabled:
+        recommended_ui_mode = "reverse_proxy_oidc"
+    elif oidc_enabled:
+        recommended_ui_mode = "oidc_bearer"
+    elif api_key_configured:
+        recommended_ui_mode = "session_api_key"
+
+    _AUTH_RUNTIME_STATUS.clear()
+    _AUTH_RUNTIME_STATUS.update(
+        {
+            "auth_required": bool(configured_modes),
+            "configured_modes": configured_modes,
+            "recommended_ui_mode": recommended_ui_mode,
+        }
+    )
+
+
+def get_auth_runtime_status() -> dict[str, object]:
+    """Return the configured auth modes for UI and operator surfaces."""
+    return dict(_AUTH_RUNTIME_STATUS)
 
 
 class InMemoryRateLimitStore:
@@ -258,9 +301,28 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     # Set AGENT_BOM_DISABLE_DOCS=1 in production to block /docs and /redoc
     _DOCS_DISABLED = os.environ.get("AGENT_BOM_DISABLE_DOCS", "").strip() in ("1", "true", "yes")
     _EXEMPT_PATHS = (
-        {"/", "/health", "/version", "/metrics", "/docs", "/redoc", "/openapi.json", "/v1/auth/saml/metadata", "/v1/auth/saml/login"}
+        {
+            "/",
+            "/health",
+            "/readyz",
+            "/version",
+            "/metrics",
+            "/docs",
+            "/redoc",
+            "/openapi.json",
+            "/v1/auth/saml/metadata",
+            "/v1/auth/saml/login",
+        }
         if not _DOCS_DISABLED
-        else {"/", "/health", "/version", "/metrics", "/v1/auth/saml/metadata", "/v1/auth/saml/login"}
+        else {
+            "/",
+            "/health",
+            "/readyz",
+            "/version",
+            "/metrics",
+            "/v1/auth/saml/metadata",
+            "/v1/auth/saml/login",
+        }
     )
 
     # Ordered route rules so narrower enterprise paths win over broad prefixes.
@@ -301,6 +363,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     def __init__(self, app: ASGIApp, api_key: str) -> None:
         super().__init__(app)
         self._api_key = api_key
+        self._trusted_proxy_auth = _env_flag("AGENT_BOM_TRUST_PROXY_AUTH")
         # OIDC config loaded lazily from env on first request
         self._oidc_config: OIDCConfig | None = None
         self._oidc_checked = False
@@ -325,6 +388,9 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             raw_key = request.headers.get("x-api-key", "")
 
         if not raw_key:
+            proxy_response = await self._try_proxy_header_auth(request, call_next)
+            if proxy_response is not None:
+                return proxy_response
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Unauthorized — provide API key via Authorization: Bearer <key> or X-API-Key header"},
@@ -402,6 +468,46 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             status_code=401,
             content={"detail": "Unauthorized — invalid API key"},
         )
+
+    async def _try_proxy_header_auth(self, request: StarletteRequest, call_next):
+        if not self._trusted_proxy_auth:
+            return None
+
+        role_header = request.headers.get("x-agent-bom-role", "").strip().lower()
+        tenant_id = request.headers.get("x-agent-bom-tenant-id", "").strip()
+        if not role_header:
+            return None
+        if not tenant_id:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Authentication required — trusted proxy requests must include X-Agent-Bom-Tenant-ID"},
+            )
+
+        from agent_bom.api.auth import _ROLE_HIERARCHY, Role
+
+        try:
+            proxy_role = Role(role_header)
+        except ValueError:
+            return JSONResponse(status_code=403, content={"detail": f"Invalid proxy role '{role_header}'"})
+
+        required = Role(self._required_role(request.method, request.url.path))
+        if _ROLE_HIERARCHY.get(proxy_role, 0) < _ROLE_HIERARCHY.get(required, 0):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": f"Forbidden — requires {required.value} role, proxy session has {proxy_role.value}"},
+            )
+
+        request.state.api_key_name = (
+            request.headers.get("x-agent-bom-subject")
+            or request.headers.get("x-forwarded-email")
+            or request.headers.get("x-auth-request-email")
+            or "proxy-header"
+        )
+        request.state.api_key_role = proxy_role.value
+        request.state.tenant_id = tenant_id
+        request.state.auth_method = "proxy_header"
+        request.state.auth_issuer = request.headers.get("x-agent-bom-auth-issuer") or None
+        return await self._call_with_tenant_context(request, call_next)
 
     async def _call_with_tenant_context(self, request: StarletteRequest, call_next):
         tenant_token = None

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -538,10 +538,15 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if os.environ.get("AGENT_BOM_POSTGRES_URL"):
             try:
                 return PostgresRateLimitStore(window_seconds=self._window)
-            except Exception:
-                if _env_flag("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT"):
-                    raise RuntimeError("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1 but Postgres rate limiter could not initialize") from None
-                _logger.warning("Postgres rate limiter unavailable, falling back to in-memory store", exc_info=True)
+            except Exception as exc:
+                raise RuntimeError(
+                    "Configured Postgres rate limiter could not initialize; refusing to fall back to process-local state"
+                ) from exc
+        if _shared_rate_limit_required():
+            raise RuntimeError(
+                "Shared rate limiting is required for multi-replica or fail-closed deployments. "
+                "Configure AGENT_BOM_POSTGRES_URL before starting the API."
+            )
         return InMemoryRateLimitStore(window_seconds=self._window)
 
     def _resolve_tenant_scope(self, request: StarletteRequest, raw_key: str) -> str | None:
@@ -606,20 +611,41 @@ def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _configured_api_replicas() -> int:
+    raw = os.environ.get("AGENT_BOM_CONTROL_PLANE_REPLICAS", "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        _logger.warning("Invalid AGENT_BOM_CONTROL_PLANE_REPLICAS=%r; defaulting to 1", raw)
+        return 1
+
+
+def _shared_rate_limit_required() -> bool:
+    return _env_flag("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT") or _configured_api_replicas() > 1
+
+
 def get_rate_limit_runtime_status() -> dict[str, object]:
     """Report whether API rate limiting is shared across replicas."""
     postgres_configured = bool(os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip())
-    shared_required = _env_flag("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT")
-    backend = "postgres_shared" if postgres_configured else "inmemory"
+    replicas = _configured_api_replicas()
+    shared_required = _shared_rate_limit_required()
+    backend = "postgres_shared" if postgres_configured else "inmemory_single_process"
     return {
         "backend": backend,
         "postgres_configured": postgres_configured,
+        "configured_api_replicas": replicas,
         "shared_required": shared_required,
         "shared_across_replicas": postgres_configured,
+        "fail_closed": postgres_configured or shared_required,
         "message": (
             "Rate limiting uses Postgres-backed shared state across replicas."
             if postgres_configured
-            else ("Rate limiting is process-local and resets on pod restart. Set AGENT_BOM_POSTGRES_URL for shared limiter state.")
+            else (
+                "Rate limiting is process-local only because the API is configured for a single replica. "
+                "Multi-replica deployments must configure AGENT_BOM_POSTGRES_URL."
+            )
         ),
     }
 

--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -6,13 +6,20 @@ existing API key authentication.
 
 Configuration via environment variables::
 
+    # Single issuer (global IdP)
     AGENT_BOM_OIDC_ISSUER   = "https://accounts.google.com"
-    AGENT_BOM_OIDC_AUDIENCE = "agent-bom"            # required when OIDC is enabled
+    AGENT_BOM_OIDC_AUDIENCE = "agent-bom"             # required when OIDC is enabled
     AGENT_BOM_OIDC_ROLE_CLAIM = "agent_bom_role"      # optional JWT claim for role
     AGENT_BOM_OIDC_TENANT_CLAIM = "tenant_id"         # optional JWT claim for tenant
     AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM = "1"         # fail closed when claim absent
     AGENT_BOM_OIDC_REQUIRED_NONCE = "random-nonce"    # optional fail-closed nonce check
     AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM = "1"           # optional fail-closed role requirement
+
+    # Multi-tenant / tenant-bound issuers (mutually exclusive with AGENT_BOM_OIDC_ISSUER)
+    AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON = (
+        '{"tenant-alpha":{"issuer":"https://alpha.okta.example","audience":"agent-bom"},'
+        '"tenant-beta":{"issuer":"https://beta.okta.example","audience":"agent-bom"}}'
+    )
 
 Role mapping (claim value → agent-bom Role):
 
@@ -29,6 +36,7 @@ Closes #278.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -284,6 +292,42 @@ def claims_to_tenant(claims: dict, tenant_claim: str = "tenant_id") -> str | Non
     return None
 
 
+def _decode_unverified_claims(token: str) -> dict:
+    """Read JWT claims without verifying the signature so issuer routing can occur."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise OIDCError("JWT is not a valid three-part token")
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(payload.encode())
+        claims = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise OIDCError("JWT payload could not be decoded before verification") from exc
+    if not isinstance(claims, dict):
+        raise OIDCError("JWT payload did not decode to an object")
+    return claims
+
+
+def _coerce_optional_bool(value: object, *, field_name: str) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise OIDCError(f"{field_name} must be a boolean when set")
+
+
+def oidc_enabled_from_env() -> bool:
+    """Return True when either single-issuer or tenant-bound OIDC config is present."""
+    return bool(os.environ.get("AGENT_BOM_OIDC_ISSUER", "").strip() or os.environ.get("AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON", "").strip())
+
+
 # ── OIDCConfig helper ──────────────────────────────────────────────────────────
 
 
@@ -310,6 +354,8 @@ class OIDCConfig:
         require_tenant_claim: Optional[bool] = None,
         required_nonce: Optional[str] = None,
         require_role_claim: Optional[bool] = None,
+        tenant_id: Optional[str] = None,
+        tenant_providers: dict[str, OIDCConfig] | None = None,
     ) -> None:
         self.issuer = issuer or os.environ.get("AGENT_BOM_OIDC_ISSUER", "")
         self.audience = audience or os.environ.get("AGENT_BOM_OIDC_AUDIENCE") or None
@@ -317,6 +363,8 @@ class OIDCConfig:
         self.jwks_uri = jwks_uri or os.environ.get("AGENT_BOM_OIDC_JWKS_URI", "") or None
         self.tenant_claim = tenant_claim or os.environ.get("AGENT_BOM_OIDC_TENANT_CLAIM", "tenant_id")
         self.required_nonce = required_nonce or os.environ.get("AGENT_BOM_OIDC_REQUIRED_NONCE", "") or None
+        self.tenant_id = tenant_id or None
+        self.tenant_providers = tenant_providers or {}
         if require_tenant_claim is None:
             require_tenant_claim = os.environ.get("AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM", "").strip().lower() in {
                 "1",
@@ -331,7 +379,46 @@ class OIDCConfig:
                 "yes",
             }
         self.require_role_claim = require_role_claim
-        self.enabled = bool(self.issuer)
+        self._tenant_providers_by_issuer = {provider.issuer: provider for provider in self.tenant_providers.values() if provider.issuer}
+        self.enabled = bool(self.issuer or self.tenant_providers)
+
+    def _provider_for_issuer(self, issuer: str) -> OIDCConfig:
+        if not self.tenant_providers:
+            return self
+        provider = self._tenant_providers_by_issuer.get(issuer)
+        if provider is None:
+            raise OIDCError(f"OIDC issuer '{issuer}' is not configured for any tenant")
+        return provider
+
+    def _provider_for_token(self, token: str) -> OIDCConfig:
+        if not self.tenant_providers:
+            return self
+        claims = _decode_unverified_claims(token)
+        issuer = str(claims.get("iss") or "").strip()
+        if not issuer:
+            raise OIDCError("JWT missing issuer claim required for tenant-bound OIDC")
+        return self._provider_for_issuer(issuer)
+
+    def _provider_for_claims(self, claims: dict) -> OIDCConfig:
+        if not self.tenant_providers:
+            return self
+        issuer = str(claims.get("iss") or "").strip()
+        if not issuer:
+            raise OIDCError("JWT missing issuer claim required for tenant-bound OIDC")
+        return self._provider_for_issuer(issuer)
+
+    def _validate_bound_tenant(self, claims: dict) -> None:
+        if self.tenant_id is None:
+            return
+        tenant_id = claims_to_tenant(claims, self.tenant_claim)
+        if tenant_id:
+            if tenant_id != self.tenant_id:
+                raise OIDCError(
+                    f"JWT tenant '{tenant_id}' does not match the configured tenant '{self.tenant_id}' for issuer '{self.issuer}'"
+                )
+            return
+        if self.require_tenant_claim:
+            raise OIDCError(f"JWT missing required tenant claim '{self.tenant_claim}'")
 
     def verify(self, token: str) -> tuple[dict, str]:
         """Verify a JWT and return ``(claims, role)``.
@@ -339,26 +426,82 @@ class OIDCConfig:
         Raises:
             OIDCError: On verification failure.
         """
-        if not self.enabled or not self.issuer:
-            raise OIDCError("OIDC is not configured (set AGENT_BOM_OIDC_ISSUER)")
-        if not self.audience:
+        provider = self._provider_for_token(token)
+        if not self.enabled or not provider.issuer:
+            raise OIDCError("OIDC is not configured (set AGENT_BOM_OIDC_ISSUER or AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON)")
+        if not provider.audience:
             raise OIDCError("OIDC is configured but AGENT_BOM_OIDC_AUDIENCE is not set")
-        claims = verify_oidc_token(token, self.issuer, self.audience, self.jwks_uri, self.required_nonce)
-        if self.require_role_claim and not claims_have_role_signal(claims, self.role_claim):
-            raise OIDCError(f"JWT missing required role claim '{self.role_claim}'")
-        role = claims_to_role(claims, self.role_claim)
+        claims = verify_oidc_token(token, provider.issuer, provider.audience, provider.jwks_uri, provider.required_nonce)
+        if provider.require_role_claim and not claims_have_role_signal(claims, provider.role_claim):
+            raise OIDCError(f"JWT missing required role claim '{provider.role_claim}'")
+        provider._validate_bound_tenant(claims)
+        role = claims_to_role(claims, provider.role_claim)
         return claims, role
 
     def resolve_tenant(self, claims: dict) -> str:
         """Resolve tenant context from claims or fail closed when required."""
-        tenant_id = claims_to_tenant(claims, self.tenant_claim)
+        provider = self._provider_for_claims(claims)
+        tenant_id = claims_to_tenant(claims, provider.tenant_claim)
         if tenant_id:
             return tenant_id
-        if self.require_tenant_claim:
-            raise OIDCError(f"JWT missing required tenant claim '{self.tenant_claim}'")
+        if provider.tenant_id is not None:
+            return provider.tenant_id
+        if provider.require_tenant_claim:
+            raise OIDCError(f"JWT missing required tenant claim '{provider.tenant_claim}'")
         return "default"
 
     @classmethod
     def from_env(cls) -> "OIDCConfig":
         """Build config from environment variables."""
+        tenant_providers_json = os.environ.get("AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON", "").strip()
+        issuer = os.environ.get("AGENT_BOM_OIDC_ISSUER", "").strip()
+        if tenant_providers_json:
+            if issuer:
+                raise OIDCError("Configure either AGENT_BOM_OIDC_ISSUER or AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON, not both")
+            try:
+                raw = json.loads(tenant_providers_json)
+            except json.JSONDecodeError as exc:
+                raise OIDCError("AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON is not valid JSON") from exc
+            if not isinstance(raw, dict) or not raw:
+                raise OIDCError("AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON must be a non-empty object keyed by tenant ID")
+
+            providers: dict[str, OIDCConfig] = {}
+            seen_issuers: set[str] = set()
+            for tenant_id, provider_raw in raw.items():
+                normalized_tenant = str(tenant_id).strip()
+                if not normalized_tenant:
+                    raise OIDCError("Tenant-bound OIDC config contains an empty tenant ID")
+                if not isinstance(provider_raw, dict):
+                    raise OIDCError(f"OIDC provider config for tenant '{normalized_tenant}' must be an object")
+                if "tenant_id" in provider_raw and str(provider_raw["tenant_id"]).strip() != normalized_tenant:
+                    raise OIDCError(
+                        f"OIDC provider config for tenant '{normalized_tenant}' has mismatched tenant_id '{provider_raw['tenant_id']}'"
+                    )
+
+                provider = cls(
+                    issuer=str(provider_raw.get("issuer", "")).strip(),
+                    audience=str(provider_raw.get("audience", "")).strip() or None,
+                    role_claim=str(provider_raw.get("role_claim", "agent_bom_role")).strip() or "agent_bom_role",
+                    jwks_uri=str(provider_raw.get("jwks_uri", "")).strip() or None,
+                    tenant_claim=str(provider_raw.get("tenant_claim", "tenant_id")).strip() or "tenant_id",
+                    require_tenant_claim=_coerce_optional_bool(
+                        provider_raw.get("require_tenant_claim"),
+                        field_name=f"{normalized_tenant}.require_tenant_claim",
+                    ),
+                    required_nonce=str(provider_raw.get("required_nonce", "")).strip() or None,
+                    require_role_claim=_coerce_optional_bool(
+                        provider_raw.get("require_role_claim"),
+                        field_name=f"{normalized_tenant}.require_role_claim",
+                    ),
+                    tenant_id=normalized_tenant,
+                )
+                if not provider.issuer:
+                    raise OIDCError(f"OIDC provider config for tenant '{normalized_tenant}' is missing 'issuer'")
+                if not provider.audience:
+                    raise OIDCError(f"OIDC provider config for tenant '{normalized_tenant}' is missing 'audience'")
+                if provider.issuer in seen_issuers:
+                    raise OIDCError(f"OIDC issuer '{provider.issuer}' is configured for more than one tenant")
+                seen_issuers.add(provider.issuer)
+                providers[normalized_tenant] = provider
+            return cls(tenant_providers=providers)
         return cls()

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -180,10 +180,11 @@ async def auth_policy() -> dict:
     past the configured maximum.
     """
     from agent_bom.api.auth import get_api_key_policy
-    from agent_bom.api.middleware import get_rate_limit_key_status
+    from agent_bom.api.middleware import get_auth_runtime_status, get_rate_limit_key_status
 
     api_policy = get_api_key_policy()
     rl_status = get_rate_limit_key_status()
+    auth_runtime = get_auth_runtime_status()
     return {
         "api_key": {
             "default_ttl_seconds": api_policy.default_ttl_seconds,
@@ -192,6 +193,17 @@ async def auth_policy() -> dict:
             "rotation_endpoint": "/v1/auth/keys/{key_id}/rotate",
         },
         "rate_limit_key": rl_status,
+        "ui": {
+            "recommended_mode": auth_runtime["recommended_ui_mode"],
+            "configured_modes": auth_runtime["configured_modes"],
+            "session_storage_fallback": "session_api_key",
+            "credentials_mode": "include",
+            "trusted_proxy_headers": ["X-Agent-Bom-Role", "X-Agent-Bom-Tenant-ID"],
+            "message": (
+                "Recommended browser auth is same-origin reverse-proxy OIDC with the proxy injecting trusted "
+                "X-Agent-Bom-* headers. For single-user local or pilot access, the UI also supports a session-only API key."
+            ),
+        },
     }
 
 
@@ -209,6 +221,8 @@ async def auth_debug(request: Request) -> dict:
     non-secret identifying attributes (name, key_id prefix, role, tenant,
     auth method) so the endpoint is safe to log.
     """
+    from agent_bom.api.middleware import get_auth_runtime_status
+
     method = getattr(request.state, "auth_method", None)
     subject = getattr(request.state, "api_key_name", None)
     role = getattr(request.state, "api_key_role", None)
@@ -221,8 +235,12 @@ async def auth_debug(request: Request) -> dict:
     key_id_prefix = key_id[:8] if isinstance(key_id, str) else None
 
     authenticated = bool(method and role)
+    auth_runtime = get_auth_runtime_status()
     return {
         "authenticated": authenticated,
+        "auth_required": auth_runtime["auth_required"],
+        "configured_modes": auth_runtime["configured_modes"],
+        "recommended_ui_mode": auth_runtime["recommended_ui_mode"],
         "auth_method": method,
         "subject": subject,
         "role": role,

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -458,7 +458,9 @@ def configure_api(
     _api_key = api_key
     _rate_limit_rpm = rate_limit_rpm
 
-    oidc_enabled = bool(os.environ.get("AGENT_BOM_OIDC_ISSUER", "").strip())
+    from agent_bom.api.oidc import oidc_enabled_from_env
+
+    oidc_enabled = oidc_enabled_from_env()
     trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
     auth_required = bool(api_key or oidc_enabled or trusted_proxy_enabled)
     configure_auth_runtime(

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -25,6 +25,7 @@ from agent_bom.api.middleware import (
     MaxBodySizeMiddleware,
     RateLimitMiddleware,
     TrustHeadersMiddleware,
+    configure_auth_runtime,
 )
 
 # ─── Extracted modules ────────────────────────────────────────────────────────
@@ -457,15 +458,24 @@ def configure_api(
     _api_key = api_key
     _rate_limit_rpm = rate_limit_rpm
 
+    oidc_enabled = bool(os.environ.get("AGENT_BOM_OIDC_ISSUER", "").strip())
+    trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
+    auth_required = bool(api_key or oidc_enabled or trusted_proxy_enabled)
+    configure_auth_runtime(
+        api_key_configured=bool(api_key),
+        oidc_enabled=oidc_enabled,
+        trusted_proxy_enabled=trusted_proxy_enabled,
+    )
+
     # Warn if API is exposed without authentication
-    if not api_key:
+    if not auth_required:
         _logger.warning(
             "SECURITY: No AGENT_BOM_API_KEY set — API endpoints are unauthenticated. "
             "Set AGENT_BOM_API_KEY environment variable for production deployments."
         )
 
     # Refresh runtime-configurable middleware
-    if api_key:
+    if auth_required:
         _replace_middleware(APIKeyMiddleware, api_key=api_key)
     else:
         app.user_middleware = [m for m in app.user_middleware if m.cls is not APIKeyMiddleware]

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -24,7 +24,9 @@ def _is_loopback_host(host: str) -> bool:
 
 def _oidc_enabled() -> bool:
     """Return True when OIDC auth is configured via environment."""
-    return bool(os.environ.get("AGENT_BOM_OIDC_ISSUER", "").strip())
+    from agent_bom.api.oidc import oidc_enabled_from_env
+
+    return oidc_enabled_from_env()
 
 
 def _enforce_auth_defaults(command: str, host: str, api_key: str | None, allow_insecure_no_auth: bool) -> None:
@@ -35,7 +37,8 @@ def _enforce_auth_defaults(command: str, host: str, api_key: str | None, allow_i
         return
     raise click.ClickException(
         f"Refusing to expose `{command}` on non-loopback host {host!r} without authentication. "
-        "Set --api-key / AGENT_BOM_API_KEY or configure AGENT_BOM_OIDC_ISSUER, "
+        "Set --api-key / AGENT_BOM_API_KEY or configure AGENT_BOM_OIDC_ISSUER / "
+        "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON, "
         "or pass --allow-insecure-no-auth to override."
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,11 +38,22 @@ def _reset_registry_state() -> None:
         pass
 
 
+def _reset_api_runtime_state() -> None:
+    try:
+        from agent_bom.api import server as api_server
+
+        api_server.configure_api(api_key=None)
+    except Exception:
+        pass
+
+
 @pytest.fixture(autouse=True)
 def reset_global_test_state():
     """Reset process-global caches so test order does not affect outcomes."""
     _reset_resolver_state()
     _reset_registry_state()
+    _reset_api_runtime_state()
     yield
     _reset_resolver_state()
     _reset_registry_state()
+    _reset_api_runtime_state()

--- a/tests/test_api_auth_debug.py
+++ b/tests/test_api_auth_debug.py
@@ -66,6 +66,9 @@ def test_auth_debug_reports_resolved_method_and_role() -> None:
     result = asyncio.run(auth_debug(_FakeRequest()))  # type: ignore[arg-type]
     assert result == {
         "authenticated": True,
+        "auth_required": False,
+        "configured_modes": [],
+        "recommended_ui_mode": "no_auth",
         "auth_method": "api_key",
         "subject": "ci-bot",
         "role": "analyst",

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -3,6 +3,7 @@
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
@@ -260,6 +261,43 @@ def test_api_key_middleware_oidc_sets_tenant_from_custom_claim():
     assert resp.json() == {"tenant_id": "tenant-zeta", "role": "analyst"}
 
 
+def test_api_key_middleware_oidc_routes_token_to_tenant_bound_issuer():
+    """Tenant-bound OIDC config should resolve issuer-specific tenant context."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"tenant_id": request.state.tenant_id, "role": request.state.api_key_role})
+
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+
+    cfg = OIDCConfig(
+        tenant_providers={
+            "tenant-alpha": OIDCConfig(
+                issuer="https://alpha.okta.example",
+                audience="agent-bom",
+                tenant_id="tenant-alpha",
+                require_tenant_claim=True,
+            )
+        }
+    )
+    token = "eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FscGhhLm9rdGEuZXhhbXBsZSJ9."
+    with (
+        patch("agent_bom.api.oidc.OIDCConfig.from_env", return_value=cfg),
+        patch(
+            "agent_bom.api.oidc.verify_oidc_token",
+            return_value={"iss": "https://alpha.okta.example", "sub": "u1", "agent_bom_role": "analyst", "tenant_id": "tenant-alpha"},
+        ),
+    ):
+        client = TestClient(test_app)
+        resp = client.get("/v1/test", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"tenant_id": "tenant-alpha", "role": "analyst"}
+
+
 def test_configure_api_enables_auth_middleware_for_oidc(monkeypatch):
     """OIDC-only deployments still need the auth middleware installed."""
     monkeypatch.setenv("AGENT_BOM_OIDC_ISSUER", "https://corp.okta.com")
@@ -270,6 +308,20 @@ def test_configure_api_enables_auth_middleware_for_oidc(monkeypatch):
     finally:
         monkeypatch.delenv("AGENT_BOM_OIDC_ISSUER", raising=False)
         monkeypatch.delenv("AGENT_BOM_OIDC_AUDIENCE", raising=False)
+        configure_api(api_key=None)
+
+
+def test_configure_api_enables_auth_middleware_for_tenant_bound_oidc(monkeypatch):
+    """Tenant-bound OIDC issuer maps should also install auth middleware."""
+    monkeypatch.setenv(
+        "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON",
+        '{"tenant-alpha":{"issuer":"https://alpha.okta.example","audience":"agent-bom"}}',
+    )
+    configure_api(api_key=None)
+    try:
+        assert any(m.cls is APIKeyMiddleware for m in app.user_middleware)
+    finally:
+        monkeypatch.delenv("AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON", raising=False)
         configure_api(api_key=None)
 
 
@@ -362,8 +414,8 @@ def test_rate_limit_middleware_uses_postgres_store_when_available(monkeypatch):
     fake_store.hit.assert_called_once()
 
 
-def test_rate_limit_middleware_falls_back_when_postgres_store_unavailable(monkeypatch):
-    """Limiter should keep serving requests if shared Postgres state cannot initialize."""
+def test_rate_limit_middleware_fails_closed_when_postgres_store_unavailable(monkeypatch):
+    """Configured shared Postgres state must not silently downgrade to local buckets."""
     from starlette.applications import Starlette
     from starlette.responses import JSONResponse as StarletteJSONResponse
     from starlette.routing import Route
@@ -376,9 +428,8 @@ def test_rate_limit_middleware_falls_back_when_postgres_store_unavailable(monkey
         test_app = Starlette(routes=[Route("/v1/test", dummy)])
         test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=10)
         client = TestClient(test_app)
-        resp = client.get("/v1/test")
-
-    assert resp.status_code == 200
+        with pytest.raises(RuntimeError, match="Configured Postgres rate limiter could not initialize"):
+            client.get("/v1/test")
 
 
 def test_rate_limit_middleware_can_fail_closed_when_shared_store_required(monkeypatch):
@@ -390,7 +441,26 @@ def test_rate_limit_middleware_can_fail_closed_when_shared_store_required(monkey
     async def dummy(request):
         return StarletteJSONResponse({"ok": True})
 
-    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://example/test")
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=10)
+    client = TestClient(test_app)
+    try:
+        client.get("/v1/test")
+        raise AssertionError("expected shared rate-limit initialization to fail")
+    except RuntimeError as exc:
+        assert "Shared rate limiting is required" in str(exc)
+
+
+def test_rate_limit_middleware_respects_explicit_shared_rate_limit_requirement(monkeypatch):
+    """The explicit fail-closed flag should reject startup without Postgres too."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
     monkeypatch.setenv("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT", "1")
     with patch("agent_bom.api.middleware.PostgresRateLimitStore", side_effect=RuntimeError("boom")):
         test_app = Starlette(routes=[Route("/v1/test", dummy)])
@@ -400,7 +470,7 @@ def test_rate_limit_middleware_can_fail_closed_when_shared_store_required(monkey
             client.get("/v1/test")
             raise AssertionError("expected shared rate-limit initialization to fail")
         except RuntimeError as exc:
-            assert "AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT" in str(exc)
+            assert "Shared rate limiting is required" in str(exc)
 
 
 def test_rate_limit_middleware_scopes_by_auth_credential():

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -1,5 +1,7 @@
 """Tests for API server hardening — auth, rate limiting, CORS, body size."""
 
+import base64
+import json
 import time
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +18,12 @@ from agent_bom.api.server import (
     app,
     configure_api,
 )
+
+
+def _unsigned_test_jwt(claims: dict[str, str]) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"{header}.{payload}."
 
 
 def test_health_no_auth():
@@ -283,7 +291,7 @@ def test_api_key_middleware_oidc_routes_token_to_tenant_bound_issuer():
             )
         }
     )
-    token = "eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FscGhhLm9rdGEuZXhhbXBsZSJ9."
+    token = _unsigned_test_jwt({"iss": "https://alpha.okta.example"})
     with (
         patch("agent_bom.api.oidc.OIDCConfig.from_env", return_value=cfg),
         patch(

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -132,6 +132,57 @@ def test_api_key_middleware_health_exempt():
     assert resp.status_code == 200
 
 
+def test_api_key_middleware_proxy_headers_authenticate_when_enabled(monkeypatch):
+    """Trusted proxy headers should satisfy auth when explicitly enabled."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse(
+            {
+                "role": request.state.api_key_role,
+                "tenant_id": request.state.tenant_id,
+                "method": request.state.auth_method,
+            }
+        )
+
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(APIKeyMiddleware, api_key="")
+
+    client = TestClient(test_app)
+    resp = client.get(
+        "/v1/test",
+        headers={
+            "X-Agent-Bom-Role": "analyst",
+            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+            "X-Agent-Bom-Subject": "alice@corp.example",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"role": "analyst", "tenant_id": "tenant-alpha", "method": "proxy_header"}
+
+
+def test_api_key_middleware_proxy_headers_require_tenant(monkeypatch):
+    """Trusted proxy auth must fail closed when the tenant header is missing."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(APIKeyMiddleware, api_key="")
+
+    client = TestClient(test_app)
+    resp = client.get("/v1/test", headers={"X-Agent-Bom-Role": "viewer"})
+    assert resp.status_code == 401
+    assert "X-Agent-Bom-Tenant-ID" in resp.json()["detail"]
+
+
 def test_api_key_middleware_exception_create_allows_analyst_role():
     """Analyst API keys should keep write access to exception creation paths."""
     from starlette.applications import Starlette
@@ -207,6 +258,30 @@ def test_api_key_middleware_oidc_sets_tenant_from_custom_claim():
 
     assert resp.status_code == 200
     assert resp.json() == {"tenant_id": "tenant-zeta", "role": "analyst"}
+
+
+def test_configure_api_enables_auth_middleware_for_oidc(monkeypatch):
+    """OIDC-only deployments still need the auth middleware installed."""
+    monkeypatch.setenv("AGENT_BOM_OIDC_ISSUER", "https://corp.okta.com")
+    monkeypatch.setenv("AGENT_BOM_OIDC_AUDIENCE", "agent-bom")
+    configure_api(api_key=None)
+    try:
+        assert any(m.cls is APIKeyMiddleware for m in app.user_middleware)
+    finally:
+        monkeypatch.delenv("AGENT_BOM_OIDC_ISSUER", raising=False)
+        monkeypatch.delenv("AGENT_BOM_OIDC_AUDIENCE", raising=False)
+        configure_api(api_key=None)
+
+
+def test_configure_api_enables_auth_middleware_for_trusted_proxy(monkeypatch):
+    """Trusted-proxy browser auth must also install the auth middleware."""
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    configure_api(api_key=None)
+    try:
+        assert any(m.cls is APIKeyMiddleware for m in app.user_middleware)
+    finally:
+        monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
+        configure_api(api_key=None)
 
 
 def test_api_key_middleware_oidc_requires_explicit_role_claim_when_enabled():

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -19,6 +19,8 @@ Tests cover:
 
 from __future__ import annotations
 
+import base64
+import json
 import os
 from unittest.mock import MagicMock, patch
 
@@ -36,6 +38,12 @@ from agent_bom.api.oidc import (
 )
 
 # ── OIDCConfig ────────────────────────────────────────────────────────────────
+
+
+def _unsigned_test_jwt(claims: dict[str, str]) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"{header}.{payload}."
 
 
 def test_oidc_config_disabled_when_no_issuer():
@@ -331,7 +339,7 @@ def test_oidc_config_verify_routes_token_by_issuer_for_tenant_bound_providers():
             )
         }
     )
-    token = "eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FscGhhLm9rdGEuZXhhbXBsZSJ9."
+    token = _unsigned_test_jwt({"iss": "https://alpha.okta.example"})
     with patch(
         "agent_bom.api.oidc.verify_oidc_token",
         return_value={"iss": "https://alpha.okta.example", "sub": "user-1", "agent_bom_role": "analyst", "tenant_id": "tenant-alpha"},
@@ -357,7 +365,7 @@ def test_oidc_config_resolve_tenant_rejects_mismatched_bound_tenant():
         return_value={"iss": "https://alpha.okta.example", "sub": "user-1", "agent_bom_role": "viewer", "tenant_id": "tenant-beta"},
     ):
         with pytest.raises(OIDCError, match="does not match the configured tenant"):
-            cfg.verify("eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FscGhhLm9rdGEuZXhhbXBsZSJ9.")
+            cfg.verify(_unsigned_test_jwt({"iss": "https://alpha.okta.example"}))
 
 
 # ── API middleware OIDC integration ───────────────────────────────────────────

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -30,6 +30,7 @@ from agent_bom.api.oidc import (
     claims_have_role_signal,
     claims_to_role,
     claims_to_tenant,
+    oidc_enabled_from_env,
     record_oidc_decode_failure,
     reset_oidc_decode_failures,
 )
@@ -55,6 +56,15 @@ def test_oidc_config_from_env_reads_issuer():
         cfg = OIDCConfig.from_env()
         assert cfg.enabled is True
         assert cfg.issuer == "https://test.okta.com"
+
+
+def test_oidc_enabled_from_env_detects_tenant_bound_config():
+    with patch.dict(
+        os.environ,
+        {"AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON": '{"tenant-alpha":{"issuer":"https://alpha.okta.example","audience":"agent-bom"}}'},
+        clear=False,
+    ):
+        assert oidc_enabled_from_env() is True
 
 
 def test_oidc_config_audience_is_unset_without_explicit_value():
@@ -116,6 +126,53 @@ def test_oidc_config_require_role_claim_from_env():
     ):
         cfg = OIDCConfig.from_env()
         assert cfg.require_role_claim is True
+
+
+def test_oidc_config_from_env_reads_tenant_bound_providers():
+    with patch.dict(
+        os.environ,
+        {
+            "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON": (
+                '{"tenant-alpha":{"issuer":"https://alpha.okta.example","audience":"agent-bom"},'
+                '"tenant-beta":{"issuer":"https://beta.okta.example","audience":"agent-bom","require_tenant_claim":true}}'
+            )
+        },
+        clear=False,
+    ):
+        cfg = OIDCConfig.from_env()
+
+    assert cfg.enabled is True
+    assert cfg.issuer == ""
+    assert set(cfg.tenant_providers) == {"tenant-alpha", "tenant-beta"}
+    assert cfg.tenant_providers["tenant-beta"].require_tenant_claim is True
+
+
+def test_oidc_config_from_env_rejects_mixed_global_and_tenant_bound_modes():
+    with patch.dict(
+        os.environ,
+        {
+            "AGENT_BOM_OIDC_ISSUER": "https://global.okta.example",
+            "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON": '{"tenant-alpha":{"issuer":"https://alpha.okta.example","audience":"agent-bom"}}',
+        },
+        clear=False,
+    ):
+        with pytest.raises(OIDCError, match="either AGENT_BOM_OIDC_ISSUER or AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON"):
+            OIDCConfig.from_env()
+
+
+def test_oidc_config_from_env_rejects_duplicate_issuers():
+    with patch.dict(
+        os.environ,
+        {
+            "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON": (
+                '{"tenant-alpha":{"issuer":"https://shared.okta.example","audience":"agent-bom"},'
+                '"tenant-beta":{"issuer":"https://shared.okta.example","audience":"agent-bom"}}'
+            )
+        },
+        clear=False,
+    ):
+        with pytest.raises(OIDCError, match="configured for more than one tenant"):
+            OIDCConfig.from_env()
 
 
 @pytest.fixture(autouse=True)
@@ -261,6 +318,46 @@ def test_oidc_config_resolve_tenant_raises_when_required_claim_missing():
     cfg = OIDCConfig(issuer="https://corp.example.com", audience="agent-bom", require_tenant_claim=True)
     with pytest.raises(OIDCError, match="tenant claim"):
         cfg.resolve_tenant({"sub": "user-1"})
+
+
+def test_oidc_config_verify_routes_token_by_issuer_for_tenant_bound_providers():
+    cfg = OIDCConfig(
+        tenant_providers={
+            "tenant-alpha": OIDCConfig(
+                issuer="https://alpha.okta.example",
+                audience="agent-bom",
+                tenant_id="tenant-alpha",
+                require_tenant_claim=True,
+            )
+        }
+    )
+    token = "eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FscGhhLm9rdGEuZXhhbXBsZSJ9."
+    with patch(
+        "agent_bom.api.oidc.verify_oidc_token",
+        return_value={"iss": "https://alpha.okta.example", "sub": "user-1", "agent_bom_role": "analyst", "tenant_id": "tenant-alpha"},
+    ):
+        claims, role = cfg.verify(token)
+
+    assert claims["iss"] == "https://alpha.okta.example"
+    assert role == "analyst"
+
+
+def test_oidc_config_resolve_tenant_rejects_mismatched_bound_tenant():
+    cfg = OIDCConfig(
+        tenant_providers={
+            "tenant-alpha": OIDCConfig(
+                issuer="https://alpha.okta.example",
+                audience="agent-bom",
+                tenant_id="tenant-alpha",
+            )
+        }
+    )
+    with patch(
+        "agent_bom.api.oidc.verify_oidc_token",
+        return_value={"iss": "https://alpha.okta.example", "sub": "user-1", "agent_bom_role": "viewer", "tenant_id": "tenant-beta"},
+    ):
+        with pytest.raises(OIDCError, match="does not match the configured tenant"):
+            cfg.verify("eyJhbGciOiJub25lIn0.eyJpc3MiOiJodHRwczovL2FscGhhLm9rdGEuZXhhbXBsZSJ9.")
 
 
 # ── API middleware OIDC integration ───────────────────────────────────────────

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -126,8 +126,10 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["rate_limit_key"]["status"] in {"ok", "ephemeral", "unknown_age", "rotation_due", "max_age_exceeded"}
     assert body["ui"]["recommended_mode"] in {"no_auth", "reverse_proxy_oidc", "oidc_bearer", "session_api_key"}
     assert body["ui"]["session_storage_fallback"] == "session_api_key"
-    assert body["rate_limit_runtime"]["backend"] in {"inmemory", "postgres_shared"}
+    assert body["rate_limit_runtime"]["backend"] in {"inmemory_single_process", "postgres_shared"}
     assert "shared_across_replicas" in body["rate_limit_runtime"]
+    assert "configured_api_replicas" in body["rate_limit_runtime"]
+    assert "fail_closed" in body["rate_limit_runtime"]
 
 
 def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -137,9 +139,28 @@ def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPat
     assert status == {
         "backend": "postgres_shared",
         "postgres_configured": True,
+        "configured_api_replicas": 1,
         "shared_required": True,
         "shared_across_replicas": True,
+        "fail_closed": True,
         "message": "Rate limiting uses Postgres-backed shared state across replicas.",
+    }
+
+
+def test_rate_limit_runtime_reports_single_replica_process_local_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "1")
+    status = get_rate_limit_runtime_status()
+    assert status == {
+        "backend": "inmemory_single_process",
+        "postgres_configured": False,
+        "configured_api_replicas": 1,
+        "shared_required": False,
+        "shared_across_replicas": False,
+        "fail_closed": False,
+        "message": (
+            "Rate limiting is process-local only because the API is configured for a single replica. "
+            "Multi-replica deployments must configure AGENT_BOM_POSTGRES_URL."
+        ),
     }
 
 

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -124,12 +124,35 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "default_ttl_seconds" in body["api_key"]
     assert "max_ttl_seconds" in body["api_key"]
     assert body["rate_limit_key"]["status"] in {"ok", "ephemeral", "unknown_age", "rotation_due", "max_age_exceeded"}
+    assert body["ui"]["recommended_mode"] in {"no_auth", "reverse_proxy_oidc", "oidc_bearer", "session_api_key"}
+    assert body["ui"]["session_storage_fallback"] == "session_api_key"
 
 
 def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
     middleware = APIKeyMiddleware(app, api_key="static-secret")
     assert middleware._required_role("GET", "/v1/auth/policy") == "admin"
     assert middleware._required_role("GET", "/v1/auth/debug") == "viewer"
+
+
+def test_auth_debug_reports_runtime_auth_modes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    _reload_config()
+    _server_mod.configure_api(api_key=None)
+
+    client = TestClient(app)
+    resp = client.get(
+        "/v1/auth/debug",
+        headers={
+            "X-Agent-Bom-Role": "viewer",
+            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["authenticated"] is True
+    assert body["auth_required"] is True
+    assert "trusted_proxy" in body["configured_modes"]
+    assert body["recommended_ui_mode"] == "reverse_proxy_oidc"
 
 
 # ─── /readyz drain behavior ──────────────────────────────────────────────────

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/ui/README.md
+++ b/ui/README.md
@@ -39,6 +39,15 @@ NEXT_PUBLIC_API_URL=
 That keeps browser requests relative (`/v1/...`) so the ingress can route API
 paths to the backend service without rebuilding the UI image.
 
+## Browser auth model
+
+The dashboard supports two browser auth modes:
+
+- Recommended: same-origin reverse-proxy OIDC/session auth. The proxy keeps the browser session and injects trusted `X-Agent-Bom-Role` plus `X-Agent-Bom-Tenant-ID` headers to the API. Enable `AGENT_BOM_TRUST_PROXY_AUTH=1` on the backend for this mode.
+- Fallback: a short-lived API key entered into the dashboard and stored in `sessionStorage` for the current browser tab/session only.
+
+All browser fetches use `credentials: "include"` so proxy-managed sessions work without custom patches.
+
 If you see `Failed to fetch`:
 
 1. Make sure `agent-bom api` is running.

--- a/ui/README.md
+++ b/ui/README.md
@@ -48,6 +48,20 @@ The dashboard supports two browser auth modes:
 
 All browser fetches use `credentials: "include"` so proxy-managed sessions work without custom patches.
 
+## Frontend quality gates
+
+The UI now ships with two extra release guards:
+
+- `npm run bundle:check` verifies the checked-in client bundle budget against the built `.next/` output.
+- `npm run test:e2e` runs the packaged browser path (`scan -> result -> export`) with Playwright.
+
+For local E2E runs, build first:
+
+```bash
+npm run build
+npm run test:e2e
+```
+
 If you see `Failed to fetch`:
 
 1. Make sure `agent-bom api` is running.

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import Script from "next/script";
 import "./globals.css";
+import { AuthGate } from "@/components/auth-gate";
 import { Nav } from "@/components/nav";
 
 // Local fonts — no network fetch at build time (works in air-gapped environments)
@@ -54,11 +55,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </Script>
         <Nav />
         {/* Main content — offset by sidebar width on desktop, offset by top bar on mobile */}
-        <main id="main-content" className="lg:pl-[240px] pt-14 lg:pt-0 min-h-screen transition-[padding-left] duration-200">
-          <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            {children}
-          </div>
-        </main>
+        <AuthGate>
+          <main id="main-content" className="lg:pl-[240px] pt-14 lg:pt-0 min-h-screen transition-[padding-left] duration-200">
+            <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
+              {children}
+            </div>
+          </main>
+        </AuthGate>
       </body>
     </html>
   );

--- a/ui/app/proxy/page.tsx
+++ b/ui/app/proxy/page.tsx
@@ -7,6 +7,7 @@ import {
   type ProxyAlert,
   formatDate,
 } from "@/lib/api";
+import { getSessionWebSocketToken } from "@/lib/auth";
 import { getConfiguredApiUrl } from "@/lib/runtime-config";
 import {
   ResponsiveContainer,
@@ -95,7 +96,12 @@ export default function ProxyDashboard() {
   // WebSocket for live metrics
   useEffect(() => {
     const base = getConfiguredApiUrl() || window.location.origin;
-    const wsUrl = base.replace(/^http/, "ws") + "/ws/proxy/metrics";
+    const wsTarget = new URL(base.replace(/^http/, "ws") + "/ws/proxy/metrics");
+    const token = getSessionWebSocketToken();
+    if (token) {
+      wsTarget.searchParams.set("token", token);
+    }
+    const wsUrl = wsTarget.toString();
 
     let ws: WebSocket;
     let reconnectTimer: ReturnType<typeof setTimeout>;

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { KeyRound, Loader2, Lock, ShieldCheck } from "lucide-react";
+
+import { api, type AuthDebugResponse } from "@/lib/api";
+import { clearSessionApiKey, getSessionApiKey, setSessionApiKey } from "@/lib/auth";
+
+function isAuthFailure(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes("unauthorized") || normalized.includes("invalid api key") || normalized.includes("forbidden");
+}
+
+export function AuthGate({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<AuthDebugResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [apiKey, setApiKey] = useState("");
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await api.getAuthDebug();
+      setStatus(next);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to determine auth status";
+      setStatus(null);
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const stored = getSessionApiKey();
+    if (stored) {
+      setApiKey(stored);
+    }
+    void refresh();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+      </div>
+    );
+  }
+
+  if (status && (!status.auth_required || status.authenticated)) {
+    return <>{children}</>;
+  }
+
+  if (!error || isAuthFailure(error)) {
+    return (
+      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
+        <div className="w-full max-w-2xl rounded-3xl border border-zinc-800 bg-zinc-950/80 p-8 shadow-2xl shadow-black/20">
+          <div className="mb-6 flex items-center gap-3 text-zinc-100">
+            <ShieldCheck className="h-6 w-6 text-emerald-400" />
+            <div>
+              <h1 className="text-xl font-semibold tracking-tight">Control-plane authentication required</h1>
+              <p className="mt-1 text-sm text-zinc-400">
+                Recommended for enterprise: same-origin reverse-proxy OIDC/session auth. For single-user local or pilot access, enter a short-lived API key for this browser session only.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-2xl border border-emerald-900/60 bg-emerald-950/20 p-5">
+              <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-emerald-300">
+                <Lock className="h-4 w-4" />
+                Recommended: reverse-proxy OIDC
+              </div>
+              <p className="text-sm leading-6 text-zinc-400">
+                Keep the UI and API on the same origin, terminate browser auth at the proxy, and inject trusted
+                <code className="mx-1 rounded bg-zinc-900 px-1 py-0.5 font-mono text-zinc-200">X-Agent-Bom-Role</code>
+                plus
+                <code className="mx-1 rounded bg-zinc-900 px-1 py-0.5 font-mono text-zinc-200">X-Agent-Bom-Tenant-ID</code>
+                headers upstream.
+              </p>
+            </div>
+
+            <form
+              className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5"
+              onSubmit={async (event) => {
+                event.preventDefault();
+                setSessionApiKey(apiKey);
+                await refresh();
+              }}
+            >
+              <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-zinc-200">
+                <KeyRound className="h-4 w-4 text-amber-300" />
+                Session API key fallback
+              </div>
+              <p className="mb-4 text-sm leading-6 text-zinc-400">
+                Stored in
+                <code className="mx-1 rounded bg-zinc-950 px-1 py-0.5 font-mono text-zinc-200">sessionStorage</code>
+                only and cleared when the browser session ends.
+              </p>
+              <label className="mb-3 block text-xs uppercase tracking-[0.2em] text-zinc-500">API key</label>
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 font-mono text-sm text-zinc-100 outline-none ring-0 placeholder:text-zinc-600 focus:border-emerald-500"
+                placeholder="abk_..."
+                autoComplete="off"
+              />
+              <div className="mt-4 flex gap-3">
+                <button
+                  type="submit"
+                  className="rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400"
+                >
+                  Unlock dashboard
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    clearSessionApiKey();
+                    setApiKey("");
+                    setError(null);
+                  }}
+                  className="rounded-xl border border-zinc-700 px-4 py-2 text-sm text-zinc-300 transition hover:bg-zinc-900"
+                >
+                  Clear key
+                </button>
+              </div>
+            </form>
+          </div>
+
+          {error ? (
+            <div className="mt-5 rounded-2xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-300">
+              {error}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
+      <div className="max-w-xl rounded-2xl border border-red-900/50 bg-red-950/20 p-6 text-sm text-red-300">
+        {error}
+      </div>
+    </div>
+  );
+}

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
-import { api, type ScanJob, type ScanResult, type BlastRadius, type RemediationItem, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS, severityColor } from "@/lib/api";
+import { api, type ScanJob, type ScanResult, type BlastRadius, type RemediationItem, type GraphExportFormat, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS, severityColor } from "@/lib/api";
 import type { StepEvent, SSEEvent } from "@/lib/api";
 import { ScanPipeline } from "@/components/scan-pipeline";
 import { SeverityBadge } from "@/components/severity-badge";
 import {
   ArrowLeft, Loader2, CheckCircle, Clock, Zap, Key, Wrench,
-  ArrowUpCircle, AlertTriangle, ChevronDown, ChevronRight, GitBranch, Server,
+  ArrowUpCircle, AlertTriangle, ChevronDown, ChevronRight, Download, GitBranch, Server,
 } from "lucide-react";
 
 // ─── Scan Result View ───────────────────────────────────────────────────────
@@ -18,6 +18,8 @@ export function ScanResultView({ id }: { id: string }) {
   const [messages, setMessages] = useState<string[]>([]);
   const [streaming, setStreaming] = useState(true);
   const [pipelineSteps, setPipelineSteps] = useState<Map<string, StepEvent>>(new Map());
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState("");
   const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -67,21 +69,60 @@ export function ScanResultView({ id }: { id: string }) {
   const summary = result?.summary;
   const blastRadius = result?.blast_radius ?? [];
 
+  async function handleExport(format: GraphExportFormat = "json") {
+    setExporting(true);
+    setExportError("");
+    try {
+      const blob = await api.downloadScanGraph(id, format);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `scan-${id}-graph.${format === "json" ? "json" : format}`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : "Failed to export graph");
+    } finally {
+      setExporting(false);
+    }
+  }
+
   return (
     <div className="space-y-8">
       {/* Back + header */}
-      <div className="flex items-center gap-4">
-        <Link href="/" className="text-zinc-500 hover:text-zinc-300 transition-colors">
-          <ArrowLeft className="w-4 h-4" />
-        </Link>
-        <div>
-          <div className="flex items-center gap-3">
-            <h1 className="text-xl font-semibold">Scan Results</h1>
-            <JobStatusBadge status={job?.status ?? "pending"} streaming={streaming} />
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          <Link href="/" className="text-zinc-500 hover:text-zinc-300 transition-colors">
+            <ArrowLeft className="w-4 h-4" />
+          </Link>
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-xl font-semibold">Scan Results</h1>
+              <JobStatusBadge status={job?.status ?? "pending"} streaming={streaming} />
+            </div>
+            <p className="text-xs text-zinc-500 font-mono mt-0.5">{id}</p>
           </div>
-          <p className="text-xs text-zinc-500 font-mono mt-0.5">{id}</p>
         </div>
+        {job?.status === "done" ? (
+          <button
+            type="button"
+            onClick={() => void handleExport("json")}
+            disabled={exporting}
+            className="inline-flex items-center gap-2 rounded-lg border border-cyan-900/60 bg-cyan-950/30 px-3 py-2 text-sm font-medium text-cyan-200 transition-colors hover:border-cyan-800 hover:bg-cyan-950/50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+            Export graph JSON
+          </button>
+        ) : null}
       </div>
+
+      {exportError ? (
+        <div className="rounded-xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-300">
+          {exportError}
+        </div>
+      ) : null}
 
       {/* Scan Pipeline DAG */}
       {(streaming || pipelineSteps.size > 0) && (

--- a/ui/e2e/scan-export.spec.ts
+++ b/ui/e2e/scan-export.spec.ts
@@ -1,0 +1,166 @@
+import { expect, test } from "@playwright/test";
+
+const scanJob = {
+  job_id: "job-e2e",
+  status: "done",
+  created_at: "2026-04-20T12:00:00Z",
+  request: {
+    images: ["nginx:1.25"],
+  },
+  progress: [],
+  result: {
+    agents: [
+      {
+        name: "Claude Desktop",
+        agent_type: "desktop",
+        source: "local",
+        status: "configured",
+        mcp_servers: [
+          {
+            name: "filesystem",
+            has_credentials: false,
+            packages: [
+              {
+                name: "requests",
+                version: "2.32.3",
+                ecosystem: "pypi",
+                vulnerabilities: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    blast_radius: [
+      {
+        vulnerability_id: "CVE-2026-0001",
+        package: "requests",
+        ecosystem: "pypi",
+        severity: "high",
+        blast_score: 8.1,
+        affected_agents: ["Claude Desktop"],
+        exposed_credentials: [],
+        reachable_tools: ["filesystem"],
+        owasp_tags: [],
+        atlas_tags: [],
+      },
+    ],
+    remediation_plan: [],
+    summary: {
+      total_agents: 1,
+      total_packages: 1,
+      total_vulnerabilities: 1,
+      critical_findings: 0,
+    },
+  },
+};
+
+test("scan flow reaches result view and exports graph JSON", async ({ page }) => {
+  await page.route("**/health", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ status: "ok" }),
+    });
+  });
+
+  await page.route("**/v1/posture/counts", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        total: 0,
+        kev: 0,
+        compound_issues: 0,
+      }),
+    });
+  });
+
+  await page.route("**/v1/auth/debug", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        auth_required: false,
+        configured_modes: [],
+        recommended_ui_mode: "no_auth",
+        auth_method: null,
+        subject: null,
+        role: null,
+        tenant_id: "default",
+        oidc_issuer_suffix: null,
+        api_key_id_prefix: null,
+        request_id: "req-e2e",
+        trace_id: "trace-e2e",
+        span_id: "span-e2e",
+      }),
+    });
+  });
+
+  await page.route("**/v1/scan", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: scanJob.job_id,
+        status: "pending",
+        created_at: scanJob.created_at,
+        request: scanJob.request,
+        progress: [],
+      }),
+    });
+  });
+
+  await page.route(`**/v1/scan/${scanJob.job_id}`, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(scanJob),
+    });
+  });
+
+  await page.route(`**/v1/scan/${scanJob.job_id}/stream`, async (route) => {
+    await route.fulfill({
+      contentType: "text/event-stream",
+      body: [
+        'data: {"type":"step","step_id":"analysis","status":"done","message":"Analysis complete"}',
+        "",
+        `data: {"type":"done","status":"done","job_id":"${scanJob.job_id}"}`,
+        "",
+      ].join("\n"),
+    });
+  });
+
+  await page.route(`**/v1/scan/${scanJob.job_id}/graph-export?format=json`, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      headers: {
+        "content-disposition": `attachment; filename="scan-${scanJob.job_id}-graph.json"`,
+      },
+      body: JSON.stringify({
+        nodes: [{ id: "agent:Claude Desktop", label: "Claude Desktop" }],
+        edges: [],
+      }),
+    });
+  });
+
+  await page.goto("/scan");
+  await page.getByPlaceholder("nginx:1.25 or ghcr.io/org/app:v1").fill("nginx:1.25");
+  await page.getByPlaceholder("nginx:1.25 or ghcr.io/org/app:v1").press("Enter");
+  await page.getByRole("button", { name: /start scan/i }).click();
+
+  await expect(page).toHaveURL(/\/scan\?id=job-e2e/);
+  await expect(page.getByRole("heading", { name: "Scan Results" })).toBeVisible();
+  await expect(page.getByText("Vulnerabilities")).toBeVisible();
+  await expect(page.getByText("Blast Radius (1)")).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: /export graph json/i }).click();
+  const download = await downloadPromise;
+
+  await expect(download.suggestedFilename()).toContain("scan-job-e2e-graph.json");
+});

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -4,6 +4,7 @@
  */
 
 import type { UnifiedEdge, UnifiedGraphData, UnifiedNode } from "./graph-schema";
+import { getSessionAuthHeaders } from "./auth";
 import { getConfiguredApiUrl } from "./runtime-config";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -445,6 +446,22 @@ export interface VersionInfo {
   python_package: string;
 }
 
+export interface AuthDebugResponse {
+  authenticated: boolean;
+  auth_required: boolean;
+  configured_modes: string[];
+  recommended_ui_mode: string;
+  auth_method: string | null;
+  subject: string | null;
+  role: string | null;
+  tenant_id: string;
+  oidc_issuer_suffix: string | null;
+  api_key_id_prefix: string | null;
+  request_id: string | null;
+  trace_id: string | null;
+  span_id: string | null;
+}
+
 export interface JobsResponse {
   jobs: JobListItem[];
   count: number;
@@ -776,7 +793,11 @@ async function errorMessage(res: Response): Promise<string> {
 }
 
 async function get<T>(path: string): Promise<T> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, { signal: withTimeout() });
+  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+    credentials: "include",
+    headers: getSessionAuthHeaders(),
+    signal: withTimeout(),
+  });
   if (!res.ok) throw new Error(await errorMessage(res));
   return res.json() as Promise<T>;
 }
@@ -784,7 +805,8 @@ async function get<T>(path: string): Promise<T> {
 async function post<T>(path: string, body: unknown, headers: Record<string, string> = {}): Promise<T> {
   const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", ...headers },
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...getSessionAuthHeaders(), ...headers },
     body: JSON.stringify(body),
     signal: withTimeout(),
   });
@@ -795,7 +817,8 @@ async function post<T>(path: string, body: unknown, headers: Record<string, stri
 async function put<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...getSessionAuthHeaders() },
     body: JSON.stringify(body),
     signal: withTimeout(),
   });
@@ -804,7 +827,12 @@ async function put<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function del(path: string): Promise<void> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, { method: "DELETE", signal: withTimeout() });
+  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers: getSessionAuthHeaders(),
+    signal: withTimeout(),
+  });
   if (!res.ok) throw new Error(await errorMessage(res));
 }
 
@@ -813,6 +841,7 @@ async function del(path: string): Promise<void> {
 export const api = {
   health: () => get<HealthResponse>("/health"),
   version: () => get<VersionInfo>("/version"),
+  getAuthDebug: () => get<AuthDebugResponse>("/v1/auth/debug"),
 
   /** Start a scan — returns immediately with job_id */
   startScan: (req: ScanRequest) => post<ScanJob>("/v1/scan", req),

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -135,6 +135,8 @@ export interface GraphSearchResponse {
   pagination: GraphPagination;
 }
 
+export type GraphExportFormat = "json" | "dot" | "mermaid" | "graphml" | "cypher";
+
 export type DeploymentMode = "local" | "fleet" | "cluster" | "hybrid";
 
 export interface PostureCountsResponse {
@@ -836,6 +838,16 @@ async function del(path: string): Promise<void> {
   if (!res.ok) throw new Error(await errorMessage(res));
 }
 
+async function getBlob(path: string): Promise<Blob> {
+  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+    credentials: "include",
+    headers: getSessionAuthHeaders(),
+    signal: withTimeout(),
+  });
+  if (!res.ok) throw new Error(await errorMessage(res));
+  return res.blob();
+}
+
 // ─── API functions ────────────────────────────────────────────────────────────
 
 export const api = {
@@ -848,6 +860,10 @@ export const api = {
 
   /** Poll scan status + results */
   getScan: (jobId: string) => get<ScanJob>(`/v1/scan/${jobId}`),
+
+  /** Export a completed scan graph in a graph-native format. */
+  downloadScanGraph: (jobId: string, format: GraphExportFormat = "json") =>
+    getBlob(`/v1/scan/${encodeURIComponent(jobId)}/graph-export?format=${encodeURIComponent(format)}`),
 
   /** Delete a job record */
   deleteScan: (jobId: string) => del(`/v1/scan/${jobId}`),

--- a/ui/lib/auth.ts
+++ b/ui/lib/auth.ts
@@ -1,0 +1,46 @@
+const SESSION_API_KEY = "agent-bom-ui-api-key";
+
+function hasWindow(): boolean {
+  return typeof window !== "undefined";
+}
+
+export function getSessionApiKey(): string {
+  if (!hasWindow()) return "";
+  try {
+    return window.sessionStorage.getItem(SESSION_API_KEY)?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function setSessionApiKey(rawKey: string): void {
+  if (!hasWindow()) return;
+  const value = rawKey.trim();
+  try {
+    if (!value) {
+      window.sessionStorage.removeItem(SESSION_API_KEY);
+      return;
+    }
+    window.sessionStorage.setItem(SESSION_API_KEY, value);
+  } catch {
+    // Ignore storage failures; the user can still retry within the current render.
+  }
+}
+
+export function clearSessionApiKey(): void {
+  if (!hasWindow()) return;
+  try {
+    window.sessionStorage.removeItem(SESSION_API_KEY);
+  } catch {
+    // Ignore storage failures; best-effort cleanup only.
+  }
+}
+
+export function getSessionAuthHeaders(): Record<string, string> {
+  const apiKey = getSessionApiKey();
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
+
+export function getSessionWebSocketToken(): string {
+  return getSessionApiKey();
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -132,7 +132,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -466,7 +465,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -515,7 +513,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -534,6 +531,28 @@
       "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
       "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1499,7 +1518,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -2229,6 +2247,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2249,6 +2268,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2324,7 +2344,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2482,7 +2503,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2493,7 +2513,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2504,7 +2523,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2560,7 +2578,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3244,7 +3261,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3285,6 +3301,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3295,6 +3312,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3608,7 +3626,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3884,7 +3901,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4124,6 +4140,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4155,7 +4172,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4436,7 +4454,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4555,7 +4572,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5391,7 +5407,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6373,6 +6388,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6986,6 +7002,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7000,7 +7017,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7050,7 +7068,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7060,7 +7077,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7072,15 +7088,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7147,8 +7161,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7931,7 +7944,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8137,7 +8149,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8319,7 +8330,6 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8731,7 +8741,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^16.2.4",
+        "@playwright/test": "^1.56.1",
         "@tailwindcss/postcss": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -131,6 +132,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -464,6 +466,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -512,6 +515,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -530,28 +534,6 @@
       "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
       "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1511,6 +1493,23 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -2230,7 +2229,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2251,7 +2249,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2327,8 +2324,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2486,6 +2482,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2496,6 +2493,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2506,6 +2504,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2561,6 +2560,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3244,6 +3244,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3284,7 +3285,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3295,7 +3295,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3609,6 +3608,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3884,6 +3884,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4123,7 +4124,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4155,8 +4155,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4437,6 +4436,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4555,6 +4555,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5390,6 +5391,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6371,7 +6373,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6883,6 +6884,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6938,7 +6986,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6953,8 +7000,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7004,6 +7050,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7013,6 +7060,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7024,13 +7072,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7097,7 +7147,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7880,6 +7931,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8085,6 +8137,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8266,6 +8319,7 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8677,6 +8731,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,9 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
+    "bundle:check": "node scripts/check-bundle-budget.mjs",
     "lint": "eslint",
+    "test:e2e": "playwright test",
     "verify:toolchain": "node scripts/verify-toolchain.mjs",
     "test": "vitest",
     "test:run": "vitest run"
@@ -26,6 +28,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.1",
     "@next/eslint-plugin-next": "^16.2.4",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3001;
+const baseURL = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `npm run start -- --hostname 127.0.0.1 --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_API_URL: "",
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -1,0 +1,68 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const NEXT_DIR = path.join(ROOT, ".next");
+const CHUNKS_DIR = path.join(NEXT_DIR, "static", "chunks");
+const BUILD_MANIFEST = path.join(NEXT_DIR, "build-manifest.json");
+
+const BUDGETS = {
+  totalClientJsBytes: 2_700_000,
+  largestChunkBytes: 950_000,
+  sharedAppBytes: 450_000,
+};
+
+function listJsFiles(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listJsFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile() && fullPath.endsWith(".js")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}
+
+if (!statSync(NEXT_DIR, { throwIfNoEntry: false })) {
+  console.error("Missing .next/ build output. Run `npm run build` before `npm run bundle:check`.");
+  process.exit(1);
+}
+
+const chunkFiles = listJsFiles(CHUNKS_DIR);
+const totalClientJsBytes = chunkFiles.reduce((sum, file) => sum + statSync(file).size, 0);
+const largestChunkBytes = chunkFiles.reduce((max, file) => Math.max(max, statSync(file).size), 0);
+
+const manifest = JSON.parse(readFileSync(BUILD_MANIFEST, "utf8"));
+let sharedAppBytes = 0;
+for (const file of manifest.rootMainFiles ?? manifest.pages?.["/_app"] ?? []) {
+  if (!file.endsWith(".js")) continue;
+  const fullPath = path.join(NEXT_DIR, file);
+  sharedAppBytes += statSync(fullPath, { throwIfNoEntry: false })?.size ?? 0;
+}
+
+const checks = [
+  ["total client JS", totalClientJsBytes, BUDGETS.totalClientJsBytes],
+  ["largest chunk", largestChunkBytes, BUDGETS.largestChunkBytes],
+  ["shared app runtime", sharedAppBytes, BUDGETS.sharedAppBytes],
+];
+
+let failed = false;
+for (const [label, actual, budget] of checks) {
+  const status = actual > budget ? "FAIL" : "PASS";
+  console.log(`${status} ${label}: ${formatBytes(actual)} / budget ${formatBytes(budget)}`);
+  if (actual > budget) failed = true;
+}
+
+if (failed) {
+  console.error("UI bundle budget exceeded. Reduce client bundle size or intentionally raise the checked-in budget.");
+  process.exit(1);
+}

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -13,6 +13,16 @@ function mockFetch(data: unknown, ok = true, status = 200) {
   })
 }
 
+function mockBlobFetch(contents: string, ok = true, status = 200, type = 'application/json') {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: () => Promise.resolve({}),
+    blob: () => Promise.resolve(new Blob([contents], { type })),
+  })
+}
+
 const originalFetch = global.fetch
 
 afterEach(() => {
@@ -228,6 +238,26 @@ describe('api.getScan', () => {
   it('throws on error', async () => {
     global.fetch = mockFetch({}, false, 500)
     await expect(api.getScan('bad-id')).rejects.toThrow('500')
+  })
+})
+
+describe('api.downloadScanGraph', () => {
+  it('downloads graph export with session auth headers', async () => {
+    setSessionApiKey('pilot-key-123')
+    const fetchMock = mockBlobFetch('{"nodes":[],"edges":[]}')
+    global.fetch = fetchMock
+
+    const blob = await api.downloadScanGraph('job-1')
+
+    expect(blob).toBeInstanceOf(Blob)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/scan/job-1/graph-export?format=json',
+      expect.objectContaining({
+        credentials: 'include',
+        headers: { Authorization: 'Bearer pilot-key-123' },
+        signal: expect.any(AbortSignal),
+      }),
+    )
   })
 })
 

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { api } from '@/lib/api'
+import { setSessionApiKey, clearSessionApiKey } from '@/lib/auth'
 
 // ─── Mock fetch globally ───────────────────────────────────────────────────────
 
@@ -16,6 +17,7 @@ const originalFetch = global.fetch
 
 afterEach(() => {
   global.fetch = originalFetch
+  clearSessionApiKey()
   vi.restoreAllMocks()
 })
 
@@ -76,6 +78,23 @@ describe('api.listJobs', () => {
     expect(result.jobs).toHaveLength(1)
     expect(result.jobs[0].job_id).toBe('abc123')
     expect(result.count).toBe(1)
+  })
+
+  it('propagates a session API key and browser credentials', async () => {
+    setSessionApiKey("pilot-key-123")
+    const fetchMock = mockFetch({ jobs: [], count: 0 })
+    global.fetch = fetchMock
+
+    await api.listJobs()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/jobs",
+      expect.objectContaining({
+        credentials: "include",
+        headers: { Authorization: "Bearer pilot-key-123" },
+        signal: expect.any(AbortSignal),
+      }),
+    )
   })
 
   it('throws on non-ok response', async () => {

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { AuthGate } from "@/components/auth-gate";
+import { clearSessionApiKey, setSessionApiKey } from "@/lib/auth";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  clearSessionApiKey();
+  vi.restoreAllMocks();
+});
+
+describe("AuthGate", () => {
+  it("renders protected content when auth is not required", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve({
+        authenticated: false,
+        auth_required: false,
+        configured_modes: [],
+        recommended_ui_mode: "no_auth",
+        auth_method: null,
+        subject: null,
+        role: null,
+        tenant_id: "default",
+        oidc_issuer_suffix: null,
+        api_key_id_prefix: null,
+        request_id: null,
+        trace_id: null,
+        span_id: null,
+      }),
+    }) as typeof fetch;
+
+    render(
+      <AuthGate>
+        <div>protected surface</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(screen.getByText("protected surface")).toBeInTheDocument());
+  });
+
+  it("shows the session API key fallback when the API returns 401", async () => {
+    setSessionApiKey("stale-key")
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () => Promise.resolve({ detail: "Unauthorized — invalid API key" }),
+    }) as typeof fetch;
+
+    render(
+      <AuthGate>
+        <div>protected surface</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Control-plane authentication required")).toBeInTheDocument());
+    expect(screen.getByDisplayValue("stale-key")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- finish the remaining release hardening backlog on top of the UI auth work
- remove silent multi-replica rate-limit fallback by requiring Postgres-backed shared state when replicas > 1 or fail-closed mode is enabled
- add tenant-bound OIDC issuer support, operator/docs wiring, and reset leaked API auth state between tests
- publish the UI image with smoke test, cosign signing, and provenance attestation; publish the Helm chart to GHCR OCI in `release.yml`
- add a UI graph export action, bundle-budget guard, and Playwright E2E for `scan -> result -> export`

## Validation
- `uv run pytest tests/test_api_oidc.py tests/test_api_hardening.py tests/test_api_operator_policy.py tests/test_api_auth_debug.py -q`
- `uv run pytest tests/test_api_proxy_scorecard.py -q`
- `uv run ruff check src/agent_bom/api/oidc.py src/agent_bom/api/middleware.py src/agent_bom/api/server.py src/agent_bom/cli/_server.py tests/conftest.py tests/test_api_oidc.py tests/test_api_hardening.py tests/test_api_operator_policy.py tests/test_api_auth_debug.py`
- `cd ui && npm run lint`
- `cd ui && npm run test:run`
- `cd ui && npm run build`
- `cd ui && npm run bundle:check`
- `cd ui && npm run test:e2e`
