### PR TITLE
fix release workflow reusable docs permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
     needs: version-guard
     permissions:
       contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false


### PR DESCRIPTION
## Summary
- fix the `Release` workflow caller permissions for the reusable docs workflow
- unblock tag-triggered releases that were failing at workflow startup before any jobs ran

## Root Cause
The `docs-site` job in `.github/workflows/release.yml` calls `.github/workflows/docs.yml`, which declares `pages: write` and `id-token: write` on its deploy job. The caller only granted `contents: read`, so the tag workflow could not be instantiated and failed with `startup_failure`.

## Impact
- allows `v0.79.0` to run the full release workflow
- does not change application code or release artifacts

## Validation
- `/tmp/actionlint-bin/actionlint .github/workflows/release.yml .github/workflows/docs.yml`
