### PR TITLE
docs: enterprise deployment topology with trust boundary + MCP flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,23 @@ MCP upstream calls (outbound, policy-audited) cross it.*
 5. Every hop emits OTEL spans with a W3C trace context, so a single trace
    ties developer → proxy → gateway → remote MCP → back.
 
+#### Who owns what
+
+| Owner | Owns | Touches agent-bom via |
+|---|---|---|
+| Security / platform team | Policy, fleet, remediation, gateway upstreams | Dashboard, API, Helm values |
+| Developers + service owners | Local scans, CI gates, proxy config on their workload | CLI, GitHub Action, proxy sidecar |
+| Platform / SRE | Cluster, ingress, secrets, observability | Helm chart, ExternalSecrets, ServiceMonitor |
+
+```mermaid
+flowchart LR
+    sec["Security / platform team"] --> ui["Dashboard + API<br/>policy · fleet · remediation"]
+    dev["Developers + service owners"] --> cli["CLI + CI gate + proxy sidecar"]
+    sre["Platform / SRE"] --> helm["Helm chart + secrets + observability"]
+    cli --> ui
+    helm --> ui
+```
+
 This is the architecture. A **pilot** is just a narrower rollout profile
 over the same surfaces and stores.
 

--- a/README.md
+++ b/README.md
@@ -148,58 +148,99 @@ rollout runbooks live under [`site-docs/deployment/`](site-docs/deployment/).
 
 ### Default self-hosted deployment shape
 
-`agent-bom` is easiest to reason about as three layers:
+Everything agent-bom ships runs inside one trust boundary — the customer's
+VPC, EKS account, or self-managed cluster. The only arrows that cross that
+boundary are OIDC (inbound, terminated at ingress) and policy-audited MCP
+upstream calls (outbound). Enrichment to OSV/NVD is optional and
+allow-listable.
 
-- **entry points**: local CLI scans, GitHub Action CI/CD gates, endpoint fleet
-  sync, proxy sidecars/wrappers, and an optional central gateway
-- **operator plane**: the self-hosted API + UI, scan/fleet/gateway/compliance
-  routes, and job orchestration in your EKS cluster or self-managed compute
-- **data plane**: Postgres/Supabase for transactional state, with ClickHouse or
-  Snowflake added only when your deployment actually needs them
+| Layer | Lives in | Scales via | Talks to |
+|---|---|---|---|
+| **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
+| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
+| **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
+| **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
 flowchart LR
-    subgraph entry["Entry points in your environment"]
-      cli["CLI scans<br/>agents · image · iac"]
-      gha["GitHub Action<br/>CI/CD gate + SARIF"]
-      fleet["Endpoint fleet<br/>--push-url sync"]
-      proxy["Proxy / sidecar<br/>stdio or HTTP/SSE"]
-      gateway["Central gateway<br/>agent-bom gateway serve"]
+    subgraph outside["Outside customer trust boundary"]
+      dev["Developer laptop<br/>Claude Desktop · Cursor · Claude Code"]
+      gh["GitHub<br/>Actions runner"]
+      osv["OSV / NVD / GHSA<br/>optional egress, allow-listable"]
+      mcp_saas["Remote MCPs<br/>SaaS + partner tools"]
+      idp["Corporate IdP<br/>Okta · Entra · Google"]
     end
 
-    subgraph targets["Targets under review"]
-      local["Local repos + stdio MCPs"]
-      remote["Remote MCPs + SaaS + cluster workloads"]
+    subgraph vpc["Customer VPC / EKS account — single trust boundary"]
+      ingress["Ingress + TLS<br/>ALB / Istio Gateway"]
+
+      subgraph cp["Control plane — Helm chart: agent-bom"]
+        api["API + UI<br/>2× Deployment + HPA + PDB"]
+        gw["MCP gateway<br/>Deployment + HPA<br/>agent-bom gateway serve"]
+        px["MCP proxy sidecar<br/>stdio · SSE · HTTP<br/>sidecar or laptop wrapper"]
+        jobs["Scan + ingest workers<br/>CronJob + Job"]
+        backup["Backup CronJob<br/>pg_dump → S3"]
+      end
+
+      subgraph glue["Platform integration"]
+        es["ExternalSecrets<br/>AWS SM / Vault"]
+        otel["OTEL collector<br/>traces + metrics"]
+        prom["Prometheus<br/>ServiceMonitor"]
+      end
+
+      subgraph dataplane["Data plane in your account"]
+        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
+        ch["ClickHouse (optional)<br/>analytics + long-retention"]
+        s3["S3 (optional)<br/>backups + SBOM archive"]
+      end
     end
 
-    subgraph control["Self-hosted operator plane"]
-      api["API + UI<br/>findings · graph · remediation"]
-      routes["Fleet / policy / compliance routes<br/>tenant-scoped API"]
-      jobs["Scan jobs + ingest workers"]
-    end
+    idp -. OIDC .-> ingress
+    ingress --> api
+    ingress --> gw
 
-    subgraph data["Your data stores"]
-      pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-      ch["ClickHouse (optional)<br/>analytics + long-retention events"]
-      snow["Snowflake (optional)<br/>warehouse-native deployment"]
-    end
+    dev -->|MCP JSON-RPC| px
+    px -->|audited relay| gw
+    gw -->|policy + audit| mcp_saas
+    gw -->|/v1/proxy/audit| api
 
-    cli --> local
-    gha --> local
-    fleet --> jobs
-    proxy --> remote
-    gateway --> remote
-    proxy --> routes
-    gateway --> routes
+    gh -->|SARIF + findings| api
+
     jobs --> api
-    routes --> api
     api --> pg
-    api -. optional analytics .-> ch
-    api -. optional warehouse path .-> snow
+    api -. optional .-> ch
+    backup --> s3
+
+    api -. optional egress .-> osv
+
+    es --> api
+    es --> gw
+    api --> otel
+    gw --> otel
+    api --> prom
+    gw --> prom
 ```
 
-This is the architecture. A **pilot** is just a narrower rollout profile over
-the same surfaces and stores.
+*Everything in the boundary runs in your account. Only OIDC (inbound) and
+MCP upstream calls (outbound, policy-audited) cross it.*
+
+#### How an MCP call actually flows
+
+1. Developer client (Claude Desktop / Cursor / Claude Code) speaks MCP
+   JSON-RPC to the local `agent-bom proxy` (stdio or SSE).
+2. The proxy inspects and audits the call, enforces policy, then relays to
+   the central `agent-bom gateway` inside your cluster.
+3. The gateway applies shared policy, records the audit event to
+   `/v1/proxy/audit`, and forwards to the remote MCP upstream.
+4. Responses flow back on the same path; screenshot/image responses run
+   through the `VisualLeakDetector` for OCR-based redaction before the
+   developer sees them.
+5. Every hop emits OTEL spans with a W3C trace context, so a single trace
+   ties developer → proxy → gateway → remote MCP → back.
+
+This is the architecture. A **pilot** is just a narrower rollout profile
+over the same surfaces and stores.
 
 ### Rollout profiles
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -34,6 +34,99 @@ flowchart LR
     H[OIDC or SAML / API key auth] --> D
 ```
 
+## Enterprise deployment topology
+
+Everything agent-bom ships runs inside one trust boundary — the customer's
+VPC, EKS account, or self-managed cluster. The only arrows that cross that
+boundary are OIDC (inbound, terminated at ingress) and policy-audited MCP
+upstream calls (outbound). Enrichment to OSV/NVD is optional and
+allow-listable.
+
+| Layer | Lives in | Scales via | Talks to |
+|---|---|---|---|
+| **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
+| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
+| **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
+| **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
+
+```mermaid
+flowchart LR
+    subgraph outside["Outside customer trust boundary"]
+      dev["Developer laptop<br/>Claude Desktop · Cursor · Claude Code"]
+      gh["GitHub<br/>Actions runner"]
+      osv["OSV / NVD / GHSA<br/>optional egress, allow-listable"]
+      mcp_saas["Remote MCPs<br/>SaaS + partner tools"]
+      idp["Corporate IdP<br/>Okta · Entra · Google"]
+    end
+
+    subgraph vpc["Customer VPC / EKS account — single trust boundary"]
+      ingress["Ingress + TLS<br/>ALB / Istio Gateway"]
+
+      subgraph cp["Control plane — Helm chart: agent-bom"]
+        api["API + UI<br/>2× Deployment + HPA + PDB"]
+        gw["MCP gateway<br/>Deployment + HPA<br/>agent-bom gateway serve"]
+        px["MCP proxy sidecar<br/>stdio · SSE · HTTP<br/>sidecar or laptop wrapper"]
+        jobs["Scan + ingest workers<br/>CronJob + Job"]
+        backup["Backup CronJob<br/>pg_dump → S3"]
+      end
+
+      subgraph glue["Platform integration"]
+        es["ExternalSecrets<br/>AWS SM / Vault"]
+        otel["OTEL collector<br/>traces + metrics"]
+        prom["Prometheus<br/>ServiceMonitor"]
+      end
+
+      subgraph dataplane["Data plane in your account"]
+        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
+        ch["ClickHouse (optional)<br/>analytics + long-retention"]
+        s3["S3 (optional)<br/>backups + SBOM archive"]
+      end
+    end
+
+    idp -. OIDC .-> ingress
+    ingress --> api
+    ingress --> gw
+
+    dev -->|MCP JSON-RPC| px
+    px -->|audited relay| gw
+    gw -->|policy + audit| mcp_saas
+    gw -->|/v1/proxy/audit| api
+
+    gh -->|SARIF + findings| api
+
+    jobs --> api
+    api --> pg
+    api -. optional .-> ch
+    backup --> s3
+
+    api -. optional egress .-> osv
+
+    es --> api
+    es --> gw
+    api --> otel
+    gw --> otel
+    api --> prom
+    gw --> prom
+```
+
+*Everything in the boundary runs in your account. Only OIDC (inbound) and
+MCP upstream calls (outbound, policy-audited) cross it.*
+
+### How an MCP call actually flows
+
+1. Developer client (Claude Desktop / Cursor / Claude Code) speaks MCP
+   JSON-RPC to the local `agent-bom proxy` (stdio or SSE).
+2. The proxy inspects and audits the call, enforces policy, then relays to
+   the central `agent-bom gateway` inside your cluster.
+3. The gateway applies shared policy, records the audit event to
+   `/v1/proxy/audit`, and forwards to the remote MCP upstream.
+4. Responses flow back on the same path; screenshot/image responses run
+   through the `VisualLeakDetector` for OCR-based redaction before the
+   developer sees them.
+5. Every hop emits OTEL spans with a W3C trace context, so a single trace
+   ties developer → proxy → gateway → remote MCP → back.
+
 ## Same-origin default
 
 The UI runtime contract from `#1452` is what makes this honest.

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -56,6 +56,99 @@ flowchart LR
     API --> CH
 ```
 
+## Enterprise deployment topology
+
+Everything agent-bom ships runs inside one trust boundary — the customer's
+VPC, EKS account, or self-managed cluster. The only arrows that cross that
+boundary are OIDC (inbound, terminated at ingress) and policy-audited MCP
+upstream calls (outbound). Enrichment to OSV/NVD is optional and
+allow-listable.
+
+| Layer | Lives in | Scales via | Talks to |
+|---|---|---|---|
+| **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
+| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
+| **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
+| **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
+
+```mermaid
+flowchart LR
+    subgraph outside["Outside customer trust boundary"]
+      dev["Developer laptop<br/>Claude Desktop · Cursor · Claude Code"]
+      gh["GitHub<br/>Actions runner"]
+      osv["OSV / NVD / GHSA<br/>optional egress, allow-listable"]
+      mcp_saas["Remote MCPs<br/>SaaS + partner tools"]
+      idp["Corporate IdP<br/>Okta · Entra · Google"]
+    end
+
+    subgraph vpc["Customer VPC / EKS account — single trust boundary"]
+      ingress["Ingress + TLS<br/>ALB / Istio Gateway"]
+
+      subgraph cp["Control plane — Helm chart: agent-bom"]
+        api["API + UI<br/>2× Deployment + HPA + PDB"]
+        gw["MCP gateway<br/>Deployment + HPA<br/>agent-bom gateway serve"]
+        px["MCP proxy sidecar<br/>stdio · SSE · HTTP<br/>sidecar or laptop wrapper"]
+        jobs["Scan + ingest workers<br/>CronJob + Job"]
+        backup["Backup CronJob<br/>pg_dump → S3"]
+      end
+
+      subgraph glue["Platform integration"]
+        es["ExternalSecrets<br/>AWS SM / Vault"]
+        otel["OTEL collector<br/>traces + metrics"]
+        prom["Prometheus<br/>ServiceMonitor"]
+      end
+
+      subgraph dataplane["Data plane in your account"]
+        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
+        ch["ClickHouse (optional)<br/>analytics + long-retention"]
+        s3["S3 (optional)<br/>backups + SBOM archive"]
+      end
+    end
+
+    idp -. OIDC .-> ingress
+    ingress --> api
+    ingress --> gw
+
+    dev -->|MCP JSON-RPC| px
+    px -->|audited relay| gw
+    gw -->|policy + audit| mcp_saas
+    gw -->|/v1/proxy/audit| api
+
+    gh -->|SARIF + findings| api
+
+    jobs --> api
+    api --> pg
+    api -. optional .-> ch
+    backup --> s3
+
+    api -. optional egress .-> osv
+
+    es --> api
+    es --> gw
+    api --> otel
+    gw --> otel
+    api --> prom
+    gw --> prom
+```
+
+*Everything in the boundary runs in your account. Only OIDC (inbound) and
+MCP upstream calls (outbound, policy-audited) cross it.*
+
+### How an MCP call actually flows
+
+1. Developer client (Claude Desktop / Cursor / Claude Code) speaks MCP
+   JSON-RPC to the local `agent-bom proxy` (stdio or SSE).
+2. The proxy inspects and audits the call, enforces policy, then relays to
+   the central `agent-bom gateway` inside your cluster.
+3. The gateway applies shared policy, records the audit event to
+   `/v1/proxy/audit`, and forwards to the remote MCP upstream.
+4. Responses flow back on the same path; screenshot/image responses run
+   through the `VisualLeakDetector` for OCR-based redaction before the
+   developer sees them.
+5. Every hop emits OTEL spans with a W3C trace context, so a single trace
+   ties developer → proxy → gateway → remote MCP → back.
+
 ## Control flow
 
 ```mermaid


### PR DESCRIPTION
## Summary
- replace the flat three-layer README diagram with a trust-boundary view that shows what runs in the customer VPC vs what crosses it (OIDC inbound, MCP upstream outbound, optional OSV egress)
- show the MCP traffic plane on the actual request path (developer → proxy → gateway → remote MCP) instead of as abstract boxes
- label each control-plane box with its Helm shape (Deployment + HPA + PDB, CronJob, Job) so operators can match the diagram to the chart templates
- include ExternalSecrets, ServiceMonitor, and OTEL collector so the per-tenant OIDC, distributed rate-limit, and observability work that landed in v0.80.0 is reflected in the topology
- add a companion layer table and a five-step "how an MCP call actually flows" walkthrough
- mirror the same topology into `site-docs/deployment/control-plane-helm.md` and `site-docs/deployment/enterprise-pilot.md` so every deployment entry point shows the same picture

## Why
The previous diagram answered "what are the layers" but not the question every enterprise buyer asks first: "what runs inside my trust boundary, what talks out, and where does the gateway sit on the network path." This PR puts the boundary, the auth direction, the MCP request path, and the Helm resource shapes in one picture, and keeps the rest of the README (rollout profiles, surface table) unchanged.

## Scope
- Docs only. No application code, chart templates, or release artifacts change.
- Mermaid diagrams only; no new image assets.
- One-line caption added under each new diagram: *"Everything in the boundary runs in your account. Only OIDC (inbound) and MCP upstream calls (outbound, policy-audited) cross it."*

## Test plan
- [ ] Mermaid renders on GitHub for `README.md`
- [ ] Mermaid renders on GitHub for `site-docs/deployment/control-plane-helm.md`
- [ ] Mermaid renders on GitHub for `site-docs/deployment/enterprise-pilot.md`
- [ ] Docs site build passes in CI