### PR TITLE
fix UI image release path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,38 @@ jobs:
           cd ui
           npm run build
 
+      - name: Verify standalone server output
+        run: |
+          test -d ui/.next/standalone || {
+            echo "::error::UI production build did not produce .next/standalone"
+            exit 1
+          }
+
+      - name: UI container smoke test
+        run: |
+          set -euo pipefail
+          cleanup() {
+            status=$?
+            if [ $status -ne 0 ]; then
+              docker logs agent-bom-ui-ci-smoke || true
+            fi
+            docker stop agent-bom-ui-ci-smoke >/dev/null 2>&1 || true
+            exit $status
+          }
+          docker build -f ui/Dockerfile -t agent-bom-ui:ci-test ui
+          docker run -d --rm --name agent-bom-ui-ci-smoke -p 3000:3000 -e NEXT_PUBLIC_API_URL= agent-bom-ui:ci-test
+          trap cleanup EXIT
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:3000/ >/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://127.0.0.1:3000/ >/dev/null || {
+            echo "::error::UI container did not become healthy in time"
+            exit 1
+          }
+
       - name: UI bundle budget
         run: |
           cd ui

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -9,7 +9,9 @@ const isExport = process.env.NEXT_EXPORT === "1";
 const nextConfig: NextConfig = {
   images: { unoptimized: true },
   productionBrowserSourceMaps: false,
-  ...(isExport && { output: "export" }),
+  // The Python package uses static export, while the standalone Docker image
+  // needs a Node server bundle for the separate control-plane UI container.
+  output: isExport ? "export" : "standalone",
   // Proxy /v1/* and /health to the FastAPI backend so the dev server works
   // without CORS issues and without needing a separate nginx/caddy setup.
   ...(!isExport && {


### PR DESCRIPTION
Summary
- make the UI build produce standalone output for the separate Node container path
- catch standalone/container regressions in PR CI before a tag release
- keep the static export path for the bundled Python UI build intact

Validation
- cd ui && npm ci && npm run build && test -d .next/standalone
- Docker smoke path could not be run locally because the Docker daemon is not running on this machine; CI now exercises that path on PRs