### PR TITLE
clarify hosted intake architecture

### DIFF
--- a/site-docs/architecture/data-ingestion-and-security.md
+++ b/site-docs/architecture/data-ingestion-and-security.md
@@ -20,6 +20,30 @@ Those are not the same thing, and the security model is different for each.
 | `Pushed ingest` | Accepts evidence pushed by the customer or collector | OTLP traces, runtime events, fleet sync, security-lake feeds | Inbound ingest with API/auth boundaries |
 | `Imported artifact` | Parses customer-exported files without owning collection | SBOMs, inventories, JSON findings, offline exports | File import only |
 
+## Hosted control plane rule
+
+In a hosted deployment, the UI is not a collector. The web app should only act
+as the operator surface for the control plane.
+
+The secure and scalable split is:
+
+- `UI` = trigger jobs, configure sources, show health, review findings
+- `API / control plane` = auth, RBAC, tenant scope, orchestration, graph, persistence, audit, and policy
+- `workers / connectors` = collect from cloud APIs, connected systems, repos, images, and IaC targets
+- `proxy / gateway` = capture runtime MCP evidence and apply policy at the execution boundary
+
+That is why every supported intake path should be reachable through one of these
+backend paths:
+
+- API-triggered scan jobs
+- read-only connectors
+- authenticated pushed ingest
+- imported artifacts
+- proxy or gateway audit flows
+
+This keeps credentials, execution, rate limits, retries, and tenant isolation
+in the backend instead of moving collection logic into the Node.js UI.
+
 ## End-to-end flow
 
 ```mermaid

--- a/site-docs/architecture/how-agent-bom-works.md
+++ b/site-docs/architecture/how-agent-bom-works.md
@@ -172,6 +172,59 @@ The same normalized model powers multiple purpose-built views.
 | Proxy / gateway | inspect and enforce runtime MCP traffic | runtime policy + audit path |
 | Analytics / warehouse | central event and trend analysis | ClickHouse or Snowflake |
 
+## How the packaged app gets the data
+
+The packaged product is not “just the Node.js app.” The UI is a client of the
+control plane. The actual collection paths are the API, scan jobs, proxy,
+gateway, and connected sources behind it.
+
+That means `agent-bom` does not require a local CLI for every use case:
+
+- the UI can trigger API-backed scan jobs for repos, images, IaC, and cloud reads
+- scheduled workers and CronJobs can collect data inside the customer EKS cluster
+- CI pipelines can push results in without an interactive local install
+- fleet sync, traces, and proxy or gateway audit routes can push runtime evidence into the control plane
+- read-only integrations can pull from cloud accounts, warehouses, and governance systems with customer-managed credentials
+- imported artifacts let customers upload SBOMs, inventories, or third-party scanner output when collection already happens elsewhere
+
+So the honest model is:
+
+- `UI` = review, remediation, graph, compliance, and job trigger surface
+- `API + workers` = scan orchestration, normalization, and persistence
+- `proxy + gateway` = runtime MCP inspection, policy, and audit
+- `connected sources + imports` = non-CLI intake paths for enterprise deployments
+
+What still needs a local wrapper, CLI, or proxy is anything that lives only on a
+developer machine or inside a local stdio MCP session. Everything else can be
+collected through the control plane, scheduled jobs, pushed ingest, or
+read-only integrations.
+
+## Hosted product architecture
+
+For a secure, scalable hosted deployment, the product boundary should stay
+clean:
+
+- `UI` = operator workflow only: configure sources, trigger jobs, review status, and work findings
+- `API / control plane` = auth, tenant scope, orchestration, graph, persistence, audit, and policy decisions
+- `workers / connectors` = execute scan jobs and read from customer-approved cloud APIs or connected systems
+- `proxy / gateway` = inspect and govern live MCP or runtime traffic
+
+That leads to one implementation rule:
+
+- never make the Node.js UI the collector
+- make every supported intake path reachable through API-triggered jobs, connectors, imports, or proxy and gateway flows
+
+In practice, that means:
+
+- cloud inventory and posture data should come from read-only cloud APIs through backend jobs or connectors
+- repo, image, and IaC scans should run as worker jobs triggered through the API
+- runtime evidence should arrive through proxy, gateway, traces, fleet sync, or other authenticated ingest routes
+- the UI should manage and observe those flows, not replace them
+
+This is the same control-plane pattern used by modern hosted security products:
+the web app is the operator surface, while the backend and collection paths do
+the work.
+
 ## Security and trust boundaries
 
 Mode matters.

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -109,6 +109,70 @@ webhooks.
 | **API + UI** | you want one operator control plane | findings, graph, remediation, fleet review, audit, policy management | a hosted vendor control plane |
 | **MCP server** | you want `agent-bom` exposed as tools to assistants or remote clients | `agent-bom mcp server` tool surface | the same thing as the runtime proxy |
 
+## Hosted product checklist
+
+For the packaged product to feel end to end, the UI should drive the control
+plane instead of collecting data itself.
+
+| Operator action in UI | Backend/API owner | Data actually comes from |
+|---|---|---|
+| Create a scan job | `POST /v1/scan` | worker jobs that scan repos, images, IaC, MCP configs, or cloud targets |
+| Poll progress / stream status | `GET /v1/scan/{job_id}`, `GET /v1/scan/{job_id}/stream`, `GET /v1/jobs` | control-plane job state |
+| Export graph / licenses / VEX / reports | `GET /v1/scan/{job_id}/graph-export`, `/licenses`, `/vex`, `/skill-audit`; `GET /v1/compliance/{framework}/report` | normalized findings and graph state already stored in the control plane |
+| Schedule recurring collection | `POST /v1/schedules`, `GET /v1/schedules`, `PUT /v1/schedules/{id}/toggle`, `DELETE /v1/schedules/{id}` | scheduled worker execution |
+| Review fleet and endpoint inventory | `GET /v1/fleet`, `GET /v1/fleet/stats`, `GET /v1/fleet/{agent_id}` | endpoint or collector pushes to `POST /v1/fleet/sync` |
+| Review traces and pushed results | `POST /v1/traces`, `POST /v1/results/push`, `GET /v1/activity`, `GET /v1/governance` | OTLP, event collectors, or customer-owned push paths |
+| Manage runtime policy | `GET/POST/PUT/DELETE /v1/gateway/policies`, `POST /v1/gateway/evaluate` | proxy and gateway policy pull/evaluation |
+| Review runtime audit and health | `GET /v1/proxy/status`, `GET /v1/proxy/alerts`, `GET /v1/gateway/audit`, `GET /v1/gateway/stats` | `agent-bom proxy` and gateway audit push to `/v1/proxy/audit` |
+| Manage auth, keys, and audit export | `/v1/auth/*`, `/v1/audit*`, `/v1/exceptions*` | control-plane auth, RBAC, audit, and policy state |
+| Review graph, findings, posture, and compliance | `/v1/graph*`, `/v1/assets*`, `/v1/compliance*`, `/v1/posture*`, `/v1/governance*` | canonical entities, findings, events, and graph state in the control plane |
+
+That is the intended split:
+
+- `UI` = configure, trigger, schedule, review, export
+- `API / control plane` = auth, RBAC, tenant scope, orchestration, graph, persistence, audit, policy
+- `workers / connectors` = do the privileged read or collection work
+- `proxy / gateway` = enforce and audit runtime MCP traffic
+
+## Approved intake paths today
+
+“Approved” here means explicit, customer-controlled backend intake paths. The
+Node UI is not one of them.
+
+| Intake path | Code-backed today | How it enters `agent-bom` |
+|---|---|---|
+| Direct scan | yes | CLI, CI, or API-triggered worker job reads repos, lockfiles, images, IaC, MCP configs, and selected cloud targets |
+| Read-only integration | partial, source-dependent | backend connector or worker reads customer-approved cloud or warehouse APIs with customer-managed credentials |
+| Pushed ingest | yes | `POST /v1/fleet/sync`, `POST /v1/traces`, `POST /v1/results/push`, `POST /v1/proxy/audit` |
+| Imported artifact | yes | uploaded or provided SBOMs, inventories, and external scanner JSON are parsed by the backend |
+| Proxy enforcement | yes | `agent-bom proxy` sidecar or local wrapper inspects MCP traffic and pushes audit to the API |
+| Central gateway traffic plane | present, still maturing operationally | `agent-bom gateway serve` fronts remote MCP upstreams and pushes the same audit/policy signals back to the control plane |
+
+Covered source categories today:
+
+- repos, packages, and lockfiles
+- container images
+- IaC: Terraform, Kubernetes, Helm, CloudFormation, Dockerfile
+- agents, MCP servers, tools, skills, and instruction files
+- runtime traces and proxy/gateway audit events
+- fleet inventory pushed by endpoints or collectors
+- exported SBOMs and third-party scanner artifacts
+- selected cloud and AI infrastructure surfaces where the scanner or connector exists
+
+## What is live now vs still maturing
+
+The self-hosted control-plane pattern is live now. The rough edges are mostly
+operator polish, not the core trust boundary.
+
+| Area | Live now | Still maturing |
+|---|---|---|
+| API + UI control plane | findings, graph, remediation, fleet, audit, compliance, auth | source/connector UX should become more explicit in the UI |
+| Direct scans | repo, image, IaC, package, MCP, cloud-backed scan jobs | broader one-click source onboarding in the UI |
+| Pushed ingest | fleet sync, traces, proxy audit, pushed results | clearer product-level “data sources” management surface |
+| Proxy runtime path | sidecar and local wrapper deployment docs, metrics, audit, enforcement | more turnkey rollout guidance by workload type |
+| Gateway | central policy and audit are real; traffic-plane shape and docs exist | still more design/runbook than a single polished operator guide |
+| Hosted packaging | self-hosted API/UI and Helm control plane are real | release-path polish for every artifact path should stay under CI guard |
+
 ## Security and Data-Flow Boundaries
 
 The deployment model is intentionally split by trust boundary:


### PR DESCRIPTION
Summary
- document that the Node UI is an operator surface, not the collector
- define the hosted control-plane split between UI, API, workers/connectors, and proxy/gateway
- clarify which backend intake paths are valid in self-hosted deployments

Validation
- docs-only change; no tests run