### PR TITLE
add hosted product spec and split deployment diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,86 +163,94 @@ allow-listable.
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart TB
-    subgraph outside["Outside customer trust boundary"]
+flowchart LR
+    subgraph outside["Outside your account"]
       idp["Corporate IdP<br/>Okta · Entra · Google"]
-      dev["Developer laptop<br/>Claude Desktop · Cursor · Claude Code"]
-      gh["GitHub Actions / CI runner"]
+      ci["GitHub Actions / CI"]
       remote["Remote MCPs<br/>SaaS + partner tools"]
-      osv["OSV / NVD / GHSA<br/>optional egress, allow-listable"]
+      osv["OSV / NVD / GHSA<br/>optional enrichment"]
     end
 
-    subgraph vpc["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio Gateway"]
+    subgraph customer["Customer VPC / EKS account"]
+      ingress["Ingress + TLS<br/>ALB / Istio"]
 
-      subgraph traffic["Agent-Bom traffic plane in your EKS cluster"]
-        px["MCP proxy<br/>sidecar or laptop wrapper<br/>stdio · SSE · HTTP"]
-        gw["MCP gateway<br/>agent-bom gateway serve<br/>Deployment + HPA"]
+      subgraph control["Agent-BOM control plane"]
+        ui["UI<br/>same-origin browser app"]
+        api["API<br/>auth · fleet · findings · audit"]
+        jobs["Scan + ingest workers<br/>CronJob + Job"]
+        backup["Backup job<br/>pg_dump -> S3"]
       end
 
-      subgraph control["Agent-Bom control plane in your EKS cluster"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>fleet · policy · audit · findings"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup CronJob<br/>pg_dump -> S3"]
+      subgraph runtime["Runtime MCP plane"]
+        proxy["Proxy<br/>sidecar or laptop wrapper"]
+        gateway["Gateway<br/>agent-bom gateway serve"]
       end
 
       subgraph data["Customer-owned data plane"]
         pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics + long-retention"]
+        ch["ClickHouse (optional)<br/>analytics"]
         s3["S3 (optional)<br/>backups + SBOM archive"]
       end
 
-      subgraph platform["Platform integration in your account"]
-        es["ExternalSecrets<br/>AWS SM / Vault"]
-        otel["OTEL collector<br/>traces + metrics"]
-        prom["Prometheus / ServiceMonitor"]
+      subgraph ops["Platform glue"]
+        secrets["ExternalSecrets<br/>AWS SM / Vault"]
+        metrics["OTEL + Prometheus"]
       end
     end
 
     idp -. OIDC .-> ingress
-    ingress -->|"browser traffic"| ui
-    ingress -->|"API + WS"| api
-    ingress -->|"optional shared MCP URL"| gw
-
-    dev -->|"MCP JSON-RPC"| px
-    px -->|"audited relay"| gw
-    gw -->|"policy-audited upstream call"| remote
-    px -->|"/v1/proxy/audit"| api
-    gw -->|"/v1/proxy/audit"| api
-
-    gh -->|"SARIF + findings"| api
+    ingress --> ui
+    ingress --> api
+    ingress --> gateway
+    ci -->|"SARIF + findings"| api
     jobs -->|"scan results + inventory"| api
-
-    api -->|"transactional state"| pg
-    api -. "optional analytics" .-> ch
-    backup -->|"backup archive"| s3
-
-    es -->|"runtime secrets"| api
-    es -->|"runtime secrets"| gw
-    api -->|"telemetry"| otel
-    gw -->|"telemetry"| otel
-    api -->|"metrics"| prom
-    gw -->|"metrics"| prom
-    api -. "optional enrichment egress" .-> osv
+    api --> pg
+    api -. optional .-> ch
+    backup --> s3
+    secrets --> api
+    secrets --> gateway
+    api --> metrics
+    gateway --> metrics
+    gateway -->|"policy-audited upstream call"| remote
+    api -. optional egress .-> osv
 ```
 
-*Everything in the boundary runs in your account. Only OIDC (inbound) and
-MCP upstream calls (outbound, policy-audited) cross it.*
+*Everything inside the customer boundary runs in the customer's account. The
+default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
+upstream calls.*
 
-#### How an MCP call actually flows
+#### How MCP traffic actually flows
 
-1. Developer client (Claude Desktop / Cursor / Claude Code) speaks MCP
-   JSON-RPC to the local `agent-bom proxy` (stdio or SSE).
-2. The proxy inspects and audits the call, enforces policy, then relays to
-   the central `agent-bom gateway` inside your cluster.
-3. The gateway applies shared policy, records the audit event to
-   `/v1/proxy/audit`, and forwards to the remote MCP upstream.
-4. Responses flow back on the same path; screenshot/image responses run
-   through the `VisualLeakDetector` for OCR-based redaction before the
-   developer sees them.
-5. Every hop emits OTEL spans with a W3C trace context, so a single trace
-   ties developer → proxy → gateway → remote MCP → back.
+```mermaid
+sequenceDiagram
+    participant Dev as Developer client
+    participant Proxy as agent-bom proxy
+    participant Gateway as agent-bom gateway
+    participant API as Control-plane API
+    participant Remote as Remote MCP
+    participant Store as Postgres / audit store
+
+    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
+    Proxy->>Proxy: inspect request + local policy
+    Proxy->>Gateway: audited relay
+    Gateway->>API: POST /v1/proxy/audit
+    Gateway->>Remote: upstream MCP call
+    Remote-->>Gateway: MCP response
+    Gateway-->>Proxy: shared policy + response
+    Proxy->>Proxy: optional VLD / OCR redaction
+    Proxy-->>Dev: safe response
+    API->>Store: persist audit, findings, graph links
+```
+
+1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
+2. The proxy inspects and audits the call, enforces local policy, and relays
+   to the central `agent-bom gateway`.
+3. The gateway applies shared policy, records audit to `/v1/proxy/audit`, and
+   forwards to the remote MCP upstream.
+4. Responses come back on the same path; image responses can run through the
+   visual leak detector before they reach the developer.
+5. The control plane persists audit, findings, and graph state for the UI,
+   exports, and compliance surfaces.
 
 #### Who owns what
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
   - Architecture:
       - Overview: architecture/overview.md
       - How Agent-BOM Works: architecture/how-agent-bom-works.md
+      - Hosted Product Control Plane: architecture/hosted-product-spec.md
       - AI Infrastructure Scanning: architecture/ai-infrastructure.md
       - Data Ingestion and Security: architecture/data-ingestion-and-security.md
       - Supply Chain and Trust: architecture/supply-chain-and-trust.md

--- a/site-docs/architecture/hosted-product-spec.md
+++ b/site-docs/architecture/hosted-product-spec.md
@@ -1,0 +1,215 @@
+# Hosted Product Control-Plane Spec
+
+This is the next implementation spec for making `agent-bom` feel like one
+coherent hosted product instead of a collection of good but partially separate
+surfaces.
+
+The product rule stays simple:
+
+- `UI` drives workflows
+- `API / control plane` owns auth, RBAC, tenant scope, orchestration, graph, persistence, audit, and policy
+- `workers / connectors` do the privileged read and collection work
+- `proxy / gateway` handles runtime MCP enforcement and audit
+- the Node.js UI is **never** the collector
+
+## Goals
+
+1. Map every meaningful UI action to a real API route and persisted control-plane state.
+2. Make source, job, schedule, evidence, and policy lifecycles visible in the product.
+3. Enforce tenant scope, RBAC, and auditability across UI, API, workers, and storage.
+4. Make ingest and discovery paths explicit, secure, and operable at enterprise scale.
+
+## Canonical control-plane entities
+
+These are the core entities the hosted product should expose directly.
+
+| Entity | Purpose | Required fields |
+|---|---|---|
+| `Source` | Operator-managed data source or runtime intake path | `source_id`, `tenant_id`, `kind`, `display_name`, `status`, `owner`, `credential_mode`, `scope`, `last_run_at`, `last_success_at` |
+| `Job` | One execution of a scan, sync, import, or connector run | `job_id`, `tenant_id`, `source_id`, `job_type`, `status`, `requested_by`, `started_at`, `finished_at`, `result_summary`, `evidence_count` |
+| `Schedule` | Recurring execution policy for a source or scan profile | `schedule_id`, `tenant_id`, `source_id`, `cron`, `enabled`, `last_run_at`, `next_run_at` |
+| `Evidence` | Immutable pointer to raw or normalized output | `evidence_id`, `tenant_id`, `job_id`, `source_id`, `kind`, `storage_uri`, `content_type`, `hash`, `created_at` |
+| `CredentialRef` | Reference to customer-managed credentials or roles | `credential_ref_id`, `tenant_id`, `provider`, `mode`, `external_ref`, `last_validated_at`, `health` |
+| `PolicyBinding` | Policy attached to a source, gateway, or tenant scope | `binding_id`, `tenant_id`, `policy_kind`, `target_type`, `target_id`, `mode`, `updated_at` |
+| `AuditEvent` | Immutable record of control-plane actions | `event_id`, `tenant_id`, `actor`, `target_type`, `target_id`, `action`, `request_id`, `trace_id`, `timestamp` |
+
+## Source types
+
+Every supported intake path should map to one of these `Source.kind` values:
+
+- `scan.repo`
+- `scan.image`
+- `scan.iac`
+- `scan.cloud`
+- `scan.mcp_config`
+- `connector.cloud_read_only`
+- `connector.registry`
+- `connector.warehouse`
+- `ingest.fleet_sync`
+- `ingest.trace_push`
+- `ingest.result_push`
+- `ingest.artifact_import`
+- `runtime.proxy`
+- `runtime.gateway`
+
+That keeps the UI model, job model, and audit model aligned even when the
+collection paths differ.
+
+## Backend model and storage expectations
+
+The control plane should persist these entities in the transactional backend
+today (`Postgres` / `Supabase`) and project them into graph or analytics stores
+only where needed.
+
+### Transactional state
+
+- `sources`
+- `source_runs` or `jobs`
+- `schedules`
+- `credential_refs`
+- `source_policy_bindings`
+- `evidence_index`
+- `audit_events`
+- `tenant_settings`
+
+### Derived or projected state
+
+- findings and graph nodes
+- fleet inventory
+- compliance snapshots
+- gateway and proxy alerts
+- long-retention event history in optional analytics backends
+
+## Existing API routes the hosted product already uses
+
+These routes are already code-backed and should remain the foundation of the
+product surface.
+
+| Product surface | Existing routes |
+|---|---|
+| Scan jobs | `POST /v1/scan`, `GET /v1/scan/{job_id}`, `GET /v1/scan/{job_id}/stream`, `GET /v1/jobs`, `DELETE /v1/scan/{job_id}` |
+| Scan exports | `GET /v1/scan/{job_id}/graph-export`, `/licenses`, `/vex`, `/skill-audit` |
+| Schedules | `POST /v1/schedules`, `GET /v1/schedules`, `GET /v1/schedules/{schedule_id}`, `PUT /v1/schedules/{schedule_id}/toggle`, `DELETE /v1/schedules/{schedule_id}` |
+| Fleet | `GET /v1/fleet`, `GET /v1/fleet/stats`, `GET /v1/fleet/{agent_id}`, `POST /v1/fleet/sync` |
+| Runtime proxy | `POST /v1/proxy/audit`, `GET /v1/proxy/status`, `GET /v1/proxy/alerts` |
+| Gateway | `GET/POST/PUT/DELETE /v1/gateway/policies`, `POST /v1/gateway/evaluate`, `GET /v1/gateway/audit`, `GET /v1/gateway/stats`, `GET /v1/gateway/upstreams/discovered` |
+| Connectors | `GET /v1/connectors`, `GET /v1/connectors/{name}/health` |
+| Pushed ingest | `POST /v1/traces`, `POST /v1/results/push` |
+| Auth / audit | `/v1/auth/*`, `/v1/audit*`, `/v1/exceptions*` |
+| Findings / posture / graph | `/v1/assets*`, `/v1/graph*`, `/v1/compliance*`, `/v1/posture*`, `/v1/governance*` |
+
+## New API surface to add next
+
+The control plane is still missing a first-class source registry. That should
+be the next backend slice.
+
+### `Source` registry routes
+
+| Route | Purpose |
+|---|---|
+| `POST /v1/sources` | create a source definition |
+| `GET /v1/sources` | list sources in tenant scope |
+| `GET /v1/sources/{source_id}` | load one source |
+| `PUT /v1/sources/{source_id}` | update metadata, scope, labels, ownership |
+| `DELETE /v1/sources/{source_id}` | disable or remove a source |
+| `POST /v1/sources/{source_id}/test` | validate credentials and connectivity |
+| `POST /v1/sources/{source_id}/run` | trigger a job now |
+| `GET /v1/sources/{source_id}/jobs` | show source-linked job history |
+| `GET /v1/sources/{source_id}/evidence` | show evidence and provenance linked to the source |
+
+### Credential reference routes
+
+| Route | Purpose |
+|---|---|
+| `POST /v1/credentials` | create a credential reference |
+| `GET /v1/credentials` | list references without exposing secrets |
+| `GET /v1/credentials/{credential_ref_id}` | show status, provider, scope, last validation |
+| `POST /v1/credentials/{credential_ref_id}/test` | validate connectivity or role assumption |
+| `DELETE /v1/credentials/{credential_ref_id}` | retire the reference |
+
+## Worker and connector contract
+
+Workers should never invent their own tenancy or persistence rules. They should
+execute from one persisted control-plane contract.
+
+Each queued job should include:
+
+- `job_id`
+- `tenant_id`
+- `source_id`
+- `job_type`
+- `requested_by`
+- `credential_ref_id` when needed
+- `scope`
+- `policy_bindings`
+- `trace_id`
+- `idempotency_key`
+
+Each worker result should emit:
+
+- normalized summary
+- raw evidence reference
+- findings and graph updates
+- connector or scan health
+- audit event on success, partial success, timeout, or failure
+
+## UI surfaces to productize
+
+The next UI work should make the control plane legible rather than adding more
+static explanation pages.
+
+| Screen | Purpose | Must show |
+|---|---|---|
+| `Sources` | source registry and connector health | source status, credential mode, scope, last run, last result |
+| `Source detail` | one source end to end | jobs, schedules, evidence, audit trail, linked findings |
+| `Schedules` | recurring collection control | cron, enabled state, next run, last run outcome |
+| `Jobs` | execution lifecycle | running, queued, failed, retried, evidence count |
+| `Evidence / provenance` | why a result exists | source, job, collector, raw artifact references |
+| `Auth / tenant` | operator trust model | auth mode, tenant scope, role, active policy mode |
+| `Gateway / runtime` | runtime control plane | policies, alerts, upstream discovery, audit |
+
+## Security and isolation rules
+
+These rules should be enforced in both the API and background execution paths.
+
+- every `Source`, `Job`, `Schedule`, `Evidence`, and `AuditEvent` is tenant-bound
+- RBAC is checked at the API boundary and rechecked in worker claim logic where needed
+- credential material is referenced, not echoed back into the UI
+- imports and pushed ingest use idempotency keys and request-size limits
+- audit events are emitted for create, update, run, toggle, delete, export, allow, and block actions
+- gateway and proxy events carry tenant context, source identity, and trace correlation
+
+## Rollout order for the next PRs
+
+This should land as alignment work, not surface-area sprawl.
+
+1. **Source registry backend**  
+   Add `sources`, `credential_refs`, and source-linked job metadata.
+2. **Real Sources control-plane UI**  
+   Replace brochure content with source list, health, status, and run actions.
+3. **Schedule CRUD in UI**  
+   Make recurring runs editable from the product, not only via API.
+4. **Source / job / evidence linkage**  
+   Add provenance views so every finding can be traced to a source and job.
+5. **Auth / RBAC / tenant enforcement pass**  
+   Confirm every source, job, schedule, and evidence route is tenant-scoped and role-gated.
+6. **Credential reference model**  
+   Support customer-managed secrets and role references without leaking secret material into the UI.
+7. **Audit trail views**  
+   Add source and job-level audit visibility in the product.
+8. **Multi-tenant isolation hardening**  
+   Make tenant ownership explicit in DB access paths, worker claims, exports, and UI filters.
+
+## Short implementation rule
+
+If the UI cannot answer these for a given data path, the hosted product is not
+finished yet:
+
+- what source was configured
+- who owns it
+- how it authenticates
+- what tenant it belongs to
+- when it last ran
+- what it collected
+- where the evidence came from
+- what policy and audit trail apply to it

--- a/site-docs/architecture/how-agent-bom-works.md
+++ b/site-docs/architecture/how-agent-bom-works.md
@@ -256,6 +256,7 @@ CLI, API/UI, MCP, proxy, and export surfaces.
 ## Related docs
 
 - [Architecture Overview](overview.md)
+- [Hosted Product Control-Plane Spec](hosted-product-spec.md)
 - [Data Ingestion and Security](data-ingestion-and-security.md)
 - [Canonical Model vs OCSF](canonical-vs-ocsf.md)
 - [Backend Parity](../deployment/backend-parity.md)

--- a/site-docs/architecture/overview.md
+++ b/site-docs/architecture/overview.md
@@ -8,6 +8,9 @@ For the end-to-end intake story across direct scans, read-only integrations, pus
 
 For the shortest operator-facing explanation of inputs, engine, outputs, deployment models, and product surfaces, see [How Agent-BOM Works](how-agent-bom-works.md).
 
+For the next-phase hosted product plan that maps UI actions to control-plane
+entities, routes, and rollout order, see [Hosted Product Control-Plane Spec](hosted-product-spec.md).
+
 ## Scanning pipeline
 
 ```mermaid

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -51,86 +51,94 @@ allow-listable.
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart TB
-    subgraph outside["Outside customer trust boundary"]
+flowchart LR
+    subgraph outside["Outside your account"]
       idp["Corporate IdP<br/>Okta · Entra · Google"]
-      dev["Developer laptop<br/>Claude Desktop · Cursor · Claude Code"]
-      gh["GitHub Actions / CI runner"]
+      ci["GitHub Actions / CI"]
       remote["Remote MCPs<br/>SaaS + partner tools"]
-      osv["OSV / NVD / GHSA<br/>optional egress, allow-listable"]
+      osv["OSV / NVD / GHSA<br/>optional enrichment"]
     end
 
-    subgraph vpc["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio Gateway"]
+    subgraph customer["Customer VPC / EKS account"]
+      ingress["Ingress + TLS<br/>ALB / Istio"]
 
-      subgraph traffic["Agent-Bom traffic plane in your EKS cluster"]
-        px["MCP proxy<br/>sidecar or laptop wrapper<br/>stdio · SSE · HTTP"]
-        gw["MCP gateway<br/>agent-bom gateway serve<br/>Deployment + HPA"]
+      subgraph control["Agent-BOM control plane"]
+        ui["UI<br/>same-origin browser app"]
+        api["API<br/>auth · fleet · findings · audit"]
+        jobs["Scan + ingest workers<br/>CronJob + Job"]
+        backup["Backup job<br/>pg_dump -> S3"]
       end
 
-      subgraph control["Agent-Bom control plane in your EKS cluster"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>fleet · policy · audit · findings"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup CronJob<br/>pg_dump -> S3"]
+      subgraph runtime["Runtime MCP plane"]
+        proxy["Proxy<br/>sidecar or laptop wrapper"]
+        gateway["Gateway<br/>agent-bom gateway serve"]
       end
 
       subgraph data["Customer-owned data plane"]
         pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics + long-retention"]
+        ch["ClickHouse (optional)<br/>analytics"]
         s3["S3 (optional)<br/>backups + SBOM archive"]
       end
 
-      subgraph platform["Platform integration in your account"]
-        es["ExternalSecrets<br/>AWS SM / Vault"]
-        otel["OTEL collector<br/>traces + metrics"]
-        prom["Prometheus / ServiceMonitor"]
+      subgraph ops["Platform glue"]
+        secrets["ExternalSecrets<br/>AWS SM / Vault"]
+        metrics["OTEL + Prometheus"]
       end
     end
 
     idp -. OIDC .-> ingress
-    ingress -->|"browser traffic"| ui
-    ingress -->|"API + WS"| api
-    ingress -->|"optional shared MCP URL"| gw
-
-    dev -->|"MCP JSON-RPC"| px
-    px -->|"audited relay"| gw
-    gw -->|"policy-audited upstream call"| remote
-    px -->|"/v1/proxy/audit"| api
-    gw -->|"/v1/proxy/audit"| api
-
-    gh -->|"SARIF + findings"| api
+    ingress --> ui
+    ingress --> api
+    ingress --> gateway
+    ci -->|"SARIF + findings"| api
     jobs -->|"scan results + inventory"| api
-
-    api -->|"transactional state"| pg
-    api -. "optional analytics" .-> ch
-    backup -->|"backup archive"| s3
-
-    es -->|"runtime secrets"| api
-    es -->|"runtime secrets"| gw
-    api -->|"telemetry"| otel
-    gw -->|"telemetry"| otel
-    api -->|"metrics"| prom
-    gw -->|"metrics"| prom
-    api -. "optional enrichment egress" .-> osv
+    api --> pg
+    api -. optional .-> ch
+    backup --> s3
+    secrets --> api
+    secrets --> gateway
+    api --> metrics
+    gateway --> metrics
+    gateway -->|"policy-audited upstream call"| remote
+    api -. optional egress .-> osv
 ```
 
-*Everything in the boundary runs in your account. Only OIDC (inbound) and
-MCP upstream calls (outbound, policy-audited) cross it.*
+*Everything inside the customer boundary runs in the customer's account. The
+default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
+upstream calls.*
 
-### How an MCP call actually flows
+### How MCP traffic actually flows
 
-1. Developer client (Claude Desktop / Cursor / Claude Code) speaks MCP
-   JSON-RPC to the local `agent-bom proxy` (stdio or SSE).
-2. The proxy inspects and audits the call, enforces policy, then relays to
-   the central `agent-bom gateway` inside your cluster.
-3. The gateway applies shared policy, records the audit event to
-   `/v1/proxy/audit`, and forwards to the remote MCP upstream.
-4. Responses flow back on the same path; screenshot/image responses run
-   through the `VisualLeakDetector` for OCR-based redaction before the
-   developer sees them.
-5. Every hop emits OTEL spans with a W3C trace context, so a single trace
-   ties developer → proxy → gateway → remote MCP → back.
+```mermaid
+sequenceDiagram
+    participant Dev as Developer client
+    participant Proxy as agent-bom proxy
+    participant Gateway as agent-bom gateway
+    participant API as Control-plane API
+    participant Remote as Remote MCP
+    participant Store as Postgres / audit store
+
+    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
+    Proxy->>Proxy: inspect request + local policy
+    Proxy->>Gateway: audited relay
+    Gateway->>API: POST /v1/proxy/audit
+    Gateway->>Remote: upstream MCP call
+    Remote-->>Gateway: MCP response
+    Gateway-->>Proxy: shared policy + response
+    Proxy->>Proxy: optional VLD / OCR redaction
+    Proxy-->>Dev: safe response
+    API->>Store: persist audit, findings, graph links
+```
+
+1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
+2. The proxy inspects and audits the call, enforces local policy, and relays
+   to the central `agent-bom gateway`.
+3. The gateway applies shared policy, records audit to `/v1/proxy/audit`, and
+   forwards to the remote MCP upstream.
+4. Responses come back on the same path; image responses can run through the
+   visual leak detector before they reach the developer.
+5. The control plane persists audit, findings, and graph state for the UI,
+   exports, and compliance surfaces.
 
 ## Same-origin default
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -73,86 +73,94 @@ allow-listable.
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart TB
-    subgraph outside["Outside customer trust boundary"]
+flowchart LR
+    subgraph outside["Outside your account"]
       idp["Corporate IdP<br/>Okta · Entra · Google"]
-      dev["Developer laptop<br/>Claude Desktop · Cursor · Claude Code"]
-      gh["GitHub Actions / CI runner"]
+      ci["GitHub Actions / CI"]
       remote["Remote MCPs<br/>SaaS + partner tools"]
-      osv["OSV / NVD / GHSA<br/>optional egress, allow-listable"]
+      osv["OSV / NVD / GHSA<br/>optional enrichment"]
     end
 
-    subgraph vpc["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio Gateway"]
+    subgraph customer["Customer VPC / EKS account"]
+      ingress["Ingress + TLS<br/>ALB / Istio"]
 
-      subgraph traffic["Agent-Bom traffic plane in your EKS cluster"]
-        px["MCP proxy<br/>sidecar or laptop wrapper<br/>stdio · SSE · HTTP"]
-        gw["MCP gateway<br/>agent-bom gateway serve<br/>Deployment + HPA"]
+      subgraph control["Agent-BOM control plane"]
+        ui["UI<br/>same-origin browser app"]
+        api["API<br/>auth · fleet · findings · audit"]
+        jobs["Scan + ingest workers<br/>CronJob + Job"]
+        backup["Backup job<br/>pg_dump -> S3"]
       end
 
-      subgraph control["Agent-Bom control plane in your EKS cluster"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>fleet · policy · audit · findings"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup CronJob<br/>pg_dump -> S3"]
+      subgraph runtime["Runtime MCP plane"]
+        proxy["Proxy<br/>sidecar or laptop wrapper"]
+        gateway["Gateway<br/>agent-bom gateway serve"]
       end
 
       subgraph data["Customer-owned data plane"]
         pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics + long-retention"]
+        ch["ClickHouse (optional)<br/>analytics"]
         s3["S3 (optional)<br/>backups + SBOM archive"]
       end
 
-      subgraph platform["Platform integration in your account"]
-        es["ExternalSecrets<br/>AWS SM / Vault"]
-        otel["OTEL collector<br/>traces + metrics"]
-        prom["Prometheus / ServiceMonitor"]
+      subgraph ops["Platform glue"]
+        secrets["ExternalSecrets<br/>AWS SM / Vault"]
+        metrics["OTEL + Prometheus"]
       end
     end
 
     idp -. OIDC .-> ingress
-    ingress -->|"browser traffic"| ui
-    ingress -->|"API + WS"| api
-    ingress -->|"optional shared MCP URL"| gw
-
-    dev -->|"MCP JSON-RPC"| px
-    px -->|"audited relay"| gw
-    gw -->|"policy-audited upstream call"| remote
-    px -->|"/v1/proxy/audit"| api
-    gw -->|"/v1/proxy/audit"| api
-
-    gh -->|"SARIF + findings"| api
+    ingress --> ui
+    ingress --> api
+    ingress --> gateway
+    ci -->|"SARIF + findings"| api
     jobs -->|"scan results + inventory"| api
-
-    api -->|"transactional state"| pg
-    api -. "optional analytics" .-> ch
-    backup -->|"backup archive"| s3
-
-    es -->|"runtime secrets"| api
-    es -->|"runtime secrets"| gw
-    api -->|"telemetry"| otel
-    gw -->|"telemetry"| otel
-    api -->|"metrics"| prom
-    gw -->|"metrics"| prom
-    api -. "optional enrichment egress" .-> osv
+    api --> pg
+    api -. optional .-> ch
+    backup --> s3
+    secrets --> api
+    secrets --> gateway
+    api --> metrics
+    gateway --> metrics
+    gateway -->|"policy-audited upstream call"| remote
+    api -. optional egress .-> osv
 ```
 
-*Everything in the boundary runs in your account. Only OIDC (inbound) and
-MCP upstream calls (outbound, policy-audited) cross it.*
+*Everything inside the customer boundary runs in the customer's account. The
+default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
+upstream calls.*
 
-### How an MCP call actually flows
+### How MCP traffic actually flows
 
-1. Developer client (Claude Desktop / Cursor / Claude Code) speaks MCP
-   JSON-RPC to the local `agent-bom proxy` (stdio or SSE).
-2. The proxy inspects and audits the call, enforces policy, then relays to
-   the central `agent-bom gateway` inside your cluster.
-3. The gateway applies shared policy, records the audit event to
-   `/v1/proxy/audit`, and forwards to the remote MCP upstream.
-4. Responses flow back on the same path; screenshot/image responses run
-   through the `VisualLeakDetector` for OCR-based redaction before the
-   developer sees them.
-5. Every hop emits OTEL spans with a W3C trace context, so a single trace
-   ties developer → proxy → gateway → remote MCP → back.
+```mermaid
+sequenceDiagram
+    participant Dev as Developer client
+    participant Proxy as agent-bom proxy
+    participant Gateway as agent-bom gateway
+    participant API as Control-plane API
+    participant Remote as Remote MCP
+    participant Store as Postgres / audit store
+
+    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
+    Proxy->>Proxy: inspect request + local policy
+    Proxy->>Gateway: audited relay
+    Gateway->>API: POST /v1/proxy/audit
+    Gateway->>Remote: upstream MCP call
+    Remote-->>Gateway: MCP response
+    Gateway-->>Proxy: shared policy + response
+    Proxy->>Proxy: optional VLD / OCR redaction
+    Proxy-->>Dev: safe response
+    API->>Store: persist audit, findings, graph links
+```
+
+1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
+2. The proxy inspects and audits the call, enforces local policy, and relays
+   to the central `agent-bom gateway`.
+3. The gateway applies shared policy, records audit to `/v1/proxy/audit`, and
+   forwards to the remote MCP upstream.
+4. Responses come back on the same path; image responses can run through the
+   visual leak detector before they reach the developer.
+5. The control plane persists audit, findings, and graph state for the UI,
+   exports, and compliance surfaces.
 
 ## Control flow
 

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -134,6 +134,9 @@ That is the intended split:
 - `workers / connectors` = do the privileged read or collection work
 - `proxy / gateway` = enforce and audit runtime MCP traffic
 
+For the concrete backend and UI rollout plan behind this split, see [Hosted
+Product Control-Plane Spec](../architecture/hosted-product-spec.md).
+
 ## Approved intake paths today
 
 “Approved” here means explicit, customer-controlled backend intake paths. The


### PR DESCRIPTION
## What changed
- added a hosted product control-plane spec that maps UI actions to backend entities, routes, and rollout order
- linked the new spec into the architecture and deployment docs nav
- split the hosted deployment diagrams into a clearer control-plane topology and MCP traffic flow narrative across the README and deployment guides

## Why
The hosted-product and deployment docs needed one coherent control-plane story so the hosted roadmap, operator-facing topology, and runtime MCP flow are documented from the same model.

## Impact
- gives operators and contributors one canonical hosted control-plane spec
- makes the deployment docs easier to read by separating boundary/topology from request flow
- keeps the docs-only patch isolated from unrelated source and lockfile changes

## Validation
- `mkdocs build --strict`
