### PR TITLE
Add source registry and wire the Sources page

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -338,6 +338,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("PUT", "/v1/gateway/policies/", "admin"),
         ("DELETE", "/v1/gateway/policies/", "admin"),
         ("POST", "/v1/fleet/sync", "admin"),
+        ("DELETE", "/v1/sources/", "admin"),
         ("PUT", "/v1/fleet/", "admin"),
         ("PUT", "/v1/exceptions/", "admin"),
         ("DELETE", "/v1/exceptions/", "admin"),
@@ -356,8 +357,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("POST", "/v1/traces", "analyst"),
         ("POST", "/v1/results/push", "analyst"),
         ("POST", "/v1/schedules", "analyst"),
+        ("POST", "/v1/sources", "analyst"),
+        ("POST", "/v1/sources/", "analyst"),
         ("DELETE", "/v1/schedules/", "analyst"),
         ("PUT", "/v1/schedules/", "analyst"),
+        ("PUT", "/v1/sources/", "analyst"),
     )
 
     def __init__(self, app: ASGIApp, api_key: str) -> None:

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -98,6 +98,7 @@ class ScanJob(BaseModel):
 
     job_id: str
     tenant_id: str = "default"
+    source_id: str | None = None
     triggered_by: str | None = None
     status: JobStatus = JobStatus.PENDING
     created_at: str
@@ -143,6 +144,7 @@ class StorageHealth(BaseModel):
     job_store: str = "inmemory"
     fleet_store: str = "inmemory"
     policy_store: str = "inmemory"
+    source_store: str = "inmemory"
     schedule_store: str = "inmemory"
     exception_store: str = "inmemory"
     trend_store: str = "inmemory"
@@ -358,6 +360,78 @@ class ScheduleCreate(BaseModel):
     scan_config: dict[str, Any] = Field(default_factory=dict)
     enabled: bool = True
     tenant_id: str = "default"
+
+
+class SourceKind(str, Enum):
+    SCAN_REPO = "scan.repo"
+    SCAN_IMAGE = "scan.image"
+    SCAN_IAC = "scan.iac"
+    SCAN_CLOUD = "scan.cloud"
+    SCAN_MCP_CONFIG = "scan.mcp_config"
+    CONNECTOR_CLOUD_READ_ONLY = "connector.cloud_read_only"
+    CONNECTOR_REGISTRY = "connector.registry"
+    CONNECTOR_WAREHOUSE = "connector.warehouse"
+    INGEST_FLEET_SYNC = "ingest.fleet_sync"
+    INGEST_TRACE_PUSH = "ingest.trace_push"
+    INGEST_RESULT_PUSH = "ingest.result_push"
+    INGEST_ARTIFACT_IMPORT = "ingest.artifact_import"
+    RUNTIME_PROXY = "runtime.proxy"
+    RUNTIME_GATEWAY = "runtime.gateway"
+
+
+class SourceStatus(str, Enum):
+    CONFIGURED = "configured"
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    DISABLED = "disabled"
+
+
+class SourceRecord(BaseModel):
+    source_id: str
+    tenant_id: str = "default"
+    display_name: str
+    kind: SourceKind
+    description: str = ""
+    owner: str = ""
+    connector_name: str | None = None
+    credential_mode: str = "none"
+    credential_ref: str | None = None
+    enabled: bool = True
+    status: SourceStatus = SourceStatus.CONFIGURED
+    config: dict[str, Any] = Field(default_factory=dict)
+    last_tested_at: str | None = None
+    last_test_status: str | None = None
+    last_test_message: str | None = None
+    last_run_at: str | None = None
+    last_run_status: str | None = None
+    last_job_id: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+
+class SourceCreate(BaseModel):
+    display_name: str
+    kind: SourceKind
+    description: str = ""
+    owner: str = ""
+    connector_name: str | None = None
+    credential_mode: str = "none"
+    credential_ref: str | None = None
+    enabled: bool = True
+    config: dict[str, Any] = Field(default_factory=dict)
+    tenant_id: str = "default"
+
+
+class SourceUpdate(BaseModel):
+    display_name: str | None = None
+    description: str | None = None
+    owner: str | None = None
+    connector_name: str | None = None
+    credential_mode: str | None = None
+    credential_ref: str | None = None
+    enabled: bool | None = None
+    status: SourceStatus | None = None
+    config: dict[str, Any] | None = None
 
 
 class CreateKeyRequest(BaseModel):

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -27,7 +27,28 @@ from agent_bom.security import sanitize_error
 _logger = logging.getLogger(__name__)
 
 # ─── Shared executor ─────────────────────────────────────────────────────────
+# The scan pool is a module-level singleton so submit sites can reuse it across
+# requests, but graceful shutdown in the API lifespan calls `.shutdown()` — and
+# once that fires, the pool rejects further submissions with
+# ``RuntimeError: cannot schedule new futures after shutdown``. In long-lived
+# production processes the lifespan only fires at exit, so the effect is
+# invisible. In the test suite, any test that enters a ``TestClient`` context
+# manager exercises the full lifespan, leaves the global shut down, and breaks
+# every subsequent test that reaches the scan path. ``get_executor()`` restores
+# the pool on demand so shutdown becomes idempotent and recoverable rather than
+# terminal.
+_executor_lock = threading.Lock()
 _executor = ThreadPoolExecutor(max_workers=min(8, (os.cpu_count() or 4) + 2))
+
+
+def get_executor() -> ThreadPoolExecutor:
+    """Return the shared scan executor, recreating it if a prior lifespan shut it down."""
+    global _executor
+    with _executor_lock:
+        if _executor._shutdown:
+            _executor = ThreadPoolExecutor(max_workers=min(8, (os.cpu_count() or 4) + 2))
+        return _executor
+
 
 # ─── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -1,4 +1,4 @@
-"""PostgreSQL-backed gateway policy and schedule stores."""
+"""PostgreSQL-backed gateway policy, source, and schedule stores."""
 
 from __future__ import annotations
 
@@ -267,3 +267,92 @@ class PostgresScheduleStore:
                 (now_iso,),
             ).fetchall()
             return [ScanSchedule.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
+
+
+class PostgresSourceStore:
+    """PostgreSQL-backed hosted product source registry."""
+
+    def __init__(self, pool=None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS control_plane_sources (
+                    source_id TEXT PRIMARY KEY,
+                    enabled INTEGER DEFAULT 1,
+                    tenant_id TEXT NOT NULL DEFAULT 'default',
+                    updated_at TEXT NOT NULL,
+                    data JSONB NOT NULL
+                )
+            """)
+            conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'control_plane_sources' AND column_name = 'tenant_id'
+                    ) THEN
+                        ALTER TABLE control_plane_sources ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'control_plane_sources' AND column_name = 'updated_at'
+                    ) THEN
+                        ALTER TABLE control_plane_sources ADD COLUMN updated_at TEXT NOT NULL DEFAULT '';
+                    END IF;
+                END
+                $$;
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_control_plane_sources_tenant_updated ON control_plane_sources(tenant_id, updated_at DESC)"
+            )
+            _ensure_tenant_rls(conn, "control_plane_sources", "tenant_id")
+            conn.commit()
+
+    def put(self, source) -> None:
+        data = source.model_dump_json()
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """INSERT INTO control_plane_sources (source_id, enabled, tenant_id, updated_at, data)
+                   VALUES (%s, %s, %s, %s, %s)
+                   ON CONFLICT (source_id) DO UPDATE SET
+                     enabled = EXCLUDED.enabled,
+                     tenant_id = EXCLUDED.tenant_id,
+                     updated_at = EXCLUDED.updated_at,
+                     data = EXCLUDED.data""",
+                (source.source_id, int(source.enabled), source.tenant_id, source.updated_at, data),
+            )
+            conn.commit()
+
+    def get(self, source_id: str):
+        from .models import SourceRecord
+
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute("SELECT data FROM control_plane_sources WHERE source_id = %s", (source_id,)).fetchone()
+            if row is None:
+                return None
+            raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
+            return SourceRecord.model_validate_json(raw)
+
+    def delete(self, source_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute("DELETE FROM control_plane_sources WHERE source_id = %s", (source_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def list_all(self, tenant_id: str | None = None) -> list:
+        from .models import SourceRecord
+
+        with _tenant_connection(self._pool) as conn:
+            if tenant_id is None:
+                rows = conn.execute("SELECT data FROM control_plane_sources ORDER BY updated_at DESC, source_id").fetchall()
+            else:
+                rows = conn.execute(
+                    """SELECT data FROM control_plane_sources
+                       WHERE tenant_id = %s
+                       ORDER BY updated_at DESC, source_id""",
+                    (tenant_id,),
+                ).fetchall()
+            return [SourceRecord.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0])) for row in rows]

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -29,7 +29,7 @@ from agent_bom.api.postgres_common import (
     set_current_tenant,
 )
 from agent_bom.api.postgres_graph import PostgresGraphStore, PostgresScanCache
-from agent_bom.api.postgres_policy import PostgresPolicyStore, PostgresScheduleStore
+from agent_bom.api.postgres_policy import PostgresPolicyStore, PostgresScheduleStore, PostgresSourceStore  # noqa: F401
 
 _JOB_TTL_SECONDS = 3600
 

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -156,6 +156,7 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
     job = ScanJob(
         job_id=str(uuid.uuid4()),
         tenant_id=tenant_id,
+        source_id=body.source_id or None,
         triggered_by=f"{_triggered_by(request)}:{body.source_id}" if body.source_id else _triggered_by(request),
         created_at=_now(),
         request=ScanRequest(),

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -153,6 +153,34 @@ def _job_for_request(request: Request, job_id: str) -> ScanJob:
     return job
 
 
+def enqueue_scan_job(
+    *,
+    tenant_id: str,
+    triggered_by: str,
+    request_body: ScanRequest,
+    source_id: str | None = None,
+) -> ScanJob:
+    """Persist and queue a scan job for async execution."""
+    store = _get_store()
+    enforce_active_scan_quota(tenant_id)
+    enforce_retained_jobs_quota(tenant_id)
+
+    job = ScanJob(
+        job_id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        source_id=source_id,
+        triggered_by=triggered_by,
+        created_at=_now(),
+        request=request_body,
+    )
+    store.put(job)
+    _jobs_put(job.job_id, job)
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(_executor, _run_scan_sync, job)
+    return job
+
+
 # ─── Core Scan Endpoints ─────────────────────────────────────────────────────
 
 
@@ -161,26 +189,11 @@ async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
     """Start a scan. Returns immediately with a job_id.
     Poll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.
     """
-    store = _get_store()
-    tenant_id = _tenant_id(request)
-    enforce_active_scan_quota(tenant_id)
-    enforce_retained_jobs_quota(tenant_id)
-
-    job = ScanJob(
-        job_id=str(uuid.uuid4()),
-        tenant_id=tenant_id,
+    return enqueue_scan_job(
+        tenant_id=_tenant_id(request),
         triggered_by=_triggered_by(request),
-        created_at=_now(),
-        request=body,
+        request_body=body,
     )
-    store.put(job)
-    # Keep in-memory ref for SSE streaming (progress list updates in real-time)
-    _jobs_put(job.job_id, job)
-
-    loop = asyncio.get_running_loop()
-    loop.run_in_executor(_executor, _run_scan_sync, job)
-
-    return job
 
 
 @router.get("/v1/scan/{job_id}", response_model=ScanJob, tags=["scan"])

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -42,7 +42,7 @@ from agent_bom.api.models import (
     ScanRequest,
     TrainingPipelinesRequest,
 )
-from agent_bom.api.pipeline import _executor, _now, _run_scan_sync
+from agent_bom.api.pipeline import _now, _run_scan_sync, get_executor
 from agent_bom.api.stores import (
     _get_store,
     _job_lock,
@@ -177,7 +177,7 @@ def enqueue_scan_job(
     _jobs_put(job.job_id, job)
 
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(_executor, _run_scan_sync, job)
+    loop.run_in_executor(get_executor(), _run_scan_sync, job)
     return job
 
 

--- a/src/agent_bom/api/routes/sources.py
+++ b/src/agent_bom/api/routes/sources.py
@@ -1,0 +1,250 @@
+"""Hosted product source registry API routes."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+
+from agent_bom.api.audit_log import log_action
+from agent_bom.api.models import (
+    ScanRequest,
+    SourceCreate,
+    SourceKind,
+    SourceRecord,
+    SourceStatus,
+    SourceUpdate,
+)
+from agent_bom.api.routes.scan import enqueue_scan_job
+from agent_bom.api.stores import _get_source_store, _get_store
+
+router = APIRouter()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _tenant_id(request: Request) -> str:
+    return getattr(request.state, "tenant_id", "default")
+
+
+def _actor(request: Request) -> str:
+    return getattr(request.state, "api_key_name", "") or getattr(request.state, "auth_method", "") or "system"
+
+
+def _source_for_request(request: Request, source_id: str) -> SourceRecord:
+    source = _get_source_store().get(source_id)
+    tenant_id = _tenant_id(request)
+    if source is None or source.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail=f"Source {source_id} not found")
+    return source
+
+
+def _apply_update(source: SourceRecord, body: SourceUpdate) -> SourceRecord:
+    for field in (
+        "display_name",
+        "description",
+        "owner",
+        "connector_name",
+        "credential_mode",
+        "credential_ref",
+        "enabled",
+        "status",
+        "config",
+    ):
+        value = getattr(body, field)
+        if value is not None:
+            setattr(source, field, value)
+    source.updated_at = _now()
+    if not source.enabled:
+        source.status = SourceStatus.DISABLED
+    elif source.status == SourceStatus.DISABLED:
+        source.status = SourceStatus.CONFIGURED
+    return source
+
+
+def _request_for_source(source: SourceRecord) -> ScanRequest:
+    config = dict(source.config or {})
+    if "scan_request" in config and isinstance(config["scan_request"], dict):
+        config = dict(config["scan_request"])
+
+    if source.kind in (
+        SourceKind.CONNECTOR_CLOUD_READ_ONLY,
+        SourceKind.CONNECTOR_REGISTRY,
+        SourceKind.CONNECTOR_WAREHOUSE,
+    ):
+        connector_name = source.connector_name or str(config.get("connector_name") or "").strip()
+        if not connector_name:
+            raise HTTPException(status_code=409, detail="Connector-backed sources require connector_name to run")
+        config.setdefault("connectors", [connector_name])
+
+    if source.kind in (SourceKind.INGEST_FLEET_SYNC, SourceKind.INGEST_TRACE_PUSH, SourceKind.INGEST_RESULT_PUSH):
+        raise HTTPException(status_code=409, detail="Push-driven sources do not support Run now; they ingest from external producers")
+
+    if source.kind in (SourceKind.RUNTIME_PROXY, SourceKind.RUNTIME_GATEWAY):
+        raise HTTPException(status_code=409, detail="Runtime sources are audited by proxy/gateway traffic, not by direct scan jobs")
+
+    return ScanRequest.model_validate(config)
+
+
+@router.post("/v1/sources", tags=["sources"], status_code=201)
+async def create_source(request: Request, body: SourceCreate) -> dict:
+    tenant_id = _tenant_id(request)
+    if body.tenant_id not in ("default", tenant_id):
+        raise HTTPException(status_code=403, detail="Forbidden — tenant_id must match the authenticated tenant")
+
+    now = _now()
+    source = SourceRecord(
+        source_id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        display_name=body.display_name,
+        kind=body.kind,
+        description=body.description,
+        owner=body.owner,
+        connector_name=body.connector_name,
+        credential_mode=body.credential_mode,
+        credential_ref=body.credential_ref,
+        enabled=body.enabled,
+        status=SourceStatus.CONFIGURED if body.enabled else SourceStatus.DISABLED,
+        config=body.config,
+        created_at=now,
+        updated_at=now,
+    )
+    _get_source_store().put(source)
+    log_action(
+        "source.create",
+        actor=_actor(request),
+        resource=f"source/{source.source_id}",
+        tenant_id=tenant_id,
+        kind=source.kind.value,
+        connector_name=source.connector_name,
+    )
+    return source.model_dump()
+
+
+@router.get("/v1/sources", tags=["sources"])
+async def list_sources(request: Request) -> dict:
+    tenant_id = _tenant_id(request)
+    sources = [source.model_dump() for source in _get_source_store().list_all(tenant_id=tenant_id)]
+    return {"sources": sources, "count": len(sources)}
+
+
+@router.get("/v1/sources/{source_id}", tags=["sources"])
+async def get_source(request: Request, source_id: str) -> dict:
+    return _source_for_request(request, source_id).model_dump()
+
+
+@router.put("/v1/sources/{source_id}", tags=["sources"])
+async def update_source(request: Request, source_id: str, body: SourceUpdate) -> dict:
+    source = _apply_update(_source_for_request(request, source_id), body)
+    _get_source_store().put(source)
+    log_action(
+        "source.update",
+        actor=_actor(request),
+        resource=f"source/{source_id}",
+        tenant_id=source.tenant_id,
+        enabled=source.enabled,
+        status=source.status.value,
+    )
+    return source.model_dump()
+
+
+@router.delete("/v1/sources/{source_id}", tags=["sources"], status_code=204)
+async def delete_source(request: Request, source_id: str) -> None:
+    source = _source_for_request(request, source_id)
+    _get_source_store().delete(source_id)
+    log_action(
+        "source.delete",
+        actor=_actor(request),
+        resource=f"source/{source_id}",
+        tenant_id=source.tenant_id,
+        kind=source.kind.value,
+    )
+
+
+@router.post("/v1/sources/{source_id}/test", tags=["sources"])
+async def test_source(request: Request, source_id: str) -> dict:
+    source = _source_for_request(request, source_id)
+    message = "Configuration recorded"
+    status = SourceStatus.CONFIGURED
+
+    if (
+        source.kind
+        in (
+            SourceKind.CONNECTOR_CLOUD_READ_ONLY,
+            SourceKind.CONNECTOR_REGISTRY,
+            SourceKind.CONNECTOR_WAREHOUSE,
+        )
+        and source.connector_name
+    ):
+        from agent_bom.connectors import check_connector_health
+
+        connector_status = check_connector_health(source.connector_name)
+        status = SourceStatus.HEALTHY if connector_status.state.value == "healthy" else SourceStatus.DEGRADED
+        message = connector_status.message
+    elif source.kind in (SourceKind.RUNTIME_PROXY, SourceKind.RUNTIME_GATEWAY):
+        message = "Runtime source is configured. Health comes from proxy/gateway audit and alert streams."
+        status = SourceStatus.CONFIGURED
+    elif source.kind in (SourceKind.INGEST_FLEET_SYNC, SourceKind.INGEST_TRACE_PUSH, SourceKind.INGEST_RESULT_PUSH):
+        message = "Push-driven source is configured. Evidence arrives through authenticated ingest routes."
+        status = SourceStatus.CONFIGURED
+    else:
+        _request_for_source(source)
+        message = "Direct scan source is valid and can be launched from the control plane."
+        status = SourceStatus.CONFIGURED
+
+    source.last_tested_at = _now()
+    source.last_test_status = status.value
+    source.last_test_message = message
+    if source.enabled:
+        source.status = status
+    source.updated_at = _now()
+    _get_source_store().put(source)
+    log_action(
+        "source.test",
+        actor=_actor(request),
+        resource=f"source/{source_id}",
+        tenant_id=source.tenant_id,
+        status=status.value,
+    )
+    return {
+        "source_id": source.source_id,
+        "status": status.value,
+        "message": message,
+        "tested_at": source.last_tested_at,
+    }
+
+
+@router.post("/v1/sources/{source_id}/run", tags=["sources"], status_code=202)
+async def run_source(request: Request, source_id: str) -> dict:
+    source = _source_for_request(request, source_id)
+    if not source.enabled:
+        raise HTTPException(status_code=409, detail="Source is disabled")
+    job = enqueue_scan_job(
+        tenant_id=source.tenant_id,
+        triggered_by=f"{_actor(request)}:source:{source.source_id}",
+        request_body=_request_for_source(source),
+        source_id=source.source_id,
+    )
+    source.last_run_at = _now()
+    source.last_run_status = job.status.value
+    source.last_job_id = job.job_id
+    source.updated_at = _now()
+    _get_source_store().put(source)
+    log_action(
+        "source.run",
+        actor=_actor(request),
+        resource=f"source/{source_id}",
+        tenant_id=source.tenant_id,
+        job_id=job.job_id,
+    )
+    return {"source_id": source.source_id, "job_id": job.job_id, "status": job.status.value}
+
+
+@router.get("/v1/sources/{source_id}/jobs", tags=["sources"])
+async def list_source_jobs(request: Request, source_id: str) -> dict:
+    source = _source_for_request(request, source_id)
+    jobs = [job.model_dump() for job in _get_store().list_all(tenant_id=source.tenant_id) if job.source_id == source.source_id]
+    return {"source_id": source.source_id, "jobs": jobs, "count": len(jobs)}

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -366,7 +366,7 @@ async def _lifespan(app_instance: FastAPI):
         _get_store().put(job)
         _jobs_put(job.job_id, job)
         loop = asyncio.get_running_loop()
-        loop.run_in_executor(_executor, _run_scan, job)
+        loop.run_in_executor(get_executor(), _run_scan, job)
         return job.job_id
 
     _scheduler_task = asyncio.create_task(scheduler_loop(_get_schedule_store(), _schedule_scan))
@@ -389,7 +389,7 @@ async def _lifespan(app_instance: FastAPI):
     _drain_seconds = float(os.environ.get("AGENT_BOM_SHUTDOWN_DRAIN_SECONDS", "25"))
     try:
         await asyncio.wait_for(
-            asyncio.to_thread(lambda: _executor.shutdown(wait=True, cancel_futures=False)),
+            asyncio.to_thread(lambda: get_executor().shutdown(wait=True, cancel_futures=False)),
             timeout=_drain_seconds,
         )
     except asyncio.TimeoutError:
@@ -397,7 +397,7 @@ async def _lifespan(app_instance: FastAPI):
             "shutdown drain timeout after %.1fs; force-cancelling in-flight scans",
             _drain_seconds,
         )
-        _executor.shutdown(wait=False, cancel_futures=True)
+        get_executor().shutdown(wait=False, cancel_futures=True)
     # Close Postgres connection pool if active
     try:
         if os.environ.get("AGENT_BOM_POSTGRES_URL"):
@@ -520,9 +520,10 @@ def configure_api(
 from agent_bom.api.pipeline import (  # noqa: E402
     PIPELINE_STEPS,  # noqa: F401 — re-exported for tests
     ScanPipeline,  # noqa: F401 — re-exported for tests
-    _executor,  # noqa: F401 — re-exported for tests
+    _executor,  # noqa: F401 — re-exported for tests (may be replaced on shutdown; use get_executor() for new submissions)
     _run_scan_sync,  # noqa: F401 — re-exported for backward compat
     _sync_scan_agents_to_fleet,  # noqa: F401 — re-exported for tests
+    get_executor,  # noqa: F401 — re-exported for tests
 )
 
 # ─── Route modules ────────────────────────────────────────────────────────

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -42,6 +42,7 @@ from agent_bom.api.models import (
 )
 from agent_bom.api.stores import (
     _get_schedule_store,
+    _get_source_store,
     _get_store,
     _jobs,
     _jobs_get,  # noqa: F401 — re-exported for tests
@@ -55,6 +56,7 @@ from agent_bom.api.stores import (
     set_job_store,
     set_policy_store,
     set_schedule_store,
+    set_source_store,
     set_trend_store,
 )
 from agent_bom.api.tracing import configure_otel_tracing, get_tracing_health
@@ -132,7 +134,7 @@ def _backend_name(store: object | None) -> str:
 
 
 def _control_plane_backend(storage: StorageHealth) -> str:
-    primary = [storage.job_store, storage.fleet_store, storage.policy_store]
+    primary = [storage.job_store, storage.fleet_store, storage.policy_store, storage.source_store]
     if any(name == "snowflake" for name in primary):
         return "snowflake"
     if any(name == "postgres" for name in primary):
@@ -144,6 +146,10 @@ def _control_plane_backend(storage: StorageHealth) -> str:
 
 def _storage_health() -> StorageHealth:
     try:
+        source_store = _get_source_store()
+    except RuntimeError:
+        source_store = None
+    try:
         schedule_store = _get_schedule_store()
     except RuntimeError:
         schedule_store = None
@@ -152,6 +158,7 @@ def _storage_health() -> StorageHealth:
         job_store=_backend_name(_stores._store or _stores._get_store()),
         fleet_store=_backend_name(_stores._fleet_store or _stores._get_fleet_store()),
         policy_store=_backend_name(_stores._policy_store or _stores._get_policy_store()),
+        source_store=_backend_name(_stores._source_store or source_store),
         schedule_store=_backend_name(_stores._schedule_store or schedule_store),
         exception_store=_backend_name(_stores._exception_store or _stores._get_exception_store()),
         trend_store=_backend_name(_stores._trend_store or _stores._get_trend_store()),
@@ -196,6 +203,7 @@ async def _lifespan(app_instance: FastAPI):
             PostgresJobStore,
             PostgresKeyStore,
             PostgresPolicyStore,
+            PostgresSourceStore,
             PostgresTrendStore,
         )
 
@@ -205,6 +213,8 @@ async def _lifespan(app_instance: FastAPI):
             set_fleet_store(PostgresFleetStore())
         if _stores._policy_store is None:
             set_policy_store(PostgresPolicyStore())
+        if _stores._source_store is None:
+            set_source_store(PostgresSourceStore())
         if _stores._exception_store is None:
             set_exception_store(PostgresExceptionStore())
         if _stores._trend_store is None:
@@ -232,6 +242,10 @@ async def _lifespan(app_instance: FastAPI):
             from agent_bom.api.policy_store import SQLitePolicyStore
 
             set_policy_store(SQLitePolicyStore(db_path))
+        if _stores._source_store is None:
+            from agent_bom.api.source_store import SQLiteSourceStore
+
+            set_source_store(SQLiteSourceStore(db_path))
         if _stores._trend_store is None:
             from agent_bom.baseline import SQLiteTrendStore
 
@@ -242,6 +256,20 @@ async def _lifespan(app_instance: FastAPI):
             set_graph_store(SQLiteGraphStore())
         if _audit_log_mod._audit_log is None:
             set_audit_log(SQLiteAuditLog(db_path))
+
+    if _stores._source_store is None:
+        if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+            from agent_bom.api.postgres_store import PostgresSourceStore
+
+            set_source_store(PostgresSourceStore())
+        elif os.environ.get("AGENT_BOM_DB"):
+            from agent_bom.api.source_store import SQLiteSourceStore
+
+            set_source_store(SQLiteSourceStore(os.environ["AGENT_BOM_DB"]))
+        else:
+            from agent_bom.api.source_store import InMemorySourceStore
+
+            set_source_store(InMemorySourceStore())
 
     # ── Schedule store ──
     if _stores._schedule_store is None:
@@ -512,6 +540,7 @@ from agent_bom.api.routes.observability import router as _observability_router  
 from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
 from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
 from agent_bom.api.routes.schedules import router as _schedules_router  # noqa: E402
+from agent_bom.api.routes.sources import router as _sources_router  # noqa: E402
 
 app.include_router(_assets_router)
 app.include_router(_compliance_router)
@@ -527,6 +556,7 @@ app.include_router(_observability_router)
 app.include_router(_proxy_router)
 app.include_router(_scan_router)
 app.include_router(_schedules_router)
+app.include_router(_sources_router)
 
 # Re-export proxy push functions for backward compatibility
 # Re-export connectors helpers for backward compatibility

--- a/src/agent_bom/api/source_store.py
+++ b/src/agent_bom/api/source_store.py
@@ -1,0 +1,112 @@
+"""Source registry storage backends for hosted control-plane data sources."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from typing import Protocol
+
+from agent_bom.api.models import SourceRecord
+
+
+class SourceStore(Protocol):
+    """Protocol for source registry persistence."""
+
+    def put(self, source: SourceRecord) -> None: ...
+    def get(self, source_id: str) -> SourceRecord | None: ...
+    def delete(self, source_id: str) -> bool: ...
+    def list_all(self, tenant_id: str | None = None) -> list[SourceRecord]: ...
+
+
+class InMemorySourceStore:
+    """Dict-based source registry store."""
+
+    def __init__(self) -> None:
+        self._sources: dict[str, SourceRecord] = {}
+
+    def put(self, source: SourceRecord) -> None:
+        self._sources[source.source_id] = source
+
+    def get(self, source_id: str) -> SourceRecord | None:
+        return self._sources.get(source_id)
+
+    def delete(self, source_id: str) -> bool:
+        return self._sources.pop(source_id, None) is not None
+
+    def list_all(self, tenant_id: str | None = None) -> list[SourceRecord]:
+        sources = list(self._sources.values())
+        if tenant_id is None:
+            return sorted(sources, key=lambda source: source.display_name.lower())
+        return sorted(
+            [source for source in sources if source.tenant_id == tenant_id],
+            key=lambda source: source.display_name.lower(),
+        )
+
+
+class SQLiteSourceStore:
+    """SQLite-backed persistent source registry."""
+
+    def __init__(self, db_path: str = "agent_bom_sources.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        return self._local.conn
+
+    def _init_db(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS sources (
+                source_id TEXT PRIMARY KEY,
+                enabled INTEGER DEFAULT 1,
+                tenant_id TEXT NOT NULL DEFAULT 'default',
+                updated_at TEXT NOT NULL,
+                data TEXT NOT NULL
+            )
+        """)
+        cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sources)").fetchall()}
+        if "tenant_id" not in cols:
+            self._conn.execute("ALTER TABLE sources ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
+        if "updated_at" not in cols:
+            self._conn.execute("ALTER TABLE sources ADD COLUMN updated_at TEXT NOT NULL DEFAULT ''")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_sources_tenant_name ON sources(tenant_id, updated_at)")
+        self._conn.commit()
+
+    def put(self, source: SourceRecord) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO sources (source_id, enabled, tenant_id, updated_at, data)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                source.source_id,
+                int(source.enabled),
+                source.tenant_id,
+                source.updated_at,
+                source.model_dump_json(),
+            ),
+        )
+        self._conn.commit()
+
+    def get(self, source_id: str) -> SourceRecord | None:
+        row = self._conn.execute("SELECT data FROM sources WHERE source_id = ?", (source_id,)).fetchone()
+        if row is None:
+            return None
+        return SourceRecord.model_validate_json(row[0])
+
+    def delete(self, source_id: str) -> bool:
+        cursor = self._conn.execute("DELETE FROM sources WHERE source_id = ?", (source_id,))
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def list_all(self, tenant_id: str | None = None) -> list[SourceRecord]:
+        if tenant_id is None:
+            rows = self._conn.execute("SELECT data FROM sources ORDER BY updated_at DESC, source_id").fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT data FROM sources WHERE tenant_id = ? ORDER BY updated_at DESC, source_id",
+                (tenant_id,),
+            ).fetchall()
+        return [SourceRecord.model_validate_json(row[0]) for row in rows]

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from agent_bom.api.graph_store import GraphStoreProtocol
     from agent_bom.api.models import ScanJob
     from agent_bom.api.schedule_store import ScheduleStore
+    from agent_bom.api.source_store import SourceStore
 
 # ── Shared lock (protects lazy init of all stores) ───────────────────────────
 _store_lock = threading.Lock()
@@ -191,6 +192,23 @@ def set_schedule_store(store: ScheduleStore) -> None:
     """Switch the schedule store backend."""
     global _schedule_store
     _schedule_store = store
+
+
+# ─── Source store (pluggable) ───────────────────────────────────────────────
+_source_store: SourceStore | None = None
+
+
+def _get_source_store() -> SourceStore:
+    """Get the active source registry store. Must be initialized during lifespan."""
+    if _source_store is None:
+        raise RuntimeError("Source store not initialized")
+    return _source_store
+
+
+def set_source_store(store: SourceStore) -> None:
+    """Switch the source registry store backend."""
+    global _source_store
+    _source_store = store
 
 
 # ─── Exception store (enterprise) ───────────────────────────────────────────

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -1,0 +1,206 @@
+"""Tests for hosted-product source registry routes."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as _stores
+from agent_bom.api.server import app, configure_api
+from agent_bom.api.source_store import InMemorySourceStore
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.connectors.base import ConnectorHealthState, ConnectorStatus
+
+ADMIN_HEADERS = {
+    "X-Agent-Bom-Role": "admin",
+    "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+}
+ANALYST_HEADERS = {
+    "X-Agent-Bom-Role": "analyst",
+    "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+}
+VIEWER_HEADERS = {
+    "X-Agent-Bom-Role": "viewer",
+    "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+}
+OTHER_TENANT_HEADERS = {
+    "X-Agent-Bom-Role": "viewer",
+    "X-Agent-Bom-Tenant-ID": "tenant-beta",
+}
+
+
+@pytest.fixture
+def source_client(monkeypatch: pytest.MonkeyPatch):
+    old_source_store = _stores._source_store
+    old_job_store = _stores._store
+
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    configure_api(api_key=None)
+    _stores.set_source_store(InMemorySourceStore())
+    _stores.set_job_store(InMemoryJobStore())
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
+        configure_api(api_key=None)
+        _stores._source_store = old_source_store
+        _stores._store = old_job_store
+
+
+def test_source_crud_and_role_enforcement(source_client: TestClient) -> None:
+    create = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "AWS production account",
+            "kind": "connector.cloud_read_only",
+            "owner": "platform-security",
+            "connector_name": "jira",
+            "credential_mode": "reference",
+            "description": "Read-only cloud discovery source",
+        },
+    )
+    assert create.status_code == 201
+    body = create.json()
+    source_id = body["source_id"]
+    assert body["tenant_id"] == "tenant-alpha"
+    assert body["status"] == "configured"
+
+    listed = source_client.get("/v1/sources", headers=VIEWER_HEADERS)
+    assert listed.status_code == 200
+    listed_body = listed.json()
+    assert listed_body["count"] == 1
+    assert listed_body["sources"][0]["source_id"] == source_id
+
+    updated = source_client.put(
+        f"/v1/sources/{source_id}",
+        headers=ANALYST_HEADERS,
+        json={"description": "Updated source description", "owner": "security-engineering"},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["owner"] == "security-engineering"
+
+    other_tenant = source_client.get(f"/v1/sources/{source_id}", headers=OTHER_TENANT_HEADERS)
+    assert other_tenant.status_code == 404
+
+    delete_forbidden = source_client.delete(f"/v1/sources/{source_id}", headers=ANALYST_HEADERS)
+    assert delete_forbidden.status_code == 403
+
+    deleted = source_client.delete(f"/v1/sources/{source_id}", headers=ADMIN_HEADERS)
+    assert deleted.status_code == 204
+    assert source_client.get("/v1/sources", headers=VIEWER_HEADERS).json()["count"] == 0
+
+
+def test_source_create_rejects_mismatched_tenant(source_client: TestClient) -> None:
+    resp = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "Wrong tenant source",
+            "kind": "scan.repo",
+            "tenant_id": "tenant-beta",
+        },
+    )
+    assert resp.status_code == 403
+    assert "tenant_id must match" in resp.json()["detail"]
+
+
+def test_connector_source_test_updates_health(source_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "agent_bom.connectors.check_connector_health",
+        lambda connector_name: ConnectorStatus(
+            connector=connector_name,
+            state=ConnectorHealthState.HEALTHY,
+            message="Connector can authenticate",
+            api_version="2026-04",
+        ),
+    )
+
+    create = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "Snowflake lake",
+            "kind": "connector.warehouse",
+            "connector_name": "slack",
+            "credential_mode": "reference",
+        },
+    )
+    source_id = create.json()["source_id"]
+
+    tested = source_client.post(f"/v1/sources/{source_id}/test", headers=ANALYST_HEADERS)
+    assert tested.status_code == 200
+    tested_body = tested.json()
+    assert tested_body["status"] == "healthy"
+    assert tested_body["message"] == "Connector can authenticate"
+
+    fetched = source_client.get(f"/v1/sources/{source_id}", headers=VIEWER_HEADERS)
+    assert fetched.status_code == 200
+    fetched_body = fetched.json()
+    assert fetched_body["last_test_status"] == "healthy"
+    assert fetched_body["status"] == "healthy"
+
+
+def test_running_source_queues_source_linked_job(source_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.api.models import ScanJob
+    from agent_bom.api.stores import _get_store, _jobs_put
+
+    def _fake_enqueue(*, tenant_id: str, triggered_by: str, request_body, source_id: str | None = None) -> ScanJob:
+        job = ScanJob(
+            job_id="job-source-1",
+            tenant_id=tenant_id,
+            source_id=source_id,
+            triggered_by=triggered_by,
+            created_at="2026-04-20T00:00:00+00:00",
+            request=request_body,
+        )
+        _get_store().put(job)
+        _jobs_put(job.job_id, job)
+        return job
+
+    monkeypatch.setattr("agent_bom.api.routes.sources.enqueue_scan_job", _fake_enqueue)
+
+    created = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "Repo scan source",
+            "kind": "scan.repo",
+            "config": {"scan_request": {"inventory": "agents.json", "format": "json"}},
+        },
+    )
+    source_id = created.json()["source_id"]
+
+    run = source_client.post(f"/v1/sources/{source_id}/run", headers=ANALYST_HEADERS)
+    assert run.status_code == 202
+    run_body = run.json()
+    assert run_body["source_id"] == source_id
+    assert run_body["status"] == "pending"
+
+    source = source_client.get(f"/v1/sources/{source_id}", headers=VIEWER_HEADERS).json()
+    assert source["last_job_id"] == run_body["job_id"]
+    assert source["last_run_status"] == "pending"
+
+    jobs = source_client.get(f"/v1/sources/{source_id}/jobs", headers=VIEWER_HEADERS)
+    assert jobs.status_code == 200
+    jobs_body = jobs.json()
+    assert jobs_body["count"] == 1
+    assert jobs_body["jobs"][0]["job_id"] == run_body["job_id"]
+    assert jobs_body["jobs"][0]["source_id"] == source_id
+
+
+def test_push_and_runtime_sources_reject_run_now(source_client: TestClient) -> None:
+    for kind in ("ingest.trace_push", "runtime.gateway"):
+        created = source_client.post(
+            "/v1/sources",
+            headers=ANALYST_HEADERS,
+            json={
+                "display_name": f"Source for {kind}",
+                "kind": kind,
+            },
+        )
+        source_id = created.json()["source_id"]
+        resp = source_client.post(f"/v1/sources/{source_id}/run", headers=ANALYST_HEADERS)
+        assert resp.status_code == 409

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -165,6 +165,21 @@ def test_get_schedule_store_raises_runtime_error_when_uninitialized():
         _stores._schedule_store = old
 
 
+def test_get_source_store_raises_runtime_error_when_uninitialized():
+    from agent_bom.api import stores as _stores
+
+    old = _stores._source_store
+    try:
+        _stores._source_store = None
+        try:
+            _stores._get_source_store()
+            assert False, "expected RuntimeError"
+        except RuntimeError as exc:
+            assert "not initialized" in str(exc)
+    finally:
+        _stores._source_store = old
+
+
 # ── Pagination ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -938,6 +938,48 @@ def test_schedule_store_list_due(mock_pool):
     assert isinstance(result, list)
 
 
+def test_source_store_init(mock_pool):
+    from agent_bom.api.postgres_store import PostgresSourceStore
+
+    store = PostgresSourceStore(pool=mock_pool)
+    assert store is not None
+
+
+def test_source_store_put_get_list_delete(mock_pool):
+    from agent_bom.api.models import SourceKind, SourceRecord
+    from agent_bom.api.postgres_store import PostgresSourceStore
+
+    store = PostgresSourceStore(pool=mock_pool)
+    source = SourceRecord(
+        source_id="source-1",
+        tenant_id="tenant-alpha",
+        display_name="AWS production",
+        kind=SourceKind.CONNECTOR_CLOUD_READ_ONLY,
+        connector_name="jira",
+        credential_mode="reference",
+        created_at="2026-04-20T00:00:00+00:00",
+        updated_at="2026-04-20T00:00:00+00:00",
+    )
+    store.put(source)
+
+    mock_pool._conn._store.setdefault("control_plane_sources", {})["source-1"] = (
+        "source-1",
+        1,
+        "tenant-alpha",
+        "2026-04-20T00:00:00+00:00",
+        source.model_dump_json(),
+    )
+
+    loaded = store.get("source-1")
+    assert loaded is not None
+    assert loaded.source_id == "source-1"
+
+    listed = store.list_all(tenant_id="tenant-alpha")
+    assert isinstance(listed, list)
+
+    assert store.delete("source-1") is True
+
+
 def test_tenant_context_is_applied_to_postgres_session(mock_pool):
     from agent_bom.api.postgres_store import PostgresFleetStore, reset_current_tenant, set_current_tenant
 
@@ -1083,3 +1125,13 @@ def test_server_lifespan_postgres_enterprise_stores():
     assert "PostgresExceptionStore" in source
     assert "PostgresAuditLog" in source
     assert "PostgresTrendStore" in source
+
+
+def test_server_lifespan_postgres_source_store():
+    """PostgresSourceStore is referenced in server lifespan."""
+    import inspect
+
+    from agent_bom.api import server
+
+    source = inspect.getsource(server._lifespan)
+    assert "PostgresSourceStore" in source

--- a/ui/app/sources/page.tsx
+++ b/ui/app/sources/page.tsx
@@ -1,239 +1,711 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 import {
   Activity,
   ArrowRight,
+  CalendarClock,
   Cloud,
   Database,
+  Plus,
   Radio,
-  ScanSearch,
+  RefreshCcw,
+  ServerCog,
   Shield,
+  ShieldCheck,
   Workflow,
 } from "lucide-react";
 
-type SourceMode = "Direct scan" | "Read-only integration" | "Pushed ingest" | "Imported artifact";
+import {
+  api,
+  type AuthDebugResponse,
+  type ConnectorHealthResponse,
+  type ScanSchedule,
+  type SourceCreateRequest,
+  type SourceKind,
+  type SourceRecord,
+} from "@/lib/api";
 
-interface SourceCard {
-  title: string;
-  mode: SourceMode;
-  description: string;
-  href?: string;
-  action?: string;
-  status: string;
+type IngestMode = "Direct scan" | "Read-only connector" | "Pushed ingest" | "Runtime" | "Imported artifact";
+
+interface KindOption {
+  value: SourceKind;
+  label: string;
+  mode: IngestMode;
+  detail: string;
 }
 
-const SOURCE_GROUPS: Array<{
-  label: string;
-  icon: React.ComponentType<{ className?: string }>;
-  summary: string;
-  cards: SourceCard[];
-}> = [
+interface FormState {
+  display_name: string;
+  kind: SourceKind;
+  description: string;
+  owner: string;
+  connector_name: string;
+}
+
+const SOURCE_KIND_OPTIONS: KindOption[] = [
   {
-    label: "Direct scans",
-    icon: ScanSearch,
-    summary: "Agentless or local scan jobs that agent-bom launches directly.",
-    cards: [
-      {
-        title: "Local inventory and MCP discovery",
-        mode: "Direct scan",
-        description: "Scan local MCP configs, Python agent projects, GitHub Actions, inventories, container images, and Terraform from the New Scan flow.",
-        href: "/scan",
-        action: "Open New Scan",
-        status: "Shipping now",
-      },
-      {
-        title: "Kubernetes and image analysis",
-        mode: "Direct scan",
-        description: "Use the same scan flow for cluster inventory and container/image package analysis where you can point agent-bom at the runtime or artifact directly.",
-        href: "/scan",
-        action: "Launch direct scan",
-        status: "Shipping now",
-      },
-    ],
+    value: "scan.repo",
+    label: "Repo / package scan",
+    mode: "Direct scan",
+    detail: "Trigger repo, package, or SBOM-oriented discovery jobs through the control plane.",
   },
   {
-    label: "Connected sources",
-    icon: Cloud,
-    summary: "Read-only sources where the customer points us at a cloud or SaaS system that already contains the data.",
-    cards: [
-      {
-        title: "Governance and cloud activity",
-        mode: "Read-only integration",
-        description: "Snowflake-backed governance, access history, and activity pages already consume cloud-side telemetry without forcing everything through the local scan form.",
-        href: "/governance",
-        action: "Open Governance",
-        status: "Shipping now",
-      },
-      {
-        title: "Connector-backed discovery",
-        mode: "Read-only integration",
-        description: "The backend exposes connector and SIEM connector routes today. The product still needs a first-class setup wizard in the UI.",
-        status: "API first today",
-      },
-    ],
+    value: "scan.image",
+    label: "Container / image scan",
+    mode: "Direct scan",
+    detail: "Run image and package analysis as a queued scan job instead of from the browser.",
   },
   {
-    label: "Ingested evidence",
-    icon: Radio,
-    summary: "Evidence pushed into agent-bom from an existing collector, exporter, or security data lake workflow.",
-    cards: [
-      {
-        title: "OTLP traces and runtime events",
-        mode: "Pushed ingest",
-        description: "The traces surface and POST /v1/traces route accept OTLP JSON so teams can correlate runtime calls against known vulnerable assets.",
-        href: "/traces",
-        action: "Open Traces",
-        status: "Shipping now",
-      },
-      {
-        title: "Security lake and warehouse feeds",
-        mode: "Pushed ingest",
-        description: "If customers already centralize evidence in Snowflake or another data platform, agent-bom should consume that source of truth instead of duplicating collection.",
-        href: "/activity",
-        action: "Open Activity",
-        status: "Partial today",
-      },
-    ],
+    value: "scan.iac",
+    label: "IaC / cluster scan",
+    mode: "Direct scan",
+    detail: "Schedule Terraform, Kubernetes, and infrastructure posture scans.",
   },
   {
-    label: "Imported artifacts",
-    icon: Database,
-    summary: "Customer-exported files that agent-bom can analyze without managing the source system.",
-    cards: [
-      {
-        title: "SBOM and custom inventory inputs",
-        mode: "Imported artifact",
-        description: "SBOMs, custom inventory JSON, and similar exported artifacts remain valid entry points when direct access is not available or not desired.",
-        href: "/scan",
-        action: "Use scan inputs",
-        status: "Shipping now",
-      },
-    ],
+    value: "scan.cloud",
+    label: "Cloud account scan",
+    mode: "Direct scan",
+    detail: "Launch cloud discovery through backend-owned jobs and read-only account access.",
+  },
+  {
+    value: "scan.mcp_config",
+    label: "MCP configuration scan",
+    mode: "Direct scan",
+    detail: "Discover MCP servers, tools, and agent config entry points from inventory sources.",
+  },
+  {
+    value: "connector.cloud_read_only",
+    label: "Cloud API connector",
+    mode: "Read-only connector",
+    detail: "Use a named backend connector to read approved cloud APIs with customer-managed credentials.",
+  },
+  {
+    value: "connector.registry",
+    label: "Registry / package connector",
+    mode: "Read-only connector",
+    detail: "Attach registry-style connectors and run them as first-class sources.",
+  },
+  {
+    value: "connector.warehouse",
+    label: "Warehouse / lake connector",
+    mode: "Read-only connector",
+    detail: "Consume inventory or security-lake evidence from the customer’s existing data platform.",
+  },
+  {
+    value: "ingest.fleet_sync",
+    label: "Fleet sync",
+    mode: "Pushed ingest",
+    detail: "Accept fleet inventory from authenticated push routes instead of direct browser collection.",
+  },
+  {
+    value: "ingest.trace_push",
+    label: "Trace ingest",
+    mode: "Pushed ingest",
+    detail: "Receive OTLP-style traces and correlate runtime evidence inside the control plane.",
+  },
+  {
+    value: "ingest.result_push",
+    label: "Result push",
+    mode: "Pushed ingest",
+    detail: "Store pushed findings or inventory evidence from other approved producers.",
+  },
+  {
+    value: "ingest.artifact_import",
+    label: "Artifact import",
+    mode: "Imported artifact",
+    detail: "Use exported SBOMs, inventories, or third-party results as a customer-approved intake path.",
+  },
+  {
+    value: "runtime.proxy",
+    label: "MCP proxy runtime",
+    mode: "Runtime",
+    detail: "Track runtime evidence from agent-bom proxy deployment paths in customer-controlled environments.",
+  },
+  {
+    value: "runtime.gateway",
+    label: "MCP gateway runtime",
+    mode: "Runtime",
+    detail: "Treat the MCP gateway as a first-class runtime source with policy-audited upstream traffic.",
   },
 ];
 
-const OPERATING_SURFACES: Array<{
-  title: string;
-  icon: React.ComponentType<{ className?: string }>;
-  href: string;
-  summary: string;
-  status: string;
-}> = [
+const DEFAULT_FORM_STATE: FormState = {
+  display_name: "",
+  kind: "scan.repo",
+  description: "",
+  owner: "",
+  connector_name: "",
+};
+
+const OPERATING_SURFACES = [
   {
     title: "Security graph and path analysis",
-    icon: Workflow,
     href: "/security-graph",
     summary: "Persisted graph snapshots, attack-path focus, and blast-radius analysis across agents, servers, packages, tools, and credentials.",
     status: "Analyze",
+    icon: Workflow,
   },
   {
     title: "Fleet management",
-    icon: Activity,
     href: "/fleet",
-    summary: "Persisted agent inventory, lifecycle state, trust score, and operational review state for the agent fleet.",
+    summary: "Persisted fleet inventory and trust posture once the data lands in the control plane.",
     status: "Operate",
+    icon: Activity,
   },
   {
     title: "Runtime proxy and alerts",
-    icon: Radio,
     href: "/proxy",
     summary: "Live runtime enforcement, detector alerts, drift protection, and audit review for MCP and tool-call activity.",
     status: "Runtime",
+    icon: Radio,
   },
   {
     title: "Gateway and policy enforcement",
-    icon: Shield,
     href: "/gateway",
-    summary: "Policy evaluation, review, and enforcement surfaces for controlling high-impact tool usage and approval workflows.",
+    summary: "Policy evaluation and enforcement for high-impact tool usage and approval workflows.",
     status: "Protect",
+    icon: Shield,
   },
 ];
 
-function modeTone(mode: SourceMode): string {
+function formatWhen(value: string | null): string {
+  if (!value) return "Not yet";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function toneForMode(mode: IngestMode): string {
   switch (mode) {
     case "Direct scan":
-      return "text-emerald-400 border-emerald-900/60 bg-emerald-950/30";
-    case "Read-only integration":
-      return "text-sky-400 border-sky-900/60 bg-sky-950/30";
+      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-400";
+    case "Read-only connector":
+      return "border-sky-900/60 bg-sky-950/30 text-sky-400";
     case "Pushed ingest":
-      return "text-amber-400 border-amber-900/60 bg-amber-950/30";
+      return "border-amber-900/60 bg-amber-950/30 text-amber-400";
+    case "Runtime":
+      return "border-violet-900/60 bg-violet-950/30 text-violet-400";
     case "Imported artifact":
-      return "text-fuchsia-400 border-fuchsia-900/60 bg-fuchsia-950/30";
+      return "border-fuchsia-900/60 bg-fuchsia-950/30 text-fuchsia-400";
+  }
+}
+
+function toneForStatus(status: string): string {
+  switch (status) {
+    case "healthy":
+      return "text-emerald-400";
+    case "degraded":
+      return "text-amber-400";
+    case "disabled":
+      return "text-zinc-400";
+    default:
+      return "text-sky-400";
   }
 }
 
 export default function SourcesPage() {
+  const [authDebug, setAuthDebug] = useState<AuthDebugResponse | null>(null);
+  const [connectorHealth, setConnectorHealth] = useState<ConnectorHealthResponse[]>([]);
+  const [schedules, setSchedules] = useState<ScanSchedule[]>([]);
+  const [sources, setSources] = useState<SourceRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [syncingFleet, setSyncingFleet] = useState(false);
+  const [fleetSyncSummary, setFleetSyncSummary] = useState<string | null>(null);
+  const [formState, setFormState] = useState<FormState>(DEFAULT_FORM_STATE);
+  const [submitting, setSubmitting] = useState(false);
+  const [formMessage, setFormMessage] = useState<string | null>(null);
+  const [busySourceId, setBusySourceId] = useState<string | null>(null);
+
+  const connectorNames = useMemo(
+    () => connectorHealth.map((connector) => connector.connector).sort((left, right) => left.localeCompare(right)),
+    [connectorHealth]
+  );
+  const selectedKind = useMemo(
+    () => SOURCE_KIND_OPTIONS.find((option) => option.value === formState.kind) ?? SOURCE_KIND_OPTIONS[0],
+    [formState.kind]
+  );
+  const sourceCount = sources.length;
+  const healthyConnectors = useMemo(
+    () => connectorHealth.filter((connector) => connector.state === "healthy").length,
+    [connectorHealth]
+  );
+
+  function updateForm<K extends keyof FormState>(field: K, value: FormState[K]) {
+    setFormState((current) => ({ ...current, [field]: value }));
+  }
+
+  async function refreshControlPlane() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [authResult, connectorsResult, schedulesResult, sourcesResult] = await Promise.allSettled([
+        api.getAuthDebug(),
+        api.listConnectors(),
+        api.listSchedules(),
+        api.listSources(),
+      ]);
+
+      if (authResult.status === "fulfilled") {
+        setAuthDebug(authResult.value);
+      }
+
+      if (sourcesResult.status === "fulfilled") {
+        setSources(sourcesResult.value.sources);
+      } else {
+        setSources([]);
+      }
+
+      if (schedulesResult.status === "fulfilled") {
+        const sorted = [...schedulesResult.value].sort((left, right) => {
+          const leftTime = left.next_run ? Date.parse(left.next_run) : Number.POSITIVE_INFINITY;
+          const rightTime = right.next_run ? Date.parse(right.next_run) : Number.POSITIVE_INFINITY;
+          return leftTime - rightTime;
+        });
+        setSchedules(sorted);
+      } else {
+        setSchedules([]);
+      }
+
+      if (connectorsResult.status === "fulfilled") {
+        const healthResults = await Promise.allSettled(
+          connectorsResult.value.connectors.map((name) => api.getConnectorHealth(name))
+        );
+        const healthy = healthResults.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []));
+        setConnectorHealth(healthy);
+      } else {
+        setConnectorHealth([]);
+      }
+
+      const failures = [authResult, connectorsResult, schedulesResult, sourcesResult].filter(
+        (result) => result.status === "rejected"
+      );
+      if (failures.length === 4) {
+        setError("Failed to load control-plane source state.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refreshControlPlane().catch((err) => {
+      setError(err instanceof Error ? err.message : "Failed to load source state.");
+      setLoading(false);
+    });
+  }, []);
+
+  async function handleFleetSync() {
+    setSyncingFleet(true);
+    setFleetSyncSummary(null);
+    try {
+      const result = await api.syncFleet();
+      setFleetSyncSummary(`${result.synced} synced · ${result.new} new · ${result.updated} updated`);
+      await refreshControlPlane();
+    } catch (err) {
+      setFleetSyncSummary(err instanceof Error ? err.message : "Fleet sync failed");
+    } finally {
+      setSyncingFleet(false);
+    }
+  }
+
+  async function handleCreateSource(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFormMessage(null);
+
+    const payload: SourceCreateRequest = {
+      display_name: formState.display_name.trim(),
+      kind: formState.kind,
+      description: formState.description.trim(),
+      owner: formState.owner.trim(),
+      enabled: true,
+      credential_mode: selectedKind.mode === "Read-only connector" ? "reference" : "none",
+    };
+
+    if (!payload.display_name) {
+      setFormMessage("Display name is required.");
+      return;
+    }
+
+    if (selectedKind.mode === "Read-only connector") {
+      if (!formState.connector_name.trim()) {
+        setFormMessage("Connector-backed sources require a connector name.");
+        return;
+      }
+      payload.connector_name = formState.connector_name.trim();
+    }
+
+    setSubmitting(true);
+    try {
+      await api.createSource(payload);
+      setFormMessage(`Created source ${payload.display_name}.`);
+      setFormState({
+        ...DEFAULT_FORM_STATE,
+        kind: payload.kind,
+      });
+      await refreshControlPlane();
+    } catch (err) {
+      setFormMessage(err instanceof Error ? err.message : "Failed to create source.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function runSourceAction(sourceId: string, action: "test" | "run" | "delete") {
+    setBusySourceId(sourceId);
+    setFormMessage(null);
+
+    try {
+      if (action === "test") {
+        const result = await api.testSource(sourceId);
+        setFormMessage(result.message);
+      } else if (action === "run") {
+        const result = await api.runSource(sourceId);
+        setFormMessage(`Queued job ${result.job_id}.`);
+      } else {
+        await api.deleteSource(sourceId);
+        setFormMessage("Source deleted.");
+      }
+      await refreshControlPlane();
+    } catch (err) {
+      setFormMessage(err instanceof Error ? err.message : "Source action failed.");
+    } finally {
+      setBusySourceId(null);
+    }
+  }
+
   return (
     <div className="space-y-6">
       <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] p-6 shadow-2xl shadow-black/10">
-        <p className="text-[11px] uppercase tracking-[0.22em] text-emerald-400">Data sources</p>
-        <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--foreground)]">Data sources and operating surfaces</h1>
-        <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--text-secondary)]">
-          The product should support three honest modes: launch direct scans, connect to a read-only source, or ingest evidence that the customer already
-          centralizes elsewhere. This page makes those boundaries explicit and also shows where runtime, fleet, graph, and policy surfaces fit once the data
-          is in the system.
-        </p>
-        <div className="mt-5 flex flex-wrap gap-3 text-xs text-[var(--text-secondary)]">
-          <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5">Canonical model first</span>
-          <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5">Read-only where possible</span>
-          <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5">Bring your data when collection already exists</span>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.22em] text-emerald-400">Hosted control plane</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--foreground)]">Sources and ingest control</h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--text-secondary)]">
+              The UI should declare intent and review state. The API owns auth, orchestration, graph, persistence, audit, and policy. Workers,
+              connectors, proxy, and gateway paths do the privileged collection work.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              onClick={() => refreshControlPlane()}
+              className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+            >
+              <RefreshCcw className="h-4 w-4" />
+              Refresh
+            </button>
+            <button
+              onClick={handleFleetSync}
+              disabled={syncingFleet}
+              className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Activity className="h-4 w-4" />
+              {syncingFleet ? "Syncing fleet…" : "Run fleet sync"}
+            </button>
+          </div>
         </div>
+
+        <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <MetricCard
+            icon={ShieldCheck}
+            label="Auth mode"
+            value={authDebug?.auth_method ?? (loading ? "Loading…" : "Unknown")}
+            detail={
+              authDebug
+                ? `${authDebug.role ?? "no role"} · tenant ${authDebug.tenant_id} · ${authDebug.recommended_ui_mode}`
+                : "API/control plane owns auth and tenant scope"
+            }
+          />
+          <MetricCard
+            icon={ServerCog}
+            label="Registered sources"
+            value={loading ? "Loading…" : String(sourceCount)}
+            detail={sources[0]?.updated_at ? `Last update ${formatWhen(sources[0].updated_at)}` : "No source registry records yet"}
+          />
+          <MetricCard
+            icon={Cloud}
+            label="Connector health"
+            value={loading ? "Loading…" : `${healthyConnectors}/${connectorHealth.length || 0}`}
+            detail="Read-only integrations checked through backend health routes"
+          />
+          <MetricCard
+            icon={CalendarClock}
+            label="Schedules"
+            value={loading ? "Loading…" : String(schedules.length)}
+            detail={schedules[0]?.next_run ? `Next run ${formatWhen(schedules[0].next_run)}` : "No persisted schedules yet"}
+          />
+        </div>
+
+        {fleetSyncSummary ? <p className="mt-4 text-sm text-emerald-400">{fleetSyncSummary}</p> : null}
+        {formMessage ? <p className="mt-2 text-sm text-emerald-400">{formMessage}</p> : null}
+        {error ? <p className="mt-2 text-sm text-red-400">{error}</p> : null}
       </section>
 
-      <div className="grid gap-6 xl:grid-cols-2">
-        {SOURCE_GROUPS.map((group) => {
-          const Icon = group.icon;
-          return (
-            <section
-              key={group.label}
-              className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5"
-            >
-              <div className="flex items-start gap-3">
-                <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-                  <Icon className="h-5 w-5 text-emerald-400" />
-                </span>
-                <div>
-                  <h2 className="text-base font-semibold text-[var(--foreground)]">{group.label}</h2>
-                  <p className="mt-1 text-sm text-[var(--text-secondary)]">{group.summary}</p>
-                </div>
-              </div>
+      <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+        <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
+          <div className="flex items-start gap-3">
+            <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
+              <Database className="h-5 w-5 text-emerald-400" />
+            </span>
+            <div>
+              <h2 className="text-base font-semibold text-[var(--foreground)]">Source registry</h2>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                Each source is a persisted control-plane record with tenant scope, ownership, credential mode, last test, and last run state.
+              </p>
+            </div>
+          </div>
 
-              <div className="mt-5 space-y-3">
-                {group.cards.map((card) => {
-                  const content = (
-                    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 transition-colors hover:border-[color:var(--border-strong)]">
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <div className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-medium ${modeTone(card.mode)}`}>
-                            {card.mode}
-                          </div>
-                          <h3 className="mt-3 text-sm font-semibold text-[var(--foreground)]">{card.title}</h3>
+          <div className="mt-5 space-y-3">
+            {sources.length === 0 && !loading ? (
+              <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
+                No registered sources yet. Create one here, then test it or run it from the control plane.
+              </div>
+            ) : (
+              sources.map((source) => {
+                const option = SOURCE_KIND_OPTIONS.find((entry) => entry.value === source.kind);
+                const isBusy = busySourceId === source.source_id;
+                return (
+                  <div
+                    key={source.source_id}
+                    className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-medium ${toneForMode(option?.mode ?? "Direct scan")}`}>
+                          {option?.mode ?? source.kind}
                         </div>
-                        {card.href ? <ArrowRight className="mt-1 h-4 w-4 text-[var(--text-tertiary)]" /> : null}
+                        <h3 className="mt-3 text-sm font-semibold text-[var(--foreground)]">{source.display_name}</h3>
+                        <p className="mt-1 text-xs text-[var(--text-secondary)]">{option?.label ?? source.kind}</p>
                       </div>
-                      <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">{card.description}</p>
-                      <div className="mt-4 flex items-center justify-between gap-3">
-                        <span className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{card.status}</span>
-                        {card.href && card.action ? (
-                          <span className="text-xs font-medium text-emerald-400">{card.action}</span>
-                        ) : null}
+                      <div className="text-right">
+                        <p className={`text-[11px] uppercase tracking-[0.18em] ${toneForStatus(source.status)}`}>{source.status}</p>
+                        <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">{source.enabled ? "Enabled" : "Disabled"}</p>
                       </div>
                     </div>
-                  );
 
-                  return card.href ? (
-                    <Link key={card.title} href={card.href}>
-                      {content}
-                    </Link>
-                  ) : (
-                    <div key={card.title}>{content}</div>
-                  );
-                })}
+                    {source.description ? <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">{source.description}</p> : null}
+
+                    <div className="mt-3 grid gap-2 text-xs text-[var(--text-secondary)] sm:grid-cols-2">
+                      <span>Owner: {source.owner || "Unassigned"}</span>
+                      <span>Credential mode: {source.credential_mode}</span>
+                      <span>Connector: {source.connector_name || "—"}</span>
+                      <span>Last tested: {formatWhen(source.last_tested_at)}</span>
+                      <span>Last run: {formatWhen(source.last_run_at)}</span>
+                      <span>Last job: {source.last_job_id || "—"}</span>
+                    </div>
+
+                    {source.last_test_message ? (
+                      <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">{source.last_test_message}</p>
+                    ) : null}
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <button
+                        onClick={() => runSourceAction(source.source_id, "test")}
+                        disabled={isBusy}
+                        className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {isBusy ? "Working…" : "Test"}
+                      </button>
+                      <button
+                        onClick={() => runSourceAction(source.source_id, "run")}
+                        disabled={isBusy || !source.enabled}
+                        className="rounded-xl bg-emerald-500 px-3 py-2 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Run now
+                      </button>
+                      <button
+                        onClick={() => runSourceAction(source.source_id, "delete")}
+                        disabled={isBusy}
+                        className="rounded-xl border border-red-900/60 bg-red-950/20 px-3 py-2 text-xs font-medium text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
+            <div className="flex items-start gap-3">
+              <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
+                <Plus className="h-5 w-5 text-emerald-400" />
+              </span>
+              <div>
+                <h2 className="text-base font-semibold text-[var(--foreground)]">Create source</h2>
+                <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                  Register the source here, then let backend jobs, connectors, proxy, or gateway paths do the collection work.
+                </p>
               </div>
-            </section>
-          );
-        })}
+            </div>
+
+            <form className="mt-5 space-y-4" onSubmit={handleCreateSource}>
+              <label className="block">
+                <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Display name</span>
+                <input
+                  value={formState.display_name}
+                  onChange={(event) => updateForm("display_name", event.target.value)}
+                  className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                  placeholder="AWS production account"
+                />
+              </label>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="block">
+                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Kind</span>
+                  <select
+                    value={formState.kind}
+                    onChange={(event) => updateForm("kind", event.target.value as SourceKind)}
+                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                  >
+                    {SOURCE_KIND_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Owner</span>
+                  <input
+                    value={formState.owner}
+                    onChange={(event) => updateForm("owner", event.target.value)}
+                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    placeholder="platform-security"
+                  />
+                </label>
+              </div>
+
+              {selectedKind.mode === "Read-only connector" ? (
+                <label className="block">
+                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Connector name</span>
+                  <select
+                    value={formState.connector_name}
+                    onChange={(event) => updateForm("connector_name", event.target.value)}
+                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                  >
+                    <option value="">Choose connector…</option>
+                    {connectorNames.map((connector) => (
+                      <option key={connector} value={connector}>
+                        {connector}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+
+              <label className="block">
+                <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Description</span>
+                <textarea
+                  value={formState.description}
+                  onChange={(event) => updateForm("description", event.target.value)}
+                  rows={3}
+                  className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                  placeholder={selectedKind.detail}
+                />
+              </label>
+
+              <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-xs leading-5 text-[var(--text-secondary)]">
+                <div className={`inline-flex rounded-full border px-2.5 py-1 font-medium ${toneForMode(selectedKind.mode)}`}>{selectedKind.mode}</div>
+                <p className="mt-3">{selectedKind.detail}</p>
+              </div>
+
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <Plus className="h-4 w-4" />
+                {submitting ? "Creating…" : "Create source"}
+              </button>
+            </form>
+          </section>
+
+          <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
+            <div className="flex items-start gap-3">
+              <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
+                <Cloud className="h-5 w-5 text-emerald-400" />
+              </span>
+              <div>
+                <h2 className="text-base font-semibold text-[var(--foreground)]">Connector health</h2>
+                <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                  Read-only integrations are backend-owned. The browser only reviews health and initiates control-plane actions.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 space-y-3">
+              {connectorHealth.length === 0 && !loading ? (
+                <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
+                  No connector health state loaded yet.
+                </div>
+              ) : (
+                connectorHealth.map((connector) => (
+                  <div key={connector.connector} className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-sm font-semibold text-[var(--foreground)]">{connector.connector}</h3>
+                        <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">{connector.message}</p>
+                      </div>
+                      <span className={`text-[11px] uppercase tracking-[0.18em] ${toneForStatus(connector.state)}`}>{connector.state}</span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
+            <div className="flex items-start gap-3">
+              <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
+                <CalendarClock className="h-5 w-5 text-emerald-400" />
+              </span>
+              <div>
+                <h2 className="text-base font-semibold text-[var(--foreground)]">Persisted schedules</h2>
+                <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                  Recurring collection belongs to the control plane. This page already reflects real schedule state from the backend.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 space-y-3">
+              {schedules.length === 0 && !loading ? (
+                <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+                  <p className="text-sm text-[var(--text-secondary)]">No scan schedules yet.</p>
+                  <Link href="/scan" className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-emerald-400">
+                    Open New Scan
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </div>
+              ) : (
+                schedules.slice(0, 4).map((schedule) => (
+                  <div key={schedule.schedule_id} className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-sm font-semibold text-[var(--foreground)]">{schedule.name}</h3>
+                        <p className="mt-1 font-mono text-xs text-[var(--text-secondary)]">{schedule.cron_expression}</p>
+                      </div>
+                      <span className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                        {schedule.enabled ? "Enabled" : "Paused"}
+                      </span>
+                    </div>
+                    <div className="mt-3 grid gap-2 text-xs text-[var(--text-secondary)] sm:grid-cols-2">
+                      <span>Next run: {formatWhen(schedule.next_run)}</span>
+                      <span>Last run: {formatWhen(schedule.last_run)}</span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </section>
       </div>
 
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
@@ -244,8 +716,8 @@ export default function SourcesPage() {
           <div>
             <h2 className="text-base font-semibold text-[var(--foreground)]">Operating surfaces after ingest</h2>
             <p className="mt-1 text-sm text-[var(--text-secondary)]">
-              Discovery and ingest are only the front door. Agent-bom also needs clear surfaces for runtime review, fleet operations, policy enforcement,
-              and graph analysis after the data lands.
+              Discovery and ingest are only the front door. Agent-bom also needs clear surfaces for runtime review, fleet operations, policy
+              enforcement, and graph analysis after the data lands.
             </p>
           </div>
         </div>
@@ -275,21 +747,33 @@ export default function SourcesPage() {
           })}
         </div>
       </section>
+    </div>
+  );
+}
 
-      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
-        <div className="flex items-start gap-3">
-          <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-            <Shield className="h-5 w-5 text-emerald-400" />
-          </span>
-          <div>
-            <h2 className="text-base font-semibold text-[var(--foreground)]">Guardrail principle</h2>
-            <p className="mt-2 text-sm leading-6 text-[var(--text-secondary)]">
-              Prefer agentless read-only discovery when the product can safely gather the data itself. When the customer already owns the collection path,
-              use imported artifacts or pushed ingest instead of rebuilding their telemetry pipeline inside agent-bom.
-            </p>
-          </div>
+function MetricCard({
+  icon: Icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <div className="flex items-center gap-3">
+        <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-2">
+          <Icon className="h-4 w-4 text-emerald-400" />
+        </span>
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{label}</p>
+          <p className="mt-1 text-lg font-semibold text-[var(--foreground)]">{value}</p>
         </div>
-      </section>
+      </div>
+      <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">{detail}</p>
     </div>
   );
 }

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -68,6 +68,9 @@ export interface ScanJob {
   job_id: string;
   status: JobStatus;
   created_at: string;
+  tenant_id?: string;
+  source_id?: string;
+  triggered_by?: string;
   started_at?: string;
   completed_at?: string;
   request: ScanRequest;
@@ -464,6 +467,107 @@ export interface AuthDebugResponse {
   span_id: string | null;
 }
 
+export interface ConnectorsResponse {
+  connectors: string[];
+}
+
+export interface ConnectorHealthResponse {
+  connector: string;
+  state: string;
+  message: string;
+  api_version: string | null;
+}
+
+export type SourceKind =
+  | "scan.repo"
+  | "scan.image"
+  | "scan.iac"
+  | "scan.cloud"
+  | "scan.mcp_config"
+  | "connector.cloud_read_only"
+  | "connector.registry"
+  | "connector.warehouse"
+  | "ingest.fleet_sync"
+  | "ingest.trace_push"
+  | "ingest.result_push"
+  | "ingest.artifact_import"
+  | "runtime.proxy"
+  | "runtime.gateway";
+
+export type SourceStatus = "configured" | "healthy" | "degraded" | "disabled";
+
+export interface SourceRecord {
+  source_id: string;
+  tenant_id: string;
+  display_name: string;
+  kind: SourceKind;
+  description: string;
+  owner: string;
+  connector_name: string | null;
+  credential_mode: string;
+  credential_ref: string | null;
+  enabled: boolean;
+  status: SourceStatus;
+  config: Record<string, unknown>;
+  last_tested_at: string | null;
+  last_test_status: string | null;
+  last_test_message: string | null;
+  last_run_at: string | null;
+  last_run_status: string | null;
+  last_job_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SourcesResponse {
+  sources: SourceRecord[];
+  count: number;
+}
+
+export interface SourceCreateRequest {
+  display_name: string;
+  kind: SourceKind;
+  description?: string;
+  owner?: string;
+  connector_name?: string | null;
+  credential_mode?: string;
+  credential_ref?: string | null;
+  enabled?: boolean;
+  config?: Record<string, unknown>;
+  tenant_id?: string;
+}
+
+export interface SourceUpdateRequest {
+  display_name?: string;
+  description?: string;
+  owner?: string;
+  connector_name?: string | null;
+  credential_mode?: string;
+  credential_ref?: string | null;
+  enabled?: boolean;
+  status?: SourceStatus;
+  config?: Record<string, unknown>;
+}
+
+export interface SourceCheckResponse {
+  source_id: string;
+  status: SourceStatus;
+  message: string;
+  tested_at: string;
+}
+
+export interface SourceRunResponse {
+  source_id: string;
+  job_id: string;
+  status: JobStatus;
+}
+
+export interface SourceJobsResponse {
+  source_id: string;
+  jobs: ScanJob[];
+  count: number;
+}
+
 export interface JobsResponse {
   jobs: JobListItem[];
   count: number;
@@ -693,6 +797,28 @@ export interface FleetSyncResult {
   synced: number;
   new: number;
   updated: number;
+}
+
+export interface ScanSchedule {
+  schedule_id: string;
+  name: string;
+  cron_expression: string;
+  scan_config: Record<string, unknown>;
+  enabled: boolean;
+  last_run: string | null;
+  next_run: string | null;
+  last_job_id: string | null;
+  created_at: string;
+  updated_at: string;
+  tenant_id: string;
+}
+
+export interface ScheduleCreateRequest {
+  name: string;
+  cron_expression: string;
+  scan_config?: Record<string, unknown>;
+  enabled?: boolean;
+  tenant_id?: string;
 }
 
 // ─── Gateway types ───────────────────────────────────────────────────────────
@@ -1021,6 +1147,23 @@ export const api = {
   updateFleetAgent: (agentId: string, update: Partial<FleetAgent>) =>
     put<unknown>(`/v1/fleet/${agentId}`, update),
   getFleetStats: () => get<FleetStatsResponse>("/v1/fleet/stats"),
+
+  // ── Connectors / sources ──
+  listConnectors: () => get<ConnectorsResponse>("/v1/connectors"),
+  getConnectorHealth: (name: string) => get<ConnectorHealthResponse>(`/v1/connectors/${encodeURIComponent(name)}/health`),
+  listSources: () => get<SourcesResponse>("/v1/sources"),
+  getSource: (sourceId: string) => get<SourceRecord>(`/v1/sources/${encodeURIComponent(sourceId)}`),
+  createSource: (body: SourceCreateRequest) => post<SourceRecord>("/v1/sources", body),
+  updateSource: (sourceId: string, body: SourceUpdateRequest) =>
+    put<SourceRecord>(`/v1/sources/${encodeURIComponent(sourceId)}`, body),
+  deleteSource: (sourceId: string) => del(`/v1/sources/${encodeURIComponent(sourceId)}`),
+  testSource: (sourceId: string) => post<SourceCheckResponse>(`/v1/sources/${encodeURIComponent(sourceId)}/test`, {}),
+  runSource: (sourceId: string) => post<SourceRunResponse>(`/v1/sources/${encodeURIComponent(sourceId)}/run`, {}),
+  listSourceJobs: (sourceId: string) => get<SourceJobsResponse>(`/v1/sources/${encodeURIComponent(sourceId)}/jobs`),
+  listSchedules: () => get<ScanSchedule[]>("/v1/schedules"),
+  createSchedule: (body: ScheduleCreateRequest) => post<ScanSchedule>("/v1/schedules", body),
+  toggleSchedule: (scheduleId: string) => put<ScanSchedule>(`/v1/schedules/${scheduleId}/toggle`, {}),
+  deleteSchedule: (scheduleId: string) => del(`/v1/schedules/${scheduleId}`),
 
   // ── Gateway ──
   listGatewayPolicies: () => get<GatewayPolicyResponse>("/v1/gateway/policies"),


### PR DESCRIPTION
## Summary
- add a first-class control-plane source registry with in-memory, SQLite, and Postgres-backed stores
- expose `/v1/sources` CRUD, test, run, and source-linked job history routes with tenant scoping and audit events
- wire the `/sources` UI to real source records, connector health, persisted schedules, and control-plane actions instead of static explanatory copy
- add focused tests for source lifecycle, tenant isolation, and source store initialization

## Validation
- `/tmp/agent-bom-hosted-test-venv/bin/python -m pytest tests/test_api_sources.py tests/test_hardening.py tests/test_postgres_store.py tests/test_api_operator_policy.py -q`
- `cd ui && npm run lint -- app/sources/page.tsx lib/api.ts`
- `cd ui && npm run test:run`
- `cd ui && npm run build`
