### PR TITLE
Fix release coherence and tenant isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,9 +307,40 @@ jobs:
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.title=agent-bom-ui
-            org.opencontainers.image.description=agent-bom control-plane dashboard.
+            org.opencontainers.image.description=Standalone browser UI for the self-hosted agent-bom control plane. Requires the agent-bom API image.
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Sync UI Docker Hub README
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          SHORT_DESCRIPTION="Standalone browser UI for the self-hosted agent-bom control plane. Requires the agent-bom API image."
+          TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
+            | jq -r '.token')
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "::error::Docker Hub login failed"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          DESCRIPTION=$(jq -Rs . < DOCKER_HUB_UI_README.md)
+          SHORT_DESCRIPTION_JSON=$(printf '%s' "$SHORT_DESCRIPTION" | jq -Rs .)
+          RESPONSE_FILE=$(mktemp)
+          HTTP_CODE=$(curl -sS -o "$RESPONSE_FILE" -w "%{http_code}" -X PATCH \
+            "https://hub.docker.com/v2/repositories/agentbom/agent-bom-ui/" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"full_description\": ${DESCRIPTION}, \"description\": ${SHORT_DESCRIPTION_JSON}}")
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Docker Hub UI README sync failed (HTTP $HTTP_CODE)"
+            cat "$RESPONSE_FILE"
+            exit 1
+          fi
+          rm -f "$RESPONSE_FILE"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ Work targeting the next release.
 
 ---
 
+## [0.80.1] – 2026-04-21
+
+### Fixed
+- **Standalone UI image release path** — the Next.js container build now emits the `.next/standalone` output expected by the published `agent-bom-ui` image, and CI smoke-tests that path before release.
+- **Version-surface coherence** — Helm examples, runtime sidecar manifests, release verification docs, and product metrics now align on `0.80.1` so the public release surfaces match the shipped tag.
+
+### Security
+- **Tenant and gateway auth hardening** — Postgres-backed API key verification can now resolve non-default tenant keys during auth and gateway relay paths, instead of silently falling back to default-tenant visibility under RLS.
+
+---
+
+## [0.80.0] – 2026-04-21
+
+### Added
+- **Control-plane auth for the shipped UI** — OIDC, trusted-proxy browser auth, session API-key fallback, and runtime auth introspection now let the dashboard operate as a real operator surface instead of a same-origin-only shell.
+- **Hosted-product source registry baseline** — the API and UI now expose first-class source records, source-linked jobs, and persisted schedule state as the first slice of the hosted control-plane model.
+- **Signed release surfaces** — Helm OCI publish, UI image release wiring, and stronger release verification/docs were added to the productized deployment path.
+
+### Changed
+- **P0/P1 audit closure** — visual leak detector races, timeout audit gaps, resolver/VEX strictness, ServiceMonitor/operator defaults, CSP documentation, and UI dependency/release guardrails were tightened across the release lane.
+- **Deployment docs and diagrams** — self-hosted operator guidance, EKS rollout docs, and enterprise topology explanations were rewritten to match the actual control-plane/runtime split in code.
+
+### Fixed
+- **Gateway and runtime audit integrity** — timeout paths now audit correctly, OCR runs once per response instead of once per image block, and the control plane/runtime surfaces agree on the operator deployment contract.
+- **UI packaging accuracy** — README and deployment copy now describe the Python image and standalone UI image honestly instead of implying a single bundled live dashboard path.
+
+---
+
 ## [0.79.0] – 2026-04-20
 
 ### Added

--- a/DOCKER_HUB_UI_README.md
+++ b/DOCKER_HUB_UI_README.md
@@ -1,0 +1,40 @@
+# agent-bom-ui
+
+**Standalone browser UI for the self-hosted `agent-bom` control plane.**
+
+`agentbom/agent-bom-ui` is the separate Next.js UI container used when you run
+the browser dashboard independently from the API.
+
+It is **not** the scanner or control-plane backend by itself.
+
+Use it with:
+
+- `agentbom/agent-bom` for the API, scan jobs, gateway, proxy-related
+  entrypoints, and other non-browser control-plane services
+- your own ingress / SSO / Postgres setup when deploying the split UI + API
+  control-plane shape
+
+## Quick Start
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e NEXT_PUBLIC_API_URL=http://localhost:8422 \
+  agentbom/agent-bom-ui:latest
+```
+
+Then run the API separately:
+
+```bash
+docker run --rm -p 8422:8422 agentbom/agent-bom:latest api
+```
+
+## Product Split
+
+- `agentbom/agent-bom` = scanner, API, jobs, runtime/gateway entrypoints
+- `agentbom/agent-bom-ui` = standalone browser UI only
+
+## Links
+
+- GitHub: https://github.com/msaad00/agent-bom
+- Docs: https://msaad00.github.io/agent-bom/
+- Helm chart: `oci://ghcr.io/msaad00/charts/agent-bom`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The demo uses a curated sample so the output stays reproducible across releases.
 | Check a package before install | `agent-bom check flask@2.2.0 --ecosystem pypi` | Machine-readable pre-install verdict |
 | Scan a container image | `agent-bom image nginx:latest` | OS and package CVEs with fixability |
 | Audit IaC or cloud posture | `agent-bom iac Dockerfile k8s/ infra/main.tf` | Misconfigurations, manifest hardening, optional live cluster posture |
-| Review findings in a persistent graph | `agent-bom serve` | API plus bundled local UI; Kubernetes uses the separate `agent-bom-ui` image |
+| Review findings in a persistent graph | `agent-bom serve` | API plus bundled local UI on one machine; Kubernetes and Compose split the API image (`agentbom/agent-bom`) from the browser UI image (`agentbom/agent-bom-ui`) |
 | Inspect live MCP traffic | `agent-bom proxy "<server command>"` | Inline runtime inspection, detector chaining, response/argument review |
 
 ## Quick start
@@ -157,89 +157,84 @@ allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + workload rollout | Remote MCPs, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
 flowchart LR
-    subgraph outside["Outside your account"]
-      idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["GitHub Actions / CI"]
-      remote["Remote MCPs<br/>SaaS + partner tools"]
-      osv["OSV / NVD / GHSA<br/>optional enrichment"]
+    subgraph outside["Outside customer infrastructure"]
+      idp["Corporate IdP"]
+      ci["CI / scheduled jobs"]
+      remote["Remote MCPs"]
+      osv["OSV / NVD / GHSA<br/>optional"]
     end
 
-    subgraph customer["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio"]
+    subgraph customer["Customer VPC / cluster"]
+      ingress["Ingress + SSO"]
 
-      subgraph control["Agent-BOM control plane"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>auth · fleet · findings · audit"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup job<br/>pg_dump -> S3"]
+      subgraph control["Control plane"]
+        ui["UI"]
+        api["API"]
+        jobs["Scan / ingest jobs"]
+        backup["Backup / scheduler"]
       end
 
-      subgraph runtime["Runtime MCP plane"]
-        proxy["Proxy<br/>sidecar or laptop wrapper"]
-        gateway["Gateway<br/>agent-bom gateway serve"]
+      subgraph runtime["Runtime MCP path"]
+        proxy["agent-bom proxy"]
+        gateway["agent-bom gateway"]
       end
 
-      subgraph data["Customer-owned data plane"]
-        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics"]
-        s3["S3 (optional)<br/>backups + SBOM archive"]
+      subgraph data["Customer-owned stores"]
+        pg["Postgres"]
+        ch["ClickHouse optional"]
+        s3["S3 optional"]
       end
 
-      subgraph ops["Platform glue"]
-        secrets["ExternalSecrets<br/>AWS SM / Vault"]
-        metrics["OTEL + Prometheus"]
-      end
+      ops["Secrets + telemetry"]
     end
 
     idp -. OIDC .-> ingress
     ingress --> ui
     ingress --> api
-    ingress --> gateway
-    ci -->|"SARIF + findings"| api
-    jobs -->|"scan results + inventory"| api
-    api --> pg
-    api -. optional .-> ch
+    ingress -. optional shared runtime URL .-> gateway
+    ci --> jobs
+    jobs --> api
     backup --> s3
-    secrets --> api
-    secrets --> gateway
-    api --> metrics
-    gateway --> metrics
-    gateway -->|"policy-audited upstream call"| remote
-    api -. optional egress .-> osv
+    api --> pg
+    api -. analytics .-> ch
+    proxy --> gateway
+    gateway --> api
+    gateway --> remote
+    api -. enrichment .-> osv
+    ops --> api
+    ops --> gateway
 ```
 
 *Everything inside the customer boundary runs in the customer's account. The
 default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
 upstream calls.*
 
-#### How MCP traffic actually flows
+#### Runtime MCP flow in customer infra
 
 ```mermaid
-sequenceDiagram
-    participant Dev as Developer client
-    participant Proxy as agent-bom proxy
-    participant Gateway as agent-bom gateway
-    participant API as Control-plane API
-    participant Remote as Remote MCP
-    participant Store as Postgres / audit store
+flowchart LR
+    dev["Developer client or MCP-enabled workload"]
+    proxy["Local / sidecar<br/>agent-bom proxy"]
+    gateway["In-cluster<br/>agent-bom gateway"]
+    api["Control-plane API"]
+    store["Postgres / audit store"]
+    remote["Approved remote MCP"]
 
-    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: inspect request + local policy
-    Proxy->>Gateway: audited relay
-    Gateway->>API: POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: shared policy + response
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Dev: safe response
-    API->>Store: persist audit, findings, graph links
+    dev -->|"MCP JSON-RPC"| proxy
+    proxy -->|"inspect + local policy"| gateway
+    gateway -->|"shared policy + relay"| remote
+    remote --> gateway
+    gateway -->|"response"| proxy
+    proxy -->|"safe response"| dev
+    gateway -->|"POST /v1/proxy/audit"| api
+    api --> store
 ```
 
 1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
@@ -450,7 +445,7 @@ Pilot teams run:
 ```bash
 # 1. Pick your backend shape (postgres default; snowflake / istio / production also shipped)
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.79.0 \
+  --version 0.80.1 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
 
@@ -534,12 +529,20 @@ pip install agent-bom                        # CLI
 docker run --rm agentbom/agent-bom agents    # Docker
 ```
 
+For published containers, the split is:
+
+- `agentbom/agent-bom` = the main runtime image for CLI, API, jobs, gateway,
+  proxy-related entrypoints, and MCP server mode
+- `agentbom/agent-bom-ui` = the standalone browser UI image used when the
+  self-hosted control plane runs the UI separately from the API
+
 | Mode | Best for |
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
 | GitHub Action (`uses: msaad00/agent-bom@v0.80.1`) | CI/CD + SARIF |
-| Docker (`agentbom/agent-bom`) | isolated scans, containerized self-hosting |
+| Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
+| Browser UI image (`agentbom/agent-bom-ui`) | the separate Next.js UI container paired with a self-hosted API |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
 | REST API (`agent-bom api`) | platform integration, self-hosted control plane |
 | MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agent-bom-runtime:latest
+    image: agentbom/agent-bom:0.80.1
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -9,7 +9,7 @@ uiImage:
   pullPolicy: IfNotPresent
 
 runtimeImage:
-  repository: agentbom/agent-bom-runtime
+  repository: agentbom/agent-bom
   tag: "0.80.1"
   pullPolicy: IfNotPresent
 

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom-runtime:latest
+          image: agentbom/agent-bom:0.80.1
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom-runtime:0.79.0
+          image: agentbom/agent-bom:0.80.1
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom-runtime:0.79.0
+          image: agentbom/agent-bom:0.80.1
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
-  "generated_on": "2026-04-19",
-  "version": "0.79.0",
+  "generated_on": "2026-04-21",
+  "version": "0.80.1",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,8 +5,8 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-04-19`
-- Version: `0.79.0`
+- Generated on: `2026-04-21`
+- Version: `0.80.1`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -118,6 +118,8 @@ Automated via `.github/workflows/release.yml` on each tag push.
 Images published:
 - `agentbom/agent-bom:{version}`
 - `agentbom/agent-bom:latest`
+- `agentbom/agent-bom-ui:{version}`
+- `agentbom/agent-bom-ui:latest`
 
 The Git tag remains `v{version}`. Docker Hub image tags are published without the `v` prefix.
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.79.0
+TAG=v0.80.1
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -30,22 +30,22 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 
 ### Docker
 
-Build the slim runtime image:
+Use the published main runtime image:
 
 ```bash
-docker build -f deploy/docker/Dockerfile.runtime -t agent-bom-runtime .
+docker pull agentbom/agent-bom:0.80.1
 ```
 
-The maintained runtime image now builds from the checked-out `agent-bom` source tree,
-not from a separately downloaded PyPI artifact, so the runtime sidecar stays aligned
-with the repo revision you are deploying.
+If you need to rebuild locally from the checked-out repo, you can still use
+`deploy/docker/Dockerfile.runtime`, but the public runtime/proxy path now ships
+through `agentbom/agent-bom`.
 
 Run as a wrapper around any MCP server:
 
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agent-bom-runtime \
+  agentbom/agent-bom:0.80.1 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agent-bom-runtime:latest
+          image: agentbom/agent-bom:0.80.1
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -321,7 +321,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agent-bom-runtime:latest",
+        "agentbom/agent-bom:0.80.1",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -55,6 +55,13 @@ DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("site-docs/features/policy.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("site-docs/deployment/overview.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("docs/ENTERPRISE_DEPLOYMENT.md", re.compile(r"(agentbom/agent-bom:)(?:v)?\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("README.md", re.compile(r"(--version\s+)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("site-docs/deployment/control-plane-helm.md", re.compile(r"(--version\s+)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("deploy/k8s/sidecar-example.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("deploy/k8s/proxy-sidecar-pilot.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("docs/PRODUCT_METRICS.md", re.compile(r"(- Version: `)\d+\.\d+\.\d+(`)"), r"\g<1>{v}\g<2>"),
+    ("docs/PRODUCT_METRICS.json", re.compile(r'("version":\s*")\d+\.\d+\.\d+(")'), r"\g<1>{v}\g<2>"),
+    ("docs/RELEASE_VERIFICATION.md", re.compile(r"^(TAG=v)\d+\.\d+\.\d+$", re.M), r"\g<1>{v}"),
     ("DOCKER_HUB_README.md", re.compile(r"(\| `)\d+\.\d+\.\d+(` \| Current stable version \(pinned\) \|)"), r"\g<1>{v}\g<2>"),
     # PUBLISHING.md — version examples
     ("docs/PUBLISHING.md", re.compile(r'(--version\s+")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -12,6 +12,7 @@ This is the right path when you want:
 - the scanner CronJob and optional runtime monitor packaged alongside the
   control plane
 - production operator defaults without pretending there is a managed vendor plane
+- a clean split between the API/runtime image and the standalone UI image
 
 ## What the chart deploys
 
@@ -22,6 +23,13 @@ When you set `controlPlane.enabled=true`, the Helm chart can package:
 - same-origin Ingress that routes API paths to the API service and `/` to the UI
 - scanner CronJob
 - optional runtime monitor DaemonSet
+
+The image split is intentional:
+
+- `agentbom/agent-bom` runs the API, scanner jobs, gateway, proxy-related
+  entrypoints, and other non-browser workloads
+- `agentbom/agent-bom-ui` runs the standalone browser UI that sits behind the
+  same ingress or a separate UI service
 
 ```mermaid
 flowchart LR
@@ -45,89 +53,84 @@ allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + workload rollout | Remote MCPs, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
 flowchart LR
-    subgraph outside["Outside your account"]
-      idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["GitHub Actions / CI"]
-      remote["Remote MCPs<br/>SaaS + partner tools"]
-      osv["OSV / NVD / GHSA<br/>optional enrichment"]
+    subgraph outside["Outside customer infrastructure"]
+      idp["Corporate IdP"]
+      ci["CI / scheduled jobs"]
+      remote["Remote MCPs"]
+      osv["OSV / NVD / GHSA<br/>optional"]
     end
 
-    subgraph customer["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio"]
+    subgraph customer["Customer VPC / cluster"]
+      ingress["Ingress + SSO"]
 
-      subgraph control["Agent-BOM control plane"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>auth · fleet · findings · audit"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup job<br/>pg_dump -> S3"]
+      subgraph control["Control plane"]
+        ui["UI"]
+        api["API"]
+        jobs["Scan / ingest jobs"]
+        backup["Backup / scheduler"]
       end
 
-      subgraph runtime["Runtime MCP plane"]
-        proxy["Proxy<br/>sidecar or laptop wrapper"]
-        gateway["Gateway<br/>agent-bom gateway serve"]
+      subgraph runtime["Runtime MCP path"]
+        proxy["agent-bom proxy"]
+        gateway["agent-bom gateway"]
       end
 
-      subgraph data["Customer-owned data plane"]
-        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics"]
-        s3["S3 (optional)<br/>backups + SBOM archive"]
+      subgraph data["Customer-owned stores"]
+        pg["Postgres"]
+        ch["ClickHouse optional"]
+        s3["S3 optional"]
       end
 
-      subgraph ops["Platform glue"]
-        secrets["ExternalSecrets<br/>AWS SM / Vault"]
-        metrics["OTEL + Prometheus"]
-      end
+      ops["Secrets + telemetry"]
     end
 
     idp -. OIDC .-> ingress
     ingress --> ui
     ingress --> api
-    ingress --> gateway
-    ci -->|"SARIF + findings"| api
-    jobs -->|"scan results + inventory"| api
-    api --> pg
-    api -. optional .-> ch
+    ingress -. optional shared runtime URL .-> gateway
+    ci --> jobs
+    jobs --> api
     backup --> s3
-    secrets --> api
-    secrets --> gateway
-    api --> metrics
-    gateway --> metrics
-    gateway -->|"policy-audited upstream call"| remote
-    api -. optional egress .-> osv
+    api --> pg
+    api -. analytics .-> ch
+    proxy --> gateway
+    gateway --> api
+    gateway --> remote
+    api -. enrichment .-> osv
+    ops --> api
+    ops --> gateway
 ```
 
 *Everything inside the customer boundary runs in the customer's account. The
 default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
 upstream calls.*
 
-### How MCP traffic actually flows
+### Runtime MCP flow in customer infra
 
 ```mermaid
-sequenceDiagram
-    participant Dev as Developer client
-    participant Proxy as agent-bom proxy
-    participant Gateway as agent-bom gateway
-    participant API as Control-plane API
-    participant Remote as Remote MCP
-    participant Store as Postgres / audit store
+flowchart LR
+    dev["Developer client or MCP-enabled workload"]
+    proxy["Local / sidecar<br/>agent-bom proxy"]
+    gateway["In-cluster<br/>agent-bom gateway"]
+    api["Control-plane API"]
+    store["Postgres / audit store"]
+    remote["Approved remote MCP"]
 
-    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: inspect request + local policy
-    Proxy->>Gateway: audited relay
-    Gateway->>API: POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: shared policy + response
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Dev: safe response
-    API->>Store: persist audit, findings, graph links
+    dev -->|"MCP JSON-RPC"| proxy
+    proxy -->|"inspect + local policy"| gateway
+    gateway -->|"shared policy + relay"| remote
+    remote --> gateway
+    gateway -->|"response"| proxy
+    proxy -->|"safe response"| dev
+    gateway -->|"POST /v1/proxy/audit"| api
+    api --> store
 ```
 
 1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
@@ -223,7 +226,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.79.0 \
+  --version 0.80.1 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -259,7 +262,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.79.0 \
+  --version 0.80.1 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -1,5 +1,15 @@
 # Docker Deployment
 
+Use this page for containerized entrypoints. The published image split is:
+
+- `agentbom/agent-bom` = the main runtime image for CLI scans, the API,
+  scanner jobs, gateway, MCP server mode, and other non-browser entrypoints
+- `agentbom/agent-bom-ui` = the standalone browser UI image used when the
+  self-hosted control plane runs the UI separately from the API
+
+The UI image does not replace the API image. A self-hosted browser deployment
+still needs the API/control-plane service from `agentbom/agent-bom`.
+
 ## Quick scan
 
 ```bash
@@ -54,10 +64,10 @@ docker run --rm \
 ## Runtime proxy sidecar
 
 ```bash
-docker build -f deploy/docker/Dockerfile.runtime -t agent-bom-runtime .
+docker pull agentbom/agent-bom:0.80.1
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agent-bom-runtime \
+  agentbom/agent-bom:0.80.1 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -67,7 +77,8 @@ docker run --rm -i \
 
 | Image | Purpose |
 |-------|---------|
-| `ghcr.io/msaad00/agent-bom:latest` | CLI scanner |
+| `ghcr.io/msaad00/agent-bom:latest` | Main runtime image: CLI, API, scanner jobs, gateway, MCP server |
+| `agentbom/agent-bom-ui` | Standalone browser UI image for split control-plane deploys |
 | `deploy/docker/Dockerfile.sse` | SSE MCP server |
-| `deploy/docker/Dockerfile.runtime` | Runtime proxy |
+| `deploy/docker/Dockerfile.runtime` | Local rebuild recipe for the runtime proxy path shipped in `agentbom/agent-bom` |
 | `deploy/docker/Dockerfile.snowpark` | Snowflake Native App |

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -73,7 +73,7 @@ This manifest shows:
 - a namespace labeled for Pod Security Admission `restricted`
 - a starter proxy policy `ConfigMap`
 - a metrics `Service`
-- a sample MCP workload with `agent-bom-runtime` sidecar
+- a sample MCP workload with an `agent-bom` runtime proxy sidecar (container name `agent-bom-runtime`)
 - control-plane policy pull and proxy audit push
 - audit logging, undeclared tool blocking, credential detection, and basic rate limiting
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -67,89 +67,84 @@ allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + workload rollout | Remote MCPs, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
 flowchart LR
-    subgraph outside["Outside your account"]
-      idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["GitHub Actions / CI"]
-      remote["Remote MCPs<br/>SaaS + partner tools"]
-      osv["OSV / NVD / GHSA<br/>optional enrichment"]
+    subgraph outside["Outside customer infrastructure"]
+      idp["Corporate IdP"]
+      ci["CI / scheduled jobs"]
+      remote["Remote MCPs"]
+      osv["OSV / NVD / GHSA<br/>optional"]
     end
 
-    subgraph customer["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio"]
+    subgraph customer["Customer VPC / cluster"]
+      ingress["Ingress + SSO"]
 
-      subgraph control["Agent-BOM control plane"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>auth · fleet · findings · audit"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup job<br/>pg_dump -> S3"]
+      subgraph control["Control plane"]
+        ui["UI"]
+        api["API"]
+        jobs["Scan / ingest jobs"]
+        backup["Backup / scheduler"]
       end
 
-      subgraph runtime["Runtime MCP plane"]
-        proxy["Proxy<br/>sidecar or laptop wrapper"]
-        gateway["Gateway<br/>agent-bom gateway serve"]
+      subgraph runtime["Runtime MCP path"]
+        proxy["agent-bom proxy"]
+        gateway["agent-bom gateway"]
       end
 
-      subgraph data["Customer-owned data plane"]
-        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics"]
-        s3["S3 (optional)<br/>backups + SBOM archive"]
+      subgraph data["Customer-owned stores"]
+        pg["Postgres"]
+        ch["ClickHouse optional"]
+        s3["S3 optional"]
       end
 
-      subgraph ops["Platform glue"]
-        secrets["ExternalSecrets<br/>AWS SM / Vault"]
-        metrics["OTEL + Prometheus"]
-      end
+      ops["Secrets + telemetry"]
     end
 
     idp -. OIDC .-> ingress
     ingress --> ui
     ingress --> api
-    ingress --> gateway
-    ci -->|"SARIF + findings"| api
-    jobs -->|"scan results + inventory"| api
-    api --> pg
-    api -. optional .-> ch
+    ingress -. optional shared runtime URL .-> gateway
+    ci --> jobs
+    jobs --> api
     backup --> s3
-    secrets --> api
-    secrets --> gateway
-    api --> metrics
-    gateway --> metrics
-    gateway -->|"policy-audited upstream call"| remote
-    api -. optional egress .-> osv
+    api --> pg
+    api -. analytics .-> ch
+    proxy --> gateway
+    gateway --> api
+    gateway --> remote
+    api -. enrichment .-> osv
+    ops --> api
+    ops --> gateway
 ```
 
 *Everything inside the customer boundary runs in the customer's account. The
 default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
 upstream calls.*
 
-### How MCP traffic actually flows
+### Runtime MCP flow in customer infra
 
 ```mermaid
-sequenceDiagram
-    participant Dev as Developer client
-    participant Proxy as agent-bom proxy
-    participant Gateway as agent-bom gateway
-    participant API as Control-plane API
-    participant Remote as Remote MCP
-    participant Store as Postgres / audit store
+flowchart LR
+    dev["Developer client or MCP-enabled workload"]
+    proxy["Local / sidecar<br/>agent-bom proxy"]
+    gateway["In-cluster<br/>agent-bom gateway"]
+    api["Control-plane API"]
+    store["Postgres / audit store"]
+    remote["Approved remote MCP"]
 
-    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: inspect request + local policy
-    Proxy->>Gateway: audited relay
-    Gateway->>API: POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: shared policy + response
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Dev: safe response
-    API->>Store: persist audit, findings, graph links
+    dev -->|"MCP JSON-RPC"| proxy
+    proxy -->|"inspect + local policy"| gateway
+    gateway -->|"shared policy + relay"| remote
+    remote --> gateway
+    gateway -->|"response"| proxy
+    proxy -->|"safe response"| dev
+    gateway -->|"POST /v1/proxy/audit"| api
+    api --> store
 ```
 
 1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -14,6 +14,13 @@ monolith:
 - **API + UI** for operator review, audit, graph, remediation, and control-plane workflows
 - **MCP server mode** when you want `agent-bom` itself exposed as tools
 
+The published container split follows the same model:
+
+- `agentbom/agent-bom` is the main runtime image for CLI, API, jobs, gateway,
+  proxy-related entrypoints, and MCP server mode
+- `agentbom/agent-bom-ui` is only the standalone browser UI image used when the
+  control plane runs the UI separately from the API
+
 ## What You Can Offer In Customer-Controlled Infra
 
 This is the current code-backed self-hosted story:

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -245,7 +245,12 @@ def get_key_store() -> KeyStoreProtocol:
     if _key_store is None:
         with _store_lock:
             if _key_store is None:
-                _key_store = KeyStore()
+                if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+                    from agent_bom.api.postgres_access import PostgresKeyStore
+
+                    _key_store = PostgresKeyStore()
+                else:
+                    _key_store = KeyStore()
     return _key_store
 
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -397,7 +397,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             )
 
         # Simple mode: single static key (backward compatible, all access)
-        if secrets.compare_digest(raw_key, self._api_key):
+        if self._api_key and secrets.compare_digest(raw_key, self._api_key):
             request.state.api_key_name = "static-key"
             request.state.api_key_role = "admin"
             request.state.tenant_id = "default"

--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -44,6 +44,7 @@ import threading
 import time
 from typing import Optional
 from urllib.error import URLError
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 logger = logging.getLogger(__name__)
@@ -105,6 +106,12 @@ def reset_oidc_decode_failures() -> None:
         _oidc_decode_failures = 0
 
 
+def _csv_env_list(value: str | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
 # ── Discovery ──────────────────────────────────────────────────────────────────
 
 
@@ -140,6 +147,39 @@ def discover_oidc(issuer: str) -> dict:
     return doc
 
 
+def _validate_jwks_uri(
+    issuer: str,
+    jwks_uri: str,
+    *,
+    allowed_jwks_uris: tuple[str, ...] = (),
+    explicit_jwks_uri: bool = False,
+) -> str:
+    from agent_bom.security import validate_url
+
+    normalized_jwks_uri = str(jwks_uri or "").strip()
+    if not normalized_jwks_uri:
+        raise OIDCError("OIDC JWKS URI is empty")
+
+    validate_url(normalized_jwks_uri)
+    if explicit_jwks_uri:
+        return normalized_jwks_uri
+
+    if not allowed_jwks_uris:
+        raise OIDCError(
+            "OIDC discovery requires a pinned JWKS URI. Set AGENT_BOM_OIDC_JWKS_URI "
+            "or allowlist the discovered value via AGENT_BOM_OIDC_ALLOWED_JWKS_URIS."
+        )
+
+    if normalized_jwks_uri not in allowed_jwks_uris:
+        issuer_host = urlparse(issuer).netloc
+        raise OIDCError(
+            f"OIDC discovery returned untrusted jwks_uri '{normalized_jwks_uri}' for issuer '{issuer_host}'. "
+            "Pin AGENT_BOM_OIDC_JWKS_URI or add the URI to AGENT_BOM_OIDC_ALLOWED_JWKS_URIS."
+        )
+
+    return normalized_jwks_uri
+
+
 # ── JWT verification ───────────────────────────────────────────────────────────
 
 
@@ -161,6 +201,7 @@ def verify_oidc_token(
     audience: Optional[str] = None,
     jwks_uri: Optional[str] = None,
     required_nonce: Optional[str] = None,
+    allowed_jwks_uris: tuple[str, ...] = (),
 ) -> dict:
     """Verify an OIDC JWT and return its claims.
 
@@ -184,12 +225,19 @@ def verify_oidc_token(
     import jwt
     from jwt import PyJWKClient, PyJWTError
 
+    explicit_jwks_uri = bool(jwks_uri)
     if not jwks_uri:
         try:
             discovery = discover_oidc(issuer)
-            jwks_uri = discovery["jwks_uri"]
+            jwks_uri = str(discovery["jwks_uri"])
         except OIDCError:
             raise
+    jwks_uri = _validate_jwks_uri(
+        issuer,
+        jwks_uri,
+        allowed_jwks_uris=allowed_jwks_uris,
+        explicit_jwks_uri=explicit_jwks_uri,
+    )
 
     try:
         jwks_client = PyJWKClient(jwks_uri, cache_jwk_set=True, lifespan=_JWKS_CACHE_TTL)
@@ -354,6 +402,8 @@ class OIDCConfig:
         require_tenant_claim: Optional[bool] = None,
         required_nonce: Optional[str] = None,
         require_role_claim: Optional[bool] = None,
+        allow_default_tenant: Optional[bool] = None,
+        allowed_jwks_uris: tuple[str, ...] | None = None,
         tenant_id: Optional[str] = None,
         tenant_providers: dict[str, OIDCConfig] | None = None,
     ) -> None:
@@ -365,6 +415,7 @@ class OIDCConfig:
         self.required_nonce = required_nonce or os.environ.get("AGENT_BOM_OIDC_REQUIRED_NONCE", "") or None
         self.tenant_id = tenant_id or None
         self.tenant_providers = tenant_providers or {}
+        self.allowed_jwks_uris = allowed_jwks_uris or _csv_env_list(os.environ.get("AGENT_BOM_OIDC_ALLOWED_JWKS_URIS"))
         if require_tenant_claim is None:
             require_tenant_claim = os.environ.get("AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM", "").strip().lower() in {
                 "1",
@@ -372,6 +423,13 @@ class OIDCConfig:
                 "yes",
             }
         self.require_tenant_claim = require_tenant_claim
+        if allow_default_tenant is None:
+            allow_default_tenant = os.environ.get("AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+        self.allow_default_tenant = allow_default_tenant
         if require_role_claim is None:
             require_role_claim = os.environ.get("AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM", "").strip().lower() in {
                 "1",
@@ -431,7 +489,14 @@ class OIDCConfig:
             raise OIDCError("OIDC is not configured (set AGENT_BOM_OIDC_ISSUER or AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON)")
         if not provider.audience:
             raise OIDCError("OIDC is configured but AGENT_BOM_OIDC_AUDIENCE is not set")
-        claims = verify_oidc_token(token, provider.issuer, provider.audience, provider.jwks_uri, provider.required_nonce)
+        claims = verify_oidc_token(
+            token,
+            provider.issuer,
+            provider.audience,
+            provider.jwks_uri,
+            provider.required_nonce,
+            provider.allowed_jwks_uris,
+        )
         if provider.require_role_claim and not claims_have_role_signal(claims, provider.role_claim):
             raise OIDCError(f"JWT missing required role claim '{provider.role_claim}'")
         provider._validate_bound_tenant(claims)
@@ -448,6 +513,12 @@ class OIDCConfig:
             return provider.tenant_id
         if provider.require_tenant_claim:
             raise OIDCError(f"JWT missing required tenant claim '{provider.tenant_claim}'")
+        if not provider.allow_default_tenant:
+            raise OIDCError(
+                f"JWT missing tenant claim '{provider.tenant_claim}'. "
+                "Configure a tenant-bound issuer, set AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1, "
+                "or explicitly opt into single-tenant default mode with AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT=1."
+            )
         return "default"
 
     @classmethod
@@ -493,6 +564,12 @@ class OIDCConfig:
                         provider_raw.get("require_role_claim"),
                         field_name=f"{normalized_tenant}.require_role_claim",
                     ),
+                    allow_default_tenant=_coerce_optional_bool(
+                        provider_raw.get("allow_default_tenant"),
+                        field_name=f"{normalized_tenant}.allow_default_tenant",
+                    ),
+                    allowed_jwks_uris=tuple(str(item).strip() for item in provider_raw.get("allowed_jwks_uris", []) if str(item).strip())
+                    or None,
                     tenant_id=normalized_tenant,
                 )
                 if not provider.issuer:

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -571,6 +571,24 @@ def _run_scan_sync(job: ScanJob) -> None:
             with lock:
                 job.progress.append(f"Graph persistence skipped: {sanitize_error(graph_exc)}")
 
+        try:
+            from agent_bom.asset_tracker import AssetTracker
+
+            tracker = AssetTracker(tenant_id=str(getattr(job, "tenant_id", None) or "default"))
+            asset_diff = tracker.record_scan(report_json)
+            tracker.close()
+            with lock:
+                job.progress.append(
+                    "Asset tracker synced "
+                    f"(new={asset_diff['summary']['new_count']}, "
+                    f"resolved={asset_diff['summary']['resolved_count']}, "
+                    f"open={asset_diff['summary']['total_open']})"
+                )
+        except Exception as asset_exc:  # noqa: BLE001
+            _logger.warning("Asset tracker persistence failed: %s", asset_exc)
+            with lock:
+                job.progress.append(f"Asset tracker skipped: {sanitize_error(asset_exc)}")
+
         pipeline.complete_step("output", "Report ready")
 
         # Auto-sync discovered agents to fleet registry

--- a/src/agent_bom/api/postgres_access.py
+++ b/src/agent_bom/api/postgres_access.py
@@ -7,7 +7,7 @@ import json
 from agent_bom.api.auth import ApiKey, Role, verify_api_key
 from agent_bom.api.exception_store import ExceptionStatus, VulnException
 
-from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
+from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection, bypass_tenant_rls
 
 
 class PostgresKeyStore:
@@ -138,19 +138,21 @@ class PostgresKeyStore:
 
     def verify(self, raw_key: str) -> ApiKey | None:
         prefix = raw_key[:12]
-        with _tenant_connection(self._pool) as conn:
-            rows = conn.execute(
-                """SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
-                   FROM api_keys
-                   WHERE key_prefix = %s AND revoked = FALSE""",
-                (prefix,),
-            ).fetchall()
+        with bypass_tenant_rls():
+            with _tenant_connection(self._pool) as conn:
+                rows = conn.execute(
+                    """SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
+                       FROM api_keys
+                       WHERE key_prefix = %s AND revoked = FALSE""",
+                    (prefix,),
+                ).fetchall()
         return verify_api_key(raw_key, [self._row_to_key(row) for row in rows])
 
     def has_keys(self) -> bool:
-        with _tenant_connection(self._pool) as conn:
-            row = conn.execute("SELECT COUNT(*) FROM api_keys WHERE revoked = FALSE").fetchone()
-            return bool(row and row[0] > 0)
+        with bypass_tenant_rls():
+            with _tenant_connection(self._pool) as conn:
+                row = conn.execute("SELECT COUNT(*) FROM api_keys WHERE revoked = FALSE").fetchone()
+                return bool(row and row[0] > 0)
 
 
 class PostgresExceptionStore:

--- a/src/agent_bom/api/routes/assets.py
+++ b/src/agent_bom/api/routes/assets.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
@@ -17,6 +17,7 @@ _logger = logging.getLogger(__name__)
 
 @router.get("/v1/assets", tags=["assets"])
 async def list_assets(
+    request: Request,
     status: str | None = None,
     severity: str | None = None,
     limit: int = 500,
@@ -31,7 +32,7 @@ async def list_assets(
     try:
         from agent_bom.asset_tracker import AssetTracker
 
-        tracker = AssetTracker()
+        tracker = AssetTracker(tenant_id=getattr(request.state, "tenant_id", "default"))
         assets = tracker.list_assets(status=status, severity=severity, limit=limit)
         stats = tracker.stats()
         mttr = tracker.mttr_days()
@@ -54,12 +55,12 @@ async def list_assets(
 
 
 @router.get("/v1/assets/stats", tags=["assets"])
-async def get_asset_stats() -> dict:
+async def get_asset_stats(request: Request) -> dict:
     """Return aggregate asset tracking statistics including MTTR."""
     try:
         from agent_bom.asset_tracker import AssetTracker
 
-        tracker = AssetTracker()
+        tracker = AssetTracker(tenant_id=getattr(request.state, "tenant_id", "default"))
         stats = tracker.stats()
         mttr = tracker.mttr_days()
         tracker.close()

--- a/src/agent_bom/asset_tracker.py
+++ b/src/agent_bom/asset_tracker.py
@@ -1,9 +1,13 @@
 """Persistent asset tracker — first_seen / last_seen / resolved per vulnerability.
 
 Stores a lightweight SQLite database at ``~/.agent-bom/assets.db`` that tracks
-every vulnerability across scans.  Each scan call to ``record_scan()`` updates
+every vulnerability across scans. Each scan call to ``record_scan()`` updates
 the tracker: new findings get ``first_seen``, existing findings get ``last_seen``
 bumped, and findings no longer present are marked ``resolved``.
+
+The tracker is tenant-aware. API/control-plane scans record and query assets
+within the authenticated tenant partition, while local CLI usage defaults to the
+single-tenant ``"default"`` namespace.
 
 Usage::
 
@@ -26,6 +30,7 @@ DEFAULT_DB_PATH = Path.home() / ".agent-bom" / "assets.db"
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS assets (
+    tenant_id   TEXT NOT NULL DEFAULT 'default',
     vuln_id     TEXT NOT NULL,
     package     TEXT NOT NULL,
     ecosystem   TEXT NOT NULL DEFAULT '',
@@ -36,23 +41,47 @@ CREATE TABLE IF NOT EXISTS assets (
     resolved_at TEXT,
     scan_count  INTEGER NOT NULL DEFAULT 1,
     metadata    TEXT NOT NULL DEFAULT '{}',
-    PRIMARY KEY (vuln_id, package, ecosystem)
+    PRIMARY KEY (tenant_id, vuln_id, package, ecosystem)
 );
 
-CREATE INDEX IF NOT EXISTS idx_assets_status ON assets(status);
-CREATE INDEX IF NOT EXISTS idx_assets_severity ON assets(severity);
+CREATE INDEX IF NOT EXISTS idx_assets_tenant_status ON assets(tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_assets_tenant_severity ON assets(tenant_id, severity);
 """
 
 
 class AssetTracker:
     """SQLite-backed vulnerability asset tracker."""
 
-    def __init__(self, db_path: Optional[Path] = None) -> None:
+    def __init__(self, db_path: Optional[Path] = None, *, tenant_id: str = "default") -> None:
         self._db_path = db_path or DEFAULT_DB_PATH
+        self._tenant_id = tenant_id or "default"
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(self._db_path))
         self._conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
         self._conn.executescript(_SCHEMA)
+        columns = {row["name"] for row in self._conn.execute("PRAGMA table_info(assets)")}
+        if "tenant_id" in columns:
+            return
+
+        self._conn.execute("ALTER TABLE assets RENAME TO assets_legacy")
+        self._conn.executescript(_SCHEMA)
+        self._conn.execute(
+            """
+            INSERT INTO assets (
+                tenant_id, vuln_id, package, ecosystem, severity, status,
+                first_seen, last_seen, resolved_at, scan_count, metadata
+            )
+            SELECT
+                'default', vuln_id, package, ecosystem, severity, status,
+                first_seen, last_seen, resolved_at, scan_count, metadata
+            FROM assets_legacy
+            """
+        )
+        self._conn.execute("DROP TABLE assets_legacy")
+        self._conn.commit()
 
     def close(self) -> None:
         self._conn.close()
@@ -83,13 +112,23 @@ class AssetTracker:
                 current[key] = br
 
         # Load existing open/reopened assets
-        cursor = self._conn.execute("SELECT vuln_id, package, ecosystem, status FROM assets WHERE status IN ('open', 'reopened')")
+        cursor = self._conn.execute(
+            """
+            SELECT vuln_id, package, ecosystem, status
+            FROM assets
+            WHERE tenant_id = ? AND status IN ('open', 'reopened')
+            """,
+            (self._tenant_id,),
+        )
         existing_open: set[tuple[str, str, str]] = set()
         for row in cursor:
             existing_open.add((row["vuln_id"], row["package"], row["ecosystem"]))
 
         # Load all known assets (including resolved) for reopening detection
-        cursor = self._conn.execute("SELECT vuln_id, package, ecosystem, status FROM assets")
+        cursor = self._conn.execute(
+            "SELECT vuln_id, package, ecosystem, status FROM assets WHERE tenant_id = ?",
+            (self._tenant_id,),
+        )
         all_known: dict[tuple[str, str, str], str] = {}
         for row in cursor:
             all_known[(row["vuln_id"], row["package"], row["ecosystem"])] = row["status"]
@@ -115,9 +154,11 @@ class AssetTracker:
             if key not in all_known:
                 # Brand new finding
                 self._conn.execute(
-                    """INSERT INTO assets (vuln_id, package, ecosystem, severity, status, first_seen, last_seen, scan_count, metadata)
-                       VALUES (?, ?, ?, ?, 'open', ?, ?, 1, ?)""",
-                    (vuln_id, package, ecosystem, severity, now, now, meta),
+                    """INSERT INTO assets (
+                           tenant_id, vuln_id, package, ecosystem, severity, status, first_seen, last_seen, scan_count, metadata
+                       )
+                       VALUES (?, ?, ?, ?, ?, 'open', ?, ?, 1, ?)""",
+                    (self._tenant_id, vuln_id, package, ecosystem, severity, now, now, meta),
                 )
                 new_findings.append(vuln_id)
             elif all_known[key] == "resolved":
@@ -125,16 +166,16 @@ class AssetTracker:
                 self._conn.execute(
                     """UPDATE assets SET status='reopened', last_seen=?, resolved_at=NULL,
                        scan_count=scan_count+1, severity=?, metadata=?
-                       WHERE vuln_id=? AND package=? AND ecosystem=?""",
-                    (now, severity, meta, vuln_id, package, ecosystem),
+                       WHERE tenant_id=? AND vuln_id=? AND package=? AND ecosystem=?""",
+                    (now, severity, meta, self._tenant_id, vuln_id, package, ecosystem),
                 )
                 reopened_findings.append(vuln_id)
             else:
                 # Still open — bump last_seen
                 self._conn.execute(
                     """UPDATE assets SET last_seen=?, scan_count=scan_count+1, severity=?, metadata=?
-                       WHERE vuln_id=? AND package=? AND ecosystem=?""",
-                    (now, severity, meta, vuln_id, package, ecosystem),
+                       WHERE tenant_id=? AND vuln_id=? AND package=? AND ecosystem=?""",
+                    (now, severity, meta, self._tenant_id, vuln_id, package, ecosystem),
                 )
                 unchanged_count += 1
 
@@ -146,8 +187,8 @@ class AssetTracker:
                 vuln_id, package, ecosystem = key
                 self._conn.execute(
                     """UPDATE assets SET status='resolved', resolved_at=?
-                       WHERE vuln_id=? AND package=? AND ecosystem=?""",
-                    (now, vuln_id, package, ecosystem),
+                       WHERE tenant_id=? AND vuln_id=? AND package=? AND ecosystem=?""",
+                    (now, self._tenant_id, vuln_id, package, ecosystem),
                 )
                 resolved_findings.append(vuln_id)
 
@@ -185,8 +226,8 @@ class AssetTracker:
         Returns:
             List of asset dicts with first_seen, last_seen, status, etc.
         """
-        query = "SELECT * FROM assets WHERE 1=1"
-        params: list = []
+        query = "SELECT * FROM assets WHERE tenant_id = ?"
+        params: list = [self._tenant_id]
         if status:
             query += " AND status = ?"
             params.append(status)
@@ -208,8 +249,8 @@ class AssetTracker:
     def get_asset(self, vuln_id: str, package: str, ecosystem: str = "") -> Optional[dict]:
         """Get a single asset by primary key."""
         cursor = self._conn.execute(
-            "SELECT * FROM assets WHERE vuln_id=? AND package=? AND ecosystem=?",
-            (vuln_id, package, ecosystem),
+            "SELECT * FROM assets WHERE tenant_id=? AND vuln_id=? AND package=? AND ecosystem=?",
+            (self._tenant_id, vuln_id, package, ecosystem),
         )
         row = cursor.fetchone()
         if row:
@@ -229,7 +270,9 @@ class AssetTracker:
                 SUM(CASE WHEN severity = 'critical' AND status IN ('open','reopened') THEN 1 ELSE 0 END) as critical_open,
                 SUM(CASE WHEN severity = 'high' AND status IN ('open','reopened') THEN 1 ELSE 0 END) as high_open,
                 AVG(scan_count) as avg_scan_count
-            FROM assets"""
+            FROM assets
+            WHERE tenant_id = ?""",
+            (self._tenant_id,),
         )
         row = cursor.fetchone()
         return dict(row) if row else {}
@@ -244,7 +287,9 @@ class AssetTracker:
             """SELECT AVG(
                 (julianday(resolved_at) - julianday(first_seen))
             ) as avg_days
-            FROM assets WHERE status = 'resolved' AND resolved_at IS NOT NULL"""
+            FROM assets
+            WHERE tenant_id = ? AND status = 'resolved' AND resolved_at IS NOT NULL""",
+            (self._tenant_id,),
         )
         row = cursor.fetchone()
         val = row["avg_days"] if row else None

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -215,6 +215,44 @@ def verify_hmac_entries(log: AuditLog, sign_key: str) -> tuple[int, int]:
     return verified, failed
 
 
+def verify_hash_chain(path: Path) -> tuple[int, int]:
+    """Verify prev-hash chaining across JSONL audit records.
+
+    Returns ``(verified_count, tampered_count)``.
+    """
+    verified = 0
+    tampered = 0
+    previous_hash = ""
+
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            tampered += 1
+            continue
+        if not isinstance(entry, dict):
+            tampered += 1
+            continue
+
+        actual_prev = str(entry.get("prev_hash", ""))
+        actual_hash = str(entry.get("record_hash", ""))
+        payload = {k: v for k, v in entry.items() if k not in {"prev_hash", "record_hash"}}
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        expected_hash = hashlib.sha256(f"{actual_prev}|{canonical}".encode("utf-8")).hexdigest()
+
+        if actual_prev == previous_hash and actual_hash and hmac.compare_digest(actual_hash, expected_hash):
+            verified += 1
+        else:
+            tampered += 1
+
+        previous_hash = actual_hash or previous_hash
+
+    return verified, tampered
+
+
 # ─── Rich display ─────────────────────────────────────────────────────────────
 
 
@@ -239,6 +277,7 @@ def display_rich(
     blocked_only: bool = False,
     alerts_only: bool = False,
     verify_hmac_key: Optional[str] = None,
+    verify_chain_result: tuple[int, int] | None = None,
 ) -> int:
     """Render audit log to terminal using Rich. Returns exit code (1 if issues found)."""
     from rich import box
@@ -375,6 +414,14 @@ def display_rich(
         elif verified:
             console.print(f"[green]HMAC verification passed for {verified} entries[/green]")
 
+    if verify_chain_result is not None:
+        verified_chain, tampered_chain = verify_chain_result
+        if tampered_chain:
+            console.print(f"[bold red]Audit chain verification FAILED for {tampered_chain} entries![/bold red]")
+            exit_code = 1
+        elif verified_chain:
+            console.print(f"[green]Audit chain verification passed for {verified_chain} entries[/green]")
+
     # ── Nothing to show ────────────────────────────────────────────────────
     total_entries = len(log.tool_calls) + len(log.alerts) + len(log.relay_errors) + len(log.hmac_entries)
     if total_entries == 0 and not log.summary:
@@ -383,7 +430,7 @@ def display_rich(
     return exit_code
 
 
-def display_json(log: AuditLog) -> int:
+def display_json(log: AuditLog, *, chain_verification: tuple[int, int] | None = None) -> int:
     """Output structured JSON summary (for CI/scripting)."""
     s = log.summary
     out = {
@@ -411,11 +458,17 @@ def display_json(log: AuditLog) -> int:
         else None,
         "alert_details": [{"severity": a.severity, "detector": a.detector, "tool": a.tool, "message": a.message} for a in log.alerts],
     }
+    if chain_verification is not None:
+        out["chain_verification"] = {
+            "verified": chain_verification[0],
+            "tampered": chain_verification[1],
+        }
     sys.stdout.write(json.dumps(out, indent=2))
     sys.stdout.write("\n")
     blocked = out["blocked"]
     errors = out["relay_errors"]
-    return 1 if (blocked or errors) else 0
+    tampered = chain_verification[1] if chain_verification is not None else 0
+    return 1 if (blocked or errors or tampered) else 0
 
 
 # ─── Public entry point ───────────────────────────────────────────────────────
@@ -430,6 +483,7 @@ def replay(
     alerts_only: bool = False,
     sign_key: Optional[str] = None,
     verify_hmac: bool = False,
+    verify_chain: bool = False,
     as_json: bool = False,
 ) -> int:
     """Parse and display an audit log. Returns exit code (0 = clean, 1 = issues)."""
@@ -439,9 +493,10 @@ def replay(
         return 2
 
     log = parse_audit_log(path)
+    chain_result = verify_hash_chain(path) if verify_chain else None
 
     if as_json:
-        return display_json(log)
+        return display_json(log, chain_verification=chain_result)
 
     return display_rich(
         log,
@@ -450,4 +505,5 @@ def replay(
         blocked_only=blocked_only,
         alerts_only=alerts_only,
         verify_hmac_key=sign_key if verify_hmac else None,
+        verify_chain_result=chain_result,
     )

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -489,8 +489,9 @@ def watch_cmd(webhook, alert_log, interval):
     help="Secret key used when the proxy was started with --response-sign-key",
 )
 @click.option("--verify-hmac", is_flag=True, help="Verify HMAC-SHA256 response signatures in the log")
+@click.option("--verify-chain", is_flag=True, help="Verify prev-hash chaining across audit log records")
 @click.option("--json", "as_json", is_flag=True, help="Output machine-readable JSON summary (for CI)")
-def audit_replay_cmd(log_path, tool, entry_type, blocked_only, alerts_only, sign_key, verify_hmac, as_json):
+def audit_replay_cmd(log_path, tool, entry_type, blocked_only, alerts_only, sign_key, verify_hmac, verify_chain, as_json):
     """View and analyse a proxy audit JSONL log.
 
     \b
@@ -508,6 +509,7 @@ def audit_replay_cmd(log_path, tool, entry_type, blocked_only, alerts_only, sign
       agent-bom runtime audit audit.jsonl --alerts-only
       agent-bom runtime audit audit.jsonl --tool read_file
       agent-bom runtime audit audit.jsonl --sign-key $SECRET --verify-hmac
+      agent-bom runtime audit audit.jsonl --verify-chain
       agent-bom runtime audit audit.jsonl --json
     """
     from agent_bom.audit_replay import replay
@@ -520,6 +522,7 @@ def audit_replay_cmd(log_path, tool, entry_type, blocked_only, alerts_only, sign
         alerts_only=alerts_only,
         sign_key=sign_key,
         verify_hmac=verify_hmac,
+        verify_chain=verify_chain,
         as_json=as_json,
     )
     sys.exit(exit_code)

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -36,6 +36,7 @@ from typing import Any, Awaitable, Callable
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
+from agent_bom.api.auth import get_key_store
 from agent_bom.api.metrics import record_gateway_relay
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc
@@ -92,6 +93,44 @@ def _request_has_expected_token(request: Request, expected_token: str) -> bool:
     return request.headers.get("x-api-key", "").strip() == expected_token
 
 
+def _extract_request_token(request: Request) -> str:
+    auth = request.headers.get("authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[len("Bearer ") :].strip()
+    return request.headers.get("x-api-key", "").strip()
+
+
+def _gateway_requires_auth(settings: GatewaySettings) -> bool:
+    if settings.bearer_token:
+        return True
+    try:
+        return get_key_store().has_keys()
+    except Exception:
+        return False
+
+
+def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -> tuple[str, str]:
+    raw_token = _extract_request_token(request)
+    if settings.bearer_token:
+        if not raw_token or not _request_has_expected_token(request, settings.bearer_token):
+            raise HTTPException(status_code=401, detail="gateway authentication required")
+        return "default", "static_gateway_token"
+
+    try:
+        store = get_key_store()
+        if store.has_keys():
+            api_key = store.verify(raw_token) if raw_token else None
+            if api_key is None:
+                raise HTTPException(status_code=401, detail="gateway authentication required")
+            return api_key.tenant_id or "default", "api_key"
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("Gateway key verification unavailable: %s", _sanitize_for_log(exc))
+
+    return "default", "none"
+
+
 async def _default_upstream_caller(
     upstream: UpstreamConfig,
     message: dict[str, Any],
@@ -136,7 +175,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         health: dict[str, Any] = {
             "status": "ok",
             "upstreams": settings.registry.names(),
-            "auth": {"incoming_token_required": bool(settings.bearer_token)},
+            "auth": {"incoming_token_required": _gateway_requires_auth(settings)},
         }
         if settings.enable_visual_leak_detection:
             from agent_bom.runtime.visual_leak_detector import visual_leak_runtime_health
@@ -161,8 +200,12 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     @app.post("/mcp/{server_name}")
     async def relay(server_name: str, request: Request) -> JSONResponse:
         """Route an MCP JSON-RPC request to the named upstream after policy + audit."""
-        if settings.bearer_token and not _request_has_expected_token(request, settings.bearer_token):
-            raise HTTPException(status_code=401, detail="gateway authentication required")
+        tenant_id = "default"
+        auth_method = "none"
+        if _gateway_requires_auth(settings):
+            tenant_id, auth_method = _authenticate_gateway_request(request, settings)
+            request.state.tenant_id = tenant_id
+            request.state.auth_method = auth_method
 
         upstream = settings.registry.get(server_name)
         if upstream is None:

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -50,6 +50,7 @@ compute_payload_hash = _proxy_audit.compute_payload_hash
 compute_response_hmac = _proxy_audit.compute_response_hmac
 log_tool_call = _proxy_audit.log_tool_call
 summarize_runtime_alerts = _proxy_audit.summarize_runtime_alerts
+write_audit_record = _proxy_audit.write_audit_record
 
 _safe_compile = _proxy_policy._safe_compile
 _safe_regex_match = _proxy_policy._safe_regex_match
@@ -318,7 +319,7 @@ async def _proxy_sse_server(
             runtime_alerts.append(alert_dict)
             logger.warning("Runtime alert: %s", alert.message)
             if log_f:
-                log_f.write(json.dumps(alert_dict) + "\n")
+                write_audit_record(log_f, alert_dict)
                 log_f.flush()
             if alert_webhook:
                 asyncio.ensure_future(_send_webhook(alert_webhook, alert_dict))
@@ -804,7 +805,7 @@ async def run_proxy(
             runtime_alerts.append(alert_dict)
             logger.warning("Runtime alert: %s", alert.message)
             if log_f:
-                log_f.write(json.dumps(alert_dict) + "\n")
+                write_audit_record(log_f, alert_dict)
                 log_f.flush()
             if alert_webhook:
                 asyncio.ensure_future(_send_webhook(alert_webhook, alert_dict))
@@ -1135,18 +1136,16 @@ async def run_proxy(
                 # the server's actual response, not a scanner-modified version).
                 if response_signing_key and log_file:
                     sig = compute_response_hmac(msg, response_signing_key)
-                    sig_entry = (
-                        json.dumps(
-                            {
-                                "ts": datetime.now(timezone.utc).isoformat(),
-                                "type": "response_hmac",
-                                "id": msg.get("id"),
-                                "hmac_sha256": sig,
-                            }
-                        )
-                        + "\n"
+                    sig_entry = {
+                        "ts": datetime.now(timezone.utc).isoformat(),
+                        "type": "response_hmac",
+                        "id": msg.get("id"),
+                        "hmac_sha256": sig,
+                    }
+                    write_audit_record(
+                        log_file,
+                        sig_entry,
                     )
-                    log_file.write(sig_entry)
 
                 # Visual leak detection — OCR-scan image blocks in the result
                 # and either log (log_only) or paint redactions over the
@@ -1253,18 +1252,16 @@ async def run_proxy(
                 metrics.relay_errors += 1
                 logger.warning("Relay task exited with unexpected error: %s", result)
                 if log_file:
-                    err_entry = (
-                        json.dumps(
-                            {
-                                "ts": datetime.now(timezone.utc).isoformat(),
-                                "type": "relay_error",
-                                "error": str(result),
-                                "error_type": type(result).__name__,
-                            }
-                        )
-                        + "\n"
+                    err_entry = {
+                        "ts": datetime.now(timezone.utc).isoformat(),
+                        "type": "relay_error",
+                        "error": str(result),
+                        "error_type": type(result).__name__,
+                    }
+                    write_audit_record(
+                        log_file,
+                        err_entry,
                     )
-                    log_file.write(err_entry)
     finally:
         # Write metrics summary + runtime alerts to audit log before closing
         summary = metrics.summary()
@@ -1276,8 +1273,7 @@ async def run_proxy(
         if control_plane_url:
             await _flush_audit_buffer(summary=summary)
         if log_file:
-            summary_line = json.dumps(summary) + "\n"
-            log_file.write(summary_line)
+            write_audit_record(log_file, summary)
             log_file.close()
         await metrics_server.stop()
         set_gateway_evaluator(None)

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 # Maximum audit log size before rotation (100 MB). Prevents disk exhaustion
 # on long-running proxy instances.
 _AUDIT_LOG_MAX_BYTES = 100 * 1024 * 1024
+_AUDIT_CHAIN_STATE: dict[int, str] = {}
 
 
 class RotatingAuditLog:
@@ -450,7 +451,7 @@ def log_tool_call(
     if event_relationships is not None:
         record["event_relationships"] = event_relationships
 
-    log_file.write(json.dumps(record) + "\n")
+    write_audit_record(log_file, record)
     log_file.flush()
 
 
@@ -490,6 +491,25 @@ def compute_payload_hash(payload: dict) -> str:
 def compute_response_hmac(payload: dict, key: str) -> str:
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hmac.new(key.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _record_digest(record: dict) -> str:
+    payload = {k: v for k, v in record.items() if k not in {"prev_hash", "record_hash"}}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    prev_hash = str(record.get("prev_hash", ""))
+    return hashlib.sha256(f"{prev_hash}|{canonical}".encode("utf-8")).hexdigest()
+
+
+def write_audit_record(log_file: "IO[str] | RotatingAuditLog", record: dict) -> dict:
+    """Write a chain-hashed audit record to the JSONL sink."""
+    log_id = id(log_file)
+    prev_hash = _AUDIT_CHAIN_STATE.get(log_id, "")
+    payload = dict(record)
+    payload["prev_hash"] = prev_hash
+    payload["record_hash"] = _record_digest(payload)
+    log_file.write(json.dumps(payload) + "\n")
+    _AUDIT_CHAIN_STATE[log_id] = payload["record_hash"]
+    return payload
 
 
 @dataclass

--- a/tests/benchmarks/test_graph_hot_paths.py
+++ b/tests/benchmarks/test_graph_hot_paths.py
@@ -94,7 +94,7 @@ def _synth_report(n_agents: int, servers_per_agent: int = 2, pkgs_per_server: in
     return {
         "scan_id": f"bench-{n_agents}",
         "generated_at": "2026-01-01T00:00:00Z",
-        "tool_version": "0.79.0",
+        "tool_version": "0.80.1",
         "agents": agents,
         "blast_radius": blast_radius,
         "scan_sources": ["mcp-scan"],

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -25,6 +25,8 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
 
 from agent_bom.api.oidc import (
     OIDCConfig,
@@ -134,6 +136,20 @@ def test_oidc_config_require_role_claim_from_env():
     ):
         cfg = OIDCConfig.from_env()
         assert cfg.require_role_claim is True
+
+
+def test_oidc_config_reads_allow_default_tenant_and_jwks_allowlist_from_env():
+    with patch.dict(
+        os.environ,
+        {
+            "AGENT_BOM_OIDC_ISSUER": "https://test.okta.com",
+            "AGENT_BOM_OIDC_ALLOWED_JWKS_URIS": "https://test.okta.com/keys, https://backup.okta.com/keys",
+            "AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT": "true",
+        },
+    ):
+        cfg = OIDCConfig.from_env()
+        assert cfg.allow_default_tenant is True
+        assert cfg.allowed_jwks_uris == ("https://test.okta.com/keys", "https://backup.okta.com/keys")
 
 
 def test_oidc_config_from_env_reads_tenant_bound_providers():
@@ -274,6 +290,32 @@ def test_verify_raises_oidc_error_on_discovery_failure():
                 verify_oidc_token("tok", "https://down.example.com")
 
 
+def test_verify_oidc_token_requires_pinned_or_allowlisted_jwks_uri():
+    from agent_bom.api.oidc import verify_oidc_token
+
+    with patch("agent_bom.api.oidc.discover_oidc", return_value={"jwks_uri": "https://example.com/jwks.json"}):
+        with pytest.raises(OIDCError, match="requires a pinned JWKS URI"):
+            verify_oidc_token("tok", "https://example.com", audience="agent-bom")
+
+
+def test_verify_oidc_token_accepts_allowlisted_discovered_jwks_uri():
+    from agent_bom.api.oidc import verify_oidc_token
+
+    mock_jwks_client = MagicMock()
+    mock_jwks_client.get_signing_key_from_jwt.side_effect = Exception("InvalidSignature")
+    mock_jwt_module = MagicMock()
+    mock_jwt_module.PyJWKClient.return_value = mock_jwks_client
+    with patch.dict("sys.modules", {"jwt": mock_jwt_module, "cryptography": MagicMock()}):
+        with patch("agent_bom.api.oidc.discover_oidc", return_value={"jwks_uri": "https://example.com/jwks.json"}):
+            with pytest.raises(OIDCError, match="Failed to resolve signing key"):
+                verify_oidc_token(
+                    "not.a.real.jwt",
+                    "https://example.com",
+                    audience="agent-bom",
+                    allowed_jwks_uris=("https://example.com/jwks.json",),
+                )
+
+
 def test_verify_raises_oidc_error_on_bad_jwt():
     """Invalid JWT signature raises OIDCError."""
     from agent_bom.api.oidc import verify_oidc_token
@@ -317,14 +359,14 @@ def test_oidc_config_verify_requires_explicit_role_when_enabled():
             cfg.verify("valid.jwt.token")
 
 
-def test_oidc_config_resolve_tenant_defaults_when_not_required():
-    cfg = OIDCConfig(issuer="https://corp.example.com", audience="agent-bom")
+def test_oidc_config_resolve_tenant_defaults_only_when_explicitly_enabled():
+    cfg = OIDCConfig(issuer="https://corp.example.com", audience="agent-bom", allow_default_tenant=True)
     assert cfg.resolve_tenant({"sub": "user-1"}) == "default"
 
 
-def test_oidc_config_resolve_tenant_raises_when_required_claim_missing():
-    cfg = OIDCConfig(issuer="https://corp.example.com", audience="agent-bom", require_tenant_claim=True)
-    with pytest.raises(OIDCError, match="tenant claim"):
+def test_oidc_config_resolve_tenant_raises_when_claim_missing_without_opt_in():
+    cfg = OIDCConfig(issuer="https://corp.example.com", audience="agent-bom")
+    with pytest.raises(OIDCError, match="missing tenant claim"):
         cfg.resolve_tenant({"sub": "user-1"})
 
 
@@ -391,6 +433,38 @@ def test_middleware_oidc_success_sets_request_state():
 
     assert role == "analyst"
     assert claims["email"] == "alice@corp.com"
+
+
+def test_api_key_middleware_accepts_oidc_bearer_without_static_api_key(monkeypatch):
+    from agent_bom.api.middleware import APIKeyMiddleware
+
+    app = FastAPI()
+
+    @app.get("/secure")
+    async def secure(request: Request):
+        return {
+            "tenant_id": request.state.tenant_id,
+            "role": request.state.api_key_role,
+            "auth_method": request.state.auth_method,
+        }
+
+    app.add_middleware(APIKeyMiddleware, api_key=None)
+
+    cfg = OIDCConfig(issuer="https://corp.okta.com", audience="agent-bom", allow_default_tenant=True)
+    monkeypatch.setattr("agent_bom.api.oidc.OIDCConfig.from_env", lambda: cfg)
+    monkeypatch.setattr(
+        "agent_bom.api.oidc.verify_oidc_token",
+        lambda *args, **kwargs: {"sub": "u1", "email": "alice@corp.com", "agent_bom_role": "analyst"},
+    )
+
+    client = TestClient(app)
+    resp = client.get("/secure", headers={"Authorization": "Bearer token"})
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "tenant_id": "default",
+        "role": "analyst",
+        "auth_method": "oidc",
+    }
 
 
 def test_middleware_oidc_failure_does_not_raise():

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -17,6 +17,7 @@ from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.models import FleetAgentUpdate, JobStatus, PushPayload, ScanJob, ScanRequest, ScheduleCreate, StateUpdate
 from agent_bom.api.pipeline import _sync_scan_agents_to_fleet
 from agent_bom.api.policy_store import GatewayPolicy, InMemoryPolicyStore
+from agent_bom.api.routes import assets as asset_routes
 from agent_bom.api.routes import compliance as compliance_routes
 from agent_bom.api.routes import discovery as discovery_routes
 from agent_bom.api.routes import fleet as fleet_routes
@@ -26,6 +27,7 @@ from agent_bom.api.routes import schedules as schedule_routes
 from agent_bom.api.schedule_store import InMemoryScheduleStore, ScanSchedule
 from agent_bom.api.store import InMemoryJobStore, SQLiteJobStore
 from agent_bom.api.stores import _jobs, set_fleet_store, set_graph_store, set_job_store, set_policy_store, set_schedule_store
+from agent_bom.asset_tracker import AssetTracker
 
 
 def _now() -> str:
@@ -780,6 +782,52 @@ async def test_discovery_and_traces_are_tenant_scoped():
     # Trace analytics ingest must carry the authed tenant through to
     # ClickHouse so cross-tenant queries cannot see each other's events.
     assert analytics.event_tenants[0] == req.state.tenant_id
+
+
+@pytest.mark.asyncio
+async def test_asset_routes_are_tenant_scoped(tmp_path, monkeypatch):
+    db_path = tmp_path / "assets.db"
+    monkeypatch.setattr("agent_bom.asset_tracker.DEFAULT_DB_PATH", db_path)
+
+    alpha = AssetTracker(db_path=db_path, tenant_id="tenant-alpha")
+    beta = AssetTracker(db_path=db_path, tenant_id="tenant-beta")
+    try:
+        alpha.record_scan(
+            {
+                "blast_radius": [
+                    {
+                        "vulnerability_id": "CVE-alpha",
+                        "package": "langchain",
+                        "ecosystem": "pip",
+                        "severity": "critical",
+                    }
+                ]
+            }
+        )
+        beta.record_scan(
+            {
+                "blast_radius": [
+                    {
+                        "vulnerability_id": "CVE-beta",
+                        "package": "requests",
+                        "ecosystem": "pip",
+                        "severity": "high",
+                    }
+                ]
+            }
+        )
+
+        req = _request("tenant-alpha")
+        data = await asset_routes.list_assets(req)
+        assert data["count"] == 1
+        assert [asset["vuln_id"] for asset in data["assets"]] == ["CVE-alpha"]
+
+        stats = await asset_routes.get_asset_stats(req)
+        assert stats["stats"]["total"] == 1
+        assert stats["stats"]["critical_open"] == 1
+    finally:
+        alpha.close()
+        beta.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_asset_tracker.py
+++ b/tests/test_asset_tracker.py
@@ -235,3 +235,19 @@ def test_same_cve_different_packages(tracker: AssetTracker) -> None:
     diff2 = tracker.record_scan(_report([_finding("CVE-2024-0001", "lodash", "npm")]))
     assert diff2["summary"]["resolved_count"] == 1
     assert diff2["summary"]["unchanged_count"] == 1
+
+
+def test_tenant_scopes_assets_with_shared_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "shared-assets.db"
+    alpha = AssetTracker(db_path=db_path, tenant_id="tenant-alpha")
+    beta = AssetTracker(db_path=db_path, tenant_id="tenant-beta")
+    try:
+        alpha.record_scan(_report([_finding("CVE-2024-0001", "lodash", "npm")]))
+        beta.record_scan(_report([_finding("CVE-2024-0002", "requests", "pip")]))
+
+        assert [asset["vuln_id"] for asset in alpha.list_assets()] == ["CVE-2024-0001"]
+        assert [asset["vuln_id"] for asset in beta.list_assets()] == ["CVE-2024-0002"]
+        assert alpha.get_asset("CVE-2024-0002", "requests", "pip") is None
+    finally:
+        alpha.close()
+        beta.close()

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import tempfile
 from pathlib import Path
@@ -19,6 +20,7 @@ from agent_bom.audit_replay import (
     display_rich,
     parse_audit_log,
     replay,
+    verify_hash_chain,
     verify_hmac_entries,
 )
 
@@ -32,6 +34,19 @@ def _write_log(entries: list[dict]) -> Path:
         tmp.write(json.dumps(e) + "\n")
     tmp.close()
     return Path(tmp.name)
+
+
+def _chained(entries: list[dict]) -> list[dict]:
+    chained: list[dict] = []
+    prev_hash = ""
+    for entry in entries:
+        payload = dict(entry)
+        payload["prev_hash"] = prev_hash
+        canonical = json.dumps(entry, sort_keys=True, separators=(",", ":"))
+        payload["record_hash"] = hashlib.sha256(f"{prev_hash}|{canonical}".encode("utf-8")).hexdigest()
+        prev_hash = payload["record_hash"]
+        chained.append(payload)
+    return chained
 
 
 TOOL_CALL = {
@@ -287,6 +302,14 @@ def test_replay_json_output_structure(capsys):
     assert "alert_details" in data
 
 
+def test_replay_json_includes_chain_verification_when_requested(capsys):
+    p = _write_log(_chained([TOOL_CALL]))
+    replay(str(p), verify_chain=True, as_json=True)
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["chain_verification"] == {"verified": 1, "tampered": 0}
+
+
 # ── verify_hmac_entries ───────────────────────────────────────────────────────
 
 
@@ -394,6 +417,22 @@ def test_verify_hmac_mismatch():
     verified, failed = verify_hmac_entries(log, "secret")
     assert verified == 0
     assert failed == 1
+
+
+def test_verify_hash_chain_passes_for_valid_records():
+    p = _write_log(_chained([TOOL_CALL, BLOCKED_CALL]))
+    verified, tampered = verify_hash_chain(p)
+    assert verified == 2
+    assert tampered == 0
+
+
+def test_verify_hash_chain_detects_tamper():
+    entries = _chained([TOOL_CALL, BLOCKED_CALL])
+    entries[1]["tool"] = "tampered_tool"
+    p = _write_log(entries)
+    verified, tampered = verify_hash_chain(p)
+    assert verified == 1
+    assert tampered == 1
 
 
 def test_display_json_empty(capsys):

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -96,7 +96,7 @@ def test_sidecar_example_pins_runtime_image():
     doc = yaml.safe_load((K8S_DIR / "sidecar-example.yaml").read_text())
     containers = doc["spec"]["template"]["spec"]["containers"]
     proxy = next(container for container in containers if container["name"] == "agent-bom-proxy")
-    assert proxy["image"].startswith("agentbom/agent-bom-runtime:")
+    assert proxy["image"].startswith("agentbom/agent-bom:")
     assert not proxy["image"].endswith(":latest")
 
 

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -17,6 +17,7 @@ import asyncio
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 from typing import Any
 
 from starlette.testclient import TestClient
@@ -152,6 +153,50 @@ def test_relay_requires_gateway_token_when_configured() -> None:
     )
     assert allowed.status_code == 200
     assert allowed.json()["result"]["ok"] is True
+
+
+def test_relay_accepts_control_plane_api_key_and_applies_tenant(monkeypatch) -> None:
+    audit_events: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "tenant-alpha-key":
+                return SimpleNamespace(tenant_id="tenant-alpha")
+            return None
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+
+    denied = client.post(
+        "/mcp/filesystem",
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+    assert denied.status_code == 401
+
+    allowed = client.post(
+        "/mcp/filesystem",
+        headers={"X-API-Key": "tenant-alpha-key"},
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+    assert allowed.status_code == 200
+    assert allowed.json()["result"]["ok"] is True
+    assert audit_events[-1]["tenant_id"] == "tenant-alpha"
 
 
 # ─── Policy block ─────────────────────────────────────────────────────────

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -89,6 +89,8 @@ def test_log_tool_call():
     assert record["policy"] == "allowed"
     assert "ts" in record
     assert record["args"]["path"] == "/etc/hosts"
+    assert record["prev_hash"] == ""
+    assert len(record["record_hash"]) == 64
 
 
 # ── check_policy ─────────────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.79.0"
+version = "0.80.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -92,6 +92,7 @@ dev = [
     { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -110,6 +111,7 @@ dev-all = [
     { name = "psycopg-pool" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "scipy" },
@@ -177,6 +179,10 @@ ui = [
     { name = "sse-starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
+visual = [
+    { name = "pillow" },
+    { name = "pytesseract" },
+]
 wandb = [
     { name = "wandb" },
 ]
@@ -239,6 +245,7 @@ requires-dist = [
     { name = "packageurl-python", specifier = ">=0.17" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pandas", marker = "extra == 'dashboard'", specifier = ">=2.0.0" },
+    { name = "pillow", marker = "extra == 'visual'", specifier = ">=10.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10" },
     { name = "plotly", marker = "extra == 'dashboard'", specifier = ">=5.18.0" },
     { name = "protobuf", marker = "extra == 'otel'", specifier = ">=6.33.5" },
@@ -248,8 +255,10 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pyjwt", marker = "extra == 'oidc'", specifier = ">=2.8" },
+    { name = "pytesseract", marker = "extra == 'visual'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
     { name = "python3-saml", marker = "extra == 'saml'", specifier = ">=1.16.0" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -272,7 +281,7 @@ requires-dist = [
     { name = "watchdog", marker = "extra == 'watch'", specifier = ">=4.0" },
     { name = "werkzeug", specifier = ">=3.1.6" },
 ]
-provides-extras = ["api", "otel", "ui", "aws", "azure", "gcp", "coreweave", "databricks", "snowflake", "nebius", "huggingface", "wandb", "openai", "ai-enrich", "graph", "pdf", "postgres", "watch", "runtime", "mcp-server", "dashboard", "snyk", "oidc", "saml", "cloud", "docs", "dev", "dev-all"]
+provides-extras = ["api", "otel", "ui", "aws", "azure", "gcp", "coreweave", "databricks", "snowflake", "nebius", "huggingface", "wandb", "openai", "ai-enrich", "graph", "pdf", "postgres", "watch", "runtime", "visual", "mcp-server", "dashboard", "snyk", "oidc", "saml", "cloud", "docs", "dev", "dev-all"]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -3481,6 +3490,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3770,6 +3788,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytesseract"
+version = "0.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a6/7d679b83c285974a7cb94d739b461fa7e7a9b17a3abfd7bf6cbc5c2394b0/pytesseract-0.3.13.tar.gz", hash = "sha256:4bf5f880c99406f52a3cfc2633e42d9dc67615e69d8a509d74867d3baddb5db9", size = 17689, upload-time = "2024-08-16T02:33:56.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/33/8312d7ce74670c9d39a532b2c246a853861120486be9443eebf048043637/pytesseract-0.3.13-py3-none-any.whl", hash = "sha256:7a99c6c2ac598360693d83a416e36e0b33a67638bb9d77fdcac094a3589d4b34", size = 14705, upload-time = "2024-08-16T02:36:10.09Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3796,6 +3827,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- finish the 0.80.1 release coherence pass across versioned docs, changelog, Docker/public image surfaces, and release automation
- harden tenant isolation and auth paths with tenant-scoped asset tracking, fail-closed OIDC tenant/JWKS handling, and control-plane API key verification in the gateway
- add audit hash-chain verification plus focused regression coverage for OIDC, gateway auth, audit replay, tenant-scoped assets, and deployment manifests

## Validation
- uv run pytest tests/test_api_oidc.py tests/test_gateway_server.py tests/test_asset_tracker.py tests/test_audit_replay.py tests/test_api_tenant_isolation.py tests/test_proxy.py tests/test_deploy_manifests.py tests/test_postgres_store.py -q
- uv run pytest tests/test_api_oidc.py tests/test_gateway_server.py tests/test_audit_replay.py tests/test_deploy_manifests.py -q
- uv run ruff check src/agent_bom/api/auth.py src/agent_bom/api/middleware.py src/agent_bom/api/oidc.py src/agent_bom/api/pipeline.py src/agent_bom/api/postgres_access.py src/agent_bom/api/routes/assets.py src/agent_bom/asset_tracker.py src/agent_bom/audit_replay.py src/agent_bom/cli/_runtime.py src/agent_bom/gateway_server.py src/agent_bom/proxy.py src/agent_bom/proxy_audit.py tests/test_api_oidc.py tests/test_gateway_server.py tests/test_asset_tracker.py tests/test_audit_replay.py tests/test_api_tenant_isolation.py tests/test_proxy.py tests/test_deploy_manifests.py tests/benchmarks/test_graph_hot_paths.py
- uv run mypy src/agent_bom/api/oidc.py
- mkdocs build --strict
- python3 scripts/bump-version.py --check 0.80.1
