### PR TITLE
[docs] simplify self-hosted deployment and runtime flow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,89 +157,89 @@ allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
 flowchart LR
-    subgraph outside["Outside your account"]
+    subgraph outside["Outside customer-owned infrastructure"]
       idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["GitHub Actions / CI"]
-      remote["Remote MCPs<br/>SaaS + partner tools"]
+      ci["CI / scheduled jobs"]
+      remote["Approved remote MCPs"]
       osv["OSV / NVD / GHSA<br/>optional enrichment"]
     end
 
-    subgraph customer["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio"]
+    subgraph customer["Customer VPC / cluster / account"]
+      ingress["Ingress + TLS + SSO"]
 
       subgraph control["Agent-BOM control plane"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>auth · fleet · findings · audit"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup job<br/>pg_dump -> S3"]
+        ui["UI"]
+        api["API"]
+        jobs["Scan / ingest jobs"]
+        backup["Backup / scheduler"]
       end
 
       subgraph runtime["Runtime MCP plane"]
-        proxy["Proxy<br/>sidecar or laptop wrapper"]
-        gateway["Gateway<br/>agent-bom gateway serve"]
+        proxy["agent-bom proxy<br/>sidecar or local wrapper"]
+        gateway["agent-bom gateway"]
       end
 
-      subgraph data["Customer-owned data plane"]
-        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics"]
-        s3["S3 (optional)<br/>backups + SBOM archive"]
+      subgraph data["Customer-owned data stores"]
+        pg["Postgres"]
+        ch["ClickHouse<br/>optional analytics"]
+        s3["Object storage<br/>optional backups / archive"]
       end
 
       subgraph ops["Platform glue"]
-        secrets["ExternalSecrets<br/>AWS SM / Vault"]
-        metrics["OTEL + Prometheus"]
+        secrets["Secrets manager"]
+        metrics["Telemetry / monitoring"]
       end
     end
 
     idp -. OIDC .-> ingress
     ingress --> ui
     ingress --> api
-    ingress --> gateway
-    ci -->|"SARIF + findings"| api
-    jobs -->|"scan results + inventory"| api
+    ingress -. optional shared runtime URL .-> gateway
+    ci --> jobs
+    jobs --> api
+    proxy --> gateway
+    gateway --> api
+    gateway --> remote
     api --> pg
-    api -. optional .-> ch
+    api -. analytics .-> ch
     backup --> s3
     secrets --> api
     secrets --> gateway
     api --> metrics
     gateway --> metrics
-    gateway -->|"policy-audited upstream call"| remote
-    api -. optional egress .-> osv
+    api -. enrichment .-> osv
 ```
 
 *Everything inside the customer boundary runs in the customer's account. The
 default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
 upstream calls.*
 
-#### How MCP traffic actually flows
+#### Runtime MCP flow in customer infra
 
 ```mermaid
-sequenceDiagram
-    participant Dev as Developer client
-    participant Proxy as agent-bom proxy
-    participant Gateway as agent-bom gateway
-    participant API as Control-plane API
-    participant Remote as Remote MCP
-    participant Store as Postgres / audit store
+flowchart LR
+    dev["Developer client or MCP-enabled workload"]
+    proxy["Local / sidecar<br/>agent-bom proxy"]
+    gateway["In-cluster<br/>agent-bom gateway"]
+    api["Control-plane API"]
+    store["Postgres / audit store"]
+    remote["Approved remote MCP"]
 
-    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: inspect request + local policy
-    Proxy->>Gateway: audited relay
-    Gateway->>API: POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: shared policy + response
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Dev: safe response
-    API->>Store: persist audit, findings, graph links
+    dev -->|"MCP JSON-RPC"| proxy
+    proxy -->|"inspect + local policy"| gateway
+    gateway -->|"shared policy + relay"| remote
+    remote --> gateway
+    gateway -->|"response"| proxy
+    proxy -->|"safe response"| dev
+    gateway -->|"POST /v1/proxy/audit"| api
+    api --> store
 ```
 
 1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -45,89 +45,89 @@ allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
 flowchart LR
-    subgraph outside["Outside your account"]
+    subgraph outside["Outside customer-owned infrastructure"]
       idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["GitHub Actions / CI"]
-      remote["Remote MCPs<br/>SaaS + partner tools"]
+      ci["CI / scheduled jobs"]
+      remote["Approved remote MCPs"]
       osv["OSV / NVD / GHSA<br/>optional enrichment"]
     end
 
-    subgraph customer["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio"]
+    subgraph customer["Customer VPC / cluster / account"]
+      ingress["Ingress + TLS + SSO"]
 
       subgraph control["Agent-BOM control plane"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>auth · fleet · findings · audit"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup job<br/>pg_dump -> S3"]
+        ui["UI"]
+        api["API"]
+        jobs["Scan / ingest jobs"]
+        backup["Backup / scheduler"]
       end
 
       subgraph runtime["Runtime MCP plane"]
-        proxy["Proxy<br/>sidecar or laptop wrapper"]
-        gateway["Gateway<br/>agent-bom gateway serve"]
+        proxy["agent-bom proxy<br/>sidecar or local wrapper"]
+        gateway["agent-bom gateway"]
       end
 
-      subgraph data["Customer-owned data plane"]
-        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics"]
-        s3["S3 (optional)<br/>backups + SBOM archive"]
+      subgraph data["Customer-owned data stores"]
+        pg["Postgres"]
+        ch["ClickHouse<br/>optional analytics"]
+        s3["Object storage<br/>optional backups / archive"]
       end
 
       subgraph ops["Platform glue"]
-        secrets["ExternalSecrets<br/>AWS SM / Vault"]
-        metrics["OTEL + Prometheus"]
+        secrets["Secrets manager"]
+        metrics["Telemetry / monitoring"]
       end
     end
 
     idp -. OIDC .-> ingress
     ingress --> ui
     ingress --> api
-    ingress --> gateway
-    ci -->|"SARIF + findings"| api
-    jobs -->|"scan results + inventory"| api
+    ingress -. optional shared runtime URL .-> gateway
+    ci --> jobs
+    jobs --> api
+    proxy --> gateway
+    gateway --> api
+    gateway --> remote
     api --> pg
-    api -. optional .-> ch
+    api -. analytics .-> ch
     backup --> s3
     secrets --> api
     secrets --> gateway
     api --> metrics
     gateway --> metrics
-    gateway -->|"policy-audited upstream call"| remote
-    api -. optional egress .-> osv
+    api -. enrichment .-> osv
 ```
 
 *Everything inside the customer boundary runs in the customer's account. The
 default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
 upstream calls.*
 
-### How MCP traffic actually flows
+### Runtime MCP flow in customer infra
 
 ```mermaid
-sequenceDiagram
-    participant Dev as Developer client
-    participant Proxy as agent-bom proxy
-    participant Gateway as agent-bom gateway
-    participant API as Control-plane API
-    participant Remote as Remote MCP
-    participant Store as Postgres / audit store
+flowchart LR
+    dev["Developer client or MCP-enabled workload"]
+    proxy["Local / sidecar<br/>agent-bom proxy"]
+    gateway["In-cluster<br/>agent-bom gateway"]
+    api["Control-plane API"]
+    store["Postgres / audit store"]
+    remote["Approved remote MCP"]
 
-    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: inspect request + local policy
-    Proxy->>Gateway: audited relay
-    Gateway->>API: POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: shared policy + response
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Dev: safe response
-    API->>Store: persist audit, findings, graph links
+    dev -->|"MCP JSON-RPC"| proxy
+    proxy -->|"inspect + local policy"| gateway
+    gateway -->|"shared policy + relay"| remote
+    remote --> gateway
+    gateway -->|"response"| proxy
+    proxy -->|"safe response"| dev
+    gateway -->|"POST /v1/proxy/audit"| api
+    api --> store
 ```
 
 1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -67,89 +67,89 @@ allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **MCP traffic plane** | `gateway` + `proxy` Deployments | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
 flowchart LR
-    subgraph outside["Outside your account"]
+    subgraph outside["Outside customer-owned infrastructure"]
       idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["GitHub Actions / CI"]
-      remote["Remote MCPs<br/>SaaS + partner tools"]
+      ci["CI / scheduled jobs"]
+      remote["Approved remote MCPs"]
       osv["OSV / NVD / GHSA<br/>optional enrichment"]
     end
 
-    subgraph customer["Customer VPC / EKS account"]
-      ingress["Ingress + TLS<br/>ALB / Istio"]
+    subgraph customer["Customer VPC / cluster / account"]
+      ingress["Ingress + TLS + SSO"]
 
       subgraph control["Agent-BOM control plane"]
-        ui["UI<br/>same-origin browser app"]
-        api["API<br/>auth · fleet · findings · audit"]
-        jobs["Scan + ingest workers<br/>CronJob + Job"]
-        backup["Backup job<br/>pg_dump -> S3"]
+        ui["UI"]
+        api["API"]
+        jobs["Scan / ingest jobs"]
+        backup["Backup / scheduler"]
       end
 
       subgraph runtime["Runtime MCP plane"]
-        proxy["Proxy<br/>sidecar or laptop wrapper"]
-        gateway["Gateway<br/>agent-bom gateway serve"]
+        proxy["agent-bom proxy<br/>sidecar or local wrapper"]
+        gateway["agent-bom gateway"]
       end
 
-      subgraph data["Customer-owned data plane"]
-        pg["Postgres / Supabase<br/>jobs · fleet · graph · audit"]
-        ch["ClickHouse (optional)<br/>analytics"]
-        s3["S3 (optional)<br/>backups + SBOM archive"]
+      subgraph data["Customer-owned data stores"]
+        pg["Postgres"]
+        ch["ClickHouse<br/>optional analytics"]
+        s3["Object storage<br/>optional backups / archive"]
       end
 
       subgraph ops["Platform glue"]
-        secrets["ExternalSecrets<br/>AWS SM / Vault"]
-        metrics["OTEL + Prometheus"]
+        secrets["Secrets manager"]
+        metrics["Telemetry / monitoring"]
       end
     end
 
     idp -. OIDC .-> ingress
     ingress --> ui
     ingress --> api
-    ingress --> gateway
-    ci -->|"SARIF + findings"| api
-    jobs -->|"scan results + inventory"| api
+    ingress -. optional shared runtime URL .-> gateway
+    ci --> jobs
+    jobs --> api
+    proxy --> gateway
+    gateway --> api
+    gateway --> remote
     api --> pg
-    api -. optional .-> ch
+    api -. analytics .-> ch
     backup --> s3
     secrets --> api
     secrets --> gateway
     api --> metrics
     gateway --> metrics
-    gateway -->|"policy-audited upstream call"| remote
-    api -. optional egress .-> osv
+    api -. enrichment .-> osv
 ```
 
 *Everything inside the customer boundary runs in the customer's account. The
 default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
 upstream calls.*
 
-### How MCP traffic actually flows
+### Runtime MCP flow in customer infra
 
 ```mermaid
-sequenceDiagram
-    participant Dev as Developer client
-    participant Proxy as agent-bom proxy
-    participant Gateway as agent-bom gateway
-    participant API as Control-plane API
-    participant Remote as Remote MCP
-    participant Store as Postgres / audit store
+flowchart LR
+    dev["Developer client or MCP-enabled workload"]
+    proxy["Local / sidecar<br/>agent-bom proxy"]
+    gateway["In-cluster<br/>agent-bom gateway"]
+    api["Control-plane API"]
+    store["Postgres / audit store"]
+    remote["Approved remote MCP"]
 
-    Dev->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: inspect request + local policy
-    Proxy->>Gateway: audited relay
-    Gateway->>API: POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: shared policy + response
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Dev: safe response
-    API->>Store: persist audit, findings, graph links
+    dev -->|"MCP JSON-RPC"| proxy
+    proxy -->|"inspect + local policy"| gateway
+    gateway -->|"shared policy + relay"| remote
+    remote --> gateway
+    gateway -->|"response"| proxy
+    proxy -->|"safe response"| dev
+    gateway -->|"POST /v1/proxy/audit"| api
+    api --> store
 ```
 
 1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.


### PR DESCRIPTION
## Summary
- replace the repeated enterprise self-hosted Mermaid spaghetti with two simpler diagrams
- split the story into a customer-owned deployment topology and a separate MCP proxy/gateway runtime flow
- rename the table row to `Runtime MCP plane` for clearer terminology

## Validation
- `mkdocs build --strict`