### PR TITLE
[platform] sharpen scoring, lookup, and tracing

### DIFF
--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -185,6 +185,12 @@ async def auth_policy() -> dict:
         get_rate_limit_key_status,
         get_rate_limit_runtime_status,
     )
+    from agent_bom.config import (
+        API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT,
+        API_MAX_FLEET_AGENTS_PER_TENANT,
+        API_MAX_RETAINED_JOBS_PER_TENANT,
+        API_MAX_SCHEDULES_PER_TENANT,
+    )
 
     api_policy = get_api_key_policy()
     rl_status = get_rate_limit_key_status()
@@ -210,6 +216,12 @@ async def auth_policy() -> dict:
             ),
         },
         "rate_limit_runtime": rl_runtime,
+        "tenant_quotas": {
+            "active_scan_jobs": API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT,
+            "retained_scan_jobs": API_MAX_RETAINED_JOBS_PER_TENANT,
+            "fleet_agents": API_MAX_FLEET_AGENTS_PER_TENANT,
+            "schedules": API_MAX_SCHEDULES_PER_TENANT,
+        },
     }
 
 

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -61,7 +61,6 @@ from agent_bom.api.stores import (
 )
 from agent_bom.api.tracing import configure_otel_tracing, get_tracing_health
 from agent_bom.config import API_JOB_TTL_SECONDS as _JOB_TTL_SECONDS
-from agent_bom.config import API_MAX_CONCURRENT_JOBS as _MAX_CONCURRENT_JOBS  # noqa: F401 — re-exported for tests
 
 _logger = logging.getLogger(__name__)
 

--- a/src/agent_bom/api/tracing.py
+++ b/src/agent_bom/api/tracing.py
@@ -99,6 +99,49 @@ def make_request_trace(headers: dict[str, Any]) -> dict[str, str | bool | None]:
     }
 
 
+def inject_trace_headers(
+    headers: dict[str, str] | None = None,
+    *,
+    traceparent: str | None = None,
+    tracestate: str | None = None,
+    baggage: str | None = None,
+) -> dict[str, str]:
+    """Return a headers dict with bounded W3C trace headers attached."""
+    merged = dict(headers or {})
+    if traceparent:
+        merged["traceparent"] = traceparent
+    if tracestate:
+        merged["tracestate"] = tracestate
+    if baggage:
+        merged["baggage"] = baggage
+    return merged
+
+
+def inject_current_trace_headers(headers: dict[str, str] | None = None) -> dict[str, str]:
+    """Inject active OpenTelemetry context into outbound headers when enabled."""
+    merged = dict(headers or {})
+    if not configure_otel_tracing():
+        return merged
+    try:
+        from opentelemetry.propagate import inject
+    except ImportError:
+        return merged
+    inject(merged)
+    if traceparent := parse_traceparent(merged.get("traceparent")):
+        merged["traceparent"] = build_traceparent(traceparent["trace_id"], traceparent["parent_span_id"], traceparent["trace_flags"])
+    else:
+        merged.pop("traceparent", None)
+    if tracestate := parse_tracestate(merged.get("tracestate")):
+        merged["tracestate"] = tracestate
+    else:
+        merged.pop("tracestate", None)
+    if baggage := parse_baggage(merged.get("baggage")):
+        merged["baggage"] = baggage
+    else:
+        merged.pop("baggage", None)
+    return merged
+
+
 def configure_otel_tracing() -> bool:
     """Enable OTLP trace export when explicitly configured.
 
@@ -152,6 +195,17 @@ def configure_otel_tracing() -> bool:
     _otel_tracing_state = "configured"
     _logger.info("OTLP tracing enabled for agent-bom API: %s", endpoint)
     return True
+
+
+def get_tracer(name: str):
+    """Return an OpenTelemetry tracer when OTLP tracing is enabled."""
+    if not configure_otel_tracing():
+        return None
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return None
+    return trace.get_tracer(name)
 
 
 def get_tracing_health() -> TracingHealthSnapshot:

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -13,11 +13,16 @@ from __future__ import annotations
 import logging
 import sqlite3
 from collections import defaultdict
+from contextlib import nullcontext
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
+from agent_bom.api.tracing import get_tracer
+
 _logger = logging.getLogger(__name__)
+_LOOKUP_TRACER = get_tracer("agent_bom.db.lookup")
 
 
 @dataclass
@@ -129,56 +134,64 @@ def lookup_package(
     norm_name = normalize_package_name(name, ecosystem)
     eco_lower = ecosystem.lower()
 
-    rows = conn.execute(
-        """
-        SELECT
-            v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.cwe_ids, COALESCE(v.aliases, '') AS aliases, v.source,
-            v.published, v.modified,
-            a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
-            e.probability AS epss_prob, e.percentile AS epss_pct,
-            k.date_added AS kev_date
-        FROM affected a
-        JOIN vulns v ON v.id = a.vuln_id
-        LEFT JOIN epss_scores e ON e.cve_id = v.id
-        LEFT JOIN kev_entries k ON k.cve_id = v.id
-        WHERE a.ecosystem = ? AND a.package_name = ?
-        ORDER BY v.cvss_score DESC NULLS LAST
-        """,
-        (eco_lower, norm_name),
-    ).fetchall()
+    span_cm = _LOOKUP_TRACER.start_as_current_span("db.lookup_package") if _LOOKUP_TRACER else nullcontext()
+    with span_cm as span:
+        rows = conn.execute(
+            """
+            SELECT
+                v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.cwe_ids, COALESCE(v.aliases, '') AS aliases, v.source,
+                v.published, v.modified,
+                a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
+                e.probability AS epss_prob, e.percentile AS epss_pct,
+                k.date_added AS kev_date
+            FROM affected a
+            JOIN vulns v ON v.id = a.vuln_id
+            LEFT JOIN epss_scores e ON e.cve_id = v.id
+            LEFT JOIN kev_entries k ON k.cve_id = v.id
+            WHERE a.ecosystem = ? AND a.package_name = ?
+            ORDER BY v.cvss_score DESC NULLS LAST
+            """,
+            (eco_lower, norm_name),
+        ).fetchall()
 
-    epss_map, kev_map = _load_cve_enrichment(conn, rows)
-    results: list[LocalVuln] = []
-    for row in _select_vulnerability_rows(rows, version):
-        # Parse comma-separated CWE IDs from DB column
-        raw_cwes = row["cwe_ids"] or ""
-        cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
-        raw_aliases = row["aliases"] or ""
-        alias_list = [a for a in raw_aliases.split(",") if a] if raw_aliases else []
-        epss_prob, epss_pct, kev_date = _resolve_row_enrichment(row, epss_map, kev_map)
+        epss_map, kev_map = _load_cve_enrichment(conn, rows)
+        results: list[LocalVuln] = []
+        for row in _select_vulnerability_rows(rows, version):
+            # Parse comma-separated CWE IDs from DB column
+            raw_cwes = row["cwe_ids"] or ""
+            cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
+            raw_aliases = row["aliases"] or ""
+            alias_list = [a for a in raw_aliases.split(",") if a] if raw_aliases else []
+            epss_prob, epss_pct, kev_date = _resolve_row_enrichment(row, epss_map, kev_map)
 
-        results.append(
-            LocalVuln(
-                id=row["id"],
-                summary=row["summary"],
-                severity=row["severity"],
-                cvss_score=row["cvss_score"],
-                fixed_version=row["fixed_version"] or row["fixed"],
-                epss_probability=epss_prob,
-                epss_percentile=epss_pct,
-                is_kev=kev_date is not None,
-                kev_date_added=kev_date,
-                published_at=row["published"],
-                modified_at=row["modified"],
-                source=row["source"],
-                ecosystem=row["ecosystem"],
-                package_name=row["package_name"],
-                introduced=row["introduced"],
-                aliases=alias_list,
-                cwe_ids=cwe_list,
+            results.append(
+                LocalVuln(
+                    id=row["id"],
+                    summary=row["summary"],
+                    severity=row["severity"],
+                    cvss_score=row["cvss_score"],
+                    fixed_version=row["fixed_version"] or row["fixed"],
+                    epss_probability=epss_prob,
+                    epss_percentile=epss_pct,
+                    is_kev=kev_date is not None,
+                    kev_date_added=kev_date,
+                    published_at=row["published"],
+                    modified_at=row["modified"],
+                    source=row["source"],
+                    ecosystem=row["ecosystem"],
+                    package_name=row["package_name"],
+                    introduced=row["introduced"],
+                    aliases=alias_list,
+                    cwe_ids=cwe_list,
+                )
             )
-        )
-    return results
+
+        if span is not None:
+            span.set_attribute("agent_bom.lookup.ecosystem", eco_lower)
+            span.set_attribute("agent_bom.lookup.package_name", norm_name)
+            span.set_attribute("agent_bom.lookup.row_count", len(rows))
+            span.set_attribute("agent_bom.lookup.match_count", len(results))
+        return results
 
 
 def _version_affected(
@@ -194,14 +207,14 @@ def _version_affected(
     return version_in_range(version, introduced, fixed, last_affected, ecosystem)
 
 
-def _version_match_state(
+@lru_cache(maxsize=131072)
+def _cached_version_match_state(
     version: str,
     introduced: Optional[str],
     fixed: Optional[str],
     last_affected: Optional[str],
     ecosystem: str = "",
 ) -> str:
-    """Return ``affected``, ``unaffected``, or ``unknown`` for one affected-range row."""
     from agent_bom.version_utils import _looks_like_commit_sha, compare_version_order
 
     intro = introduced or None
@@ -234,6 +247,17 @@ def _version_match_state(
             unknown = True
 
     return "unknown" if unknown else "affected"
+
+
+def _version_match_state(
+    version: str,
+    introduced: Optional[str],
+    fixed: Optional[str],
+    last_affected: Optional[str],
+    ecosystem: str = "",
+) -> str:
+    """Return ``affected``, ``unaffected``, or ``unknown`` for one affected-range row."""
+    return _cached_version_match_state(version, introduced, fixed, last_affected, ecosystem)
 
 
 def _select_vulnerability_rows(rows: list[sqlite3.Row], version: Optional[str]) -> list[sqlite3.Row]:
@@ -309,78 +333,84 @@ def lookup_packages_batch(
 
     pairs = list(pair_set)
 
-    # Fetch all rows in chunks
-    all_rows: list[sqlite3.Row] = []
-    for start in range(0, len(pairs), chunk_size):
-        chunk = pairs[start : start + chunk_size]
-        placeholders = ", ".join(["(?, ?)"] * len(chunk))
-        params: list[str] = []
-        for eco, nm in chunk:
-            params.extend([eco, nm])
+    span_cm = _LOOKUP_TRACER.start_as_current_span("db.lookup_packages_batch") if _LOOKUP_TRACER else nullcontext()
+    with span_cm as span:
+        # Fetch all rows in chunks
+        all_rows: list[sqlite3.Row] = []
+        for start in range(0, len(pairs), chunk_size):
+            chunk = pairs[start : start + chunk_size]
+            placeholders = ", ".join(["(?, ?)"] * len(chunk))
+            params: list[str] = []
+            for eco, nm in chunk:
+                params.extend([eco, nm])
 
-        # placeholders is only "(?, ?)" repeated — no user data in the SQL string.
-        query = f"""
-            SELECT
-                v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.cwe_ids, COALESCE(v.aliases, '') AS aliases, v.source,
-                v.published, v.modified,
-                a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
-                e.probability AS epss_prob, e.percentile AS epss_pct,
-                k.date_added AS kev_date
-            FROM affected a
-            JOIN vulns v ON v.id = a.vuln_id
-            LEFT JOIN epss_scores e ON e.cve_id = v.id
-            LEFT JOIN kev_entries k ON k.cve_id = v.id
-            WHERE (a.ecosystem, a.package_name) IN (VALUES {placeholders})
-            ORDER BY v.cvss_score DESC NULLS LAST
-        """  # nosec B608
-        all_rows.extend(conn.execute(query, params).fetchall())
+            # placeholders is only "(?, ?)" repeated — no user data in the SQL string.
+            query = f"""
+                SELECT
+                    v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.cwe_ids, COALESCE(v.aliases, '') AS aliases, v.source,
+                    v.published, v.modified,
+                    a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
+                    e.probability AS epss_prob, e.percentile AS epss_pct,
+                    k.date_added AS kev_date
+                FROM affected a
+                JOIN vulns v ON v.id = a.vuln_id
+                LEFT JOIN epss_scores e ON e.cve_id = v.id
+                LEFT JOIN kev_entries k ON k.cve_id = v.id
+                WHERE (a.ecosystem, a.package_name) IN (VALUES {placeholders})
+                ORDER BY v.cvss_score DESC NULLS LAST
+            """  # nosec B608
+            all_rows.extend(conn.execute(query, params).fetchall())
 
-    epss_map, kev_map = _load_cve_enrichment(conn, all_rows)
+        epss_map, kev_map = _load_cve_enrichment(conn, all_rows)
 
-    # Group rows by (lower_ecosystem, package_name)
-    grouped: dict[tuple[str, str], list[sqlite3.Row]] = defaultdict(list)
-    for row in all_rows:
-        grouped[(row["ecosystem"].lower(), row["package_name"])].append(row)
+        # Group rows by (lower_ecosystem, package_name)
+        grouped: dict[tuple[str, str], list[sqlite3.Row]] = defaultdict(list)
+        for row in all_rows:
+            grouped[(row["ecosystem"].lower(), row["package_name"])].append(row)
 
-    # Build results per input package (with version filtering)
-    results: dict[tuple[str, str, str], list[LocalVuln]] = {}
-    for eco, name, version in packages:
-        key = (eco, name, version)
-        eco_lower = eco.lower()
-        rows = grouped.get((eco_lower, name), [])
+        # Build results per input package (with version filtering)
+        results: dict[tuple[str, str, str], list[LocalVuln]] = {}
+        for eco, name, version in packages:
+            key = (eco, name, version)
+            eco_lower = eco.lower()
+            rows = grouped.get((eco_lower, name), [])
 
-        vulns: list[LocalVuln] = []
-        for row in _select_vulnerability_rows(rows, version):
-            raw_cwes = row["cwe_ids"] or ""
-            cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
-            raw_aliases = row["aliases"] or ""
-            alias_list = [a for a in raw_aliases.split(",") if a] if raw_aliases else []
-            epss_prob, epss_pct, kev_date = _resolve_row_enrichment(row, epss_map, kev_map)
+            vulns: list[LocalVuln] = []
+            for row in _select_vulnerability_rows(rows, version):
+                raw_cwes = row["cwe_ids"] or ""
+                cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
+                raw_aliases = row["aliases"] or ""
+                alias_list = [a for a in raw_aliases.split(",") if a] if raw_aliases else []
+                epss_prob, epss_pct, kev_date = _resolve_row_enrichment(row, epss_map, kev_map)
 
-            vulns.append(
-                LocalVuln(
-                    id=row["id"],
-                    summary=row["summary"],
-                    severity=row["severity"],
-                    cvss_score=row["cvss_score"],
-                    fixed_version=row["fixed_version"] or row["fixed"],
-                    epss_probability=epss_prob,
-                    epss_percentile=epss_pct,
-                    is_kev=kev_date is not None,
-                    kev_date_added=kev_date,
-                    published_at=row["published"],
-                    modified_at=row["modified"],
-                    source=row["source"],
-                    ecosystem=row["ecosystem"],
-                    package_name=row["package_name"],
-                    introduced=row["introduced"],
-                    aliases=alias_list,
-                    cwe_ids=cwe_list,
+                vulns.append(
+                    LocalVuln(
+                        id=row["id"],
+                        summary=row["summary"],
+                        severity=row["severity"],
+                        cvss_score=row["cvss_score"],
+                        fixed_version=row["fixed_version"] or row["fixed"],
+                        epss_probability=epss_prob,
+                        epss_percentile=epss_pct,
+                        is_kev=kev_date is not None,
+                        kev_date_added=kev_date,
+                        published_at=row["published"],
+                        modified_at=row["modified"],
+                        source=row["source"],
+                        ecosystem=row["ecosystem"],
+                        package_name=row["package_name"],
+                        introduced=row["introduced"],
+                        aliases=alias_list,
+                        cwe_ids=cwe_list,
+                    )
                 )
-            )
-        results[key] = vulns
+            results[key] = vulns
 
-    return results
+        if span is not None:
+            span.set_attribute("agent_bom.lookup.package_count", len(packages))
+            span.set_attribute("agent_bom.lookup.unique_pairs", len(pairs))
+            span.set_attribute("agent_bom.lookup.row_count", len(all_rows))
+        return results
 
 
 def package_in_db(conn: sqlite3.Connection, ecosystem: str, name: str) -> bool:
@@ -397,6 +427,35 @@ def package_in_db(conn: sqlite3.Connection, ecosystem: str, name: str) -> bool:
         (ecosystem.lower(), norm_name),
     ).fetchone()
     return row is not None
+
+
+def package_in_db_batch(
+    conn: sqlite3.Connection,
+    packages: list[tuple[str, str]],
+) -> set[tuple[str, str]]:
+    """Return the subset of ``(ecosystem, package_name)`` pairs present in affected."""
+    if not packages:
+        return set()
+
+    normalized = {(ecosystem.lower(), name) for ecosystem, name in packages}
+    pairs = list(normalized)
+    chunk_size = 400
+    present: set[tuple[str, str]] = set()
+
+    for start in range(0, len(pairs), chunk_size):
+        chunk = pairs[start : start + chunk_size]
+        placeholders = ", ".join(["(?, ?)"] * len(chunk))
+        params: list[str] = []
+        for eco, name in chunk:
+            params.extend([eco, name])
+        query = f"""
+            SELECT DISTINCT ecosystem, package_name
+            FROM affected
+            WHERE (ecosystem, package_name) IN (VALUES {placeholders})
+        """  # nosec B608
+        present.update((row["ecosystem"], row["package_name"]) for row in conn.execute(query, params).fetchall())
+
+    return present
 
 
 class VulnDB:

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
+from agent_bom.api.tracing import get_tracer
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode
@@ -23,6 +24,9 @@ except ImportError:  # pragma: no cover
     def _is_credential_key(name: str) -> bool:
         low = name.lower()
         return any(p in low for p in ("key", "token", "secret", "password", "auth"))
+
+
+_GRAPH_TRACER = get_tracer("agent_bom.graph")
 
 
 def build_unified_graph_from_report(
@@ -41,6 +45,7 @@ def build_unified_graph_from_report(
     Returns:
         A fully populated :class:`UnifiedGraph`.
     """
+    span = _GRAPH_TRACER.start_span("graph.build_unified_graph_from_report") if _GRAPH_TRACER else None
     sid = scan_id or report_json.get("scan_id", "")
     graph = UnifiedGraph(scan_id=sid, tenant_id=tenant_id)
 
@@ -639,7 +644,15 @@ def build_unified_graph_from_report(
             vuln_node.attributes["reachability"] = br_dict.get("reachability", "")
             vuln_node.attributes["actionable"] = br_dict.get("actionable", False)
 
-    return graph
+        if span is not None:
+            span.set_attribute("agent_bom.graph.scan_id", sid)
+            span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")
+            span.set_attribute("agent_bom.graph.agent_count", len(agents_data))
+            span.set_attribute("agent_bom.graph.blast_radius_count", len(blast_data))
+            span.set_attribute("agent_bom.graph.node_count", len(graph.nodes))
+            span.set_attribute("agent_bom.graph.edge_count", len(graph.edges))
+            span.end()
+        return graph
 
 
 def _add_vuln_node(

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -644,15 +644,15 @@ def build_unified_graph_from_report(
             vuln_node.attributes["reachability"] = br_dict.get("reachability", "")
             vuln_node.attributes["actionable"] = br_dict.get("actionable", False)
 
-        if span is not None:
-            span.set_attribute("agent_bom.graph.scan_id", sid)
-            span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")
-            span.set_attribute("agent_bom.graph.agent_count", len(agents_data))
-            span.set_attribute("agent_bom.graph.blast_radius_count", len(blast_data))
-            span.set_attribute("agent_bom.graph.node_count", len(graph.nodes))
-            span.set_attribute("agent_bom.graph.edge_count", len(graph.edges))
-            span.end()
-        return graph
+    if span is not None:
+        span.set_attribute("agent_bom.graph.scan_id", sid)
+        span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")
+        span.set_attribute("agent_bom.graph.agent_count", len(agents_data))
+        span.set_attribute("agent_bom.graph.blast_radius_count", len(blast_data))
+        span.set_attribute("agent_bom.graph.node_count", len(graph.nodes))
+        span.set_attribute("agent_bom.graph.edge_count", len(graph.edges))
+        span.end()
+    return graph
 
 
 def _add_vuln_node(

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import time
 import uuid
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -28,6 +29,7 @@ from typing import TYPE_CHECKING, Optional
 from agent_bom import proxy_audit as _proxy_audit
 from agent_bom import proxy_policy as _proxy_policy
 from agent_bom.agent_identity import check_identity
+from agent_bom.api.tracing import get_tracer, inject_current_trace_headers
 from agent_bom.async_stdin import create_async_stdin_reader, read_async_stdin_line
 from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call, scan_tool_response
 from agent_bom.security import validate_arguments, validate_command
@@ -60,6 +62,7 @@ resolve_rate_limit_threshold = _proxy_policy.resolve_rate_limit_threshold
 # Maximum JSON-RPC message size accepted from client or server (10 MB).
 # Guards against DoS via oversized payloads in the stdio relay loop.
 _MAX_MESSAGE_BYTES = 10 * 1024 * 1024  # 10 MB
+_PROXY_TRACER = get_tracer("agent_bom.proxy")
 
 
 # ─── JSON-RPC parsing ────────────────────────────────────────────────────────
@@ -162,7 +165,11 @@ def _control_plane_headers(token: str | None, etag: str | None = None) -> dict[s
         headers["Authorization"] = f"Bearer {token}"
     if etag:
         headers["If-None-Match"] = etag
-    return headers
+    return inject_current_trace_headers(headers)
+
+
+def _proxy_request_headers(headers: dict[str, str] | None = None) -> dict[str, str]:
+    return inject_current_trace_headers(headers)
 
 
 async def _fetch_enabled_gateway_policies(
@@ -174,13 +181,20 @@ async def _fetch_enabled_gateway_policies(
     from agent_bom.http_client import create_client
 
     url = base_url.rstrip("/") + "/v1/gateway/policies?enabled=true"
-    async with create_client(timeout=15.0) as client:
-        response = await client.get(url, headers=_control_plane_headers(token, etag))
+    span_cm = _PROXY_TRACER.start_as_current_span("proxy.fetch_gateway_policies") if _PROXY_TRACER else nullcontext()
+    with span_cm as span:
+        if span is not None:
+            span.set_attribute("agent_bom.proxy.control_plane_url", base_url.rstrip("/"))
+            span.set_attribute("agent_bom.proxy.gateway_policy_etag_present", bool(etag))
+        async with create_client(timeout=15.0) as client:
+            response = await client.get(url, headers=_control_plane_headers(token, etag))
     if response.status_code == 304:
         return None, response.headers.get("ETag", etag)
     response.raise_for_status()
     payload = response.json()
     policies = [GatewayPolicy(**item) for item in payload.get("policies", [])]
+    if span is not None:
+        span.set_attribute("agent_bom.proxy.gateway_policy_count", len(policies))
     return policies, response.headers.get("ETag")
 
 
@@ -231,8 +245,13 @@ async def _push_proxy_audit_batch(
         "alerts": alerts,
         "summary": summary,
     }
-    async with create_client(timeout=15.0) as client:
-        response = await client.post(url, json=payload, headers=_control_plane_headers(token))
+    span_cm = _PROXY_TRACER.start_as_current_span("proxy.push_audit_batch") if _PROXY_TRACER else nullcontext()
+    with span_cm as span:
+        if span is not None:
+            span.set_attribute("agent_bom.proxy.audit_alert_count", len(alerts))
+            span.set_attribute("agent_bom.proxy.audit_has_summary", summary is not None)
+        async with create_client(timeout=15.0) as client:
+            response = await client.post(url, json=payload, headers=_control_plane_headers(token))
     response.raise_for_status()
     return True
 
@@ -329,16 +348,23 @@ async def _proxy_sse_server(
         async with httpx.AsyncClient(timeout=30) as client:
             # Fetch tool list from the remote server
             try:
-                tools_resp = await client.post(
-                    url.rstrip("/") + "/tools/list",
-                    json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
-                )
+                span_cm = _PROXY_TRACER.start_as_current_span("proxy.sse_tools_list") if _PROXY_TRACER else nullcontext()
+                with span_cm as span:
+                    if span is not None:
+                        span.set_attribute("agent_bom.proxy.upstream_url", url.rstrip("/"))
+                    tools_resp = await client.post(
+                        url.rstrip("/") + "/tools/list",
+                        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+                        headers=_proxy_request_headers(),
+                    )
                 tools_resp.raise_for_status()
                 tools_data = tools_resp.json()
                 if isinstance(tools_data, dict) and "result" in tools_data:
                     result = tools_data["result"]
                     if isinstance(result, dict) and "tools" in result:
                         declared_tools = {t["name"] for t in result["tools"] if isinstance(t, dict) and "name" in t}
+                        if span is not None:
+                            span.set_attribute("agent_bom.proxy.declared_tool_count", len(declared_tools))
                         logger.info("SSE proxy: discovered %d declared tools", len(declared_tools))
             except Exception as exc:  # noqa: BLE001
                 logger.warning("SSE proxy: could not fetch tools/list from %s: %s", url, exc)
@@ -370,6 +396,7 @@ async def _proxy_sse_server(
                             url.rstrip("/") + "/message",
                             json=msg or json.loads(line_str),
                             timeout=30,
+                            headers=_proxy_request_headers(),
                         )
                         sys.stdout.buffer.write((json.dumps(fwd.json()) + "\n").encode())
                         sys.stdout.buffer.flush()
@@ -489,11 +516,17 @@ async def _proxy_sse_server(
                 # Forward tool call to remote SSE/HTTP server
                 call_counter += 1
                 try:
-                    resp = await client.post(
-                        url.rstrip("/") + "/tools/call",
-                        json=msg,
-                        timeout=30,
-                    )
+                    span_cm = _PROXY_TRACER.start_as_current_span("proxy.sse_tools_call") if _PROXY_TRACER else nullcontext()
+                    with span_cm as span:
+                        if span is not None:
+                            span.set_attribute("agent_bom.proxy.tool_name", tool_name)
+                            span.set_attribute("agent_bom.proxy.call_counter", call_counter)
+                        resp = await client.post(
+                            url.rstrip("/") + "/tools/call",
+                            json=msg,
+                            timeout=30,
+                            headers=_proxy_request_headers(),
+                        )
                     resp.raise_for_status()
                     response_data = resp.json()
                 except httpx.HTTPStatusError as exc:
@@ -1066,10 +1099,16 @@ async def run_proxy(
                             agent_id=agent_id,
                         )
 
-            # Forward to server
-            if process.stdin:
-                process.stdin.write(line)
-                await process.stdin.drain()
+            span_cm = _PROXY_TRACER.start_as_current_span("proxy.relay_client_to_server") if (msg and _PROXY_TRACER) else nullcontext()
+            with span_cm as span:
+                if span is not None and msg is not None:
+                    span.set_attribute("agent_bom.proxy.message_kind", msg.get("method", "unknown"))
+                    if is_tools_call(msg):
+                        span.set_attribute("agent_bom.proxy.tool_name", extract_tool_name(msg) or "unknown")
+                # Forward to server
+                if process.stdin:
+                    process.stdin.write(line)
+                    await process.stdin.drain()
 
     async def relay_server_to_client():
         """Read from server stdout, forward to our stdout."""

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -598,7 +598,7 @@ def _scan_packages_local_db_batch(
     Uses :func:`lookup_packages_batch` to fetch all vulnerabilities in bulk,
     then applies the same dedup / tagging logic as the per-package path.
     """
-    from agent_bom.db.lookup import lookup_packages_batch, package_in_db
+    from agent_bom.db.lookup import lookup_packages_batch, package_in_db_batch
 
     # Build batch keys: (db_ecosystem, normalized_name, version)
     pkg_index: list[tuple[Package, list[str], str, str, list[str]]] = []  # (pkg, db_ecos, primary_norm_name, db_key, candidate_names)
@@ -616,6 +616,15 @@ def _scan_packages_local_db_batch(
                 batch_keys.append((db_eco, candidate_name, pkg.version))
 
     batch_results = lookup_packages_batch(conn, batch_keys)
+    existing_pairs = package_in_db_batch(
+        conn,
+        [
+            (db_eco, candidate_name)
+            for _pkg, db_ecos, _norm_name, _db_key, candidate_names in pkg_index
+            for db_eco in db_ecos
+            for candidate_name in candidate_names
+        ],
+    )
 
     total = 0
     for pkg, db_ecos, norm_name, db_key, candidate_names in pkg_index:
@@ -624,7 +633,7 @@ def _scan_packages_local_db_batch(
             for candidate_name in candidate_names:
                 local_vulns.extend(batch_results.get((db_eco, candidate_name, pkg.version), []))
 
-        if any(package_in_db(conn, db_eco, candidate_name) for db_eco in db_ecos for candidate_name in candidate_names):
+        if any((db_eco.lower(), candidate_name) in existing_pairs for db_eco in db_ecos for candidate_name in candidate_names):
             covered.add(db_key)
 
         if local_vulns:

--- a/src/agent_bom/trust_score.py
+++ b/src/agent_bom/trust_score.py
@@ -5,8 +5,8 @@ security signals. Every deduction is backed by specific evidence (CVE IDs,
 credential names, tool names, etc.) so operators can understand exactly
 why a server scored the way it did.
 
-Score categories (max deduction from 100):
-- CVE/Vulnerability posture:  -35 max
+Score categories (deduction budget from 100):
+- CVE/Vulnerability posture:  -35 baseline, but evidence can exhaust the full score
 - Credential exposure:        -15 max
 - Tool capability risk:       -15 max
 - Registry risk level:        -10 max
@@ -34,13 +34,41 @@ _CVE_SEVERITY_WEIGHTS: dict[Severity, float] = {
     Severity.LOW: 0.5,
 }
 
-# Maximum deduction caps per category
+# Baseline category budgets. CVE deductions can exceed the historical
+# 35-point ceiling so heavily exposed servers no longer collapse into the
+# same score bucket.
 _MAX_CVE_DEDUCTION = 35.0
 _MAX_CREDENTIAL_DEDUCTION = 15.0
 _MAX_CAPABILITY_DEDUCTION = 15.0
 _MAX_REGISTRY_DEDUCTION = 10.0
 _MAX_DRIFT_DEDUCTION = 10.0
 _MAX_SCORECARD_DEDUCTION = 15.0
+
+_EPSS_PERCENTILE_TIERS: tuple[tuple[float, float], ...] = (
+    (99.0, 4.0),
+    (95.0, 3.0),
+    (90.0, 2.0),
+    (80.0, 1.0),
+)
+
+
+def _epss_bonus(vuln) -> tuple[float, str]:
+    """Return additive EPSS/KEV pressure and evidence text."""
+    if vuln.is_kev:
+        return 3.0, " [CISA KEV: actively exploited]"
+
+    percentile = vuln.epss_percentile or 0.0
+    probability = vuln.epss_score or 0.0
+
+    for threshold, bonus in _EPSS_PERCENTILE_TIERS:
+        if percentile >= threshold:
+            return bonus, f" [EPSS percentile: {percentile:.1f}]"
+
+    if probability >= 0.7:
+        return 2.0, f" [EPSS: {probability:.1%} exploit probability]"
+    if probability >= 0.5:
+        return 1.0, f" [EPSS: {probability:.1%} exploit probability]"
+    return 0.0, ""
 
 
 @dataclass
@@ -138,7 +166,8 @@ def _score_cves(server: MCPServer) -> CategoryScore:
     """Score CVE/vulnerability posture.
 
     Each CVE deducts points based on severity. CRITICAL CVEs deduct the most.
-    Actively exploited CVEs (KEV or high EPSS) get an additional penalty.
+    Actively exploited CVEs and high-percentile EPSS entries get additional
+    pressure, and the category no longer flattens at a hard 35-point ceiling.
     """
     evidence: list[TrustEvidence] = []
     total_deduction = 0.0
@@ -146,33 +175,18 @@ def _score_cves(server: MCPServer) -> CategoryScore:
     for pkg in server.packages:
         for vuln in pkg.vulnerabilities:
             weight = _CVE_SEVERITY_WEIGHTS.get(vuln.severity, 0.5)
-
-            # Bonus penalty for actively exploited vulnerabilities
-            if vuln.is_kev:
-                weight += 3.0
-            elif vuln.epss_score is not None and vuln.epss_score > 0.5:
-                weight += 2.0
-
-            deduction = min(weight, _MAX_CVE_DEDUCTION - total_deduction)
-            if deduction <= 0:
-                break
-
+            epss_bonus, epss_note = _epss_bonus(vuln)
+            deduction = weight + epss_bonus
             total_deduction += deduction
 
             fixed_info = ""
             if vuln.fixed_version:
                 fixed_info = f" (fix available: {vuln.fixed_version})"
 
-            kev_info = ""
-            if vuln.is_kev:
-                kev_info = " [CISA KEV: actively exploited]"
-            elif vuln.epss_score is not None and vuln.epss_score > 0.5:
-                kev_info = f" [EPSS: {vuln.epss_score:.1%} exploit probability]"
-
             evidence.append(
                 TrustEvidence(
                     category="cve",
-                    description=(f"{vuln.id} ({vuln.severity.value.upper()}) in {pkg.name}@{pkg.version}{fixed_info}{kev_info}"),
+                    description=f"{vuln.id} ({vuln.severity.value.upper()}) in {pkg.name}@{pkg.version}{fixed_info}{epss_note}",
                     deduction=round(deduction, 1),
                     severity=vuln.severity.value,
                     cve_id=vuln.id,
@@ -180,15 +194,14 @@ def _score_cves(server: MCPServer) -> CategoryScore:
                     package_version=pkg.version,
                 )
             )
-        if total_deduction >= _MAX_CVE_DEDUCTION:
-            break
 
-    actual = min(total_deduction, _MAX_CVE_DEDUCTION)
+    actual = round(total_deduction, 1)
+    max_points = max(_MAX_CVE_DEDUCTION, actual)
     return CategoryScore(
         category="cve",
-        max_deduction=_MAX_CVE_DEDUCTION,
+        max_deduction=max_points,
         actual_deduction=actual,
-        score=_MAX_CVE_DEDUCTION - actual,
+        score=max(max_points - actual, 0.0),
         evidence=evidence,
     )
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -561,15 +561,16 @@ def test_max_body_size_middleware():
 
 
 def test_max_concurrent_jobs():
-    """Should return 429 when max concurrent jobs exceeded."""
-    from agent_bom.api.server import _MAX_CONCURRENT_JOBS, JobStatus, ScanJob, ScanRequest, _get_store, set_job_store
+    """Should return 429 when the tenant's active scan quota is exceeded."""
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest, _get_store, set_job_store
     from agent_bom.api.store import InMemoryJobStore
+    from agent_bom.config import API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT
 
     # Use a fresh in-memory store filled with running jobs
     original_store = _get_store()
     fake_store = InMemoryJobStore()
     dummy_request = ScanRequest()
-    for i in range(_MAX_CONCURRENT_JOBS):
+    for i in range(API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT):
         fake_store.put(
             ScanJob(
                 job_id=f"fake-{i}",
@@ -577,6 +578,7 @@ def test_max_concurrent_jobs():
                 created_at="2026-01-01T00:00:00Z",
                 request=dummy_request,
                 progress=[],
+                tenant_id="default",
             )
         )
 

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -130,6 +130,10 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "shared_across_replicas" in body["rate_limit_runtime"]
     assert "configured_api_replicas" in body["rate_limit_runtime"]
     assert "fail_closed" in body["rate_limit_runtime"]
+    assert body["tenant_quotas"]["active_scan_jobs"] >= 1
+    assert body["tenant_quotas"]["retained_scan_jobs"] >= 1
+    assert body["tenant_quotas"]["fleet_agents"] >= 1
+    assert body["tenant_quotas"]["schedules"] >= 1
 
 
 def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -6,11 +6,13 @@ import io
 import json
 from pathlib import Path
 
+import agent_bom.proxy as proxy_mod
 from agent_bom.proxy import (
     AuditDeliveryController,
     AuditSpilloverStore,
     ProxyMetrics,
     ReplayDetector,
+    _control_plane_headers,
     check_policy,
     compute_payload_hash,
     compute_response_hmac,
@@ -163,6 +165,25 @@ def test_check_policy_blocks_unknown_egress_host():
     allowed, reason = check_policy(policy, "web_fetch", {"url": "https://evil.example/path"})
     assert allowed is False
     assert "allowlisted" in reason.lower()
+
+
+def test_control_plane_headers_propagate_w3c_trace_context(monkeypatch):
+    """Control-plane requests should carry bounded W3C trace headers when present."""
+
+    def _fake_inject(headers):
+        headers = dict(headers)
+        headers["traceparent"] = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+        headers["tracestate"] = "vendor-a=foo"
+        headers["baggage"] = "tenant=acme"
+        return headers
+
+    monkeypatch.setattr(proxy_mod, "inject_current_trace_headers", _fake_inject)
+    headers = _control_plane_headers("secret-token", "etag-1")
+    assert headers["Authorization"] == "Bearer secret-token"
+    assert headers["If-None-Match"] == "etag-1"
+    assert headers["traceparent"].startswith("00-")
+    assert headers["tracestate"] == "vendor-a=foo"
+    assert headers["baggage"] == "tenant=acme"
 
 
 # ── ProxyMetrics ────────────────────────────────────────────────────────────

--- a/tests/test_trust_score.py
+++ b/tests/test_trust_score.py
@@ -38,6 +38,7 @@ def _vuln(
     severity: Severity = Severity.HIGH,
     fixed_version: str | None = None,
     epss_score: float | None = None,
+    epss_percentile: float | None = None,
     is_kev: bool = False,
 ) -> Vulnerability:
     return Vulnerability(
@@ -46,6 +47,7 @@ def _vuln(
         severity=severity,
         fixed_version=fixed_version,
         epss_score=epss_score,
+        epss_percentile=epss_percentile,
         is_kev=is_kev,
     )
 
@@ -192,13 +194,29 @@ def test_high_epss_extra_penalty():
     assert "EPSS" in cve_cat.evidence[0].description
 
 
-def test_cve_deduction_capped():
-    """CVE deductions are capped at max."""
+def test_high_epss_percentile_gets_tiered_bonus():
+    """High EPSS percentile gets a stronger tiered bonus than a boolean flag."""
+    pkg = Package(
+        name="requests",
+        version="2.25.0",
+        ecosystem="pypi",
+        vulnerabilities=[_vuln("CVE-2024-0099", Severity.HIGH, epss_score=0.3, epss_percentile=99.2)],
+    )
+    server = _server(packages=[pkg], registry_verified=True)
+    cve_cat = _score_cves(server)
+    assert cve_cat.actual_deduction == 9.0
+    assert "EPSS percentile" in cve_cat.evidence[0].description
+
+
+def test_cve_deduction_scales_past_old_cap():
+    """Large critical sets no longer flatten at the historical 35-point cap."""
     vulns = [_vuln(f"CVE-2024-{i:04d}", Severity.CRITICAL) for i in range(10)]
     pkg = Package(name="bad-pkg", version="1.0.0", ecosystem="npm", vulnerabilities=vulns)
     server = _server(packages=[pkg], registry_verified=True)
     cve_cat = _score_cves(server)
-    assert cve_cat.actual_deduction <= 35.0
+    assert cve_cat.actual_deduction == 80.0
+    assert cve_cat.max_deduction == 80.0
+    assert cve_cat.score == 0.0
 
 
 def test_cve_fix_version_in_evidence():


### PR DESCRIPTION
Summary
- sharpen blast-radius scoring with EPSS percentile tiers and removal of the old 35-point deduction ceiling
- cut package lookup overhead with cached version matching, batched package existence checks, and lookup batch tracing
- make per-tenant quota surfaces explicit in auth policy and tests
- add OTEL spans plus W3C trace propagation on the control-plane and SSE proxy hot paths

Validation
- uv run pytest tests/test_trust_score.py tests/test_batch_db_lookup.py tests/test_api_operator_policy.py tests/test_api_hardening.py tests/test_proxy.py tests/test_graph_builder.py tests/test_graph_backend.py -q
- uv run ruff check src/agent_bom/trust_score.py src/agent_bom/db/lookup.py src/agent_bom/scanners/__init__.py src/agent_bom/api/tracing.py src/agent_bom/proxy.py src/agent_bom/graph/builder.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/server.py tests/test_trust_score.py tests/test_batch_db_lookup.py tests/test_api_operator_policy.py tests/test_api_hardening.py tests/test_proxy.py
