### PR TITLE
[docs] simplify self-hosted deployment and runtime diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,16 @@ rollout runbooks live under [`site-docs/deployment/`](site-docs/deployment/).
 
 ### Default self-hosted deployment shape
 
-Everything agent-bom ships runs inside one trust boundary — the customer's
-VPC, EKS account, or self-managed cluster. The only arrows that cross that
-boundary are OIDC (inbound, terminated at ingress) and policy-audited MCP
-upstream calls (outbound). Enrichment to OSV/NVD is optional and
-allow-listable.
+Keep the deployment story split into two views:
+
+- **deployment topology**: what runs in the customer's environment
+- **runtime MCP flow**: how proxy, gateway, API, and upstream MCP calls
+  interact
+
+Everything agent-bom ships runs inside one trust boundary: the customer's VPC,
+EKS account, or self-managed cluster. The normal cross-boundary paths are
+inbound OIDC and outbound, policy-audited MCP upstream calls. Enrichment to
+OSV/NVD is optional and allow-listable.
 
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
@@ -163,94 +168,108 @@ allow-listable.
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart LR
-    subgraph outside["Outside customer-owned infrastructure"]
-      idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["CI / scheduled jobs"]
-      remote["Approved remote MCPs"]
-      osv["OSV / NVD / GHSA<br/>optional enrichment"]
+flowchart TB
+    classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
+    classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
+    classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
+    classDef run  fill:#0f172a,stroke:#10b981,color:#d1fae5
+    classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
+    classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
+
+    Browser["Browser operators"]:::ext
+    IdP["Corporate IdP"]:::ext
+    CI["CI + scheduled scans"]:::ext
+    Remote["Remote MCPs"]:::ext
+    Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
+
+    subgraph Customer["Customer VPC / EKS / self-managed cluster"]
+      direction TB
+      Ingress["Ingress + TLS"]:::edge
+
+      subgraph Control["Control plane"]
+        direction LR
+        UI["UI<br/>same-origin browser app"]:::ctrl
+        API["API<br/>auth · findings · fleet · audit"]:::ctrl
+        Jobs["Workers<br/>CronJob / Job"]:::ctrl
+        Backup["Backup job"]:::ctrl
+      end
+
+      subgraph Runtime["Runtime MCP plane"]
+        direction LR
+        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
+        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
+      end
+
+      subgraph Data["Customer-owned data"]
+        direction LR
+        PG[("Postgres / Supabase")]:::data
+        CH[("ClickHouse optional")]:::data
+        S3[("S3 optional")]:::data
+      end
+
+      subgraph Platform["Platform services"]
+        direction LR
+        Secrets["ExternalSecrets / IRSA / Vault"]:::ops
+        Obs["OTEL + Prometheus"]:::ops
+      end
     end
 
-    subgraph customer["Customer VPC / cluster / account"]
-      ingress["Ingress + TLS + SSO"]
-
-      subgraph control["Agent-BOM control plane"]
-        ui["UI"]
-        api["API"]
-        jobs["Scan / ingest jobs"]
-        backup["Backup / scheduler"]
-      end
-
-      subgraph runtime["Runtime MCP plane"]
-        proxy["agent-bom proxy<br/>sidecar or local wrapper"]
-        gateway["agent-bom gateway"]
-      end
-
-      subgraph data["Customer-owned data stores"]
-        pg["Postgres"]
-        ch["ClickHouse<br/>optional analytics"]
-        s3["Object storage<br/>optional backups / archive"]
-      end
-
-      subgraph ops["Platform glue"]
-        secrets["Secrets manager"]
-        metrics["Telemetry / monitoring"]
-      end
-    end
-
-    idp -. OIDC .-> ingress
-    ingress --> ui
-    ingress --> api
-    ingress -. optional shared runtime URL .-> gateway
-    ci --> jobs
-    jobs --> api
-    proxy --> gateway
-    gateway --> api
-    gateway --> remote
-    api --> pg
-    api -. analytics .-> ch
-    backup --> s3
-    secrets --> api
-    secrets --> gateway
-    api --> metrics
-    gateway --> metrics
-    api -. enrichment .-> osv
+    Browser --> Ingress
+    IdP -. OIDC .-> Ingress
+    Ingress --> UI
+    UI -->|same-origin API calls| API
+    CI --> Jobs
+    Jobs -->|results + inventory| API
+    Proxy -->|audited relay| Gateway
+    Gateway -->|POST /v1/proxy/audit| API
+    Gateway -->|policy-audited upstream| Remote
+    API --> PG
+    API -. optional analytics .-> CH
+    Backup --> S3
+    Secrets --> API
+    Secrets --> Gateway
+    API --> Obs
+    Gateway --> Obs
+    API -. optional egress .-> Intel
 ```
 
-*Everything inside the customer boundary runs in the customer's account. The
-default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
-upstream calls.*
+*Deployment truth: the UI is not the collector. The browser drives workflows,
+the API owns control-plane state, workers do scans, and proxy plus gateway
+handle runtime MCP traffic. For the role split, see the [Self-Hosted Product
+Architecture](site-docs/architecture/self-hosted-product-architecture.md).*
 
-#### Runtime MCP flow in customer infra
+#### MCP proxy and gateway runtime flow
 
 ```mermaid
-flowchart LR
-    dev["Developer client or MCP-enabled workload"]
-    proxy["Local / sidecar<br/>agent-bom proxy"]
-    gateway["In-cluster<br/>agent-bom gateway"]
-    api["Control-plane API"]
-    store["Postgres / audit store"]
-    remote["Approved remote MCP"]
+sequenceDiagram
+    participant Client as Developer or workload client
+    participant Proxy as agent-bom proxy
+    participant Gateway as agent-bom gateway
+    participant API as Control-plane API
+    participant Remote as Remote MCP
+    participant Store as Postgres / audit store
 
-    dev -->|"MCP JSON-RPC"| proxy
-    proxy -->|"inspect + local policy"| gateway
-    gateway -->|"shared policy + relay"| remote
-    remote --> gateway
-    gateway -->|"response"| proxy
-    proxy -->|"safe response"| dev
-    gateway -->|"POST /v1/proxy/audit"| api
-    api --> store
+    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
+    Proxy->>Proxy: local policy + runtime checks
+    Proxy->>Gateway: audited relay
+    Gateway->>API: policy fetch / POST /v1/proxy/audit
+    Gateway->>Remote: upstream MCP call
+    Remote-->>Gateway: MCP response
+    Gateway-->>Proxy: response + shared policy result
+    Proxy->>Proxy: optional VLD / OCR redaction
+    Proxy-->>Client: safe response
+    API->>Store: persist audit, findings, graph links
 ```
 
-1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
-2. The proxy inspects and audits the call, enforces local policy, and relays
-   to the central `agent-bom gateway`.
-3. The gateway applies shared policy, records audit to `/v1/proxy/audit`, and
-   forwards to the remote MCP upstream.
-4. Responses come back on the same path; image responses can run through the
-   visual leak detector before they reach the developer.
-5. The control plane persists audit, findings, and graph state for the UI,
-   exports, and compliance surfaces.
+1. The client talks to a local or sidecar `agent-bom proxy`.
+2. The proxy applies local runtime checks and relays to the central
+   `agent-bom gateway`.
+3. The gateway evaluates shared policy, records audit to `/v1/proxy/audit`,
+   then calls the remote MCP upstream.
+4. The response returns on the same path; image responses can run through the
+   visual leak detector before the client sees them.
+5. The API persists audit, findings, and graph links for the UI, exports, and
+   compliance surfaces.
 
 #### Who owns what
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
   - Architecture:
       - Overview: architecture/overview.md
       - How Agent-BOM Works: architecture/how-agent-bom-works.md
+      - Self-Hosted Product Architecture: architecture/self-hosted-product-architecture.md
       - Hosted Product Control Plane: architecture/hosted-product-spec.md
       - AI Infrastructure Scanning: architecture/ai-infrastructure.md
       - Data Ingestion and Security: architecture/data-ingestion-and-security.md

--- a/site-docs/architecture/how-agent-bom-works.md
+++ b/site-docs/architecture/how-agent-bom-works.md
@@ -256,6 +256,7 @@ CLI, API/UI, MCP, proxy, and export surfaces.
 ## Related docs
 
 - [Architecture Overview](overview.md)
+- [Self-Hosted Product Architecture](self-hosted-product-architecture.md)
 - [Hosted Product Control-Plane Spec](hosted-product-spec.md)
 - [Data Ingestion and Security](data-ingestion-and-security.md)
 - [Canonical Model vs OCSF](canonical-vs-ocsf.md)

--- a/site-docs/architecture/self-hosted-product-architecture.md
+++ b/site-docs/architecture/self-hosted-product-architecture.md
@@ -1,0 +1,94 @@
+# Self-Hosted Product Architecture
+
+This is the short, truthful product contract behind the self-hosted deployment
+diagrams.
+
+`agent-bom` is not one giant process. It is a small set of roles that work
+together inside the customer's environment.
+
+## The control-plane rule
+
+- the browser UI drives workflows
+- the API owns auth, RBAC, tenant scope, orchestration, persistence, graph,
+  audit, and policy state
+- workers do scan and ingest jobs
+- proxy and gateway handle live MCP traffic
+- the Node.js UI is never the collector
+
+That split is what keeps the deployment secure, scalable, and true to the code.
+
+## What each surface actually does
+
+| Surface | Runs where | Owns | Does not own |
+|---|---|---|---|
+| **UI** | browser, same-origin behind the customer's ingress | source setup, run-now actions, schedule management, review, export | direct cloud reads, repo scans, or runtime collection |
+| **API / control plane** | customer VPC / EKS / self-managed compute | auth, RBAC, tenant scope, job orchestration, graph, findings, audit, policy, exports | inline MCP enforcement |
+| **Workers** | CronJob, Job, CI runner, or one-off execution path | repo, image, IaC, MCP config, package, and cloud scan execution; artifact parsing; pushed-ingest normalization | browser sessions or UI state |
+| **Proxy** | sidecar or local wrapper near selected MCP workloads | low-latency MCP inspection, local allow or warn decisions, audit relay | central policy storage or operator review |
+| **Gateway** | customer-managed service in the runtime MCP plane | shared policy evaluation, upstream discovery, remote MCP relay, audit push to the API | full control-plane persistence or browser workflows |
+| **Stores** | Postgres required; ClickHouse and S3 optional | transactional state, analytics, backups, SBOM archive | orchestration or runtime policy decisions |
+
+## Deployment truth
+
+In a normal self-hosted rollout:
+
+1. operators use the UI through the customer's ingress
+2. the UI talks to the API over same-origin routes
+3. scheduled workers and CI jobs send results and inventory into the API
+4. endpoint or collector surfaces push fleet data into the API
+5. proxy and gateway send runtime audit into the API
+6. the API persists state to Postgres and optionally projects analytics or
+   backups elsewhere
+
+That means the product can feel end to end without making the browser do
+privileged collection work.
+
+## Intake paths that are real today
+
+The backend can collect or accept data through these code-backed paths:
+
+- API-triggered scan jobs
+- scheduled workers and CronJobs
+- CI pushes and imports
+- fleet sync into `/v1/fleet/sync`
+- traces and pushed results into the API
+- proxy or gateway audit into `/v1/proxy/audit`
+- imported artifacts such as SBOMs or external scanner JSON
+
+Some connector and credential-management surfaces are still maturing, but the
+core intake rule is already stable: every supported path goes through the API,
+workers, imports, or proxy and gateway flows.
+
+## What the diagrams are trying to show
+
+Use the two deployment diagrams with this reading order:
+
+1. **deployment topology** answers "what runs in the customer's environment?"
+2. **runtime MCP flow** answers "how does an MCP request move through proxy,
+   gateway, API, and the upstream?"
+
+If a diagram tries to answer both at once, it becomes harder to read and easier
+to misrepresent.
+
+## Operator checklist
+
+If the product is wired correctly, an operator should be able to answer all of
+these from the control plane:
+
+- what source or runtime path is configured
+- who owns it
+- how it authenticates
+- what tenant it belongs to
+- when it last ran
+- what evidence or audit trail it produced
+- which policy applies to it
+
+If the UI cannot answer those questions, the control plane is not fully
+productized yet.
+
+## Related docs
+
+- [Deployment Overview](../deployment/overview.md)
+- [Deploy In Your Own AWS / EKS Infrastructure](../deployment/own-infra-eks.md)
+- [Packaged API + UI Control Plane](../deployment/control-plane-helm.md)
+- [Hosted Product Control-Plane Spec](hosted-product-spec.md)

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -31,24 +31,19 @@ The image split is intentional:
 - `agentbom/agent-bom-ui` runs the standalone browser UI that sits behind the
   same ingress or a separate UI service
 
-```mermaid
-flowchart LR
-    A[Browser] --> B[Ingress]
-    B -->|/| C[agent-bom-ui Service]
-    B -->|/v1 /health /docs /ws| D[agent-bom-api Service]
-    D --> E[(Postgres)]
-    D --> F[(ClickHouse optional)]
-    G[Scanner CronJob] --> D
-    H[OIDC or SAML / API key auth] --> D
-```
-
 ## Enterprise deployment topology
 
-Everything agent-bom ships runs inside one trust boundary — the customer's
-VPC, EKS account, or self-managed cluster. The only arrows that cross that
-boundary are OIDC (inbound, terminated at ingress) and policy-audited MCP
-upstream calls (outbound). Enrichment to OSV/NVD is optional and
-allow-listable.
+Use two diagrams, not one overloaded graph:
+
+- **deployment topology** for what the Helm install actually puts in your
+  environment
+- **runtime MCP flow** for how proxy, gateway, API, and upstream MCP traffic
+  interact
+
+Everything agent-bom ships runs inside one trust boundary: the customer's VPC,
+EKS account, or self-managed cluster. The normal cross-boundary paths are
+inbound OIDC and outbound, policy-audited MCP upstream calls. Enrichment to
+OSV/NVD is optional and allow-listable.
 
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
@@ -59,94 +54,108 @@ allow-listable.
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart LR
-    subgraph outside["Outside customer-owned infrastructure"]
-      idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["CI / scheduled jobs"]
-      remote["Approved remote MCPs"]
-      osv["OSV / NVD / GHSA<br/>optional enrichment"]
+flowchart TB
+    classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
+    classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
+    classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
+    classDef run  fill:#0f172a,stroke:#10b981,color:#d1fae5
+    classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
+    classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
+
+    Browser["Browser operators"]:::ext
+    IdP["Corporate IdP"]:::ext
+    CI["CI + scheduled scans"]:::ext
+    Remote["Remote MCPs"]:::ext
+    Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
+
+    subgraph Customer["Customer VPC / EKS / self-managed cluster"]
+      direction TB
+      Ingress["Ingress + TLS"]:::edge
+
+      subgraph Control["Control plane"]
+        direction LR
+        UI["UI<br/>same-origin browser app"]:::ctrl
+        API["API<br/>auth · findings · fleet · audit"]:::ctrl
+        Jobs["Workers<br/>CronJob / Job"]:::ctrl
+        Backup["Backup job"]:::ctrl
+      end
+
+      subgraph Runtime["Runtime MCP plane"]
+        direction LR
+        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
+        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
+      end
+
+      subgraph Data["Customer-owned data"]
+        direction LR
+        PG[("Postgres / Supabase")]:::data
+        CH[("ClickHouse optional")]:::data
+        S3[("S3 optional")]:::data
+      end
+
+      subgraph Platform["Platform services"]
+        direction LR
+        Secrets["ExternalSecrets / IRSA / Vault"]:::ops
+        Obs["OTEL + Prometheus"]:::ops
+      end
     end
 
-    subgraph customer["Customer VPC / cluster / account"]
-      ingress["Ingress + TLS + SSO"]
-
-      subgraph control["Agent-BOM control plane"]
-        ui["UI"]
-        api["API"]
-        jobs["Scan / ingest jobs"]
-        backup["Backup / scheduler"]
-      end
-
-      subgraph runtime["Runtime MCP plane"]
-        proxy["agent-bom proxy<br/>sidecar or local wrapper"]
-        gateway["agent-bom gateway"]
-      end
-
-      subgraph data["Customer-owned data stores"]
-        pg["Postgres"]
-        ch["ClickHouse<br/>optional analytics"]
-        s3["Object storage<br/>optional backups / archive"]
-      end
-
-      subgraph ops["Platform glue"]
-        secrets["Secrets manager"]
-        metrics["Telemetry / monitoring"]
-      end
-    end
-
-    idp -. OIDC .-> ingress
-    ingress --> ui
-    ingress --> api
-    ingress -. optional shared runtime URL .-> gateway
-    ci --> jobs
-    jobs --> api
-    proxy --> gateway
-    gateway --> api
-    gateway --> remote
-    api --> pg
-    api -. analytics .-> ch
-    backup --> s3
-    secrets --> api
-    secrets --> gateway
-    api --> metrics
-    gateway --> metrics
-    api -. enrichment .-> osv
+    Browser --> Ingress
+    IdP -. OIDC .-> Ingress
+    Ingress --> UI
+    UI -->|same-origin API calls| API
+    CI --> Jobs
+    Jobs -->|results + inventory| API
+    Proxy -->|audited relay| Gateway
+    Gateway -->|POST /v1/proxy/audit| API
+    Gateway -->|policy-audited upstream| Remote
+    API --> PG
+    API -. optional analytics .-> CH
+    Backup --> S3
+    Secrets --> API
+    Secrets --> Gateway
+    API --> Obs
+    Gateway --> Obs
+    API -. optional egress .-> Intel
 ```
 
-*Everything inside the customer boundary runs in the customer's account. The
-default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
-upstream calls.*
+*Deployment truth: the UI is not the collector. The browser drives workflows,
+the API owns control-plane state, workers do scans, and proxy plus gateway
+handle runtime MCP traffic. For the role split, see the [Self-Hosted Product
+Architecture](../architecture/self-hosted-product-architecture.md).*
 
-### Runtime MCP flow in customer infra
+### MCP proxy and gateway runtime flow
 
 ```mermaid
-flowchart LR
-    dev["Developer client or MCP-enabled workload"]
-    proxy["Local / sidecar<br/>agent-bom proxy"]
-    gateway["In-cluster<br/>agent-bom gateway"]
-    api["Control-plane API"]
-    store["Postgres / audit store"]
-    remote["Approved remote MCP"]
+sequenceDiagram
+    participant Client as Developer or workload client
+    participant Proxy as agent-bom proxy
+    participant Gateway as agent-bom gateway
+    participant API as Control-plane API
+    participant Remote as Remote MCP
+    participant Store as Postgres / audit store
 
-    dev -->|"MCP JSON-RPC"| proxy
-    proxy -->|"inspect + local policy"| gateway
-    gateway -->|"shared policy + relay"| remote
-    remote --> gateway
-    gateway -->|"response"| proxy
-    proxy -->|"safe response"| dev
-    gateway -->|"POST /v1/proxy/audit"| api
-    api --> store
+    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
+    Proxy->>Proxy: local policy + runtime checks
+    Proxy->>Gateway: audited relay
+    Gateway->>API: policy fetch / POST /v1/proxy/audit
+    Gateway->>Remote: upstream MCP call
+    Remote-->>Gateway: MCP response
+    Gateway-->>Proxy: response + shared policy result
+    Proxy->>Proxy: optional VLD / OCR redaction
+    Proxy-->>Client: safe response
+    API->>Store: persist audit, findings, graph links
 ```
 
-1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
-2. The proxy inspects and audits the call, enforces local policy, and relays
-   to the central `agent-bom gateway`.
-3. The gateway applies shared policy, records audit to `/v1/proxy/audit`, and
-   forwards to the remote MCP upstream.
-4. Responses come back on the same path; image responses can run through the
-   visual leak detector before they reach the developer.
-5. The control plane persists audit, findings, and graph state for the UI,
-   exports, and compliance surfaces.
+1. The client talks to a local or sidecar `agent-bom proxy`.
+2. The proxy applies local runtime checks and relays to the central
+   `agent-bom gateway`.
+3. The gateway evaluates shared policy, records audit to `/v1/proxy/audit`,
+   then calls the remote MCP upstream.
+4. The response returns on the same path; image responses can run through the
+   visual leak detector before the client sees them.
+5. The API persists audit, findings, and graph links for the UI, exports, and
+   compliance surfaces.
 
 ## Same-origin default
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -14,55 +14,27 @@ surfaces.
 
 ## Scope
 
-```mermaid
-flowchart LR
-    subgraph EndpointFleet["Endpoint fleet"]
-      Cursor["Cursor / Windsurf / Cline"]
-      Claude["Claude Desktop / Claude Code"]
-      VSCode["VS Code / Copilot / Continue / Roo / Amazon Q / Cortex Code"]
-      Scan["agent-bom agents --preset enterprise --introspect --push-url .../v1/fleet/sync"]
-      Cursor --> Scan
-      Claude --> Scan
-      VSCode --> Scan
-    end
+This pilot keeps the product surface narrow on purpose:
 
-    subgraph RuntimeFleet["Runtime fleet on EKS"]
-      Cron["Scanner CronJob"]
-      Sidecars["Selected MCP sidecars"]
-      Workloads["In-cluster MCP workloads"]
-      Workloads --> Cron
-      Workloads --> Sidecars
-    end
-
-    subgraph ControlPlane["Self-hosted control plane"]
-      API["FastAPI API"]
-      UI["Next.js UI"]
-      Gateway["Gateway policy UI/API"]
-      Audit["Audit + findings + fleet stores"]
-      API --> Gateway
-      API --> Audit
-      UI --> API
-    end
-
-    subgraph DataPlane["Persistence"]
-      PG["Postgres / Supabase"]
-      CH["ClickHouse (optional analytics)"]
-    end
-
-    Scan --> API
-    Cron --> API
-    Sidecars --> API
-    API --> PG
-    API --> CH
-```
+- employee endpoints push fleet and discovery state into the control plane
+- scheduled scan jobs cover cluster, package, image, and MCP discovery
+- selected MCP workloads get `agent-bom proxy` sidecars or local wrappers
+- the control plane hosts API, UI, findings, audit, and gateway policy
+- Postgres is required; ClickHouse stays optional
 
 ## Enterprise deployment topology
 
-Everything agent-bom ships runs inside one trust boundary — the customer's
-VPC, EKS account, or self-managed cluster. The only arrows that cross that
-boundary are OIDC (inbound, terminated at ingress) and policy-audited MCP
-upstream calls (outbound). Enrichment to OSV/NVD is optional and
-allow-listable.
+Use two diagrams, not one overloaded graph:
+
+- **deployment topology** for what the pilot installs in the customer's
+  environment
+- **runtime MCP flow** for how proxy, gateway, API, and upstream MCP traffic
+  interact
+
+Everything agent-bom ships runs inside one trust boundary: the customer's VPC,
+EKS account, or self-managed cluster. The normal cross-boundary paths are
+inbound OIDC and outbound, policy-audited MCP upstream calls. Enrichment to
+OSV/NVD is optional and allow-listable.
 
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
@@ -73,114 +45,108 @@ allow-listable.
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart LR
-    subgraph outside["Outside customer-owned infrastructure"]
-      idp["Corporate IdP<br/>Okta · Entra · Google"]
-      ci["CI / scheduled jobs"]
-      remote["Approved remote MCPs"]
-      osv["OSV / NVD / GHSA<br/>optional enrichment"]
+flowchart TB
+    classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
+    classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
+    classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
+    classDef run  fill:#0f172a,stroke:#10b981,color:#d1fae5
+    classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
+    classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
+
+    Browser["Browser operators"]:::ext
+    IdP["Corporate IdP"]:::ext
+    CI["CI + scheduled scans"]:::ext
+    Remote["Remote MCPs"]:::ext
+    Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
+
+    subgraph Customer["Customer VPC / EKS / self-managed cluster"]
+      direction TB
+      Ingress["Ingress + TLS"]:::edge
+
+      subgraph Control["Control plane"]
+        direction LR
+        UI["UI<br/>same-origin browser app"]:::ctrl
+        API["API<br/>auth · findings · fleet · audit"]:::ctrl
+        Jobs["Workers<br/>CronJob / Job"]:::ctrl
+        Backup["Backup job"]:::ctrl
+      end
+
+      subgraph Runtime["Runtime MCP plane"]
+        direction LR
+        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
+        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
+      end
+
+      subgraph Data["Customer-owned data"]
+        direction LR
+        PG[("Postgres / Supabase")]:::data
+        CH[("ClickHouse optional")]:::data
+        S3[("S3 optional")]:::data
+      end
+
+      subgraph Platform["Platform services"]
+        direction LR
+        Secrets["ExternalSecrets / IRSA / Vault"]:::ops
+        Obs["OTEL + Prometheus"]:::ops
+      end
     end
 
-    subgraph customer["Customer VPC / cluster / account"]
-      ingress["Ingress + TLS + SSO"]
-
-      subgraph control["Agent-BOM control plane"]
-        ui["UI"]
-        api["API"]
-        jobs["Scan / ingest jobs"]
-        backup["Backup / scheduler"]
-      end
-
-      subgraph runtime["Runtime MCP plane"]
-        proxy["agent-bom proxy<br/>sidecar or local wrapper"]
-        gateway["agent-bom gateway"]
-      end
-
-      subgraph data["Customer-owned data stores"]
-        pg["Postgres"]
-        ch["ClickHouse<br/>optional analytics"]
-        s3["Object storage<br/>optional backups / archive"]
-      end
-
-      subgraph ops["Platform glue"]
-        secrets["Secrets manager"]
-        metrics["Telemetry / monitoring"]
-      end
-    end
-
-    idp -. OIDC .-> ingress
-    ingress --> ui
-    ingress --> api
-    ingress -. optional shared runtime URL .-> gateway
-    ci --> jobs
-    jobs --> api
-    proxy --> gateway
-    gateway --> api
-    gateway --> remote
-    api --> pg
-    api -. analytics .-> ch
-    backup --> s3
-    secrets --> api
-    secrets --> gateway
-    api --> metrics
-    gateway --> metrics
-    api -. enrichment .-> osv
+    Browser --> Ingress
+    IdP -. OIDC .-> Ingress
+    Ingress --> UI
+    UI -->|same-origin API calls| API
+    CI --> Jobs
+    Jobs -->|results + inventory| API
+    Proxy -->|audited relay| Gateway
+    Gateway -->|POST /v1/proxy/audit| API
+    Gateway -->|policy-audited upstream| Remote
+    API --> PG
+    API -. optional analytics .-> CH
+    Backup --> S3
+    Secrets --> API
+    Secrets --> Gateway
+    API --> Obs
+    Gateway --> Obs
+    API -. optional egress .-> Intel
 ```
 
-*Everything inside the customer boundary runs in the customer's account. The
-default cross-boundary paths are inbound OIDC and outbound, policy-audited MCP
-upstream calls.*
+*Deployment truth: the UI is not the collector. The browser drives workflows,
+the API owns control-plane state, workers do scans, and proxy plus gateway
+handle runtime MCP traffic. For the role split, see the [Self-Hosted Product
+Architecture](../architecture/self-hosted-product-architecture.md).*
 
-### Runtime MCP flow in customer infra
-
-```mermaid
-flowchart LR
-    dev["Developer client or MCP-enabled workload"]
-    proxy["Local / sidecar<br/>agent-bom proxy"]
-    gateway["In-cluster<br/>agent-bom gateway"]
-    api["Control-plane API"]
-    store["Postgres / audit store"]
-    remote["Approved remote MCP"]
-
-    dev -->|"MCP JSON-RPC"| proxy
-    proxy -->|"inspect + local policy"| gateway
-    gateway -->|"shared policy + relay"| remote
-    remote --> gateway
-    gateway -->|"response"| proxy
-    proxy -->|"safe response"| dev
-    gateway -->|"POST /v1/proxy/audit"| api
-    api --> store
-```
-
-1. Developer client speaks MCP JSON-RPC to the local `agent-bom proxy`.
-2. The proxy inspects and audits the call, enforces local policy, and relays
-   to the central `agent-bom gateway`.
-3. The gateway applies shared policy, records audit to `/v1/proxy/audit`, and
-   forwards to the remote MCP upstream.
-4. Responses come back on the same path; image responses can run through the
-   visual leak detector before they reach the developer.
-5. The control plane persists audit, findings, and graph state for the UI,
-   exports, and compliance surfaces.
-
-## Control flow
+### MCP proxy and gateway runtime flow
 
 ```mermaid
 sequenceDiagram
-    participant Admin as Security admin
-    participant UI as /gateway UI
-    participant API as Control-plane API
+    participant Client as Developer or workload client
     participant Proxy as agent-bom proxy
-    participant MCP as MCP server
+    participant Gateway as agent-bom gateway
+    participant API as Control-plane API
+    participant Remote as Remote MCP
+    participant Store as Postgres / audit store
 
-    Admin->>UI: Create / update policy
-    UI->>API: POST /v1/gateway/policies
-    API-->>UI: ETag + persisted policy
-    Proxy->>API: GET /v1/gateway/policies?enabled=true
-    API-->>Proxy: Cached policy bundle
-    Proxy->>MCP: Forward allowed JSON-RPC
-    Proxy-->>API: POST /v1/proxy/audit
-    API-->>UI: Fleet / findings / audit visible
+    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
+    Proxy->>Proxy: local policy + runtime checks
+    Proxy->>Gateway: audited relay
+    Gateway->>API: policy fetch / POST /v1/proxy/audit
+    Gateway->>Remote: upstream MCP call
+    Remote-->>Gateway: MCP response
+    Gateway-->>Proxy: response + shared policy result
+    Proxy->>Proxy: optional VLD / OCR redaction
+    Proxy-->>Client: safe response
+    API->>Store: persist audit, findings, graph links
 ```
+
+1. The client talks to a local or sidecar `agent-bom proxy`.
+2. The proxy applies local runtime checks and relays to the central
+   `agent-bom gateway`.
+3. The gateway evaluates shared policy, records audit to `/v1/proxy/audit`,
+   then calls the remote MCP upstream.
+4. The response returns on the same path; image responses can run through the
+   visual leak detector before the client sees them.
+5. The API persists audit, findings, and graph links for the UI, exports, and
+   compliance surfaces.
 
 ## What is in scope
 

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -36,49 +36,103 @@ This deployment model is built for teams that want:
 
 The best current EKS rollout is not "put everything behind one service." It is
 a split between a control plane and the discovery/enforcement paths around it.
+Keep that story in two diagrams:
+
+- **deployment topology** for what you run in your AWS account
+- **runtime MCP flow** for how proxy, gateway, API, and remote MCP calls move
+  between those surfaces
 
 ```mermaid
-flowchart LR
-    subgraph Workloads["Your workloads and endpoints"]
-      Endpoints["Developer endpoints"]
-      Cron["Scanner CronJob"]
-      MCP["Selected MCP workloads"]
-      Sidecars["agent-bom proxy sidecars"]
+flowchart TB
+    classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
+    classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
+    classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
+    classDef run  fill:#0f172a,stroke:#10b981,color:#d1fae5
+    classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
+    classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
+
+    Browser["Browser operators"]:::ext
+    IdP["Corporate IdP"]:::ext
+    CI["CI + scheduled scans"]:::ext
+    Remote["Remote MCPs"]:::ext
+    Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
+
+    subgraph Customer["Your AWS account / VPC / EKS cluster"]
+      direction TB
+      Ingress["Ingress + TLS"]:::edge
+
+      subgraph Control["Control plane"]
+        direction LR
+        UI["UI<br/>same-origin browser app"]:::ctrl
+        API["API<br/>auth · findings · fleet · audit"]:::ctrl
+        Jobs["Workers<br/>CronJob / Job"]:::ctrl
+        Backup["Backup job"]:::ctrl
+      end
+
+      subgraph Runtime["Runtime MCP plane"]
+        direction LR
+        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
+        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
+      end
+
+      subgraph Data["Customer-owned data"]
+        direction LR
+        PG[("Postgres / Supabase")]:::data
+        CH[("ClickHouse optional")]:::data
+        S3[("S3 optional")]:::data
+      end
+
+      subgraph Platform["Platform services"]
+        direction LR
+        Secrets["ExternalSecrets / IRSA / Vault"]:::ops
+        Obs["OTEL + Prometheus"]:::ops
+      end
     end
 
-    subgraph ControlPlane["agent-bom control plane in your VPC"]
-      API["API + UI"]
-      Fleet["Fleet"]
-      Gateway["Gateway policies"]
-      Findings["Findings / graph / remediation"]
-    end
-
-    subgraph Data["Operator-owned data plane and identity"]
-      PG["Postgres"]
-      CH["ClickHouse optional"]
-      Secrets["Secrets / IRSA / ingress / OIDC / SAML"]
-      S3["S3 / KMS optional backups and exports"]
-    end
-
-    subgraph Optional["Optional external egress"]
-      DBSync["Vuln DB sync / package metadata / enrichment"]
-      SIEM["SIEM / OTLP / webhooks"]
-    end
-
-    Endpoints -->|fleet sync| Fleet
-    Cron -->|scheduled scans| Findings
-    MCP --> Sidecars
-    Sidecars -->|policy pull + audit push| Gateway
+    Browser --> Ingress
+    IdP -. OIDC .-> Ingress
+    Ingress --> UI
+    UI -->|same-origin API calls| API
+    CI --> Jobs
+    Jobs -->|results + inventory| API
+    Proxy -->|audited relay| Gateway
+    Gateway -->|POST /v1/proxy/audit| API
+    Gateway -->|policy-audited upstream| Remote
     API --> PG
-    API --> CH
-    API --> Secrets
-    API --> S3
-    Fleet --> API
-    Gateway --> API
-    Findings --> API
-    Findings -. optional .-> DBSync
-    API -. optional .-> SIEM
+    API -. optional analytics .-> CH
+    Backup --> S3
+    Secrets --> API
+    Secrets --> Gateway
+    API --> Obs
+    Gateway --> Obs
+    API -. optional egress .-> Intel
 ```
+
+```mermaid
+sequenceDiagram
+    participant Client as Developer or workload client
+    participant Proxy as agent-bom proxy
+    participant Gateway as agent-bom gateway
+    participant API as Control-plane API
+    participant Remote as Remote MCP
+    participant Store as Postgres / audit store
+
+    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
+    Proxy->>Proxy: local policy + runtime checks
+    Proxy->>Gateway: audited relay
+    Gateway->>API: policy fetch / POST /v1/proxy/audit
+    Gateway->>Remote: upstream MCP call
+    Remote-->>Gateway: MCP response
+    Gateway-->>Proxy: response + shared policy result
+    Proxy->>Proxy: optional VLD / OCR redaction
+    Proxy-->>Client: safe response
+    API->>Store: persist audit, findings, graph links
+```
+
+*Deployment truth: the browser drives workflows, the API owns control-plane
+state, workers do scans, and proxy plus gateway handle runtime MCP traffic. For
+the role split, see the [Self-Hosted Product
+Architecture](../architecture/self-hosted-product-architecture.md).*
 
 ## Which Agent-BOM Surface Runs Where
 


### PR DESCRIPTION
Summary
- replace the overloaded self-hosted Mermaid graphs with a two-diagram pattern
- keep the deployment story split into deployment topology and MCP runtime flow
- add a short self-hosted product architecture doc for UI/API/workers/proxy/gateway roles

Validation
- mkdocs build --strict