### PR TITLE
[platform] align published runtime image surfaces

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -144,6 +144,13 @@ Focused graph:
 | `latest` | Most recent stable release |
 | `0.81.0` | Current stable version (pinned) |
 
+Published images:
+
+- `agentbom/agent-bom` — main runtime image for CLI scans, API/control-plane
+  jobs, gateway, proxy-adjacent entrypoints, and MCP server mode
+- `agentbom/agent-bom-ui` — standalone Next.js browser UI image for
+  self-hosted deployments that run the UI separately from the API
+
 ## Links
 
 - GitHub: https://github.com/msaad00/agent-bom

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -21,7 +21,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:latest
+    image: agentbom/agent-bom:0.81.0
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422
@@ -66,7 +66,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:latest
+    image: agentbom/agent-bom-ui:0.81.0
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -80,7 +80,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agent-bom-ui:latest
+    image: agentbom/agent-bom-ui:0.81.0
     container_name: agent-bom-ui
     ports:
       - "3000:3000"


### PR DESCRIPTION
Summary
- align public image references to the released 0.81.0 runtime and UI images
- document the published image split in the Docker Hub README
- pin compose examples to the current released images instead of floating/ambiguous tags

Validation
- mkdocs build --strict