### PR TITLE
[ci] normalize Dependabot UI lockfile updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,11 @@ jobs:
         run: |
           cd ui
           cp package-lock.json /tmp/ui-package-lock.before.json
-          npm install --package-lock-only --ignore-scripts
-          diff -u /tmp/ui-package-lock.before.json package-lock.json
+          npm run lock:normalize
+          if ! diff -u /tmp/ui-package-lock.before.json package-lock.json; then
+            echo "::error::ui/package-lock.json drifted under the canonical UI toolchain. Run: cd ui && npm run lock:normalize"
+            exit 1
+          fi
 
       - name: Verify UI toolchain contract
         run: |

--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -1,0 +1,52 @@
+name: Dependabot UI Lockfile Normalize
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'ui/package.json'
+      - 'ui/package-lock.json'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  normalize-ui-lockfile:
+    if: >-
+      github.actor == 'dependabot[bot]' ||
+      github.actor == 'app/dependabot' ||
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'app/dependabot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Dependabot branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Normalize UI lockfile
+        run: |
+          cd ui
+          npm ci --ignore-scripts
+          npm run lock:normalize
+
+      - name: Commit normalized lockfile
+        run: |
+          if git diff --quiet -- ui/package-lock.json; then
+            echo "No normalized lockfile changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ui/package-lock.json
+          git commit -m "chore(ui): normalize package-lock under pinned npm"
+          git push

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,7 @@
   "name": "ui",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@10.9.7",
   "engines": {
     "node": ">=20 <23"
   },
@@ -11,6 +12,7 @@
     "start": "next start",
     "bundle:check": "node scripts/check-bundle-budget.mjs",
     "lint": "eslint",
+    "lock:normalize": "npm install --package-lock-only --ignore-scripts",
     "test:e2e": "playwright test",
     "verify:toolchain": "node scripts/verify-toolchain.mjs",
     "test": "vitest",

--- a/ui/scripts/verify-toolchain.mjs
+++ b/ui/scripts/verify-toolchain.mjs
@@ -28,9 +28,15 @@ const eslintDeclared = packageJson.devDependencies?.eslint;
 const reactDeclared = packageJson.dependencies?.react;
 const reactDomDeclared = packageJson.dependencies?.["react-dom"];
 const nodeEngines = packageJson.engines?.node;
+const packageManager = packageJson.packageManager;
+const expectedPackageManager = "npm@10.9.7";
 
-if (!nextDeclared || !eslintConfigNextDeclared || !eslintDeclared || !nodeEngines) {
-  fail("UI toolchain contract is incomplete: next, eslint-config-next, eslint, and engines.node must all be declared.");
+if (!nextDeclared || !eslintConfigNextDeclared || !eslintDeclared || !nodeEngines || !packageManager) {
+  fail("UI toolchain contract is incomplete: next, eslint-config-next, eslint, engines.node, and packageManager must all be declared.");
+}
+
+if (packageManager !== expectedPackageManager) {
+  fail(`UI packageManager must stay pinned to ${expectedPackageManager}; found ${packageManager}.`);
 }
 
 if (normalizeVersionRange(nextDeclared) !== normalizeVersionRange(eslintConfigNextDeclared)) {
@@ -76,5 +82,5 @@ if (!Number.isInteger(nodeMajor) || nodeMajor < 20 || nodeMajor > 22) {
 }
 
 console.log(
-  `UI toolchain contract verified: next ${nextInstalled}, eslint-config-next ${eslintConfigNextInstalled}, eslint ${eslintInstalled}, node ${process.versions.node}.`,
+  `UI toolchain contract verified: next ${nextInstalled}, eslint-config-next ${eslintConfigNextInstalled}, eslint ${eslintInstalled}, node ${process.versions.node}, package manager ${packageManager}.`,
 );


### PR DESCRIPTION
Summary
- pin the UI package manager to the npm version validated in CI
- add a canonical lockfile normalization script and actionable drift error
- auto-normalize Dependabot UI lockfile PRs so harmless metadata drift does not keep failing UI Validate

Validation
- npx -y -p node@22 -p npm@10.9.7 npm ci --ignore-scripts
- npx -y -p node@22 node ui/scripts/verify-toolchain.mjs
- npx -y -p node@22 -p npm@10.9.7 npm run --prefix ui lock:normalize
- git diff --exit-code -- ui/package-lock.json