### PR TITLE
fix: harden tenant-scoped metrics and proxy audit

### DIFF
--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -114,14 +114,14 @@ class PostgresJobStore:
     def list_all(self, tenant_id: str | None = None) -> list:
         from .server import ScanJob
 
+        if tenant_id is None:
+            raise ValueError("tenant_id is required for PostgresJobStore.list_all()")
+
         with _tenant_connection(self._pool) as conn:
-            if tenant_id is None:
-                rows = conn.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC").fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT data FROM scan_jobs WHERE team_id = %s ORDER BY created_at DESC",
-                    (tenant_id,),
-                ).fetchall()
+            rows = conn.execute(
+                "SELECT data FROM scan_jobs WHERE team_id = %s ORDER BY created_at DESC",
+                (tenant_id,),
+            ).fetchall()
             return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_summary(self, tenant_id: str | None = None) -> list[dict]:

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -176,8 +176,7 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
     return {"job_id": job.job_id, "source_id": body.source_id, "status": "stored"}
 
 
-@router.get("/metrics", tags=["observability"])
-async def prometheus_metrics():
+async def _render_prometheus_metrics(request: Request | None = None):
     """Prometheus scrape endpoint — exposes control-plane and pilot metrics.
 
     Catalog lives in docs/OBSERVABILITY_METRICS.md — keep that doc in sync
@@ -190,7 +189,10 @@ async def prometheus_metrics():
         from agent_bom.api.oidc import oidc_decode_failure_count
 
         store = _get_fleet_store()
-        agents = store.list_all()
+        tenant_id = getattr(getattr(request, "state", None), "tenant_id", "").strip() if request is not None else ""
+        # /metrics may be scraped without a tenant-bound auth context. Avoid
+        # aggregating fleet gauges across every tenant in that case.
+        agents = store.list_by_tenant(tenant_id) if tenant_id else []
         lines = [
             "# HELP agent_bom_fleet_total Total agents in fleet",
             "# TYPE agent_bom_fleet_total gauge",
@@ -206,3 +208,8 @@ async def prometheus_metrics():
         return Response("\n".join(lines) + "\n", media_type="text/plain; version=0.0.4; charset=utf-8")
     except Exception:  # noqa: BLE001
         return Response("# No metrics available\n", media_type="text/plain; version=0.0.4; charset=utf-8")
+
+
+@router.get("/metrics", tags=["observability"])
+async def prometheus_metrics(request: Request):
+    return await _render_prometheus_metrics(request)

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -331,6 +331,7 @@ async def _proxy_sse_server(
     replay_detector = ReplayDetector()
     scan_config = load_scan_config(policy) if policy else ScanConfig()
     runtime_alerts: list[dict] = []
+    control_plane_tenant_id = (os.environ.get("AGENT_BOM_TENANT_ID") or "default").strip() or "default"
 
     def _handle_alerts_sse(alerts, log_f=None):
         for alert in alerts:
@@ -422,6 +423,7 @@ async def _proxy_sse_server(
                             payload_sha256=p_hash,
                             message_id=msg_id,
                             agent_id=agent_id,
+                            tenant_id=control_plane_tenant_id,
                         )
                     error_resp = make_error_response(msg_id, -32600, identity_block_reason)
                     sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -432,7 +434,15 @@ async def _proxy_sse_server(
                     reason = "Replayed payload detected"
                     if log_file:
                         log_tool_call(
-                            log_file, tool_name, arguments, "blocked", reason, payload_sha256=p_hash, message_id=msg_id, agent_id=agent_id
+                            log_file,
+                            tool_name,
+                            arguments,
+                            "blocked",
+                            reason,
+                            payload_sha256=p_hash,
+                            message_id=msg_id,
+                            agent_id=agent_id,
+                            tenant_id=control_plane_tenant_id,
                         )
                     error_resp = make_error_response(msg_id, -32600, reason)
                     sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -443,7 +453,15 @@ async def _proxy_sse_server(
                     reason = f"Tool '{tool_name}' not in declared tools/list"
                     if log_file:
                         log_tool_call(
-                            log_file, tool_name, arguments, "blocked", reason, payload_sha256=p_hash, message_id=msg_id, agent_id=agent_id
+                            log_file,
+                            tool_name,
+                            arguments,
+                            "blocked",
+                            reason,
+                            payload_sha256=p_hash,
+                            message_id=msg_id,
+                            agent_id=agent_id,
+                            tenant_id=control_plane_tenant_id,
                         )
                     error_resp = make_error_response(msg_id, -32600, reason)
                     sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -463,6 +481,7 @@ async def _proxy_sse_server(
                                 payload_sha256=p_hash,
                                 message_id=msg_id,
                                 agent_id=agent_id,
+                                tenant_id=control_plane_tenant_id,
                             )
                         error_resp = make_error_response(msg_id, -32600, reason)
                         sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -505,6 +524,7 @@ async def _proxy_sse_server(
                                 payload_sha256=p_hash,
                                 message_id=msg_id,
                                 agent_id=agent_id,
+                                tenant_id=control_plane_tenant_id,
                             )
                         error_resp = make_error_response(msg_id, -32600, reason)
                         sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -512,7 +532,16 @@ async def _proxy_sse_server(
                         continue
 
                 if log_file:
-                    log_tool_call(log_file, tool_name, arguments, "allowed", payload_sha256=p_hash, message_id=msg_id, agent_id=agent_id)  # type: ignore[arg-type]
+                    log_tool_call(
+                        log_file,
+                        tool_name,
+                        arguments,
+                        "allowed",
+                        payload_sha256=p_hash,
+                        message_id=msg_id,
+                        agent_id=agent_id,
+                        tenant_id=control_plane_tenant_id,
+                    )  # type: ignore[arg-type]
 
                 # Forward tool call to remote SSE/HTTP server
                 call_counter += 1
@@ -660,6 +689,7 @@ async def run_proxy(
     runtime_alerts: list[dict] = []
     control_plane_source_id = _generate_proxy_source_id()
     control_plane_session_id = str(uuid.uuid4())
+    control_plane_tenant_id = (os.environ.get("AGENT_BOM_TENANT_ID") or "default").strip() or "default"
     control_plane_policies: list["GatewayPolicy"] = []
     control_plane_etag: str | None = None
     audit_buffer: list[dict] = []
@@ -918,6 +948,7 @@ async def run_proxy(
                                 payload_sha256=p_hash,
                                 message_id=msg_id,
                                 agent_id=agent_id,
+                                tenant_id=control_plane_tenant_id,
                             )
                         error_resp = make_error_response(msg_id, -32600, identity_block_reason)
                         sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -940,6 +971,7 @@ async def run_proxy(
                                     payload_sha256=p_hash,
                                     message_id=msg_id,
                                     agent_id=agent_id,
+                                    tenant_id=control_plane_tenant_id,
                                 )
                             error_resp = make_error_response(msg_id, -32600, reason)
                             sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -962,6 +994,7 @@ async def run_proxy(
                                 payload_sha256=p_hash,
                                 message_id=msg_id,
                                 agent_id=agent_id,
+                                tenant_id=control_plane_tenant_id,
                             )
                         error_resp = make_error_response(msg_id, -32600, reason)
                         sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -983,6 +1016,7 @@ async def run_proxy(
                                     payload_sha256=p_hash,
                                     message_id=msg_id,
                                     agent_id=agent_id,
+                                    tenant_id=control_plane_tenant_id,
                                 )
                             error_resp = make_error_response(msg.get("id"), -32600, reason)
                             sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -1004,6 +1038,7 @@ async def run_proxy(
                                     payload_sha256=p_hash,
                                     message_id=msg_id,
                                     agent_id=agent_id,
+                                    tenant_id=control_plane_tenant_id,
                                 )
                             error_resp = make_error_response(msg.get("id"), -32600, gw_reason)
                             sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -1038,6 +1073,7 @@ async def run_proxy(
                                     payload_sha256=p_hash,
                                     message_id=msg_id,
                                     agent_id=agent_id,
+                                    tenant_id=control_plane_tenant_id,
                                 )
                             error_resp = make_error_response(msg_id, -32600, rl_reason)
                             sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -1077,6 +1113,7 @@ async def run_proxy(
                                     payload_sha256=p_hash,
                                     message_id=msg_id,
                                     agent_id=agent_id,
+                                    tenant_id=control_plane_tenant_id,
                                 )
                             error_resp = make_error_response(msg_id, -32600, reason)
                             sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
@@ -1098,6 +1135,7 @@ async def run_proxy(
                             payload_sha256=p_hash,
                             message_id=msg_id,
                             agent_id=agent_id,
+                            tenant_id=control_plane_tenant_id,
                         )
 
             span_cm = _PROXY_TRACER.start_as_current_span("proxy.relay_client_to_server") if (msg and _PROXY_TRACER) else nullcontext()

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -426,6 +426,7 @@ def log_tool_call(
     payload_sha256: str = "",
     message_id: int | str | None = None,
     agent_id: str = ANONYMOUS,
+    tenant_id: str = "default",
 ) -> None:
     """Append a tool call record to the audit JSONL log."""
     record: dict = {
@@ -433,6 +434,7 @@ def log_tool_call(
         "type": "tools/call",
         "tool": tool_name,
         "agent_id": agent_id,
+        "tenant_id": tenant_id,
         "args": _truncate_args(arguments),
         "policy": policy_result,
     }

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -493,11 +493,48 @@ def test_oidc_config_passes_required_nonce_to_verifier():
 
 @pytest.mark.asyncio
 async def test_observability_metrics_include_oidc_decode_failures():
-    from agent_bom.api.routes.observability import prometheus_metrics
+    from agent_bom.api.routes.observability import _render_prometheus_metrics
 
     record_oidc_decode_failure()
     record_oidc_decode_failure()
 
-    response = await prometheus_metrics()
+    response = await _render_prometheus_metrics()
     body = response.body.decode("utf-8")
     assert "agent_bom_oidc_decode_failures_total 2" in body
+
+
+@pytest.mark.asyncio
+async def test_observability_metrics_are_tenant_scoped_when_tenant_present():
+    from types import SimpleNamespace
+
+    from agent_bom.api.routes import observability as observability_routes
+
+    class _FleetStore:
+        def list_by_tenant(self, tenant_id: str):
+            assert tenant_id == "tenant-alpha"
+            return [
+                SimpleNamespace(lifecycle_state="approved"),
+                SimpleNamespace(lifecycle_state="quarantined"),
+            ]
+
+    request = SimpleNamespace(state=SimpleNamespace(tenant_id="tenant-alpha"))
+    with patch("agent_bom.api.routes.observability._get_fleet_store", return_value=_FleetStore()):
+        response = await observability_routes._render_prometheus_metrics(request)
+    body = response.body.decode("utf-8")
+    assert "agent_bom_fleet_total 2" in body
+    assert "agent_bom_fleet_quarantined 1" in body
+
+
+@pytest.mark.asyncio
+async def test_observability_metrics_do_not_aggregate_fleet_without_tenant_context():
+    from agent_bom.api.routes import observability as observability_routes
+
+    class _FleetStore:
+        def list_by_tenant(self, tenant_id: str):
+            raise AssertionError("list_by_tenant should not be called without tenant context")
+
+    with patch("agent_bom.api.routes.observability._get_fleet_store", return_value=_FleetStore()):
+        response = await observability_routes._render_prometheus_metrics()
+    body = response.body.decode("utf-8")
+    assert "agent_bom_fleet_total 0" in body
+    assert "agent_bom_fleet_quarantined 0" in body

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -298,6 +298,14 @@ def test_job_store_list_summary(mock_pool):
     assert isinstance(result, list)
 
 
+def test_job_store_list_all_requires_tenant_id(mock_pool):
+    from agent_bom.api.postgres_store import PostgresJobStore
+
+    store = PostgresJobStore(pool=mock_pool)
+    with pytest.raises(ValueError, match="tenant_id is required"):
+        store.list_all()
+
+
 def test_job_store_list_summary_includes_tenant(mock_pool):
     from agent_bom.api.postgres_store import PostgresJobStore
 

--- a/tests/test_proxy_helpers.py
+++ b/tests/test_proxy_helpers.py
@@ -181,6 +181,7 @@ def test_log_tool_call_basic():
     assert record["type"] == "tools/call"
     assert record["tool"] == "read_file"
     assert record["policy"] == "allowed"
+    assert record["tenant_id"] == "default"
     assert record["event_relationships"]["source"] == "proxy_tool_call"
     assert record["event_relationships"]["targets"][0]["id"] == "read_file"
     assert record["event_relationships"]["resources"][0]["id"] == "/tmp"
@@ -208,6 +209,14 @@ def test_log_tool_call_no_optional_fields():
     assert "message_id" not in record
     assert record["event_relationships"]["targets"][0]["id"] == "test_tool"
     assert "resources" not in record["event_relationships"]
+
+
+def test_log_tool_call_records_explicit_tenant():
+    buf = io.StringIO()
+    log_tool_call(buf, "test_tool", {}, tenant_id="tenant-alpha")
+    buf.seek(0)
+    record = json.loads(buf.readline())
+    assert record["tenant_id"] == "tenant-alpha"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- stop the metrics endpoint from aggregating fleet counts across every tenant when no tenant context is present
- make PostgresJobStore.list_all() fail closed when tenant scope is omitted
- include tenant_id in proxy runtime JSONL tool-call audit records

Why:
This is the first code-backed hardening pass from the tenant/gateway/deployment feedback. It addresses the real tenant-isolation edge cases without broad product or deployment churn.

Validation:
- uv run pytest tests/test_api_tenant_isolation.py tests/test_api_oidc.py tests/test_postgres_store.py tests/test_proxy_helpers.py -q
- pre-commit hooks via commit: ruff, ruff-format, mypy, bandit