### PR TITLE
fix: harden proxy startup and gateway HA defaults

### DIFF
--- a/deploy/helm/agent-bom/templates/gateway-hpa.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-hpa.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.gateway.enabled .Values.gateway.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agent-bom.name" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agent-bom.name" . }}-gateway
+  minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
+  {{- with .Values.gateway.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.gateway.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.gateway.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/gateway-pdb.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.gateway.enabled .Values.pdb.enabled (gt (int .Values.gateway.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "agent-bom.name" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      app.kubernetes.io/component: gateway
+  {{- if ne .Values.pdb.maxUnavailable nil }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -94,6 +94,13 @@ monitor:
 gateway:
   enabled: false
   replicas: 2
+  autoscaling:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: null
+    behavior: {}
   image:
     repository: agentbom/agent-bom
     # tag defaults to Chart.AppVersion

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -173,6 +173,78 @@ def _proxy_request_headers(headers: dict[str, str] | None = None) -> dict[str, s
     return inject_current_trace_headers(headers)
 
 
+def _gateway_policy_cache_path() -> Path:
+    configured = os.environ.get("AGENT_BOM_PROXY_POLICY_CACHE_PATH")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".agent-bom" / "cache" / "gateway-policies.json"
+
+
+def _load_cached_gateway_policies(
+    cache_path: Path,
+    max_age_seconds: int,
+) -> tuple[list["GatewayPolicy"] | None, str | None]:
+    from agent_bom.api.policy_store import GatewayPolicy
+
+    try:
+        payload = json.loads(cache_path.read_text())
+    except FileNotFoundError:
+        return None, None
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Ignoring unreadable gateway policy cache %s: %s", cache_path, exc)
+        return None, None
+
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(fetched_at, (int, float)):
+        logger.warning("Ignoring gateway policy cache %s with missing fetched_at", cache_path)
+        return None, None
+    age_seconds = time.time() - float(fetched_at)
+    if age_seconds > max(max_age_seconds, 0):
+        logger.warning(
+            "Ignoring stale gateway policy cache %s (age=%ss, max=%ss)",
+            cache_path,
+            int(age_seconds),
+            max(max_age_seconds, 0),
+        )
+        return None, None
+
+    try:
+        policies = [GatewayPolicy(**item) for item in payload.get("policies", [])]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Ignoring invalid gateway policy cache %s: %s", cache_path, exc)
+        return None, None
+    return policies, payload.get("etag")
+
+
+def _persist_gateway_policies_cache(
+    cache_path: Path,
+    policies: list["GatewayPolicy"],
+    etag: str | None,
+) -> None:
+    payload = {
+        "fetched_at": time.time(),
+        "etag": etag,
+        "policies": [policy.model_dump(mode="json") for policy in policies],
+    }
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=str(cache_path.parent),
+            prefix=f"{cache_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            json.dump(payload, handle, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temp_path = Path(handle.name)
+        temp_path.replace(cache_path)
+    except OSError as exc:
+        logger.warning("Failed to persist gateway policy cache %s: %s", cache_path, exc)
+
+
 async def _fetch_enabled_gateway_policies(
     base_url: str,
     token: str | None,
@@ -692,6 +764,11 @@ async def run_proxy(
     control_plane_tenant_id = (os.environ.get("AGENT_BOM_TENANT_ID") or "default").strip() or "default"
     control_plane_policies: list["GatewayPolicy"] = []
     control_plane_etag: str | None = None
+    control_plane_policy_cache_path = _gateway_policy_cache_path()
+    control_plane_policy_cache_max_age_seconds = max(
+        60,
+        int(os.environ.get("AGENT_BOM_PROXY_POLICY_CACHE_MAX_AGE_SECONDS", "3600")),
+    )
     audit_buffer: list[dict] = []
     audit_buffer_bytes = 0
     audit_lock = asyncio.Lock()
@@ -779,12 +856,28 @@ async def run_proxy(
         except Exception as exc:  # noqa: BLE001
             metrics.record_policy_fetch_failure()
             if initial:
-                logger.error("Failed to load enabled gateway policies from %s: %s", control_plane_url, exc)
-                raise SystemExit(1) from exc
-            logger.warning("Gateway policy refresh failed: %s", exc)
-            return
+                cached_policies, cached_etag = _load_cached_gateway_policies(
+                    control_plane_policy_cache_path,
+                    control_plane_policy_cache_max_age_seconds,
+                )
+                if cached_policies is not None:
+                    control_plane_policies = cached_policies
+                    control_plane_etag = cached_etag
+                    logger.warning(
+                        "Gateway policy fetch failed from %s; using cached bundle from %s: %s",
+                        control_plane_url,
+                        control_plane_policy_cache_path,
+                        exc,
+                    )
+                else:
+                    logger.error("Failed to load enabled gateway policies from %s: %s", control_plane_url, exc)
+                    raise SystemExit(1) from exc
+            else:
+                logger.warning("Gateway policy refresh failed: %s", exc)
+                return
         if policies is not None:
             control_plane_policies = policies
+            _persist_gateway_policies_cache(control_plane_policy_cache_path, policies, next_etag)
         if next_etag:
             control_plane_etag = next_etag
         if rate_limit_threshold <= 0:

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -246,6 +246,8 @@ def test_helm_templates_exist():
         "controlplane-ui-deployment.yaml",
         "controlplane-ui-hpa.yaml",
         "controlplane-ui-service.yaml",
+        "gateway-hpa.yaml",
+        "gateway-pdb.yaml",
         "serviceaccount.yaml",
         "rbac.yaml",
         "cronjob.yaml",
@@ -366,6 +368,18 @@ def test_helm_gateway_service_account_defaults():
     assert sa["create"] is True
     assert sa["name"] == ""
     assert sa["annotations"] == {}
+
+
+def test_helm_gateway_autoscaling_defaults():
+    """Gateway ships explicit HA knobs without forcing autoscaling on by default."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    autoscaling = doc["gateway"]["autoscaling"]
+    assert autoscaling["enabled"] is False
+    assert autoscaling["minReplicas"] == 2
+    assert autoscaling["maxReplicas"] == 6
+    assert autoscaling["targetCPUUtilizationPercentage"] == 70
+    assert autoscaling["targetMemoryUtilizationPercentage"] is None
+    assert autoscaling["behavior"] == {}
 
 
 def test_helm_control_plane_api_extra_volume_defaults():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -7,12 +7,16 @@ import json
 from pathlib import Path
 
 import agent_bom.proxy as proxy_mod
+from agent_bom.api.policy_store import GatewayPolicy, GatewayRule
 from agent_bom.proxy import (
     AuditDeliveryController,
     AuditSpilloverStore,
     ProxyMetrics,
     ReplayDetector,
     _control_plane_headers,
+    _gateway_policy_cache_path,
+    _load_cached_gateway_policies,
+    _persist_gateway_policies_cache,
     check_policy,
     compute_payload_hash,
     compute_response_hmac,
@@ -186,6 +190,60 @@ def test_control_plane_headers_propagate_w3c_trace_context(monkeypatch):
     assert headers["traceparent"].startswith("00-")
     assert headers["tracestate"] == "vendor-a=foo"
     assert headers["baggage"] == "tenant=acme"
+
+
+def test_gateway_policy_cache_path_defaults_to_user_cache_home(monkeypatch):
+    fake_home = Path("/tmp/agent-bom-home")
+    monkeypatch.delenv("AGENT_BOM_PROXY_POLICY_CACHE_PATH", raising=False)
+    monkeypatch.setattr(proxy_mod.Path, "home", staticmethod(lambda: fake_home))
+    assert _gateway_policy_cache_path() == fake_home / ".agent-bom" / "cache" / "gateway-policies.json"
+
+
+def test_gateway_policy_cache_path_honors_env_override(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_PROXY_POLICY_CACHE_PATH", "/tmp/custom-policy-cache.json")
+    assert _gateway_policy_cache_path() == Path("/tmp/custom-policy-cache.json")
+
+
+def test_gateway_policy_cache_round_trip(tmp_path: Path, monkeypatch):
+    cache_path = tmp_path / "gateway-policies.json"
+    monkeypatch.setattr(proxy_mod.time, "time", lambda: 1234.0)
+    policies = [
+        GatewayPolicy(
+            policy_id="p1",
+            name="Block secrets",
+            rules=[GatewayRule(id="r1", block_secret_paths=True)],
+            tenant_id="tenant-a",
+        )
+    ]
+    _persist_gateway_policies_cache(cache_path, policies, "etag-1")
+    loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
+    assert loaded_etag == "etag-1"
+    assert loaded_policies is not None
+    assert len(loaded_policies) == 1
+    assert loaded_policies[0].policy_id == "p1"
+    assert loaded_policies[0].tenant_id == "tenant-a"
+
+
+def test_gateway_policy_cache_rejects_stale_entries(tmp_path: Path, monkeypatch):
+    cache_path = tmp_path / "gateway-policies.json"
+    monkeypatch.setattr(proxy_mod.time, "time", lambda: 100.0)
+    _persist_gateway_policies_cache(
+        cache_path,
+        [GatewayPolicy(policy_id="p1", name="stale", rules=[])],
+        "etag-stale",
+    )
+    monkeypatch.setattr(proxy_mod.time, "time", lambda: 1000.0)
+    loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
+    assert loaded_policies is None
+    assert loaded_etag is None
+
+
+def test_gateway_policy_cache_rejects_invalid_payload(tmp_path: Path):
+    cache_path = tmp_path / "gateway-policies.json"
+    cache_path.write_text('{"fetched_at": 10, "policies": [{"policy_id": "missing-name"}]}')
+    loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
+    assert loaded_policies is None
+    assert loaded_etag is None
 
 
 # ── ProxyMetrics ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fall back to a bounded on-disk gateway policy cache when the proxy cannot reach the control plane during initial startup
- add explicit gateway autoscaling defaults plus dedicated HPA/PDB templates for HA parity with the control plane
- cover the new proxy cache helpers and gateway chart defaults with focused tests

## Testing
- uv run pytest tests/test_proxy.py tests/test_deploy_manifests.py -q
- uv run ruff check src/agent_bom/proxy.py tests/test_proxy.py tests/test_deploy_manifests.py
- uv run mypy src/agent_bom/proxy.py