### PR TITLE
chore: validate shipped helm deployment profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,21 @@ jobs:
           cd ui
           npm run test:e2e
 
+  helm-profiles:
+    name: Helm Profile Validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Render shipped Helm profiles
+        run: python3 scripts/validate_helm_profiles.py
+
   # 3. Tests
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -1,0 +1,44 @@
+# Helm Example Profiles
+
+These files are the canonical packaged deployment profiles for the `agent-bom`
+Helm chart. They are meant to reduce day-0 decision sprawl, not create a new
+product split.
+
+## Shipped profiles
+
+| Profile | File | Intended use |
+|---|---|---|
+| `sqlite-pilot` | `eks-control-plane-sqlite-pilot-values.yaml` | Single-node packaged demo or short-lived pilot where Postgres is not ready yet |
+| `focused-pilot` | `eks-mcp-pilot-values.yaml` | Narrow EKS pilot with control plane, scanner, and tightened ingress |
+| `production` | `eks-production-values.yaml` | Postgres-backed production EKS rollout with autoscaling, backup, and ExternalSecrets |
+| `mesh-hardening` | `eks-istio-kyverno-values.yaml` | Overlay for Istio mTLS/authz and Kyverno policy-controller packaging |
+| `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake-backed analytics/export deployments |
+| `gateway-runtime` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` | Focused pilot plus central gateway rendering for shared MCP relay/policy |
+
+## Validate the shipped profiles
+
+With Helm installed:
+
+```bash
+python scripts/validate_helm_profiles.py
+```
+
+List the profile names without rendering:
+
+```bash
+python scripts/validate_helm_profiles.py --list
+```
+
+Render only one profile:
+
+```bash
+python scripts/validate_helm_profiles.py --profile focused-pilot
+```
+
+## Operator guidance
+
+- Start with `focused-pilot` for the narrow customer EKS story.
+- Use `sqlite-pilot` only for demos or single-node packaged pilots.
+- Move to `production` once Postgres, ingress, and backup ownership are real.
+- Treat `mesh-hardening` and `snowflake-backend` as overlays, not separate products.
+- Gateway remains an optional runtime surface layered onto the control plane, not a mandatory chokepoint.

--- a/deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml
@@ -5,6 +5,8 @@
 {{- $secrets = list (dict "nameSuffix" "control-plane" "refreshInterval" $defaults.refreshInterval "secretStoreRef" $defaults.secretStoreRef "target" $defaults.target "data" $defaults.data) }}
 {{- end }}
 {{- range $index, $secret := $secrets }}
+{{- $secretStoreRef := default (dict) (get $secret "secretStoreRef") }}
+{{- $target := default (dict) (get $secret "target") }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -17,11 +19,11 @@ metadata:
 spec:
   refreshInterval: {{ default $defaults.refreshInterval $secret.refreshInterval | quote }}
   secretStoreRef:
-    kind: {{ default $defaults.secretStoreRef.kind $secret.secretStoreRef.kind }}
-    name: {{ default $defaults.secretStoreRef.name $secret.secretStoreRef.name | quote }}
+    kind: {{ default $defaults.secretStoreRef.kind (get $secretStoreRef "kind") }}
+    name: {{ default $defaults.secretStoreRef.name (get $secretStoreRef "name") | quote }}
   target:
-    name: {{ default $defaults.target.name $secret.target.name | quote }}
-    creationPolicy: {{ default $defaults.target.creationPolicy $secret.target.creationPolicy }}
+    name: {{ default $defaults.target.name (get $target "name") | quote }}
+    creationPolicy: {{ default $defaults.target.creationPolicy (get $target "creationPolicy") }}
   data:
     {{- toYaml (default $defaults.data $secret.data) | nindent 4 }}
 {{- end }}

--- a/scripts/validate_helm_profiles.py
+++ b/scripts/validate_helm_profiles.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Render the shipped Helm example profiles to catch deployment drift early."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_profile_helpers():
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from agent_bom.deploy_profiles import helm_chart_dir, helm_validation_profiles
+
+    return helm_chart_dir, helm_validation_profiles
+
+
+def _run(cmd: list[str]) -> None:
+    print("+", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    helm_chart_dir, helm_validation_profiles = _load_profile_helpers()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        action="append",
+        dest="profiles",
+        help="Only validate the named profile. Repeat to run multiple profiles.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List the available validation profiles and exit.",
+    )
+    args = parser.parse_args()
+
+    profiles = helm_validation_profiles(REPO_ROOT)
+    if args.list:
+        for profile in profiles:
+            print(f"{profile.name}: {profile.description}")
+        return 0
+
+    if shutil.which("helm") is None:
+        print("error: helm is required to validate chart profiles", file=sys.stderr)
+        return 1
+
+    selected = profiles
+    if args.profiles:
+        requested = set(args.profiles)
+        selected = [profile for profile in profiles if profile.name in requested]
+        missing = sorted(requested - {profile.name for profile in selected})
+        if missing:
+            parser.error(f"unknown profile(s): {', '.join(missing)}")
+
+    chart_dir = helm_chart_dir(REPO_ROOT)
+    _run(["helm", "lint", str(chart_dir)])
+    for profile in selected:
+        cmd = ["helm", "template", f"agent-bom-{profile.name}", str(chart_dir)]
+        for values_file in profile.values_files:
+            cmd.extend(["-f", str(values_file)])
+        for set_argument in profile.set_arguments:
+            cmd.extend(["--set", set_argument])
+        for key, path in profile.set_file_arguments:
+            cmd.extend(["--set-file", f"{key}={path}"])
+        _run(cmd)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -1,0 +1,65 @@
+"""Canonical Helm chart validation profiles for shipped deployment examples."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class HelmValidationProfile:
+    """A named Helm render profile backed by shipped chart examples."""
+
+    name: str
+    description: str
+    values_files: tuple[Path, ...] = field(default_factory=tuple)
+    set_arguments: tuple[str, ...] = field(default_factory=tuple)
+    set_file_arguments: tuple[tuple[str, Path], ...] = field(default_factory=tuple)
+
+
+def helm_chart_dir(repo_root: Path) -> Path:
+    return repo_root / "deploy" / "helm" / "agent-bom"
+
+
+def helm_example_dir(repo_root: Path) -> Path:
+    return helm_chart_dir(repo_root) / "examples"
+
+
+def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
+    """Return the canonical validation matrix for shipped Helm examples."""
+
+    examples = helm_example_dir(repo_root)
+    return [
+        HelmValidationProfile(
+            name="sqlite-pilot",
+            description="Single-node SQLite demo control plane for fast packaged pilots.",
+            values_files=(examples / "eks-control-plane-sqlite-pilot-values.yaml",),
+        ),
+        HelmValidationProfile(
+            name="focused-pilot",
+            description="Focused EKS pilot with control plane, scanner, and narrowed ingress.",
+            values_files=(examples / "eks-mcp-pilot-values.yaml",),
+        ),
+        HelmValidationProfile(
+            name="production",
+            description="Postgres-backed production EKS defaults with autoscaling and backups.",
+            values_files=(examples / "eks-production-values.yaml",),
+        ),
+        HelmValidationProfile(
+            name="mesh-hardening",
+            description="Istio and Kyverno hardening overlay for operator-managed clusters.",
+            values_files=(examples / "eks-istio-kyverno-values.yaml",),
+        ),
+        HelmValidationProfile(
+            name="snowflake-backend",
+            description="Warehouse export/backend overlay for Snowflake-integrated deployments.",
+            values_files=(examples / "eks-snowflake-values.yaml",),
+        ),
+        HelmValidationProfile(
+            name="gateway-runtime",
+            description="Focused pilot plus central gateway rendering with shipped upstream example.",
+            values_files=(examples / "eks-mcp-pilot-values.yaml",),
+            set_arguments=("gateway.enabled=true",),
+            set_file_arguments=(("gateway.upstreamsYaml", examples / "gateway-upstreams.example.yaml"),),
+        ),
+    ]

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -522,6 +522,14 @@ def test_production_values_enable_operator_defaults():
     assert "cert-manager.io/cluster-issuer" in production["controlPlane"]["ingress"]["annotations"]
 
 
+def test_external_secret_template_supports_top_level_secret_store_defaults():
+    """External secret template should not require per-secret secretStoreRef duplication."""
+    template = (HELM_DIR / "templates" / "controlplane-externalsecret.yaml").read_text()
+    assert 'get $secret "secretStoreRef"' in template
+    assert 'default $defaults.secretStoreRef.kind (get $secretStoreRef "kind")' in template
+    assert 'default $defaults.secretStoreRef.name (get $secretStoreRef "name")' in template
+
+
 def test_helm_single_node_sqlite_pilot_example_is_shipped():
     """Pilot preset should provide an in-cluster control-plane storage story."""
     doc = yaml.safe_load((HELM_DIR / "examples" / "eks-control-plane-sqlite-pilot-values.yaml").read_text())

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -261,6 +261,26 @@ def test_helm_templates_exist():
     assert expected.issubset(actual), f"Missing templates: {expected - actual}"
 
 
+def test_helm_examples_readme_is_shipped():
+    """Operators should get one packaged index of the supported Helm profiles."""
+    readme = HELM_DIR / "examples" / "README.md"
+    assert readme.exists()
+    body = readme.read_text()
+    assert "focused-pilot" in body
+    assert "sqlite-pilot" in body
+    assert "gateway-runtime" in body
+
+
+def test_ci_pipeline_validates_helm_profiles():
+    """CI should render the shipped Helm profiles instead of trusting docs alone."""
+    workflow = yaml.safe_load((Path(__file__).parent.parent / ".github" / "workflows" / "ci.yml").read_text())
+    jobs = workflow["jobs"]
+    assert "helm-profiles" in jobs
+    job = jobs["helm-profiles"]
+    step_runs = [step.get("run", "") for step in job["steps"] if isinstance(step, dict)]
+    assert any("scripts/validate_helm_profiles.py" in run for run in step_runs)
+
+
 def test_helm_scanner_defaults():
     """Scanner defaults are reasonable."""
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -1,0 +1,37 @@
+"""Tests for canonical Helm deployment validation profiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.deploy_profiles import helm_chart_dir, helm_validation_profiles
+
+
+def test_helm_validation_profiles_reference_existing_chart_assets():
+    repo_root = Path(__file__).resolve().parent.parent
+    chart_dir = helm_chart_dir(repo_root)
+    assert chart_dir.exists()
+    profiles = helm_validation_profiles(repo_root)
+    assert [profile.name for profile in profiles] == [
+        "sqlite-pilot",
+        "focused-pilot",
+        "production",
+        "mesh-hardening",
+        "snowflake-backend",
+        "gateway-runtime",
+    ]
+    for profile in profiles:
+        for values_file in profile.values_files:
+            assert values_file.exists(), f"{profile.name} missing values file {values_file}"
+        for _key, file_path in profile.set_file_arguments:
+            assert file_path.exists(), f"{profile.name} missing set-file input {file_path}"
+
+
+def test_gateway_runtime_profile_uses_shipped_upstreams_example():
+    repo_root = Path(__file__).resolve().parent.parent
+    profiles = {profile.name: profile for profile in helm_validation_profiles(repo_root)}
+    gateway = profiles["gateway-runtime"]
+    assert gateway.set_arguments == ("gateway.enabled=true",)
+    assert gateway.set_file_arguments == (
+        ("gateway.upstreamsYaml", repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "gateway-upstreams.example.yaml"),
+    )


### PR DESCRIPTION
## Summary
- define the canonical shipped Helm deployment profiles in code so the chart examples stay aligned with the actual install story
- add a packaged examples README plus a validator script that lists or renders the supported profiles, including the gateway runtime shape
- add a CI job that installs Helm and renders the shipped profiles instead of relying on docs/examples to stay in sync by hand

## Testing
- uv run pytest tests/test_deploy_profiles.py tests/test_deploy_manifests.py -q
- uv run ruff check src/agent_bom/deploy_profiles.py scripts/validate_helm_profiles.py tests/test_deploy_profiles.py tests/test_deploy_manifests.py
- uv run mypy src/agent_bom/deploy_profiles.py
- python3 scripts/validate_helm_profiles.py --list