### PR TITLE
feat(ui): add deployment-context-aware navigation

### DIFF
--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -48,6 +48,9 @@ import {
   Wrench,
   X,
 } from "lucide-react";
+import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
+import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 
 // ─── Agents List Helpers ────────────────────────────────────────────────────
 
@@ -97,6 +100,7 @@ function AgentsList() {
   const [error, setError] = useState("");
   const [expandedAgent, setExpandedAgent] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const { counts } = useDeploymentContext();
 
   function toggleCollapse(agentName: string) {
     setExpandedAgent((current) => (current === agentName ? null : agentName));
@@ -202,15 +206,18 @@ function AgentsList() {
         </div>
       )}
 
-      {!loading && agents.length === 0 && (
-        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-          <Server className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-500 text-sm">No agents discovered locally.</p>
-          <p className="text-zinc-600 text-xs mt-1">
-            Install Claude Desktop, Cursor, or Windsurf and configure MCP servers.
-          </p>
-        </div>
-      )}
+      {!loading && agents.length === 0 &&
+        (counts && !isDeploymentSurfaceAvailable("agents", counts) ? (
+          <DeploymentSurfaceRequiredState surface="agents" counts={counts} detail={error || null} />
+        ) : (
+          <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+            <Server className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
+            <p className="text-zinc-500 text-sm">No agents discovered locally.</p>
+            <p className="text-zinc-600 text-xs mt-1">
+              Install Claude Desktop, Cursor, or Windsurf and configure MCP servers.
+            </p>
+          </div>
+        ))}
 
       {/* Configured agents */}
         <div className="space-y-4">

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -50,6 +50,9 @@ import {
   minimapNodeColor,
 } from "@/lib/graph-utils";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
+import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
+import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 
 // ─── Stats Bar ──────────────────────────────────────────────────────────────
 
@@ -219,6 +222,7 @@ export default function ContextPage() {
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
+  const { counts } = useDeploymentContext();
 
   // Load completed jobs
   useEffect(() => {
@@ -409,6 +413,9 @@ export default function ContextPage() {
   }
 
   if (jobs.length === 0) {
+    if (counts && !isDeploymentSurfaceAvailable("context", counts)) {
+      return <DeploymentSurfaceRequiredState surface="context" counts={counts} detail={error} />;
+    }
     return (
       <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
         <ShieldAlert className="w-8 h-8 text-zinc-600" />

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -35,6 +35,9 @@ import {
   Download,
   Search,
 } from "lucide-react";
+import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
+import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 
 function downloadJson(data: unknown, filename: string) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -96,6 +99,7 @@ export default function FleetPage() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [trustThreshold, setTrustThreshold] = useState(50);
   const [autoQuarantine, setAutoQuarantine] = useState(false);
+  const { counts } = useDeploymentContext();
 
   const belowThresholdCount = useMemo(
     () => agents.filter((a) => a.trust_score < trustThreshold).length,
@@ -363,15 +367,18 @@ export default function FleetPage() {
       )}
 
       {/* Empty state */}
-      {!loading && !error && agents.length === 0 && (
-        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-          <Users className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-500 text-sm">No agents in fleet yet.</p>
-          <p className="text-zinc-600 text-xs mt-1">
-            Click &quot;Sync Now&quot; to discover and register agents.
-          </p>
-        </div>
-      )}
+      {!loading && !error && agents.length === 0 &&
+        (counts && !isDeploymentSurfaceAvailable("fleet", counts) ? (
+          <DeploymentSurfaceRequiredState surface="fleet" counts={counts} detail={warning} />
+        ) : (
+          <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+            <Users className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
+            <p className="text-zinc-500 text-sm">No agents in fleet yet.</p>
+            <p className="text-zinc-600 text-xs mt-1">
+              Click &quot;Sync Now&quot; to discover and register agents.
+            </p>
+          </div>
+        ))}
 
       {/* Agent list */}
       {!loading && filtered.length > 0 && (

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -35,6 +35,9 @@ import {
   minimapNodeColor,
 } from "@/lib/graph-utils";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
+import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
+import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 
 // ─── Filter Toolbar ─────────────────────────────────────────────────────────
 
@@ -188,6 +191,7 @@ export default function MeshPage() {
   const [vulnerableOnly, setVulnerableOnly] = useState(true);
   const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const { counts } = useDeploymentContext();
 
   useEffect(() => {
     api
@@ -389,6 +393,9 @@ export default function MeshPage() {
   }
 
   if (jobs.length === 0) {
+    if (counts && !isDeploymentSurfaceAvailable("mesh", counts)) {
+      return <DeploymentSurfaceRequiredState surface="mesh" counts={counts} detail={error} />;
+    }
     return (
       <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
         <ShieldAlert className="w-8 h-8 text-zinc-600" />

--- a/ui/components/deployment-surface-required-state.tsx
+++ b/ui/components/deployment-surface-required-state.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { PostureCountsResponse } from "@/lib/api";
+import {
+  getDeploymentSurfaceState,
+  type DeploymentSurface,
+} from "@/lib/deployment-context";
+import { IntegrationRequiredState } from "@/components/integration-required-state";
+
+export function DeploymentSurfaceRequiredState({
+  surface,
+  counts,
+  detail,
+  onRetry,
+}: {
+  surface: DeploymentSurface;
+  counts: PostureCountsResponse | null;
+  detail?: string | null;
+  onRetry?: () => void;
+}) {
+  const state = getDeploymentSurfaceState(surface, counts, detail);
+
+  return (
+    <IntegrationRequiredState
+      title={state.title}
+      summary={state.summary}
+      requirement={state.requirement}
+      command={state.command}
+      capabilities={state.capabilities}
+      detail={state.detail}
+      onRetry={onRetry}
+    />
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -28,9 +28,14 @@ import {
   LayoutDashboard,
   Wrench,
 } from "lucide-react";
-import { api, type PostureCountsResponse } from "@/lib/api";
+import { api } from "@/lib/api";
 import { BrandMark } from "@/components/brand-mark";
 import { ThemeToggle } from "@/components/theme-toggle";
+import {
+  deploymentModeLabel,
+  isNavLinkVisible,
+} from "@/lib/deployment-context";
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
 
 // ─── Navigation Structure ──────────────────────────────────────────────────
 
@@ -123,41 +128,6 @@ const ALL_GROUP_LABELS = NAV_GROUPS.map((group) => group.label);
 
 // ─── Risk counts for badges ─────────────────────────────────────────────────
 
-type RiskCounts = PostureCountsResponse;
-
-const CAPABILITY_LINKS: Partial<Record<string, keyof RiskCounts>> = {
-  "/agents": "has_local_scan",
-  "/fleet": "has_fleet_ingest",
-  "/mesh": "has_mesh",
-  "/context": "has_mcp_context",
-  "/proxy": "has_proxy",
-  "/gateway": "has_gateway",
-  "/traces": "has_traces",
-};
-
-function hasDeploymentSignals(counts: RiskCounts | null): boolean {
-  if (!counts) return false;
-  return Boolean(
-    (counts.scan_count ?? 0) > 0 ||
-      counts.has_local_scan ||
-      counts.has_fleet_ingest ||
-      counts.has_cluster_scan ||
-      counts.has_ci_cd_scan ||
-      counts.has_mesh ||
-      counts.has_gateway ||
-      counts.has_proxy ||
-      counts.has_traces ||
-      counts.has_registry
-  );
-}
-
-function isLinkVisible(href: string, counts: RiskCounts | null): boolean {
-  if (!hasDeploymentSignals(counts)) return true;
-  const capability = CAPABILITY_LINKS[href];
-  if (!capability) return true;
-  return Boolean(counts?.[capability]);
-}
-
 // ─── Sidebar Component ──────────────────────────────────────────────────────
 
 export function Nav() {
@@ -168,9 +138,9 @@ export function Nav() {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
     () => new Set(captureMode ? ALL_GROUP_LABELS : [activeGroupForPath(path)])
   );
-  const [counts, setCounts] = useState<RiskCounts | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const { counts } = useDeploymentContext();
 
   // Close mobile on route change
   useEffect(() => {
@@ -204,25 +174,6 @@ export function Nav() {
       main.style.paddingLeft = collapsed ? "60px" : "";
     }
   }, [collapsed]);
-
-  // Fetch risk counts for badges
-  useEffect(() => {
-    let mounted = true;
-    const load = () => {
-      api
-        .getPostureCounts()
-        .then((c) => {
-          if (mounted) setCounts(c as RiskCounts);
-        })
-        .catch(() => {});
-    };
-    load();
-    const interval = setInterval(load, 60_000);
-    return () => {
-      mounted = false;
-      clearInterval(interval);
-    };
-  }, []);
 
   const toggleGroup = useCallback((label: string) => {
     if (captureMode) {
@@ -265,8 +216,8 @@ export function Nav() {
       if (searchQuery) {
         return { ...group, visibleLinks: group.links, hiddenLinks: [] as NavLink[] };
       }
-      const visibleLinks = group.links.filter((link) => isLinkVisible(link.href, counts));
-      const hiddenLinks = group.links.filter((link) => !isLinkVisible(link.href, counts));
+      const visibleLinks = group.links.filter((link) => isNavLinkVisible(link.href, counts));
+      const hiddenLinks = group.links.filter((link) => !isNavLinkVisible(link.href, counts));
       return { ...group, visibleLinks, hiddenLinks };
     })
     .filter((group) => group.visibleLinks.length > 0 || group.hiddenLinks.length > 0);
@@ -287,6 +238,11 @@ export function Nav() {
             <div className="min-w-0">
               <span className="font-semibold text-sm text-[color:var(--foreground)] block truncate">agent-bom</span>
               <span className="text-[10px] text-[color:var(--text-secondary)] font-mono block">AI Supply Chain</span>
+              {counts?.deployment_mode && (
+                <span className="mt-1 inline-flex rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2 py-0.5 text-[9px] font-mono uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                  {deploymentModeLabel(counts.deployment_mode)} Mode
+                </span>
+              )}
             </div>
           )}
         </Link>
@@ -434,7 +390,7 @@ export function Nav() {
                   {group.hiddenLinks.length > 0 && (
                     <details className="mt-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2">
                       <summary className="cursor-pointer list-none text-[11px] font-medium uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">
-                        Unused capabilities ({group.hiddenLinks.length})
+                        Unused in {deploymentModeLabel(counts?.deployment_mode)} ({group.hiddenLinks.length})
                       </summary>
                       <div className="mt-2 space-y-0.5">
                         {group.hiddenLinks.map(({ href, label, icon: Icon }) => (

--- a/ui/hooks/use-deployment-context.ts
+++ b/ui/hooks/use-deployment-context.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { api, type PostureCountsResponse } from "@/lib/api";
+
+export function useDeploymentContext() {
+  const [counts, setCounts] = useState<PostureCountsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const load = () => {
+      api
+        .getPostureCounts()
+        .then((nextCounts) => {
+          if (!mounted) return;
+          setCounts(nextCounts);
+          setError(null);
+          setLoading(false);
+        })
+        .catch((nextError: Error) => {
+          if (!mounted) return;
+          setError(nextError.message);
+          setLoading(false);
+        });
+    };
+
+    load();
+    const interval = window.setInterval(load, 60_000);
+    return () => {
+      mounted = false;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  return { counts, loading, error };
+}

--- a/ui/lib/deployment-context.ts
+++ b/ui/lib/deployment-context.ts
@@ -1,0 +1,208 @@
+import type { DeploymentMode, PostureCountsResponse } from "@/lib/api";
+
+export type DeploymentSurface =
+  | "agents"
+  | "fleet"
+  | "mesh"
+  | "context"
+  | "proxy"
+  | "gateway"
+  | "traces"
+  | "audit";
+
+interface DeploymentSurfaceDefinition {
+  label: string;
+  navHref: string;
+  isAvailable: (counts: PostureCountsResponse | null) => boolean;
+  requirement: string;
+  command: string;
+  capabilities: string[];
+  summary: (mode: string) => string;
+}
+
+function bool(value: boolean | undefined): boolean {
+  return Boolean(value);
+}
+
+export function deploymentModeLabel(mode?: DeploymentMode): string {
+  switch (mode) {
+    case "fleet":
+      return "Fleet";
+    case "cluster":
+      return "Cluster";
+    case "hybrid":
+      return "Hybrid";
+    case "local":
+    default:
+      return "Local";
+  }
+}
+
+export function hasDeploymentSignals(counts: PostureCountsResponse | null): boolean {
+  if (!counts) return false;
+  return Boolean(
+    (counts.scan_count ?? 0) > 0 ||
+      counts.has_local_scan ||
+      counts.has_fleet_ingest ||
+      counts.has_cluster_scan ||
+      counts.has_ci_cd_scan ||
+      counts.has_mesh ||
+      counts.has_gateway ||
+      counts.has_proxy ||
+      counts.has_traces ||
+      counts.has_registry,
+  );
+}
+
+const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition> = {
+  agents: {
+    label: "Agents",
+    navHref: "/agents",
+    isAvailable: (counts) => bool(counts?.has_local_scan),
+    requirement: "Local agent discovery or workstation scan evidence",
+    command: "agent-bom agents --push-url https://<control-plane>/v1/fleet/sync",
+    capabilities: [
+      "Local MCP config-file discovery from developer workstations",
+      "Configured agent inventory with attached MCP servers",
+      "Agent detail views sourced from local scan output",
+    ],
+    summary: (mode) =>
+      `The Agents page is populated by local workstation discovery. Your current deployment mode is ${mode}, so this surface stays empty until local agent scans are pushed into the control plane.`,
+  },
+  fleet: {
+    label: "Fleet",
+    navHref: "/fleet",
+    isAvailable: (counts) => bool(counts?.has_fleet_ingest),
+    requirement: "Persisted fleet ingest from endpoints or collectors",
+    command: "agent-bom agents --push-url https://<control-plane>/v1/fleet/sync",
+    capabilities: [
+      "Tenant-scoped fleet inventory with lifecycle and trust score",
+      "Fleet sync state for laptops, workstations, and collectors",
+      "Persisted endpoint evidence separate from one-off local scans",
+    ],
+    summary: (mode) =>
+      `The Fleet page is populated by persisted endpoint sync, not by standalone local scans. Your current deployment mode is ${mode}, so this surface remains empty until fleet ingest is enabled.`,
+  },
+  mesh: {
+    label: "Agent Mesh",
+    navHref: "/mesh",
+    isAvailable: (counts) => bool(counts?.has_mesh),
+    requirement: "Completed scans with agent and runtime relationship context",
+    command: "agent-bom scan --introspect --preset enterprise",
+    capabilities: [
+      "Shared infrastructure across agents, tools, packages, and findings",
+      "Highest-risk agent defaults and mesh-wide overlap analysis",
+      "Runtime-aware graph exploration instead of a raw scan list",
+    ],
+    summary: (mode) =>
+      `The Agent Mesh needs relationship-rich scan data. Your current deployment mode is ${mode}, so this page stays empty until scans produce mesh context for agents, workloads, or fleet inventory.`,
+  },
+  context: {
+    label: "Context Map",
+    navHref: "/context",
+    isAvailable: (counts) => bool(counts?.has_mcp_context),
+    requirement: "MCP and agent context from completed scans",
+    command: "agent-bom scan --introspect --preset enterprise",
+    capabilities: [
+      "Lateral path analysis across agents, credentials, tools, and servers",
+      "Context graph stats for shared credentials and shared servers",
+      "Direct drilldown into MCP interaction risk instead of raw findings only",
+    ],
+    summary: (mode) =>
+      `The Context Map is built from MCP-aware scan results. Your current deployment mode is ${mode}, so this page stays empty until scans collect agent and MCP context.`,
+  },
+  proxy: {
+    label: "Proxy",
+    navHref: "/proxy",
+    isAvailable: (counts) => bool(counts?.has_proxy),
+    requirement: "Runtime proxy audit or detector telemetry",
+    command: "agent-bom proxy --help",
+    capabilities: [
+      "Runtime MCP proxy alerts and detector activity",
+      "Live tool-call blocking and severity breakdowns",
+      "Proxy-specific metrics separate from control-plane-only scans",
+    ],
+    summary: (mode) =>
+      `The Proxy dashboard is only populated when runtime proxy telemetry is present. Your current deployment mode is ${mode}, so this surface is idle until proxy enforcement is enabled.`,
+  },
+  gateway: {
+    label: "Gateway",
+    navHref: "/gateway",
+    isAvailable: (counts) => bool(counts?.has_gateway),
+    requirement: "Gateway policy usage or managed runtime policy state",
+    command: "helm upgrade --install agent-bom deploy/helm/agent-bom --set gateway.enabled=true",
+    capabilities: [
+      "Central gateway policy inventory and evaluation",
+      "Gateway audit entries tied to runtime enforcement",
+      "A shared relay/policy surface for cluster or hybrid MCP traffic",
+    ],
+    summary: (mode) =>
+      `The Gateway page becomes active when the shared runtime gateway is in use. Your current deployment mode is ${mode}, so this surface remains optional until gateway policy management is enabled.`,
+  },
+  traces: {
+    label: "Traces",
+    navHref: "/traces",
+    isAvailable: (counts) => bool(counts?.has_traces),
+    requirement: "Runtime trace payloads or proxy/gateway telemetry",
+    command: "POST /v1/traces with MCP or runtime correlation payloads",
+    capabilities: [
+      "Trace-to-asset correlation for runtime MCP traffic",
+      "Flagged call review against vulnerable packages and servers",
+      "Manual or pipeline-fed runtime evidence beyond static scans",
+    ],
+    summary: (mode) =>
+      `The Traces page needs runtime telemetry, not just stored scan results. Your current deployment mode is ${mode}, so this surface stays empty until traces or proxy/gateway telemetry are pushed in.`,
+  },
+  audit: {
+    label: "Audit Log",
+    navHref: "/audit",
+    isAvailable: (counts) => bool(counts?.has_proxy || counts?.has_gateway || counts?.has_traces),
+    requirement: "Runtime or control-plane audit activity",
+    command: "Enable proxy, gateway, or runtime audit push into the control plane",
+    capabilities: [
+      "Tamper-evident audit records for runtime and policy actions",
+      "Cross-surface activity review across proxy, gateway, and fleet actions",
+      "Integrity status for operator-visible audit history",
+    ],
+    summary: (mode) =>
+      `The Audit Log becomes useful when runtime or policy surfaces emit audit events. Your current deployment mode is ${mode}, so this page stays quiet until those surfaces are active.`,
+  },
+};
+
+export function deploymentSurfaceForHref(href: string): DeploymentSurface | null {
+  const normalized = href === "/vulns" ? "/findings" : href;
+  const match = Object.entries(SURFACE_DEFINITIONS).find(([, definition]) => definition.navHref === normalized);
+  return (match?.[0] as DeploymentSurface | undefined) ?? null;
+}
+
+export function isDeploymentSurfaceAvailable(
+  surface: DeploymentSurface,
+  counts: PostureCountsResponse | null,
+): boolean {
+  if (!counts) return true;
+  return SURFACE_DEFINITIONS[surface].isAvailable(counts);
+}
+
+export function isNavLinkVisible(href: string, counts: PostureCountsResponse | null): boolean {
+  if (!hasDeploymentSignals(counts)) return true;
+  const surface = deploymentSurfaceForHref(href);
+  if (!surface) return true;
+  return isDeploymentSurfaceAvailable(surface, counts);
+}
+
+export function getDeploymentSurfaceState(
+  surface: DeploymentSurface,
+  counts: PostureCountsResponse | null,
+  detail?: string | null,
+) {
+  const definition = SURFACE_DEFINITIONS[surface];
+  const mode = deploymentModeLabel(counts?.deployment_mode);
+  return {
+    title: `${definition.label} is not active in this deployment`,
+    summary: definition.summary(mode),
+    requirement: definition.requirement,
+    command: definition.command,
+    capabilities: definition.capabilities,
+    detail,
+  };
+}

--- a/ui/tests/deployment-context.test.ts
+++ b/ui/tests/deployment-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deploymentModeLabel,
+  getDeploymentSurfaceState,
+  hasDeploymentSignals,
+  isDeploymentSurfaceAvailable,
+  isNavLinkVisible,
+} from "@/lib/deployment-context";
+import type { PostureCountsResponse } from "@/lib/api";
+
+function makeCounts(overrides: Partial<PostureCountsResponse> = {}): PostureCountsResponse {
+  return {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    total: 0,
+    kev: 0,
+    compound_issues: 0,
+    deployment_mode: "local",
+    has_mcp_context: false,
+    has_agent_context: false,
+    has_local_scan: false,
+    has_fleet_ingest: false,
+    has_cluster_scan: false,
+    has_ci_cd_scan: false,
+    has_mesh: false,
+    has_gateway: false,
+    has_proxy: false,
+    has_traces: false,
+    has_registry: false,
+    scan_sources: [],
+    scan_count: 0,
+    ...overrides,
+  };
+}
+
+describe("deployment-context helpers", () => {
+  it("formats deployment mode labels", () => {
+    expect(deploymentModeLabel("local")).toBe("Local");
+    expect(deploymentModeLabel("fleet")).toBe("Fleet");
+    expect(deploymentModeLabel("cluster")).toBe("Cluster");
+    expect(deploymentModeLabel("hybrid")).toBe("Hybrid");
+  });
+
+  it("detects when deployment signals exist", () => {
+    expect(hasDeploymentSignals(makeCounts())).toBe(false);
+    expect(hasDeploymentSignals(makeCounts({ has_fleet_ingest: true }))).toBe(true);
+  });
+
+  it("gates local-only surfaces away from fleet-only deployments", () => {
+    const counts = makeCounts({
+      deployment_mode: "fleet",
+      has_fleet_ingest: true,
+      scan_count: 1,
+    });
+    expect(isDeploymentSurfaceAvailable("agents", counts)).toBe(false);
+    expect(isNavLinkVisible("/agents", counts)).toBe(false);
+    expect(isNavLinkVisible("/fleet", counts)).toBe(true);
+  });
+
+  it("keeps runtime surfaces visible for hybrid deployments", () => {
+    const counts = makeCounts({
+      deployment_mode: "hybrid",
+      has_local_scan: true,
+      has_fleet_ingest: true,
+      has_cluster_scan: true,
+      has_gateway: true,
+      has_proxy: true,
+      has_traces: true,
+      scan_count: 3,
+    });
+    expect(isNavLinkVisible("/gateway", counts)).toBe(true);
+    expect(isNavLinkVisible("/proxy", counts)).toBe(true);
+    expect(isNavLinkVisible("/audit", counts)).toBe(true);
+  });
+
+  it("builds deployment-aware state copy", () => {
+    const state = getDeploymentSurfaceState(
+      "agents",
+      makeCounts({ deployment_mode: "cluster" }),
+      "No local agent evidence found",
+    );
+    expect(state.title).toContain("Agents");
+    expect(state.summary).toContain("Cluster");
+    expect(state.detail).toBe("No local agent evidence found");
+    expect(state.capabilities.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -257,7 +257,7 @@ describe('Nav', () => {
       expect(document.querySelector('summary')).toBeTruthy()
     })
 
-    expect(document.querySelector('summary')?.textContent).toContain('Unused capabilities')
+    expect(document.querySelector('summary')?.textContent).toContain('Unused in Local')
     const fleetLink = screen.getByRole('link', { name: /^fleet$/i })
     expect(fleetLink).toHaveAttribute('href', '/fleet')
     expect(fleetLink).toHaveAttribute('title', 'Hidden until this deployment mode is detected')


### PR DESCRIPTION
## Summary
- add shared deployment-context helpers so the UI can interpret `local`, `fleet`, `cluster`, and `hybrid` posture signals consistently
- make the sidebar deployment-aware, including a mode badge and hidden-link bucket for surfaces not active in the detected deployment
- replace misleading empty states on `/agents`, `/fleet`, `/mesh`, and `/context` with mode-specific guidance tied to the active deployment surface

## Testing
- npm run test:run -- tests/nav.test.tsx tests/deployment-context.test.ts
- npm run lint
- npm run build

Closes #1520
