### PR TITLE
feat(auth): add key rotation overlap and admin UX

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -411,6 +411,9 @@ CREATE TABLE IF NOT EXISTS api_keys (
     created_at  TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
     expires_at  TEXT,               -- NULL = never
     last_used   TEXT,
+    revoked_at  TEXT,
+    rotation_overlap_until TEXT,
+    replacement_key_id TEXT,
     revoked     BOOLEAN NOT NULL DEFAULT FALSE
 );
 

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -47,21 +47,69 @@ class ApiKey:
     expires_at: str | None = None
     scopes: list[str] = field(default_factory=list)
     tenant_id: str = "default"
+    revoked_at: str | None = None
+    rotation_overlap_until: str | None = None
+    replacement_key_id: str | None = None
 
     def __post_init__(self) -> None:
         if not self.created_at:
             self.created_at = datetime.now(timezone.utc).isoformat()
 
-    def is_expired(self) -> bool:
+    @staticmethod
+    def _parse_timestamp(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
         if not self.expires_at:
             return False
-        return datetime.now(timezone.utc).isoformat() > self.expires_at
+        current = now or datetime.now(timezone.utc)
+        expires_at = self._parse_timestamp(self.expires_at)
+        return bool(expires_at and current > expires_at)
+
+    def is_revoked(self) -> bool:
+        return bool(self.revoked_at)
+
+    def is_within_rotation_overlap(self, *, now: datetime | None = None) -> bool:
+        if not self.replacement_key_id or not self.rotation_overlap_until:
+            return False
+        current = now or datetime.now(timezone.utc)
+        overlap_until = self._parse_timestamp(self.rotation_overlap_until)
+        return bool(overlap_until and current <= overlap_until)
+
+    def is_usable(self, *, now: datetime | None = None) -> bool:
+        if self.is_revoked():
+            return False
+        if self.is_expired(now=now):
+            return False
+        if self.replacement_key_id:
+            return self.is_within_rotation_overlap(now=now)
+        return True
+
+    def lifecycle_state(self, *, now: datetime | None = None) -> str:
+        if self.is_revoked():
+            return "revoked"
+        if self.is_expired(now=now):
+            return "expired"
+        if self.replacement_key_id:
+            return "rotation_overlap" if self.is_within_rotation_overlap(now=now) else "rotated"
+        return "active"
 
     def has_role(self, required: Role) -> bool:
         """Check if this key's role meets or exceeds the required role."""
         return _ROLE_HIERARCHY.get(self.role, 0) >= _ROLE_HIERARCHY.get(required, 0)
 
     def to_dict(self) -> dict:
+        current = datetime.now(timezone.utc)
+        overlap_remaining_seconds = None
+        if self.rotation_overlap_until:
+            overlap_until = self._parse_timestamp(self.rotation_overlap_until)
+            if overlap_until is not None:
+                overlap_remaining_seconds = max(0, int((overlap_until - current).total_seconds()))
         return {
             "key_id": self.key_id,
             "key_prefix": self.key_prefix,
@@ -71,6 +119,11 @@ class ApiKey:
             "expires_at": self.expires_at,
             "scopes": self.scopes,
             "tenant_id": self.tenant_id,
+            "revoked_at": self.revoked_at,
+            "rotation_overlap_until": self.rotation_overlap_until,
+            "replacement_key_id": self.replacement_key_id,
+            "state": self.lifecycle_state(now=current),
+            "overlap_seconds_remaining": overlap_remaining_seconds,
         }
 
 
@@ -80,19 +133,34 @@ class ApiKeyPolicy:
 
     default_ttl_seconds: int = 30 * 24 * 60 * 60
     max_ttl_seconds: int = 90 * 24 * 60 * 60
+    default_overlap_seconds: int = 15 * 60
+    max_overlap_seconds: int = 24 * 60 * 60
 
 
 def get_api_key_policy() -> ApiKeyPolicy:
     """Load API key lifetime policy from env with safe defaults."""
     default_ttl = int(os.environ.get("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS", str(30 * 24 * 60 * 60)))
     max_ttl = int(os.environ.get("AGENT_BOM_API_KEY_MAX_TTL_SECONDS", str(90 * 24 * 60 * 60)))
+    default_overlap = int(os.environ.get("AGENT_BOM_API_KEY_DEFAULT_OVERLAP_SECONDS", str(15 * 60)))
+    max_overlap = int(os.environ.get("AGENT_BOM_API_KEY_MAX_OVERLAP_SECONDS", str(24 * 60 * 60)))
     if default_ttl <= 0:
         raise ValueError("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS must be > 0")
     if max_ttl <= 0:
         raise ValueError("AGENT_BOM_API_KEY_MAX_TTL_SECONDS must be > 0")
     if default_ttl > max_ttl:
         raise ValueError("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS cannot exceed AGENT_BOM_API_KEY_MAX_TTL_SECONDS")
-    return ApiKeyPolicy(default_ttl_seconds=default_ttl, max_ttl_seconds=max_ttl)
+    if default_overlap < 0:
+        raise ValueError("AGENT_BOM_API_KEY_DEFAULT_OVERLAP_SECONDS must be >= 0")
+    if max_overlap < 0:
+        raise ValueError("AGENT_BOM_API_KEY_MAX_OVERLAP_SECONDS must be >= 0")
+    if default_overlap > max_overlap:
+        raise ValueError("AGENT_BOM_API_KEY_DEFAULT_OVERLAP_SECONDS cannot exceed AGENT_BOM_API_KEY_MAX_OVERLAP_SECONDS")
+    return ApiKeyPolicy(
+        default_ttl_seconds=default_ttl,
+        max_ttl_seconds=max_ttl,
+        default_overlap_seconds=default_overlap,
+        max_overlap_seconds=max_overlap,
+    )
 
 
 def normalize_api_key_expiry(
@@ -118,6 +186,21 @@ def normalize_api_key_expiry(
             raise ValueError(f"expires_at exceeds the maximum allowed API key lifetime ({active_policy.max_ttl_seconds} seconds)")
         return parsed.isoformat()
     return (current + timedelta(seconds=active_policy.default_ttl_seconds)).isoformat()
+
+
+def normalize_rotation_overlap_seconds(
+    overlap_seconds: int | None,
+    *,
+    policy: ApiKeyPolicy | None = None,
+) -> int:
+    """Normalize a requested key-rotation overlap window under operator policy."""
+    active_policy = policy or get_api_key_policy()
+    candidate = active_policy.default_overlap_seconds if overlap_seconds is None else overlap_seconds
+    if candidate < 0:
+        raise ValueError("overlap_seconds must be >= 0")
+    if candidate > active_policy.max_overlap_seconds:
+        raise ValueError(f"overlap_seconds exceeds the maximum allowed overlap window ({active_policy.max_overlap_seconds} seconds)")
+    return candidate
 
 
 def _derive_key(raw_key: str, salt: bytes) -> str:
@@ -177,7 +260,7 @@ def verify_api_key(raw_key: str, stored_keys: list[ApiKey]) -> ApiKey | None:
         salt = bytes.fromhex(stored.key_salt)
         candidate = _derive_key(raw_key, salt)
         if hmac.compare_digest(stored.key_hash, candidate):
-            if stored.is_expired():
+            if not stored.is_usable():
                 return None
             return stored
     return None
@@ -201,9 +284,21 @@ class KeyStore:
 
     def remove(self, key_id: str) -> bool:
         with self._lock:
-            before = len(self._keys)
-            self._keys = [k for k in self._keys if k.key_id != key_id]
-            return len(self._keys) < before
+            for key in self._keys:
+                if key.key_id == key_id and not key.is_revoked():
+                    key.revoked_at = datetime.now(timezone.utc).isoformat()
+                    key.rotation_overlap_until = None
+                    return True
+            return False
+
+    def mark_rotating(self, key_id: str, *, replacement_key_id: str, overlap_until: str) -> bool:
+        with self._lock:
+            for key in self._keys:
+                if key.key_id == key_id and not key.is_revoked():
+                    key.replacement_key_id = replacement_key_id
+                    key.rotation_overlap_until = overlap_until
+                    return True
+            return False
 
     def get(self, key_id: str) -> ApiKey | None:
         with self._lock:
@@ -230,6 +325,7 @@ class KeyStoreProtocol(Protocol):
 
     def add(self, key: ApiKey) -> None: ...
     def remove(self, key_id: str) -> bool: ...
+    def mark_rotating(self, key_id: str, *, replacement_key_id: str, overlap_until: str) -> bool: ...
     def get(self, key_id: str) -> ApiKey | None: ...
     def list_keys(self, tenant_id: str | None = None) -> list[ApiKey]: ...
     def verify(self, raw_key: str) -> ApiKey | None: ...

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -444,6 +444,7 @@ class CreateKeyRequest(BaseModel):
 class RotateKeyRequest(BaseModel):
     name: str | None = None
     expires_at: str | None = None
+    overlap_seconds: int | None = None
 
 
 class ExceptionRequest(BaseModel):

--- a/src/agent_bom/api/postgres_access.py
+++ b/src/agent_bom/api/postgres_access.py
@@ -33,6 +33,9 @@ class PostgresKeyStore:
                     created_at TEXT NOT NULL,
                     expires_at TEXT,
                     last_used TEXT,
+                    revoked_at TEXT,
+                    rotation_overlap_until TEXT,
+                    replacement_key_id TEXT,
                     revoked BOOLEAN NOT NULL DEFAULT FALSE
                 )
             """)
@@ -44,6 +47,30 @@ class PostgresKeyStore:
                         WHERE table_name = 'api_keys' AND column_name = 'team_id'
                     ) THEN
                         ALTER TABLE api_keys ADD COLUMN team_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                END
+                $$;
+            """)
+            conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'api_keys' AND column_name = 'revoked_at'
+                    ) THEN
+                        ALTER TABLE api_keys ADD COLUMN revoked_at TEXT;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'api_keys' AND column_name = 'rotation_overlap_until'
+                    ) THEN
+                        ALTER TABLE api_keys ADD COLUMN rotation_overlap_until TEXT;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'api_keys' AND column_name = 'replacement_key_id'
+                    ) THEN
+                        ALTER TABLE api_keys ADD COLUMN replacement_key_id TEXT;
                     END IF;
                 END
                 $$;
@@ -68,14 +95,20 @@ class PostgresKeyStore:
             scopes=scopes,
             created_at=row[8],
             expires_at=row[9],
+            revoked_at=row[10],
+            rotation_overlap_until=row[11],
+            replacement_key_id=row[12],
         )
 
     def add(self, key: ApiKey) -> None:
         with _tenant_connection(self._pool) as conn:
             conn.execute(
                 """INSERT INTO api_keys
-                   (key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at, revoked)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+                   (
+                     key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
+                     created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id, revoked
+                   )
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
                    ON CONFLICT (key_id) DO UPDATE SET
                      key_hash = EXCLUDED.key_hash,
                      key_salt = EXCLUDED.key_salt,
@@ -86,6 +119,9 @@ class PostgresKeyStore:
                      scopes = EXCLUDED.scopes,
                      created_at = EXCLUDED.created_at,
                      expires_at = EXCLUDED.expires_at,
+                     revoked_at = EXCLUDED.revoked_at,
+                     rotation_overlap_until = EXCLUDED.rotation_overlap_until,
+                     replacement_key_id = EXCLUDED.replacement_key_id,
                      revoked = FALSE""",
                 (
                     key.key_id,
@@ -98,6 +134,9 @@ class PostgresKeyStore:
                     json.dumps(key.scopes),
                     key.created_at,
                     key.expires_at,
+                    key.revoked_at,
+                    key.rotation_overlap_until,
+                    key.replacement_key_id,
                 ),
             )
             conn.commit()
@@ -105,8 +144,24 @@ class PostgresKeyStore:
     def remove(self, key_id: str) -> bool:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
-                "UPDATE api_keys SET revoked = TRUE WHERE key_id = %s AND revoked = FALSE",
+                """UPDATE api_keys
+                   SET revoked = TRUE,
+                       revoked_at = NOW()::text,
+                       rotation_overlap_until = NULL
+                   WHERE key_id = %s AND revoked = FALSE""",
                 (key_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def mark_rotating(self, key_id: str, *, replacement_key_id: str, overlap_until: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                """UPDATE api_keys
+                   SET replacement_key_id = %s,
+                       rotation_overlap_until = %s
+                   WHERE key_id = %s AND revoked = FALSE""",
+                (replacement_key_id, overlap_until, key_id),
             )
             conn.commit()
             return cursor.rowcount > 0
@@ -114,18 +169,22 @@ class PostgresKeyStore:
     def get(self, key_id: str) -> ApiKey | None:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
-                """SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
+                """SELECT
+                       key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
+                       created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id
                    FROM api_keys
-                   WHERE key_id = %s AND revoked = FALSE""",
+                   WHERE key_id = %s""",
                 (key_id,),
             ).fetchone()
             return self._row_to_key(row) if row else None
 
     def list_keys(self, tenant_id: str | None = None) -> list[ApiKey]:
         query = """
-            SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
+            SELECT
+                key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
+                created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id
             FROM api_keys
-            WHERE revoked = FALSE
+            WHERE TRUE
         """
         params: tuple[object, ...] = ()
         if tenant_id is not None:
@@ -141,9 +200,11 @@ class PostgresKeyStore:
         with bypass_tenant_rls():
             with _tenant_connection(self._pool) as conn:
                 rows = conn.execute(
-                    """SELECT key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes, created_at, expires_at
+                    """SELECT
+                           key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
+                           created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id
                        FROM api_keys
-                       WHERE key_prefix = %s AND revoked = FALSE""",
+                       WHERE key_prefix = %s""",
                     (prefix,),
                 ).fetchall()
         return verify_api_key(raw_key, [self._row_to_key(row) for row in rows])

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -106,7 +106,7 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
 async def rotate_key(request: Request, key_id: str, req: RotateKeyRequest) -> dict:
     """Rotate an API key by minting a replacement and revoking the old key."""
     from agent_bom.api.audit_log import log_action
-    from agent_bom.api.auth import create_api_key, get_key_store
+    from agent_bom.api.auth import create_api_key, get_api_key_policy, get_key_store, normalize_rotation_overlap_seconds
 
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
@@ -114,6 +114,9 @@ async def rotate_key(request: Request, key_id: str, req: RotateKeyRequest) -> di
     current_key = store.get(key_id)
     if current_key is None or current_key.tenant_id != tenant_id:
         raise HTTPException(status_code=404, detail=f"Key {key_id} not found")
+
+    overlap_seconds = normalize_rotation_overlap_seconds(req.overlap_seconds, policy=get_api_key_policy())
+    overlap_until = (datetime.now(timezone.utc) + timedelta(seconds=overlap_seconds)).isoformat()
 
     replacement_name = req.name or current_key.name
     try:
@@ -128,7 +131,8 @@ async def rotate_key(request: Request, key_id: str, req: RotateKeyRequest) -> di
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     store.add(replacement)
-    store.remove(current_key.key_id)
+    if not store.mark_rotating(current_key.key_id, replacement_key_id=replacement.key_id, overlap_until=overlap_until):
+        raise HTTPException(status_code=409, detail=f"Key {key_id} could not be marked for rotation")
     log_action(
         "auth.key_rotated",
         actor=actor,
@@ -137,14 +141,8 @@ async def rotate_key(request: Request, key_id: str, req: RotateKeyRequest) -> di
         replacement_key_id=replacement.key_id,
         previous_expires_at=current_key.expires_at,
         replacement_expires_at=replacement.expires_at,
-    )
-    log_action(
-        "auth.key_revoked",
-        actor=actor,
-        resource=f"key/{current_key.key_id}",
-        tenant_id=tenant_id,
-        reason="rotated",
-        replacement_key_id=replacement.key_id,
+        overlap_until=overlap_until,
+        overlap_seconds=overlap_seconds,
     )
 
     return {
@@ -157,7 +155,11 @@ async def rotate_key(request: Request, key_id: str, req: RotateKeyRequest) -> di
         "tenant_id": replacement.tenant_id,
         "created_at": replacement.created_at,
         "expires_at": replacement.expires_at,
-        "message": "Store the raw_key securely — it will not be shown again. The previous key has been revoked.",
+        "overlap_until": overlap_until,
+        "overlap_seconds": overlap_seconds,
+        "message": (
+            "Store the raw_key securely — it will not be shown again. The previous key remains valid until the overlap window ends."
+        ),
     }
 
 
@@ -200,6 +202,8 @@ async def auth_policy() -> dict:
         "api_key": {
             "default_ttl_seconds": api_policy.default_ttl_seconds,
             "max_ttl_seconds": api_policy.max_ttl_seconds,
+            "default_overlap_seconds": api_policy.default_overlap_seconds,
+            "max_overlap_seconds": api_policy.max_overlap_seconds,
             "rotation_policy": "enforced",
             "rotation_endpoint": "/v1/auth/keys/{key_id}/rotate",
         },

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -113,17 +113,24 @@ async def test_delete_key_returns_404_for_cross_tenant_key(isolated_key_store):
 
 
 @pytest.mark.asyncio
-async def test_rotate_key_replaces_old_key_and_revokes_previous(isolated_key_store):
+async def test_rotate_key_replaces_old_key_and_preserves_overlap_window(isolated_key_store):
     raw, alpha = create_api_key("alpha", Role.ADMIN, tenant_id="tenant-alpha")
     isolated_key_store.add(alpha)
 
-    result = await enterprise.rotate_key(_request("tenant-alpha", "alice-admin"), alpha.key_id, RotateKeyRequest())
+    result = await enterprise.rotate_key(
+        _request("tenant-alpha", "alice-admin"),
+        alpha.key_id,
+        RotateKeyRequest(overlap_seconds=300),
+    )
 
     assert result["replaced_key_id"] == alpha.key_id
     assert result["tenant_id"] == "tenant-alpha"
     assert result["expires_at"]
-    assert isolated_key_store.get(alpha.key_id) is None
-    assert isolated_key_store.verify(raw) is None
+    assert result["overlap_seconds"] == 300
+    previous = isolated_key_store.get(alpha.key_id)
+    assert previous is not None
+    assert previous.replacement_key_id == result["key_id"]
+    assert isolated_key_store.verify(raw) is not None
     assert isolated_key_store.verify(result["raw_key"]) is not None
 
 

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -123,6 +123,8 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["api_key"]["rotation_endpoint"] == "/v1/auth/keys/{key_id}/rotate"
     assert "default_ttl_seconds" in body["api_key"]
     assert "max_ttl_seconds" in body["api_key"]
+    assert "default_overlap_seconds" in body["api_key"]
+    assert "max_overlap_seconds" in body["api_key"]
     assert body["rate_limit_key"]["status"] in {"ok", "ephemeral", "unknown_age", "rotation_due", "max_age_exceeded"}
     assert body["ui"]["recommended_mode"] in {"no_auth", "reverse_proxy_oidc", "oidc_bearer", "session_api_key"}
     assert body["ui"]["session_storage_fallback"] == "session_api_key"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,6 +14,7 @@ from agent_bom.api.auth import (
     create_api_key,
     get_key_store,
     normalize_api_key_expiry,
+    normalize_rotation_overlap_seconds,
     set_key_store,
     verify_api_key,
 )
@@ -140,6 +141,20 @@ class TestVerifyApiKey:
         assert verify_api_key(raw2, [key1, key2]) is not None
         assert verify_api_key("abom_nope", [key1, key2]) is None
 
+    def test_rotated_key_remains_valid_during_overlap(self):
+        raw, key = create_api_key("rotate-test", Role.ADMIN)
+        key.replacement_key_id = "next-key"
+        key.rotation_overlap_until = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
+        result = verify_api_key(raw, [key])
+        assert result is not None
+
+    def test_rotated_key_fails_after_overlap_window(self):
+        raw, key = create_api_key("rotate-test", Role.ADMIN)
+        key.replacement_key_id = "next-key"
+        key.rotation_overlap_until = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+        result = verify_api_key(raw, [key])
+        assert result is None
+
     def test_prefix_narrows_candidates_before_scrypt(self, monkeypatch):
         raw1, key1 = create_api_key("key1", Role.ADMIN)
         _, key2 = create_api_key("key2", Role.VIEWER)
@@ -203,6 +218,7 @@ class TestApiKeyToDict:
         assert d["name"] == "dict-test"
         assert d["role"] == "analyst"
         assert d["scopes"] == ["scan"]
+        assert d["state"] == "active"
         assert "key_hash" not in d  # Hash should NOT be exposed
         assert "key_salt" not in d  # Salt should NOT be exposed
 
@@ -224,7 +240,9 @@ class TestKeyStore:
         _, key = create_api_key("rm-test", Role.VIEWER)
         store.add(key)
         assert store.remove(key.key_id)
-        assert len(store.list_keys()) == 0
+        listed = store.list_keys()
+        assert len(listed) == 1
+        assert listed[0].lifecycle_state() == "revoked"
 
     def test_remove_nonexistent(self):
         store = KeyStore()
@@ -243,6 +261,30 @@ class TestKeyStore:
         _, key = create_api_key("hk", Role.VIEWER)
         store.add(key)
         assert store.has_keys()
+
+    def test_mark_rotating_preserves_old_key_until_overlap(self):
+        store = KeyStore()
+        raw, key = create_api_key("rotate-me", Role.ADMIN)
+        store.add(key)
+        overlap_until = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+
+        assert store.mark_rotating(key.key_id, replacement_key_id="new-key", overlap_until=overlap_until)
+        assert store.verify(raw) is not None
+        rotated = store.get(key.key_id)
+        assert rotated is not None
+        assert rotated.replacement_key_id == "new-key"
+        assert rotated.rotation_overlap_until == overlap_until
+
+
+class TestRotationPolicy:
+    def test_normalize_overlap_uses_policy_default(self):
+        policy = ApiKeyPolicy(default_overlap_seconds=300, max_overlap_seconds=3600)
+        assert normalize_rotation_overlap_seconds(None, policy=policy) == 300
+
+    def test_normalize_overlap_rejects_excessive_window(self):
+        policy = ApiKeyPolicy(default_overlap_seconds=300, max_overlap_seconds=600)
+        with pytest.raises(ValueError, match="maximum allowed overlap window"):
+            normalize_rotation_overlap_seconds(900, policy=policy)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -262,7 +262,20 @@ def test_policy_results_status_values_documented():
 
 def test_api_keys_required_columns():
     cols = _columns_for("api_keys")
-    for col in ("key_id", "key_hash", "key_salt", "key_prefix", "name", "role", "team_id", "scopes", "revoked"):
+    for col in (
+        "key_id",
+        "key_hash",
+        "key_salt",
+        "key_prefix",
+        "name",
+        "role",
+        "team_id",
+        "scopes",
+        "revoked_at",
+        "rotation_overlap_until",
+        "replacement_key_id",
+        "revoked",
+    ):
         assert col in cols, f"api_keys missing column: {col}"
 
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -87,7 +87,7 @@ class MockConnection:
             elif (
                 "from api_keys" in sql_lower
                 and "key_id, key_hash, key_salt, key_prefix" in sql_lower
-                and "name, role, team_id, scopes, created_at, expires_at" in sql_lower
+                and "name, role, team_id, scopes" in sql_lower
             ):
                 rows = list(self._store.get("api_keys", {}).values())
                 if params:
@@ -97,7 +97,7 @@ class MockConnection:
                         rows = [r for r in rows if r[0] == params[0]]
                     elif "team_id = %s" in sql_lower:
                         rows = [r for r in rows if r[6] == params[0]]
-                cursor.rows = [(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]) for r in rows]
+                cursor.rows = [(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12]) for r in rows]
             elif (
                 "from exceptions" in sql_lower
                 and "exception_id, vuln_id, package_name" in sql_lower
@@ -178,6 +178,18 @@ class MockConnection:
                         break
         elif sql_lower.startswith("update"):
             cursor.rowcount = 1
+            if "update api_keys" in sql_lower and params:
+                rows = self._store.get("api_keys", {})
+                if "set replacement_key_id" in sql_lower:
+                    replacement_key_id, overlap_until, key_id = params
+                    row = rows.get(key_id)
+                    if row:
+                        rows[key_id] = row[:11] + (overlap_until, replacement_key_id)
+                elif "set revoked = true" in sql_lower:
+                    key_id = params[0]
+                    row = rows.get(key_id)
+                    if row:
+                        rows[key_id] = row[:10] + ("now", None, row[12])
 
         self._cursors.append(cursor)
         return cursor
@@ -520,6 +532,9 @@ def test_key_store_add_get_list_verify_remove(mock_pool):
         json.dumps(api_key.scopes),
         api_key.created_at,
         api_key.expires_at,
+        api_key.revoked_at,
+        api_key.rotation_overlap_until,
+        api_key.replacement_key_id,
     )
 
     loaded = store.get(api_key.key_id)
@@ -535,6 +550,37 @@ def test_key_store_add_get_list_verify_remove(mock_pool):
     assert verified.key_id == api_key.key_id
 
     assert store.remove(api_key.key_id) is True
+
+
+def test_key_store_mark_rotating_updates_overlap_metadata(mock_pool):
+    from agent_bom.api.auth import Role, create_api_key
+    from agent_bom.api.postgres_store import PostgresKeyStore
+
+    store = PostgresKeyStore(pool=mock_pool)
+    _, api_key = create_api_key("alpha-admin", Role.ADMIN, tenant_id="tenant-alpha")
+    store.add(api_key)
+
+    mock_pool._conn._store.setdefault("api_keys", {})[api_key.key_id] = (
+        api_key.key_id,
+        api_key.key_hash,
+        api_key.key_salt,
+        api_key.key_prefix,
+        api_key.name,
+        api_key.role.value,
+        api_key.tenant_id,
+        json.dumps(api_key.scopes),
+        api_key.created_at,
+        api_key.expires_at,
+        api_key.revoked_at,
+        api_key.rotation_overlap_until,
+        api_key.replacement_key_id,
+    )
+
+    assert store.mark_rotating(api_key.key_id, replacement_key_id="next-key", overlap_until="2030-01-01T00:00:00+00:00")
+    rotated = store.get(api_key.key_id)
+    assert rotated is not None
+    assert rotated.replacement_key_id == "next-key"
+    assert rotated.rotation_overlap_until == "2030-01-01T00:00:00+00:00"
 
 
 # ─── PostgresExceptionStore ──────────────────────────────────────────────────

--- a/ui/app/audit/page.tsx
+++ b/ui/app/audit/page.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useState, useCallback } from "react";
 import {
   api,
+  type ApiKeyRecord,
   type AuditEntry,
   type AuditIntegrityResponse,
+  type AuthPolicyResponse,
   formatDate,
 } from "@/lib/api";
 import {
@@ -20,6 +22,7 @@ import {
   CheckCircle2,
   Filter,
 } from "lucide-react";
+import { KeyLifecyclePanel } from "@/components/key-lifecycle-panel";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -44,6 +47,10 @@ export default function AuditLogPage() {
   const [integrity, setIntegrity] = useState<AuditIntegrityResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [authPolicy, setAuthPolicy] = useState<AuthPolicyResponse | null>(null);
+  const [keys, setKeys] = useState<ApiKeyRecord[]>([]);
+  const [adminLoading, setAdminLoading] = useState(true);
+  const [adminError, setAdminError] = useState<string | null>(null);
   const [page, setPage] = useState(0);
 
   // Filters
@@ -51,33 +58,50 @@ export default function AuditLogPage() {
   const [resourceFilter, setResourceFilter] = useState<string>("");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  const load = useCallback(() => {
+  const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    Promise.all([
-      api.listAuditEntries({
-        action: actionFilter || undefined,
-        resource: resourceFilter || undefined,
-        limit: PAGE_SIZE,
-        offset: page * PAGE_SIZE,
-      }),
-      api.getAuditIntegrity(),
-    ])
-      .then(([log, integ]) => {
-        setEntries(log.entries);
-        setTotal(log.total);
-        setIntegrity(integ);
-      })
-      .catch((e) => setError(e.message))
-      .finally(() => setLoading(false));
+    try {
+      const [log, integ] = await Promise.all([
+        api.listAuditEntries({
+          action: actionFilter || undefined,
+          resource: resourceFilter || undefined,
+          limit: PAGE_SIZE,
+          offset: page * PAGE_SIZE,
+        }),
+        api.getAuditIntegrity(),
+      ]);
+      setEntries(log.entries);
+      setTotal(log.total);
+      setIntegrity(integ);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load audit log");
+    } finally {
+      setLoading(false);
+    }
   }, [actionFilter, resourceFilter, page]);
+
+  const loadAdmin = useCallback(async () => {
+    setAdminLoading(true);
+    setAdminError(null);
+    try {
+      const [policy, keyList] = await Promise.all([api.getAuthPolicy(), api.listKeys()]);
+      setAuthPolicy(policy);
+      setKeys(keyList.keys);
+    } catch (e) {
+      setAdminError(e instanceof Error ? e.message : "Failed to load key lifecycle state");
+    } finally {
+      setAdminLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      load();
+      void load();
+      void loadAdmin();
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [load]);
+  }, [load, loadAdmin]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
@@ -104,13 +128,24 @@ export default function AuditLogPage() {
           </p>
         </div>
         <button
-          onClick={load}
+          onClick={() => {
+            void load();
+            void loadAdmin();
+          }}
           className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
         >
           <RefreshCw className="w-3.5 h-3.5" />
           Refresh
         </button>
       </div>
+
+      <KeyLifecyclePanel
+        loading={adminLoading}
+        error={adminError}
+        policy={authPolicy}
+        keys={keys}
+        onRefresh={loadAdmin}
+      />
 
       {/* Integrity banner + stats */}
       {integrity && (

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  api,
+  type ApiKeyRecord,
+  type AuthPolicyResponse,
+  type CreateApiKeyRequest,
+  type RotateApiKeyRequest,
+  formatDate,
+} from "@/lib/api";
+import {
+  CheckCircle2,
+  Copy,
+  KeyRound,
+  Loader2,
+  Plus,
+  RefreshCw,
+  RotateCw,
+  ShieldAlert,
+  ShieldOff,
+} from "lucide-react";
+
+function formatSeconds(value: number): string {
+  if (value < 60) return `${value}s`;
+  if (value < 3600) return `${Math.floor(value / 60)}m`;
+  if (value < 86400) return `${Math.floor(value / 3600)}h`;
+  return `${Math.floor(value / 86400)}d`;
+}
+
+function toIsoOrNull(value: string): string | null {
+  if (!value.trim()) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Expiration must be a valid date/time");
+  }
+  return parsed.toISOString();
+}
+
+function keyStateTone(state: ApiKeyRecord["state"]): string {
+  switch (state) {
+    case "active":
+      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-300";
+    case "rotation_overlap":
+      return "border-sky-900/60 bg-sky-950/30 text-sky-300";
+    case "rotated":
+      return "border-amber-900/60 bg-amber-950/30 text-amber-300";
+    case "revoked":
+      return "border-red-900/60 bg-red-950/30 text-red-300";
+    case "expired":
+    default:
+      return "border-zinc-800 bg-zinc-900 text-zinc-400";
+  }
+}
+
+function stateLabel(state: ApiKeyRecord["state"]): string {
+  switch (state) {
+    case "rotation_overlap":
+      return "Rotation overlap";
+    default:
+      return state[0].toUpperCase() + state.slice(1);
+  }
+}
+
+function isSessionKey(key: ApiKeyRecord): boolean {
+  return key.name.startsWith("saml:") || key.scopes.includes("saml-session");
+}
+
+export function KeyLifecyclePanel({
+  loading,
+  error,
+  policy,
+  keys,
+  onRefresh,
+}: {
+  loading: boolean;
+  error: string | null;
+  policy: AuthPolicyResponse | null;
+  keys: ApiKeyRecord[];
+  onRefresh: () => Promise<void> | void;
+}) {
+  const [busyKeyId, setBusyKeyId] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<"create" | "rotate" | "revoke" | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [issuedSecret, setIssuedSecret] = useState<{
+    title: string;
+    rawKey: string;
+    detail: string;
+  } | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [rotationTarget, setRotationTarget] = useState<ApiKeyRecord | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const [createForm, setCreateForm] = useState({
+    name: "",
+    role: "viewer",
+    expiresAt: "",
+  });
+  const [rotateForm, setRotateForm] = useState({
+    name: "",
+    expiresAt: "",
+    overlapSeconds: "",
+  });
+
+  const stateCounts = useMemo(() => {
+    return keys.reduce<Record<string, number>>((acc, key) => {
+      acc[key.state] = (acc[key.state] || 0) + 1;
+      return acc;
+    }, {});
+  }, [keys]);
+
+  async function copyIssuedSecret() {
+    if (!issuedSecret?.rawKey) return;
+    await navigator.clipboard.writeText(issuedSecret.rawKey);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  }
+
+  async function handleCreateSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusyAction("create");
+    setFormError(null);
+    try {
+      const body: CreateApiKeyRequest = {
+        name: createForm.name.trim(),
+        role: createForm.role,
+        expires_at: toIsoOrNull(createForm.expiresAt),
+      };
+      const created = await api.createKey(body);
+      setIssuedSecret({
+        title: `Created key ${created.name}`,
+        rawKey: created.raw_key,
+        detail: created.message,
+      });
+      setCreateOpen(false);
+      setCreateForm({ name: "", role: "viewer", expiresAt: "" });
+      await onRefresh();
+    } catch (nextError) {
+      setFormError(nextError instanceof Error ? nextError.message : "Failed to create API key");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleRotateSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!rotationTarget) return;
+    setBusyAction("rotate");
+    setBusyKeyId(rotationTarget.key_id);
+    setFormError(null);
+    try {
+      const overlap = rotateForm.overlapSeconds.trim();
+      const body: RotateApiKeyRequest = {
+        name: rotateForm.name.trim() || undefined,
+        expires_at: toIsoOrNull(rotateForm.expiresAt) ?? undefined,
+        overlap_seconds: overlap ? Number(overlap) : undefined,
+      };
+      const rotated = await api.rotateKey(rotationTarget.key_id, body);
+      setIssuedSecret({
+        title: `Rotated key ${rotationTarget.name}`,
+        rawKey: rotated.raw_key,
+        detail: `${rotated.message} Overlap ends ${formatDate(rotated.overlap_until)}.`,
+      });
+      setRotationTarget(null);
+      setRotateForm({ name: "", expiresAt: "", overlapSeconds: "" });
+      await onRefresh();
+    } catch (nextError) {
+      setFormError(nextError instanceof Error ? nextError.message : "Failed to rotate API key");
+    } finally {
+      setBusyKeyId(null);
+      setBusyAction(null);
+    }
+  }
+
+  async function handleRevoke(key: ApiKeyRecord) {
+    if (!window.confirm(`Revoke ${key.name}? Existing clients will stop authenticating immediately.`)) {
+      return;
+    }
+    setBusyAction("revoke");
+    setBusyKeyId(key.key_id);
+    setFormError(null);
+    try {
+      await api.deleteKey(key.key_id);
+      await onRefresh();
+    } catch (nextError) {
+      setFormError(nextError instanceof Error ? nextError.message : "Failed to revoke API key");
+    } finally {
+      setBusyKeyId(null);
+      setBusyAction(null);
+    }
+  }
+
+  return (
+    <section className="space-y-4 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 text-lg font-semibold text-zinc-100">
+            <KeyRound className="h-5 w-5 text-emerald-400" />
+            Control-plane auth and API keys
+          </h2>
+          <p className="mt-1 text-sm text-zinc-400">
+            Rotate service keys with an overlap window, inspect auth policy, and revoke stale machine-to-machine access
+            without leaving the control plane.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => {
+              setRotationTarget(null);
+              setCreateOpen((value) => !value);
+              setFormError(null);
+            }}
+            className="inline-flex items-center gap-1.5 rounded-xl border border-emerald-900/60 bg-emerald-950/30 px-3 py-2 text-sm text-emerald-300 transition hover:bg-emerald-950/50"
+          >
+            <Plus className="h-4 w-4" />
+            New key
+          </button>
+          <button
+            onClick={() => void onRefresh()}
+            className="inline-flex items-center gap-1.5 rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {issuedSecret ? (
+        <div className="rounded-2xl border border-emerald-900/60 bg-emerald-950/20 p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-emerald-300">{issuedSecret.title}</p>
+              <p className="mt-1 text-sm text-zinc-300">{issuedSecret.detail}</p>
+              <p className="mt-2 text-xs text-zinc-500">This raw key is shown once. Store it securely before you close this panel.</p>
+            </div>
+            <button
+              onClick={() => void copyIssuedSecret()}
+              className="inline-flex items-center gap-1.5 rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+            >
+              {copied ? <CheckCircle2 className="h-4 w-4 text-emerald-400" /> : <Copy className="h-4 w-4" />}
+              {copied ? "Copied" : "Copy raw key"}
+            </button>
+          </div>
+          <pre className="mt-3 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3 text-sm text-zinc-100">
+            {issuedSecret.rawKey}
+          </pre>
+        </div>
+      ) : null}
+
+      {formError ? (
+        <div className="rounded-xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-300">{formError}</div>
+      ) : null}
+
+      {createOpen ? (
+        <form onSubmit={handleCreateSubmit} className="grid gap-4 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4 md:grid-cols-3">
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span>Name</span>
+            <input
+              required
+              value={createForm.name}
+              onChange={(event) => setCreateForm((current) => ({ ...current, name: event.target.value }))}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+              placeholder="ci-service"
+            />
+          </label>
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span>Role</span>
+            <select
+              value={createForm.role}
+              onChange={(event) => setCreateForm((current) => ({ ...current, role: event.target.value }))}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+            >
+              <option value="viewer">viewer</option>
+              <option value="analyst">analyst</option>
+              <option value="admin">admin</option>
+            </select>
+          </label>
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span>Expires at (optional)</span>
+            <input
+              type="datetime-local"
+              value={createForm.expiresAt}
+              onChange={(event) => setCreateForm((current) => ({ ...current, expiresAt: event.target.value }))}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+            />
+          </label>
+          <div className="md:col-span-3 flex items-center justify-between gap-3">
+            <p className="text-xs text-zinc-500">
+              Default TTL: {policy ? formatSeconds(policy.api_key.default_ttl_seconds) : "policy unavailable"}.
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setCreateOpen(false)}
+                className="rounded-xl border border-zinc-700 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={busyAction === "create"}
+                className="inline-flex items-center gap-1.5 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400 disabled:opacity-60"
+              >
+                {busyAction === "create" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                Create key
+              </button>
+            </div>
+          </div>
+        </form>
+      ) : null}
+
+      {rotationTarget ? (
+        <form onSubmit={handleRotateSubmit} className="grid gap-4 rounded-2xl border border-sky-900/50 bg-sky-950/20 p-4 md:grid-cols-3">
+          <div className="md:col-span-3">
+            <p className="text-sm font-semibold text-sky-300">Rotate {rotationTarget.name}</p>
+            <p className="mt-1 text-sm text-zinc-300">
+              The current key stays valid during the overlap window so clients can roll without downtime.
+            </p>
+          </div>
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span>Replacement name (optional)</span>
+            <input
+              value={rotateForm.name}
+              onChange={(event) => setRotateForm((current) => ({ ...current, name: event.target.value }))}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-sky-500"
+              placeholder={rotationTarget.name}
+            />
+          </label>
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span>Replacement expiry (optional)</span>
+            <input
+              type="datetime-local"
+              value={rotateForm.expiresAt}
+              onChange={(event) => setRotateForm((current) => ({ ...current, expiresAt: event.target.value }))}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-sky-500"
+            />
+          </label>
+          <label className="space-y-2 text-sm text-zinc-300">
+            <span>Overlap seconds</span>
+            <input
+              type="number"
+              min={0}
+              max={policy?.api_key.max_overlap_seconds ?? 86400}
+              value={rotateForm.overlapSeconds}
+              onChange={(event) => setRotateForm((current) => ({ ...current, overlapSeconds: event.target.value }))}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-sky-500"
+              placeholder={String(policy?.api_key.default_overlap_seconds ?? 900)}
+            />
+          </label>
+          <div className="md:col-span-3 flex items-center justify-between gap-3">
+            <p className="text-xs text-zinc-500">
+              Allowed overlap: up to {policy ? formatSeconds(policy.api_key.max_overlap_seconds) : "policy unavailable"}.
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setRotationTarget(null)}
+                className="rounded-xl border border-zinc-700 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={busyAction === "rotate"}
+                className="inline-flex items-center gap-1.5 rounded-xl bg-sky-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-sky-400 disabled:opacity-60"
+              >
+                {busyAction === "rotate" ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCw className="h-4 w-4" />}
+                Rotate key
+              </button>
+            </div>
+          </div>
+        </form>
+      ) : null}
+
+      {loading ? (
+        <div className="flex items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900/40 px-4 py-10 text-zinc-400">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+          Loading auth policy and keys...
+        </div>
+      ) : error ? (
+        <div className="rounded-2xl border border-amber-900/50 bg-amber-950/20 p-4">
+          <div className="flex items-start gap-3">
+            <ShieldAlert className="mt-0.5 h-5 w-5 text-amber-300" />
+            <div>
+              <p className="text-sm font-semibold text-amber-200">Admin access is required for key lifecycle operations</p>
+              <p className="mt-1 text-sm text-amber-100/80">{error}</p>
+            </div>
+          </div>
+        </div>
+      ) : policy ? (
+        <>
+          <div className="grid gap-3 md:grid-cols-4">
+            <MetricCard label="Default TTL" value={formatSeconds(policy.api_key.default_ttl_seconds)} hint="Issued key lifetime" />
+            <MetricCard label="Default overlap" value={formatSeconds(policy.api_key.default_overlap_seconds)} hint="Rotation grace window" />
+            <MetricCard label="Recommended UI mode" value={policy.ui.recommended_mode} hint="Browser auth posture" />
+            <MetricCard label="Active keys" value={String(stateCounts.active ?? 0)} hint={`${keys.length} total in tenant`} />
+          </div>
+
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-200">Key inventory</h3>
+                <p className="mt-1 text-xs text-zinc-500">
+                  Rotation overlap lets old and new keys coexist briefly while clients roll.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2 text-xs text-zinc-500">
+                <span>{stateCounts.rotation_overlap ?? 0} rotating</span>
+                <span>{stateCounts.rotated ?? 0} rotated</span>
+                <span>{stateCounts.revoked ?? 0} revoked</span>
+              </div>
+            </div>
+
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead className="text-xs uppercase tracking-[0.18em] text-zinc-500">
+                  <tr>
+                    <th className="pb-2">Name</th>
+                    <th className="pb-2">Role</th>
+                    <th className="pb-2">State</th>
+                    <th className="pb-2">Expires</th>
+                    <th className="pb-2">Overlap</th>
+                    <th className="pb-2 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                  {keys.map((key) => {
+                    const sessionKey = isSessionKey(key);
+                    const canRotate = key.state === "active" && !sessionKey;
+                    const canRevoke = key.state !== "revoked";
+                    return (
+                      <tr key={key.key_id}>
+                        <td className="py-3">
+                          <div className="font-medium text-zinc-200">{key.name}</div>
+                          <div className="text-xs text-zinc-500">
+                            {key.key_prefix} · {sessionKey ? "session key" : "service key"}
+                          </div>
+                        </td>
+                        <td className="py-3 text-zinc-300">{key.role}</td>
+                        <td className="py-3">
+                          <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${keyStateTone(key.state)}`}>
+                            {stateLabel(key.state)}
+                          </span>
+                        </td>
+                        <td className="py-3 text-zinc-400">{key.expires_at ? formatDate(key.expires_at) : "Never"}</td>
+                        <td className="py-3 text-zinc-400">
+                          {key.rotation_overlap_until
+                            ? `${formatDate(key.rotation_overlap_until)}${
+                                key.overlap_seconds_remaining != null ? ` · ${formatSeconds(key.overlap_seconds_remaining)} left` : ""
+                              }`
+                            : "—"}
+                        </td>
+                        <td className="py-3">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              onClick={() => {
+                                setCreateOpen(false);
+                                setFormError(null);
+                                setRotateForm({
+                                  name: "",
+                                  expiresAt: "",
+                                  overlapSeconds: String(policy.api_key.default_overlap_seconds),
+                                });
+                                setRotationTarget(key);
+                              }}
+                              disabled={!canRotate || busyKeyId === key.key_id}
+                              className="inline-flex items-center gap-1.5 rounded-lg border border-sky-900/60 bg-sky-950/20 px-3 py-1.5 text-xs text-sky-300 transition hover:bg-sky-950/40 disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              {busyAction === "rotate" && busyKeyId === key.key_id ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <RotateCw className="h-3.5 w-3.5" />
+                              )}
+                              Rotate
+                            </button>
+                            <button
+                              onClick={() => void handleRevoke(key)}
+                              disabled={!canRevoke || busyKeyId === key.key_id}
+                              className="inline-flex items-center gap-1.5 rounded-lg border border-red-900/60 bg-red-950/20 px-3 py-1.5 text-xs text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              {busyAction === "revoke" && busyKeyId === key.key_id ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <ShieldOff className="h-3.5 w-3.5" />
+                              )}
+                              Revoke
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function MetricCard({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+      <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">{label}</p>
+      <p className="mt-2 text-lg font-semibold text-zinc-100">{value}</p>
+      <p className="mt-1 text-xs text-zinc-500">{hint}</p>
+    </div>
+  );
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -467,6 +467,95 @@ export interface AuthDebugResponse {
   span_id: string | null;
 }
 
+export interface AuthPolicyResponse {
+  api_key: {
+    default_ttl_seconds: number;
+    max_ttl_seconds: number;
+    default_overlap_seconds: number;
+    max_overlap_seconds: number;
+    rotation_policy: string;
+    rotation_endpoint: string;
+  };
+  rate_limit_key: {
+    status: string;
+    last_rotated: string | null;
+    age_days: number | null;
+    fallback_source?: string | null;
+    [key: string]: unknown;
+  };
+  ui: {
+    recommended_mode: string;
+    configured_modes: string[];
+    session_storage_fallback: string;
+    credentials_mode: string;
+    trusted_proxy_headers: string[];
+    message: string;
+  };
+  rate_limit_runtime: {
+    backend: string;
+    postgres_configured: boolean;
+    configured_api_replicas: number;
+    shared_required: boolean;
+    shared_across_replicas: boolean;
+    fail_closed: boolean;
+    message: string;
+  };
+  tenant_quotas: {
+    active_scan_jobs: number;
+    retained_scan_jobs: number;
+    fleet_agents: number;
+    schedules: number;
+  };
+}
+
+export type ApiKeyLifecycleState = "active" | "rotation_overlap" | "rotated" | "revoked" | "expired";
+
+export interface ApiKeyRecord {
+  key_id: string;
+  key_prefix: string;
+  name: string;
+  role: string;
+  created_at: string;
+  expires_at: string | null;
+  scopes: string[];
+  tenant_id: string;
+  revoked_at: string | null;
+  rotation_overlap_until: string | null;
+  replacement_key_id: string | null;
+  state: ApiKeyLifecycleState;
+  overlap_seconds_remaining: number | null;
+}
+
+export interface ListKeysResponse {
+  keys: ApiKeyRecord[];
+}
+
+export interface CreateApiKeyRequest {
+  name: string;
+  role: string;
+  expires_at?: string | null;
+  scopes?: string[];
+}
+
+export interface CreateApiKeyResponse extends ApiKeyRecord {
+  raw_key: string;
+  message: string;
+}
+
+export interface RotateApiKeyRequest {
+  name?: string | null;
+  expires_at?: string | null;
+  overlap_seconds?: number | null;
+}
+
+export interface RotateApiKeyResponse extends ApiKeyRecord {
+  raw_key: string;
+  replaced_key_id: string;
+  overlap_until: string;
+  overlap_seconds: number;
+  message: string;
+}
+
 export interface ConnectorsResponse {
   connectors: string[];
 }
@@ -980,6 +1069,12 @@ export const api = {
   health: () => get<HealthResponse>("/health"),
   version: () => get<VersionInfo>("/version"),
   getAuthDebug: () => get<AuthDebugResponse>("/v1/auth/debug"),
+  getAuthPolicy: () => get<AuthPolicyResponse>("/v1/auth/policy"),
+  listKeys: () => get<ListKeysResponse>("/v1/auth/keys"),
+  createKey: (body: CreateApiKeyRequest) => post<CreateApiKeyResponse>("/v1/auth/keys", body),
+  rotateKey: (keyId: string, body: RotateApiKeyRequest) =>
+    post<RotateApiKeyResponse>(`/v1/auth/keys/${encodeURIComponent(keyId)}/rotate`, body),
+  deleteKey: (keyId: string) => del(`/v1/auth/keys/${encodeURIComponent(keyId)}`),
 
   /** Start a scan — returns immediately with job_id */
   startScan: (req: ScanRequest) => post<ScanJob>("/v1/scan", req),

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -241,6 +241,79 @@ describe('api.getScan', () => {
   })
 })
 
+describe('api key lifecycle helpers', () => {
+  it('lists keys through the enterprise auth route', async () => {
+    const payload = {
+      keys: [
+        {
+          key_id: 'key-1',
+          key_prefix: 'abom_demo',
+          name: 'ci-service',
+          role: 'admin',
+          created_at: '2026-04-21T00:00:00Z',
+          expires_at: '2026-05-21T00:00:00Z',
+          scopes: [],
+          tenant_id: 'tenant-alpha',
+          revoked_at: null,
+          rotation_overlap_until: null,
+          replacement_key_id: null,
+          state: 'active',
+          overlap_seconds_remaining: null,
+        },
+      ],
+    }
+    const fetchMock = mockFetch(payload)
+    global.fetch = fetchMock
+
+    const result = await api.listKeys()
+
+    expect(result.keys).toHaveLength(1)
+    expect(result.keys[0].name).toBe('ci-service')
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/auth/keys",
+      expect.objectContaining({ credentials: "include", signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('posts rotate requests to the expected endpoint', async () => {
+    const payload = {
+      raw_key: 'abom_new_secret',
+      key_id: 'key-2',
+      replaced_key_id: 'key-1',
+      key_prefix: 'abom_new_',
+      name: 'ci-service',
+      role: 'admin',
+      created_at: '2026-04-21T00:05:00Z',
+      expires_at: '2026-05-21T00:05:00Z',
+      tenant_id: 'tenant-alpha',
+      revoked_at: null,
+      rotation_overlap_until: '2026-04-21T00:20:00Z',
+      replacement_key_id: null,
+      state: 'active',
+      overlap_seconds_remaining: null,
+      overlap_until: '2026-04-21T00:20:00Z',
+      overlap_seconds: 900,
+      scopes: [],
+      message: 'rotated',
+    }
+    const fetchMock = mockFetch(payload)
+    global.fetch = fetchMock
+
+    const result = await api.rotateKey('key-1', { overlap_seconds: 900 })
+
+    expect(result.replaced_key_id).toBe('key-1')
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/auth/keys/key-1/rotate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ overlap_seconds: 900 }),
+        signal: expect.any(AbortSignal),
+      }),
+    )
+  })
+})
+
 describe('api.downloadScanGraph', () => {
   it('downloads graph export with session auth headers', async () => {
     setSessionApiKey('pilot-key-123')


### PR DESCRIPTION
## Summary
- add overlap-based API key rotation so the previous key stays valid for a bounded grace window instead of being cut off immediately
- expose control-plane auth policy and key lifecycle operations in the UI with a dedicated `/audit` operator panel for create, rotate, and revoke flows
- persist rotation metadata in Postgres and surface lifecycle state, overlap timing, and replacement linkage through the API client contract

## Testing
- uv run pytest tests/test_auth.py tests/test_api_enterprise_tenant.py tests/test_api_operator_policy.py tests/test_postgres_store.py tests/test_postgres_schema.py -q
- npm run test:run -- tests/api.test.ts
- npm run lint
- npm run build
