### PR TITLE
feat(deploy): add one-command Helm profile installer

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -35,6 +35,28 @@ Render only one profile:
 python scripts/validate_helm_profiles.py --profile focused-pilot
 ```
 
+## Install a shipped profile in one command
+
+Print the exact Helm command for a profile:
+
+```bash
+python scripts/install_helm_profile.py focused-pilot --print-command
+```
+
+Run the packaged focused EKS pilot profile directly:
+
+```bash
+python scripts/install_helm_profile.py focused-pilot
+```
+
+Append your own values file or targeted overrides without forking the shipped profile:
+
+```bash
+python scripts/install_helm_profile.py production \
+  --values ./my-prod-overrides.yaml \
+  --set controlPlane.ingress.hosts[0].host=agent-bom.acme.internal
+```
+
 ## Operator guidance
 
 - Start with `focused-pilot` for the narrow customer EKS story.

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -169,6 +169,18 @@ agent-bom api \
 
 Server mode enables buffered ClickHouse writes by default so scan and runtime paths do not block on OLAP round-trips. `GET /health` now reports the active analytics contract (`backend`, `enabled`, `buffered`, `flush_interval_seconds`, `max_batch`) alongside tracing so operators can confirm both observability and analytics posture from one probe. The ClickHouse analytics path stores scan metadata, vulnerability rows, runtime events, posture snapshots, fleet trust/lifecycle snapshots, compliance control measurements, and audit-event trends so the fleet backend matches the operator story more closely.
 
+For a packaged self-hosted EKS pilot, use the shipped Helm profile installer instead of hand-assembling the values stack:
+
+```bash
+python scripts/install_helm_profile.py focused-pilot
+```
+
+List the available packaged profiles first if you want to inspect the matrix without installing:
+
+```bash
+python scripts/install_helm_profile.py --list
+```
+
 ### 4. Cloud Infrastructure — agentless discovery
 
 ```bash

--- a/scripts/install_helm_profile.py
+++ b/scripts/install_helm_profile.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Install or print a shipped Helm deployment profile."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_profile_helpers():
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from agent_bom.deploy_profiles import build_helm_profile_command, helm_validation_profiles
+
+    return build_helm_profile_command, helm_validation_profiles
+
+
+def _run(cmd: list[str]) -> None:
+    print("+", shlex.join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    build_helm_profile_command, helm_validation_profiles = _load_profile_helpers()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", nargs="?", help="Shipped profile name to install.")
+    parser.add_argument("--list", action="store_true", help="List the available shipped profiles and exit.")
+    parser.add_argument("--release", default="agent-bom", help="Helm release name (default: agent-bom).")
+    parser.add_argument("--namespace", default="agent-bom", help="Kubernetes namespace (default: agent-bom).")
+    parser.add_argument(
+        "--set",
+        dest="set_arguments",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Additional Helm --set argument. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--values",
+        dest="values_files",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Additional values file to append after the shipped profile values.",
+    )
+    parser.add_argument(
+        "--set-file",
+        dest="set_file_arguments",
+        action="append",
+        default=[],
+        metavar="KEY=PATH",
+        help="Additional Helm --set-file argument. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--no-create-namespace",
+        action="store_true",
+        help="Skip --create-namespace in the generated Helm command.",
+    )
+    parser.add_argument(
+        "--print-command",
+        action="store_true",
+        help="Print the resolved Helm command and exit without running it.",
+    )
+    args = parser.parse_args()
+
+    profiles = helm_validation_profiles(REPO_ROOT)
+    if args.list:
+        for profile in profiles:
+            print(f"{profile.name}: {profile.description}")
+        return 0
+
+    if not args.profile:
+        parser.error("a profile name is required unless --list is used")
+
+    extra_values_files = tuple(Path(path).resolve() for path in args.values_files)
+    extra_set_file_arguments: list[tuple[str, Path]] = []
+    for raw in args.set_file_arguments:
+        key, sep, value = raw.partition("=")
+        if not sep or not key or not value:
+            parser.error(f"invalid --set-file value '{raw}', expected KEY=PATH")
+        extra_set_file_arguments.append((key, Path(value).resolve()))
+
+    try:
+        cmd = build_helm_profile_command(
+            REPO_ROOT,
+            args.profile,
+            release_name=args.release,
+            namespace=args.namespace,
+            create_namespace=not args.no_create_namespace,
+            extra_values_files=extra_values_files,
+            extra_set_arguments=tuple(args.set_arguments),
+            extra_set_file_arguments=tuple(extra_set_file_arguments),
+        )
+    except KeyError as exc:
+        parser.error(str(exc))
+
+    if args.print_command:
+        print(shlex.join(cmd))
+        return 0
+
+    if shutil.which("helm") is None:
+        print("error: helm is required to install shipped profiles", file=sys.stderr)
+        return 1
+    _run(cmd)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -1,4 +1,4 @@
-"""Canonical Helm chart validation profiles for shipped deployment examples."""
+"""Canonical Helm chart profiles for shipped deployment examples."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class HelmValidationProfile:
-    """A named Helm render profile backed by shipped chart examples."""
+    """A named Helm profile backed by shipped chart examples."""
 
     name: str
     description: str
@@ -26,7 +26,7 @@ def helm_example_dir(repo_root: Path) -> Path:
 
 
 def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
-    """Return the canonical validation matrix for shipped Helm examples."""
+    """Return the canonical shipped Helm profile matrix."""
 
     examples = helm_example_dir(repo_root)
     return [
@@ -63,3 +63,44 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
             set_file_arguments=(("gateway.upstreamsYaml", examples / "gateway-upstreams.example.yaml"),),
         ),
     ]
+
+
+def build_helm_profile_command(
+    repo_root: Path,
+    profile_name: str,
+    *,
+    release_name: str = "agent-bom",
+    namespace: str = "agent-bom",
+    create_namespace: bool = True,
+    extra_values_files: tuple[Path, ...] = (),
+    extra_set_arguments: tuple[str, ...] = (),
+    extra_set_file_arguments: tuple[tuple[str, Path], ...] = (),
+) -> list[str]:
+    """Build the canonical Helm upgrade/install command for a shipped profile."""
+
+    profiles = {profile.name: profile for profile in helm_validation_profiles(repo_root)}
+    try:
+        profile = profiles[profile_name]
+    except KeyError as exc:
+        available = ", ".join(sorted(profiles))
+        raise KeyError(f"unknown Helm profile '{profile_name}' (available: {available})") from exc
+
+    cmd = [
+        "helm",
+        "upgrade",
+        "--install",
+        release_name,
+        str(helm_chart_dir(repo_root)),
+        "--namespace",
+        namespace,
+    ]
+    if create_namespace:
+        cmd.append("--create-namespace")
+
+    for values_file in (*profile.values_files, *extra_values_files):
+        cmd.extend(["-f", str(values_file)])
+    for set_argument in (*profile.set_arguments, *extra_set_arguments):
+        cmd.extend(["--set", set_argument])
+    for key, path in (*profile.set_file_arguments, *extra_set_file_arguments):
+        cmd.extend(["--set-file", f"{key}={path}"])
+    return cmd

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -269,6 +269,16 @@ def test_helm_examples_readme_is_shipped():
     assert "focused-pilot" in body
     assert "sqlite-pilot" in body
     assert "gateway-runtime" in body
+    assert "install_helm_profile.py" in body
+
+
+def test_packaged_helm_profile_installer_script_exists():
+    """Operators should get a one-command wrapper around the shipped Helm profiles."""
+    script = Path(__file__).parent.parent / "scripts" / "install_helm_profile.py"
+    assert script.exists()
+    body = script.read_text()
+    assert "--print-command" in body
+    assert "build_helm_profile_command" in body
 
 
 def test_ci_pipeline_validates_helm_profiles():

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
-from agent_bom.deploy_profiles import helm_chart_dir, helm_validation_profiles
+from agent_bom.deploy_profiles import build_helm_profile_command, helm_chart_dir, helm_validation_profiles
 
 
 def test_helm_validation_profiles_reference_existing_chart_assets():
@@ -35,3 +36,38 @@ def test_gateway_runtime_profile_uses_shipped_upstreams_example():
     assert gateway.set_file_arguments == (
         ("gateway.upstreamsYaml", repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "gateway-upstreams.example.yaml"),
     )
+
+
+def test_build_helm_profile_command_uses_shipped_profile_stack():
+    repo_root = Path(__file__).resolve().parent.parent
+    cmd = build_helm_profile_command(repo_root, "focused-pilot")
+    assert cmd[:6] == [
+        "helm",
+        "upgrade",
+        "--install",
+        "agent-bom",
+        str(repo_root / "deploy" / "helm" / "agent-bom"),
+        "--namespace",
+    ]
+    assert "agent-bom" in cmd
+    assert "--create-namespace" in cmd
+    assert str(repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "eks-mcp-pilot-values.yaml") in cmd
+
+
+def test_install_helm_profile_script_prints_packaged_command():
+    repo_root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/install_helm_profile.py",
+            "focused-pilot",
+            "--print-command",
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    stdout = result.stdout.strip()
+    assert stdout.startswith("helm upgrade --install agent-bom ")
+    assert "deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml" in stdout


### PR DESCRIPTION
Summary
- add a shared Helm profile command builder so shipped profile values can be installed, not just validated
- add scripts/install_helm_profile.py to list, print, or run the packaged Helm profile install path in one command
- document the one-command profile installer in the Helm examples index and enterprise deployment guide

Testing
- uv run pytest tests/test_deploy_profiles.py tests/test_deploy_manifests.py -q
- uv run ruff check src/agent_bom/deploy_profiles.py scripts/install_helm_profile.py tests/test_deploy_profiles.py tests/test_deploy_manifests.py
- uv run mypy src/agent_bom/deploy_profiles.py
- python3 scripts/install_helm_profile.py --list
- python3 scripts/install_helm_profile.py focused-pilot --print-command

Closes #1626