### PR TITLE
feat(endpoint): add managed proxy onboarding bundle

### DIFF
--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -97,6 +97,15 @@ For JSON-based configs, auto-wrap all eligible stdio servers:
 agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials --apply
 ```
 
+For enterprise-managed endpoint rollout, generate a packaged bootstrap bundle instead:
+
+```bash
+agent-bom proxy-bootstrap \
+  --bundle-dir ./endpoint-bundle \
+  --control-plane-url https://agent-bom.example.com \
+  --push-url https://agent-bom.example.com/v1/fleet/sync
+```
+
 The proxy adds runtime inspection for:
 
 - tool drift

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -91,6 +91,23 @@ agent-bom agents --format json --output /var/log/agent-bom/scan.json
 - Secret scanner shows only first 8 characters as preview, never the full value
 - PII findings show `[PII]`, never actual data
 
+For managed proxy onboarding on the same endpoints, generate a rollout bundle instead of hand-editing every client config:
+
+```bash
+agent-bom proxy-bootstrap \
+  --bundle-dir ./endpoint-bundle \
+  --control-plane-url https://agent-bom.example.com \
+  --push-url https://agent-bom.example.com/v1/fleet/sync
+```
+
+That bundle includes:
+- a macOS/Linux shell bootstrap script
+- a Windows PowerShell bootstrap script
+- a `fleet-sync.env` file for the shipped timer/service assets
+- a rendered launchd plist for managed macOS rollout
+
+The generated bootstrap scripts install or upgrade `agent-bom`, then run `agent-bom proxy-configure --apply` with the control-plane policy/audit settings you chose, so supported JSON MCP clients no longer need manual config edits.
+
 ### 3. Centralized API Server — fleet dashboard
 
 ```bash

--- a/docs/MCP_CLIENT_GUIDES.md
+++ b/docs/MCP_CLIENT_GUIDES.md
@@ -14,6 +14,7 @@ Two modes matter:
 | Ask an assistant to run `agent-bom` tools directly | `agent-bom mcp server` | Makes discovery, scan, blast-radius, compliance, and trust tools available in-chat |
 | Inspect or block live MCP traffic to another server | `agent-bom proxy` | Adds inline JSON-RPC inspection, audit logs, and policy enforcement |
 | Auto-wrap JSON-based stdio MCP configs | `agent-bom proxy-configure` | Rewrites eligible client configs so they point at the proxy wrapper |
+| Generate managed endpoint rollout artifacts | `agent-bom proxy-bootstrap` | Writes shell/PowerShell bootstrap scripts plus fleet-sync artifacts for IT-owned rollout |
 
 ## Major clients
 
@@ -78,7 +79,8 @@ args = ["proxy", "--log", "~/.agent-bom/logs/filesystem.jsonl", "--", "npx", "@m
 ## Runtime proxy notes
 
 - `agent-bom proxy` is best when the client talks to a third-party stdio server and you want runtime inspection.
-- `agent-bom proxy-configure --apply` currently targets JSON MCP configs. It is a good fit for Claude Desktop, Cursor, Windsurf, and Cortex CoCo.
+- `agent-bom proxy-configure --apply` targets JSON MCP configs and can now stamp control-plane policy/audit settings into the wrapped proxy command.
+- `agent-bom proxy-bootstrap --bundle-dir ./endpoint-bundle --control-plane-url https://agent-bom.example.com --push-url https://agent-bom.example.com/v1/fleet/sync` writes managed rollout artifacts for macOS/Linux and Windows without hand-editing JSON on every machine.
 - TOML clients like Codex CLI need manual proxy wrapping today.
 - SSE / HTTP clients can use `agent-bom mcp server --transport sse --bearer-token "$AGENT_BOM_MCP_BEARER_TOKEN"` or `--transport streamable-http`.
 - Non-loopback remote transports fail closed unless you configure `--bearer-token` / `AGENT_BOM_MCP_BEARER_TOKEN` or explicitly pass `--allow-insecure-no-auth`.

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -134,6 +134,15 @@ agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials
 
 Add `--apply` to write the wrapped config back to compatible JSON MCP config files.
 
+For IT-owned rollout across managed laptops, use:
+
+```bash
+agent-bom proxy-bootstrap \
+  --bundle-dir ./endpoint-bundle \
+  --control-plane-url https://agent-bom.example.com \
+  --push-url https://agent-bom.example.com/v1/fleet/sync
+```
+
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
 ## Tool Categories (36 tools)

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -143,6 +143,7 @@ from agent_bom.cli._runtime import (  # noqa: E402
     _NoOpDetector,
     audit_replay_cmd,
     protect_cmd,
+    proxy_bootstrap_cmd,
     proxy_cmd,
     proxy_configure_cmd,
     watch_cmd,
@@ -155,6 +156,7 @@ from agent_bom.cli._runtime_group import runtime_group  # noqa: E402
 
 runtime_group.add_command(proxy_cmd, "proxy")
 runtime_group.add_command(audit_replay_cmd, "audit")
+runtime_group.add_command(proxy_bootstrap_cmd, "bootstrap")
 # Deprecated — hidden but still work for backward compat
 runtime_group.add_command(proxy_configure_cmd, "configure")
 runtime_group.add_command(protect_cmd, "protect")
@@ -167,6 +169,7 @@ main.commands["runtime"].hidden = True  # Use proxy/audit directly
 
 # Top-level shortcuts for primary runtime commands
 main.add_command(proxy_cmd, "proxy")
+main.add_command(proxy_bootstrap_cmd, "proxy-bootstrap")
 main.add_command(audit_replay_cmd, "audit")
 
 from agent_bom.cli._analysis import (  # noqa: E402

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -192,12 +192,50 @@ def proxy_cmd(
 @click.option("--detect-credentials", is_flag=True, help="Enable credential leak detection in each proxy")
 @click.option("--block-undeclared", is_flag=True, help="Block undeclared tools in each proxy")
 @click.option(
+    "--control-plane-url",
+    default=None,
+    envvar="AGENT_BOM_API_URL",
+    help="Control-plane base URL for gateway policy pull and proxy audit push",
+)
+@click.option(
+    "--control-plane-token",
+    default=None,
+    envvar="AGENT_BOM_API_TOKEN",
+    help="Bearer token or API key for control-plane auth",
+)
+@click.option(
+    "--policy-refresh-seconds",
+    type=int,
+    default=30,
+    show_default=True,
+    help="How often to refresh enabled gateway policies from the control plane",
+)
+@click.option(
+    "--audit-push-interval",
+    type=int,
+    default=10,
+    show_default=True,
+    help="How often to batch-push proxy alerts to the control plane",
+)
+@click.option(
     "--apply",
     is_flag=True,
     help="Write proxy config back to source JSON config files (default: preview only)",
 )
 @click.option("--project", default=None, type=click.Path(exists=True), help="Project directory to scan for MCP configs")
-def proxy_configure_cmd(policy, log_dir, secure_defaults, detect_credentials, block_undeclared, apply, project):
+def proxy_configure_cmd(
+    policy,
+    log_dir,
+    secure_defaults,
+    detect_credentials,
+    block_undeclared,
+    control_plane_url,
+    control_plane_token,
+    policy_refresh_seconds,
+    audit_push_interval,
+    apply,
+    project,
+):
     """Auto-configure the agent-bom proxy for discovered MCP servers.
 
     \b
@@ -221,6 +259,7 @@ def proxy_configure_cmd(policy, log_dir, secure_defaults, detect_credentials, bl
     Example:
       agent-bom proxy-configure --log-dir ~/.agent-bom/logs
       agent-bom proxy-configure --policy policy.json --log-dir ~/.agent-bom/logs --apply
+      agent-bom proxy-configure --control-plane-url https://agent-bom.example.com --control-plane-token "$TOKEN" --apply
       agent-bom proxy-configure --no-secure-defaults --apply
     """
     from agent_bom.discovery import discover_all
@@ -236,6 +275,10 @@ def proxy_configure_cmd(policy, log_dir, secure_defaults, detect_credentials, bl
         secure_defaults=secure_defaults,
         detect_credentials=detect_credentials,
         block_undeclared=block_undeclared,
+        control_plane_url=control_plane_url,
+        control_plane_token=control_plane_token,
+        policy_refresh_seconds=policy_refresh_seconds,
+        audit_push_interval=audit_push_interval,
     )
 
     if not configs:
@@ -259,6 +302,140 @@ def proxy_configure_cmd(policy, log_dir, secure_defaults, detect_credentials, bl
             con.print("[yellow]⚠[/yellow] No JSON config files were patched (SSE servers, missing files, or no matching entries).")
     else:
         con.print("[dim]Pass --apply to write these changes to config files.[/dim]")
+
+
+@click.command("proxy-bootstrap")
+@click.option(
+    "--bundle-dir",
+    required=True,
+    type=click.Path(path_type=str),
+    help="Directory where the endpoint onboarding artifacts should be written",
+)
+@click.option(
+    "--control-plane-url",
+    required=True,
+    envvar="AGENT_BOM_API_URL",
+    help="Control-plane base URL for gateway policy pull and proxy audit push",
+)
+@click.option(
+    "--control-plane-token",
+    default=None,
+    envvar="AGENT_BOM_API_TOKEN",
+    help="Bearer token or API key for control-plane auth",
+)
+@click.option("--push-url", default=None, help="Optional fleet sync endpoint to write into managed endpoint artifacts")
+@click.option("--push-api-key", default=None, help="Optional fleet sync API key to write into managed endpoint artifacts")
+@click.option("--policy", type=click.Path(exists=True), default=None, help="Policy JSON file to pass to each proxy instance")
+@click.option(
+    "--log-dir",
+    default="~/.agent-bom/logs",
+    show_default=True,
+    type=click.Path(),
+    help="Directory for per-server audit JSONL logs",
+)
+@click.option(
+    "--secure-defaults/--no-secure-defaults",
+    default=True,
+    show_default=True,
+    help="Inject the recommended hardening flags (--detect-credentials and --block-undeclared)",
+)
+@click.option("--detect-credentials", is_flag=True, help="Enable credential leak detection in each proxy")
+@click.option("--block-undeclared", is_flag=True, help="Block undeclared tools in each proxy")
+@click.option(
+    "--policy-refresh-seconds",
+    type=int,
+    default=30,
+    show_default=True,
+    help="How often to refresh enabled gateway policies from the control plane",
+)
+@click.option(
+    "--audit-push-interval",
+    type=int,
+    default=10,
+    show_default=True,
+    help="How often to batch-push proxy alerts to the control plane",
+)
+@click.option("--project", default=None, type=click.Path(exists=True), help="Project directory to scan for MCP configs")
+@click.option("--apply", is_flag=True, help="Also patch the current machine's supported JSON MCP configs")
+def proxy_bootstrap_cmd(
+    bundle_dir,
+    control_plane_url,
+    control_plane_token,
+    push_url,
+    push_api_key,
+    policy,
+    log_dir,
+    secure_defaults,
+    detect_credentials,
+    block_undeclared,
+    policy_refresh_seconds,
+    audit_push_interval,
+    project,
+    apply,
+):
+    """Generate managed endpoint onboarding artifacts for proxy + fleet rollout.
+
+    \b
+    Writes:
+    - macOS/Linux shell bootstrap script
+    - Windows PowerShell bootstrap script
+    - optional fleet-sync env + launchd plist artifacts
+    - machine-readable summary JSON
+
+    \b
+    Use this when you want one IT-owned bundle instead of hand-editing MCP
+    configs on every laptop.
+    """
+    from pathlib import Path
+
+    from agent_bom.discovery import discover_all
+    from agent_bom.endpoint_onboarding import write_endpoint_onboarding_bundle
+    from agent_bom.proxy_configure import apply_proxy_configs, auto_configure_proxies
+
+    con = Console()
+    bundle_path = Path(bundle_dir).expanduser()
+    artifacts = write_endpoint_onboarding_bundle(
+        bundle_path,
+        control_plane_url=control_plane_url,
+        control_plane_token=control_plane_token,
+        policy_refresh_seconds=policy_refresh_seconds,
+        audit_push_interval=audit_push_interval,
+        policy_path=policy,
+        log_dir=log_dir,
+        secure_defaults=secure_defaults,
+        detect_credentials=detect_credentials,
+        block_undeclared=block_undeclared,
+        push_url=push_url,
+        push_api_key=push_api_key,
+    )
+    con.print(f"[green]✓[/green] Wrote endpoint onboarding bundle to [bold]{bundle_path}[/bold]")
+    for name, artifact_path in artifacts.items():
+        con.print(f"  [bold]{name}[/bold]: [dim]{artifact_path}[/dim]")
+
+    if not apply:
+        return
+
+    agents = discover_all(project_dir=project)
+    configs = auto_configure_proxies(
+        agents,
+        policy_path=policy,
+        log_dir=log_dir,
+        secure_defaults=secure_defaults,
+        detect_credentials=detect_credentials,
+        block_undeclared=block_undeclared,
+        control_plane_url=control_plane_url,
+        control_plane_token=control_plane_token,
+        policy_refresh_seconds=policy_refresh_seconds,
+        audit_push_interval=audit_push_interval,
+    )
+    if not configs:
+        con.print("[yellow]No eligible STDIO MCP servers found for local patching.[/yellow]")
+        return
+    patched = apply_proxy_configs(configs, dry_run=False)
+    if patched:
+        con.print(f"[green]✓[/green] Patched {patched} local config file(s).")
+    else:
+        con.print("[yellow]⚠[/yellow] No local config files were patched.")
 
 
 @click.command("protect")

--- a/src/agent_bom/endpoint_onboarding.py
+++ b/src/agent_bom/endpoint_onboarding.py
@@ -1,0 +1,220 @@
+"""Managed endpoint onboarding helpers for proxy + fleet rollout."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+
+def _write_text(path: Path, body: str, mode: int) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    os.chmod(path, mode)
+    return path
+
+
+def build_proxy_configure_command(
+    *,
+    log_dir: str,
+    control_plane_url: str,
+    control_plane_token: str | None,
+    policy_refresh_seconds: int,
+    audit_push_interval: int,
+    policy_path: str | None,
+    secure_defaults: bool,
+    detect_credentials: bool,
+    block_undeclared: bool,
+    apply: bool,
+) -> list[str]:
+    """Build the canonical endpoint proxy bootstrap command."""
+    cmd = [
+        "agent-bom",
+        "proxy-configure",
+        "--log-dir",
+        log_dir,
+        "--control-plane-url",
+        control_plane_url,
+        "--policy-refresh-seconds",
+        str(policy_refresh_seconds),
+        "--audit-push-interval",
+        str(audit_push_interval),
+    ]
+    if control_plane_token:
+        cmd.extend(["--control-plane-token", control_plane_token])
+    if policy_path:
+        cmd.extend(["--policy", policy_path])
+    if not secure_defaults:
+        cmd.append("--no-secure-defaults")
+    if detect_credentials:
+        cmd.append("--detect-credentials")
+    if block_undeclared:
+        cmd.append("--block-undeclared")
+    if apply:
+        cmd.append("--apply")
+    return cmd
+
+
+def render_shell_bootstrap_script(proxy_configure_command: list[str], *, install_dir: str = "$HOME/.local/bin") -> str:
+    """Render the managed shell bootstrap script."""
+    command = " ".join(f'"{part}"' if " " in part else part for part in proxy_configure_command)
+    return f"""#!/usr/bin/env sh
+set -eu
+
+if command -v uv >/dev/null 2>&1; then
+  uv tool install --python 3.13 agent-bom >/dev/null 2>&1 || uv tool upgrade agent-bom
+elif command -v pipx >/dev/null 2>&1; then
+  pipx install agent-bom >/dev/null 2>&1 || pipx upgrade agent-bom
+else
+  python3 -m pip install --user pipx
+  python3 -m pipx ensurepath
+  PATH="{install_dir}:$PATH"
+  python3 -m pipx install agent-bom >/dev/null 2>&1 || python3 -m pipx upgrade agent-bom
+fi
+
+mkdir -p "$HOME/.agent-bom/logs"
+{command}
+"""
+
+
+def render_powershell_bootstrap_script(proxy_configure_command: list[str]) -> str:
+    """Render the managed PowerShell bootstrap script."""
+    quoted = " ".join(f'"{part}"' for part in proxy_configure_command)
+    return f"""$ErrorActionPreference = "Stop"
+
+try {{
+    uv tool install --python 3.13 agent-bom | Out-Null
+}} catch {{
+    py -m pip install --user pipx | Out-Null
+    py -m pipx ensurepath | Out-Null
+    py -m pipx install agent-bom | Out-Null
+}}
+
+$logDir = Join-Path $HOME ".agent-bom\\logs"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+& {quoted}
+"""
+
+
+def render_fleet_sync_env(push_url: str, push_api_key: str | None) -> str:
+    """Render a fleet-sync env file for the shipped timer/service assets."""
+    lines = [f'AGENT_BOM_PUSH_URL="{push_url}"']
+    if push_api_key:
+        lines.append(f'AGENT_BOM_PUSH_API_KEY="{push_api_key}"')
+    return "\n".join(lines) + "\n"
+
+
+def render_launch_agent_plist(push_url: str, push_api_key: str | None) -> str:
+    """Render a launchd plist with concrete fleet-sync values."""
+    token_xml = (
+        f"""    <key>AGENT_BOM_PUSH_API_KEY</key>
+    <string>{push_api_key}</string>
+"""
+        if push_api_key
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentbom.fleet-sync</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-lc</string>
+    <string>$HOME/.local/share/agent-bom/agent-bom-fleet-sync.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AGENT_BOM_PUSH_URL</key>
+    <string>{push_url}</string>
+{token_xml}  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>1800</integer>
+  <key>StandardOutPath</key>
+  <string>/tmp/agent-bom-fleet-sync.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/agent-bom-fleet-sync.log</string>
+</dict>
+</plist>
+"""
+
+
+def write_endpoint_onboarding_bundle(
+    bundle_dir: Path,
+    *,
+    control_plane_url: str,
+    control_plane_token: str | None,
+    policy_refresh_seconds: int,
+    audit_push_interval: int,
+    policy_path: str | None,
+    log_dir: str,
+    secure_defaults: bool,
+    detect_credentials: bool,
+    block_undeclared: bool,
+    push_url: str | None,
+    push_api_key: str | None,
+) -> dict[str, str]:
+    """Write packaged endpoint onboarding artifacts to *bundle_dir*."""
+    command = build_proxy_configure_command(
+        log_dir=log_dir,
+        control_plane_url=control_plane_url,
+        control_plane_token=control_plane_token,
+        policy_refresh_seconds=policy_refresh_seconds,
+        audit_push_interval=audit_push_interval,
+        policy_path=policy_path,
+        secure_defaults=secure_defaults,
+        detect_credentials=detect_credentials,
+        block_undeclared=block_undeclared,
+        apply=True,
+    )
+    artifacts: dict[str, str] = {}
+    shell_path = _write_text(
+        bundle_dir / "install-agent-bom-endpoint.sh",
+        render_shell_bootstrap_script(command),
+        stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR,
+    )
+    artifacts["shell_bootstrap"] = str(shell_path)
+    powershell_path = _write_text(
+        bundle_dir / "install-agent-bom-endpoint.ps1",
+        render_powershell_bootstrap_script(command),
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    artifacts["powershell_bootstrap"] = str(powershell_path)
+
+    if push_url:
+        env_path = _write_text(
+            bundle_dir / "fleet-sync.env",
+            render_fleet_sync_env(push_url, push_api_key),
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        artifacts["fleet_sync_env"] = str(env_path)
+        plist_path = _write_text(
+            bundle_dir / "com.agentbom.fleet-sync.plist",
+            render_launch_agent_plist(push_url, push_api_key),
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        artifacts["launch_agent_plist"] = str(plist_path)
+
+    summary = {
+        "control_plane_url": control_plane_url,
+        "log_dir": log_dir,
+        "policy_path": policy_path,
+        "policy_refresh_seconds": policy_refresh_seconds,
+        "audit_push_interval": audit_push_interval,
+        "secure_defaults": secure_defaults,
+        "detect_credentials": detect_credentials,
+        "block_undeclared": block_undeclared,
+        "artifacts": artifacts,
+    }
+    summary_path = _write_text(
+        bundle_dir / "endpoint-onboarding-summary.json",
+        json.dumps(summary, indent=2),
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    artifacts["summary"] = str(summary_path)
+    return artifacts

--- a/src/agent_bom/proxy_configure.py
+++ b/src/agent_bom/proxy_configure.py
@@ -75,6 +75,10 @@ def auto_configure_proxies(
     secure_defaults: bool = True,
     detect_credentials: bool = False,
     block_undeclared: bool = False,
+    control_plane_url: Optional[str] = None,
+    control_plane_token: Optional[str] = None,
+    policy_refresh_seconds: Optional[int] = None,
+    audit_push_interval: Optional[int] = None,
 ) -> list[ProxyConfig]:
     """Generate proxy-wrapped configs for all eligible STDIO MCP servers.
 
@@ -114,6 +118,15 @@ def auto_configure_proxies(
                 slug = re.sub(r"[^a-zA-Z0-9_-]", "_", server.name)[:64]
                 log_file = str(Path(log_dir) / f"{slug}.jsonl")
                 proxy_flags += ["--log", log_file]
+
+            if control_plane_url:
+                proxy_flags += ["--control-plane-url", control_plane_url]
+                if control_plane_token:
+                    proxy_flags += ["--control-plane-token", control_plane_token]
+                if policy_refresh_seconds is not None:
+                    proxy_flags += ["--policy-refresh-seconds", str(policy_refresh_seconds)]
+                if audit_push_interval is not None:
+                    proxy_flags += ["--audit-push-interval", str(audit_push_interval)]
 
             if secure_defaults or detect_credentials:
                 proxy_flags.append("--detect-credentials")

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 from agent_bom.cli._runtime import (
     _NoOpDetector,
     audit_replay_cmd,
+    proxy_bootstrap_cmd,
     proxy_cmd,
     proxy_configure_cmd,
     watch_cmd,
@@ -180,6 +181,56 @@ def test_proxy_configure_secure_defaults_can_be_disabled():
         assert result.exit_code == 0
     mock_auto_configure.assert_called_once()
     assert mock_auto_configure.call_args.kwargs["secure_defaults"] is False
+
+
+def test_proxy_configure_passes_control_plane_settings():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.discovery.discover_all", return_value=[]),
+        patch("agent_bom.proxy_configure.auto_configure_proxies", return_value=[]) as mock_auto_configure,
+    ):
+        result = runner.invoke(
+            proxy_configure_cmd,
+            [
+                "--control-plane-url",
+                "https://agent-bom.internal.example.com",
+                "--control-plane-token",
+                "token-123",
+                "--policy-refresh-seconds",
+                "45",
+                "--audit-push-interval",
+                "15",
+            ],
+        )
+        assert result.exit_code == 0
+    assert mock_auto_configure.call_args.kwargs["control_plane_url"] == "https://agent-bom.internal.example.com"
+    assert mock_auto_configure.call_args.kwargs["control_plane_token"] == "token-123"
+    assert mock_auto_configure.call_args.kwargs["policy_refresh_seconds"] == 45
+    assert mock_auto_configure.call_args.kwargs["audit_push_interval"] == 15
+
+
+def test_proxy_bootstrap_writes_bundle(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        proxy_bootstrap_cmd,
+        [
+            "--bundle-dir",
+            str(tmp_path),
+            "--control-plane-url",
+            "https://agent-bom.internal.example.com",
+            "--control-plane-token",
+            "token-123",
+            "--push-url",
+            "https://agent-bom.internal.example.com/v1/fleet/sync",
+            "--push-api-key",
+            "fleet-key",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Wrote endpoint onboarding bundle" in result.output
+    assert (tmp_path / "install-agent-bom-endpoint.sh").exists()
+    assert (tmp_path / "install-agent-bom-endpoint.ps1").exists()
+    assert (tmp_path / "endpoint-onboarding-summary.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_endpoint_onboarding.py
+++ b/tests/test_endpoint_onboarding.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_bom.endpoint_onboarding import build_proxy_configure_command, write_endpoint_onboarding_bundle
+
+
+def test_build_proxy_configure_command_includes_control_plane_flags():
+    cmd = build_proxy_configure_command(
+        log_dir="~/.agent-bom/logs",
+        control_plane_url="https://agent-bom.internal.example.com",
+        control_plane_token="token-123",
+        policy_refresh_seconds=45,
+        audit_push_interval=15,
+        policy_path="/tmp/policy.json",
+        secure_defaults=True,
+        detect_credentials=False,
+        block_undeclared=False,
+        apply=True,
+    )
+    assert cmd[:4] == ["agent-bom", "proxy-configure", "--log-dir", "~/.agent-bom/logs"]
+    assert "--control-plane-url" in cmd
+    assert "--control-plane-token" in cmd
+    assert "--policy" in cmd
+    assert "--apply" in cmd
+
+
+def test_write_endpoint_onboarding_bundle_writes_artifacts(tmp_path):
+    artifacts = write_endpoint_onboarding_bundle(
+        tmp_path,
+        control_plane_url="https://agent-bom.internal.example.com",
+        control_plane_token="token-123",
+        policy_refresh_seconds=30,
+        audit_push_interval=10,
+        policy_path=None,
+        log_dir="~/.agent-bom/logs",
+        secure_defaults=True,
+        detect_credentials=False,
+        block_undeclared=False,
+        push_url="https://agent-bom.internal.example.com/v1/fleet/sync",
+        push_api_key="fleet-key",
+    )
+    assert set(artifacts) >= {
+        "shell_bootstrap",
+        "powershell_bootstrap",
+        "fleet_sync_env",
+        "launch_agent_plist",
+        "summary",
+    }
+    shell_script = Path(artifacts["shell_bootstrap"]).read_text()
+    assert "proxy-configure" in shell_script
+    assert "--control-plane-url" in shell_script
+    env_file = Path(artifacts["fleet_sync_env"]).read_text()
+    assert "AGENT_BOM_PUSH_URL" in env_file
+    assert "AGENT_BOM_PUSH_API_KEY" in env_file
+    summary = json.loads(Path(artifacts["summary"]).read_text())
+    assert summary["control_plane_url"] == "https://agent-bom.internal.example.com"
+    assert summary["artifacts"]["shell_bootstrap"] == artifacts["shell_bootstrap"]

--- a/tests/test_proxy_configure.py
+++ b/tests/test_proxy_configure.py
@@ -129,6 +129,26 @@ def test_all_flags_together():
     assert "--block-undeclared" in args
 
 
+def test_control_plane_flags_injected():
+    agents = [_agent([_stdio()])]
+    configs = auto_configure_proxies(
+        agents,
+        control_plane_url="https://agent-bom.internal.example.com",
+        control_plane_token="token-123",
+        policy_refresh_seconds=45,
+        audit_push_interval=15,
+    )
+    args = configs[0].proxied_args
+    assert "--control-plane-url" in args
+    assert "https://agent-bom.internal.example.com" in args
+    assert "--control-plane-token" in args
+    assert "token-123" in args
+    assert "--policy-refresh-seconds" in args
+    assert "45" in args
+    assert "--audit-push-interval" in args
+    assert "15" in args
+
+
 def test_no_flags_minimal_proxied_args():
     server = _stdio(command="uvx", args=["mcp-server-git"])
     agents = [_agent([server])]

--- a/tests/test_proxy_configure.py
+++ b/tests/test_proxy_configure.py
@@ -140,13 +140,17 @@ def test_control_plane_flags_injected():
     )
     args = configs[0].proxied_args
     assert "--control-plane-url" in args
-    assert "https://agent-bom.internal.example.com" in args
+    cp_url_index = args.index("--control-plane-url")
+    assert args[cp_url_index + 1] == "https://agent-bom.internal.example.com"
     assert "--control-plane-token" in args
-    assert "token-123" in args
+    cp_token_index = args.index("--control-plane-token")
+    assert args[cp_token_index + 1] == "token-123"
     assert "--policy-refresh-seconds" in args
-    assert "45" in args
+    refresh_index = args.index("--policy-refresh-seconds")
+    assert args[refresh_index + 1] == "45"
     assert "--audit-push-interval" in args
-    assert "15" in args
+    audit_index = args.index("--audit-push-interval")
+    assert args[audit_index + 1] == "15"
 
 
 def test_no_flags_minimal_proxied_args():


### PR DESCRIPTION
Summary
- make proxy-configure control-plane aware so wrapped JSON MCP configs can pull policy and push audit without hand-editing commands
- add agent-bom proxy-bootstrap to emit managed macOS/Linux and Windows onboarding artifacts plus optional fleet-sync files
- document the packaged endpoint rollout path in the enterprise and MCP client guides

Testing
- uv run pytest tests/test_proxy_configure.py tests/test_endpoint_onboarding.py tests/test_cli_runtime.py -q
- uv run ruff check src/agent_bom/proxy_configure.py src/agent_bom/endpoint_onboarding.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/__init__.py tests/test_proxy_configure.py tests/test_endpoint_onboarding.py tests/test_cli_runtime.py
- uv run mypy src/agent_bom/proxy_configure.py src/agent_bom/endpoint_onboarding.py src/agent_bom/cli/_runtime.py
- uv run agent-bom proxy-bootstrap --bundle-dir /tmp/agent-bom-endpoint-bundle-smoke --control-plane-url https://agent-bom.internal.example.com --control-plane-token token-123 --push-url https://agent-bom.internal.example.com/v1/fleet/sync --push-api-key fleet-key

Closes #1625