### PR TITLE
feat(packaging): add one-command pilot compose path

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -25,13 +25,31 @@ Keep the split. The Python runtime surfaces and the Node UI have different
 runtime, patch cadence, and scaling characteristics. They are companion images,
 not separate products.
 
+## Run This First
+
+Pilot on one workstation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
+```
+
+Production in your own cluster from a checked-out repo:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
 References:
 
 - GitHub README: https://github.com/msaad00/agent-bom/blob/main/README.md
 - Product brief: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_BRIEF.md
 - Verified metrics: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_METRICS.md
 
-## Quick Start
+## CLI And Runtime Quick Start
 
 **Discover and scan your AI agent environment**
 

--- a/DOCKER_HUB_UI_README.md
+++ b/DOCKER_HUB_UI_README.md
@@ -1,40 +1,41 @@
 # agent-bom-ui
 
-**Standalone browser UI for the self-hosted `agent-bom` control plane.**
+Dashboard image for `agent-bom`.
 
-`agentbom/agent-bom-ui` is the separate Next.js UI container used when you run
-the browser dashboard independently from the API.
+`agent-bom` is one product with two deployable images:
 
-It is **not** the scanner or control-plane backend by itself.
+- `agentbom/agent-bom` runs the scanner, API, jobs, gateway, proxy, and other non-browser runtimes
+- `agentbom/agent-bom-ui` runs the browser dashboard
 
-Use it with:
+This image is not a separate product and it is not meant to be the first thing a
+pilot user reasons about. Use the packaged pilot or Helm chart so both images are
+pulled for you.
 
-- `agentbom/agent-bom` for the API, scan jobs, gateway, proxy-related
-  entrypoints, and other non-browser control-plane services
-- your own ingress / SSO / Postgres setup when deploying the split UI + API
-  control-plane shape
+## Run This First
 
-## Quick Start
-
-```bash
-docker run --rm -p 3000:3000 \
-  -e NEXT_PUBLIC_API_URL=http://localhost:8422 \
-  agentbom/agent-bom-ui:latest
-```
-
-Then run the API separately:
+Pilot on one workstation:
 
 ```bash
-docker run --rm -p 8422:8422 agentbom/agent-bom:latest api
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
 ```
 
-## Product Split
+Production in your own cluster from a checked-out repo:
 
-- `agentbom/agent-bom` = scanner, API, jobs, runtime/gateway entrypoints
-- `agentbom/agent-bom-ui` = standalone browser UI only
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
+## Image Role
+
+- `agentbom/agent-bom` = runtime image for scanner, API, jobs, gateway, proxy
+- `agentbom/agent-bom-ui` = dashboard image for the same self-hosted control plane
 
 ## Links
 
 - GitHub: https://github.com/msaad00/agent-bom
 - Docs: https://msaad00.github.io/agent-bom/
-- Helm chart: `oci://ghcr.io/msaad00/charts/agent-bom`
+- Helm chart: `deploy/helm/agent-bom`

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -49,6 +49,22 @@ pip install 'agent-bom[ui]'                      # once, if you want the dashboa
 agent-bom serve                                  # API + dashboard + graph explorer
 ```
 
+Self-hosted pilot:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
+```
+
+Production chart from a checked-out repo:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
 ## Product views
 
 ### Dashboard

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ agent-bom image nginx:latest                  # container image scan
 agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC scan, optionally `--k8s-live`
 ```
 
+Self-hosted pilot:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
+```
+
+Production chart from a checked-out repo:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
 After the first scan:
 
 ```bash
@@ -553,12 +569,13 @@ pip install agent-bom                        # CLI
 docker run --rm agentbom/agent-bom agents    # Docker
 ```
 
-For published containers, the split is:
+For published containers, the packaging model is:
 
+- one product, two deployable images
 - `agentbom/agent-bom` = the main runtime image for CLI, API, jobs, gateway,
   proxy-related entrypoints, and MCP server mode
-- `agentbom/agent-bom-ui` = the standalone browser UI image used when the
-  self-hosted control plane runs the UI separately from the API
+- `agentbom/agent-bom-ui` = the browser dashboard image for the same
+  self-hosted control plane
 
 | Mode | Best for |
 |------|----------|
@@ -566,7 +583,7 @@ For published containers, the split is:
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
 | GitHub Action (`uses: msaad00/agent-bom@v0.81.0`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
-| Browser UI image (`agentbom/agent-bom-ui`) | the separate Next.js UI container paired with a self-hosted API |
+| Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
 | REST API (`agent-bom api`) | platform integration, self-hosted control plane |
 | MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -1,0 +1,53 @@
+# agent-bom packaged pilot
+# One product, two deployable images:
+#   - agentbom/agent-bom     = API, scanner, jobs, gateway, proxy runtimes
+#   - agentbom/agent-bom-ui  = browser dashboard
+#
+# Local pilot only:
+#   - binds to 127.0.0.1 only
+#   - uses SQLite persistence in a named Docker volume
+#   - allows no-auth browser access for fast evaluation on one workstation
+#
+# Usage:
+#   docker compose -f docker-compose.pilot.yml up -d
+#   open http://localhost:3000
+
+services:
+  api:
+    image: agentbom/agent-bom:0.81.0
+    container_name: agent-bom-pilot-api
+    restart: unless-stopped
+    command: >
+      api
+      --host 0.0.0.0
+      --port 8422
+      --persist /var/lib/agent-bom/jobs.db
+      --cors-allow-all
+      --allow-insecure-no-auth
+    environment:
+      AGENT_BOM_DB_PATH: /var/lib/agent-bom/vulns.db
+    ports:
+      - "127.0.0.1:8422:8422"
+    volumes:
+      - agent-bom-pilot-data:/var/lib/agent-bom
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8422/healthz')\""]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  ui:
+    image: agentbom/agent-bom-ui:0.81.0
+    container_name: agent-bom-pilot-ui
+    restart: unless-stopped
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8422
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      api:
+        condition: service_healthy
+
+volumes:
+  agent-bom-pilot-data:

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -1,11 +1,20 @@
 # Docker Deployment
 
-Use this page for containerized entrypoints. The published image split is:
+Use this page for containerized entrypoints. `agent-bom` is one product with
+two deployable images:
 
 - `agentbom/agent-bom` = the main runtime image for CLI scans, the API,
   scanner jobs, gateway, MCP server mode, and other non-browser entrypoints
 - `agentbom/agent-bom-ui` = the standalone browser UI image used when the
   self-hosted control plane runs the UI separately from the API
+
+Pilot on one workstation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
+```
 
 The UI image does not replace the API image. A self-hosted browser deployment
 still needs the API/control-plane service from `agentbom/agent-bom`.

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -4,6 +4,27 @@ Use this page when the question is not "how do I install `agent-bom`?" but
 "what do I actually deploy in my own infrastructure, and what data path does it
 create?"
 
+`agent-bom` is one product with two deployable images:
+
+- `agentbom/agent-bom` for scanner, API, jobs, gateway, proxy, and other non-browser runtimes
+- `agentbom/agent-bom-ui` for the browser dashboard
+
+Pilot on one workstation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
+```
+
+Production in your own cluster from a checked-out repo:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
 `agent-bom` is intentionally packaged as interoperable surfaces, not a forced
 monolith:
 


### PR DESCRIPTION
Summary
- add a packaged `docker-compose.pilot.yml` so pilot users bring up the dashboard and runtime API with one command while keeping the two-image architecture intact
- align README, PyPI, Docker Hub, and deployment docs on the same framing: one product, two deployable images; pilot via Compose, production via one Helm chart
- rewrite the UI image Docker Hub copy so it reads as a dashboard companion image instead of a separate product

Testing
- docker compose -f deploy/docker-compose.pilot.yml config
- uv run mkdocs build --strict
- python3 scripts/check_release_consistency.py