### PR TITLE
feat(terraform): add AWS baseline module and destroy guidance

### DIFF
--- a/deploy/terraform/aws/baseline/README.md
+++ b/deploy/terraform/aws/baseline/README.md
@@ -1,0 +1,85 @@
+# agent-bom AWS baseline module
+
+This module provisions the AWS resources Helm does not own cleanly:
+
+- PostgreSQL / RDS for the control plane
+- IRSA roles for the scanner and backup job
+- S3 backup bucket
+- Secrets Manager containers/outputs for ExternalSecrets wiring
+
+It does **not** create Kubernetes objects. Terraform owns the AWS baseline;
+Helm owns the `agent-bom` workloads inside the cluster.
+
+## What Terraform owns
+
+- RDS subnet group, security group, and Postgres instance
+- S3 backup bucket and bucket policy surface for the packaged backup job
+- IAM roles and policies for scanner + backup IRSA
+- Secrets Manager secret containers / generated secret references
+
+## What Helm still owns
+
+- Deployments, CronJobs, Services, Ingress, HPAs, PDBs
+- ExternalSecret objects that mirror AWS secrets into Kubernetes
+- runtime service accounts and pod annotations
+
+## Usage
+
+```hcl
+module "agent_bom_baseline" {
+  source = "./deploy/terraform/aws/baseline"
+
+  name                      = "agent-bom-prod"
+  namespace                 = "agent-bom"
+  release_name              = "agent-bom"
+  cluster_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE"
+  cluster_oidc_issuer_url   = "https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE"
+  vpc_id                    = "vpc-0123456789abcdef0"
+  private_subnet_ids        = ["subnet-aaa", "subnet-bbb", "subnet-ccc"]
+
+  db_allowed_security_group_ids = ["sg-eks-nodes"]
+  db_url_secret_name            = "agent-bom/control-plane-db"
+  auth_secret_name              = "agent-bom/control-plane-auth"
+
+  tags = {
+    Environment = "prod"
+    Owner       = "security-platform"
+  }
+}
+```
+
+Then wire the output into Helm:
+
+```bash
+terraform output -raw helm_values_hint
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
+Populate the chart-facing database URL secret after the first apply:
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id agent-bom/control-plane-db \
+  --secret-string '{"AGENT_BOM_POSTGRES_URL":"postgresql://agent_bom:REPLACE_ME@REPLACE_ME_RDS_ENDPOINT:5432/agent_bom"}'
+```
+
+## Destroy / decommission
+
+Use a two-step teardown so Terraform does not fight live pods:
+
+1. Disable backup jobs and remove the Helm release:
+   `helm uninstall agent-bom -n agent-bom`
+2. Confirm no pods or ExternalSecrets still reference the IRSA roles or DB.
+3. Run:
+   `terraform destroy`
+
+If you want `terraform destroy` to remove the backup bucket contents too, set:
+
+```hcl
+backup_bucket_force_destroy = true
+```
+
+Keep it `false` for production unless you intentionally want teardown to remove
+all retained backups.

--- a/deploy/terraform/aws/baseline/main.tf
+++ b/deploy/terraform/aws/baseline/main.tf
@@ -1,0 +1,270 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  oidc_provider_hostpath = replace(var.cluster_oidc_issuer_url, "https://", "")
+  common_tags = merge(
+    {
+      "app.kubernetes.io/name"       = "agent-bom"
+      "app.kubernetes.io/managed-by" = "terraform"
+      "agent-bom.io/module"          = "aws-baseline"
+    },
+    var.tags,
+  )
+  scanner_service_account_name = "${var.release_name}-scanner"
+  backup_service_account_name  = "${var.release_name}-backup"
+  backup_bucket_name = var.backup_bucket_name != "" ? var.backup_bucket_name : format(
+    "%s-backups-%s-%s",
+    var.name,
+    data.aws_caller_identity.current.account_id,
+    data.aws_region.current.name,
+  )
+}
+
+data "aws_iam_policy_document" "scanner_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.cluster_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_hostpath}:sub"
+      values = [
+        "system:serviceaccount:${var.namespace}:${local.scanner_service_account_name}",
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_hostpath}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "scanner" {
+  name               = "${var.name}-scanner"
+  assume_role_policy = data.aws_iam_policy_document.scanner_assume_role.json
+  tags               = local.common_tags
+}
+
+resource "aws_iam_policy" "scanner" {
+  name   = "${var.name}-scanner"
+  policy = file("${path.module}/../../../../scripts/provision/aws_readonly_policy.json")
+  tags   = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "scanner" {
+  role       = aws_iam_role.scanner.name
+  policy_arn = aws_iam_policy.scanner.arn
+}
+
+data "aws_iam_policy_document" "backup_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.cluster_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_hostpath}:sub"
+      values = [
+        "system:serviceaccount:${var.namespace}:${local.backup_service_account_name}",
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_hostpath}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "backup" {
+  count              = var.create_backup_bucket ? 1 : 0
+  name               = "${var.name}-backup"
+  assume_role_policy = data.aws_iam_policy_document.backup_assume_role.json
+  tags               = local.common_tags
+}
+
+data "aws_iam_policy_document" "backup" {
+  count = var.create_backup_bucket ? 1 : 0
+
+  statement {
+    sid    = "BackupBucketList"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = [aws_s3_bucket.backups[0].arn]
+  }
+
+  statement {
+    sid    = "BackupObjectWrite"
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.backups[0].arn}/*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.backup_kms_key_arn != "" ? [1] : []
+    content {
+      sid    = "BackupKms"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+      ]
+      resources = [var.backup_kms_key_arn]
+    }
+  }
+}
+
+resource "aws_iam_policy" "backup" {
+  count  = var.create_backup_bucket ? 1 : 0
+  name   = "${var.name}-backup"
+  policy = data.aws_iam_policy_document.backup[0].json
+  tags   = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  count      = var.create_backup_bucket ? 1 : 0
+  role       = aws_iam_role.backup[0].name
+  policy_arn = aws_iam_policy.backup[0].arn
+}
+
+resource "aws_s3_bucket" "backups" {
+  count         = var.create_backup_bucket ? 1 : 0
+  bucket        = local.backup_bucket_name
+  force_destroy = var.backup_bucket_force_destroy
+  tags          = local.common_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  count                   = var.create_backup_bucket ? 1 : 0
+  bucket                  = aws_s3_bucket.backups[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  count  = var.create_backup_bucket ? 1 : 0
+  bucket = aws_s3_bucket.backups[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  count  = var.create_backup_bucket ? 1 : 0
+  bucket = aws_s3_bucket.backups[0].bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.backup_kms_key_arn != "" ? "aws:kms" : "AES256"
+      kms_master_key_id = var.backup_kms_key_arn != "" ? var.backup_kms_key_arn : null
+    }
+    bucket_key_enabled = var.backup_kms_key_arn != "" ? true : null
+  }
+}
+
+resource "aws_db_subnet_group" "this" {
+  count      = var.create_rds ? 1 : 0
+  name       = "${var.name}-db"
+  subnet_ids = var.private_subnet_ids
+  tags       = local.common_tags
+}
+
+resource "aws_security_group" "db" {
+  count       = var.create_rds ? 1 : 0
+  name        = "${var.name}-db"
+  description = "Postgres access for the agent-bom control plane"
+  vpc_id      = var.vpc_id
+  tags        = local.common_tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "db_cidr" {
+  for_each          = var.create_rds ? toset(var.db_allowed_cidr_blocks) : toset([])
+  security_group_id = aws_security_group.db[0].id
+  description       = "Postgres from approved CIDR"
+  from_port         = 5432
+  ip_protocol       = "tcp"
+  to_port           = 5432
+  cidr_ipv4         = each.value
+}
+
+resource "aws_vpc_security_group_ingress_rule" "db_sg" {
+  for_each                     = var.create_rds ? toset(var.db_allowed_security_group_ids) : toset([])
+  security_group_id            = aws_security_group.db[0].id
+  description                  = "Postgres from approved security group"
+  from_port                    = 5432
+  ip_protocol                  = "tcp"
+  to_port                      = 5432
+  referenced_security_group_id = each.value
+}
+
+resource "aws_vpc_security_group_egress_rule" "db" {
+  count             = var.create_rds ? 1 : 0
+  security_group_id = aws_security_group.db[0].id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_db_instance" "this" {
+  count                       = var.create_rds ? 1 : 0
+  identifier                  = var.name
+  engine                      = "postgres"
+  engine_version              = "16"
+  instance_class              = var.db_instance_class
+  allocated_storage           = var.db_allocated_storage
+  storage_type                = var.db_storage_type
+  storage_encrypted           = true
+  db_name                     = var.db_name
+  username                    = var.db_username
+  manage_master_user_password = true
+  db_subnet_group_name        = aws_db_subnet_group.this[0].name
+  vpc_security_group_ids      = [aws_security_group.db[0].id]
+  skip_final_snapshot         = false
+  final_snapshot_identifier   = var.db_final_snapshot_identifier != "" ? var.db_final_snapshot_identifier : "${var.name}-final"
+  backup_retention_period     = var.db_backup_retention_period
+  deletion_protection         = var.db_deletion_protection
+  multi_az                    = var.db_multi_az
+  publicly_accessible         = false
+  apply_immediately           = true
+  copy_tags_to_snapshot       = true
+  tags                        = local.common_tags
+}
+
+resource "aws_secretsmanager_secret" "db_url" {
+  count       = var.create_db_url_secret ? 1 : 0
+  name        = var.db_url_secret_name
+  description = "agent-bom control-plane database URL mirrored by ExternalSecrets"
+  tags        = local.common_tags
+}
+
+resource "aws_secretsmanager_secret" "auth" {
+  count       = var.create_auth_secret ? 1 : 0
+  name        = var.auth_secret_name
+  description = "agent-bom control-plane auth settings mirrored by ExternalSecrets"
+  tags        = local.common_tags
+}

--- a/deploy/terraform/aws/baseline/outputs.tf
+++ b/deploy/terraform/aws/baseline/outputs.tf
@@ -1,0 +1,91 @@
+locals {
+  db_secret_name = var.create_rds ? split(":", aws_db_instance.this[0].master_user_secret[0].secret_arn)[6] : null
+}
+
+output "scanner_role_arn" {
+  description = "IRSA role ARN for the scanner service account."
+  value       = aws_iam_role.scanner.arn
+}
+
+output "backup_role_arn" {
+  description = "IRSA role ARN for the Postgres backup CronJob service account."
+  value       = var.create_backup_bucket ? aws_iam_role.backup[0].arn : null
+}
+
+output "backup_bucket_name" {
+  description = "S3 bucket used by the packaged Postgres backup job."
+  value       = var.create_backup_bucket ? aws_s3_bucket.backups[0].bucket : null
+}
+
+output "db_endpoint" {
+  description = "Postgres endpoint for the control plane."
+  value       = var.create_rds ? aws_db_instance.this[0].address : null
+}
+
+output "db_secret_arn" {
+  description = "Secrets Manager ARN containing the generated RDS master password."
+  value       = var.create_rds ? aws_db_instance.this[0].master_user_secret[0].secret_arn : null
+}
+
+output "db_secret_name" {
+  description = "Secrets Manager name for the generated RDS master password secret."
+  value       = local.db_secret_name
+}
+
+output "db_url_secret_name" {
+  description = "Secrets Manager name that should contain AGENT_BOM_POSTGRES_URL for ExternalSecrets."
+  value       = var.create_db_url_secret ? aws_secretsmanager_secret.db_url[0].name : null
+}
+
+output "auth_secret_name" {
+  description = "Secrets Manager name for the control-plane auth settings secret container."
+  value       = var.create_auth_secret ? aws_secretsmanager_secret.auth[0].name : null
+}
+
+output "helm_values_hint" {
+  description = "Copy/paste baseline wiring for the packaged Helm chart."
+  value = <<-EOT
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: ${aws_iam_role.scanner.arn}
+
+scanner:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: ${aws_iam_role.scanner.arn}
+
+controlPlane:
+  externalSecrets:
+    enabled: true
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: aws-secrets-manager
+    secrets:
+      - nameSuffix: control-plane-db
+        target:
+          name: agent-bom-control-plane-db
+        data:
+          - secretKey: AGENT_BOM_POSTGRES_URL
+            remoteRef:
+              key: ${coalesce(var.create_db_url_secret ? aws_secretsmanager_secret.db_url[0].name : null, "REPLACE_ME_DB_URL_SECRET_NAME")}
+              property: AGENT_BOM_POSTGRES_URL
+      - nameSuffix: control-plane-auth
+        target:
+          name: agent-bom-control-plane-auth
+        data:
+          - secretKey: AGENT_BOM_OIDC_ISSUER
+            remoteRef:
+              key: ${coalesce(var.create_auth_secret ? aws_secretsmanager_secret.auth[0].name : null, "REPLACE_ME_AUTH_SECRET_NAME")}
+              property: OIDC_ISSUER
+
+  backup:
+    enabled: ${var.create_backup_bucket ? "true" : "false"}
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: ${var.create_backup_bucket ? aws_iam_role.backup[0].arn : "REPLACE_ME_BACKUP_ROLE_ARN"}
+    destination:
+      bucket: ${var.create_backup_bucket ? aws_s3_bucket.backups[0].bucket : "REPLACE_ME_BACKUP_BUCKET"}
+      prefix: agent-bom/postgres
+      bucketRegion: ${data.aws_region.current.name}
+  EOT
+}

--- a/deploy/terraform/aws/baseline/variables.tf
+++ b/deploy/terraform/aws/baseline/variables.tf
@@ -1,0 +1,163 @@
+variable "name" {
+  description = "Base name for baseline resources."
+  type        = string
+  default     = "agent-bom"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace where the Helm release runs."
+  type        = string
+  default     = "agent-bom"
+}
+
+variable "release_name" {
+  description = "Helm release name. Used to match default service-account names."
+  type        = string
+  default     = "agent-bom"
+}
+
+variable "cluster_oidc_provider_arn" {
+  description = "ARN of the EKS OIDC provider used for IRSA trust."
+  type        = string
+}
+
+variable "cluster_oidc_issuer_url" {
+  description = "Issuer URL of the EKS OIDC provider, for example https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID that hosts the EKS cluster and RDS instance."
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the RDS subnet group."
+  type        = list(string)
+}
+
+variable "db_allowed_cidr_blocks" {
+  description = "CIDR blocks allowed to connect to the RDS instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "db_allowed_security_group_ids" {
+  description = "Security group IDs allowed to connect to the RDS instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "create_rds" {
+  description = "Whether to provision the Postgres/RDS baseline."
+  type        = bool
+  default     = true
+}
+
+variable "db_name" {
+  description = "Initial Postgres database name."
+  type        = string
+  default     = "agent_bom"
+}
+
+variable "db_username" {
+  description = "Postgres admin username. AWS stores the generated password in Secrets Manager."
+  type        = string
+  default     = "agent_bom"
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class for the control-plane Postgres database."
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage in GiB for the RDS instance."
+  type        = number
+  default     = 100
+}
+
+variable "db_storage_type" {
+  description = "AWS storage type for the RDS instance."
+  type        = string
+  default     = "gp3"
+}
+
+variable "db_multi_az" {
+  description = "Whether to enable Multi-AZ for the control-plane Postgres database."
+  type        = bool
+  default     = true
+}
+
+variable "db_backup_retention_period" {
+  description = "Retention window in days for automated RDS backups."
+  type        = number
+  default     = 7
+}
+
+variable "db_deletion_protection" {
+  description = "Whether to prevent accidental RDS deletion."
+  type        = bool
+  default     = true
+}
+
+variable "create_backup_bucket" {
+  description = "Whether to provision the S3 bucket used by the Postgres backup CronJob."
+  type        = bool
+  default     = true
+}
+
+variable "backup_bucket_name" {
+  description = "Optional explicit bucket name for backups. Defaults to <name>-backups-<account>-<region>."
+  type        = string
+  default     = ""
+}
+
+variable "backup_bucket_force_destroy" {
+  description = "Allow Terraform destroy to remove a non-empty backup bucket."
+  type        = bool
+  default     = false
+}
+
+variable "backup_kms_key_arn" {
+  description = "Optional KMS key ARN for S3 backup object encryption and IAM access."
+  type        = string
+  default     = ""
+}
+
+variable "create_auth_secret" {
+  description = "Whether to create an empty Secrets Manager secret container for control-plane auth settings."
+  type        = bool
+  default     = true
+}
+
+variable "create_db_url_secret" {
+  description = "Whether to create an empty Secrets Manager secret container for the chart-facing AGENT_BOM_POSTGRES_URL value."
+  type        = bool
+  default     = true
+}
+
+variable "db_url_secret_name" {
+  description = "Secrets Manager secret name that should hold AGENT_BOM_POSTGRES_URL for ExternalSecrets."
+  type        = string
+  default     = "agent-bom/control-plane-db"
+}
+
+variable "auth_secret_name" {
+  description = "Secrets Manager secret name that ExternalSecrets should mirror into AGENT_BOM_OIDC_* / SAML / audit HMAC settings."
+  type        = string
+  default     = "agent-bom/control-plane-auth"
+}
+
+variable "db_final_snapshot_identifier" {
+  description = "Identifier used for the final RDS snapshot on destroy when deletion protection is disabled."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags applied to all Terraform-managed baseline resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deploy/terraform/aws/baseline/versions.tf
+++ b/deploy/terraform/aws/baseline/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Endpoint Fleet: deployment/endpoint-fleet.md
       - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md
+      - Terraform AWS Baseline: deployment/terraform-aws-baseline.md
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Backend Parity: deployment/backend-parity.md

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -14,6 +14,12 @@ This is the right path when you want:
 - production operator defaults without pretending there is a managed vendor plane
 - a clean split between the API/runtime image and the standalone UI image
 
+When you also need Terraform ownership for the AWS baseline outside the
+cluster, pair this chart with the
+[Terraform AWS Baseline](terraform-aws-baseline.md) module. Terraform should
+own RDS, S3, IAM/IRSA, and Secrets Manager; Helm should own the in-cluster
+Deployments, CronJobs, and ExternalSecret objects.
+
 ## What the chart deploys
 
 When you set `controlPlane.enabled=true`, the Helm chart can package:

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -191,6 +191,8 @@ These are the maintained building blocks for this model:
 
 - control plane:
   [deploy/helm/agent-bom](https://github.com/msaad00/agent-bom/tree/main/deploy/helm/agent-bom)
+- AWS baseline module:
+  [deploy/terraform/aws/baseline](https://github.com/msaad00/agent-bom/tree/main/deploy/terraform/aws/baseline)
 - Compose references:
   [deploy/docker-compose.platform.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.platform.yml)
   and
@@ -207,6 +209,11 @@ These are the maintained building blocks for this model:
   [eks-production-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-production-values.yaml)
 - focused pilot values example:
   [eks-mcp-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
+
+For teams that want Terraform to own the AWS baseline around the chart, use the
+[Terraform AWS Baseline](terraform-aws-baseline.md) module for RDS, IRSA,
+backup bucket, and Secrets Manager ownership, then let Helm own the in-cluster
+workloads.
 
 ## Recommended Topology
 

--- a/site-docs/deployment/terraform-aws-baseline.md
+++ b/site-docs/deployment/terraform-aws-baseline.md
@@ -1,0 +1,107 @@
+# Terraform AWS Baseline
+
+Use this page when the question is not "how do I deploy the chart?" but
+"who owns the AWS pieces around the chart, and how do I destroy them cleanly?"
+
+`agent-bom` now has a supported Terraform path for the AWS baseline that sits
+around the Helm chart:
+
+- Postgres / RDS
+- IRSA roles for scanner and backup jobs
+- S3 backup bucket
+- Secrets Manager containers and references used by ExternalSecrets
+
+The module lives at:
+
+- [`deploy/terraform/aws/baseline`](https://github.com/msaad00/agent-bom/tree/main/deploy/terraform/aws/baseline)
+
+## Ownership split
+
+Keep the ownership boundary explicit:
+
+| Terraform owns | Helm owns |
+|---|---|
+| RDS subnet group, security group, Postgres instance | API, UI, scanner, gateway, backup CronJob, runtime monitor |
+| S3 backup bucket | Ingress, HPA, PDB, NetworkPolicy |
+| IAM roles and policies for IRSA | ServiceAccount objects and their annotations |
+| Secrets Manager secret containers and generated secret references | ExternalSecret objects that mirror those secrets into Kubernetes |
+
+That split matters because it gives operators a clean destroy story instead of
+leaving RDS, S3, and IAM resources behind after `helm uninstall`.
+
+## Minimal usage
+
+```hcl
+module "agent_bom_baseline" {
+  source = "./deploy/terraform/aws/baseline"
+
+  name                      = "agent-bom-prod"
+  namespace                 = "agent-bom"
+  release_name              = "agent-bom"
+  cluster_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE"
+  cluster_oidc_issuer_url   = "https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE"
+  vpc_id                    = "vpc-0123456789abcdef0"
+  private_subnet_ids        = ["subnet-aaa", "subnet-bbb", "subnet-ccc"]
+
+  db_allowed_security_group_ids = ["sg-eks-nodes"]
+  auth_secret_name              = "agent-bom/control-plane-auth"
+}
+```
+
+The module outputs:
+
+- `scanner_role_arn`
+- `backup_role_arn`
+- `backup_bucket_name`
+- `db_endpoint`
+- `db_secret_arn`
+- `db_secret_name`
+- `db_url_secret_name`
+- `auth_secret_name`
+- `helm_values_hint`
+
+`helm_values_hint` is a copy/paste bridge into the packaged chart values so the
+module and the chart stay aligned instead of relying on tribal glue.
+
+## Install flow
+
+1. Apply the AWS baseline module.
+2. Create or configure your `ClusterSecretStore` for AWS Secrets Manager.
+3. Populate the chart-facing DB URL secret with `AGENT_BOM_POSTGRES_URL`.
+4. Copy the `helm_values_hint` output into your values file or map it into your
+   Helm pipeline.
+5. Install the chart:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
+## Destroy flow
+
+Use a two-phase decommission:
+
+1. `helm uninstall agent-bom -n agent-bom`
+2. wait for pods, CronJobs, and ExternalSecrets to disappear
+3. `terraform destroy`
+
+That ordering avoids:
+
+- backup jobs still writing to S3 while the bucket is being removed
+- live pods holding IRSA assumptions while IAM roles are deleted
+- live API pods trying to reconnect to an RDS instance Terraform is tearing down
+
+## What this does not do
+
+This module is intentionally narrow. It does not attempt to own:
+
+- the EKS cluster itself
+- ALB controller installation
+- cert-manager installation
+- ExternalSecrets controller installation
+- Route53 / DNS records
+
+Those remain cluster-platform responsibilities. The goal here is to make the
+`agent-bom` baseline repeatable and destroyable, not to replace an entire AWS
+platform module stack.


### PR DESCRIPTION
Summary
- add a supported AWS baseline Terraform module for the self-hosted control-plane prerequisites Helm does not own cleanly: RDS, IRSA roles, backup bucket, and Secrets Manager containers
- add a deployment doc that makes the infra-lifecycle vs chart-lifecycle boundary explicit and documents the two-phase destroy path
- wire the new Terraform baseline doc into the deployment docs so the EKS and Helm pages point at the same baseline ownership model

Testing
- uv run mkdocs build --strict

Notes
- Terraform is not installed in the local environment used for this PR, so `terraform fmt` / `terraform validate` were not run here; the module is intentionally narrow and documented with explicit ownership boundaries rather than trying to manage cluster resources itself

Closes #1624