### PR TITLE
feat(deploy): add AWS EKS reference rollout installer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
   - Deployment:
       - Overview: deployment/overview.md
       - Deployment Modes and Alignment: deployment/deployment-modes-and-alignment.md
+      - AWS Company Rollout: deployment/aws-company-rollout.md
       - Enterprise MCP / Endpoint Pilot: deployment/enterprise-pilot.md
       - Endpoint Fleet: deployment/endpoint-fleet.md
       - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md

--- a/scripts/deploy/install-eks-reference.sh
+++ b/scripts/deploy/install-eks-reference.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+CLUSTER_NAME="agent-bom"
+REGION="${AWS_REGION:-us-east-1}"
+NAMESPACE="agent-bom"
+RELEASE_NAME="agent-bom"
+HOSTNAME=""
+INGRESS_CLASS="nginx"
+CREATE_CLUSTER=0
+ENABLE_GATEWAY=0
+ENABLE_FLEET=1
+NODE_INSTANCE_TYPE="m7i.large"
+NODE_COUNT="3"
+K8S_VERSION="1.30"
+STATE_DIR="${HOME}/.agent-bom/eks-reference"
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Reference installer for self-hosted agent-bom on AWS / EKS.
+
+This script is intentionally opinionated:
+- it can create a reference EKS cluster with eksctl
+- it provisions the agent-bom AWS baseline with Terraform/OpenTofu
+- it installs the packaged Helm chart with production defaults plus generated overrides
+- it prints the next-step commands for fleet onboarding and optional gateway rollout
+
+Usage:
+  scripts/deploy/install-eks-reference.sh [options]
+
+Options:
+  --cluster-name NAME         EKS cluster name (default: agent-bom)
+  --region REGION             AWS region (default: AWS_REGION or us-east-1)
+  --namespace NAME            Kubernetes namespace / Helm namespace (default: agent-bom)
+  --release NAME              Helm release name (default: agent-bom)
+  --hostname HOST             Optional ingress hostname for same-origin UI/API access
+  --ingress-class NAME        IngressClass to use when --hostname is set (default: nginx)
+  --create-cluster            Create a reference EKS cluster with eksctl before baseline + Helm
+  --enable-gateway            Enable the packaged gateway Deployment and generate a bearer token
+  --disable-fleet             Skip printing the endpoint onboarding bundle command
+  --node-instance-type TYPE   eksctl managed nodegroup instance type (default: m7i.large)
+  --node-count COUNT          eksctl desired/min node count (default: 3)
+  --k8s-version VERSION       EKS version for --create-cluster (default: 1.30)
+  --state-dir PATH            Local state/output root (default: ~/.agent-bom/eks-reference)
+  --dry-run                   Print actions and generated command paths without applying changes
+  -h, --help                  Show this help
+
+Examples:
+  scripts/deploy/install-eks-reference.sh --create-cluster --cluster-name corp-ai --region us-east-1
+
+  scripts/deploy/install-eks-reference.sh \
+    --cluster-name corp-ai \
+    --region us-east-1 \
+    --hostname agent-bom.internal.example.com \
+    --enable-gateway
+EOF
+}
+
+log() { printf "\n[%s] %s\n" "$(date +%H:%M:%S)" "$*"; }
+warn() { printf "\n[warn] %s\n" "$*" >&2; }
+die() { printf "\n[error] %s\n" "$*" >&2; exit 1; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf "+ %q" "$1"
+    shift
+    for arg in "$@"; do
+      printf " %q" "$arg"
+    done
+    printf "\n"
+    return 0
+  fi
+  "$@"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --release) RELEASE_NAME="$2"; shift 2 ;;
+    --hostname) HOSTNAME="$2"; shift 2 ;;
+    --ingress-class) INGRESS_CLASS="$2"; shift 2 ;;
+    --create-cluster) CREATE_CLUSTER=1; shift ;;
+    --enable-gateway) ENABLE_GATEWAY=1; shift ;;
+    --disable-fleet) ENABLE_FLEET=0; shift ;;
+    --node-instance-type) NODE_INSTANCE_TYPE="$2"; shift 2 ;;
+    --node-count) NODE_COUNT="$2"; shift 2 ;;
+    --k8s-version) K8S_VERSION="$2"; shift 2 ;;
+    --state-dir) STATE_DIR="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+need_cmd python3
+TERRAFORM_BIN="terraform"
+if [ "$DRY_RUN" -eq 0 ]; then
+  need_cmd aws
+  need_cmd kubectl
+  need_cmd helm
+  need_cmd eksctl
+  TERRAFORM_BIN="${TERRAFORM_BIN:-$(command -v terraform || command -v tofu || true)}"
+  [ -n "$TERRAFORM_BIN" ] || die "terraform or tofu is required"
+fi
+
+STATE_ROOT="${STATE_DIR}/${CLUSTER_NAME}"
+mkdir -p "${STATE_ROOT}"
+TF_ROOT="${STATE_ROOT}/terraform"
+GENERATED_DIR="${STATE_ROOT}/generated"
+mkdir -p "${TF_ROOT}" "${GENERATED_DIR}"
+
+if [ "$CREATE_CLUSTER" -eq 1 ]; then
+  CLUSTER_CONFIG="${GENERATED_DIR}/eksctl-cluster.yaml"
+  MAX_NODES=$((NODE_COUNT + 2))
+  cat >"${CLUSTER_CONFIG}" <<EOF
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: ${CLUSTER_NAME}
+  region: ${REGION}
+  version: "${K8S_VERSION}"
+
+iam:
+  withOIDC: true
+
+managedNodeGroups:
+  - name: ${CLUSTER_NAME}-workers
+    instanceType: ${NODE_INSTANCE_TYPE}
+    desiredCapacity: ${NODE_COUNT}
+    minSize: ${NODE_COUNT}
+    maxSize: ${MAX_NODES}
+    privateNetworking: true
+EOF
+  log "Creating or reconciling reference EKS cluster ${CLUSTER_NAME} in ${REGION}"
+  run eksctl create cluster -f "${CLUSTER_CONFIG}"
+fi
+
+log "Associating IAM OIDC provider for cluster ${CLUSTER_NAME}"
+run eksctl utils associate-iam-oidc-provider --cluster "${CLUSTER_NAME}" --region "${REGION}" --approve
+
+log "Updating kubeconfig"
+run aws eks update-kubeconfig --name "${CLUSTER_NAME}" --region "${REGION}"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  ACCOUNT_ID="123456789012"
+  OIDC_ISSUER="https://oidc.eks.${REGION}.amazonaws.com/id/REFERENCE"
+  VPC_ID="vpc-00000000000000000"
+  CLUSTER_SUBNETS="subnet-aaaaaaaaaaaaaaaaa subnet-bbbbbbbbbbbbbbbbb subnet-ccccccccccccccccc"
+  VPC_CIDR="10.0.0.0/16"
+else
+  ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+  CLUSTER_JSON="$(aws eks describe-cluster --name "${CLUSTER_NAME}" --region "${REGION}")"
+  OIDC_ISSUER="$(printf '%s' "${CLUSTER_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["cluster"]["identity"]["oidc"]["issuer"])')"
+  VPC_ID="$(printf '%s' "${CLUSTER_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["cluster"]["resourcesVpcConfig"]["vpcId"])')"
+  CLUSTER_SUBNETS="$(printf '%s' "${CLUSTER_JSON}" | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin)["cluster"]["resourcesVpcConfig"]["subnetIds"]))')"
+  VPC_CIDR="$(aws ec2 describe-vpcs --vpc-ids "${VPC_ID}" --region "${REGION}" --query 'Vpcs[0].CidrBlock' --output text)"
+fi
+OIDC_PROVIDER_HOSTPATH="${OIDC_ISSUER#https://}"
+OIDC_PROVIDER_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER_HOSTPATH}"
+PRIVATE_SUBNET_IDS="$(python3 - <<PY
+subnets = "${CLUSTER_SUBNETS}".split()
+print("[{}]".format(", ".join(f'"{s}"' for s in subnets)))
+PY
+)"
+
+TF_MAIN="${TF_ROOT}/main.tf"
+cat >"${TF_MAIN}" <<EOF
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+provider "aws" {
+  region = "${REGION}"
+}
+
+module "agent_bom_baseline" {
+  source = "${ROOT_DIR}/deploy/terraform/aws/baseline"
+
+  name                      = "${CLUSTER_NAME}"
+  namespace                 = "${NAMESPACE}"
+  release_name              = "${RELEASE_NAME}"
+  cluster_oidc_provider_arn = "${OIDC_PROVIDER_ARN}"
+  cluster_oidc_issuer_url   = "${OIDC_ISSUER}"
+  vpc_id                    = "${VPC_ID}"
+  private_subnet_ids        = ${PRIVATE_SUBNET_IDS}
+  db_allowed_cidr_blocks    = ["${VPC_CIDR}"]
+  db_url_secret_name        = "${RELEASE_NAME}/control-plane-db"
+  auth_secret_name          = "${RELEASE_NAME}/control-plane-auth"
+
+  tags = {
+    Environment = "reference"
+    ManagedBy   = "agent-bom-reference-installer"
+    Cluster     = "${CLUSTER_NAME}"
+  }
+}
+EOF
+
+log "Applying Terraform AWS baseline"
+run "${TERRAFORM_BIN}" -chdir="${TF_ROOT}" init
+run "${TERRAFORM_BIN}" -chdir="${TF_ROOT}" apply -auto-approve
+
+HELM_VALUES_HINT="${GENERATED_DIR}/baseline-values.yaml"
+if [ "$DRY_RUN" -eq 1 ]; then
+  cat >"${HELM_VALUES_HINT}" <<'EOF'
+# Dry-run placeholder. A real run writes Terraform-derived Helm values here.
+EOF
+else
+  "${TERRAFORM_BIN}" -chdir="${TF_ROOT}" output -raw helm_values_hint >"${HELM_VALUES_HINT}"
+fi
+
+DB_SECRET_ARN=""
+DB_URL_SECRET_NAME=""
+AUTH_SECRET_NAME=""
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  DB_SECRET_ARN="$("${TERRAFORM_BIN}" -chdir="${TF_ROOT}" output -raw db_secret_arn 2>/dev/null || true)"
+  DB_URL_SECRET_NAME="$("${TERRAFORM_BIN}" -chdir="${TF_ROOT}" output -raw db_url_secret_name 2>/dev/null || true)"
+  AUTH_SECRET_NAME="$("${TERRAFORM_BIN}" -chdir="${TF_ROOT}" output -raw auth_secret_name 2>/dev/null || true)"
+fi
+
+API_KEY=""
+AUDIT_HMAC=""
+GATEWAY_TOKEN=""
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  [ -n "${DB_SECRET_ARN}" ] || die "terraform did not return db_secret_arn"
+  DB_SECRET_JSON="$(aws secretsmanager get-secret-value --secret-id "${DB_SECRET_ARN}" --region "${REGION}" --query SecretString --output text)"
+  DB_URL="$(printf '%s' "${DB_SECRET_JSON}" | python3 - <<'PY'
+import json
+import sys
+from urllib.parse import quote
+
+payload = json.load(sys.stdin)
+username = quote(str(payload["username"]))
+password = quote(str(payload["password"]))
+host = payload["host"]
+port = payload["port"]
+dbname = payload.get("dbname") or payload.get("dbInstanceIdentifier") or "agent_bom"
+print(f"postgresql://{username}:{password}@{host}:{port}/{dbname}")
+PY
+)"
+
+  API_KEY="$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(32))
+PY
+)"
+  AUDIT_HMAC="$(python3 - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+)"
+
+  log "Creating namespace and control-plane secrets"
+  kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n "${NAMESPACE}" create secret generic agent-bom-control-plane-db \
+    --from-literal=AGENT_BOM_POSTGRES_URL="${DB_URL}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n "${NAMESPACE}" create secret generic agent-bom-control-plane-auth \
+    --from-literal=AGENT_BOM_API_KEY="${API_KEY}" \
+    --from-literal=AGENT_BOM_AUDIT_HMAC_KEY="${AUDIT_HMAC}" \
+    --from-literal=AGENT_BOM_REQUIRE_AUDIT_HMAC=1 \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  if [ -n "${DB_URL_SECRET_NAME}" ]; then
+    aws secretsmanager put-secret-value \
+      --region "${REGION}" \
+      --secret-id "${DB_URL_SECRET_NAME}" \
+      --secret-string "{\"AGENT_BOM_POSTGRES_URL\":\"${DB_URL}\"}" >/dev/null
+  fi
+
+  if [ -n "${AUTH_SECRET_NAME}" ]; then
+    aws secretsmanager put-secret-value \
+      --region "${REGION}" \
+      --secret-id "${AUTH_SECRET_NAME}" \
+      --secret-string "{\"AGENT_BOM_API_KEY\":\"${API_KEY}\",\"AGENT_BOM_AUDIT_HMAC_KEY\":\"${AUDIT_HMAC}\",\"AGENT_BOM_REQUIRE_AUDIT_HMAC\":\"1\"}" >/dev/null
+  fi
+fi
+
+INSTALL_OVERRIDES="${GENERATED_DIR}/install-overrides.yaml"
+cat >"${INSTALL_OVERRIDES}" <<EOF
+controlPlane:
+  externalSecrets:
+    enabled: false
+  api:
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane-db
+      - secretRef:
+          name: agent-bom-control-plane-auth
+  ingress:
+    enabled: $( [ -n "${HOSTNAME}" ] && printf true || printf false )
+$( [ -n "${HOSTNAME}" ] && cat <<YAML
+    className: ${INGRESS_CLASS}
+    hosts:
+      - host: ${HOSTNAME}
+YAML
+)
+gateway:
+  enabled: $( [ "$ENABLE_GATEWAY" -eq 1 ] && printf true || printf false )
+EOF
+
+if [ "$ENABLE_GATEWAY" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+  GATEWAY_TOKEN="$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(32))
+PY
+)"
+  kubectl -n "${NAMESPACE}" create secret generic agent-bom-gateway-auth \
+    --from-literal=AGENT_BOM_GATEWAY_BEARER_TOKEN="${GATEWAY_TOKEN}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  cat >>"${INSTALL_OVERRIDES}" <<'EOF'
+  envFrom:
+    - secretRef:
+        name: agent-bom-gateway-auth
+EOF
+fi
+
+log "Installing Helm chart"
+run python3 "${ROOT_DIR}/scripts/install_helm_profile.py" production \
+  --release "${RELEASE_NAME}" \
+  --namespace "${NAMESPACE}" \
+  --values "${HELM_VALUES_HINT}" \
+  --values "${INSTALL_OVERRIDES}"
+
+BASE_URL="http://localhost:8080"
+if [ -n "${HOSTNAME}" ]; then
+  BASE_URL="https://${HOSTNAME}"
+fi
+
+SUMMARY="${GENERATED_DIR}/operator-summary.txt"
+cat >"${SUMMARY}" <<EOF
+agent-bom reference install complete
+
+cluster: ${CLUSTER_NAME}
+region: ${REGION}
+namespace: ${NAMESPACE}
+release: ${RELEASE_NAME}
+base url: ${BASE_URL}
+terraform dir: ${TF_ROOT}
+helm values: ${HELM_VALUES_HINT}
+install overrides: ${INSTALL_OVERRIDES}
+mode: $( [ "$DRY_RUN" -eq 1 ] && printf dry-run || printf applied )
+EOF
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  {
+    echo
+    echo "Dashboard:"
+    if [ -n "${HOSTNAME}" ]; then
+      echo "  ${BASE_URL}"
+    else
+      echo "  kubectl -n ${NAMESPACE} port-forward svc/${RELEASE_NAME}-ui 3000:3000"
+      echo "  kubectl -n ${NAMESPACE} port-forward svc/${RELEASE_NAME}-api 8080:8422"
+    fi
+    echo
+    echo "Operator API key:"
+    echo "  ${API_KEY}"
+    if [ "$ENABLE_FLEET" -eq 1 ]; then
+      echo
+      echo "Endpoint onboarding bundle:"
+      echo "  agent-bom proxy-bootstrap --bundle-dir ./agent-bom-endpoint-bundle \\"
+      echo "    --control-plane-url ${BASE_URL} \\"
+      echo "    --control-plane-token ${API_KEY} \\"
+      echo "    --push-url ${BASE_URL}/v1/fleet/sync \\"
+      echo "    --push-api-key ${API_KEY}"
+    fi
+    if [ "$ENABLE_GATEWAY" -eq 1 ]; then
+      echo
+      echo "Gateway bearer token:"
+      echo "  ${GATEWAY_TOKEN}"
+      echo "Gateway rollout:"
+      echo "  customize deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml"
+      echo "  then re-run Helm with --set-file gateway.upstreamsYaml=./my-upstreams.yaml"
+    fi
+  } | tee -a "${SUMMARY}"
+else
+  {
+    echo
+    echo "Dry run only. No AWS, Kubernetes, or Helm resources were changed."
+    echo "Inspect the generated Terraform root and Helm values files, then rerun without --dry-run."
+  } | tee -a "${SUMMARY}"
+fi
+
+log "Reference install outputs written to ${SUMMARY}"

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -1,0 +1,279 @@
+# AWS Company Rollout
+
+Use this guide when the question is not just "how do I install `agent-bom`?" but
+"how would a company deploy `agent-bom` in AWS/EKS for fleet, gateway, proxy, and
+control-plane workflows?"
+
+This is a **reference rollout path** for self-hosted `agent-bom` on AWS:
+
+- the company platform team still owns the AWS account, VPC, EKS cluster, ingress, cert-manager, and shared controllers
+- `agent-bom` owns the product-specific baseline around that platform: Postgres, IRSA, backup bucket, auth secrets, Helm release, fleet onboarding, and optional gateway runtime
+
+`agent-bom` stays one product with two deployable images:
+
+- `agentbom/agent-bom` for scanner, API, jobs, proxy, gateway, and workers
+- `agentbom/agent-bom-ui` for the browser dashboard
+
+## Reference Entry Points
+
+Pilot on one workstation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+```
+
+Reference AWS/EKS rollout:
+
+```bash
+scripts/deploy/install-eks-reference.sh \
+  --create-cluster \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --hostname agent-bom.internal.example.com \
+  --enable-gateway
+```
+
+If the company already has an EKS platform, reuse it:
+
+```bash
+scripts/deploy/install-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --hostname agent-bom.internal.example.com \
+  --enable-gateway
+```
+
+## What The Installer Owns
+
+The reference installer at `scripts/deploy/install-eks-reference.sh` is intentionally opinionated:
+
+1. Optionally creates a reference EKS cluster with `eksctl`
+2. Applies the `agent-bom` AWS baseline Terraform module
+3. Creates the product secrets needed by the Helm release
+4. Installs the packaged Helm chart with production profile defaults
+5. Prints next-step commands for fleet onboarding and gateway rollout
+
+It does **not** try to replace a customer's full AWS platform stack. Keep these as platform-owned:
+
+- corporate VPC topology and networking policy
+- DNS and ingress controller strategy
+- cert-manager and certificate issuance
+- shared logging, SIEM, and OTLP collectors
+- ExternalSecrets controller or other shared secret operators
+- organization-wide IAM, SCP, and account guardrails
+
+## Deployment Shape
+
+```mermaid
+flowchart LR
+    subgraph AWS["Customer AWS account"]
+      subgraph Platform["Company platform-owned layer"]
+        VPC["VPC / subnets / route tables"]
+        EKS["EKS cluster"]
+        Ingress["Ingress controller + DNS + TLS"]
+        Controllers["Shared controllers<br/>cert-manager / ExternalSecrets / observability"]
+      end
+
+      subgraph AgentBom["agent-bom product-owned layer"]
+        TF["AWS baseline<br/>Terraform module"]
+        RDS["RDS Postgres"]
+        S3["S3 backup bucket"]
+        IAM["IRSA roles"]
+        Secrets["Secrets Manager"]
+        Helm["agent-bom Helm release"]
+        API["API/runtime image"]
+        UI["UI image"]
+        Jobs["Scan jobs / workers"]
+        Gateway["Optional gateway"]
+      end
+    end
+
+    VPC --> EKS
+    Ingress --> EKS
+    Controllers --> EKS
+    TF --> RDS
+    TF --> S3
+    TF --> IAM
+    TF --> Secrets
+    TF --> Helm
+    Helm --> API
+    Helm --> UI
+    Helm --> Jobs
+    Helm --> Gateway
+    API --> RDS
+    Jobs --> RDS
+    API --> S3
+    API --> Secrets
+    API --> IAM
+```
+
+This is the clean ownership model:
+
+- **platform team** provides a compliant EKS landing zone
+- **`agent-bom` installer** wires the product-specific AWS and Kubernetes pieces on top
+- **security/platform operators** onboard endpoints and selected MCP runtimes after the control plane is live
+
+## Runtime Flow For Fleet, Proxy, And Gateway
+
+```mermaid
+flowchart LR
+    subgraph Endpoints["Developer laptops / workstations"]
+      IDE["Cursor / Claude / IDE"]
+      Proxy["agent-bom proxy"]
+      Fleet["Fleet sync push"]
+    end
+
+    subgraph Cluster["Customer EKS"]
+      UI["Browser UI"]
+      API["Control-plane API"]
+      GW["Gateway"]
+      Jobs["Scheduled scans / workers"]
+      ProxySidecar["Optional proxy sidecars"]
+      DB["Postgres"]
+    end
+
+    subgraph Upstreams["Remote MCP / registries / cloud APIs"]
+      MCP["Remote MCP upstreams"]
+      Cloud["Cloud / repo / image targets"]
+    end
+
+    IDE --> Proxy
+    Proxy -->|policy pull + audit push| API
+    Proxy -->|runtime MCP relay| GW
+    Fleet -->|/v1/fleet/sync| API
+    GW --> MCP
+    Jobs --> Cloud
+    Jobs --> API
+    ProxySidecar --> GW
+    API --> DB
+    GW --> API
+    UI --> API
+```
+
+What this means in practice:
+
+- developer endpoints can push fleet inventory and use `agent-bom proxy` as a local MCP wrapper
+- selected MCP workloads in-cluster can run with `agent-bom proxy` sidecars
+- the gateway is optional and centralizes policy/audit for shared upstreams
+- the control plane persists findings, graph, fleet state, auth, and audit inside the customer's infrastructure
+
+## Recommended Rollout Sequence
+
+### 1. Company platform baseline
+
+Start with one of these shapes:
+
+- existing EKS platform: preferred for real companies
+- reference EKS cluster from the installer: good for evaluation, pilot, and demos
+
+Before installing `agent-bom`, confirm:
+
+- `kubectl` access to the target cluster
+- ingress controller strategy is known
+- DNS / hostname decision is known, or accept port-forward for first bring-up
+- AWS account permissions can create RDS, S3, IAM roles, and Secrets Manager entries
+
+### 2. Product-specific AWS baseline
+
+Run the reference installer or the Terraform module directly:
+
+```bash
+scripts/deploy/install-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --hostname agent-bom.internal.example.com \
+  --enable-gateway
+```
+
+Under the hood this uses the baseline in `deploy/terraform/aws/baseline` to create:
+
+- RDS Postgres for the control plane
+- S3 backup bucket
+- IRSA roles for scan and backup jobs
+- Secrets Manager containers for DB/auth wiring
+
+### 3. Helm release on EKS
+
+The installer then applies the production Helm profile plus generated overrides:
+
+- UI and API/runtime images behind one same-origin entrypoint
+- scheduled jobs and workers
+- optional gateway
+- auth and DB secrets wired from generated values
+
+For manual control, use the packaged chart directly:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
+See also:
+
+- [Your Own AWS / EKS](own-infra-eks.md)
+- [Terraform AWS Baseline](terraform-aws-baseline.md)
+- [Packaged API + UI Control Plane](control-plane-helm.md)
+
+### 4. Endpoint and runtime onboarding
+
+After the control plane is live, onboard people and workloads, not just pods:
+
+- use `agent-bom proxy-bootstrap` to generate endpoint onboarding bundles
+- point MCP clients at the local `agent-bom proxy` wrapper
+- enable fleet sync for workstation visibility
+- add proxy sidecars only to workloads that need inline MCP policy enforcement
+- enable the gateway when you need shared upstream policy and audit
+
+Typical endpoint bootstrap:
+
+```bash
+agent-bom proxy-bootstrap \
+  --bundle-dir ./agent-bom-endpoint-bundle \
+  --control-plane-url https://agent-bom.internal.example.com \
+  --control-plane-token <api-key> \
+  --push-url https://agent-bom.internal.example.com/v1/fleet/sync \
+  --push-api-key <api-key>
+```
+
+## What Operators Get After Deploy
+
+The goal is not just "pods are running." The goal is one coherent operator plane:
+
+- `/` for findings, graph, remediation, and operator workflows
+- `/fleet` for workstation and collector inventory
+- `/audit` for signed audit and auth workflows
+- `/gateway` and runtime views for policy/audit surfaces when enabled
+- one deployment story for pilot and production instead of two unrelated stacks
+
+## Dry-Run And Ownership Notes
+
+The reference installer supports `--dry-run` so teams can see the generated
+Terraform root, Helm values, and operator summary before any apply:
+
+```bash
+scripts/deploy/install-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --hostname agent-bom.internal.example.com \
+  --enable-gateway \
+  --dry-run
+```
+
+Use that mode when:
+
+- security wants to review what the installer owns
+- platform wants to compare the reference shape to their internal landing zone
+- you want to adapt the installer into your own wrappers without changing the product model
+
+## Recommended Positioning
+
+Use this wording consistently:
+
+> `agent-bom` is one self-hosted control plane for AI and MCP supply-chain
+> security. In AWS/EKS, the company platform owns the cluster and shared
+> controllers; `agent-bom` owns the product-specific baseline, Helm release,
+> fleet onboarding, and optional gateway/runtime surfaces.
+
+That keeps the architecture honest and the deployment story simple.

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -251,6 +251,7 @@ YAML.
 
 ## Start Here
 
+- [AWS Company Rollout](aws-company-rollout.md)
 - [Your Own AWS / EKS](own-infra-eks.md)
 - [Enterprise MCP / Endpoint Pilot](enterprise-pilot.md)
 - [Endpoint Fleet](endpoint-fleet.md)


### PR DESCRIPTION
Summary
- add scripts/deploy/install-eks-reference.sh as an opinionated reference installer for self-hosted agent-bom on AWS / EKS
- add an AWS company rollout guide with infrastructure and runtime flow diagrams
- wire the new rollout path into the deployment docs nav and overview

Testing
- bash -n scripts/deploy/install-eks-reference.sh
- scripts/deploy/install-eks-reference.sh --cluster-name corp-ai --region us-east-1 --hostname agent-bom.internal.example.com --enable-gateway --dry-run
- uv run mkdocs build --strict

Notes
- the reference installer intentionally layers on top of an existing company platform model; it can create a reference cluster with eksctl, but it does not replace ingress, DNS, cert-manager, or other shared platform controllers
- Terraform CLI is still not installed in this environment, so this PR validates the generated installer path via dry-run and docs build, not terraform fmt/validate