### PR TITLE
feat(deploy): add teardown helper for AWS EKS installs

### DIFF
--- a/scripts/deploy/teardown-eks-reference.sh
+++ b/scripts/deploy/teardown-eks-reference.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PYTHONPATH="${ROOT_DIR}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec python3 -m agent_bom.deploy_teardown "$@"

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -20,6 +20,20 @@ cluster, pair this chart with the
 own RDS, S3, IAM/IRSA, and Secrets Manager; Helm should own the in-cluster
 Deployments, CronJobs, and ExternalSecret objects.
 
+The reverse path is now explicit too:
+
+```bash
+agent-bom teardown \
+  --cluster-name agent-bom-prod \
+  --region us-east-1 \
+  --namespace agent-bom \
+  --release agent-bom \
+  --dry-run
+```
+
+That helper tears down the chart first and the product-owned Terraform baseline
+second, while leaving platform-owned cluster infrastructure alone.
+
 ## What the chart deploys
 
 When you set `controlPlane.enabled=true`, the Helm chart can package:

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -215,6 +215,22 @@ For teams that want Terraform to own the AWS baseline around the chart, use the
 backup bucket, and Secrets Manager ownership, then let Helm own the in-cluster
 workloads.
 
+For decommissioning, use the packaged reverse path instead of ad hoc `helm uninstall`
+plus cloud cleanup:
+
+```bash
+agent-bom teardown \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --namespace agent-bom \
+  --release agent-bom \
+  --dry-run
+```
+
+That helper only removes product-owned `agent-bom` surfaces. It does not
+delete the EKS cluster, ingress controller, VPC, or other platform-owned
+infrastructure.
+
 ## Recommended Topology
 
 Use two layers.

--- a/site-docs/deployment/terraform-aws-baseline.md
+++ b/site-docs/deployment/terraform-aws-baseline.md
@@ -80,17 +80,52 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 
 ## Destroy flow
 
-Use a two-phase decommission:
+Use the packaged teardown helper for the supported reverse path:
 
-1. `helm uninstall agent-bom -n agent-bom`
-2. wait for pods, CronJobs, and ExternalSecrets to disappear
-3. `terraform destroy`
+```bash
+agent-bom teardown \
+  --cluster-name agent-bom-prod \
+  --region us-east-1 \
+  --namespace agent-bom \
+  --release agent-bom \
+  --yes
+```
+
+The helper does the same two-phase decommission in the correct order:
+
+1. uninstall the Helm release
+2. wait for in-cluster workloads to disappear
+3. destroy the product-owned Terraform baseline
+
+If you want to inspect the plan first:
+
+```bash
+agent-bom teardown \
+  --cluster-name agent-bom-prod \
+  --region us-east-1 \
+  --namespace agent-bom \
+  --release agent-bom \
+  --dry-run
+```
+
+For teams working directly from a checked-out repo, the equivalent wrapper is:
+
+```bash
+scripts/deploy/teardown-eks-reference.sh --cluster-name agent-bom-prod --region us-east-1 --dry-run
+```
 
 That ordering avoids:
 
 - backup jobs still writing to S3 while the bucket is being removed
 - live pods holding IRSA assumptions while IAM roles are deleted
 - live API pods trying to reconnect to an RDS instance Terraform is tearing down
+
+The teardown helper intentionally does **not** delete platform-owned shared infrastructure such as:
+
+- the EKS cluster itself
+- VPC and subnet topology
+- ingress controllers, DNS, or cert-manager
+- shared ExternalSecrets or OTLP controllers
 
 ## What this does not do
 

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -264,6 +264,13 @@ from agent_bom.cli._doctor import doctor_cmd  # noqa: E402
 main.add_command(doctor_cmd, "doctor")
 
 # ---------------------------------------------------------------------------
+# Deployment lifecycle command
+# ---------------------------------------------------------------------------
+from agent_bom.cli._deploy import teardown_cmd  # noqa: E402
+
+main.add_command(teardown_cmd, "teardown")
+
+# ---------------------------------------------------------------------------
 # Remediate command
 # ---------------------------------------------------------------------------
 from agent_bom.cli._remediate import remediate_cmd  # noqa: E402

--- a/src/agent_bom/cli/_deploy.py
+++ b/src/agent_bom/cli/_deploy.py
@@ -1,0 +1,94 @@
+"""Deployment lifecycle helper commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from agent_bom.deploy_teardown import (
+    DEFAULT_STATE_DIR,
+    build_reference_teardown_plan,
+    execute_teardown_plan,
+    format_teardown_plan,
+    resolve_terraform_bin,
+    validate_teardown_plan,
+)
+
+
+@click.command("teardown")
+@click.option("--cluster-name", default="agent-bom", show_default=True, help="EKS cluster name used for local state resolution")
+@click.option("--region", default="us-east-1", show_default=True, help="AWS region shown in the operator summary")
+@click.option("--namespace", default="agent-bom", show_default=True, help="Kubernetes namespace containing the release")
+@click.option("--release", "release_name", default="agent-bom", show_default=True, help="Helm release name")
+@click.option(
+    "--state-dir",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_STATE_DIR,
+    show_default=True,
+    help="Local state root used by the AWS/EKS reference installer",
+)
+@click.option("--delete-namespace", is_flag=True, help="Delete the namespace after Helm uninstall completes")
+@click.option("--delete-local-state", is_flag=True, help="Delete the generated local state after teardown")
+@click.option("--skip-helm-uninstall", is_flag=True, help="Skip the Helm uninstall phase")
+@click.option("--skip-terraform-destroy", is_flag=True, help="Skip the Terraform destroy phase")
+@click.option("--wait-timeout-seconds", type=int, default=180, show_default=True, help="How long kubectl wait should block")
+@click.option("--dry-run", is_flag=True, help="Print the teardown plan without changing anything")
+@click.option("--yes", "assume_yes", is_flag=True, help="Skip the interactive confirmation prompt")
+def teardown_cmd(
+    cluster_name: str,
+    region: str,
+    namespace: str,
+    release_name: str,
+    state_dir: Path,
+    delete_namespace: bool,
+    delete_local_state: bool,
+    skip_helm_uninstall: bool,
+    skip_terraform_destroy: bool,
+    wait_timeout_seconds: int,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    """Tear down the AWS/EKS reference install owned by agent-bom.
+
+    This command intentionally removes only product-owned surfaces:
+    - Helm release resources
+    - product-owned AWS baseline resources managed by Terraform
+    - optional local generated installer state
+
+    It does not delete the EKS cluster, VPC, ingress controller, DNS, or
+    other platform-owned shared infrastructure.
+    """
+
+    plan = build_reference_teardown_plan(
+        cluster_name=cluster_name,
+        region=region,
+        namespace=namespace,
+        release_name=release_name,
+        state_dir=state_dir,
+        delete_namespace=delete_namespace,
+        delete_local_state=delete_local_state,
+        skip_helm_uninstall=skip_helm_uninstall,
+        skip_terraform_destroy=skip_terraform_destroy,
+        wait_timeout_seconds=wait_timeout_seconds,
+        terraform_bin=resolve_terraform_bin(),
+    )
+    errors = validate_teardown_plan(plan, dry_run=dry_run)
+    if errors:
+        raise click.ClickException("\n".join(errors))
+
+    summary = format_teardown_plan(plan)
+    click.echo(summary)
+
+    if dry_run:
+        execute_teardown_plan(plan, dry_run=True)
+        return
+
+    if not assume_yes and not click.confirm("\nProceed with the agent-bom teardown plan?", default=False):
+        raise click.ClickException("teardown aborted")
+
+    execute_teardown_plan(plan, dry_run=False)
+    if delete_local_state:
+        click.echo("\nTeardown completed. Local generated state was deleted after execution.")
+    else:
+        click.echo(f"\nTeardown summary written to {plan.summary_path}")

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -28,7 +28,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "Governance",
-            ["policy", "fleet", "serve", "api", "schedule", "remediate"],
+            ["policy", "fleet", "serve", "api", "schedule", "remediate", "teardown"],
         ),
         (
             "Database",

--- a/src/agent_bom/deploy_teardown.py
+++ b/src/agent_bom/deploy_teardown.py
@@ -1,0 +1,270 @@
+"""Helpers for tearing down the self-hosted AWS/EKS reference install."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_STATE_DIR = Path.home() / ".agent-bom" / "eks-reference"
+PLATFORM_OWNED_SURFACES = (
+    "EKS cluster and node groups",
+    "VPC, subnets, route tables, and security baselines",
+    "Ingress controller, DNS, and TLS/cert-manager",
+    "Shared controllers such as ExternalSecrets and OTLP collectors",
+)
+
+
+@dataclass(frozen=True)
+class CommandStep:
+    label: str
+    command: tuple[str, ...]
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class TeardownPlan:
+    cluster_name: str
+    region: str
+    namespace: str
+    release_name: str
+    state_root: Path
+    terraform_root: Path
+    generated_dir: Path
+    summary_path: Path
+    helm_uninstall: CommandStep | None
+    helm_wait: CommandStep | None
+    namespace_delete: CommandStep | None
+    terraform_destroy: CommandStep | None
+    local_state_delete: CommandStep | None
+    platform_owned_surfaces: tuple[str, ...]
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_terraform_bin() -> str | None:
+    return shutil.which("terraform") or shutil.which("tofu")
+
+
+def build_reference_teardown_plan(
+    *,
+    cluster_name: str,
+    region: str,
+    namespace: str,
+    release_name: str,
+    state_dir: Path = DEFAULT_STATE_DIR,
+    delete_namespace: bool = False,
+    delete_local_state: bool = False,
+    skip_helm_uninstall: bool = False,
+    skip_terraform_destroy: bool = False,
+    wait_timeout_seconds: int = 180,
+    terraform_bin: str | None = None,
+) -> TeardownPlan:
+    """Build a teardown plan for the AWS/EKS reference deployment."""
+
+    state_root = state_dir / cluster_name
+    terraform_root = state_root / "terraform"
+    generated_dir = state_root / "generated"
+    summary_path = generated_dir / "teardown-summary.txt"
+
+    helm_uninstall = None
+    helm_wait = None
+    namespace_delete_step = None
+    terraform_destroy = None
+    local_state_delete_step = None
+
+    if not skip_helm_uninstall:
+        helm_uninstall = CommandStep(
+            label="Uninstall the Helm release",
+            command=("helm", "uninstall", release_name, "--namespace", namespace),
+        )
+        helm_wait = CommandStep(
+            label="Wait for pods and jobs in the namespace to disappear",
+            command=(
+                "kubectl",
+                "wait",
+                "--for=delete",
+                "pod,job",
+                "--all",
+                "--namespace",
+                namespace,
+                f"--timeout={max(1, wait_timeout_seconds)}s",
+            ),
+            required=False,
+        )
+        if delete_namespace:
+            namespace_delete_step = CommandStep(
+                label="Delete the dedicated namespace after Helm resources are gone",
+                command=("kubectl", "delete", "namespace", namespace, "--ignore-not-found=true"),
+                required=False,
+            )
+
+    if not skip_terraform_destroy:
+        terraform_exec = terraform_bin or "terraform"
+        terraform_destroy = CommandStep(
+            label="Destroy the product-owned AWS baseline",
+            command=(terraform_exec, f"-chdir={terraform_root}", "destroy", "-auto-approve"),
+            required=True,
+        )
+
+    if delete_local_state:
+        local_state_delete_step = CommandStep(
+            label="Delete the local generated state and summaries",
+            command=("rm", "-rf", str(state_root)),
+            required=False,
+        )
+
+    return TeardownPlan(
+        cluster_name=cluster_name,
+        region=region,
+        namespace=namespace,
+        release_name=release_name,
+        state_root=state_root,
+        terraform_root=terraform_root,
+        generated_dir=generated_dir,
+        summary_path=summary_path,
+        helm_uninstall=helm_uninstall,
+        helm_wait=helm_wait,
+        namespace_delete=namespace_delete_step,
+        terraform_destroy=terraform_destroy,
+        local_state_delete=local_state_delete_step,
+        platform_owned_surfaces=PLATFORM_OWNED_SURFACES,
+    )
+
+
+def _format_step(step: CommandStep | None) -> list[str]:
+    if step is None:
+        return []
+    rendered = shlex.join(step.command)
+    suffix = "" if step.required else " (best effort)"
+    return [f"- {step.label}{suffix}", f"  {rendered}"]
+
+
+def format_teardown_plan(plan: TeardownPlan) -> str:
+    """Render the teardown plan for operators."""
+
+    lines = [
+        "agent-bom teardown plan",
+        "",
+        f"cluster: {plan.cluster_name}",
+        f"region: {plan.region}",
+        f"namespace: {plan.namespace}",
+        f"release: {plan.release_name}",
+        f"terraform dir: {plan.terraform_root}",
+        f"summary: {plan.summary_path}",
+        "",
+        "Will remove:",
+    ]
+    for step in (
+        plan.helm_uninstall,
+        plan.helm_wait,
+        plan.namespace_delete,
+        plan.terraform_destroy,
+        plan.local_state_delete,
+    ):
+        lines.extend(_format_step(step))
+    lines.extend(
+        [
+            "",
+            "Platform-owned surfaces left untouched:",
+        ]
+    )
+    for item in plan.platform_owned_surfaces:
+        lines.append(f"- {item}")
+    return "\n".join(lines)
+
+
+def validate_teardown_plan(plan: TeardownPlan, *, dry_run: bool = False) -> list[str]:
+    """Return a list of plan validation errors."""
+
+    errors: list[str] = []
+    if not dry_run:
+        if plan.helm_uninstall is not None and shutil.which("helm") is None:
+            errors.append("helm is required to uninstall the release")
+        if (plan.helm_wait is not None or plan.namespace_delete is not None) and shutil.which("kubectl") is None:
+            errors.append("kubectl is required for namespace wait/delete operations")
+        if plan.terraform_destroy is not None:
+            terraform_exec = plan.terraform_destroy.command[0]
+            if shutil.which(terraform_exec) is None:
+                errors.append(f"{terraform_exec} is required to destroy the AWS baseline")
+            if not plan.terraform_root.exists():
+                errors.append(f"terraform root does not exist: {plan.terraform_root}")
+    return errors
+
+
+def _run_step(step: CommandStep, *, dry_run: bool) -> None:
+    if dry_run:
+        sys.stdout.write(f"+ {shlex.join(step.command)}\n")
+        return
+    subprocess.run(step.command, check=step.required)
+
+
+def execute_teardown_plan(plan: TeardownPlan, *, dry_run: bool = False) -> str:
+    """Execute or print the teardown plan and return the rendered summary."""
+
+    summary = format_teardown_plan(plan)
+    plan.generated_dir.mkdir(parents=True, exist_ok=True)
+    plan.summary_path.write_text(summary + "\n", encoding="utf-8")
+    for step in (
+        plan.helm_uninstall,
+        plan.helm_wait,
+        plan.namespace_delete,
+        plan.terraform_destroy,
+        plan.local_state_delete,
+    ):
+        if step is not None:
+            _run_step(step, dry_run=dry_run)
+    return summary
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cluster-name", default="agent-bom", help="EKS cluster name (used to resolve local state)")
+    parser.add_argument("--region", default="us-east-1", help="AWS region for operator context (summary only)")
+    parser.add_argument("--namespace", default="agent-bom", help="Kubernetes namespace containing the release")
+    parser.add_argument("--release", default="agent-bom", help="Helm release name")
+    parser.add_argument("--state-dir", type=Path, default=DEFAULT_STATE_DIR, help="Local state root used by the reference installer")
+    parser.add_argument("--delete-namespace", action="store_true", help="Delete the namespace after Helm uninstall")
+    parser.add_argument("--delete-local-state", action="store_true", help="Delete local generated state after teardown")
+    parser.add_argument("--skip-helm-uninstall", action="store_true", help="Skip the Helm uninstall phase")
+    parser.add_argument("--skip-terraform-destroy", action="store_true", help="Skip the Terraform destroy phase")
+    parser.add_argument("--wait-timeout-seconds", type=int, default=180, help="How long kubectl wait should block")
+    parser.add_argument("--dry-run", action="store_true", help="Print the plan and commands without running them")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+
+    plan = build_reference_teardown_plan(
+        cluster_name=args.cluster_name,
+        region=args.region,
+        namespace=args.namespace,
+        release_name=args.release,
+        state_dir=args.state_dir,
+        delete_namespace=args.delete_namespace,
+        delete_local_state=args.delete_local_state,
+        skip_helm_uninstall=args.skip_helm_uninstall,
+        skip_terraform_destroy=args.skip_terraform_destroy,
+        wait_timeout_seconds=args.wait_timeout_seconds,
+        terraform_bin=resolve_terraform_bin(),
+    )
+    errors = validate_teardown_plan(plan, dry_run=args.dry_run)
+    if errors:
+        for error in errors:
+            sys.stderr.write(f"error: {error}\n")
+        return 1
+    sys.stdout.write(f"{format_teardown_plan(plan)}\n")
+    execute_teardown_plan(plan, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_teardown.py
+++ b/tests/test_deploy_teardown.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+from agent_bom.deploy_teardown import (
+    build_reference_teardown_plan,
+    format_teardown_plan,
+    validate_teardown_plan,
+)
+
+
+def test_build_reference_teardown_plan_formats_expected_steps(tmp_path: Path):
+    plan = build_reference_teardown_plan(
+        cluster_name="corp-ai",
+        region="us-east-1",
+        namespace="agent-bom",
+        release_name="agent-bom",
+        state_dir=tmp_path,
+        delete_namespace=True,
+        delete_local_state=True,
+        terraform_bin="terraform",
+    )
+
+    rendered = format_teardown_plan(plan)
+    assert "helm uninstall agent-bom --namespace agent-bom" in rendered
+    assert "kubectl delete namespace agent-bom --ignore-not-found=true" in rendered
+    assert f"terraform -chdir={tmp_path / 'corp-ai' / 'terraform'} destroy -auto-approve" in rendered
+    assert "Platform-owned surfaces left untouched:" in rendered
+    assert "EKS cluster and node groups" in rendered
+
+
+def test_validate_teardown_plan_reports_missing_binaries_and_state(tmp_path: Path, monkeypatch):
+    plan = build_reference_teardown_plan(
+        cluster_name="corp-ai",
+        region="us-east-1",
+        namespace="agent-bom",
+        release_name="agent-bom",
+        state_dir=tmp_path,
+        terraform_bin="terraform",
+    )
+
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    errors = validate_teardown_plan(plan, dry_run=False)
+
+    assert "helm is required to uninstall the release" in errors
+    assert "kubectl is required for namespace wait/delete operations" in errors
+    assert "terraform is required to destroy the AWS baseline" in errors
+    assert f"terraform root does not exist: {tmp_path / 'corp-ai' / 'terraform'}" in errors
+
+
+def test_cli_teardown_dry_run_writes_summary(tmp_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "teardown",
+            "--cluster-name",
+            "corp-ai",
+            "--region",
+            "us-east-1",
+            "--state-dir",
+            str(tmp_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "agent-bom teardown plan" in result.output
+    assert "+ helm uninstall agent-bom --namespace agent-bom" in result.output
+    assert "+ terraform" in result.output
+    assert (tmp_path / "corp-ai" / "generated" / "teardown-summary.txt").exists()
+
+
+def test_cli_teardown_runs_expected_commands(tmp_path: Path, monkeypatch):
+    terraform_root = tmp_path / "corp-ai" / "terraform"
+    terraform_root.mkdir(parents=True)
+
+    commands: list[tuple[str, ...]] = []
+
+    def fake_run(cmd: tuple[str, ...] | list[str], check: bool = True):
+        commands.append(tuple(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("shutil.which", lambda name: name)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "teardown",
+            "--cluster-name",
+            "corp-ai",
+            "--region",
+            "us-east-1",
+            "--state-dir",
+            str(tmp_path),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert ("helm", "uninstall", "agent-bom", "--namespace", "agent-bom") in commands
+    assert (
+        "kubectl",
+        "wait",
+        "--for=delete",
+        "pod,job",
+        "--all",
+        "--namespace",
+        "agent-bom",
+        "--timeout=180s",
+    ) in commands
+    assert ("terraform", f"-chdir={terraform_root}", "destroy", "-auto-approve") in commands
+
+
+def test_teardown_wrapper_script_exists():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "deploy" / "teardown-eks-reference.sh"
+    assert script_path.exists()


### PR DESCRIPTION
Summary
- add a shared AWS/EKS reference teardown helper plus `agent-bom teardown` and a repo-local wrapper script
- document the supported reverse path in the Terraform baseline, Helm control-plane, and own-infra EKS guides
- keep the teardown boundary explicit: remove product-owned Helm/Terraform surfaces, leave platform-owned cluster infrastructure alone

Testing
- bash -n scripts/deploy/teardown-eks-reference.sh
- uv run pytest tests/test_deploy_teardown.py tests/test_cli_entry_points.py -q
- uv run ruff check src/agent_bom/deploy_teardown.py src/agent_bom/cli/_deploy.py tests/test_deploy_teardown.py
- uv run mypy src/agent_bom/deploy_teardown.py src/agent_bom/cli/_deploy.py
- uv run mkdocs build --strict

Notes
- this is the teardown helper + guidance slice for #1635, not the Helm hook half
- the helper intentionally does not delete the EKS cluster, VPC, ingress controller, DNS, cert-manager, or other platform-owned shared infrastructure