### PR TITLE
feat(gateway): stitch W3C trace context across relay

### DIFF
--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -32,6 +32,7 @@ import logging
 import os
 import threading
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
@@ -41,10 +42,12 @@ from fastapi.responses import JSONResponse, Response
 from agent_bom.api.auth import get_key_store
 from agent_bom.api.metrics import record_gateway_relay, record_rate_limit_hit
 from agent_bom.api.middleware import InMemoryRateLimitStore, PostgresRateLimitStore
+from agent_bom.api.tracing import get_tracer, inject_trace_headers, make_request_trace
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc
 
 logger = logging.getLogger(__name__)
+_GATEWAY_TRACER = get_tracer("agent_bom.gateway")
 
 AuditSink = Callable[[dict[str, Any]], Awaitable[None]]
 UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awaitable[dict[str, Any]]]
@@ -201,6 +204,34 @@ def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -
     return "default", "none"
 
 
+def _inject_jsonrpc_trace_meta(
+    message: dict[str, Any],
+    *,
+    traceparent: str | None,
+    tracestate: str | None,
+    baggage: str | None,
+) -> dict[str, Any]:
+    """Return a JSON-RPC message with bounded W3C trace context in `_meta`.
+
+    MCP clients and servers increasingly use `_meta` as the least-surprising
+    place to carry end-to-end trace context across JSON-RPC boundaries.
+    """
+    if not traceparent and not tracestate and not baggage:
+        return message
+
+    enriched = dict(message)
+    raw_meta = message.get("_meta")
+    meta = dict(raw_meta) if isinstance(raw_meta, dict) else {}
+    if traceparent:
+        meta["traceparent"] = traceparent
+    if tracestate:
+        meta["tracestate"] = tracestate
+    if baggage:
+        meta["baggage"] = baggage
+    enriched["_meta"] = meta
+    return enriched
+
+
 async def _default_upstream_caller(
     upstream: UpstreamConfig,
     message: dict[str, Any],
@@ -272,6 +303,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     @app.post("/mcp/{server_name}")
     async def relay(server_name: str, request: Request) -> JSONResponse:
         """Route an MCP JSON-RPC request to the named upstream after policy + audit."""
+        trace_meta = make_request_trace(dict(request.headers))
         tenant_id = "default"
         auth_method = "none"
         if _gateway_requires_auth(settings):
@@ -365,10 +397,38 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     headers=rate_limit_headers or None,
                 )
 
-        # Forward to the upstream.
-        extra_headers: dict[str, str] = {}
+        # Forward to the upstream with bounded W3C trace headers and JSON-RPC
+        # `_meta` so both HTTP-aware and JSON-RPC-aware upstreams can stitch
+        # the same end-to-end trace.
+        extra_headers = inject_trace_headers(
+            {},
+            traceparent=str(trace_meta["traceparent"]),
+            tracestate=str(trace_meta["tracestate"]) if trace_meta["tracestate"] else None,
+            baggage=str(trace_meta["baggage"]) if trace_meta["baggage"] else None,
+        )
+        forwarded_message = _inject_jsonrpc_trace_meta(
+            message,
+            traceparent=str(trace_meta["traceparent"]),
+            tracestate=str(trace_meta["tracestate"]) if trace_meta["tracestate"] else None,
+            baggage=str(trace_meta["baggage"]) if trace_meta["baggage"] else None,
+        )
+        span_cm = _GATEWAY_TRACER.start_as_current_span("gateway.relay_upstream") if _GATEWAY_TRACER else nullcontext()
         try:
-            upstream_response = await upstream_caller(upstream, message, extra_headers)
+            with span_cm as span:
+                if span is not None:
+                    span.set_attribute("agent_bom.gateway.upstream", upstream.name)
+                    span.set_attribute("agent_bom.gateway.tenant_id", tenant_id)
+                    span.set_attribute("agent_bom.gateway.method", str(message.get("method", "unknown")))
+                    span.set_attribute("agent_bom.gateway.trace_id", str(trace_meta["trace_id"]))
+                    span.set_attribute("agent_bom.gateway.span_id", str(trace_meta["span_id"]))
+                    span.set_attribute("agent_bom.gateway.incoming_traceparent", bool(trace_meta["incoming_traceparent"]))
+                    if trace_meta["parent_span_id"]:
+                        span.set_attribute("agent_bom.gateway.parent_span_id", str(trace_meta["parent_span_id"]))
+                    if trace_meta["tracestate"]:
+                        span.set_attribute("agent_bom.gateway.tracestate_present", True)
+                    if trace_meta["baggage"]:
+                        span.set_attribute("agent_bom.gateway.baggage_present", True)
+                upstream_response = await upstream_caller(upstream, forwarded_message, extra_headers)
         except asyncio.TimeoutError as exc:
             logger.warning("gateway upstream call timed out for %s", upstream.name)
             record_gateway_relay(upstream.name, "upstream_timeout")
@@ -453,7 +513,13 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     "tool": message.get("params", {}).get("name") if is_tools_call(message) else None,
                 }
             )
-        return JSONResponse(upstream_response, headers=rate_limit_headers or None)
+        response_headers = dict(rate_limit_headers)
+        response_headers["traceparent"] = str(trace_meta["traceparent"])
+        if trace_meta["tracestate"]:
+            response_headers["tracestate"] = str(trace_meta["tracestate"])
+        if trace_meta["baggage"]:
+            response_headers["baggage"] = str(trace_meta["baggage"])
+        return JSONResponse(upstream_response, headers=response_headers or None)
 
     return app
 

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from starlette.testclient import TestClient
 
+from agent_bom.api.tracing import parse_traceparent
 from agent_bom.gateway_server import GatewaySettings, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 
@@ -137,6 +138,74 @@ def test_relay_forwards_to_upstream_and_returns_response() -> None:
     assert resp.json()["result"]["content"][0]["text"] == "ok"
     assert upstream_calls[0]["name"] == "filesystem"
     assert upstream_calls[0]["url"] == "http://fs.local:8100"
+
+
+def test_relay_propagates_trace_context_to_headers_and_jsonrpc_meta() -> None:
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append({"message": message, "headers": dict(extra_headers)})
+        return {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"content": [{"type": "text", "text": "ok"}]},
+        }
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        headers={
+            "traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+            "tracestate": "vendor-a=foo",
+            "baggage": "tenant=acme",
+        },
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+
+    assert resp.status_code == 200
+    call = upstream_calls[0]
+    assert call["headers"]["traceparent"].startswith("00-0123456789abcdef0123456789abcdef-")
+    assert call["headers"]["traceparent"] != "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+    assert call["headers"]["tracestate"] == "vendor-a=foo"
+    assert call["headers"]["baggage"] == "tenant=acme"
+    assert call["message"]["_meta"]["traceparent"] == call["headers"]["traceparent"]
+    assert call["message"]["_meta"]["tracestate"] == "vendor-a=foo"
+    assert call["message"]["_meta"]["baggage"] == "tenant=acme"
+    parsed = parse_traceparent(resp.headers["traceparent"])
+    assert parsed is not None
+    assert parsed["trace_id"] == "0123456789abcdef0123456789abcdef"
+    assert resp.headers["tracestate"] == "vendor-a=foo"
+    assert resp.headers["baggage"] == "tenant=acme"
+
+
+def test_relay_preserves_existing_jsonrpc_meta_fields_when_stitching_trace_context() -> None:
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append({"message": message, "headers": dict(extra_headers)})
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(registry=_simple_registry(), policy={}, upstream_caller=fake_caller)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        headers={"traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"},
+        json={
+            **_json_rpc("tools/list"),
+            "_meta": {"client": "cursor", "traceparent": "old"},
+        },
+    )
+
+    assert resp.status_code == 200
+    meta = upstream_calls[0]["message"]["_meta"]
+    assert meta["client"] == "cursor"
+    assert meta["traceparent"].startswith("00-0123456789abcdef0123456789abcdef-")
+    assert meta["traceparent"] != "old"
 
 
 def test_relay_requires_gateway_token_when_configured() -> None:


### PR DESCRIPTION
Summary
- propagate bounded W3C trace headers from incoming gateway requests to upstream MCP calls
- stamp JSON-RPC `_meta` with trace context so non-header-aware upstreams can still stitch the same trace
- return the gateway trace headers on the response and cover the behavior with focused gateway tests

Testing
- uv run pytest tests/test_gateway_server.py -q
- uv run ruff check src/agent_bom/gateway_server.py tests/test_gateway_server.py
- uv run mypy src/agent_bom/gateway_server.py

Closes #1638