### PR TITLE
docs(deploy): publish enterprise auth and operator guides

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,12 +93,15 @@ nav:
       - Overview: deployment/overview.md
       - Deployment Modes and Alignment: deployment/deployment-modes-and-alignment.md
       - AWS Company Rollout: deployment/aws-company-rollout.md
+      - Enterprise Auth and Tenancy: deployment/enterprise-auth-and-tenancy.md
       - Enterprise MCP / Endpoint Pilot: deployment/enterprise-pilot.md
       - Endpoint Fleet: deployment/endpoint-fleet.md
       - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md
       - Terraform AWS Baseline: deployment/terraform-aws-baseline.md
+      - Postgres Provisioning Workflow: deployment/postgres-provisioning.md
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
+      - Audit Chain vs Compliance Signing: deployment/audit-and-compliance-verification.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Backend Parity: deployment/backend-parity.md
       - Snowflake-Native Backend: deployment/snowflake-backend.md

--- a/site-docs/deployment/audit-and-compliance-verification.md
+++ b/site-docs/deployment/audit-and-compliance-verification.md
@@ -1,0 +1,133 @@
+# Audit Chain vs Compliance Signing
+
+`agent-bom` has **two different integrity mechanisms** that solve different
+problems.
+
+This page exists so operators and auditors do not confuse them.
+
+## The two mechanisms
+
+| Mechanism | What it protects | Scope | Verifier needs |
+|---|---|---|---|
+| HMAC-chained audit log | append-only action history | control-plane audit entries | shared HMAC key or online API verification |
+| Ed25519 compliance signing | exported evidence bundle | compliance report export payload | public key only |
+
+They are related, but they are not interchangeable.
+
+## Audit log chain
+
+The audit log is:
+
+- append-only
+- chained per tenant
+- HMAC-protected
+
+It answers:
+
+- was this action history tampered with?
+- did this tenant’s audit sequence remain intact?
+- was a report export recorded at all?
+
+Relevant endpoints:
+
+- `GET /v1/audit`
+- `GET /v1/audit/integrity`
+- `GET /v1/audit/export`
+
+Typical audit event for compliance export:
+
+- `compliance.report_exported`
+
+That event records details such as:
+
+- actor
+- tenant
+- nonce
+- expiry
+- framework
+
+## Compliance signing
+
+Compliance signing protects the exported report bundle itself.
+
+It answers:
+
+- was this JSON evidence bundle modified after export?
+- which signing key produced it?
+- can an external auditor verify it offline without a shared secret?
+
+Relevant endpoints:
+
+- `GET /v1/compliance/{framework}/report`
+- `GET /v1/compliance/verification-key`
+
+Ed25519 is the preferred external-auditor path because it gives asymmetric
+verification.
+
+## How the two fit together
+
+Think of them this way:
+
+- **audit chain** proves the export action is in the system history
+- **bundle signature** proves the exported payload was not changed
+
+For a stronger audit trail, use both:
+
+1. verify the evidence bundle signature
+2. verify the matching `compliance.report_exported` audit entry
+3. confirm tenant, framework, nonce, and expiry align
+
+## Auditor workflow
+
+### 1. Verify the bundle
+
+Follow the signing cookbook in:
+
+- [docs/COMPLIANCE_SIGNING.md](https://github.com/msaad00/agent-bom/blob/main/docs/COMPLIANCE_SIGNING.md)
+
+### 2. Verify the export action
+
+Example:
+
+```bash
+curl -s "https://agent-bom.example.com/v1/audit?action=compliance.report_exported&limit=20" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Then verify audit integrity:
+
+```bash
+curl -s "https://agent-bom.example.com/v1/audit/integrity?limit=1000" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### 3. Correlate them
+
+Match:
+
+- tenant
+- framework
+- nonce
+- `expires_at`
+- signing `key_id` where applicable
+
+## What each mechanism does not prove
+
+### Audit chain does not prove
+
+- non-repudiation to an external third party
+- that an exported JSON file was not modified after it left the API
+
+### Compliance signing does not prove
+
+- that the export was authorized by the right actor
+- that the action was present in the full tenant audit history
+
+That is why both are useful.
+
+## Recommended production posture
+
+- keep the audit HMAC key in your secret manager
+- enable Ed25519 signing for external evidence exchange
+- retain old public keys for the evidence retention window after rotation
+- verify both the bundle and the audit event for formal audits

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -27,6 +27,31 @@ This page documents what is wired today, not what might exist as a class on disk
 | Analytics / OLAP writes | No | No | Yes | No |
 | Snowflake governance discovery routes | No | No | No | Yes |
 
+## Route-level parity summary
+
+This is the operator-facing answer to: "which API surfaces are real on which
+backend?"
+
+| Route group | SQLite | Postgres / Supabase | ClickHouse | Snowflake |
+|---|---|---|---|---|
+| `/v1/scan*` job lifecycle | Yes | Yes | No | Yes |
+| `/v1/fleet*` | Yes | Yes | No | Yes |
+| `/v1/gateway/policies*` | Yes | Yes | No | Yes |
+| `/v1/audit*` primary trail | Yes | Yes | No | Partial; Snowflake policy audit exists, but it is not the full transactional audit replacement |
+| `/v1/auth/keys*` | No default API wiring | Yes | No | No |
+| `/v1/exceptions*` | No default API wiring | Yes | No | No |
+| `/v1/schedules*` | Yes | Yes | No | No |
+| `/v1/traces`, `/v1/proxy/audit`, `/v1/ocsf/ingest` analytics writes | No | No | Yes | No |
+| Snowflake governance/account discovery routes | No | No | No | Yes |
+
+The key distinction is:
+
+- transactional control-plane parity
+- analytics/event parity
+- warehouse-native discovery parity
+
+These are related, but not interchangeable.
+
 ## What This Means
 
 If you need the broadest control-plane coverage today, use `Postgres` or `Supabase`.
@@ -36,6 +61,10 @@ If you need local persistence, use `SQLite`.
 If you need high-volume analytics or time-series aggregation, add `ClickHouse`.
 
 If you need warehouse-native deployment or governance workflows in Snowflake, use `Snowflake` where the parity boundary is acceptable and explicit.
+
+If you need the widest route coverage with the fewest caveats, use
+`Postgres` / `Supabase` for the control plane and add `ClickHouse` only when
+analytics volume justifies it.
 
 ## Supported Deployment Modes
 
@@ -99,6 +128,16 @@ This mode is compatible with:
 | Team / enterprise API deployment | `Postgres` / `Supabase` |
 | Large analytics or trend workloads | `ClickHouse` alongside Postgres |
 | Snowflake-native governance and warehouse workflows | `Snowflake`, with explicit parity limits |
+
+## Recommended reading of this matrix
+
+Use it in this order:
+
+1. choose the backend that covers the routes you actually need
+2. treat `Postgres` as the default control-plane answer unless you have a
+   strong reason not to
+3. add `ClickHouse` when analytics scale justifies it
+4. use `Snowflake` where the documented parity boundary is acceptable
 
 ## Related Docs
 

--- a/site-docs/deployment/enterprise-auth-and-tenancy.md
+++ b/site-docs/deployment/enterprise-auth-and-tenancy.md
@@ -1,0 +1,241 @@
+# Enterprise Auth and Tenant Isolation
+
+This page is the operator-facing contract for how `agent-bom` handles:
+
+- API keys
+- OIDC
+- SAML SSO
+- trusted reverse-proxy identity
+- RBAC
+- tenant propagation
+- tenant defaults and fail-closed behavior
+
+The goal is simple: identity, authorization, and tenant scoping should all
+resolve onto the same control-plane model.
+
+## What is especially strong
+
+- **Tenant context is not UI-only.**
+  It propagates from the authenticated request into the control-plane stores and
+  Postgres row-level security.
+- **Audit is tenant-scoped and tamper-evident.**
+  Audit entries are HMAC-chained per tenant and can be filtered/exported by
+  tenant.
+- **SAML and OIDC converge onto the same RBAC + tenant model.**
+  SAML does not invent a second authorization path; it mints short-lived
+  control-plane keys that the existing middleware already understands.
+- **Operators can introspect live auth resolution.**
+  `GET /v1/auth/debug` shows auth method, subject, role, tenant, and trace IDs
+  without exposing raw secrets.
+
+## What is not perfect
+
+- **SAML is intentionally narrow.**
+  It is an assertion-verification path that returns a short-lived API key. It is
+  not a full browser session framework with logout/session federation depth.
+- **OIDC is strongest on the control-plane API today.**
+  Per-user OAuth2 auth-code / PKCE for laptop-to-gateway flows is still a later
+  runtime surface.
+- **Good enterprise posture still depends on good IdP mapping.**
+  Claim naming, tenant binding, and deployment configuration matter almost as
+  much as the code paths.
+
+## Auth modes
+
+| Mode | Best for | Tenant source | Role source | Notes |
+|---|---|---|---|---|
+| API key | machine-to-machine, automation, internal service accounts | key metadata | key metadata | hashed at rest; role hierarchy enforced in middleware |
+| OIDC | browser/API users behind corporate IdP | JWT tenant claim or tenant-bound issuer | JWT role claim / groups | issuer + audience verified; tenant defaults fail closed by default |
+| SAML | enterprises that need SAML IdP compatibility | SAML attribute | SAML attribute | assertion is verified, then converted into a short-lived API key |
+| Trusted proxy | same-origin ingress or auth gateway in front of API | `X-Agent-Bom-Tenant-ID` | `X-Agent-Bom-Role` | only when `AGENT_BOM_TRUST_PROXY_AUTH=1` |
+
+## RBAC model
+
+`agent-bom` keeps the role model intentionally small:
+
+- `admin`
+- `analyst`
+- `viewer`
+
+The permission matrix lives in
+[`src/agent_bom/rbac.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/rbac.py)
+and the route minimum-role map lives in
+[`src/agent_bom/api/middleware.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/api/middleware.py).
+
+Operationally:
+
+- `admin` can manage keys, policies, fleet writes, and configuration
+- `analyst` can run scans, push observability/runtime data, and create
+  exceptions
+- `viewer` is read-only
+
+## Tenant propagation
+
+The current tenant boundary is enforced in three places:
+
+1. **Request state**
+   - the auth middleware resolves `request.state.tenant_id`
+2. **Store calls**
+   - control-plane routes pass the request tenant into store reads/writes
+3. **Postgres session + RLS**
+   - `app.tenant_id` is set on the Postgres session and RLS policies enforce
+     the same boundary at the database layer
+
+That means tenant scoping is not just a UI filter. It is part of the control
+plane and persistence contract.
+
+## OIDC claim-to-tenant mapping
+
+The OIDC knobs are:
+
+```bash
+export AGENT_BOM_OIDC_ISSUER="https://idp.example.com"
+export AGENT_BOM_OIDC_AUDIENCE="agent-bom"
+export AGENT_BOM_OIDC_ROLE_CLAIM="agent_bom_role"
+export AGENT_BOM_OIDC_TENANT_CLAIM="tenant_id"
+```
+
+How tenant resolution works:
+
+1. if the configured tenant claim exists in the JWT, use it
+2. if the issuer is configured as a tenant-bound provider, use the bound tenant
+3. if `AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1`, fail closed
+4. otherwise, fail closed unless `AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT=1`
+5. only with that explicit opt-in does the request resolve to `default`
+
+So the safe/default behavior is now:
+
+- **missing tenant claim = reject**
+
+Single-tenant compatibility mode is explicit, not silent.
+
+### Tenant-bound issuer mode
+
+For stronger enterprise separation, bind one issuer per tenant:
+
+```bash
+export AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON='{
+  "tenant-alpha": {
+    "issuer": "https://alpha.okta.example",
+    "audience": "agent-bom",
+    "tenant_claim": "tenant_id",
+    "require_tenant_claim": true
+  },
+  "tenant-beta": {
+    "issuer": "https://beta.okta.example",
+    "audience": "agent-bom",
+    "tenant_claim": "tenant_id",
+    "require_tenant_claim": true
+  }
+}'
+```
+
+This mode gives you two protections:
+
+- a token from the wrong issuer is rejected
+- a token whose tenant claim does not match the bound tenant is rejected
+
+## SAML mapping
+
+SAML configuration is driven by:
+
+- `AGENT_BOM_SAML_IDP_ENTITY_ID`
+- `AGENT_BOM_SAML_IDP_SSO_URL`
+- `AGENT_BOM_SAML_IDP_X509_CERT`
+- `AGENT_BOM_SAML_SP_ENTITY_ID`
+- `AGENT_BOM_SAML_SP_ACS_URL`
+- `AGENT_BOM_SAML_ROLE_ATTRIBUTE`
+- `AGENT_BOM_SAML_TENANT_ATTRIBUTE`
+
+Recommended production posture:
+
+- set `AGENT_BOM_SAML_REQUIRE_ROLE_ATTRIBUTE=1`
+- set `AGENT_BOM_SAML_REQUIRE_TENANT_ATTRIBUTE=1`
+
+That keeps SAML fail-closed in the same way OIDC is now fail-closed for tenant
+resolution.
+
+## API keys and rotation
+
+API keys remain the best fit for:
+
+- automation
+- internal services
+- gateway/control-plane machine-to-machine traffic
+
+The control plane supports:
+
+- tenant-scoped keys
+- role-scoped keys
+- enforced TTL policy
+- rotation in place
+- revoke/delete flows
+
+Key rotation endpoints and policy introspection:
+
+- `GET /v1/auth/policy`
+- `GET /v1/auth/keys`
+- `POST /v1/auth/keys`
+- `POST /v1/auth/keys/{key_id}/rotate`
+- `DELETE /v1/auth/keys/{key_id}`
+
+## Operator debugging
+
+Use:
+
+```bash
+curl -s https://agent-bom.example.com/v1/auth/debug \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+This returns:
+
+- `auth_method`
+- `subject`
+- `role`
+- `tenant_id`
+- `oidc_issuer_suffix`
+- `request_id`
+- `trace_id`
+- `span_id`
+
+That endpoint is the fastest way to answer:
+
+- why did this request get `403`
+- which auth path was used
+- which tenant was actually resolved
+- whether the wrong issuer or tenant mapping was applied
+
+## Recommended deployment posture
+
+For enterprise control-plane users:
+
+- prefer **OIDC** or **SAML**
+- keep MFA at the IdP
+- require explicit tenant claims or tenant-bound issuers
+
+For machine-to-machine paths:
+
+- use **tenant-scoped API keys**
+- keep TTLs finite
+- rotate under the published policy
+
+For same-origin enterprise ingress:
+
+- use **trusted proxy mode** only when your reverse proxy is already enforcing
+  user identity and tenant headers
+
+## Evidence and tests
+
+- OIDC implementation:
+  [`src/agent_bom/api/oidc.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/api/oidc.py)
+- SAML implementation:
+  [`src/agent_bom/api/saml.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/api/saml.py)
+- auth middleware:
+  [`src/agent_bom/api/middleware.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/api/middleware.py)
+- RBAC:
+  [`src/agent_bom/rbac.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/rbac.py)
+- auth/tenant tests:
+  [`tests/test_api_oidc.py`](https://github.com/msaad00/agent-bom/blob/main/tests/test_api_oidc.py),
+  [`tests/test_api_hardening.py`](https://github.com/msaad00/agent-bom/blob/main/tests/test_api_hardening.py),
+  [`tests/test_api_cross_tenant_matrix.py`](https://github.com/msaad00/agent-bom/blob/main/tests/test_api_cross_tenant_matrix.py)

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -55,6 +55,22 @@ backend and Helm values before running your own load tests.
 | Initial enterprise pilot | ~250-2,000 endpoints, scheduled endpoint sync, selected runtime sidecars, retained proxy audit | `Postgres`, packaged `HPA`, topology spread, internal ingress, add `ClickHouse` only if audit/query latency grows |
 | Broader rollout | 2,000+ endpoints or sustained high-volume proxy audit/event analytics | `Postgres` for transactional state plus `ClickHouse` for analytics, explicit retention policy, benchmark before rollout |
 
+## Practical switch points
+
+These are planning thresholds, not product-enforced limits.
+
+| Signal | Stay on Postgres only | Add ClickHouse |
+|---|---|---|
+| Endpoint count | up to ~2,000 endpoints | above ~2,000 endpoints with retained analytics needs |
+| Scan cadence | low to moderate scheduled scans/day | sustained high-volume scheduled scans across many tenants |
+| Runtime / proxy audit volume | recent operational visibility | long retention, heavy trend queries, event-style analytics |
+| Dashboard/query shape | mostly transactional reads | trend-heavy or fleet-wide historical analytics |
+
+The product intent is:
+
+- `Postgres` remains the transactional control-plane source of truth
+- `ClickHouse` is the scale-out answer for analytics-heavy workloads
+
 ## Control-plane sizing guidance
 
 Start from the packaged production example:
@@ -213,6 +229,25 @@ Run these in your own environment before broader rollout:
    retained analytics volume.
 5. Record your chosen replica floor, resource requests, and retention policy in
    your operator runbook.
+
+## Publish your own benchmark numbers
+
+`agent-bom` deliberately does not claim a universal scans/day SLA. Real
+throughput depends on:
+
+- scan shape
+- endpoint mix
+- retention window
+- whether analytics stays in Postgres or moves to ClickHouse
+
+What the project does ship is:
+
+- a benchmark harness
+- packaged HPA/PDB controls
+- explicit backend guidance
+
+That keeps the deployment story honest while still giving operators a concrete
+starting point.
 
 ## Current boundary
 

--- a/site-docs/deployment/postgres-provisioning.md
+++ b/site-docs/deployment/postgres-provisioning.md
@@ -1,0 +1,118 @@
+# Postgres Provisioning Workflow
+
+This page documents the Postgres contract for self-hosted `agent-bom`
+operators.
+
+Use this when you are deploying the control plane in your own infra and want to
+understand:
+
+- what Postgres is responsible for
+- what Terraform or platform automation should provision
+- what Helm should own
+- what secrets/env vars the chart expects
+
+## What Postgres owns
+
+Postgres is the primary transactional control-plane store for:
+
+- scan jobs
+- fleet state
+- gateway policy state
+- audit log
+- API key store
+- exceptions
+- schedules
+- graph state
+- trend/baseline history
+
+If you need the widest backend parity today, Postgres is the default.
+
+## What to provision before Helm
+
+Your company platform or the shipped AWS baseline module should provision:
+
+- a Postgres instance or cluster
+- network reachability from the `agent-bom` namespace
+- a database and application user
+- TLS policy according to your platform standard
+- secret storage for the connection string
+- backup policy and retention
+
+For AWS/EKS, the reference path is:
+
+- [Terraform AWS Baseline](terraform-aws-baseline.md)
+- [AWS Company Rollout](aws-company-rollout.md)
+
+## Connection contract
+
+The chart expects:
+
+- `AGENT_BOM_POSTGRES_URL`
+
+Typical shape:
+
+```bash
+export AGENT_BOM_POSTGRES_URL="postgresql://agent_bom:***@postgres.internal:5432/agent_bom"
+```
+
+Recommended operator practice:
+
+- inject this through `Secret` / `ExternalSecret`
+- do not inline it in values files
+- treat it as the switch that enables:
+  - Postgres transactional stores
+  - shared rate limiting in multi-replica deployments
+  - tenant-scoped RLS enforcement in the database layer
+
+## How Helm and Postgres relate
+
+Helm should own:
+
+- Deployments
+- Services
+- HPAs / PDBs
+- CronJobs
+- product ConfigMaps / Secrets references
+
+Helm should **not** be your primary database provisioning layer.
+
+That split is deliberate:
+
+- company platform teams usually already own database provisioning standards
+- destroy/cleanup ownership stays clearer
+- the product can deploy into an existing EKS platform cleanly
+
+## Request-to-database tenant flow
+
+For Postgres-backed deployments, a successful authenticated request does this:
+
+1. auth middleware resolves tenant
+2. request state carries `tenant_id`
+3. middleware binds `app.tenant_id` into the Postgres session
+4. Postgres RLS enforces that tenant boundary on protected tables
+
+That means Postgres is not just a passive storage backend; it participates in
+tenant enforcement.
+
+## Operational checklist
+
+Before calling the deployment production-ready:
+
+1. confirm `AGENT_BOM_POSTGRES_URL` is injected from a secret source
+2. confirm API replicas are using Postgres-backed shared rate limiting
+3. confirm audit log backend is Postgres or an explicitly chosen alternative
+4. confirm backups and restore workflow exist for the database
+5. confirm connection pool sizing matches your endpoint and scan volume
+
+## What this does not try to do
+
+This page does not replace your company’s full database platform standard.
+
+It is intentionally the `agent-bom` contract:
+
+- what the product needs
+- what the product assumes
+- what the product wires when Postgres is present
+
+If your platform team already provisions Postgres another way, keep that and
+just satisfy the same runtime contract.


### PR DESCRIPTION
## Summary
- add operator guides for enterprise auth and tenant isolation, Postgres provisioning, and audit-chain vs compliance-signing verification
- expand performance and sizing with practical Postgres-to-ClickHouse switch points and explicit operator planning thresholds
- expand backend parity with route-level control-plane and analytics coverage so backend limits are visible in public docs

## Testing
- uv run mkdocs build --strict

Closes #1642
Closes #1643
Closes #1644
Closes #1645
Closes #1646