### PR TITLE
docs(runtime): publish operator guides and remediation contract

### DIFF
--- a/docs/design/MULTI_MCP_GATEWAY.md
+++ b/docs/design/MULTI_MCP_GATEWAY.md
@@ -1,6 +1,9 @@
 # Design: multi-MCP gateway — `agent-bom gateway serve`
 
-**Status:** design, not yet implemented. Tracked for the current pilot cycle.
+**Status:** implemented and operator-documented. The core relay, policy, audit,
+tenant auth, runtime rate limiting, visual leak detection, and control-plane
+auto-discovery paths now ship; this design doc remains the architectural
+overview behind those runtime surfaces.
 
 **Problem statement:** a pilot team wants to front-door every MCP connection in their environment through a single host so they can apply policy + audit centrally without touching every laptop's editor config. Today, `agent-bom proxy` is **per-MCP** — one instance per upstream server, either as a K8s sidecar next to a workload or as a stdio wrapper on a developer laptop. Central policy + audit already exist (`/v1/gateway/policies`, `/v1/proxy/audit`); central *traffic* does not.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,9 @@ nav:
       - Terraform AWS Baseline: deployment/terraform-aws-baseline.md
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
+      - Visual Leak Detection: deployment/visual-leak-detection.md
+      - Worker and Scheduler Concurrency: deployment/worker-and-scheduler-concurrency.md
+      - Gateway Auto-Discovery: deployment/gateway-auto-discovery.md
       - Backend Parity: deployment/backend-parity.md
       - Snowflake-Native Backend: deployment/snowflake-backend.md
       - Docker: deployment/docker.md
@@ -120,6 +123,7 @@ nav:
       - MCP Tools: reference/mcp-tools.md
       - CLI Commands: reference/cli.md
       - CLI Debug Guide: reference/cli-debug.md
+      - Remediate Output Contract: reference/remediate-output.md
       - Configuration: reference/configuration.md
   - API Reference:
       - Models: api/models.md

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -9,6 +9,10 @@ This is a **reference rollout path** for self-hosted `agent-bom` on AWS:
 - the company platform team still owns the AWS account, VPC, EKS cluster, ingress, cert-manager, and shared controllers
 - `agent-bom` owns the product-specific baseline around that platform: Postgres, IRSA, backup bucket, auth secrets, Helm release, fleet onboarding, and optional gateway runtime
 
+For the concrete runtime gateway discovery path after fleet and cluster scans
+have populated remote MCPs, see [Gateway Auto-Discovery From the Control
+Plane](gateway-auto-discovery.md).
+
 `agent-bom` stays one product with two deployable images:
 
 - `agentbom/agent-bom` for scanner, API, jobs, proxy, gateway, and workers

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -177,6 +177,12 @@ sequenceDiagram
 5. The API persists audit, findings, and graph links for the UI, exports, and
    compliance surfaces.
 
+For the runtime operator guides behind this flow, see:
+
+- [Visual Leak Detection](visual-leak-detection.md)
+- [Worker and Scheduler Concurrency](worker-and-scheduler-concurrency.md)
+- [Gateway Auto-Discovery From the Control Plane](gateway-auto-discovery.md)
+
 ## Same-origin default
 
 The UI runtime contract from `#1452` is what makes this honest.

--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -121,6 +121,9 @@ That path now supports:
 - control-plane audit push
 - local inline MCP enforcement
 
+For OCR rollout on screenshot-heavy tools, see [Visual Leak
+Detection](visual-leak-detection.md).
+
 ## How this fits with the EKS pilot
 
 Use both when you want one pilot across laptops and infra:

--- a/site-docs/deployment/gateway-auto-discovery.md
+++ b/site-docs/deployment/gateway-auto-discovery.md
@@ -1,0 +1,164 @@
+# Gateway Auto-Discovery From the Control Plane
+
+`agent-bom gateway serve --from-control-plane` lets the gateway load remote MCP
+upstreams directly from fleet and scan data already stored in the control plane.
+
+This avoids starting from a blank `upstreams.yaml` for every pilot.
+
+## What auto-discovery does
+
+The gateway pulls:
+
+- `GET /v1/gateway/upstreams/discovered`
+
+That endpoint aggregates tenant-scoped remote MCP servers already surfaced by:
+
+- endpoint fleet sync
+- in-cluster scans
+- other scan results stored in the tenant's job history
+
+Important boundaries:
+
+- only remote `http` / `https` / `sse` upstreams are returned
+- `stdio` MCPs are intentionally excluded
+- discovered upstreams always come back with `auth: "none"`
+- credentials stay in Secrets and are overlaid locally through `--upstreams`
+
+## Minimal prerequisites
+
+You need:
+
+1. a control plane with discovered MCP servers for the tenant
+2. a gateway bearer token or API key that can read the discovery endpoint
+3. remote MCPs that actually expose HTTP/SSE transport
+
+## Minimal worked example
+
+Start the gateway from discovered upstreams only:
+
+```bash
+agent-bom gateway serve \
+  --bind 0.0.0.0:8090 \
+  --from-control-plane https://agent-bom.internal.example.com \
+  --control-plane-token "$AGENT_BOM_CONTROL_PLANE_TOKEN" \
+  --bearer-token "$AGENT_BOM_GATEWAY_BEARER_TOKEN"
+```
+
+Overlay secrets or transport-specific auth with a local YAML file:
+
+```bash
+agent-bom gateway serve \
+  --bind 0.0.0.0:8090 \
+  --from-control-plane https://agent-bom.internal.example.com \
+  --control-plane-token "$AGENT_BOM_CONTROL_PLANE_TOKEN" \
+  --upstreams gateway-upstreams.overlay.yaml \
+  --bearer-token "$AGENT_BOM_GATEWAY_BEARER_TOKEN"
+```
+
+Example overlay:
+
+```yaml
+upstreams:
+  - name: github
+    url: https://mcp.github.example.com/sse
+    auth: bearer
+    token_env: GITHUB_MCP_TOKEN
+```
+
+## Validation flow
+
+### 1. Validate discovery at the control plane
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $AGENT_BOM_CONTROL_PLANE_TOKEN" \
+  https://agent-bom.internal.example.com/v1/gateway/upstreams/discovered | jq
+```
+
+Expected response shape:
+
+```json
+{
+  "tenant_id": "tenant-alpha",
+  "source": "fleet_scan_aggregate",
+  "upstreams": [
+    {
+      "name": "jira",
+      "url": "https://mcp.example.internal/jira",
+      "transport": "sse",
+      "auth": "none",
+      "source_agents": ["mac-laptop-1", "windows-laptop-3"]
+    }
+  ],
+  "conflicts": []
+}
+```
+
+### 2. Validate gateway startup
+
+At boot, the gateway prints the number and names of discovered upstreams.
+
+Healthy startup looks like:
+
+```text
+discovered 2 upstream(s) from https://agent-bom.internal.example.com: github, jira
+agent-bom gateway serving on http://0.0.0.0:8090 fronting 2 upstream(s): github, jira
+```
+
+### 3. Validate runtime posture
+
+```bash
+curl -s http://127.0.0.1:8090/healthz | jq
+```
+
+Look for:
+
+- `status: ok`
+- expected `upstreams`
+- `auth.incoming_token_required`
+- runtime rate-limit posture
+
+### 4. Validate policy flow
+
+If proxies or clients route tool traffic through the gateway, validate:
+
+- the gateway can fetch policy from the control plane
+- audit reaches `/v1/proxy/audit`
+- requests to blocked tools are denied with gateway policy errors
+
+## Discovery edge cases
+
+### Name collisions
+
+If two different URLs are discovered with the same MCP name:
+
+- the first entry keeps the bare name
+- later entries are renamed with suffixes such as `jira-1`
+- the API returns a `conflicts` array so the operator can reconcile names
+
+This avoids silently collapsing two different upstreams into one.
+
+### Empty discovery
+
+If a tenant only has `stdio` MCPs, discovery returns an empty list. That is not
+an error; it just means the gateway has nothing remote to front.
+
+## EKS shape
+
+For a customer EKS deployment, the normal sequence is:
+
+1. deploy the control plane
+2. push endpoint fleet sync or run cluster scans
+3. verify `/v1/gateway/upstreams/discovered`
+4. deploy the gateway with `--from-control-plane`
+5. overlay any per-upstream credentials from Secrets
+
+That keeps the source of truth in the control plane while keeping secrets out of
+scan results.
+
+## Related guides
+
+- [Your Own AWS / EKS](own-infra-eks.md)
+- [AWS Company Rollout](aws-company-rollout.md)
+- [Packaged API + UI Control Plane](control-plane-helm.md)
+- [Endpoint Fleet](endpoint-fleet.md)

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -258,6 +258,9 @@ YAML.
 - [Focused EKS MCP Pilot](eks-mcp-pilot.md)
 - [Packaged API + UI Control Plane](control-plane-helm.md)
 - [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
+- [Visual Leak Detection](visual-leak-detection.md)
+- [Worker and Scheduler Concurrency](worker-and-scheduler-concurrency.md)
+- [Gateway Auto-Discovery From the Control Plane](gateway-auto-discovery.md)
 - [Backend Parity](backend-parity.md)
 
 ## Hosting and Storage Boundaries

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -149,6 +149,11 @@ The important boundary is that `agent-bom proxy` is the inline runtime path,
 while the gateway is the central policy surface. One does not replace the
 other.
 
+For the concrete gateway startup path against discovered fleet MCPs, see
+[Gateway Auto-Discovery From the Control Plane](gateway-auto-discovery.md).
+For screenshot and OCR rollout on runtime paths, see [Visual Leak
+Detection](visual-leak-detection.md).
+
 ## What Stays In Your Infrastructure
 
 For this model, the sensitive operator surfaces stay inside your environment

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -114,6 +114,11 @@ If scans begin overlapping, do not immediately add more control-plane replicas.
 First widen the CronJob interval, split scope, or reduce introspection scope for
 the rollout phase.
 
+For the full execution model, including scheduler leader election, tenant quota
+enforcement, and the split between recurring schedules and the packaged scanner
+`CronJob`, see [Worker and Scheduler
+Concurrency](worker-and-scheduler-concurrency.md).
+
 ## Postgres vs ClickHouse
 
 Use `Postgres` as the source of truth for:

--- a/site-docs/deployment/runtime-monitoring.md
+++ b/site-docs/deployment/runtime-monitoring.md
@@ -10,6 +10,7 @@ The runtime proxy (`agent-bom proxy`) intercepts MCP JSON-RPC messages between c
 - 7-detector anomaly engine (tool drift, argument analysis, credential leak, rate limiting, sequence analysis, response inspector, vector DB injection)
 - Policy enforcement with block/allow rules
 - Prometheus metrics on port 8422
+- Optional visual leak detection for image and screenshot responses
 
 ## Deployment modes
 
@@ -32,3 +33,9 @@ The `watch` command supports webhook alerts to:
 ```bash
 agent-bom watch --webhook-url https://hooks.slack.com/... --watch-interval 60
 ```
+
+## Operator guides
+
+- [Visual Leak Detection](visual-leak-detection.md)
+- [Worker and Scheduler Concurrency](worker-and-scheduler-concurrency.md)
+- [Gateway Auto-Discovery From the Control Plane](gateway-auto-discovery.md)

--- a/site-docs/deployment/visual-leak-detection.md
+++ b/site-docs/deployment/visual-leak-detection.md
@@ -1,0 +1,164 @@
+# Visual Leak Detection
+
+The visual leak detector is the OCR-backed response safety layer for screenshot
+and image-heavy MCP tools. It is intentionally opt-in because it adds OCR
+dependencies and CPU cost to the runtime path.
+
+Use this guide when you want to understand:
+
+- when OCR inspection actually runs
+- what the detector scans and redacts
+- how proxy and gateway startup behave
+- how to roll it out without creating avoidable false positives or latency
+
+## What it inspects
+
+The detector only runs on MCP response content blocks that look like image
+payloads:
+
+- `result.content[]`
+- `type: "image"`
+- base64-encoded `data`
+- `mimeType` such as `image/png` or `image/jpeg`
+
+It does not OCR arbitrary text responses, prompt bodies, or request payloads.
+Those stay on the normal runtime detector path.
+
+The OCR pass joins all image blocks in a single response into one stitched
+canvas, extracts words above the current confidence floor, and matches them
+against the shipped credential and PII pattern sets.
+
+Current matching behavior:
+
+- single-word and short multi-word matches
+- OCR confidence floor: `40`
+- categories: `credential_leak` and `pii_leak`
+- redaction shape: opaque black rectangles over matched bounding boxes
+
+## Runtime contract
+
+The detector needs both:
+
+- `agent-bom[visual]`
+- a working `tesseract` binary on `PATH`
+
+If either is missing, the runtime is considered unavailable.
+
+## Proxy behavior
+
+Enable it on the proxy path with:
+
+```bash
+agent-bom proxy \
+  --control-plane-url https://agent-bom.internal.example.com \
+  --control-plane-token "$AGENT_BOM_API_TOKEN" \
+  --detect-visual-leaks \
+  -- npx @modelcontextprotocol/server-playwright
+```
+
+Proxy startup behavior is strict:
+
+- if `--detect-visual-leaks` is set, proxy startup requires the OCR runtime
+- there is no best-effort startup flag on the proxy path
+- timeouts during response inspection fail open and let the original response
+  continue
+
+Response-path behavior:
+
+- if no leak is found, the response passes through unchanged
+- if a leak is found, alerts are logged and the image content is redacted before
+  the client sees it
+- response HMAC signing happens before redaction so the audit trail still pins
+  the original server response
+
+## Gateway behavior
+
+Enable it on the gateway path with:
+
+```bash
+agent-bom gateway serve \
+  --from-control-plane https://agent-bom.internal.example.com \
+  --control-plane-token "$AGENT_BOM_CONTROL_PLANE_TOKEN" \
+  --detect-visual-leaks
+```
+
+Gateway startup gives you two modes:
+
+- required: `--detect-visual-leaks`
+- best effort: `--detect-visual-leaks --allow-visual-leak-best-effort`
+
+Required mode fails startup if OCR support is unavailable. Best-effort mode
+keeps the gateway up and reports the missing runtime through `/healthz`.
+
+Example readiness check:
+
+```bash
+curl -s http://gateway.agent-bom.svc.cluster.local:8090/healthz | jq .visual_leak_detection
+```
+
+Expected shape:
+
+```json
+{
+  "enabled": true,
+  "ready": true,
+  "mode": "enforcing",
+  "reason": null,
+  "required": true
+}
+```
+
+Like the proxy path, gateway response inspection fails open on OCR timeout. The
+response is still returned, and the timeout is logged instead of blocking tool
+traffic.
+
+## Where it helps most
+
+The detector is most useful for:
+
+- browser automation MCPs
+- screenshot or screen-read tools
+- visual review or QA MCPs
+- any tool that returns image evidence from customer environments
+
+It is much less useful for:
+
+- text-only MCPs
+- stdio wrappers around file or git tools
+- workflows where screenshots are disabled entirely
+
+## False-positive and latency posture
+
+This detector is designed to be useful, not magical.
+
+Operationally important limits:
+
+- OCR quality depends on image quality and font rendering
+- small text, blurred screenshots, and heavily compressed images reduce recall
+- high-noise screenshots may still cause matches on credential-like patterns
+- the detector only sees pixels, not semantic page context
+
+Recommended rollout:
+
+1. Start on a narrow set of screenshot-heavy tools.
+2. Turn it on first in non-critical user groups or review environments.
+3. Watch response latency and the `gateway.visual_leak_blocked` /
+   proxy-side audit events before widening coverage.
+4. Use required mode only after validating that your runtime image actually
+   includes `tesseract`.
+
+## Recommended deployment shapes
+
+| Surface | Recommended mode | Why |
+|---|---|---|
+| Developer laptop proxy | required only after package validation | laptops are sensitive to startup surprises |
+| EKS sidecar proxy | required | image contents are fully operator-controlled |
+| Shared gateway pilot | best effort first | easier to validate OCR packaging and latency |
+| Shared gateway production | required | fail closed only after runtime support is proven |
+
+## Related guides
+
+- [Runtime Monitoring](runtime-monitoring.md)
+- [Endpoint Fleet](endpoint-fleet.md)
+- [Your Own AWS / EKS](own-infra-eks.md)
+- [Packaged API + UI Control Plane](control-plane-helm.md)

--- a/site-docs/deployment/worker-and-scheduler-concurrency.md
+++ b/site-docs/deployment/worker-and-scheduler-concurrency.md
@@ -1,0 +1,156 @@
+# Worker and Scheduler Concurrency
+
+`agent-bom` uses a few different execution models at once:
+
+- API-triggered ad hoc scans
+- recurring schedules
+- packaged CronJobs
+- long-running runtime services such as proxy and gateway
+
+This guide explains which component owns which kind of work, where concurrency
+limits apply, and how to scale without turning the control plane into a noisy
+monolith.
+
+## Execution model at a glance
+
+```mermaid
+flowchart LR
+    Browser["Browser / API client"]
+    API["API replicas"]
+    Scheduler["Scheduler loop<br/>one leader"]
+    Schedules[("scan_schedules")]
+    Jobs[("scan_jobs")]
+    Cron["Scanner CronJob"]
+    Fleet["Endpoint fleet sync"]
+    Runtime["Gateway / proxy"]
+
+    Browser --> API
+    API --> Jobs
+    API --> Schedules
+    API --> Scheduler
+    Scheduler -->|due schedules only| Jobs
+    Cron -->|cluster scan results| API
+    Fleet -->|/v1/fleet/sync| API
+    Runtime -->|runtime audit + policy| API
+```
+
+## What runs where
+
+| Surface | Execution model | Typical lifetime |
+|---|---|---|
+| `POST /v1/scan` and related API-triggered jobs | ad hoc job creation | one-off |
+| `/v1/schedules` recurring scans | scheduler loop plus stored cron expressions | periodic |
+| Helm scanner | Kubernetes `CronJob` | periodic |
+| backup job | Kubernetes `CronJob` | periodic |
+| endpoint fleet sync | endpoint timer / launchd / systemd | periodic |
+| gateway and proxy | long-running service / sidecar / wrapper | long-running |
+
+## Scheduler leader model
+
+Recurring schedules are not fired by every API pod at once.
+
+Current control-plane behavior:
+
+- each API process starts the scheduler loop during server lifespan
+- with `AGENT_BOM_POSTGRES_URL` set, only the replica that acquires the
+  Postgres advisory lock acts as scheduler leader
+- non-leaders sleep and do not trigger scans
+- due schedules are checked every `60` seconds by default
+- failed scheduler iterations back off exponentially up to `900` seconds
+
+That means the scheduler is safe to run in a multi-replica API deployment
+without duplicate schedule execution, as long as the deployment uses Postgres.
+
+## Quotas and noisy-neighbor control
+
+The scheduler and API share the same tenant quota enforcement path.
+
+The key per-tenant limits are:
+
+- `AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT`
+- `AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT`
+- `AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT`
+- `AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT`
+
+What each one protects:
+
+- active scan jobs: caps concurrent pending/running scans for one tenant
+- retained jobs: caps stored scan history growth
+- fleet agents: caps pushed endpoint or collector inventory
+- schedules: caps recurring scan definitions
+
+These are enforced when the API accepts new work. They are not soft dashboard
+warnings; they return quota errors and emit tenant-scoped audit events.
+
+## CronJob vs scheduler
+
+The scanner `CronJob` and the recurring schedule subsystem are different
+surfaces.
+
+Use the packaged scanner `CronJob` when:
+
+- you want cluster-wide or namespace-wide periodic discovery
+- the work is an operator-owned infrastructure sweep
+- the cadence belongs in Helm and Kubernetes
+
+Use `/v1/schedules` when:
+
+- a tenant or operator needs recurring logical scans through the API
+- you want the schedule visible in the product
+- you want tenant-scoped quota and audit around that schedule
+
+Do not treat them as interchangeable knobs. The CronJob is cluster automation;
+the scheduler is control-plane orchestration.
+
+## Scaling guidance
+
+When scans start overlapping, use this order:
+
+1. widen the schedule interval
+2. narrow scan scope or split jobs by target
+3. raise tenant quotas only if the rollout genuinely needs it
+4. scale API replicas and resource requests after queue pressure is real
+
+Recommended posture:
+
+- keep API replicas at `2+`
+- keep the scheduler on Postgres-backed deployments
+- avoid using quotas of `0` unless you truly want “unlimited”
+- keep scanner CronJobs scoped and predictable before increasing frequency
+
+## What is periodic, ad hoc, or long-running
+
+| Workload | Category | Notes |
+|---|---|---|
+| API-triggered scan | ad hoc | user or automation triggered |
+| scheduled scan | periodic | stored in `scan_schedules`, executed by one leader |
+| cluster scanner | periodic | Kubernetes `CronJob` |
+| backup job | periodic | Kubernetes `CronJob` |
+| endpoint fleet sync | periodic | endpoint-owned timer or agent bundle |
+| gateway | long-running | multi-replica service, runtime rate-limited |
+| proxy | long-running | local wrapper or sidecar |
+
+## Failure model
+
+The current failure contract is explicit:
+
+- scheduler store failures trigger exponential backoff
+- lack of Postgres leader lock means “do not schedule,” not “schedule anyway”
+- tenant quota violations are returned synchronously and audited
+- CronJob overlap is an operator problem to solve with cadence and scope, not by
+  silently widening concurrency
+
+## Recommended operator checks
+
+Before widening rollout, confirm:
+
+- schedule run time stays below the configured interval
+- API `p95` latency stays healthy during scheduled runs
+- Postgres can handle scheduler, job, and audit write pressure together
+- tenant quotas match the deployment shape you intend to support
+
+## Related guides
+
+- [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
+- [Packaged API + UI Control Plane](control-plane-helm.md)
+- [Your Own AWS / EKS](own-infra-eks.md)

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -17,6 +17,7 @@
 | `runtime proxy` | Runtime MCP proxy with enforcement |
 | `runtime protect` | 7-detector anomaly engine |
 | `runtime watch` | Config file change monitoring |
+| `remediate` | Generate a prioritized remediation plan |
 | `report` | History, diff, analytics, dashboard |
 | `policy` | Templates and remediation |
 | `serve` | Start REST API server |
@@ -27,6 +28,7 @@
 
 - `check` supports terminal output by default plus `--format json` for machine-readable pre-install verdicts.
 - `report history` and `report diff` support `--format json` for CI and automation.
+- `remediate` supports `--format json` as the machine-readable remediation contract.
 - Use `agent-bom agents -f <format> -o <path>` for SARIF, HTML, SBOM, and richer environment exports.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.
 - `where` is available both as `agent-bom where` and `agent-bom mcp where`.
@@ -73,6 +75,9 @@ agent-bom agents --config-dir /path/to/configs
 ## Troubleshooting
 
 See [CLI Debug Guide](cli-debug.md) for quiet/logging behavior, stdout vs file output, discovery triage, and package verification workflows.
+
+For the JSON contract behind `agent-bom remediate`, see [`remediate` Output
+Contract](remediate-output.md).
 
 ## Environment variables
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -34,6 +34,9 @@ compliance(frameworks=["owasp-llm", "eu-ai-act"])
 ### remediate
 Generate a prioritized remediation plan for discovered vulnerabilities.
 
+For the JSON contract and example artifact shape, see [`remediate` Output
+Contract](remediate-output.md).
+
 ### skill_scan
 Scan instruction files such as `CLAUDE.md`, `.cursorrules`, `AGENTS.md`, and `skills/*.md` for package references, MCP server configs, credential env vars, trust verdicts, and audit findings.
 ```

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -1,0 +1,173 @@
+# `agent-bom remediate` Output Contract
+
+Use this page when you need the machine-readable contract for
+`agent-bom remediate`.
+
+The command supports:
+
+- `console`
+- `json`
+- `markdown`
+
+The only format intended as a stable automation contract is `json`.
+
+## Example command
+
+```bash
+agent-bom remediate -p . --format json --output plan.json
+```
+
+Optional grouping:
+
+```bash
+agent-bom remediate -p . --format json --server-group --output plan.json
+```
+
+## Top-level JSON shape
+
+```json
+{
+  "version": "0.81.0",
+  "generated_at": "2026-04-21T12:00:00+00:00",
+  "remediation_plan": [],
+  "summary": {
+    "total_items": 0,
+    "fixable": 0,
+    "unfixable": 0,
+    "p1_count": 0,
+    "p2_count": 0,
+    "p3_count": 0,
+    "p4_count": 0
+  }
+}
+```
+
+When `--server-group` is set, one additional top-level field is present:
+
+```json
+{
+  "server_groups": {
+    "jira": ["urllib3", "requests"],
+    "github": ["openssl"]
+  }
+}
+```
+
+## Per-item schema
+
+Each entry in `remediation_plan` has this shape:
+
+```json
+{
+  "package": "requests",
+  "ecosystem": "pypi",
+  "current_version": "2.28.0",
+  "fixed_version": "2.32.0",
+  "priority": "P1",
+  "action": "",
+  "command": "pip install 'requests>=2.32.0'",
+  "verify_command": "agent-bom check requests@2.32.0 --ecosystem pypi",
+  "max_severity": "high",
+  "blast_radius_score": 7.5,
+  "impact": 1,
+  "vulnerabilities": ["CVE-2024-0001"],
+  "affected_agents": ["mac-laptop-1"],
+  "exposed_credentials": [],
+  "exposed_tools": [],
+  "references": ["https://nvd.nist.gov/vuln/detail/CVE-2024-0001"],
+  "has_kev": false,
+  "ai_risk": false,
+  "compliance_tags": {
+    "owasp": [],
+    "atlas": [],
+    "nist": [],
+    "owasp_mcp": [],
+    "owasp_agentic": [],
+    "eu_ai_act": [],
+    "nist_csf": [],
+    "iso_27001": [],
+    "soc2": [],
+    "cis": []
+  }
+}
+```
+
+## Stable vs advisory fields
+
+### Stable contract
+
+These keys are the supported JSON contract for automation:
+
+- top level: `version`, `generated_at`, `remediation_plan`, `summary`
+- optional top level with `--server-group`: `server_groups`
+- item fields:
+  - `package`
+  - `ecosystem`
+  - `current_version`
+  - `fixed_version`
+  - `priority`
+  - `action`
+  - `command`
+  - `verify_command`
+  - `max_severity`
+  - `blast_radius_score`
+  - `impact`
+  - `vulnerabilities`
+  - `affected_agents`
+  - `exposed_credentials`
+  - `exposed_tools`
+  - `references`
+  - `has_kev`
+  - `ai_risk`
+  - `compliance_tags`
+
+### Advisory semantics
+
+These values are intentionally advisory and may change as scoring or enrichment
+improves:
+
+- item ordering
+- `blast_radius_score`
+- `priority`
+- `impact`
+- suggested `command`
+- suggested `verify_command`
+- membership and size of `references`
+- compliance tag population
+- derived `summary` counts
+
+Treat the JSON shape as stable, but treat prioritization and enrichment values
+as versioned security analysis output.
+
+## Nullability and empty values
+
+Operators and automation should expect:
+
+- `fixed_version` may be `null`
+- `command` may be `null`
+- `verify_command` may be `null`
+- arrays may be empty
+- `server_groups` is absent unless `--server-group` is used
+
+## Empty-plan behavior
+
+If no vulnerabilities are found, JSON output still uses the same top-level
+shape with:
+
+- `remediation_plan: []`
+- all summary counts set to `0`
+
+If filters remove every item, the same empty JSON shape is returned.
+
+## Output modes
+
+| Format | Best use | Contract strength |
+|---|---|---|
+| `console` | humans in a terminal | presentation only |
+| `json` | CI, automation, dashboards, export | supported contract |
+| `markdown` | PRs, tickets, review threads | presentation only |
+
+## Related references
+
+- [CLI Reference](cli.md)
+- [MCP Tools Reference](mcp-tools.md)


### PR DESCRIPTION
## Summary
- publish operator-facing guides for visual leak detection rollout, worker/scheduler concurrency, and gateway auto-discovery from the control plane
- publish the machine-readable JSON contract for `agent-bom remediate`, including stable vs advisory fields and example payload shape
- wire the new guides into deployment, CLI, and runtime docs, and update the multi-MCP gateway design doc status so architecture pages match the current implementation

## Testing
- `uv run mkdocs build --strict`

Closes #1647
Closes #1648
Closes #1649
Closes #1650
