### PR TITLE
docs(model): publish control-plane data model and store parity

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -123,6 +123,9 @@ Four backends, one canonical model. Each store enforces tenant
 isolation either via a `tenant_id` column (Postgres / ClickHouse /
 Snowflake) or via per-tenant SQLite paths.
 
+For the operator-facing logical entity → store/table contract, see
+[`site-docs/deployment/control-plane-data-model.md`](../site-docs/deployment/control-plane-data-model.md).
+
 ### SQLite — `src/agent_bom/db/schema.py`
 
 Single-file local store. Used for the offline vuln DB and the
@@ -131,10 +134,14 @@ single-node `agent-bom serve` deployment.
 | Table | Purpose | Tenant-scoped? |
 |---|---|---|
 | `vulns`, `affected`, `epss_scores`, `kev_entries` | Bundled offline OSV/EPSS/KEV catalog | n/a (read-only catalog) |
-| `scan_jobs` | Scan job state | yes (per-tenant SQLite path or in-row column) |
+| `jobs` | Scan job state | yes (per-tenant SQLite path or in-row column) |
 | `fleet_agents` | Fleet inventory | yes |
 | `gateway_policies` | Gateway policy rules | yes |
+| `policy_audit_log` | Gateway policy mutation audit | yes |
+| `sources` | Source registry | yes |
 | `audit_log` | HMAC-chained audit | yes (in `details.tenant_id`) |
+| `idempotency_keys` | idempotent write tracking | yes |
+| `api_rate_limits` | shared runtime rate-limit state | yes |
 
 ### Postgres — `src/agent_bom/api/postgres_store.py`
 
@@ -158,6 +165,7 @@ list/put plus session-scoped `app.current_tenant` for RLS.
 ### ClickHouse — `src/agent_bom/cloud/clickhouse.py`
 
 OLAP-only. Append-only analytics for trends, runtime events, posture.
+This is not a transactional control-plane replacement.
 
 | Table | Source dataclass | tenant_id |
 |---|---|---|
@@ -175,9 +183,18 @@ is deliberately cross-tenant and reserved for admin surfaces.
 
 ### Snowflake — `src/agent_bom/api/snowflake_store.py`
 
-Warehouse-native deployment for governance-heavy customers. Mirrors
-Postgres tables with Snowflake-specific column types. Not yet at full
-control-plane parity — see roadmap for the gap list.
+Warehouse-native deployment for governance-heavy customers. Today it
+persists `scan_jobs`, `fleet_agents`, `gateway_policies`, and
+`policy_audit_log` with Snowflake-specific column types. It is not yet
+at full control-plane parity:
+
+- no source registry persistence
+- no API-key / RBAC persistence
+- no exceptions persistence
+- no schedule persistence
+- no graph persistence
+- no trend/baseline persistence
+- no full `audit_log` transactional replacement
 
 ### Deployment-context posture contract — `GET /v1/posture/counts`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - Terraform AWS Baseline: deployment/terraform-aws-baseline.md
       - Postgres Provisioning Workflow: deployment/postgres-provisioning.md
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
+      - Control-Plane Data Model and Store Parity: deployment/control-plane-data-model.md
       - Audit Chain vs Compliance Signing: deployment/audit-and-compliance-verification.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Backend Parity: deployment/backend-parity.md

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -19,6 +19,7 @@ This page documents what is wired today, not what might exist as a class on disk
 | Fleet agent persistence | Yes | Yes | No | Yes |
 | Gateway policy persistence | Yes | Yes | No | Yes |
 | Audit log persistence | Yes | Yes | No | Yes, via `SnowflakePolicyStore` |
+| Source registry persistence | Yes | Yes | No | No |
 | Exception workflow persistence | No default API wiring | Yes | No | No |
 | API key persistence / RBAC store | No default API wiring | Yes | No | No |
 | Schedule persistence | Yes | Yes | No | No |
@@ -37,6 +38,7 @@ backend?"
 | `/v1/scan*` job lifecycle | Yes | Yes | No | Yes |
 | `/v1/fleet*` | Yes | Yes | No | Yes |
 | `/v1/gateway/policies*` | Yes | Yes | No | Yes |
+| `/v1/sources*` source registry | Yes | Yes | No | No |
 | `/v1/audit*` primary trail | Yes | Yes | No | Partial; Snowflake policy audit exists, but it is not the full transactional audit replacement |
 | `/v1/auth/keys*` | No default API wiring | Yes | No | No |
 | `/v1/exceptions*` | No default API wiring | Yes | No | No |
@@ -51,6 +53,9 @@ The key distinction is:
 - warehouse-native discovery parity
 
 These are related, but not interchangeable.
+
+For the exact logical entity → table/store mapping, see
+[Control-Plane Data Model and Store Parity](control-plane-data-model.md).
 
 ## What This Means
 
@@ -141,6 +146,7 @@ Use it in this order:
 
 ## Related Docs
 
+- [Control-Plane Data Model and Store Parity](control-plane-data-model.md)
 - [Deployment Overview](overview.md)
 - [SIEM Integration](siem-integration.md)
 - [Canonical Model vs OCSF](../architecture/canonical-vs-ocsf.md)

--- a/site-docs/deployment/control-plane-data-model.md
+++ b/site-docs/deployment/control-plane-data-model.md
@@ -1,0 +1,205 @@
+# Control-Plane Data Model and Store Parity
+
+This is the operator and auditor view of the `agent-bom` control-plane
+data model.
+
+It answers four questions directly:
+
+1. Which logical entities are part of the control plane?
+2. Which store or table backs each entity today?
+3. Which backends are transactional control-plane stores versus
+   analytics-only stores?
+4. Which schema objects are created by bootstrap SQL versus lazily by
+   the runtime?
+
+Use this page together with [Backend Parity](backend-parity.md) and the
+repo-root `docs/DATA_MODEL.md`.
+
+## Canonical control-plane entities
+
+The stable logical entities are:
+
+- scan jobs
+- fleet agents
+- gateway policies
+- gateway policy audit log
+- source registry
+- API keys and RBAC bindings
+- exceptions
+- schedules
+- audit chain
+- graph snapshots and attack paths
+- trend/baseline history
+- idempotency keys
+- rate-limit state
+
+Those names are the product contract. Table names vary by backend.
+
+## Transactional vs analytics backends
+
+Not every backend is meant to carry the same workload.
+
+- `SQLite`: local and single-node transactional store
+- `Postgres` / `Supabase`: default transactional control-plane store
+- `ClickHouse`: analytics/event store, not a transactional control-plane
+  replacement
+- `Snowflake`: partial transactional control plane with explicit parity
+  limits
+
+The main operator rule is:
+
+- if you need the broadest route and workflow coverage, use `Postgres`
+- add `ClickHouse` only for analytics scale
+- use `Snowflake` where the documented parity boundary is acceptable
+
+## Entity-to-store matrix
+
+| Logical entity | SQLite | Postgres / Supabase | ClickHouse | Snowflake |
+|---|---|---|---|---|
+| Scan jobs | `jobs` | `scan_jobs` | No | `scan_jobs` |
+| Fleet agents | `fleet_agents` | `fleet_agents` | snapshot-only | `fleet_agents` |
+| Gateway policies | `gateway_policies` | `gateway_policies` | No | `gateway_policies` |
+| Gateway policy audit | `policy_audit_log` | `policy_audit_log` | No | `policy_audit_log` |
+| Source registry | `sources` | `control_plane_sources` | No | No |
+| API keys / RBAC | No default API wiring | `api_keys` | No | No |
+| Exceptions | No default API wiring | `exceptions` | No | No |
+| Schedules | `scan_schedules` | `scan_schedules` | No | No |
+| Audit chain | `audit_log` | `audit_log` | denormalized analytics copy only | No full transactional replacement |
+| Graph / attack path | SQLite graph tables | Postgres graph tables | No | No |
+| Trend / baseline | local control-plane tables | `trend_history` and related control-plane tables | analytics/event aggregation only | No |
+| Idempotency | `idempotency_keys` | `idempotency_keys` | No | No |
+| Rate-limit state | `api_rate_limits` | `api_rate_limits` | No | No shared runtime store |
+
+## Important naming differences
+
+These differences are intentional or historical, but operators should
+not have to discover them by reading code.
+
+### `jobs` vs `scan_jobs`
+
+- SQLite uses `jobs`
+- Postgres and Snowflake use `scan_jobs`
+
+This is a backend table-name difference, not a product-model difference.
+The logical entity remains "scan jobs."
+
+### `sources` vs `control_plane_sources`
+
+- SQLite uses `sources`
+- Postgres uses `control_plane_sources`
+
+This exists because the hosted/control-plane source registry was added
+after the original local source store path. The logical entity remains
+"source registry."
+
+### Audit chain vs policy audit
+
+These are separate mechanisms:
+
+- `audit_log`: full control-plane HMAC-chained audit trail
+- `policy_audit_log`: gateway policy mutation audit trail
+
+`policy_audit_log` is not a replacement for the full audit chain.
+
+## Bootstrap SQL vs runtime-created schema
+
+Some schema objects exist in bootstrap SQL. Others are created lazily by
+the runtime stores on first use.
+
+### Bootstrap-first
+
+These are primarily defined in the shipped Postgres bootstrap SQL under
+`deploy/supabase/postgres/init.sql`:
+
+- broad control-plane tables such as `scan_jobs`, `fleet_agents`,
+  `api_keys`, `exceptions`, `audit_log`, graph tables, and
+  `api_rate_limits`
+- analytics and supporting indexes for the packaged self-hosted control
+  plane
+
+### Runtime-created or runtime-upgraded
+
+These are created or upgraded by the runtime stores/middleware on first
+use:
+
+- SQLite `jobs`
+- SQLite `sources`
+- SQLite and Postgres `idempotency_keys`
+- SQLite and Postgres `api_rate_limits` in the shared rate-limit path
+- Postgres `gateway_policies`, `policy_audit_log`, `scan_schedules`,
+  `control_plane_sources`
+- Snowflake `scan_jobs`, `fleet_agents`, `gateway_policies`,
+  `policy_audit_log`
+
+This is why "table exists in SQL" and "route is fully supported on this
+backend" are different questions.
+
+## Backend-specific operator notes
+
+### SQLite
+
+Use for:
+
+- local development
+- laptop or single-node control-plane deployments
+- pilot paths where one file-backed store is acceptable
+
+Caveats:
+
+- broad enough for local control-plane work
+- not the recommended answer for multi-operator transactional workloads
+- table names differ from Postgres in a few places, especially `jobs`
+  and `sources`
+
+### Postgres / Supabase
+
+Use for:
+
+- the default control-plane deployment
+- tenant-scoped transactional APIs
+- API keys, schedules, exceptions, source registry, and graph
+
+This is the current broadest parity backend.
+
+### ClickHouse
+
+Use for:
+
+- high-volume runtime events
+- trend and observability analytics
+- OCSF / proxy / trace/event analytics paths
+
+Do not treat it as a drop-in transactional control-plane backend. It is
+analytics-only in the product contract.
+
+### Snowflake
+
+Use for:
+
+- warehouse-native deployments
+- fleet, scan jobs, gateway policies, and policy audit trails where
+  Snowflake is the system of record
+
+Current transactional parity boundary:
+
+- supported: `scan_jobs`, `fleet_agents`, `gateway_policies`,
+  `policy_audit_log`
+- not supported: source registry, API keys, exceptions, schedules,
+  graph, trend/baseline, full audit-chain replacement
+
+## Recommended selection
+
+| Need | Recommended backend shape |
+|---|---|
+| Local or demo deployment | `SQLite` |
+| Default self-hosted control plane | `Postgres` / `Supabase` |
+| High analytics/event volume | `Postgres` + `ClickHouse` |
+| Warehouse-native governance deployment | `Snowflake` with explicit parity limits |
+
+## Related docs
+
+- [Backend Parity](backend-parity.md)
+- [Snowflake-Native Backend](snowflake-backend.md)
+- [Postgres Provisioning Workflow](postgres-provisioning.md)
+- [Packaged API + UI Control Plane](control-plane-helm.md)
+- repo-root `docs/DATA_MODEL.md`

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -1,14 +1,15 @@
 # Snowflake-native backend
 
 `agent-bom` runs against Snowflake as the primary store for scan jobs,
-fleet agents, gateway policies, and the HMAC-chained audit log. Use this
+fleet agents, gateway policies, and the policy audit trail. Use this
 mode when your organisation already governs data in Snowflake and you
-want the control plane's persistence to land in the same warehouse.
+want selected control-plane persistence to land in the same warehouse.
 
-The parity boundary is explicit — some API surfaces (exceptions, API
-keys, schedules, trend, graph) have not been ported to
-`SnowflakeStore` yet. See [backend-parity.md](backend-parity.md) for
-the current capability matrix.
+The parity boundary is explicit — some API surfaces (source registry,
+exceptions, API keys, schedules, trend, graph, and the full audit
+chain) have not been ported to `SnowflakeStore` yet. See
+[backend-parity.md](backend-parity.md) for the current capability
+matrix.
 
 ---
 
@@ -19,13 +20,15 @@ Pick Snowflake when:
 - Your security and platform teams already have Snowflake as the system
   of record; adding another Postgres instance creates a data-governance
   headache.
-- You want the audit log, scan inventory, and compliance evidence in the
-  same warehouse that drives your other security analytics.
+- You want the policy audit trail, scan inventory, and compliance
+  evidence in the same warehouse that drives your other security
+  analytics.
 - You want to join `agent-bom` findings against other Snowflake
   governance data (user activity, cloud asset tables) without moving
   data across systems.
-- You want **one backend that covers transactional, streaming, and
-  analytical workloads**. Snowflake now ships:
+- You want **one backend that covers the Snowflake-supported
+  transactional, streaming, and analytical workloads**. Snowflake now
+  ships:
   - **Hybrid Tables** (row-oriented) for fast transactional writes to
     the scan / fleet / policy / audit stores.
   - **Standard columnar tables** for the analytics queries the
@@ -146,7 +149,8 @@ applies here. Snowflake-specific signals worth alerting on:
 
 ## Caveats
 
-- Exceptions, API-key persistence, scheduler, trend, graph — not yet on
+- Source registry, exceptions, API-key persistence, scheduler, trend,
+  graph, and the full HMAC-chained `audit_log` are not yet on
   `SnowflakeStore`. Run Postgres alongside for these, or wait for
   parity.
 - The scanner CronJob still runs in-cluster; it does not run inside


### PR DESCRIPTION
Summary
- publish a control-plane data model and store parity contract for operators and auditors
- document the logical entity to table/store mapping across SQLite, Postgres, ClickHouse, and Snowflake
- correct backend parity and Snowflake docs to reflect source registry and full audit-chain limits

Testing
- uv run mkdocs build --strict

Closes #1653