### PR TITLE
docs(deploy): refresh self-hosted diagrams and runtime flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ OSV/NVD is optional and allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | optional `gateway` + selected `proxy` sidecars / local wrappers | HPA + PDB | Remote MCPs, local MCP workloads, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart TB
+flowchart LR
     classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
     classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
     classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
@@ -192,13 +192,19 @@ flowchart TB
     classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
     classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
 
-    Browser["Browser operators"]:::ext
     IdP["Corporate IdP"]:::ext
-    CI["CI + scheduled scans"]:::ext
     Remote["Remote MCPs"]:::ext
     Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
 
-    subgraph Customer["Customer VPC / EKS / self-managed cluster"]
+    subgraph Endpoints["Customer endpoints and workloads"]
+      direction TB
+      Browser["Browser operators"]:::ext
+      Fleet["Developer endpoints / collectors"]:::ops
+      Proxy["Proxy<br/>local wrapper or sidecar"]:::run
+      LocalMCP["Selected local or in-cluster MCPs"]:::ops
+    end
+
+    subgraph Cluster["Customer VPC / EKS / self-managed cluster"]
       direction TB
       Ingress["Ingress + TLS"]:::edge
 
@@ -210,11 +216,7 @@ flowchart TB
         Backup["Backup job"]:::ctrl
       end
 
-      subgraph Runtime["Runtime MCP plane"]
-        direction LR
-        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
-        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
-      end
+      Gateway["Gateway<br/>optional shared MCP traffic plane"]:::run
 
       subgraph Data["Customer-owned data"]
         direction LR
@@ -231,14 +233,16 @@ flowchart TB
     end
 
     Browser --> Ingress
-    IdP -. OIDC .-> Ingress
+    IdP -. OIDC / SAML .-> Ingress
     Ingress --> UI
+    Ingress --> API
     UI -->|same-origin API calls| API
-    CI --> Jobs
     Jobs -->|results + inventory| API
-    Proxy -->|audited relay| Gateway
-    Gateway -->|POST /v1/proxy/audit| API
-    Gateway -->|policy-audited upstream| Remote
+    Fleet -->|fleet sync / pushed results| API
+    Proxy -->|policy pull + audit push| API
+    Proxy -->|inline runtime path| LocalMCP
+    Gateway -->|policy pull + audit push| API
+    Gateway -->|shared remote MCP traffic| Remote
     API --> PG
     API -. optional analytics .-> CH
     Backup --> S3
@@ -246,46 +250,54 @@ flowchart TB
     Secrets --> Gateway
     API --> Obs
     Gateway --> Obs
-    API -. optional egress .-> Intel
+    API -. optional enrichment .-> Intel
 ```
 
 *Deployment truth: the UI is not the collector. The browser drives workflows,
-the API owns control-plane state, workers do scans, and proxy plus gateway
-handle runtime MCP traffic. For the role split, see the [Self-Hosted Product
-Architecture](site-docs/architecture/self-hosted-product-architecture.md).*
+the API owns control-plane state, workers do scans, and proxy plus gateway are
+peer runtime surfaces, not a required serial chain. For the role split, see the
+[Self-Hosted Product Architecture](site-docs/architecture/self-hosted-product-architecture.md).*
 
 #### MCP proxy and gateway runtime flow
 
 ```mermaid
 sequenceDiagram
-    participant Client as Developer or workload client
+    participant Client as Editor or workload client
+    participant API as Control-plane API
     participant Proxy as agent-bom proxy
     participant Gateway as agent-bom gateway
-    participant API as Control-plane API
+    participant Local as Local / sidecar MCP
     participant Remote as Remote MCP
     participant Store as Postgres / audit store
 
-    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: local policy + runtime checks
-    Proxy->>Gateway: audited relay
-    Gateway->>API: policy fetch / POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: response + shared policy result
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Client: safe response
+    par Local / sidecar enforcement path
+        Client->>Proxy: MCP request
+        Proxy->>API: policy pull / audit push
+        Proxy->>Local: direct MCP call
+        Local-->>Proxy: response
+        Proxy->>Proxy: detector chain + optional VLD
+        Proxy-->>Client: safe response
+    and Shared remote gateway path
+        Client->>Gateway: MCP request
+        Gateway->>API: policy pull / audit push
+        Gateway->>Remote: upstream MCP call
+        Remote-->>Gateway: response
+        Gateway->>Gateway: policy + rate limit + optional VLD
+        Gateway-->>Client: safe response
+    end
     API->>Store: persist audit, findings, graph links
 ```
 
-1. The client talks to a local or sidecar `agent-bom proxy`.
-2. The proxy applies local runtime checks and relays to the central
-   `agent-bom gateway`.
-3. The gateway evaluates shared policy, records audit to `/v1/proxy/audit`,
-   then calls the remote MCP upstream.
-4. The response returns on the same path; image responses can run through the
-   visual leak detector before the client sees them.
-5. The API persists audit, findings, and graph links for the UI, exports, and
-   compliance surfaces.
+1. Local stdio or workload-local MCPs use `agent-bom proxy` as the inline
+   runtime path.
+2. Shared remote MCPs can go directly to `agent-bom gateway serve` without a
+   local proxy hop.
+3. Both runtime surfaces pull policy from the control plane and push audit to
+   `/v1/proxy/audit`.
+4. Runtime detections, optional visual leak checks, and tenant-scoped limits
+   happen on the enforcement surface that handled the call.
+5. The API persists audit, findings, fleet/runtime evidence, and graph links
+   for the UI, exports, and compliance surfaces.
 
 #### Who owns what
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -68,13 +68,13 @@ OSV/NVD is optional and allow-listable.
 | Layer | Lives in | Scales via | Talks to |
 |---|---|---|---|
 | **Ingress + auth** | ALB / Istio Gateway + OIDC | — | Corporate IdP (Okta / Entra / Google) |
-| **Runtime MCP plane** | `gateway` + selected `proxy` sidecars / local wrappers | HPA + PDB | Remote MCPs, `/v1/proxy/audit` |
+| **Runtime MCP plane** | optional `gateway` + selected `proxy` sidecars / local wrappers | HPA + PDB | Remote MCPs, local MCP workloads, `/v1/proxy/audit` |
 | **Control plane** | `api`, `ui`, `jobs`, `backup` (Helm) | HPA + CronJob | Data plane, OTEL, Prometheus |
 | **Data plane** | Customer-owned Postgres (+ optional ClickHouse, S3) | Operator-managed | — |
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart TB
+flowchart LR
     classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
     classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
     classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
@@ -82,11 +82,17 @@ flowchart TB
     classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
     classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
 
-    Browser["Browser operators"]:::ext
     IdP["Corporate IdP"]:::ext
-    CI["CI + scheduled scans"]:::ext
     Remote["Remote MCPs"]:::ext
     Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
+
+    subgraph Endpoints["Customer endpoints and workloads"]
+      direction TB
+      Browser["Browser operators"]:::ext
+      Fleet["Developer endpoints / collectors"]:::ops
+      Proxy["Proxy<br/>local wrapper or sidecar"]:::run
+      LocalMCP["Selected local or in-cluster MCPs"]:::ops
+    end
 
     subgraph Customer["Customer VPC / EKS / self-managed cluster"]
       direction TB
@@ -100,11 +106,7 @@ flowchart TB
         Backup["Backup job"]:::ctrl
       end
 
-      subgraph Runtime["Runtime MCP plane"]
-        direction LR
-        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
-        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
-      end
+      Gateway["Gateway<br/>optional shared MCP traffic plane"]:::run
 
       subgraph Data["Customer-owned data"]
         direction LR
@@ -121,14 +123,16 @@ flowchart TB
     end
 
     Browser --> Ingress
-    IdP -. OIDC .-> Ingress
+    IdP -. OIDC / SAML .-> Ingress
     Ingress --> UI
+    Ingress --> API
     UI -->|same-origin API calls| API
-    CI --> Jobs
     Jobs -->|results + inventory| API
-    Proxy -->|audited relay| Gateway
-    Gateway -->|POST /v1/proxy/audit| API
-    Gateway -->|policy-audited upstream| Remote
+    Fleet -->|fleet sync / pushed results| API
+    Proxy -->|policy pull + audit push| API
+    Proxy -->|inline runtime path| LocalMCP
+    Gateway -->|policy pull + audit push| API
+    Gateway -->|shared remote MCP traffic| Remote
     API --> PG
     API -. optional analytics .-> CH
     Backup --> S3
@@ -136,46 +140,54 @@ flowchart TB
     Secrets --> Gateway
     API --> Obs
     Gateway --> Obs
-    API -. optional egress .-> Intel
+    API -. optional enrichment .-> Intel
 ```
 
 *Deployment truth: the UI is not the collector. The browser drives workflows,
-the API owns control-plane state, workers do scans, and proxy plus gateway
-handle runtime MCP traffic. For the role split, see the [Self-Hosted Product
-Architecture](../architecture/self-hosted-product-architecture.md).*
+the API owns control-plane state, workers do scans, and proxy plus gateway are
+peer runtime surfaces, not a required serial chain. For the role split, see the
+[Self-Hosted Product Architecture](../architecture/self-hosted-product-architecture.md).*
 
 ### MCP proxy and gateway runtime flow
 
 ```mermaid
 sequenceDiagram
-    participant Client as Developer or workload client
+    participant Client as Editor or workload client
+    participant API as Control-plane API
     participant Proxy as agent-bom proxy
     participant Gateway as agent-bom gateway
-    participant API as Control-plane API
+    participant Local as Local / sidecar MCP
     participant Remote as Remote MCP
     participant Store as Postgres / audit store
 
-    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: local policy + runtime checks
-    Proxy->>Gateway: audited relay
-    Gateway->>API: policy fetch / POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: response + shared policy result
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Client: safe response
+    par Local / sidecar enforcement path
+        Client->>Proxy: MCP request
+        Proxy->>API: policy pull / audit push
+        Proxy->>Local: direct MCP call
+        Local-->>Proxy: response
+        Proxy->>Proxy: detector chain + optional VLD
+        Proxy-->>Client: safe response
+    and Shared remote gateway path
+        Client->>Gateway: MCP request
+        Gateway->>API: policy pull / audit push
+        Gateway->>Remote: upstream MCP call
+        Remote-->>Gateway: response
+        Gateway->>Gateway: policy + rate limit + optional VLD
+        Gateway-->>Client: safe response
+    end
     API->>Store: persist audit, findings, graph links
 ```
 
-1. The client talks to a local or sidecar `agent-bom proxy`.
-2. The proxy applies local runtime checks and relays to the central
-   `agent-bom gateway`.
-3. The gateway evaluates shared policy, records audit to `/v1/proxy/audit`,
-   then calls the remote MCP upstream.
-4. The response returns on the same path; image responses can run through the
-   visual leak detector before the client sees them.
-5. The API persists audit, findings, and graph links for the UI, exports, and
-   compliance surfaces.
+1. Local stdio or workload-local MCPs use `agent-bom proxy` as the inline
+   runtime path.
+2. Shared remote MCPs can go directly to `agent-bom gateway serve` without a
+   local proxy hop.
+3. Both runtime surfaces pull policy from the control plane and push audit to
+   `/v1/proxy/audit`.
+4. Runtime detections, optional visual leak checks, and tenant-scoped limits
+   happen on the enforcement surface that handled the call.
+5. The API persists audit, findings, fleet/runtime evidence, and graph links
+   for the UI, exports, and compliance surfaces.
 
 For the runtime operator guides behind this flow, see:
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -45,7 +45,7 @@ OSV/NVD is optional and allow-listable.
 | **Platform glue** | ExternalSecrets, ServiceMonitor, OTEL collector | Operator-managed | AWS Secrets Manager / Vault / Grafana |
 
 ```mermaid
-flowchart TB
+flowchart LR
     classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
     classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
     classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
@@ -53,11 +53,17 @@ flowchart TB
     classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
     classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
 
-    Browser["Browser operators"]:::ext
     IdP["Corporate IdP"]:::ext
-    CI["CI + scheduled scans"]:::ext
     Remote["Remote MCPs"]:::ext
     Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
+
+    subgraph Endpoints["Customer endpoints and workloads"]
+      direction TB
+      Browser["Browser operators"]:::ext
+      Fleet["Developer endpoints / collectors"]:::ops
+      Proxy["Proxy<br/>local wrapper or sidecar"]:::run
+      LocalMCP["Selected local or in-cluster MCPs"]:::ops
+    end
 
     subgraph Customer["Customer VPC / EKS / self-managed cluster"]
       direction TB
@@ -71,11 +77,7 @@ flowchart TB
         Backup["Backup job"]:::ctrl
       end
 
-      subgraph Runtime["Runtime MCP plane"]
-        direction LR
-        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
-        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
-      end
+      Gateway["Gateway<br/>optional shared MCP traffic plane"]:::run
 
       subgraph Data["Customer-owned data"]
         direction LR
@@ -92,14 +94,16 @@ flowchart TB
     end
 
     Browser --> Ingress
-    IdP -. OIDC .-> Ingress
+    IdP -. OIDC / SAML .-> Ingress
     Ingress --> UI
+    Ingress --> API
     UI -->|same-origin API calls| API
-    CI --> Jobs
     Jobs -->|results + inventory| API
-    Proxy -->|audited relay| Gateway
-    Gateway -->|POST /v1/proxy/audit| API
-    Gateway -->|policy-audited upstream| Remote
+    Fleet -->|fleet sync / pushed results| API
+    Proxy -->|policy pull + audit push| API
+    Proxy -->|inline runtime path| LocalMCP
+    Gateway -->|policy pull + audit push| API
+    Gateway -->|shared remote MCP traffic| Remote
     API --> PG
     API -. optional analytics .-> CH
     Backup --> S3
@@ -107,46 +111,54 @@ flowchart TB
     Secrets --> Gateway
     API --> Obs
     Gateway --> Obs
-    API -. optional egress .-> Intel
+    API -. optional enrichment .-> Intel
 ```
 
 *Deployment truth: the UI is not the collector. The browser drives workflows,
-the API owns control-plane state, workers do scans, and proxy plus gateway
-handle runtime MCP traffic. For the role split, see the [Self-Hosted Product
-Architecture](../architecture/self-hosted-product-architecture.md).*
+the API owns control-plane state, workers do scans, and proxy plus gateway are
+peer runtime surfaces, not a required serial chain. For the role split, see the
+[Self-Hosted Product Architecture](../architecture/self-hosted-product-architecture.md).*
 
 ### MCP proxy and gateway runtime flow
 
 ```mermaid
 sequenceDiagram
-    participant Client as Developer or workload client
+    participant Client as Editor or workload client
+    participant API as Control-plane API
     participant Proxy as agent-bom proxy
     participant Gateway as agent-bom gateway
-    participant API as Control-plane API
+    participant Local as Local / sidecar MCP
     participant Remote as Remote MCP
     participant Store as Postgres / audit store
 
-    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: local policy + runtime checks
-    Proxy->>Gateway: audited relay
-    Gateway->>API: policy fetch / POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: response + shared policy result
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Client: safe response
+    par Local / sidecar enforcement path
+        Client->>Proxy: MCP request
+        Proxy->>API: policy pull / audit push
+        Proxy->>Local: direct MCP call
+        Local-->>Proxy: response
+        Proxy->>Proxy: detector chain + optional VLD
+        Proxy-->>Client: safe response
+    and Shared remote gateway path
+        Client->>Gateway: MCP request
+        Gateway->>API: policy pull / audit push
+        Gateway->>Remote: upstream MCP call
+        Remote-->>Gateway: response
+        Gateway->>Gateway: policy + rate limit + optional VLD
+        Gateway-->>Client: safe response
+    end
     API->>Store: persist audit, findings, graph links
 ```
 
-1. The client talks to a local or sidecar `agent-bom proxy`.
-2. The proxy applies local runtime checks and relays to the central
-   `agent-bom gateway`.
-3. The gateway evaluates shared policy, records audit to `/v1/proxy/audit`,
-   then calls the remote MCP upstream.
-4. The response returns on the same path; image responses can run through the
-   visual leak detector before the client sees them.
-5. The API persists audit, findings, and graph links for the UI, exports, and
-   compliance surfaces.
+1. Local stdio or workload-local MCPs use `agent-bom proxy` as the inline
+   runtime path.
+2. Shared remote MCPs can go directly to `agent-bom gateway serve` without a
+   local proxy hop.
+3. Both runtime surfaces pull policy from the control plane and push audit to
+   `/v1/proxy/audit`.
+4. Runtime detections, optional visual leak checks, and tenant-scoped limits
+   happen on the enforcement surface that handled the call.
+5. The API persists audit, findings, fleet/runtime evidence, and graph links
+   for the UI, exports, and compliance surfaces.
 
 ## What is in scope
 

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -51,7 +51,7 @@ This is the current code-backed self-hosted story:
 | **agent-bom Scan** | CronJobs, CI runners, one-off jobs, endpoint CLI runs | Discovers agents, MCP servers, packages, images, IaC, Kubernetes, and cloud assets; writes findings and graph state |
 | **agent-bom Fleet** | Endpoint collectors or workstation CLI pushes | Persists inventory and scan history into the control plane without requiring a separate endpoint daemon product |
 | **agent-bom Proxy** | Sidecar or local wrapper near selected MCP servers | Enforces allow/warn/deny policy, detects credential exposure, blocks undeclared tools, and emits signed audit logs |
-| **agent-bom Gateway** | Central API + UI policy surface | Stores, serves, and audits the policies consumed by proxies and managed runtime paths |
+| **agent-bom Gateway** | Shared remote MCP traffic plane plus policy/audit surface | Stores, serves, and audits the policies consumed by proxies and managed runtime paths |
 | **agent-bom Runtime** | Proxy + audit + policy pull + event persistence | Gives runtime visibility without forcing all traffic through one shared chokepoint |
 | **agent-bom Control Plane** | API + UI + Postgres, with optional ClickHouse | Presents findings, graph, remediation, fleet review, audit, and policy management from one operator-owned plane |
 
@@ -76,8 +76,8 @@ start with this shape:
 3. Add endpoint fleet sync for developer laptops and workstations.
 4. Add `agent-bom proxy` only to the MCP workloads that need inline runtime
    enforcement.
-5. Use the gateway surface to manage policy centrally, then let proxies pull
-   those policies and push audit events back.
+5. Use the gateway surface to manage policy centrally and front shared remote
+   MCPs, while proxies pull the same policies and push audit events back.
 
 That gives you one operator story without pretending every workload needs the
 same runtime path.
@@ -88,14 +88,15 @@ flowchart LR
       subgraph Sources["Scan and runtime surfaces"]
         CI["CI / scheduled scan jobs"]
         Endpoints["Developer laptops / workstations"]
-        MCP["Selected MCP workloads"]
-        Proxy["agent-bom proxy sidecars or local wrappers"]
+        Proxy["agent-bom proxy<br/>local wrapper or sidecar"]
+        LocalMCP["Selected local or in-cluster MCPs"]
+        Gateway["agent-bom gateway<br/>shared remote MCP traffic"]
       end
 
       subgraph Plane["agent-bom control plane"]
         API["API + UI"]
         Fleet["Fleet inventory"]
-        Gateway["Gateway policy"]
+        Policy["Gateway policy + audit"]
         Findings["Findings / graph / remediation"]
         PG["Postgres"]
         CH["ClickHouse optional"]
@@ -103,17 +104,20 @@ flowchart LR
     end
 
     subgraph Optional["Optional operator-enabled egress"]
+      Remote["Remote MCPs"]
       Vuln["Vulnerability DB refresh"]
       Enrich["Enrichment / package metadata / webhooks / SIEM"]
     end
 
     CI -->|scan output| Findings
     Endpoints -->|fleet or results push| Fleet
-    MCP --> Proxy
-    Proxy -->|policy pull + audit push| Gateway
+    Proxy -->|inline runtime path| LocalMCP
+    Proxy -->|policy pull + audit push| Policy
+    Gateway -->|policy pull + audit push| Policy
+    Gateway -->|shared remote MCP traffic| Remote
     Findings --> API
     Fleet --> API
-    Gateway --> API
+    Policy --> API
     API --> PG
     API --> CH
     Findings -. optional .-> Vuln
@@ -133,7 +137,7 @@ webhooks.
 | **Scan** | you need discovery, CVE analysis, Kubernetes inventory, CI gates, or scheduled audits | package, container, IaC, MCP, cloud, and cluster scanning | a live enforcement layer |
 | **Fleet** | you want laptops, workstations, or other collectors to persist inventory into one control plane | endpoint and collector push into `/v1/fleet/sync`, review in `/fleet` | an always-on endpoint agent or MDM product |
 | **Proxy / runtime** | you need inline MCP inspection or policy enforcement on live tool traffic | `agent-bom proxy`, audit push, selected blocks/warns, local or sidecar enforcement | a generic shared network gateway for every workload |
-| **Gateway** | you want central policy authoring and evaluation | `/gateway`, `/v1/gateway/policies`, policy pull for proxies | a replacement for the proxy itself |
+| **Gateway** | you want central policy authoring and optional shared remote MCP traffic | `/gateway`, `/v1/gateway/policies`, policy pull for proxies, `agent-bom gateway serve` | a replacement for the proxy itself |
 | **API + UI** | you want one operator control plane | findings, graph, remediation, fleet review, audit, policy management | a hosted vendor control plane |
 | **MCP server** | you want `agent-bom` exposed as tools to assistants or remote clients | `agent-bom mcp server` tool surface | the same thing as the runtime proxy |
 
@@ -211,7 +215,8 @@ The deployment model is intentionally split by trust boundary:
 1. **Discovery and scan paths** read from repos, images, manifests, cloud APIs, or local configs and write findings into the control plane.
 2. **Fleet ingest** persists workstation and collector inventory without requiring a shared privileged daemon across every endpoint.
 3. **Proxy/runtime** stays near the MCP servers so enforcement is low-latency and least-privilege.
-4. **Gateway** centralizes policy definition and auditability, not packet forwarding.
+4. **Gateway** centralizes policy definition and auditability, and can also
+   front shared remote MCP traffic when that is the better fit.
 5. **Control plane** owns storage, graph views, remediation, audit review, and operator workflows.
 
 That keeps request latency low, avoids a single giant runtime chokepoint, and

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -43,7 +43,7 @@ Keep that story in two diagrams:
   between those surfaces
 
 ```mermaid
-flowchart TB
+flowchart LR
     classDef ext  fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
     classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
     classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
@@ -51,11 +51,17 @@ flowchart TB
     classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
     classDef ops  fill:#0f172a,stroke:#64748b,color:#cbd5e1
 
-    Browser["Browser operators"]:::ext
     IdP["Corporate IdP"]:::ext
-    CI["CI + scheduled scans"]:::ext
     Remote["Remote MCPs"]:::ext
     Intel["OSV / NVD / GHSA<br/>optional enrichment"]:::ext
+
+    subgraph Endpoints["Customer endpoints and workloads"]
+      direction TB
+      Browser["Browser operators"]:::ext
+      Fleet["Developer endpoints / collectors"]:::ops
+      Proxy["Proxy<br/>local wrapper or sidecar"]:::run
+      LocalMCP["Selected local or in-cluster MCPs"]:::ops
+    end
 
     subgraph Customer["Your AWS account / VPC / EKS cluster"]
       direction TB
@@ -69,11 +75,7 @@ flowchart TB
         Backup["Backup job"]:::ctrl
       end
 
-      subgraph Runtime["Runtime MCP plane"]
-        direction LR
-        Proxy["Proxy<br/>sidecar or laptop wrapper"]:::run
-        Gateway["Gateway<br/>agent-bom gateway serve"]:::run
-      end
+      Gateway["Gateway<br/>optional shared MCP traffic plane"]:::run
 
       subgraph Data["Customer-owned data"]
         direction LR
@@ -90,14 +92,16 @@ flowchart TB
     end
 
     Browser --> Ingress
-    IdP -. OIDC .-> Ingress
+    IdP -. OIDC / SAML .-> Ingress
     Ingress --> UI
+    Ingress --> API
     UI -->|same-origin API calls| API
-    CI --> Jobs
     Jobs -->|results + inventory| API
-    Proxy -->|audited relay| Gateway
-    Gateway -->|POST /v1/proxy/audit| API
-    Gateway -->|policy-audited upstream| Remote
+    Fleet -->|fleet sync / pushed results| API
+    Proxy -->|policy pull + audit push| API
+    Proxy -->|inline runtime path| LocalMCP
+    Gateway -->|policy pull + audit push| API
+    Gateway -->|shared remote MCP traffic| Remote
     API --> PG
     API -. optional analytics .-> CH
     Backup --> S3
@@ -105,34 +109,50 @@ flowchart TB
     Secrets --> Gateway
     API --> Obs
     Gateway --> Obs
-    API -. optional egress .-> Intel
+    API -. optional enrichment .-> Intel
 ```
 
 ```mermaid
 sequenceDiagram
-    participant Client as Developer or workload client
+    participant Client as Editor or workload client
+    participant API as Control-plane API
     participant Proxy as agent-bom proxy
     participant Gateway as agent-bom gateway
-    participant API as Control-plane API
+    participant Local as Local / sidecar MCP
     participant Remote as Remote MCP
     participant Store as Postgres / audit store
 
-    Client->>Proxy: MCP JSON-RPC (stdio / SSE / HTTP)
-    Proxy->>Proxy: local policy + runtime checks
-    Proxy->>Gateway: audited relay
-    Gateway->>API: policy fetch / POST /v1/proxy/audit
-    Gateway->>Remote: upstream MCP call
-    Remote-->>Gateway: MCP response
-    Gateway-->>Proxy: response + shared policy result
-    Proxy->>Proxy: optional VLD / OCR redaction
-    Proxy-->>Client: safe response
+    par Local / sidecar enforcement path
+        Client->>Proxy: MCP request
+        Proxy->>API: policy pull / audit push
+        Proxy->>Local: direct MCP call
+        Local-->>Proxy: response
+        Proxy->>Proxy: detector chain + optional VLD
+        Proxy-->>Client: safe response
+    and Shared remote gateway path
+        Client->>Gateway: MCP request
+        Gateway->>API: policy pull / audit push
+        Gateway->>Remote: upstream MCP call
+        Remote-->>Gateway: response
+        Gateway->>Gateway: policy + rate limit + optional VLD
+        Gateway-->>Client: safe response
+    end
     API->>Store: persist audit, findings, graph links
 ```
 
 *Deployment truth: the browser drives workflows, the API owns control-plane
-state, workers do scans, and proxy plus gateway handle runtime MCP traffic. For
-the role split, see the [Self-Hosted Product
+state, workers do scans, and proxy plus gateway are peer runtime surfaces, not
+a required serial chain. For the role split, see the [Self-Hosted Product
 Architecture](../architecture/self-hosted-product-architecture.md).*
+
+1. Local stdio or workload-local MCPs use `agent-bom proxy` as the inline
+   runtime path.
+2. Shared remote MCPs can go directly to `agent-bom gateway serve` without a
+   local proxy hop.
+3. Both runtime surfaces pull policy from the control plane and push audit to
+   `/v1/proxy/audit`.
+4. Runtime detections, optional visual leak checks, and tenant-scoped limits
+   happen on the enforcement surface that handled the call.
 
 ## Which Agent-BOM Surface Runs Where
 
@@ -142,12 +162,12 @@ Architecture](../architecture/self-hosted-product-architecture.md).*
 | **Scan** | CronJob, CI runner, or one-off job | Kubernetes, container, package, MCP, cloud, and inventory scanning |
 | **Fleet** | pushed into the control plane from endpoints or collectors | persisted workstation and collector inventory in `/fleet` |
 | **Proxy / runtime** | only next to the MCP workloads you want inline enforcement on | live JSON-RPC inspection, allow/warn/deny, audit push |
-| **Gateway** | central control plane API + UI | store and manage policies that proxies evaluate and pull |
+| **Gateway** | central service in-cluster | store and manage policies, and optionally front shared remote MCP traffic |
 | **MCP server** | wherever you expose `agent-bom` itself as a tool server | assistant-facing tool access, separate from the proxy path |
 
 The important boundary is that `agent-bom proxy` is the inline runtime path,
-while the gateway is the central policy surface. One does not replace the
-other.
+while the gateway is the central policy and shared remote MCP surface. One does
+not replace the other.
 
 For the concrete gateway startup path against discovered fleet MCPs, see
 [Gateway Auto-Discovery From the Control Plane](gateway-auto-discovery.md).
@@ -183,7 +203,7 @@ These are the current deployable capabilities this EKS model supports:
 | **Scan** | package, image, IaC, Kubernetes, MCP, cloud, and inventory scanning via CronJob, CI, or one-off runs |
 | **Fleet** | endpoint and collector inventory persistence, state review, trust/lifecycle tracking |
 | **Proxy / runtime** | MCP policy evaluation, undeclared-tool blocking, credential detection, audit push, local or sidecar deployment |
-| **Gateway** | central policy authoring, distribution, and evaluation surface for proxies |
+| **Gateway** | central policy authoring, distribution, and evaluation surface for proxies, plus optional shared remote MCP traffic |
 | **Storage** | Postgres-backed control-plane state, optional ClickHouse analytics, optional S3-backed backups/exports |
 
 This is the important product boundary: customers can deploy one or all of


### PR DESCRIPTION
Summary
- replace the overloaded self-hosted deployment diagrams with simpler topology views that match the current control-plane, proxy, and gateway split
- update runtime flow diagrams to show proxy and gateway as peer runtime surfaces instead of a required proxy-to-gateway chain
- align README and mirrored deployment docs on the current self-hosted, EKS, and enterprise pilot messaging

Testing
- uv run mkdocs build --strict

Closes #1660