### PR TITLE
feat(deploy): add Helm teardown cleanup hooks

### DIFF
--- a/deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml
@@ -24,6 +24,11 @@ spec:
   target:
     name: {{ default $defaults.target.name (get $target "name") | quote }}
     creationPolicy: {{ default $defaults.target.creationPolicy (get $target "creationPolicy") }}
+    template:
+      metadata:
+        labels:
+          {{- include "agent-bom.labels" $ | nindent 10 }}
+          app.kubernetes.io/component: control-plane
   data:
     {{- toYaml (default $defaults.data $secret.data) | nindent 4 }}
 {{- end }}

--- a/deploy/helm/agent-bom/templates/teardown-hook-job.yaml
+++ b/deploy/helm/agent-bom/templates/teardown-hook-job.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.teardownHooks.enabled }}
+{{- $defaults := .Values.controlPlane.externalSecrets }}
+{{- $secrets := $defaults.secrets }}
+{{- if not $secrets }}
+{{- $secrets = list (dict "target" $defaults.target) }}
+{{- end }}
+{{- $targetSecretNames := list }}
+{{- range $secret := $secrets }}
+{{- $target := default (dict) (get $secret "target") }}
+{{- $targetSecretNames = append $targetSecretNames (default $defaults.target.name (get $target "name")) }}
+{{- end }}
+{{- $targetSecretNames = concat $targetSecretNames (.Values.teardownHooks.extraTargetSecrets | default list) }}
+{{- range $hook := list "pre-delete" "post-delete" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agent-bom.name" $ }}-{{ $hook }}-cleanup
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: teardown-hook
+  annotations:
+    helm.sh/hook: {{ $hook }}
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: {{ $.Values.teardownHooks.deletePolicy | quote }}
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "agent-bom.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: teardown-hook
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "agent-bom.name" $ }}-teardown-hook
+      securityContext:
+        {{- toYaml $.Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: cleanup
+          image: "{{ $.Values.teardownHooks.image.repository }}:{{ $.Values.teardownHooks.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.teardownHooks.image.pullPolicy }}
+          command:
+            - python
+            - -m
+            - agent_bom.deploy_k8s_cleanup
+            - --namespace
+            - {{ $.Release.Namespace }}
+            - --label-selector
+            - app.kubernetes.io/name={{ include "agent-bom.name" $ }},app.kubernetes.io/managed-by={{ $.Release.Service }}
+            {{- range $targetName := $targetSecretNames }}
+            - --target-secret
+            - {{ $targetName | quote }}
+            {{- end }}
+          securityContext:
+            {{- toYaml $.Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml $.Values.teardownHooks.resources | nindent 12 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/teardown-hook-rbac.yaml
+++ b/deploy/helm/agent-bom/templates/teardown-hook-rbac.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.teardownHooks.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-bom.name" . }}-teardown-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teardown-hook
+  annotations:
+    helm.sh/hook: pre-delete,post-delete
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: {{ .Values.teardownHooks.deletePolicy | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agent-bom.name" . }}-teardown-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teardown-hook
+  annotations:
+    helm.sh/hook: pre-delete,post-delete
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: {{ .Values.teardownHooks.deletePolicy | quote }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agent-bom.name" . }}-teardown-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teardown-hook
+  annotations:
+    helm.sh/hook: pre-delete,post-delete
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: {{ .Values.teardownHooks.deletePolicy | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agent-bom.name" . }}-teardown-hook
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agent-bom.name" . }}-teardown-hook
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -140,6 +140,22 @@ gateway:
       cpu: 1
       memory: 1Gi
 
+teardownHooks:
+  enabled: true
+  deletePolicy: before-hook-creation,hook-succeeded
+  image:
+    repository: agentbom/agent-bom
+    # tag defaults to Chart.AppVersion
+    pullPolicy: IfNotPresent
+  extraTargetSecrets: []
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
 controlPlane:
   enabled: false
   serviceMesh:

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -34,6 +34,10 @@ agent-bom teardown \
 That helper tears down the chart first and the product-owned Terraform baseline
 second, while leaving platform-owned cluster infrastructure alone.
 
+Chart removal now includes packaged Helm pre/post-delete hooks that clean up
+product-owned in-cluster leftovers such as generated ExternalSecret target
+secrets, CronJobs, Jobs, and PVCs before the Terraform baseline is destroyed.
+
 ## What the chart deploys
 
 When you set `controlPlane.enabled=true`, the Helm chart can package:

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -236,6 +236,10 @@ That helper only removes product-owned `agent-bom` surfaces. It does not
 delete the EKS cluster, ingress controller, VPC, or other platform-owned
 infrastructure.
 
+When the chart is removed, packaged Helm pre/post-delete hooks also clean up
+product-owned in-cluster leftovers such as generated ExternalSecret target
+secrets, CronJobs, Jobs, and PVCs before Terraform destroys the AWS baseline.
+
 ## Recommended Topology
 
 Use two layers.

--- a/site-docs/deployment/terraform-aws-baseline.md
+++ b/site-docs/deployment/terraform-aws-baseline.md
@@ -94,8 +94,9 @@ agent-bom teardown \
 The helper does the same two-phase decommission in the correct order:
 
 1. uninstall the Helm release
-2. wait for in-cluster workloads to disappear
-3. destroy the product-owned Terraform baseline
+2. run Helm pre/post-delete cleanup hooks for generated target secrets, CronJobs, Jobs, and PVCs
+3. wait for in-cluster workloads to disappear
+4. destroy the product-owned Terraform baseline
 
 If you want to inspect the plan first:
 

--- a/src/agent_bom/deploy_k8s_cleanup.py
+++ b/src/agent_bom/deploy_k8s_cleanup.py
@@ -1,0 +1,168 @@
+"""Best-effort namespace cleanup for Helm pre/post-delete hooks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Literal
+
+SERVICEACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+SERVICEACCOUNT_CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+
+@dataclass(frozen=True)
+class CleanupOperation:
+    kind: str
+    target: Literal["collection", "named"]
+    api_path: str
+    name: str | None = None
+    label_selector: str | None = None
+
+
+def build_cleanup_operations(
+    *,
+    namespace: str,
+    label_selector: str,
+    target_secrets: list[str],
+) -> list[CleanupOperation]:
+    """Build the ordered cleanup operations for a release namespace."""
+
+    operations = [
+        CleanupOperation(
+            kind="ExternalSecret",
+            target="collection",
+            api_path=f"/apis/external-secrets.io/v1beta1/namespaces/{namespace}/externalsecrets",
+            label_selector=label_selector,
+        ),
+    ]
+    operations.extend(
+        CleanupOperation(
+            kind="Secret",
+            target="named",
+            api_path=f"/api/v1/namespaces/{namespace}/secrets/{secret_name}",
+            name=secret_name,
+        )
+        for secret_name in target_secrets
+        if secret_name
+    )
+    operations.extend(
+        [
+            CleanupOperation(
+                kind="CronJob",
+                target="collection",
+                api_path=f"/apis/batch/v1/namespaces/{namespace}/cronjobs",
+                label_selector=label_selector,
+            ),
+            CleanupOperation(
+                kind="Job",
+                target="collection",
+                api_path=f"/apis/batch/v1/namespaces/{namespace}/jobs",
+                label_selector=label_selector,
+            ),
+            CleanupOperation(
+                kind="PersistentVolumeClaim",
+                target="collection",
+                api_path=f"/api/v1/namespaces/{namespace}/persistentvolumeclaims",
+                label_selector=label_selector,
+            ),
+        ]
+    )
+    return operations
+
+
+def _incluster_api_server() -> str:
+    host = os.environ.get("KUBERNETES_SERVICE_HOST")
+    port = os.environ.get("KUBERNETES_SERVICE_PORT_HTTPS") or os.environ.get("KUBERNETES_SERVICE_PORT")
+    if not host or not port:
+        raise RuntimeError("KUBERNETES_SERVICE_HOST/KUBERNETES_SERVICE_PORT are required for in-cluster cleanup")
+    return f"https://{host}:{port}"
+
+
+def _read_serviceaccount_file(path: str) -> str:
+    return open(path, encoding="utf-8").read().strip()
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    query: dict[str, str] | None = None,
+) -> tuple[int, str]:
+    server = _incluster_api_server()
+    token = _read_serviceaccount_file(SERVICEACCOUNT_TOKEN_PATH)
+    query_string = f"?{urllib.parse.urlencode(query)}" if query else ""
+    request = urllib.request.Request(
+        f"{server}{path}{query_string}",
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+    )
+    ssl_context = ssl.create_default_context(cafile=SERVICEACCOUNT_CA_PATH)
+    try:
+        # This is restricted to the in-cluster Kubernetes API host and the
+        # mounted service-account CA/token, not an operator-controlled URL.
+        with urllib.request.urlopen(request, context=ssl_context, timeout=15) as response:  # nosec B310
+            return response.status, response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return exc.code, body
+
+
+def execute_cleanup(operations: list[CleanupOperation]) -> int:
+    """Execute best-effort cleanup operations and emit one line per result."""
+
+    failed = 0
+    for operation in operations:
+        query = {"labelSelector": operation.label_selector} if operation.target == "collection" and operation.label_selector else None
+        status, body = _request("DELETE", operation.api_path, query=query)
+        if status in {200, 202, 404}:
+            suffix = operation.name or operation.label_selector or ""
+            sys.stdout.write(f"{operation.kind}: ok {suffix}\n")
+            continue
+        failed += 1
+        detail = body
+        try:
+            payload = json.loads(body)
+            detail = payload.get("message") or payload.get("details") or body
+        except json.JSONDecodeError:
+            pass
+        suffix = operation.name or operation.label_selector or ""
+        sys.stderr.write(f"{operation.kind}: failed {suffix} ({status}) {detail}\n")
+    return failed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--namespace", required=True, help="Namespace containing the Helm release")
+    parser.add_argument("--label-selector", required=True, help="Label selector used for collection deletes")
+    parser.add_argument(
+        "--target-secret",
+        dest="target_secrets",
+        action="append",
+        default=[],
+        help="Generated Secret name to delete explicitly (repeatable)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    operations = build_cleanup_operations(
+        namespace=args.namespace,
+        label_selector=args.label_selector,
+        target_secrets=args.target_secrets,
+    )
+    return 1 if execute_cleanup(operations) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_k8s_cleanup.py
+++ b/tests/test_deploy_k8s_cleanup.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from agent_bom.deploy_k8s_cleanup import CleanupOperation, build_cleanup_operations, execute_cleanup
+
+
+def test_build_cleanup_operations_orders_external_secret_then_generated_secret_cleanup():
+    ops = build_cleanup_operations(
+        namespace="agent-bom",
+        label_selector="app.kubernetes.io/name=agent-bom,app.kubernetes.io/managed-by=Helm",
+        target_secrets=["agent-bom-control-plane"],
+    )
+    assert ops[0] == CleanupOperation(
+        kind="ExternalSecret",
+        target="collection",
+        api_path="/apis/external-secrets.io/v1beta1/namespaces/agent-bom/externalsecrets",
+        label_selector="app.kubernetes.io/name=agent-bom,app.kubernetes.io/managed-by=Helm",
+    )
+    assert ops[1] == CleanupOperation(
+        kind="Secret",
+        target="named",
+        api_path="/api/v1/namespaces/agent-bom/secrets/agent-bom-control-plane",
+        name="agent-bom-control-plane",
+    )
+    assert ops[-1].kind == "PersistentVolumeClaim"
+
+
+def test_execute_cleanup_treats_missing_resources_as_success(monkeypatch):
+    monkeypatch.setattr(
+        "agent_bom.deploy_k8s_cleanup._request",
+        lambda method, path, query=None: (404, '{"message":"not found"}'),
+    )
+    failed = execute_cleanup(
+        [
+            CleanupOperation(
+                kind="Secret",
+                target="named",
+                api_path="/api/v1/namespaces/agent-bom/secrets/example",
+                name="example",
+            )
+        ]
+    )
+    assert failed == 0
+
+
+def test_execute_cleanup_reports_non_404_failures(monkeypatch):
+    monkeypatch.setattr(
+        "agent_bom.deploy_k8s_cleanup._request",
+        lambda method, path, query=None: (500, '{"message":"boom"}'),
+    )
+    failed = execute_cleanup(
+        [
+            CleanupOperation(
+                kind="Job",
+                target="collection",
+                api_path="/apis/batch/v1/namespaces/agent-bom/jobs",
+                label_selector="app.kubernetes.io/name=agent-bom",
+            )
+        ]
+    )
+    assert failed == 1

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -248,6 +248,8 @@ def test_helm_templates_exist():
         "controlplane-ui-service.yaml",
         "gateway-hpa.yaml",
         "gateway-pdb.yaml",
+        "teardown-hook-rbac.yaml",
+        "teardown-hook-job.yaml",
         "serviceaccount.yaml",
         "rbac.yaml",
         "cronjob.yaml",
@@ -344,6 +346,16 @@ def test_helm_external_secrets_defaults():
     assert ext["secretStoreRef"]["kind"] == "ClusterSecretStore"
     assert ext["target"]["name"] == "agent-bom-control-plane"
     assert ext["secrets"] == []
+
+
+def test_helm_teardown_hooks_defaults():
+    """Teardown hooks should ship enabled with explicit runtime defaults."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    hooks = doc["teardownHooks"]
+    assert hooks["enabled"] is True
+    assert hooks["deletePolicy"] == "before-hook-creation,hook-succeeded"
+    assert hooks["image"]["repository"] == "agentbom/agent-bom"
+    assert hooks["extraTargetSecrets"] == []
 
 
 def test_helm_control_plane_observability_defaults():
@@ -538,6 +550,20 @@ def test_external_secret_template_supports_top_level_secret_store_defaults():
     assert 'get $secret "secretStoreRef"' in template
     assert 'default $defaults.secretStoreRef.kind (get $secretStoreRef "kind")' in template
     assert 'default $defaults.secretStoreRef.name (get $secretStoreRef "name")' in template
+
+
+def test_external_secret_template_labels_generated_target_secret():
+    """Generated target secrets should inherit chart labels for hook cleanup."""
+    template = (HELM_DIR / "templates" / "controlplane-externalsecret.yaml").read_text()
+    assert "template:" in template
+    assert "app.kubernetes.io/component: control-plane" in template
+
+
+def test_teardown_hook_template_uses_cleanup_module():
+    """Teardown hook jobs should call the packaged Python cleanup entrypoint."""
+    template = (HELM_DIR / "templates" / "teardown-hook-job.yaml").read_text()
+    assert "agent_bom.deploy_k8s_cleanup" in template
+    assert "helm.sh/hook: {{ $hook }}" in template
 
 
 def test_helm_single_node_sqlite_pilot_example_is_shipped():


### PR DESCRIPTION
## Summary
- add packaged Helm pre/post-delete cleanup hooks for product-owned in-cluster leftovers
- label ExternalSecret-generated target secrets so the cleanup hook can remove them explicitly
- document the updated destroy flow alongside the existing Terraform baseline and teardown helper

## Testing
- uv run pytest tests/test_deploy_k8s_cleanup.py tests/test_deploy_manifests.py -q
- uv run ruff check src/agent_bom/deploy_k8s_cleanup.py tests/test_deploy_k8s_cleanup.py tests/test_deploy_manifests.py
- uv run mypy src/agent_bom/deploy_k8s_cleanup.py
- uv run mkdocs build --strict
- PATH="/tmp/helm-bin/darwin-arm64:$PATH" python3 scripts/validate_helm_profiles.py --profile focused-pilot
- PATH="/tmp/helm-bin/darwin-arm64:$PATH" python3 scripts/validate_helm_profiles.py --profile production

Closes #1635