### PR TITLE
feat(endpoint): add packaged installer assets and MDM rollout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -295,7 +298,7 @@ jobs:
       - name: Validate Homebrew formula renderer
         if: matrix.os == 'ubuntu-latest'
         run: |
-          VERSION=$(python -c "from agent_bom import __version__; print(__version__)")
+          VERSION=$(uv run python -c "from agent_bom import __version__; print(__version__)")
           python scripts/render_homebrew_formula.py \
             --version "$VERSION" \
             --url "https://example.invalid/agent-bom-${VERSION}.tar.gz" \
@@ -306,7 +309,7 @@ jobs:
         env:
           BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
         run: |
-          VERSION=$(python -c "from agent_bom import __version__; print(__version__)")
+          VERSION=$(uv run python -c "from agent_bom import __version__; print(__version__)")
           bash scripts/build-pkg.sh \
             --bundle-dir "$BUNDLE_DIR" \
             --output "$RUNNER_TEMP/agent-bom-endpoint.pkg" \
@@ -320,7 +323,7 @@ jobs:
           BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
         shell: pwsh
         run: |
-          $version = python -c "from agent_bom import __version__; print(__version__)"
+          $version = uv run python -c "from agent_bom import __version__; print(__version__)"
           ./scripts/build-msi.ps1 -BundleDir $env:BUNDLE_DIR -OutputPath (Join-Path $env:RUNNER_TEMP "agent-bom-endpoint.msi") -Version $version -DryRun
 
   # 3. Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,64 @@ jobs:
       - name: Render shipped Helm profiles
         run: python3 scripts/validate_helm_profiles.py
 
+  endpoint-packaging:
+    name: Endpoint Packaging (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Generate endpoint bundle
+        run: |
+          uv run agent-bom proxy-bootstrap \
+            --bundle-dir "$BUNDLE_DIR" \
+            --control-plane-url https://agent-bom.internal.example.com \
+            --control-plane-token token-123 \
+            --push-url https://agent-bom.internal.example.com/v1/fleet/sync \
+            --push-api-key fleet-key
+        shell: bash
+
+      - name: Validate Homebrew formula renderer
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          VERSION=$(python -c "from agent_bom import __version__; print(__version__)")
+          python scripts/render_homebrew_formula.py \
+            --version "$VERSION" \
+            --url "https://example.invalid/agent-bom-${VERSION}.tar.gz" \
+            --sha256 "$(python -c 'print(\"a\" * 64)')"
+
+      - name: Validate macOS pkg builder
+        if: matrix.os == 'macos-latest'
+        run: |
+          VERSION=$(python -c "from agent_bom import __version__; print(__version__)")
+          bash scripts/build-pkg.sh \
+            --bundle-dir "$BUNDLE_DIR" \
+            --output "$RUNNER_TEMP/agent-bom-endpoint.pkg" \
+            --version "$VERSION" \
+            --dry-run
+        shell: bash
+
+      - name: Validate Windows MSI builder
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $version = python -c "from agent_bom import __version__; print(__version__)"
+          ./scripts/build-msi.ps1 -BundleDir $env:BUNDLE_DIR -OutputPath (Join-Path $env:RUNNER_TEMP "agent-bom-endpoint.msi") -Version $version -DryRun
+
   # 3. Tests
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,8 +270,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    env:
-      BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -283,6 +281,8 @@ jobs:
         run: uv sync --extra dev
 
       - name: Generate endpoint bundle
+        env:
+          BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
         run: |
           uv run agent-bom proxy-bootstrap \
             --bundle-dir "$BUNDLE_DIR" \
@@ -303,6 +303,8 @@ jobs:
 
       - name: Validate macOS pkg builder
         if: matrix.os == 'macos-latest'
+        env:
+          BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
         run: |
           VERSION=$(python -c "from agent_bom import __version__; print(__version__)")
           bash scripts/build-pkg.sh \
@@ -314,6 +316,8 @@ jobs:
 
       - name: Validate Windows MSI builder
         if: matrix.os == 'windows-latest'
+        env:
+          BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
         shell: pwsh
         run: |
           $version = python -c "from agent_bom import __version__; print(__version__)"

--- a/deploy/endpoints/intune/detect-agent-bom-endpoint.ps1
+++ b/deploy/endpoints/intune/detect-agent-bom-endpoint.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+
+if (Get-Command agent-bom -ErrorAction SilentlyContinue) {
+  exit 0
+}
+exit 1

--- a/deploy/endpoints/intune/install-agent-bom-endpoint.ps1
+++ b/deploy/endpoints/intune/install-agent-bom-endpoint.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+
+$bundleRoot = Join-Path $env:ProgramData "agent-bom-endpoint"
+New-Item -ItemType Directory -Force -Path $bundleRoot | Out-Null
+Copy-Item (Join-Path $PSScriptRoot "..\\install-agent-bom-endpoint.ps1") (Join-Path $bundleRoot "install-agent-bom-endpoint.ps1") -Force
+& (Join-Path $bundleRoot "install-agent-bom-endpoint.ps1")

--- a/deploy/endpoints/jamf/install-agent-bom-endpoint.sh
+++ b/deploy/endpoints/jamf/install-agent-bom-endpoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+BUNDLE_ROOT="/Library/Application Support/agent-bom-endpoint"
+mkdir -p "$BUNDLE_ROOT"
+cp "$(dirname "$0")/../install-agent-bom-endpoint.sh" "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+chmod 755 "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+"$BUNDLE_ROOT/install-agent-bom-endpoint.sh"

--- a/deploy/endpoints/kandji/install-agent-bom-endpoint.sh
+++ b/deploy/endpoints/kandji/install-agent-bom-endpoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+BUNDLE_ROOT="/Library/Application Support/agent-bom-endpoint"
+mkdir -p "$BUNDLE_ROOT"
+cp "$(dirname "$0")/../install-agent-bom-endpoint.sh" "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+chmod 755 "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+su "${CURRENT_USER:-$(stat -f %Su /dev/console)}" -c "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -103,10 +103,19 @@ agent-bom proxy-bootstrap \
 That bundle includes:
 - a macOS/Linux shell bootstrap script
 - a Windows PowerShell bootstrap script
+- Jamf and Kandji shell wrappers
+- Intune install and detect PowerShell wrappers
 - a `fleet-sync.env` file for the shipped timer/service assets
 - a rendered launchd plist for managed macOS rollout
 
 The generated bootstrap scripts install or upgrade `agent-bom`, then run `agent-bom proxy-configure --apply` with the control-plane policy/audit settings you chose, so supported JSON MCP clients no longer need manual config edits.
+
+For packaged rollout beyond shell scripts, the repo now also ships:
+
+- `scripts/build-pkg.sh` for macOS `.pkg` assembly from a generated endpoint bundle
+- `scripts/build-msi.ps1` for Windows `.msi` assembly via WiX from the same bundle
+- `scripts/render_homebrew_formula.py` for publishing a version-pinned Homebrew formula into your tap/release pipeline
+- static Jamf / Intune / Kandji templates under `deploy/endpoints/`
 
 ### 3. Centralized API Server — fleet dashboard
 

--- a/docs/MCP_CLIENT_GUIDES.md
+++ b/docs/MCP_CLIENT_GUIDES.md
@@ -81,6 +81,7 @@ args = ["proxy", "--log", "~/.agent-bom/logs/filesystem.jsonl", "--", "npx", "@m
 - `agent-bom proxy` is best when the client talks to a third-party stdio server and you want runtime inspection.
 - `agent-bom proxy-configure --apply` targets JSON MCP configs and can now stamp control-plane policy/audit settings into the wrapped proxy command.
 - `agent-bom proxy-bootstrap --bundle-dir ./endpoint-bundle --control-plane-url https://agent-bom.example.com --push-url https://agent-bom.example.com/v1/fleet/sync` writes managed rollout artifacts for macOS/Linux and Windows without hand-editing JSON on every machine.
+- the bundle now also includes Jamf, Intune, and Kandji wrappers plus repo-shipped `.pkg` / `.msi` build scripts for IT-owned rollout
 - TOML clients like Codex CLI need manual proxy wrapping today.
 - SSE / HTTP clients can use `agent-bom mcp server --transport sse --bearer-token "$AGENT_BOM_MCP_BEARER_TOKEN"` or `--transport streamable-http`.
 - Non-loopback remote transports fail closed unless you configure `--bearer-token` / `AGENT_BOM_MCP_BEARER_TOKEN` or explicitly pass `--allow-insecure-no-auth`.

--- a/scripts/build-msi.ps1
+++ b/scripts/build-msi.ps1
@@ -1,11 +1,11 @@
-$ErrorActionPreference = "Stop"
-
 param(
   [Parameter(Mandatory = $true)][string]$BundleDir,
   [Parameter(Mandatory = $true)][string]$OutputPath,
   [string]$Version = "0.0.0",
   [switch]$DryRun
 )
+
+$ErrorActionPreference = "Stop"
 
 $stageDir = Join-Path $env:TEMP "agent-bom-msi-stage"
 $wxsPath = Join-Path $stageDir "agent-bom-endpoint.wxs"

--- a/scripts/build-msi.ps1
+++ b/scripts/build-msi.ps1
@@ -1,0 +1,47 @@
+$ErrorActionPreference = "Stop"
+
+param(
+  [Parameter(Mandatory = $true)][string]$BundleDir,
+  [Parameter(Mandatory = $true)][string]$OutputPath,
+  [string]$Version = "0.0.0",
+  [switch]$DryRun
+)
+
+$stageDir = Join-Path $env:TEMP "agent-bom-msi-stage"
+$wxsPath = Join-Path $stageDir "agent-bom-endpoint.wxs"
+Remove-Item -Recurse -Force $stageDir -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
+Copy-Item -Recurse -Force (Join-Path $BundleDir "*") $stageDir
+
+$wxs = @"
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="agent-bom Endpoint" Manufacturer="agent-bom" Version="$Version" UpgradeCode="8F1A44B0-AE74-4F7B-BA95-9C3ACD493630">
+    <MediaTemplate />
+    <Feature Id="MainFeature" Title="agent-bom Endpoint" Level="1">
+      <ComponentGroupRef Id="EndpointBundle" />
+    </Feature>
+  </Package>
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="agent-bom-endpoint" />
+      </Directory>
+    </Directory>
+  </Fragment>
+  <Fragment>
+    <ComponentGroup Id="EndpointBundle" Directory="INSTALLFOLDER">
+      <Files Include="$stageDir\**" />
+    </ComponentGroup>
+  </Fragment>
+</Wix>
+"@
+Set-Content -Path $wxsPath -Value $wxs -Encoding UTF8
+
+$buildCommand = @("wix", "build", $wxsPath, "-o", $OutputPath)
+Write-Output ("+ " + ($buildCommand -join " "))
+
+if ($DryRun) {
+  exit 0
+}
+
+& $buildCommand[0] $buildCommand[1..($buildCommand.Length - 1)]

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-pkg.sh --bundle-dir <dir> --output <path> [--identifier id] [--version v] [--signing-identity name] [--dry-run]
+
+Packages a generated `agent-bom proxy-bootstrap` bundle into a macOS installer payload.
+EOF
+}
+
+BUNDLE_DIR=""
+OUTPUT_PATH=""
+IDENTIFIER="io.agentbom.endpoint"
+VERSION="0.0.0"
+SIGNING_IDENTITY=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle-dir) BUNDLE_DIR="$2"; shift 2 ;;
+    --output) OUTPUT_PATH="$2"; shift 2 ;;
+    --identifier) IDENTIFIER="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --signing-identity) SIGNING_IDENTITY="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+[[ -n "$BUNDLE_DIR" ]] || { echo "--bundle-dir is required" >&2; exit 1; }
+[[ -n "$OUTPUT_PATH" ]] || { echo "--output is required" >&2; exit 1; }
+
+PKGROOT="${TMPDIR:-/tmp}/agent-bom-pkgroot"
+SCRIPTS_DIR="${TMPDIR:-/tmp}/agent-bom-pkg-scripts"
+rm -rf "$PKGROOT" "$SCRIPTS_DIR"
+mkdir -p "$PKGROOT/usr/local/share/agent-bom-endpoint" "$SCRIPTS_DIR"
+cp -R "$BUNDLE_DIR"/. "$PKGROOT/usr/local/share/agent-bom-endpoint/"
+
+cat >"$SCRIPTS_DIR/postinstall" <<'EOF'
+#!/bin/sh
+set -eu
+if [ -x /usr/local/share/agent-bom-endpoint/install-agent-bom-endpoint.sh ]; then
+  /usr/local/share/agent-bom-endpoint/install-agent-bom-endpoint.sh || true
+fi
+EOF
+chmod 755 "$SCRIPTS_DIR/postinstall"
+
+PKGBUILD_CMD=(
+  pkgbuild
+  --root "$PKGROOT"
+  --identifier "$IDENTIFIER"
+  --version "$VERSION"
+  --scripts "$SCRIPTS_DIR"
+  "${OUTPUT_PATH%.pkg}.unsigned.pkg"
+)
+PRODUCTBUILD_CMD=(productbuild --package "${OUTPUT_PATH%.pkg}.unsigned.pkg" "$OUTPUT_PATH")
+if [[ -n "$SIGNING_IDENTITY" ]]; then
+  PRODUCTBUILD_CMD=(productbuild --sign "$SIGNING_IDENTITY" --package "${OUTPUT_PATH%.pkg}.unsigned.pkg" "$OUTPUT_PATH")
+fi
+
+printf '+ %q ' "${PKGBUILD_CMD[@]}"; printf '\n'
+printf '+ %q ' "${PRODUCTBUILD_CMD[@]}"; printf '\n'
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  exit 0
+fi
+
+"${PKGBUILD_CMD[@]}"
+"${PRODUCTBUILD_CMD[@]}"

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -1,0 +1,45 @@
+"""Render a Homebrew formula for agent-bom release packaging."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def render_formula(*, version: str, url: str, sha256: str) -> str:
+    return f"""class AgentBom < Formula
+  desc "Security scanner for AI infrastructure"
+  homepage "https://github.com/msaad00/agent-bom"
+  url "{url}"
+  sha256 "{sha256}"
+  license "Apache-2.0"
+  depends_on "python@3.13"
+
+  def install
+    system Formula["python@3.13"].opt_bin/"python3.13", "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
+  end
+
+  test do
+    assert_match "{version}", shell_output("#{{bin}}/agent-bom --version")
+  end
+end
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args(argv)
+    formula = render_formula(version=args.version, url=args.url, sha256=args.sha256)
+    if args.output:
+        args.output.write_text(formula, encoding="utf-8")
+    else:
+        print(formula)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -225,6 +225,8 @@ See also:
 After the control plane is live, onboard people and workloads, not just pods:
 
 - use `agent-bom proxy-bootstrap` to generate endpoint onboarding bundles
+- package the generated bundle into `.pkg` / `.msi` artifacts when IT needs
+  managed rollout instead of ad hoc shell execution
 - point MCP clients at the local `agent-bom proxy` wrapper
 - enable fleet sync for workstation visibility
 - add proxy sidecars only to workloads that need inline MCP policy enforcement
@@ -239,6 +241,33 @@ agent-bom proxy-bootstrap \
   --control-plane-token <api-key> \
   --push-url https://agent-bom.internal.example.com/v1/fleet/sync \
   --push-api-key <api-key>
+```
+
+For packaged endpoint rollout, reuse that same generated bundle:
+
+```bash
+bash scripts/build-pkg.sh \
+  --bundle-dir ./agent-bom-endpoint-bundle \
+  --output ./dist/agent-bom-endpoint.pkg \
+  --dry-run
+```
+
+```powershell
+./scripts/build-msi.ps1 `
+  -BundleDir .\agent-bom-endpoint-bundle `
+  -OutputPath .\dist\agent-bom-endpoint.msi `
+  -DryRun
+```
+
+The bundle also ships Jamf, Kandji, and Intune wrapper scripts plus a
+Homebrew formula renderer for organizations that distribute `agent-bom`
+through a managed tap instead of direct package upload.
+
+```bash
+python3 scripts/render_homebrew_formula.py \
+  --version 0.81.0 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.81.0.tar.gz \
+  --sha256 <release-sha256>
 ```
 
 ## What Operators Get After Deploy

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -79,6 +79,14 @@ start with this shape:
 5. Use the gateway surface to manage policy centrally and front shared remote
    MCPs, while proxies pull the same policies and push audit events back.
 
+For managed endpoint rollout, `agent-bom proxy-bootstrap` now generates a
+single onboarding bundle that can be:
+
+- pushed directly as shell / PowerShell bootstrap assets
+- wrapped into Jamf, Kandji, or Intune rollout scripts
+- assembled into `.pkg` and `.msi` installers from the same generated bundle
+- published into a Homebrew tap via the shipped formula renderer
+
 That gives you one operator story without pretending every workload needs the
 same runtime path.
 

--- a/src/agent_bom/endpoint_onboarding.py
+++ b/src/agent_bom/endpoint_onboarding.py
@@ -105,6 +105,54 @@ def render_fleet_sync_env(push_url: str, push_api_key: str | None) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_jamf_install_script(*, bundle_subdir: str = "agent-bom-endpoint") -> str:
+    """Render a Jamf-friendly shell installer wrapper."""
+    return f"""#!/bin/sh
+set -eu
+
+BUNDLE_ROOT="/Library/Application Support/{bundle_subdir}"
+mkdir -p "$BUNDLE_ROOT"
+cp "$(dirname "$0")/../install-agent-bom-endpoint.sh" "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+chmod 755 "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+"$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+"""
+
+
+def render_kandji_install_script(*, bundle_subdir: str = "agent-bom-endpoint") -> str:
+    """Render a Kandji custom-script wrapper."""
+    return f"""#!/bin/sh
+set -eu
+
+BUNDLE_ROOT="/Library/Application Support/{bundle_subdir}"
+mkdir -p "$BUNDLE_ROOT"
+cp "$(dirname "$0")/../install-agent-bom-endpoint.sh" "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+chmod 755 "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+su "${{CURRENT_USER:-$(stat -f %Su /dev/console)}}" -c "$BUNDLE_ROOT/install-agent-bom-endpoint.sh"
+"""
+
+
+def render_intune_install_script(*, bundle_subdir: str = "agent-bom-endpoint") -> str:
+    """Render an Intune remediation/install wrapper."""
+    return f"""$ErrorActionPreference = "Stop"
+
+$bundleRoot = Join-Path $env:ProgramData "{bundle_subdir}"
+New-Item -ItemType Directory -Force -Path $bundleRoot | Out-Null
+Copy-Item (Join-Path $PSScriptRoot "..\\install-agent-bom-endpoint.ps1") (Join-Path $bundleRoot "install-agent-bom-endpoint.ps1") -Force
+& (Join-Path $bundleRoot "install-agent-bom-endpoint.ps1")
+"""
+
+
+def render_intune_detect_script() -> str:
+    """Render a simple Intune detection script."""
+    return """$ErrorActionPreference = "Stop"
+
+if (Get-Command agent-bom -ErrorAction SilentlyContinue) {
+    exit 0
+}
+exit 1
+"""
+
+
 def render_launch_agent_plist(push_url: str, push_api_key: str | None) -> str:
     """Render a launchd plist with concrete fleet-sync values."""
     token_xml = (
@@ -185,6 +233,34 @@ def write_endpoint_onboarding_bundle(
         stat.S_IRUSR | stat.S_IWUSR,
     )
     artifacts["powershell_bootstrap"] = str(powershell_path)
+
+    jamf_path = _write_text(
+        bundle_dir / "jamf" / "install-agent-bom-endpoint.sh",
+        render_jamf_install_script(),
+        stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR,
+    )
+    artifacts["jamf_install"] = str(jamf_path)
+
+    kandji_path = _write_text(
+        bundle_dir / "kandji" / "install-agent-bom-endpoint.sh",
+        render_kandji_install_script(),
+        stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR,
+    )
+    artifacts["kandji_install"] = str(kandji_path)
+
+    intune_install_path = _write_text(
+        bundle_dir / "intune" / "install-agent-bom-endpoint.ps1",
+        render_intune_install_script(),
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    artifacts["intune_install"] = str(intune_install_path)
+
+    intune_detect_path = _write_text(
+        bundle_dir / "intune" / "detect-agent-bom-endpoint.ps1",
+        render_intune_detect_script(),
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    artifacts["intune_detect"] = str(intune_detect_path)
 
     if push_url:
         env_path = _write_text(

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -230,6 +230,10 @@ def test_proxy_bootstrap_writes_bundle(tmp_path):
     assert "Wrote endpoint onboarding bundle" in result.output
     assert (tmp_path / "install-agent-bom-endpoint.sh").exists()
     assert (tmp_path / "install-agent-bom-endpoint.ps1").exists()
+    assert (tmp_path / "jamf" / "install-agent-bom-endpoint.sh").exists()
+    assert (tmp_path / "intune" / "install-agent-bom-endpoint.ps1").exists()
+    assert (tmp_path / "intune" / "detect-agent-bom-endpoint.ps1").exists()
+    assert (tmp_path / "kandji" / "install-agent-bom-endpoint.sh").exists()
     assert (tmp_path / "endpoint-onboarding-summary.json").exists()
 
 

--- a/tests/test_endpoint_onboarding.py
+++ b/tests/test_endpoint_onboarding.py
@@ -44,6 +44,10 @@ def test_write_endpoint_onboarding_bundle_writes_artifacts(tmp_path):
     assert set(artifacts) >= {
         "shell_bootstrap",
         "powershell_bootstrap",
+        "jamf_install",
+        "kandji_install",
+        "intune_install",
+        "intune_detect",
         "fleet_sync_env",
         "launch_agent_plist",
         "summary",
@@ -54,6 +58,10 @@ def test_write_endpoint_onboarding_bundle_writes_artifacts(tmp_path):
     env_file = Path(artifacts["fleet_sync_env"]).read_text()
     assert "AGENT_BOM_PUSH_URL" in env_file
     assert "AGENT_BOM_PUSH_API_KEY" in env_file
+    jamf_script = Path(artifacts["jamf_install"]).read_text()
+    assert "install-agent-bom-endpoint.sh" in jamf_script
+    intune_script = Path(artifacts["intune_install"]).read_text()
+    assert "install-agent-bom-endpoint.ps1" in intune_script
     summary = json.loads(Path(artifacts["summary"]).read_text())
     assert summary["control_plane_url"] == "https://agent-bom.internal.example.com"
     assert summary["artifacts"]["shell_bootstrap"] == artifacts["shell_bootstrap"]

--- a/tests/test_endpoint_packaging.py
+++ b/tests/test_endpoint_packaging.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from agent_bom.endpoint_onboarding import (
+    render_intune_detect_script,
+    render_intune_install_script,
+    render_jamf_install_script,
+    render_kandji_install_script,
+)
+
+
+def _load_render_formula():
+    script_path = Path(__file__).parent.parent / "scripts" / "render_homebrew_formula.py"
+    spec = importlib.util.spec_from_file_location("render_homebrew_formula", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.render_formula
+
+
+def test_render_jamf_install_script_reuses_bundle_bootstrap():
+    body = render_jamf_install_script()
+    assert "/Library/Application Support/agent-bom-endpoint" in body
+    assert "install-agent-bom-endpoint.sh" in body
+
+
+def test_render_kandji_install_script_runs_as_console_user():
+    body = render_kandji_install_script()
+    assert "CURRENT_USER" in body
+    assert "install-agent-bom-endpoint.sh" in body
+
+
+def test_render_intune_scripts_are_operator_ready():
+    install_body = render_intune_install_script()
+    detect_body = render_intune_detect_script()
+    assert "ProgramData" in install_body
+    assert "Get-Command agent-bom" in detect_body
+
+
+def test_render_homebrew_formula_embeds_release_metadata():
+    render_formula = _load_render_formula()
+    body = render_formula(
+        version="0.81.0",
+        url="https://example.invalid/agent-bom-0.81.0.tar.gz",
+        sha256="a" * 64,
+    )
+    assert 'url "https://example.invalid/agent-bom-0.81.0.tar.gz"' in body
+    assert 'sha256 "' + ("a" * 64) + '"' in body
+    assert 'assert_match "0.81.0"' in body
+
+
+def test_packaged_endpoint_rollout_assets_exist():
+    root = Path(__file__).parent.parent / "deploy" / "endpoints"
+    assert (root / "jamf" / "install-agent-bom-endpoint.sh").exists()
+    assert (root / "intune" / "install-agent-bom-endpoint.ps1").exists()
+    assert (root / "intune" / "detect-agent-bom-endpoint.ps1").exists()
+    assert (root / "kandji" / "install-agent-bom-endpoint.sh").exists()


### PR DESCRIPTION
## Summary
- extend `proxy-bootstrap` bundles with Jamf, Kandji, and Intune rollout wrappers so managed endpoint onboarding does not stop at shell scripts
- ship repo-owned packaging helpers for macOS `.pkg`, Windows `.msi` (WiX), and Homebrew formula generation from the same generated bundle
- add cross-platform CI smoke validation plus deployment docs so the packaged endpoint path is code-backed and documented

Closes #1636

## Testing
- `uv run pytest tests/test_endpoint_onboarding.py tests/test_endpoint_packaging.py tests/test_cli_runtime.py tests/test_proxy_configure.py -q`
- `uv run ruff check src/agent_bom/endpoint_onboarding.py tests/test_endpoint_onboarding.py tests/test_endpoint_packaging.py tests/test_cli_runtime.py tests/test_proxy_configure.py scripts/render_homebrew_formula.py`
- `uv run mypy src/agent_bom/endpoint_onboarding.py`
- `uv run mkdocs build --strict`
- `uv run agent-bom proxy-bootstrap --bundle-dir /tmp/agent-bom-endpoint-bundle-smoke --control-plane-url https://agent-bom.internal.example.com --control-plane-token token-123 --push-url https://agent-bom.internal.example.com/v1/fleet/sync --push-api-key fleet-key`
- `bash scripts/build-pkg.sh --bundle-dir /tmp/agent-bom-endpoint-bundle-smoke --output /tmp/agent-bom-endpoint.pkg --dry-run`
- `python3 scripts/render_homebrew_formula.py --version 0.81.0 --url https://example.invalid/agent-bom-0.81.0.tar.gz --sha256 $(python3 - <<'PY'
print('a' * 64)
PY
)`

## Notes
- Windows `.msi` dry-run is validated in the new GitHub Actions matrix job because `pwsh` is not installed in this local environment.
