### PR TITLE
feat(k8s): add proxy sidecar mutating webhook

### DIFF
--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -10,3 +10,5 @@ Enterprise pilot notes:
   `kubectl label namespace {{ .Release.Namespace }} pod-security.kubernetes.io/enforce=restricted pod-security.kubernetes.io/audit=restricted pod-security.kubernetes.io/warn=restricted --overwrite`
 - The focused EKS pilot values lock ingress down; adjust `networkPolicy.ingress` if your ingress controller does not run in `ingress-nginx`.
 - For production operator defaults, start from `deploy/helm/agent-bom/examples/eks-production-values.yaml`.
+- `sidecarInjection.enabled=true` requires cert-manager because the chart packages
+  the webhook TLS certificate and CA injection path.

--- a/deploy/helm/agent-bom/templates/_helpers.tpl
+++ b/deploy/helm/agent-bom/templates/_helpers.tpl
@@ -38,6 +38,13 @@ Gateway service account name.
 {{- end }}
 
 {{/*
+Sidecar injector full name.
+*/}}
+{{- define "agent-bom.sidecarInjectorName" -}}
+{{- printf "%s-sidecar-injector" (include "agent-bom.name" .) -}}
+{{- end }}
+
+{{/*
 Scanner service account name.
 */}}
 {{- define "agent-bom.scannerServiceAccountName" -}}

--- a/deploy/helm/agent-bom/templates/sidecar-injector-cert.yaml
+++ b/deploy/helm/agent-bom/templates/sidecar-injector-cert.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.sidecarInjection.enabled .Values.sidecarInjection.certManager.enabled }}
+{{- $name := include "agent-bom.sidecarInjectorName" . }}
+{{- $tlsSecretName := default (printf "%s-tls" $name) .Values.sidecarInjection.certManager.tlsSecretName }}
+{{- if .Values.sidecarInjection.certManager.createSelfSignedIssuer }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sidecar-injector
+spec:
+  selfSigned: {}
+---
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sidecar-injector
+spec:
+  secretName: {{ $tlsSecretName }}
+  duration: {{ .Values.sidecarInjection.certManager.duration | quote }}
+  renewBefore: {{ .Values.sidecarInjection.certManager.renewBefore | quote }}
+  dnsNames:
+    - {{ printf "%s.%s.svc" $name .Release.Namespace | quote }}
+    - {{ printf "%s.%s.svc.cluster.local" $name .Release.Namespace | quote }}
+  issuerRef:
+    name: {{ default $name .Values.sidecarInjection.certManager.issuerRef.name | quote }}
+    kind: {{ default "Issuer" .Values.sidecarInjection.certManager.issuerRef.kind | quote }}
+    group: {{ default "cert-manager.io" .Values.sidecarInjection.certManager.issuerRef.group | quote }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/sidecar-injector-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/sidecar-injector-deployment.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.sidecarInjection.enabled }}
+{{- $name := include "agent-bom.sidecarInjectorName" . }}
+{{- $tlsSecretName := default (printf "%s-tls" $name) .Values.sidecarInjection.certManager.tlsSecretName }}
+{{- $apiUrl := .Values.sidecarInjection.controlPlane.apiUrl | default (printf "http://%s-api.%s.svc.cluster.local:%v" (include "agent-bom.name" .) .Release.Namespace .Values.controlPlane.api.port) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sidecar-injector
+spec:
+  replicas: {{ .Values.sidecarInjection.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      app.kubernetes.io/component: sidecar-injector
+  template:
+    metadata:
+      labels:
+        {{- include "agent-bom.labels" . | nindent 8 }}
+        app.kubernetes.io/component: sidecar-injector
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: webhook
+          image: "{{ .Values.sidecarInjection.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.sidecarInjection.image.pullPolicy }}
+          args:
+            - sidecar-injector
+            - --host
+            - 0.0.0.0
+            - --port
+            - {{ .Values.sidecarInjection.service.targetPort | quote }}
+            - --tls-cert-file
+            - /tls/tls.crt
+            - --tls-key-file
+            - /tls/tls.key
+            - --proxy-image
+            - {{ printf "%s:%s" .Values.runtimeImage.repository .Values.runtimeImage.tag | quote }}
+            - --control-plane-url
+            - {{ $apiUrl | quote }}
+            - --control-plane-token-secret-name
+            - {{ .Values.sidecarInjection.controlPlane.tokenSecretName | quote }}
+            - --control-plane-token-secret-key
+            - {{ .Values.sidecarInjection.controlPlane.tokenSecretKey | quote }}
+            - --default-mcp-port
+            - {{ .Values.sidecarInjection.defaultMcpPort | quote }}
+            - --metrics-port
+            - {{ .Values.sidecarInjection.metricsPort | quote }}
+            - --policy-refresh-seconds
+            - {{ .Values.sidecarInjection.policyRefreshSeconds | quote }}
+            - --audit-push-interval
+            - {{ .Values.sidecarInjection.auditPushInterval | quote }}
+            - --tenant-label-key
+            - {{ .Values.sidecarInjection.selectors.tenantLabelKey | quote }}
+            {{- if .Values.sidecarInjection.detectCredentials }}
+            - --detect-credentials
+            {{- else }}
+            - --no-detect-credentials
+            {{- end }}
+            {{- if .Values.sidecarInjection.blockUndeclared }}
+            - --block-undeclared
+            {{- else }}
+            - --no-block-undeclared
+            {{- end }}
+            {{- if .Values.sidecarInjection.policyConfigMapName }}
+            - --policy-configmap-name
+            - {{ .Values.sidecarInjection.policyConfigMapName | quote }}
+            {{- end }}
+          ports:
+            - name: https
+              containerPort: {{ .Values.sidecarInjection.service.targetPort }}
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+          resources:
+            {{- toYaml .Values.sidecarInjection.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+      volumes:
+        - name: tls
+          secret:
+            secretName: {{ $tlsSecretName }}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/sidecar-injector-service.yaml
+++ b/deploy/helm/agent-bom/templates/sidecar-injector-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.sidecarInjection.enabled }}
+{{- $name := include "agent-bom.sidecarInjectorName" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sidecar-injector
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+    app.kubernetes.io/component: sidecar-injector
+  ports:
+    - name: https
+      port: {{ .Values.sidecarInjection.service.port }}
+      targetPort: https
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/agent-bom/templates/sidecar-injector-webhook.yaml
+++ b/deploy/helm/agent-bom/templates/sidecar-injector-webhook.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.sidecarInjection.enabled }}
+{{- $name := include "agent-bom.sidecarInjectorName" . }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sidecar-injector
+  annotations:
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace $name | quote }}
+webhooks:
+  - name: namespace.{{ $name }}.agent-bom.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: {{ .Values.sidecarInjection.webhook.failurePolicy }}
+    timeoutSeconds: {{ .Values.sidecarInjection.webhook.timeoutSeconds }}
+    reinvocationPolicy: {{ .Values.sidecarInjection.webhook.reinvocationPolicy }}
+    namespaceSelector:
+      matchExpressions:
+        - key: {{ .Values.sidecarInjection.selectors.namespaceLabelKey | quote }}
+          operator: In
+          values:
+            - {{ .Values.sidecarInjection.selectors.namespaceLabelValue | quote }}
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ $name }}
+        path: /mutate
+        port: {{ .Values.sidecarInjection.service.port }}
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+        scope: "*"
+  - name: pod.{{ $name }}.agent-bom.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: {{ .Values.sidecarInjection.webhook.failurePolicy }}
+    timeoutSeconds: {{ .Values.sidecarInjection.webhook.timeoutSeconds }}
+    reinvocationPolicy: {{ .Values.sidecarInjection.webhook.reinvocationPolicy }}
+    objectSelector:
+      matchExpressions:
+        - key: {{ .Values.sidecarInjection.selectors.podLabelKey | quote }}
+          operator: In
+          values:
+            - {{ .Values.sidecarInjection.selectors.podLabelValue | quote }}
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ $name }}
+        path: /mutate
+        port: {{ .Values.sidecarInjection.service.port }}
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+        scope: "*"
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -140,6 +140,55 @@ gateway:
       cpu: 1
       memory: 1Gi
 
+sidecarInjection:
+  enabled: false
+  replicas: 2
+  image:
+    repository: agentbom/agent-bom
+    # tag defaults to Chart.AppVersion
+    pullPolicy: IfNotPresent
+  service:
+    port: 443
+    targetPort: 8443
+  certManager:
+    enabled: true
+    createSelfSignedIssuer: true
+    issuerRef:
+      name: ""
+      kind: Issuer
+      group: cert-manager.io
+    duration: 2160h
+    renewBefore: 360h
+    tlsSecretName: ""
+  webhook:
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    reinvocationPolicy: IfNeeded
+  selectors:
+    namespaceLabelKey: agent-bom.io/proxy-inject
+    namespaceLabelValue: enabled
+    podLabelKey: agent-bom.io/proxy
+    podLabelValue: "true"
+    tenantLabelKey: agent-bom.io/tenant
+  defaultMcpPort: 3000
+  metricsPort: 8422
+  policyRefreshSeconds: 30
+  auditPushInterval: 10
+  detectCredentials: true
+  blockUndeclared: true
+  policyConfigMapName: ""
+  controlPlane:
+    apiUrl: ""
+    tokenSecretName: ""
+    tokenSecretKey: token
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
 teardownHooks:
   enabled: true
   deletePolicy: before-hook-creation,hook-succeeded

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -137,6 +137,19 @@ volumeMounts:
 
 Then add `--policy /etc/agent-bom/policy.json` to the proxy args.
 
+For the packaged Helm control-plane path, the chart now also ships an
+optional mutating webhook for the HTTP/SSE sidecar model. Enable
+`sidecarInjection.enabled=true`, then opt in either:
+
+- an entire namespace with `agent-bom.io/proxy-inject=enabled`
+- or a single workload with pod label `agent-bom.io/proxy=true`
+
+Each opted-in pod must still declare the local MCP target explicitly through
+`agent-bom.io/mcp-url` or `agent-bom.io/mcp-port`. The webhook injects the
+`agent-bom proxy` container, audit volume, metrics annotations, and
+control-plane policy/audit wiring; it does not try to infer stdio server
+commands for you.
+
 ---
 
 ## Log vs Enforce Mode

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -349,6 +349,8 @@ That example adds:
 - packaged Postgres backup `CronJob` that runs `pg_dump` and uploads to S3 through IRSA with SSE or KMS
 - dedicated service-account hooks for gateway and backup jobs, inheriting the scanner IRSA annotations unless you override them
 - restricted ingress defaults for the chart network policy
+- optional cert-manager-backed sidecar auto-injection webhook for HTTP/SSE MCP
+  workloads
 
 For clusters that already standardize on a service mesh and policy controller,
 start from:

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -15,6 +15,15 @@ Located in `deploy/k8s/`:
 
 Those static manifests are still the scanner/runtime path.
 
+The packaged Helm chart now also ships an optional mutating webhook for the
+HTTP/SSE sidecar path:
+
+- enable `sidecarInjection.enabled=true`
+- opt in an entire namespace with label `agent-bom.io/proxy-inject=enabled`
+- or opt in a single workload with pod label `agent-bom.io/proxy=true`
+- declare the local MCP target with annotation `agent-bom.io/mcp-url` or
+  `agent-bom.io/mcp-port`
+
 If you want the packaged API + dashboard control plane, use the Helm chart
 described below.
 
@@ -82,6 +91,7 @@ helm install agent-bom deploy/helm/agent-bom/ \
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments and Services |
 | `controlPlane.ingress.enabled` | `false` | Add same-origin ingress routing for UI + API |
 | `controlPlane.ui.env` | `NEXT_PUBLIC_API_URL=\"\"` | Blank by default so the browser uses same-origin paths |
+| `sidecarInjection.enabled` | `false` | Package the cert-manager-backed mutating webhook for proxy sidecar auto-injection |
 | `networkPolicy.restrictIngress` | `true` | Deny ingress by default; add explicit ingress policy rules for allowed callers |
 | `rbac.create` | `true` | Create RBAC resources |
 | `serviceAccount.annotations` | `{}` | Attach provider-specific identity such as AWS IRSA |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -266,9 +266,10 @@ main.add_command(doctor_cmd, "doctor")
 # ---------------------------------------------------------------------------
 # Deployment lifecycle command
 # ---------------------------------------------------------------------------
-from agent_bom.cli._deploy import teardown_cmd  # noqa: E402
+from agent_bom.cli._deploy import sidecar_injector_cmd, teardown_cmd  # noqa: E402
 
 main.add_command(teardown_cmd, "teardown")
+main.add_command(sidecar_injector_cmd, "sidecar-injector")
 
 # ---------------------------------------------------------------------------
 # Remediate command

--- a/src/agent_bom/cli/_deploy.py
+++ b/src/agent_bom/cli/_deploy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import click
@@ -92,3 +93,134 @@ def teardown_cmd(
         click.echo("\nTeardown completed. Local generated state was deleted after execution.")
     else:
         click.echo(f"\nTeardown summary written to {plan.summary_path}")
+
+
+@click.command("sidecar-injector")
+@click.option(
+    "--host",
+    default="0.0.0.0",  # nosec B104 - intended for in-cluster ClusterIP admission webhook serving
+    show_default=True,
+    help="Host for the admission webhook listener.",
+)
+@click.option("--port", default=8443, show_default=True, type=int, help="TLS port for the admission webhook listener.")
+@click.option("--tls-cert-file", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True, help="TLS certificate file.")
+@click.option("--tls-key-file", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True, help="TLS private key file.")
+@click.option(
+    "--proxy-image",
+    envvar="AGENT_BOM_SIDECAR_PROXY_IMAGE",
+    required=True,
+    help="Container image injected as the agent-bom proxy sidecar.",
+)
+@click.option(
+    "--control-plane-url",
+    envvar="AGENT_BOM_API_URL",
+    required=True,
+    help="Control-plane API base URL the injected sidecar uses for policy pull and audit push.",
+)
+@click.option(
+    "--control-plane-token-secret-name",
+    envvar="AGENT_BOM_SIDECAR_TOKEN_SECRET_NAME",
+    required=True,
+    help="Secret name injected into the sidecar as AGENT_BOM_API_TOKEN.",
+)
+@click.option(
+    "--control-plane-token-secret-key",
+    envvar="AGENT_BOM_SIDECAR_TOKEN_SECRET_KEY",
+    default="token",
+    show_default=True,
+    help="Secret key holding the control-plane API token.",
+)
+@click.option(
+    "--default-mcp-port",
+    default=3000,
+    show_default=True,
+    type=int,
+    help="Fallback localhost MCP port when no explicit mcp-url annotation is set.",
+)
+@click.option("--metrics-port", default=8422, show_default=True, type=int, help="Metrics port exposed by the injected proxy sidecar.")
+@click.option("--policy-refresh-seconds", default=30, show_default=True, type=int, help="Policy pull interval for the injected sidecar.")
+@click.option("--audit-push-interval", default=10, show_default=True, type=int, help="Audit push interval for the injected sidecar.")
+@click.option(
+    "--detect-credentials/--no-detect-credentials",
+    default=True,
+    show_default=True,
+    help="Enable credential detection in the injected sidecar.",
+)
+@click.option(
+    "--block-undeclared/--no-block-undeclared",
+    default=True,
+    show_default=True,
+    help="Enable undeclared-tool blocking in the injected sidecar.",
+)
+@click.option(
+    "--policy-configmap-name",
+    default=None,
+    help="Default ConfigMap name mounted at /etc/agent-bom/policy.json inside injected sidecars.",
+)
+@click.option(
+    "--tenant-label-key",
+    default="agent-bom.io/tenant",
+    show_default=True,
+    help="Pod label or annotation key used to stamp tenant_id into injection audit records.",
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+    default="info",
+    show_default=True,
+)
+def sidecar_injector_cmd(
+    host: str,
+    port: int,
+    tls_cert_file: Path,
+    tls_key_file: Path,
+    proxy_image: str,
+    control_plane_url: str,
+    control_plane_token_secret_name: str,
+    control_plane_token_secret_key: str,
+    default_mcp_port: int,
+    metrics_port: int,
+    policy_refresh_seconds: int,
+    audit_push_interval: int,
+    detect_credentials: bool,
+    block_undeclared: bool,
+    policy_configmap_name: str | None,
+    tenant_label_key: str,
+    log_level: str,
+) -> None:
+    """Run the TLS admission webhook that auto-injects proxy sidecars."""
+    try:
+        import uvicorn
+    except ImportError:
+        click.echo(
+            "ERROR: uvicorn is required for `agent-bom sidecar-injector`.\nInstall it with:  pip install 'agent-bom[api]'",
+            err=True,
+        )
+        sys.exit(1)
+
+    from agent_bom.sidecar_injector import SidecarInjectorSettings, create_sidecar_injector_app
+
+    settings = SidecarInjectorSettings(
+        proxy_image=proxy_image,
+        control_plane_url=control_plane_url,
+        control_plane_token_secret_name=control_plane_token_secret_name,
+        control_plane_token_secret_key=control_plane_token_secret_key,
+        default_mcp_port=max(default_mcp_port, 1),
+        metrics_port=max(metrics_port, 1),
+        policy_refresh_seconds=max(policy_refresh_seconds, 1),
+        audit_push_interval=max(audit_push_interval, 1),
+        detect_credentials=detect_credentials,
+        block_undeclared=block_undeclared,
+        policy_configmap_name=policy_configmap_name,
+        tenant_label_key=tenant_label_key,
+    )
+    app = create_sidecar_injector_app(settings)
+    click.echo(f"agent-bom sidecar injector serving on https://{host}:{port}")
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=log_level.lower(),
+        ssl_certfile=str(tls_cert_file),
+        ssl_keyfile=str(tls_key_file),
+    )

--- a/src/agent_bom/sidecar_injector.py
+++ b/src/agent_bom/sidecar_injector.py
@@ -1,0 +1,248 @@
+"""Kubernetes mutating webhook for agent-bom proxy sidecar injection."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from agent_bom.api.audit_log import log_action
+
+
+def _is_enabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _is_disabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"0", "false", "no", "off", "disabled"}
+
+
+@dataclass(frozen=True)
+class SidecarInjectorSettings:
+    proxy_image: str
+    control_plane_url: str
+    control_plane_token_secret_name: str
+    control_plane_token_secret_key: str = "token"
+    container_name: str = "agent-bom-proxy"
+    tenant_label_key: str = "agent-bom.io/tenant"
+    inject_label_key: str = "agent-bom.io/proxy"
+    inject_annotation_key: str = "agent-bom.io/proxy"
+    injected_annotation_key: str = "agent-bom.io/proxy-injected"
+    mcp_url_annotation_key: str = "agent-bom.io/mcp-url"
+    mcp_port_annotation_key: str = "agent-bom.io/mcp-port"
+    policy_configmap_annotation_key: str = "agent-bom.io/proxy-policy-configmap"
+    default_mcp_port: int = 3000
+    metrics_port: int = 8422
+    policy_refresh_seconds: int = 30
+    audit_push_interval: int = 10
+    detect_credentials: bool = True
+    block_undeclared: bool = True
+    policy_configmap_name: str | None = None
+    audit_actor: str = "sidecar-injector"
+    audit_logger: Callable[..., None] = log_action
+
+
+def _patch_add(path: str, value: Any) -> dict[str, Any]:
+    return {"op": "add", "path": path, "value": value}
+
+
+def _coerce_port(value: str | None, default: int) -> int:
+    try:
+        port = int(value or default)
+    except (TypeError, ValueError):
+        return default
+    return port if port > 0 else default
+
+
+def _target_url(metadata: dict[str, Any], settings: SidecarInjectorSettings) -> str:
+    annotations = metadata.get("annotations") or {}
+    explicit = str(annotations.get(settings.mcp_url_annotation_key, "") or "").strip()
+    if explicit:
+        return explicit
+    port = _coerce_port(annotations.get(settings.mcp_port_annotation_key), settings.default_mcp_port)
+    return f"http://127.0.0.1:{port}"
+
+
+def _already_injected(pod: dict[str, Any], settings: SidecarInjectorSettings) -> bool:
+    containers = (pod.get("spec") or {}).get("containers") or []
+    return any(container.get("name") == settings.container_name for container in containers)
+
+
+def _should_inject(metadata: dict[str, Any], settings: SidecarInjectorSettings) -> bool:
+    labels = metadata.get("labels") or {}
+    annotations = metadata.get("annotations") or {}
+    requested = labels.get(settings.inject_label_key) or annotations.get(settings.inject_annotation_key)
+    if _is_disabled(requested):
+        return False
+    return True
+
+
+def _sidecar_container(settings: SidecarInjectorSettings, metadata: dict[str, Any]) -> dict[str, Any]:
+    policy_configmap = (
+        str((metadata.get("annotations") or {}).get(settings.policy_configmap_annotation_key, "") or "").strip()
+        or settings.policy_configmap_name
+    )
+    args = [
+        "proxy",
+        "--url",
+        _target_url(metadata, settings),
+        "--policy-refresh-seconds",
+        str(settings.policy_refresh_seconds),
+        "--audit-push-interval",
+        str(settings.audit_push_interval),
+        "--log",
+        "/var/log/agent-bom/audit.jsonl",
+    ]
+    if policy_configmap:
+        args.extend(["--policy", "/etc/agent-bom/policy.json"])
+    if settings.detect_credentials:
+        args.append("--detect-credentials")
+    if settings.block_undeclared:
+        args.append("--block-undeclared")
+    mounts: list[dict[str, Any]] = [{"name": "agent-bom-audit-logs", "mountPath": "/var/log/agent-bom"}]
+    if policy_configmap:
+        mounts.append({"name": "agent-bom-proxy-policy", "mountPath": "/etc/agent-bom", "readOnly": True})
+    return {
+        "name": settings.container_name,
+        "image": settings.proxy_image,
+        "args": args,
+        "env": [
+            {"name": "AGENT_BOM_API_URL", "value": settings.control_plane_url},
+            {
+                "name": "AGENT_BOM_API_TOKEN",
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": settings.control_plane_token_secret_name,
+                        "key": settings.control_plane_token_secret_key,
+                    }
+                },
+            },
+        ],
+        "ports": [{"containerPort": settings.metrics_port, "name": "metrics", "protocol": "TCP"}],
+        "volumeMounts": mounts,
+        "resources": {
+            "requests": {"cpu": "50m", "memory": "64Mi"},
+            "limits": {"cpu": "500m", "memory": "256Mi"},
+        },
+        "securityContext": {
+            "allowPrivilegeEscalation": False,
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+            "capabilities": {"drop": ["ALL"]},
+        },
+    }
+
+
+def _volumes(metadata: dict[str, Any], settings: SidecarInjectorSettings) -> list[dict[str, Any]]:
+    policy_configmap = (
+        str((metadata.get("annotations") or {}).get(settings.policy_configmap_annotation_key, "") or "").strip()
+        or settings.policy_configmap_name
+    )
+    volumes: list[dict[str, Any]] = [{"name": "agent-bom-audit-logs", "emptyDir": {}}]
+    if policy_configmap:
+        volumes.append({"name": "agent-bom-proxy-policy", "configMap": {"name": policy_configmap}})
+    return volumes
+
+
+def _build_patch(pod: dict[str, Any], settings: SidecarInjectorSettings) -> list[dict[str, Any]]:
+    metadata = pod.setdefault("metadata", {})
+    spec = pod.setdefault("spec", {})
+    patches: list[dict[str, Any]] = []
+
+    annotations = metadata.get("annotations")
+    if annotations is None:
+        patches.append(_patch_add("/metadata/annotations", {}))
+        annotations = {}
+    if settings.injected_annotation_key not in annotations:
+        patches.append(_patch_add(f"/metadata/annotations/{settings.injected_annotation_key.replace('/', '~1')}", "true"))
+    if "prometheus.io/scrape" not in annotations:
+        patches.append(_patch_add("/metadata/annotations/prometheus.io~1scrape", "true"))
+    if "prometheus.io/port" not in annotations:
+        patches.append(_patch_add("/metadata/annotations/prometheus.io~1port", str(settings.metrics_port)))
+    if "prometheus.io/path" not in annotations:
+        patches.append(_patch_add("/metadata/annotations/prometheus.io~1path", "/metrics"))
+
+    if spec.get("volumes") is None:
+        patches.append(_patch_add("/spec/volumes", []))
+    existing_volumes = {volume.get("name") for volume in (spec.get("volumes") or [])}
+    for volume in _volumes(metadata, settings):
+        if volume["name"] not in existing_volumes:
+            patches.append(_patch_add("/spec/volumes/-", volume))
+
+    if spec.get("containers") is None:
+        patches.append(_patch_add("/spec/containers", []))
+    patches.append(_patch_add("/spec/containers/-", _sidecar_container(settings, metadata)))
+    return patches
+
+
+def _audit_injection(review_request: dict[str, Any], metadata: dict[str, Any], settings: SidecarInjectorSettings, target_url: str) -> None:
+    request_info = review_request.get("request") or {}
+    namespace = request_info.get("namespace") or metadata.get("namespace") or "default"
+    name = metadata.get("name") or metadata.get("generateName") or "generated"
+    tenant_id = (
+        (metadata.get("labels") or {}).get(settings.tenant_label_key)
+        or (metadata.get("annotations") or {}).get(settings.tenant_label_key)
+        or "default"
+    )
+    owner_refs = metadata.get("ownerReferences") or []
+    workload_ref = owner_refs[0].get("name") if owner_refs else ""
+    settings.audit_logger(
+        "runtime.sidecar_injected",
+        actor=settings.audit_actor,
+        resource=f"k8s/pod/{namespace}/{name}",
+        tenant_id=tenant_id,
+        namespace=namespace,
+        workload_ref=workload_ref or name,
+        target_url=target_url,
+        request_uid=request_info.get("uid", ""),
+    )
+
+
+def _review_response(uid: str, *, allowed: bool = True, patch: list[dict[str, Any]] | None = None) -> JSONResponse:
+    review: dict[str, Any] = {
+        "apiVersion": "admission.k8s.io/v1",
+        "kind": "AdmissionReview",
+        "response": {"uid": uid, "allowed": allowed},
+    }
+    if patch:
+        patch_bytes = json.dumps(patch, separators=(",", ":")).encode("utf-8")
+        review["response"]["patchType"] = "JSONPatch"
+        review["response"]["patch"] = base64.b64encode(patch_bytes).decode("ascii")
+    return JSONResponse(review)
+
+
+def create_sidecar_injector_app(settings: SidecarInjectorSettings) -> FastAPI:
+    app = FastAPI(title="agent-bom sidecar injector", version="1")
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/mutate")
+    async def mutate(review: dict[str, Any]) -> JSONResponse:
+        request = review.get("request") or {}
+        uid = str(request.get("uid") or "")
+        if request.get("operation") != "CREATE":
+            return _review_response(uid)
+        if (request.get("kind") or {}).get("kind") != "Pod":
+            return _review_response(uid)
+
+        pod = request.get("object") or {}
+        metadata = pod.get("metadata") or {}
+        if not _should_inject(metadata, settings):
+            return _review_response(uid)
+        if _already_injected(pod, settings):
+            return _review_response(uid)
+
+        patch = _build_patch(pod, settings)
+        _audit_injection(review, metadata, settings, _target_url(metadata, settings))
+        return _review_response(uid, patch=patch)
+
+    return app
+
+
+__all__ = ["SidecarInjectorSettings", "create_sidecar_injector_app"]

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -209,6 +209,7 @@ def test_helm_values_yaml_keys():
         "runtimeImage",
         "scanner",
         "monitor",
+        "sidecarInjection",
         "controlPlane",
         "rbac",
         "serviceAccount",
@@ -248,6 +249,10 @@ def test_helm_templates_exist():
         "controlplane-ui-service.yaml",
         "gateway-hpa.yaml",
         "gateway-pdb.yaml",
+        "sidecar-injector-cert.yaml",
+        "sidecar-injector-deployment.yaml",
+        "sidecar-injector-service.yaml",
+        "sidecar-injector-webhook.yaml",
         "teardown-hook-rbac.yaml",
         "teardown-hook-job.yaml",
         "serviceaccount.yaml",
@@ -356,6 +361,17 @@ def test_helm_teardown_hooks_defaults():
     assert hooks["deletePolicy"] == "before-hook-creation,hook-succeeded"
     assert hooks["image"]["repository"] == "agentbom/agent-bom"
     assert hooks["extraTargetSecrets"] == []
+
+
+def test_helm_sidecar_injection_defaults():
+    """Sidecar injector ships as an opt-in chart surface with explicit selectors."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    injector = doc["sidecarInjection"]
+    assert injector["enabled"] is False
+    assert injector["replicas"] == 2
+    assert injector["selectors"]["namespaceLabelKey"] == "agent-bom.io/proxy-inject"
+    assert injector["selectors"]["podLabelKey"] == "agent-bom.io/proxy"
+    assert injector["certManager"]["enabled"] is True
 
 
 def test_helm_control_plane_observability_defaults():

--- a/tests/test_sidecar_injector.py
+++ b/tests/test_sidecar_injector.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import base64
+import json
+
+from starlette.testclient import TestClient
+
+from agent_bom.sidecar_injector import SidecarInjectorSettings, create_sidecar_injector_app
+
+
+def _decode_patch(response) -> list[dict]:
+    body = response.json()
+    patch = body["response"]["patch"]
+    return json.loads(base64.b64decode(patch))
+
+
+def _settings(audit_events: list[dict]) -> SidecarInjectorSettings:
+    def _audit(action: str, actor: str = "system", resource: str = "", **details: object) -> None:
+        audit_events.append({"action": action, "actor": actor, "resource": resource, "details": details})
+
+    return SidecarInjectorSettings(
+        proxy_image="agentbom/agent-bom:0.81.0",
+        control_plane_url="http://agent-bom-api.agent-bom.svc.cluster.local:8422",
+        control_plane_token_secret_name="agent-bom-proxy-auth",
+        audit_logger=_audit,
+    )
+
+
+def test_sidecar_injector_mutates_pod_with_proxy_container():
+    audit_events: list[dict] = []
+    client = TestClient(create_sidecar_injector_app(_settings(audit_events)))
+    payload = {
+        "request": {
+            "uid": "req-1",
+            "operation": "CREATE",
+            "kind": {"kind": "Pod"},
+            "namespace": "agent-bom",
+            "object": {
+                "metadata": {
+                    "name": "mcp-pod",
+                    "labels": {"agent-bom.io/proxy": "true", "agent-bom.io/tenant": "tenant-a"},
+                },
+                "spec": {
+                    "containers": [{"name": "app", "image": "example.com/mcp:1"}],
+                },
+            },
+        }
+    }
+    response = client.post("/mutate", json=payload)
+    assert response.status_code == 200
+    patch = _decode_patch(response)
+    sidecar = next(item["value"] for item in patch if item["path"] == "/spec/containers/-")
+    assert sidecar["name"] == "agent-bom-proxy"
+    assert "--url" in sidecar["args"]
+    assert "http://127.0.0.1:3000" in sidecar["args"]
+    assert any(item["path"] == "/metadata/annotations/agent-bom.io~1proxy-injected" for item in patch)
+    assert audit_events[0]["details"]["tenant_id"] == "tenant-a"
+
+
+def test_sidecar_injector_honors_explicit_mcp_url():
+    audit_events: list[dict] = []
+    client = TestClient(create_sidecar_injector_app(_settings(audit_events)))
+    payload = {
+        "request": {
+            "uid": "req-2",
+            "operation": "CREATE",
+            "kind": {"kind": "Pod"},
+            "namespace": "agent-bom",
+            "object": {
+                "metadata": {
+                    "generateName": "mcp-pod-",
+                    "annotations": {"agent-bom.io/mcp-url": "http://127.0.0.1:9090/sse"},
+                },
+                "spec": {"containers": [{"name": "app", "image": "example.com/mcp:1"}]},
+            },
+        }
+    }
+    response = client.post("/mutate", json=payload)
+    patch = _decode_patch(response)
+    sidecar = next(item["value"] for item in patch if item["path"] == "/spec/containers/-")
+    assert "http://127.0.0.1:9090/sse" in sidecar["args"]
+
+
+def test_sidecar_injector_skips_existing_sidecar_or_opt_out():
+    audit_events: list[dict] = []
+    client = TestClient(create_sidecar_injector_app(_settings(audit_events)))
+    payload = {
+        "request": {
+            "uid": "req-3",
+            "operation": "CREATE",
+            "kind": {"kind": "Pod"},
+            "namespace": "agent-bom",
+            "object": {
+                "metadata": {
+                    "name": "mcp-pod",
+                    "labels": {"agent-bom.io/proxy": "false"},
+                },
+                "spec": {
+                    "containers": [
+                        {"name": "app", "image": "example.com/mcp:1"},
+                        {"name": "agent-bom-proxy", "image": "agentbom/agent-bom:0.81.0"},
+                    ]
+                },
+            },
+        }
+    }
+    response = client.post("/mutate", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert "patch" not in body["response"]
+    assert audit_events == []


### PR DESCRIPTION
## Summary
- add a cert-manager-backed mutating webhook that auto-injects the packaged `agent-bom proxy` sidecar for opted-in Kubernetes pods and namespaces
- ship the standalone webhook runtime, Helm templates, selectors, and audited mutation path instead of requiring every selected workload to be hand-patched
- document the packaged auto-injection flow and the honest scope: HTTP/SSE sidecar targets can be injected automatically, while stdio sidecar wrapping still stays manual

Closes #1637

## Testing
- `uv run pytest tests/test_sidecar_injector.py tests/test_deploy_manifests.py -q`
- `uv run ruff check src/agent_bom/sidecar_injector.py src/agent_bom/cli/_deploy.py src/agent_bom/cli/__init__.py tests/test_sidecar_injector.py tests/test_deploy_manifests.py`
- `uv run mypy src/agent_bom/sidecar_injector.py src/agent_bom/cli/_deploy.py`
- `uv run mkdocs build --strict`
- `PATH="/tmp/helm-bin/darwin-arm64:$PATH" helm template agent-bom deploy/helm/agent-bom --namespace agent-bom --set controlPlane.enabled=true --set sidecarInjection.enabled=true --set sidecarInjection.controlPlane.tokenSecretName=agent-bom-proxy-auth`

## Notes
- The webhook is packaged as a dedicated TLS pod behind a ClusterIP service instead of forcing TLS into the control-plane API deployment.
- Namespace opt-in uses `agent-bom.io/proxy-inject=enabled`; single-workload opt-in uses `agent-bom.io/proxy=true`.
- Pods still declare their local MCP HTTP/SSE target explicitly via `agent-bom.io/mcp-url` or `agent-bom.io/mcp-port`.
