### PR TITLE
fix(api): close middleware RBAC route coverage gaps

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -333,6 +333,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("GET", "/v1/auth/policy", "admin"),
         ("GET", "/v1/auth/keys", "admin"),
         ("POST", "/v1/auth/keys", "admin"),
+        ("POST", "/v1/auth/keys/", "admin"),
         ("DELETE", "/v1/auth/keys/", "admin"),
         ("POST", "/v1/gateway/policies", "admin"),
         ("PUT", "/v1/gateway/policies/", "admin"),
@@ -360,7 +361,10 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("POST", "/v1/schedules", "analyst"),
         ("POST", "/v1/sources", "analyst"),
         ("POST", "/v1/sources/", "analyst"),
+        ("POST", "/v1/baseline/compare", "analyst"),
+        ("POST", "/v1/graph/presets", "analyst"),
         ("DELETE", "/v1/schedules/", "analyst"),
+        ("DELETE", "/v1/graph/presets/", "analyst"),
         ("PUT", "/v1/schedules/", "analyst"),
         ("PUT", "/v1/sources/", "analyst"),
     )

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -242,6 +242,81 @@ def test_api_key_middleware_auth_key_list_requires_admin_role():
         set_key_store(original_store)
 
 
+def test_api_key_middleware_auth_key_rotate_requires_admin_role():
+    """Analyst API keys must not be able to rotate enterprise API keys."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    original_store = get_key_store()
+    store = KeyStore()
+    raw_key, analyst = create_api_key("analyst", Role.ANALYST, tenant_id="tenant-alpha")
+    store.add(analyst)
+    set_key_store(store)
+    try:
+        test_app = Starlette(routes=[Route("/v1/auth/keys/key-123/rotate", dummy, methods=["POST"])])
+        test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+        client = TestClient(test_app)
+        resp = client.post("/v1/auth/keys/key-123/rotate", headers={"Authorization": f"Bearer {raw_key}"})
+        assert resp.status_code == 403
+        assert "requires admin role" in resp.json()["detail"]
+    finally:
+        set_key_store(original_store)
+
+
+def test_api_key_middleware_exception_approve_requires_admin_role():
+    """Analyst API keys must not be able to approve exceptions."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    original_store = get_key_store()
+    store = KeyStore()
+    raw_key, analyst = create_api_key("analyst", Role.ANALYST, tenant_id="tenant-alpha")
+    store.add(analyst)
+    set_key_store(store)
+    try:
+        test_app = Starlette(routes=[Route("/v1/exceptions/exc-1/approve", dummy, methods=["PUT"])])
+        test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+        client = TestClient(test_app)
+        resp = client.put("/v1/exceptions/exc-1/approve", headers={"Authorization": f"Bearer {raw_key}"})
+        assert resp.status_code == 403
+        assert "requires admin role" in resp.json()["detail"]
+    finally:
+        set_key_store(original_store)
+
+
+def test_api_key_middleware_graph_preset_mutation_requires_analyst_role():
+    """Viewer API keys must not be able to create graph presets."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    original_store = get_key_store()
+    store = KeyStore()
+    raw_key, viewer = create_api_key("viewer", Role.VIEWER, tenant_id="tenant-alpha")
+    store.add(viewer)
+    set_key_store(store)
+    try:
+        test_app = Starlette(routes=[Route("/v1/graph/presets", dummy, methods=["POST"])])
+        test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+        client = TestClient(test_app)
+        resp = client.post("/v1/graph/presets", headers={"Authorization": f"Bearer {raw_key}"})
+        assert resp.status_code == 403
+        assert "requires analyst role" in resp.json()["detail"]
+    finally:
+        set_key_store(original_store)
+
+
 def test_api_key_middleware_oidc_sets_tenant_from_custom_claim():
     """OIDC tenant scoping should honor AGENT_BOM_OIDC_TENANT_CLAIM semantics."""
     from starlette.applications import Starlette


### PR DESCRIPTION
## Summary
- add explicit middleware RBAC coverage for missing write-route prefixes
- protect key rotation, baseline compare, and graph preset mutations at the same middleware layer as the rest of the control-plane write surface
- add focused middleware tests for the newly-covered admin and analyst routes

Closes #1667

## Testing
- pre-commit hooks on commit (`ruff`, `ruff-format`, `mypy`, `bandit`) passed
- `uv run ruff check src/agent_bom/api/middleware.py tests/test_api_hardening.py`
- targeted local pytest invocation is running in the shared local environment; final gate is the normal PR CI matrix
