### PR TITLE
feat(deploy): add EKS preflight and post-deploy verify

### DIFF
--- a/scripts/deploy/install-eks-reference.sh
+++ b/scripts/deploy/install-eks-reference.sh
@@ -12,6 +12,10 @@ INGRESS_CLASS="nginx"
 CREATE_CLUSTER=0
 ENABLE_GATEWAY=0
 ENABLE_FLEET=1
+OIDC_ISSUER="${AGENT_BOM_OIDC_ISSUER:-}"
+OIDC_AUDIENCE="${AGENT_BOM_OIDC_AUDIENCE:-agent-bom}"
+OIDC_TENANT_CLAIM="${AGENT_BOM_OIDC_TENANT_CLAIM:-tenant_id}"
+OIDC_ROLE_CLAIM="${AGENT_BOM_OIDC_ROLE_CLAIM:-agent_bom_role}"
 NODE_INSTANCE_TYPE="m7i.large"
 NODE_COUNT="3"
 K8S_VERSION="1.30"
@@ -41,6 +45,10 @@ Options:
   --create-cluster            Create a reference EKS cluster with eksctl before baseline + Helm
   --enable-gateway            Enable the packaged gateway Deployment and generate a bearer token
   --disable-fleet             Skip printing the endpoint onboarding bundle command
+  --oidc-issuer URL           Configure AGENT_BOM_OIDC_ISSUER in the control-plane auth secret
+  --oidc-audience VALUE       Configure AGENT_BOM_OIDC_AUDIENCE (default: agent-bom when OIDC is enabled)
+  --oidc-tenant-claim CLAIM   Configure AGENT_BOM_OIDC_TENANT_CLAIM (default: tenant_id)
+  --oidc-role-claim CLAIM     Configure AGENT_BOM_OIDC_ROLE_CLAIM (default: agent_bom_role)
   --node-instance-type TYPE   eksctl managed nodegroup instance type (default: m7i.large)
   --node-count COUNT          eksctl desired/min node count (default: 3)
   --k8s-version VERSION       EKS version for --create-cluster (default: 1.30)
@@ -67,6 +75,44 @@ need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
+version_ge() {
+  python3 - "$1" "$2" <<'PY'
+import re
+import sys
+
+def normalize(raw: str) -> list[int]:
+    parts = [int(piece) for piece in re.findall(r"\d+", raw)]
+    return (parts + [0, 0, 0])[:3]
+
+current = normalize(sys.argv[1])
+minimum = normalize(sys.argv[2])
+raise SystemExit(0 if current >= minimum else 1)
+PY
+}
+
+extract_first_semver() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+match = re.search(r"(\d+\.\d+(?:\.\d+)?)", sys.argv[1])
+if not match:
+    raise SystemExit(1)
+print(match.group(1))
+PY
+}
+
+check_tool_version() {
+  local tool="$1"
+  local minimum="$2"
+  shift 2
+  local version
+  version="$("$@")" || die "failed to determine ${tool} version"
+  version="${version//$'\n'/ }"
+  version="$(extract_first_semver "${version}")" || die "unable to parse ${tool} version from: ${version}"
+  version_ge "${version}" "${minimum}" || die "${tool} ${minimum}+ is required (found ${version})"
+}
+
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then
     printf "+ %q" "$1"
@@ -91,6 +137,10 @@ while [ "$#" -gt 0 ]; do
     --create-cluster) CREATE_CLUSTER=1; shift ;;
     --enable-gateway) ENABLE_GATEWAY=1; shift ;;
     --disable-fleet) ENABLE_FLEET=0; shift ;;
+    --oidc-issuer) OIDC_ISSUER="$2"; shift 2 ;;
+    --oidc-audience) OIDC_AUDIENCE="$2"; shift 2 ;;
+    --oidc-tenant-claim) OIDC_TENANT_CLAIM="$2"; shift 2 ;;
+    --oidc-role-claim) OIDC_ROLE_CLAIM="$2"; shift 2 ;;
     --node-instance-type) NODE_INSTANCE_TYPE="$2"; shift 2 ;;
     --node-count) NODE_COUNT="$2"; shift 2 ;;
     --k8s-version) K8S_VERSION="$2"; shift 2 ;;
@@ -101,6 +151,15 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+if [ -n "${OIDC_ISSUER}" ]; then
+  case "${OIDC_ISSUER}" in
+    https://*) ;;
+    *) die "--oidc-issuer must use https:// (got ${OIDC_ISSUER})" ;;
+  esac
+  [ -n "${HOSTNAME}" ] || die "--hostname is required when --oidc-issuer is set so browser auth has a stable same-origin entrypoint"
+  [ -n "${OIDC_AUDIENCE}" ] || die "--oidc-audience is required when --oidc-issuer is set"
+fi
+
 need_cmd python3
 TERRAFORM_BIN="terraform"
 if [ "$DRY_RUN" -eq 0 ]; then
@@ -110,6 +169,13 @@ if [ "$DRY_RUN" -eq 0 ]; then
   need_cmd eksctl
   TERRAFORM_BIN="${TERRAFORM_BIN:-$(command -v terraform || command -v tofu || true)}"
   [ -n "$TERRAFORM_BIN" ] || die "terraform or tofu is required"
+
+  log "Running installer preflight checks"
+  check_tool_version "aws" "2.15.0" aws --version
+  check_tool_version "kubectl" "1.29.0" kubectl version --client=true
+  check_tool_version "helm" "3.14.0" helm version --template '{{.Version}}'
+  check_tool_version "eksctl" "0.178.0" eksctl version
+  check_tool_version "$("${TERRAFORM_BIN}" version | head -n 1 | awk '{print $1}')" "1.5.0" "${TERRAFORM_BIN}" version
 fi
 
 STATE_ROOT="${STATE_DIR}/${CLUSTER_NAME}"
@@ -270,6 +336,11 @@ PY
     --from-literal=AGENT_BOM_API_KEY="${API_KEY}" \
     --from-literal=AGENT_BOM_AUDIT_HMAC_KEY="${AUDIT_HMAC}" \
     --from-literal=AGENT_BOM_REQUIRE_AUDIT_HMAC=1 \
+    $( [ -n "${OIDC_ISSUER}" ] && printf -- "--from-literal=AGENT_BOM_OIDC_ISSUER=%s " "${OIDC_ISSUER}" ) \
+    $( [ -n "${OIDC_ISSUER}" ] && printf -- "--from-literal=AGENT_BOM_OIDC_AUDIENCE=%s " "${OIDC_AUDIENCE}" ) \
+    $( [ -n "${OIDC_ISSUER}" ] && printf -- "--from-literal=AGENT_BOM_OIDC_TENANT_CLAIM=%s " "${OIDC_TENANT_CLAIM}" ) \
+    $( [ -n "${OIDC_ISSUER}" ] && printf -- "--from-literal=AGENT_BOM_OIDC_ROLE_CLAIM=%s " "${OIDC_ROLE_CLAIM}" ) \
+    $( [ -n "${OIDC_ISSUER}" ] && printf -- "--from-literal=AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM=1 " ) \
     --dry-run=client -o yaml | kubectl apply -f -
 
   if [ -n "${DB_URL_SECRET_NAME}" ]; then
@@ -280,10 +351,27 @@ PY
   fi
 
   if [ -n "${AUTH_SECRET_NAME}" ]; then
+    AUTH_SECRET_PAYLOAD="$(python3 - <<PY
+import json
+
+payload = {
+    "AGENT_BOM_API_KEY": "${API_KEY}",
+    "AGENT_BOM_AUDIT_HMAC_KEY": "${AUDIT_HMAC}",
+    "AGENT_BOM_REQUIRE_AUDIT_HMAC": "1",
+}
+if "${OIDC_ISSUER}":
+    payload["AGENT_BOM_OIDC_ISSUER"] = "${OIDC_ISSUER}"
+    payload["AGENT_BOM_OIDC_AUDIENCE"] = "${OIDC_AUDIENCE}"
+    payload["AGENT_BOM_OIDC_TENANT_CLAIM"] = "${OIDC_TENANT_CLAIM}"
+    payload["AGENT_BOM_OIDC_ROLE_CLAIM"] = "${OIDC_ROLE_CLAIM}"
+    payload["AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM"] = "1"
+print(json.dumps(payload))
+PY
+)"
     aws secretsmanager put-secret-value \
       --region "${REGION}" \
       --secret-id "${AUTH_SECRET_NAME}" \
-      --secret-string "{\"AGENT_BOM_API_KEY\":\"${API_KEY}\",\"AGENT_BOM_AUDIT_HMAC_KEY\":\"${AUDIT_HMAC}\",\"AGENT_BOM_REQUIRE_AUDIT_HMAC\":\"1\"}" >/dev/null
+      --secret-string "${AUTH_SECRET_PAYLOAD}" >/dev/null
   fi
 fi
 
@@ -337,8 +425,13 @@ BASE_URL="http://localhost:8080"
 if [ -n "${HOSTNAME}" ]; then
   BASE_URL="https://${HOSTNAME}"
 fi
+VERIFY_GATEWAY_FLAG=""
+if [ "${ENABLE_GATEWAY}" -eq 1 ]; then
+  VERIFY_GATEWAY_FLAG=" --check-gateway"
+fi
 
 SUMMARY="${GENERATED_DIR}/operator-summary.txt"
+VERIFY_SCRIPT="${ROOT_DIR}/scripts/deploy/verify-eks-reference.sh"
 cat >"${SUMMARY}" <<EOF
 agent-bom reference install complete
 
@@ -351,6 +444,8 @@ terraform dir: ${TF_ROOT}
 helm values: ${HELM_VALUES_HINT}
 install overrides: ${INSTALL_OVERRIDES}
 mode: $( [ "$DRY_RUN" -eq 1 ] && printf dry-run || printf applied )
+auth mode: $( [ -n "${OIDC_ISSUER}" ] && printf 'oidc + api key fallback' || printf 'api key' )
+verify script: ${VERIFY_SCRIPT}
 EOF
 
 if [ "$DRY_RUN" -eq 0 ]; then
@@ -383,12 +478,17 @@ if [ "$DRY_RUN" -eq 0 ]; then
       echo "  customize deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml"
       echo "  then re-run Helm with --set-file gateway.upstreamsYaml=./my-upstreams.yaml"
     fi
+    echo
+    echo "Post-deploy verify:"
+    echo "  ${VERIFY_SCRIPT} --cluster-name ${CLUSTER_NAME} --region ${REGION} --namespace ${NAMESPACE} --release ${RELEASE_NAME} --base-url ${BASE_URL} --api-key ${API_KEY}${VERIFY_GATEWAY_FLAG}"
   } | tee -a "${SUMMARY}"
 else
   {
     echo
     echo "Dry run only. No AWS, Kubernetes, or Helm resources were changed."
     echo "Inspect the generated Terraform root and Helm values files, then rerun without --dry-run."
+    echo "Verify flow after apply:"
+    echo "  ${VERIFY_SCRIPT} --cluster-name ${CLUSTER_NAME} --region ${REGION} --namespace ${NAMESPACE} --release ${RELEASE_NAME} --base-url ${BASE_URL}${VERIFY_GATEWAY_FLAG}"
   } | tee -a "${SUMMARY}"
 fi
 

--- a/scripts/deploy/verify-eks-reference.sh
+++ b/scripts/deploy/verify-eks-reference.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="agent-bom"
+REGION="${AWS_REGION:-us-east-1}"
+NAMESPACE="agent-bom"
+RELEASE_NAME="agent-bom"
+BASE_URL=""
+API_KEY="${AGENT_BOM_API_KEY:-}"
+CHECK_GATEWAY=0
+
+usage() {
+  cat <<'EOF'
+Post-deploy verification for the AWS / EKS reference install path.
+
+Usage:
+  scripts/deploy/verify-eks-reference.sh [options]
+
+Options:
+  --cluster-name NAME   EKS cluster name (default: agent-bom)
+  --region REGION       AWS region (default: AWS_REGION or us-east-1)
+  --namespace NAME      Kubernetes namespace (default: agent-bom)
+  --release NAME        Helm release name (default: agent-bom)
+  --base-url URL        Reachable control-plane base URL (required)
+  --api-key VALUE       Operator API key for /v1/auth/debug verification
+  --check-gateway       Also verify the gateway Deployment rollout and /healthz
+  -h, --help            Show this help
+
+Examples:
+  scripts/deploy/verify-eks-reference.sh \
+    --cluster-name corp-ai \
+    --region us-east-1 \
+    --base-url https://agent-bom.internal.example.com \
+    --api-key "$AGENT_BOM_API_KEY"
+EOF
+}
+
+bold() { printf "\033[1m%s\033[0m\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+fail() { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+need_cmd() { command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"; }
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --release) RELEASE_NAME="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --api-key) API_KEY="$2"; shift 2 ;;
+    --check-gateway) CHECK_GATEWAY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown option: $1" ;;
+  esac
+done
+
+[ -n "${BASE_URL}" ] || fail "--base-url is required"
+
+need_cmd aws
+need_cmd kubectl
+need_cmd helm
+need_cmd curl
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+hdrs=()
+if [ -n "${API_KEY}" ]; then
+  hdrs=(-H "Authorization: Bearer ${API_KEY}" -H "X-Agent-Bom-Role: admin" -H "X-Agent-Bom-Tenant-ID: reference-verify")
+fi
+
+bold "1/7 Kubeconfig"
+aws eks update-kubeconfig --name "${CLUSTER_NAME}" --region "${REGION}" >/dev/null
+ok "kubeconfig updated for ${CLUSTER_NAME}"
+
+bold "2/7 Helm release"
+helm status "${RELEASE_NAME}" --namespace "${NAMESPACE}" >/dev/null || fail "helm release ${RELEASE_NAME} not found in namespace ${NAMESPACE}"
+ok "helm release present"
+
+bold "3/7 Control-plane rollouts"
+kubectl rollout status deployment/"${RELEASE_NAME}"-api --namespace "${NAMESPACE}" --timeout=180s >/dev/null \
+  || fail "API deployment did not become ready"
+kubectl rollout status deployment/"${RELEASE_NAME}"-ui --namespace "${NAMESPACE}" --timeout=180s >/dev/null \
+  || fail "UI deployment did not become ready"
+ok "API and UI deployments are ready"
+
+if [ "${CHECK_GATEWAY}" -eq 1 ]; then
+  bold "4/7 Gateway rollout"
+  kubectl rollout status deployment/"${RELEASE_NAME}"-gateway --namespace "${NAMESPACE}" --timeout=180s >/dev/null \
+    || fail "gateway deployment did not become ready"
+  kubectl get svc "${RELEASE_NAME}"-gateway --namespace "${NAMESPACE}" >/dev/null \
+    || fail "gateway service missing"
+  ok "gateway deployment and service are ready"
+else
+  bold "4/7 Gateway rollout"
+  ok "skipped (pass --check-gateway to verify the shared gateway path)"
+fi
+
+bold "5/7 Control-plane health"
+status=$(curl -sS -o "$tmp/health.json" -w "%{http_code}" "${BASE_URL}/healthz") || fail "control plane unreachable at ${BASE_URL}"
+[ "$status" = "200" ] || fail "healthz returned ${status}"
+ok "control plane /healthz returned 200"
+
+bold "6/7 Browser UI"
+status=$(curl -sS -o "$tmp/ui.html" -w "%{http_code}" "${BASE_URL}/") || fail "UI root unreachable at ${BASE_URL}/"
+[ "$status" = "200" ] || fail "UI root returned ${status}"
+ok "UI root returned 200"
+
+bold "7/7 Auth resolution"
+if [ -n "${API_KEY}" ]; then
+  status=$(curl -sS -o "$tmp/auth.json" -w "%{http_code}" "${hdrs[@]}" "${BASE_URL}/v1/auth/debug") || fail "auth debug unreachable"
+  [ "$status" = "200" ] || fail "auth debug returned ${status}"
+  ok "auth resolved ($(python3 - <<'PY' "$tmp/auth.json"
+import json
+import sys
+payload = json.load(open(sys.argv[1]))
+print(payload.get("method", "unknown"))
+PY
+))"
+else
+  ok "skipped (pass --api-key to verify /v1/auth/debug resolution)"
+fi
+
+bold "reference verification passed"
+echo "  cluster: ${CLUSTER_NAME}"
+echo "  namespace: ${NAMESPACE}"
+echo "  release: ${RELEASE_NAME}"
+echo "  base: ${BASE_URL}"

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -48,6 +48,18 @@ scripts/deploy/install-eks-reference.sh \
   --enable-gateway
 ```
 
+If you want browser operators behind corporate SSO on day 1, add OIDC at install
+time:
+
+```bash
+scripts/deploy/install-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --hostname agent-bom.internal.example.com \
+  --oidc-issuer https://idp.example.com \
+  --oidc-audience agent-bom
+```
+
 ## What The Installer Owns
 
 The reference installer at `scripts/deploy/install-eks-reference.sh` is intentionally opinionated:
@@ -56,7 +68,7 @@ The reference installer at `scripts/deploy/install-eks-reference.sh` is intentio
 2. Applies the `agent-bom` AWS baseline Terraform module
 3. Creates the product secrets needed by the Helm release
 4. Installs the packaged Helm chart with production profile defaults
-5. Prints next-step commands for fleet onboarding and gateway rollout
+5. Prints next-step commands for fleet onboarding, gateway rollout, and post-deploy verification
 
 It does **not** try to replace a customer's full AWS platform stack. Keep these as platform-owned:
 
@@ -190,6 +202,11 @@ scripts/deploy/install-eks-reference.sh \
   --enable-gateway
 ```
 
+The installer now does two important safety checks before it mutates anything:
+
+- verifies the minimum supported `aws`, `kubectl`, `helm`, `eksctl`, and `terraform`/`tofu` versions
+- rejects OIDC installs without a stable `--hostname` same-origin entrypoint
+
 Under the hood this uses the baseline in `deploy/terraform/aws/baseline` to create:
 
 - RDS Postgres for the control plane
@@ -218,6 +235,32 @@ See also:
 
 - [Your Own AWS / EKS](own-infra-eks.md)
 - [Terraform AWS Baseline](terraform-aws-baseline.md)
+
+## Post-Deploy Verification
+
+After install, run the reference verification script before onboarding employees
+or shared upstream MCPs:
+
+```bash
+scripts/deploy/verify-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --namespace agent-bom \
+  --release agent-bom \
+  --base-url https://agent-bom.internal.example.com \
+  --api-key "$AGENT_BOM_API_KEY" \
+  --check-gateway
+```
+
+That check is intentionally narrow and release-focused:
+
+1. refresh kubeconfig for the target cluster
+2. confirm the Helm release exists
+3. wait for API and UI rollouts
+4. optionally verify the gateway rollout
+5. hit `/healthz`
+6. confirm the UI root is reachable
+7. verify `/v1/auth/debug` with the operator API key when provided
 - [Packaged API + UI Control Plane](control-plane-helm.md)
 
 ### 4. Endpoint and runtime onboarding

--- a/tests/test_deploy_reference.py
+++ b/tests/test_deploy_reference.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_fake_command(bin_dir: Path, name: str, body: str) -> None:
+    path = bin_dir / name
+    path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def test_install_reference_dry_run_writes_verify_hint(tmp_path: Path):
+    result = subprocess.run(
+        [
+            "bash",
+            str(ROOT / "scripts" / "deploy" / "install-eks-reference.sh"),
+            "--cluster-name",
+            "corp-ai",
+            "--region",
+            "us-east-1",
+            "--state-dir",
+            str(tmp_path),
+            "--dry-run",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = tmp_path / "corp-ai" / "generated" / "operator-summary.txt"
+    assert summary.exists()
+    rendered = summary.read_text()
+    assert "verify-eks-reference.sh" in rendered
+    assert "--base-url http://localhost:8080" in rendered
+
+
+def test_install_reference_rejects_oidc_without_hostname(tmp_path: Path):
+    result = subprocess.run(
+        [
+            "bash",
+            str(ROOT / "scripts" / "deploy" / "install-eks-reference.sh"),
+            "--cluster-name",
+            "corp-ai",
+            "--region",
+            "us-east-1",
+            "--state-dir",
+            str(tmp_path),
+            "--dry-run",
+            "--oidc-issuer",
+            "https://idp.example.com",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "--hostname is required when --oidc-issuer is set" in result.stderr
+
+
+def test_install_reference_preflight_rejects_old_aws_version(tmp_path: Path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_command(fake_bin, "aws", 'echo "aws-cli/2.10.0 Python/3.12.0 Linux/6.0 exe/x86_64"\n')
+    _write_fake_command(fake_bin, "kubectl", 'echo "Client Version: v1.30.1"\n')
+    _write_fake_command(fake_bin, "helm", 'echo "v3.15.0"\n')
+    _write_fake_command(fake_bin, "eksctl", 'echo "0.180.0"\n')
+    _write_fake_command(fake_bin, "terraform", 'echo "Terraform v1.6.0"\n')
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ROOT / "scripts" / "deploy" / "install-eks-reference.sh"),
+            "--cluster-name",
+            "corp-ai",
+            "--region",
+            "us-east-1",
+            "--state-dir",
+            str(tmp_path / "state"),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert "aws 2.15.0+ is required" in result.stderr
+
+
+def test_verify_wrapper_script_exists_and_parses():
+    script_path = ROOT / "scripts" / "deploy" / "verify-eks-reference.sh"
+    result = subprocess.run(
+        ["bash", "-n", str(script_path)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert script_path.exists()
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Summary
- add installer preflight checks for minimum aws/kubectl/helm/eksctl/terraform versions
- add optional OIDC install inputs with hostname validation for the AWS/EKS reference path
- add scripts/deploy/verify-eks-reference.sh plus docs and tests for the post-deploy verify flow

Testing
- bash -n scripts/deploy/install-eks-reference.sh
- bash -n scripts/deploy/verify-eks-reference.sh
- uv run pytest tests/test_deploy_reference.py tests/test_deploy_teardown.py -q
- uv run mkdocs build --strict
- scripts/deploy/install-eks-reference.sh --cluster-name corp-ai --region us-east-1 --state-dir /tmp/agent-bom-eks-verify-smoke --dry-run --oidc-issuer https://idp.example.com --oidc-audience agent-bom --hostname agent-bom.internal.example.com --enable-gateway

Closes #1666