### PR TITLE
feat(proxy): sign cached gateway policy bundles

### DIFF
--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -50,7 +50,7 @@ This is the current code-backed self-hosted story:
 |---|---|---|
 | **agent-bom Scan** | CronJobs, CI runners, one-off jobs, endpoint CLI runs | Discovers agents, MCP servers, packages, images, IaC, Kubernetes, and cloud assets; writes findings and graph state |
 | **agent-bom Fleet** | Endpoint collectors or workstation CLI pushes | Persists inventory and scan history into the control plane without requiring a separate endpoint daemon product |
-| **agent-bom Proxy** | Sidecar or local wrapper near selected MCP servers | Enforces allow/warn/deny policy, detects credential exposure, blocks undeclared tools, and emits signed audit logs |
+| **agent-bom Proxy** | Sidecar or local wrapper near selected MCP servers | Enforces allow/warn/deny policy, detects credential exposure, blocks undeclared tools, emits signed audit logs, and can fail closed on tampered cached policy bundles |
 | **agent-bom Gateway** | Shared remote MCP traffic plane plus policy/audit surface | Stores, serves, and audits the policies consumed by proxies and managed runtime paths |
 | **agent-bom Runtime** | Proxy + audit + policy pull + event persistence | Gives runtime visibility without forcing all traffic through one shared chokepoint |
 | **agent-bom Control Plane** | API + UI + Postgres, with optional ClickHouse | Presents findings, graph, remediation, fleet review, audit, and policy management from one operator-owned plane |

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -24,7 +24,7 @@ import uuid
 from contextlib import nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Mapping, Optional
 
 from agent_bom import proxy_audit as _proxy_audit
 from agent_bom import proxy_policy as _proxy_policy
@@ -72,6 +72,7 @@ resolve_rate_limit_threshold = _proxy_policy.resolve_rate_limit_threshold
 # Guards against DoS via oversized payloads in the stdio relay loop.
 _MAX_MESSAGE_BYTES = 10 * 1024 * 1024  # 10 MB
 _PROXY_TRACER = get_tracer("agent_bom.proxy")
+_PROXY_POLICY_CACHE_SIGNING_ENV_VAR = "AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM"
 
 
 # ─── JSON-RPC parsing ────────────────────────────────────────────────────────
@@ -269,6 +270,68 @@ def _gateway_policy_cache_path() -> Path:
     return Path.home() / ".agent-bom" / "cache" / "gateway-policies.json"
 
 
+def _gateway_policy_cache_signature_path(cache_path: Path) -> Path:
+    return cache_path.with_name(f"{cache_path.name}.sig")
+
+
+class _GatewayPolicyCacheSigner:
+    def __init__(self, pem: str) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        loaded = serialization.load_pem_private_key(pem.encode(), password=None)
+        if not isinstance(loaded, Ed25519PrivateKey):
+            raise ValueError(f"{_PROXY_POLICY_CACHE_SIGNING_ENV_VAR} is not an Ed25519 key")
+        self._private_key = loaded
+        public_bytes: bytes = loaded.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        self.key_id = hashlib.sha256(public_bytes).hexdigest()[:16]
+
+    def sign(self, payload: bytes) -> str:
+        return self._private_key.sign(payload).hex()
+
+    def verify(self, payload: bytes, signature_hex: str) -> None:
+        self._private_key.public_key().verify(bytes.fromhex(signature_hex), payload)
+
+
+_gateway_policy_cache_signer: _GatewayPolicyCacheSigner | None = None
+_gateway_policy_cache_signer_error: str | None = None
+
+
+def _load_gateway_policy_cache_signer() -> _GatewayPolicyCacheSigner | None:
+    global _gateway_policy_cache_signer, _gateway_policy_cache_signer_error
+    if _gateway_policy_cache_signer is not None:
+        return _gateway_policy_cache_signer
+    pem = os.environ.get(_PROXY_POLICY_CACHE_SIGNING_ENV_VAR, "").strip()
+    if not pem:
+        return None
+    if _gateway_policy_cache_signer_error is not None:
+        return None
+    try:
+        _gateway_policy_cache_signer = _GatewayPolicyCacheSigner(pem)
+        logger.info(
+            "proxy gateway policy cache signing enabled (key_id=%s)",
+            _gateway_policy_cache_signer.key_id,
+        )
+        return _gateway_policy_cache_signer
+    except Exception as exc:  # noqa: BLE001
+        _gateway_policy_cache_signer_error = str(exc)
+        logger.error("%s could not be parsed: %s", _PROXY_POLICY_CACHE_SIGNING_ENV_VAR, exc)
+        return None
+
+
+def _reset_gateway_policy_cache_signer_for_tests() -> None:
+    global _gateway_policy_cache_signer, _gateway_policy_cache_signer_error
+    _gateway_policy_cache_signer = None
+    _gateway_policy_cache_signer_error = None
+
+
+def _canonicalize_gateway_policy_cache(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
 def _load_cached_gateway_policies(
     cache_path: Path,
     max_age_seconds: int,
@@ -297,6 +360,36 @@ def _load_cached_gateway_policies(
         )
         return None, None
 
+    signer = _load_gateway_policy_cache_signer()
+    if os.environ.get(_PROXY_POLICY_CACHE_SIGNING_ENV_VAR, "").strip():
+        if signer is None:
+            logger.warning("Ignoring gateway policy cache %s because cache signing is misconfigured", cache_path)
+            return None, None
+        signature_path = _gateway_policy_cache_signature_path(cache_path)
+        try:
+            signature_payload = json.loads(signature_path.read_text())
+            signature_hex = str(signature_payload["signature_hex"])
+            key_id = str(signature_payload["key_id"])
+        except FileNotFoundError:
+            logger.warning("Ignoring unsigned gateway policy cache %s because signing is required", cache_path)
+            return None, None
+        except (KeyError, TypeError, json.JSONDecodeError, OSError) as exc:
+            logger.warning("Ignoring unreadable gateway policy cache signature %s: %s", signature_path, exc)
+            return None, None
+        if key_id != signer.key_id:
+            logger.warning(
+                "Ignoring gateway policy cache %s signed with unexpected key_id=%s (expected %s)",
+                cache_path,
+                key_id,
+                signer.key_id,
+            )
+            return None, None
+        try:
+            signer.verify(_canonicalize_gateway_policy_cache(payload), signature_hex)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Ignoring gateway policy cache %s with invalid signature: %s", cache_path, exc)
+            return None, None
+
     try:
         policies = [GatewayPolicy(**item) for item in payload.get("policies", [])]
     except Exception as exc:  # noqa: BLE001
@@ -317,6 +410,8 @@ def _persist_gateway_policies_cache(
     }
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
+        signature_path = _gateway_policy_cache_signature_path(cache_path)
+        signer = _load_gateway_policy_cache_signer()
         with tempfile.NamedTemporaryFile(
             "w",
             encoding="utf-8",
@@ -330,6 +425,25 @@ def _persist_gateway_policies_cache(
             os.fsync(handle.fileno())
             temp_path = Path(handle.name)
         temp_path.replace(cache_path)
+        if signer is not None:
+            signature_payload = {
+                "algorithm": "Ed25519",
+                "key_id": signer.key_id,
+                "signature_hex": signer.sign(_canonicalize_gateway_policy_cache(payload)),
+            }
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=str(signature_path.parent),
+                prefix=f"{signature_path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                json.dump(signature_payload, handle, sort_keys=True)
+                handle.flush()
+                os.fsync(handle.fileno())
+                temp_sig_path = Path(handle.name)
+            temp_sig_path.replace(signature_path)
     except OSError as exc:
         logger.warning("Failed to persist gateway policy cache %s: %s", cache_path, exc)
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -6,6 +6,10 @@ import io
 import json
 from pathlib import Path
 
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 import agent_bom.proxy as proxy_mod
 from agent_bom.api.policy_store import GatewayPolicy, GatewayRule
 from agent_bom.proxy import (
@@ -16,9 +20,11 @@ from agent_bom.proxy import (
     _control_plane_headers,
     _extract_jsonrpc_trace_meta,
     _gateway_policy_cache_path,
+    _gateway_policy_cache_signature_path,
     _inject_jsonrpc_trace_meta,
     _load_cached_gateway_policies,
     _persist_gateway_policies_cache,
+    _reset_gateway_policy_cache_signer_for_tests,
     _stitch_jsonrpc_trace_meta,
     check_policy,
     compute_payload_hash,
@@ -28,6 +34,14 @@ from agent_bom.proxy import (
     log_tool_call,
     parse_jsonrpc,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_policy_cache_signer():
+    _reset_gateway_policy_cache_signer_for_tests()
+    yield
+    _reset_gateway_policy_cache_signer_for_tests()
+
 
 # ── parse_jsonrpc ────────────────────────────────────────────────────────────
 
@@ -311,6 +325,66 @@ def test_gateway_policy_cache_rejects_stale_entries(tmp_path: Path, monkeypatch)
 def test_gateway_policy_cache_rejects_invalid_payload(tmp_path: Path):
     cache_path = tmp_path / "gateway-policies.json"
     cache_path.write_text('{"fetched_at": 10, "policies": [{"policy_id": "missing-name"}]}')
+    loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
+    assert loaded_policies is None
+    assert loaded_etag is None
+
+
+def _ed25519_private_key_pem() -> str:
+    private_key = Ed25519PrivateKey.generate()
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+def test_gateway_policy_cache_round_trip_requires_valid_signature_when_enabled(tmp_path: Path, monkeypatch):
+    cache_path = tmp_path / "gateway-policies.json"
+    monkeypatch.setattr(proxy_mod.time, "time", lambda: 1234.0)
+    monkeypatch.setenv("AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM", _ed25519_private_key_pem())
+    _reset_gateway_policy_cache_signer_for_tests()
+
+    policies = [GatewayPolicy(policy_id="p1", name="signed", rules=[], tenant_id="tenant-a")]
+    _persist_gateway_policies_cache(cache_path, policies, "etag-signed")
+
+    signature_path = _gateway_policy_cache_signature_path(cache_path)
+    assert signature_path.exists()
+
+    loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
+    assert loaded_etag == "etag-signed"
+    assert loaded_policies is not None
+    assert loaded_policies[0].policy_id == "p1"
+
+
+def test_gateway_policy_cache_rejects_signature_mismatch(tmp_path: Path, monkeypatch):
+    cache_path = tmp_path / "gateway-policies.json"
+    monkeypatch.setattr(proxy_mod.time, "time", lambda: 1234.0)
+    monkeypatch.setenv("AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM", _ed25519_private_key_pem())
+    _reset_gateway_policy_cache_signer_for_tests()
+
+    policies = [GatewayPolicy(policy_id="p1", name="signed", rules=[], tenant_id="tenant-a")]
+    _persist_gateway_policies_cache(cache_path, policies, "etag-signed")
+
+    payload = json.loads(cache_path.read_text())
+    payload["policies"][0]["name"] = "tampered"
+    cache_path.write_text(json.dumps(payload))
+
+    loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
+    assert loaded_policies is None
+    assert loaded_etag is None
+
+
+def test_gateway_policy_cache_rejects_missing_signature_when_enabled(tmp_path: Path, monkeypatch):
+    cache_path = tmp_path / "gateway-policies.json"
+    monkeypatch.setattr(proxy_mod.time, "time", lambda: 1234.0)
+    monkeypatch.setenv("AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM", _ed25519_private_key_pem())
+    _reset_gateway_policy_cache_signer_for_tests()
+
+    policies = [GatewayPolicy(policy_id="p1", name="unsigned", rules=[], tenant_id="tenant-a")]
+    _persist_gateway_policies_cache(cache_path, policies, "etag-signed")
+    _gateway_policy_cache_signature_path(cache_path).unlink()
+
     loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
     assert loaded_policies is None
     assert loaded_etag is None


### PR DESCRIPTION
Summary
- sign persisted proxy gateway policy cache bundles with an Ed25519 sidecar when cache signing is enabled
- fail closed on tampered, missing, or unexpected signatures before using the cached bundle at startup
- document the hardened proxy runtime posture in the deployment overview

Testing
- uv run pytest tests/test_proxy.py -q
- uv run ruff check src/agent_bom/proxy.py tests/test_proxy.py
- uv run mypy src/agent_bom/proxy.py
- uv run mkdocs build --strict

Closes #1668