### PR TITLE
feat(gateway): hot-reload file-backed policy

### DIFF
--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -50,7 +50,7 @@ This is the current code-backed self-hosted story:
 |---|---|---|
 | **agent-bom Scan** | CronJobs, CI runners, one-off jobs, endpoint CLI runs | Discovers agents, MCP servers, packages, images, IaC, Kubernetes, and cloud assets; writes findings and graph state |
 | **agent-bom Fleet** | Endpoint collectors or workstation CLI pushes | Persists inventory and scan history into the control plane without requiring a separate endpoint daemon product |
-| **agent-bom Proxy** | Sidecar or local wrapper near selected MCP servers | Enforces allow/warn/deny policy, detects credential exposure, blocks undeclared tools, and emits signed audit logs |
+| **agent-bom Proxy** | Sidecar or local wrapper near selected MCP servers | Enforces allow/warn/deny policy, detects credential exposure, blocks undeclared tools, emits signed audit logs, and can fail closed on tampered cached policy bundles |
 | **agent-bom Gateway** | Shared remote MCP traffic plane plus policy/audit surface | Stores, serves, and audits the policies consumed by proxies and managed runtime paths, including in-process reload for file-backed policy bundles |
 | **agent-bom Runtime** | Proxy + audit + policy pull + event persistence | Gives runtime visibility without forcing all traffic through one shared chokepoint |
 | **agent-bom Control Plane** | API + UI + Postgres, with optional ClickHouse | Presents findings, graph, remediation, fleet review, audit, and policy management from one operator-owned plane |

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -51,7 +51,7 @@ This is the current code-backed self-hosted story:
 | **agent-bom Scan** | CronJobs, CI runners, one-off jobs, endpoint CLI runs | Discovers agents, MCP servers, packages, images, IaC, Kubernetes, and cloud assets; writes findings and graph state |
 | **agent-bom Fleet** | Endpoint collectors or workstation CLI pushes | Persists inventory and scan history into the control plane without requiring a separate endpoint daemon product |
 | **agent-bom Proxy** | Sidecar or local wrapper near selected MCP servers | Enforces allow/warn/deny policy, detects credential exposure, blocks undeclared tools, and emits signed audit logs |
-| **agent-bom Gateway** | Shared remote MCP traffic plane plus policy/audit surface | Stores, serves, and audits the policies consumed by proxies and managed runtime paths |
+| **agent-bom Gateway** | Shared remote MCP traffic plane plus policy/audit surface | Stores, serves, and audits the policies consumed by proxies and managed runtime paths, including in-process reload for file-backed policy bundles |
 | **agent-bom Runtime** | Proxy + audit + policy pull + event persistence | Gives runtime visibility without forcing all traffic through one shared chokepoint |
 | **agent-bom Control Plane** | API + UI + Postgres, with optional ClickHouse | Presents findings, graph, remediation, fleet review, audit, and policy management from one operator-owned plane |
 

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -64,6 +64,14 @@ def gateway_group() -> None:
     default=None,
     help="Optional runtime policy JSON file (same format as `agent-bom proxy --policy`).",
 )
+@click.option(
+    "--policy-reload-seconds",
+    type=int,
+    envvar="AGENT_BOM_GATEWAY_POLICY_RELOAD_SECONDS",
+    default=0,
+    show_default=True,
+    help="Reload the gateway policy JSON file in-process on this interval (0 disables hot reload).",
+)
 @click.option("--bind", default="0.0.0.0:8090", show_default=True, help="Bind address host:port.")
 @click.option(
     "--runtime-rate-limit-per-tenant-per-minute",
@@ -116,6 +124,7 @@ def serve_cmd(
     control_plane_url: str | None,
     control_plane_token: str | None,
     policy_path: Path | None,
+    policy_reload_seconds: int,
     bind: str,
     runtime_rate_limit_per_tenant_per_minute: int,
     require_shared_rate_limit: bool,
@@ -189,6 +198,10 @@ def serve_cmd(
         except (json.JSONDecodeError, OSError) as exc:
             click.echo(f"policy file error: {exc}", err=True)
             sys.exit(2)
+    if policy_reload_seconds < 0:
+        raise click.ClickException("--policy-reload-seconds must be >= 0")
+    if policy_reload_seconds > 0 and policy_path is None:
+        raise click.ClickException("--policy-reload-seconds requires --policy")
 
     host, _, port = bind.partition(":")
     host = host or "0.0.0.0"  # nosec B104
@@ -208,6 +221,8 @@ def serve_cmd(
         require_visual_leak_detection_ready=detect_visual_leaks and not allow_visual_leak_best_effort,
         runtime_rate_limit_per_tenant_per_minute=max(runtime_rate_limit_per_tenant_per_minute, 0),
         require_shared_rate_limit=require_shared_rate_limit,
+        policy_path=policy_path,
+        policy_reload_interval_seconds=max(policy_reload_seconds, 0),
     )
     app = create_gateway_app(settings)
 
@@ -225,6 +240,8 @@ def serve_cmd(
     if detect_visual_leaks:
         mode = "best-effort" if allow_visual_leak_best_effort else "required"
         click.echo(f"Visual leak detection: enabled ({mode})")
+    if policy_path and policy_reload_seconds > 0:
+        click.echo(f"Policy hot reload: enabled every {policy_reload_seconds}s from {policy_path}")
     uvicorn.run(app, host=host, port=port_num, log_level=log_level.lower())
 
 

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -28,12 +28,14 @@ Non-goals for MVP (see design doc):
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import threading
 import time
-from contextlib import nullcontext
+from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from fastapi import FastAPI, HTTPException, Request
@@ -92,6 +94,15 @@ class GatewaySettings:
     require_visual_leak_detection_ready: bool = False
     runtime_rate_limit_per_tenant_per_minute: int = 0
     require_shared_rate_limit: bool = False
+    policy_path: Path | None = None
+    policy_reload_interval_seconds: int = 0
+
+
+def _load_policy_file(policy_path: Path) -> dict[str, Any]:
+    payload = json.loads(policy_path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError("gateway policy file must contain a JSON object")
+    return payload
 
 
 def _gateway_configured_replicas() -> int:
@@ -268,17 +279,90 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
         require_visual_leak_runtime()
 
-    app = FastAPI(title="agent-bom gateway", version="1")
     upstream_caller = settings.upstream_caller or _default_upstream_caller
     rate_limit_store = _build_gateway_rate_limit_store(settings)
+    policy_state: dict[str, Any] = {
+        "policy": dict(settings.policy),
+        "source": str(settings.policy_path) if settings.policy_path else "inline",
+        "last_loaded_at": None,
+        "last_error": None,
+        "last_mtime": None,
+    }
+    policy_lock = asyncio.Lock()
+    reload_task: asyncio.Task[None] | None = None
+
+    async def _reload_policy_if_changed(force: bool = False) -> bool:
+        if settings.policy_path is None:
+            return False
+        try:
+            stat = settings.policy_path.stat()
+        except OSError as exc:
+            async with policy_lock:
+                policy_state["last_error"] = str(exc)
+            logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
+            return False
+
+        mtime = stat.st_mtime
+        if not force and policy_state["last_mtime"] == mtime:
+            return False
+
+        try:
+            next_policy = _load_policy_file(settings.policy_path)
+        except Exception as exc:  # noqa: BLE001
+            async with policy_lock:
+                policy_state["last_error"] = str(exc)
+            logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
+            return False
+
+        async with policy_lock:
+            policy_state["policy"] = next_policy
+            policy_state["last_loaded_at"] = time.time()
+            policy_state["last_error"] = None
+            policy_state["last_mtime"] = mtime
+        logger.info("gateway policy reloaded from %s", settings.policy_path)
+        return True
+
+    async def _policy_reload_loop() -> None:
+        while True:
+            await asyncio.sleep(max(settings.policy_reload_interval_seconds, 1))
+            await _reload_policy_if_changed()
+
+    @asynccontextmanager
+    async def _lifespan(_app: FastAPI):
+        nonlocal reload_task
+        try:
+            if settings.policy_path is not None:
+                await _reload_policy_if_changed(force=True)
+                if settings.policy_reload_interval_seconds > 0:
+                    reload_task = asyncio.create_task(_policy_reload_loop())
+            yield
+        finally:
+            if reload_task is not None:
+                reload_task.cancel()
+                try:
+                    await reload_task
+                except asyncio.CancelledError:
+                    pass
+                reload_task = None
+
+    app = FastAPI(title="agent-bom gateway", version="1", lifespan=_lifespan)
 
     @app.get("/healthz")
     async def healthz() -> dict[str, Any]:
+        async with policy_lock:
+            policy_runtime = {
+                "source": policy_state["source"],
+                "reload_enabled": bool(settings.policy_path and settings.policy_reload_interval_seconds > 0),
+                "reload_interval_seconds": settings.policy_reload_interval_seconds,
+                "last_loaded_at": policy_state["last_loaded_at"],
+                "last_error": policy_state["last_error"],
+            }
         health: dict[str, Any] = {
             "status": "ok",
             "upstreams": settings.registry.names(),
             "auth": {"incoming_token_required": _gateway_requires_auth(settings)},
             "rate_limit_runtime": _gateway_rate_limit_runtime_status(settings),
+            "policy_runtime": policy_runtime,
         }
         if settings.enable_visual_leak_detection:
             from agent_bom.runtime.visual_leak_detector import visual_leak_runtime_health
@@ -371,7 +455,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             params = message.get("params", {}) or {}
             tool_name = params.get("name", "")
             arguments = params.get("arguments", {}) or {}
-            allowed, reason = check_policy(settings.policy, tool_name, arguments)
+            async with policy_lock:
+                current_policy = dict(policy_state["policy"])
+            allowed, reason = check_policy(current_policy, tool_name, arguments)
             if not allowed:
                 record_gateway_relay(upstream.name, "blocked")
                 audit_event: dict[str, Any] = {

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -318,6 +318,54 @@ def test_gateway_serve_passes_runtime_rate_limit_settings(tmp_path):
     mock_run.assert_called_once()
 
 
+def test_gateway_serve_rejects_policy_reload_without_policy_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        upstreams = "upstreams.yaml"
+        with open(upstreams, "w", encoding="utf-8") as handle:
+            handle.write("upstreams:\n  - name: jira\n    url: https://jira.example.com/mcp\n")
+        result = runner.invoke(
+            gateway_serve_cmd,
+            ["--bind", "127.0.0.1:8090", "--upstreams", upstreams, "--policy-reload-seconds", "5"],
+        )
+    assert result.exit_code == 1
+    assert "--policy-reload-seconds requires --policy" in result.output
+
+
+def test_gateway_serve_passes_policy_reload_settings(tmp_path):
+    runner = CliRunner()
+    upstreams = tmp_path / "upstreams.yaml"
+    policy = tmp_path / "policy.json"
+    upstreams.write_text("upstreams:\n  - name: jira\n    url: https://jira.example.com/mcp\n")
+    policy.write_text('{"rules":[]}')
+
+    with (
+        patch("agent_bom.gateway_server.create_gateway_app") as mock_create_app,
+        patch("uvicorn.run") as mock_run,
+    ):
+        mock_create_app.return_value = object()
+        result = runner.invoke(
+            gateway_serve_cmd,
+            [
+                "--bind",
+                "127.0.0.1:8090",
+                "--upstreams",
+                str(upstreams),
+                "--policy",
+                str(policy),
+                "--policy-reload-seconds",
+                "5",
+            ],
+        )
+
+    assert result.exit_code == 0
+    settings = mock_create_app.call_args.args[0]
+    assert settings.policy_path == policy
+    assert settings.policy_reload_interval_seconds == 5
+    assert "Policy hot reload: enabled every 5s" in result.output
+    mock_run.assert_called_once()
+
+
 def test_mcp_server_cmd_missing_sdk():
     """Test mcp-server command when MCP SDK is not installed."""
     runner = CliRunner()

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -14,9 +14,11 @@ paths a pilot team would actually run into.
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -68,7 +70,34 @@ def test_healthz_lists_configured_upstreams() -> None:
             "fail_closed": False,
             "message": "Gateway runtime rate limiting disabled.",
         },
+        "policy_runtime": {
+            "source": "inline",
+            "reload_enabled": False,
+            "reload_interval_seconds": 0,
+            "last_loaded_at": None,
+            "last_error": None,
+        },
     }
+
+
+def test_healthz_reports_policy_reload_runtime(tmp_path: Path) -> None:
+    policy_path = tmp_path / "gateway-policy.json"
+    policy_path.write_text('{"rules":[]}')
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        policy_path=policy_path,
+        policy_reload_interval_seconds=2,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        runtime = resp.json()["policy_runtime"]
+        assert runtime["source"] == str(policy_path)
+        assert runtime["reload_enabled"] is True
+        assert runtime["reload_interval_seconds"] == 2
+        assert runtime["last_loaded_at"] is not None
+        assert runtime["last_error"] is None
 
 
 def test_healthz_reports_visual_leak_readiness_when_enabled(monkeypatch) -> None:
@@ -418,7 +447,40 @@ def test_relay_allows_tool_not_in_blocklist() -> None:
         json=_json_rpc("tools/call", name="query_issues", arguments={"jql": "project = ACME"}),
     )
     assert resp.status_code == 200
-    assert resp.json()["result"]["ok"] is True
+
+
+def test_gateway_hot_reload_updates_policy_without_restart(tmp_path: Path) -> None:
+    policy_path = tmp_path / "gateway-policy.json"
+    policy_path.write_text(json.dumps({"rules": [{"id": "no-shell", "action": "block", "block_tools": ["run_shell"]}]}))
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+        policy_path=policy_path,
+        policy_reload_interval_seconds=1,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+        blocked = client.post(
+            "/mcp/filesystem",
+            json=_json_rpc("tools/call", name="run_shell", arguments={"command": "whoami"}),
+        )
+        assert blocked.status_code == 200
+        assert blocked.json()["error"]["code"] == -32001
+
+        time.sleep(1.1)
+        policy_path.write_text(json.dumps({"rules": []}))
+        time.sleep(1.2)
+
+        allowed = client.post(
+            "/mcp/filesystem",
+            json=_json_rpc("tools/call", name="run_shell", arguments={"command": "whoami"}),
+        )
+        assert allowed.status_code == 200
+        assert allowed.json()["result"]["ok"] is True
 
 
 # ─── Error cases ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary
- add in-process hot reload for file-backed gateway policy bundles
- expose policy reload runtime status in /healthz
- wire the gateway CLI with --policy-reload-seconds and validation for invalid combinations

Testing
- uv run pytest tests/test_gateway_server.py tests/test_cli_server.py -q
- uv run ruff check src/agent_bom/gateway_server.py src/agent_bom/cli/_gateway.py tests/test_gateway_server.py tests/test_cli_server.py
- uv run mypy src/agent_bom/gateway_server.py src/agent_bom/cli/_gateway.py
- uv run mkdocs build --strict

Closes #1670