### PR TITLE
test(runtime): add gateway and OCSF contract coverage

### DIFF
--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -897,6 +897,68 @@ async def test_ocsf_ingest_is_tenant_scoped_and_audited(isolated_audit_log):
 
 
 @pytest.mark.asyncio
+async def test_ocsf_ingest_normalizes_expected_analytics_contract():
+    req = _request("tenant-alpha")
+
+    class _Analytics:
+        def __init__(self):
+            self.events = []
+            self.event_tenants: list[str] = []
+
+        def record_events(self, events, *, tenant_id: str = "default"):
+            self.events.extend(events)
+            self.event_tenants.append(tenant_id)
+
+    analytics = _Analytics()
+    payload = {
+        "class_uid": 2004,
+        "class_name": "Detection Finding",
+        "severity_id": 5,
+        "message": "Credential exposed in screenshot",
+        "time": "2026-04-22T04:00:00+00:00",
+        "finding_info": {
+            "uid": "finding-42",
+            "analytic": {"name": "visual_leak"},
+        },
+        "resources": [{"name": "screenshot-tool"}],
+        "metadata": {
+            "product": {"name": "splunk"},
+            "uid": "meta-1",
+        },
+    }
+
+    with patch("agent_bom.api.routes.observability._get_analytics_store", return_value=analytics):
+        result = await observability_routes.ingest_ocsf(req, payload)
+
+    assert result == {
+        "ingested": 1,
+        "tenant_id": "tenant-alpha",
+        "class_counts": {"2004": 1},
+        "sources": ["splunk"],
+    }
+    assert analytics.event_tenants == ["tenant-alpha"]
+    assert analytics.events == [
+        {
+            "event_id": "finding-42",
+            "event_timestamp": "2026-04-22T04:00:00+00:00",
+            "tenant_id": "tenant-alpha",
+            "event_type": "ocsf_detection_finding",
+            "detector": "visual_leak",
+            "severity": "critical",
+            "tool_name": "screenshot-tool",
+            "message": "Credential exposed in screenshot",
+            "agent_name": "",
+            "session_id": "",
+            "trace_id": "",
+            "request_id": "",
+            "source_id": "splunk",
+            "ocsf_class_uid": 2004,
+            "ocsf_class_name": "Detection Finding",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ocsf_ingest_rejects_non_event_payload():
     req = _request("tenant-alpha")
 

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -357,6 +357,69 @@ def test_gateway_rate_limit_is_tenant_scoped(monkeypatch) -> None:
     assert other_tenant.status_code == 200
 
 
+def test_gateway_rate_limit_shared_store_holds_under_concurrency(monkeypatch) -> None:
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "tenant-alpha-key":
+                return SimpleNamespace(tenant_id="tenant-alpha")
+            return None
+
+    class _ConcurrentSharedStore:
+        def __init__(self) -> None:
+            self._lock = threading.Lock()
+            self._counts: dict[str, int] = {}
+            self._arrivals = 0
+            self._ready = threading.Event()
+
+        def hit(self, bucket: str, now: float) -> tuple[int, float]:
+            with self._lock:
+                self._arrivals += 1
+                if self._arrivals >= 2:
+                    self._ready.set()
+            self._ready.wait(timeout=0.5)
+            with self._lock:
+                count = self._counts.get(bucket, 0) + 1
+                self._counts[bucket] = count
+            return count, now + 60
+
+        @property
+        def counts(self) -> dict[str, int]:
+            with self._lock:
+                return dict(self._counts)
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+    shared_store = _ConcurrentSharedStore()
+    monkeypatch.setattr("agent_bom.gateway_server._build_gateway_rate_limit_store", lambda _settings: shared_store)
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+        runtime_rate_limit_per_tenant_per_minute=1,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+
+        def _post() -> int:
+            response = client.post(
+                "/mcp/filesystem",
+                headers={"X-API-Key": "tenant-alpha-key"},
+                json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+            )
+            return response.status_code
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            statuses = list(executor.map(lambda _idx: _post(), range(2)))
+
+    assert sorted(statuses) == [200, 429]
+    assert shared_store.counts == {"gateway:tenant:tenant-alpha": 2}
+
+
 def test_gateway_rate_limit_can_require_shared_backend(monkeypatch) -> None:
     monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
     monkeypatch.setenv("AGENT_BOM_GATEWAY_REPLICAS", "2")


### PR DESCRIPTION
## Summary
- add a concurrent same-tenant gateway rate-limit contract test using a shared store shim
- add an explicit OCSF ingest analytics-contract test for normalized event shape and tenant propagation
- keep the scope to tests only so this hardens release proof without changing runtime behavior

## Testing
- uv run pytest tests/test_gateway_server.py tests/test_api_tenant_isolation.py -q
- uv run ruff check tests/test_gateway_server.py tests/test_api_tenant_isolation.py
- uv run mypy tests/test_gateway_server.py tests/test_api_tenant_isolation.py

Closes #1679