### PR TITLE
feat(ui): add feedback and bug-report entrypoints

### DIFF
--- a/ui/app/help/page.tsx
+++ b/ui/app/help/page.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, ArrowUpRight, Bug, CheckCircle2, Copy, MessageSquareQuote } from "lucide-react";
+
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
+import { api, type AuthDebugResponse, type VersionInfo } from "@/lib/api";
+import { buildIssueUrl, buildSupportBundle } from "@/lib/feedback";
+
+export default function HelpPage() {
+  const searchParams = useSearchParams();
+  const from = searchParams.get("from") || "/";
+  const { counts, loading: deploymentLoading } = useDeploymentContext();
+  const [version, setVersion] = useState<VersionInfo | null>(null);
+  const [authDebug, setAuthDebug] = useState<AuthDebugResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    Promise.allSettled([api.version(), api.getAuthDebug()])
+      .then(([versionResult, authResult]) => {
+        if (!mounted) return;
+        if (versionResult.status === "fulfilled") setVersion(versionResult.value);
+        if (authResult.status === "fulfilled") setAuthDebug(authResult.value);
+      })
+      .finally(() => {
+        if (!mounted) return;
+        setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const supportBundle = useMemo(() => {
+    return buildSupportBundle({
+      from,
+      currentUrl: typeof window !== "undefined" ? window.location.href : "/help",
+      userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
+      version,
+      authDebug,
+      counts,
+    });
+  }, [authDebug, counts, from, version]);
+
+  async function copyBundle() {
+    try {
+      await navigator.clipboard.writeText(supportBundle);
+      setCopyState("copied");
+      window.setTimeout(() => setCopyState("idle"), 1500);
+    } catch {
+      setCopyState("error");
+      window.setTimeout(() => setCopyState("idle"), 2000);
+    }
+  }
+
+  const bugTitle = `bug(ui): issue from ${from}`;
+  const feedbackTitle = `feedback(ui): ${counts?.deployment_mode ?? "self-hosted"} operator feedback`;
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-6">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">
+              Operator Help
+            </p>
+            <h1 className="text-2xl font-semibold text-[color:var(--foreground)]">Feedback and bug reporting</h1>
+            <p className="max-w-3xl text-sm leading-6 text-[color:var(--text-secondary)]">
+              This UI is the browser control-plane for the self-hosted <code>agent-bom</code> product. Use this page
+              to share product feedback, report a bug, and copy a redaction-friendly support bundle without sending
+              any hidden telemetry.
+            </p>
+          </div>
+          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3 text-xs text-[color:var(--text-secondary)]">
+            <div>Opened from: <span className="font-mono text-[color:var(--foreground)]">{from}</span></div>
+            <div>Deployment mode: <span className="font-mono text-[color:var(--foreground)]">{counts?.deployment_mode ?? "unknown"}</span></div>
+            <div>Version: <span className="font-mono text-[color:var(--foreground)]">{version?.version ?? (loading ? "Loading…" : "unknown")}</span></div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <article className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+          <div className="mb-4 flex items-center gap-3">
+            <div className="rounded-xl bg-emerald-500/10 p-2 text-emerald-400">
+              <MessageSquareQuote className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-[color:var(--foreground)]">Share feedback</h2>
+              <p className="text-sm text-[color:var(--text-secondary)]">
+                Product UX, deployment friction, missing workflows, or integration requests.
+              </p>
+            </div>
+          </div>
+          <div className="space-y-3 text-sm text-[color:var(--text-secondary)]">
+            <p>
+              Opens the existing feature-request issue flow and gives you a copyable bundle for deployment, auth,
+              and runtime context.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <a
+                href={buildIssueUrl("feature_request.yml", feedbackTitle)}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-3 py-2 text-sm font-medium text-black transition-opacity hover:opacity-90"
+              >
+                Open feature request
+                <ArrowUpRight className="h-4 w-4" />
+              </a>
+              <button
+                onClick={() => void copyBundle()}
+                className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] px-3 py-2 text-sm font-medium text-[color:var(--foreground)] transition-colors hover:bg-[color:var(--surface-muted)]"
+              >
+                <Copy className="h-4 w-4" />
+                Copy support bundle
+              </button>
+            </div>
+          </div>
+        </article>
+
+        <article className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+          <div className="mb-4 flex items-center gap-3">
+            <div className="rounded-xl bg-rose-500/10 p-2 text-rose-400">
+              <Bug className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-[color:var(--foreground)]">Report bug</h2>
+              <p className="text-sm text-[color:var(--text-secondary)]">
+                Broken UI flow, bad API response, deployment mismatch, or runtime behavior that regressed.
+              </p>
+            </div>
+          </div>
+          <div className="space-y-3 text-sm text-[color:var(--text-secondary)]">
+            <p>
+              Opens the existing bug-report issue template. The copied support bundle is redaction-friendly and avoids
+              sending telemetry automatically.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <a
+                href={buildIssueUrl("bug_report.yml", bugTitle)}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg bg-rose-500 px-3 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+              >
+                Open bug report
+                <ArrowUpRight className="h-4 w-4" />
+              </a>
+              <button
+                onClick={() => void copyBundle()}
+                className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] px-3 py-2 text-sm font-medium text-[color:var(--foreground)] transition-colors hover:bg-[color:var(--surface-muted)]"
+              >
+                <Copy className="h-4 w-4" />
+                Copy support bundle
+              </button>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-[color:var(--foreground)]">Support bundle preview</h2>
+            <p className="text-sm text-[color:var(--text-secondary)]">
+              Review and redact if needed before sharing externally.
+            </p>
+          </div>
+          <div className="text-xs">
+            {copyState === "copied" && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-1 text-emerald-400">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Copied
+              </span>
+            )}
+            {copyState === "error" && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-rose-500/10 px-2 py-1 text-rose-400">
+                <AlertCircle className="h-3.5 w-3.5" />
+                Copy failed
+              </span>
+            )}
+          </div>
+        </div>
+        <textarea
+          readOnly
+          value={supportBundle}
+          className="min-h-[340px] w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4 font-mono text-xs leading-6 text-[color:var(--foreground)] outline-none"
+        />
+      </section>
+
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 text-sm text-[color:var(--text-secondary)]">
+        <h2 className="mb-2 text-lg font-semibold text-[color:var(--foreground)]">Support policy</h2>
+        <ul className="space-y-2">
+          <li>No hidden telemetry is sent from this page. It only prepares links and copyable text.</li>
+          <li>Security issues should still go through the repository security policy, not the public bug form.</li>
+          <li>
+            The browser UI is part of the same <code>agent-bom</code> product, not a separate SaaS or separate
+            collector.
+          </li>
+        </ul>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link
+            href="https://github.com/msaad00/agent-bom/blob/main/SECURITY.md"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 text-sm font-medium text-emerald-400 hover:text-emerald-300"
+          >
+            Security policy
+            <ArrowUpRight className="h-4 w-4" />
+          </Link>
+          <Link
+            href="https://github.com/msaad00/agent-bom/discussions"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 text-sm font-medium text-emerald-400 hover:text-emerald-300"
+          >
+            Discussions
+            <ArrowUpRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+
+      {!deploymentLoading && counts?.deployment_mode == null && (
+        <p className="text-xs text-[color:var(--text-tertiary)]">
+          Deployment context is not fully detected yet. That usually means the control plane has not seen enough scan,
+          fleet, or runtime state to infer a mode.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -7,6 +7,7 @@ import {
   Scan,
   Server,
   Bug,
+  MessageSquareQuote,
   Database,
   Activity,
   GitBranch,
@@ -440,6 +441,14 @@ export function Nav() {
       {/* Bottom section */}
       <div className={`border-t border-[color:var(--border-subtle)] ${collapsed ? "px-2 py-3" : "px-3 py-3"}`}>
         <div className="space-y-2">
+          <Link
+            href={`/help?from=${encodeURIComponent(path ?? "/")}`}
+            className={`flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[12px] text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)] ${collapsed ? "justify-center px-2" : ""}`}
+            title="Share feedback or report a bug"
+          >
+            <MessageSquareQuote className="h-4 w-4 shrink-0" />
+            {!collapsed && <span>Feedback &amp; Bug Report</span>}
+          </Link>
           <ThemeToggle compact={collapsed} />
           <ApiStatus collapsed={collapsed} />
         </div>

--- a/ui/lib/feedback.ts
+++ b/ui/lib/feedback.ts
@@ -1,0 +1,59 @@
+import type { AuthDebugResponse, PostureCountsResponse, VersionInfo } from "./api";
+
+export function buildIssueUrl(template: string, title: string) {
+  const params = new URLSearchParams({
+    template,
+    title,
+  });
+  return `https://github.com/msaad00/agent-bom/issues/new?${params.toString()}`;
+}
+
+export function buildSupportBundle(input: {
+  from: string;
+  currentUrl?: string;
+  userAgent?: string;
+  version: VersionInfo | null;
+  authDebug: AuthDebugResponse | null;
+  counts: PostureCountsResponse | null;
+}) {
+  const { authDebug, counts, currentUrl, from, userAgent, version } = input;
+  const lines = [
+    "# agent-bom support bundle",
+    "",
+    "## Product surface",
+    "- UI role: browser control-plane for the self-hosted agent-bom product",
+    `- Page opened from: \`${from}\``,
+    `- Browser URL: \`${currentUrl ?? "/help"}\``,
+    "",
+    "## Version",
+    `- UI/API version: \`${version?.version ?? "unknown"}\``,
+    `- API version: \`${version?.api_version ?? "unknown"}\``,
+    `- Python package: \`${version?.python_package ?? "unknown"}\``,
+    "",
+    "## Deployment context",
+    `- Deployment mode: \`${counts?.deployment_mode ?? "unknown"}\``,
+    `- Scan sources: \`${(counts?.scan_sources ?? []).join(", ") || "unknown"}\``,
+    `- Fleet ingest: \`${counts?.has_fleet_ingest ?? false}\``,
+    `- Gateway detected: \`${counts?.has_gateway ?? false}\``,
+    `- Proxy detected: \`${counts?.has_proxy ?? false}\``,
+    `- Cluster scan detected: \`${counts?.has_cluster_scan ?? false}\``,
+    `- Local scan detected: \`${counts?.has_local_scan ?? false}\``,
+    "",
+    "## Auth/debug context",
+    `- Authenticated: \`${authDebug?.authenticated ?? false}\``,
+    `- Auth required: \`${authDebug?.auth_required ?? false}\``,
+    `- Auth method: \`${authDebug?.auth_method ?? "unknown"}\``,
+    `- Role: \`${authDebug?.role ?? "unknown"}\``,
+    `- Tenant: \`${authDebug?.tenant_id ?? "unknown"}\``,
+    `- Recommended UI mode: \`${authDebug?.recommended_ui_mode ?? "unknown"}\``,
+    `- Trace ID: \`${authDebug?.trace_id ?? "unknown"}\``,
+    `- Request ID: \`${authDebug?.request_id ?? "unknown"}\``,
+    "",
+    "## Browser",
+    `- User agent: \`${userAgent ?? "unknown"}\``,
+    "",
+    "## What happened",
+    "- Describe the bug, feedback, or missing workflow here.",
+  ];
+  return lines.join("\n");
+}

--- a/ui/tests/feedback.test.ts
+++ b/ui/tests/feedback.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { buildIssueUrl, buildSupportBundle } from "@/lib/feedback";
+
+describe("feedback helpers", () => {
+  it("builds GitHub issue template links", () => {
+    const url = buildIssueUrl("bug_report.yml", "bug(ui): issue from /proxy");
+    expect(url).toContain("template=bug_report.yml");
+    expect(url).toContain("title=bug%28ui%29%3A+issue+from+%2Fproxy");
+  });
+
+  it("builds a support bundle with deployment and auth context", () => {
+    const bundle = buildSupportBundle({
+      from: "/gateway",
+      currentUrl: "https://agent-bom.internal.example.com/help?from=%2Fgateway",
+      userAgent: "VitestBrowser/1.0",
+      version: {
+        version: "0.81.1",
+        api_version: "v1",
+        python_package: "agent-bom",
+      },
+      authDebug: {
+        authenticated: true,
+        auth_required: true,
+        configured_modes: ["oidc"],
+        recommended_ui_mode: "session",
+        auth_method: "oidc",
+        subject: "alice@example.com",
+        role: "admin",
+        tenant_id: "tenant-alpha",
+        oidc_issuer_suffix: "okta.example.com",
+        api_key_id_prefix: null,
+        request_id: "req-1",
+        trace_id: "trace-1",
+        span_id: "span-1",
+      },
+      counts: {
+        critical: 1,
+        high: 2,
+        medium: 3,
+        low: 4,
+        total: 10,
+        kev: 1,
+        compound_issues: 1,
+        deployment_mode: "hybrid",
+        has_fleet_ingest: true,
+        has_gateway: true,
+        has_proxy: true,
+        has_cluster_scan: true,
+        has_local_scan: false,
+        scan_sources: ["fleet", "cluster"],
+      },
+    });
+
+    expect(bundle).toContain("Page opened from: `/gateway`");
+    expect(bundle).toContain("Deployment mode: `hybrid`");
+    expect(bundle).toContain("Tenant: `tenant-alpha`");
+    expect(bundle).toContain("Trace ID: `trace-1`");
+    expect(bundle).toContain("Scan sources: `fleet, cluster`");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Help page in the browser control-plane UI for feedback and bug reporting
- prefill GitHub bug/feature issue links and generate a copyable support bundle from version, deployment context, and auth/debug state
- wire a sidebar footer entry point without adding any hidden telemetry or vendor lock-in

## Testing
- npm --prefix ui run test:run -- tests/feedback.test.ts
- npm --prefix ui run lint
- npm --prefix ui run build

Closes #1684