### PR TITLE
feat(platform): surface MCP provenance across discovery and fleet

### DIFF
--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -120,15 +120,35 @@ def _serialize_agent(
     payload["mcp_servers"] = []
     for server in agent.mcp_servers:
         server_payload = asdict(server)
-        server_payload["auth_mode"] = server.auth_mode
-        server_payload["has_credentials"] = server.has_credentials
-        server_payload["credential_env_vars"] = server.credential_names
+        credential_names = list(getattr(server, "credential_names", []) or [])
+        server_url = getattr(server, "url", None)
+        auth_mode = getattr(server, "auth_mode", None)
+        if auth_mode is None:
+            if credential_names:
+                auth_mode = "env-credentials"
+            elif server_url and "@" in server_url:
+                auth_mode = "url-embedded-credentials"
+            elif server_url:
+                auth_mode = "network-no-auth-observed"
+            else:
+                auth_mode = "local-stdio"
+        has_credentials = getattr(server, "has_credentials", None)
+        if has_credentials is None:
+            has_credentials = bool(credential_names)
+
+        server_payload["auth_mode"] = auth_mode
+        server_payload["has_credentials"] = has_credentials
+        server_payload["credential_env_vars"] = credential_names
+        server_payload.setdefault("args", list(getattr(server, "args", []) or []))
+        server_payload.setdefault("url", server_url)
+        server_payload.setdefault("config_path", getattr(server, "config_path", None))
+        server_payload.setdefault("security_warnings", list(getattr(server, "security_warnings", []) or []))
         scan_history = (scan_history_index or {}).get(
             (agent.name, server.name),
             {"present": False, "scan_sources": [], "first_seen": None, "last_seen": None},
         )
         gateway_state = (gateway_index or {}).get(
-            (server.name, server.url or ""),
+            (server.name, server_url or ""),
             {"gateway_registered": False, "source_agents": []},
         )
         observed_via = ["local_discovery"]

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -10,11 +10,13 @@ Endpoints:
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
 from agent_bom.api.models import JobStatus
-from agent_bom.api.stores import _get_store
+from agent_bom.api.stores import _get_fleet_store, _get_store
 from agent_bom.security import sanitize_error
 
 router = APIRouter()
@@ -25,14 +27,145 @@ def _tenant_id(request: Request) -> str:
     return getattr(request.state, "tenant_id", "default")
 
 
+def _completed_jobs(tenant_id: str) -> list[Any]:
+    return [job for job in _get_store().list_all(tenant_id=tenant_id) if job.status == JobStatus.DONE and job.result]
+
+
+def _iter_report_servers(report: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    rows: list[tuple[str, dict[str, Any]]] = []
+    for agent in report.get("agents", []):
+        agent_name = str(agent.get("name") or agent.get("agent_name") or "").strip()
+        for server in agent.get("mcp_servers", []) or []:
+            if isinstance(server, dict):
+                rows.append((agent_name, server))
+        # Back-compat for older pushed reports and gateway discovery seed data.
+        for server in agent.get("servers", []) or []:
+            if isinstance(server, dict):
+                rows.append((agent_name, server))
+    return rows
+
+
+def _build_scan_history_index(tenant_id: str) -> dict[tuple[str, str], dict[str, Any]]:
+    index: dict[tuple[str, str], dict[str, Any]] = {}
+    for job in _completed_jobs(tenant_id):
+        report = job.result or {}
+        for report_agent_name, report_server in _iter_report_servers(report):
+            server_name = str(report_server.get("name") or "").strip()
+            if not report_agent_name or not server_name:
+                continue
+            key = (report_agent_name, server_name)
+            record = index.setdefault(
+                key,
+                {
+                    "scan_sources": set(),
+                    "first_seen": "",
+                    "last_seen": "",
+                },
+            )
+            for source in report.get("scan_sources", []) or []:
+                if source:
+                    record["scan_sources"].add(str(source))
+            created_at = str(job.created_at or "")
+            completed_at = str(job.completed_at or created_at)
+            if created_at and (not record["first_seen"] or created_at < record["first_seen"]):
+                record["first_seen"] = created_at
+            if completed_at and completed_at > record["last_seen"]:
+                record["last_seen"] = completed_at
+
+    return {
+        key: {
+            "present": True,
+            "scan_sources": sorted(value["scan_sources"]),
+            "first_seen": value["first_seen"] or None,
+            "last_seen": value["last_seen"] or None,
+        }
+        for key, value in index.items()
+    }
+
+
+def _build_gateway_index(tenant_id: str) -> dict[tuple[str, str], dict[str, Any]]:
+    index: dict[tuple[str, str], dict[str, Any]] = {}
+    for job in _completed_jobs(tenant_id):
+        for agent_name, report_server in _iter_report_servers(job.result or {}):
+            server_name = str(report_server.get("name") or "").strip()
+            server_url = str(report_server.get("url") or "").strip()
+            if not server_name or not server_url.startswith(("http://", "https://")):
+                continue
+            record = index.setdefault(
+                (server_name, server_url),
+                {
+                    "gateway_registered": True,
+                    "source_agents": set(),
+                },
+            )
+            if agent_name:
+                record["source_agents"].add(agent_name)
+    return {
+        key: {
+            "gateway_registered": value["gateway_registered"],
+            "source_agents": sorted(value["source_agents"]),
+        }
+        for key, value in index.items()
+    }
+
+
+def _serialize_agent(
+    agent,
+    *,
+    fleet_agent: dict[str, Any] | None = None,
+    scan_history_index: dict[tuple[str, str], dict[str, Any]] | None = None,
+    gateway_index: dict[tuple[str, str], dict[str, Any]] | None = None,
+) -> dict:
+    payload = asdict(agent)
+    payload["mcp_servers"] = []
+    for server in agent.mcp_servers:
+        server_payload = asdict(server)
+        server_payload["auth_mode"] = server.auth_mode
+        server_payload["has_credentials"] = server.has_credentials
+        server_payload["credential_env_vars"] = server.credential_names
+        scan_history = (scan_history_index or {}).get(
+            (agent.name, server.name),
+            {"present": False, "scan_sources": [], "first_seen": None, "last_seen": None},
+        )
+        gateway_state = (gateway_index or {}).get(
+            (server.name, server.url or ""),
+            {"gateway_registered": False, "source_agents": []},
+        )
+        observed_via = ["local_discovery"]
+        observed_scopes = ["endpoint"]
+        if scan_history["present"]:
+            observed_via.append("scan_result")
+            observed_scopes.append("scan")
+        if fleet_agent is not None:
+            observed_via.append("fleet_sync")
+        if gateway_state["gateway_registered"]:
+            observed_via.append("gateway_discovery")
+            observed_scopes.append("gateway")
+        payload["mcp_servers"].append(server_payload)
+        server_payload["provenance"] = {
+            "observed_via": observed_via,
+            "observed_scopes": observed_scopes,
+            "scan_sources": scan_history["scan_sources"],
+            "source_agents": gateway_state["source_agents"],
+            "configured_locally": True,
+            "fleet_present": fleet_agent is not None,
+            "gateway_registered": gateway_state["gateway_registered"],
+            # Runtime correlation for per-server MCP objects is not yet wired through
+            # a canonical store. Keep this explicit instead of inferring from alert volume.
+            "runtime_observed": False,
+            "first_seen": scan_history["first_seen"],
+            "last_seen": fleet_agent.get("last_discovery") if fleet_agent else scan_history["last_seen"],
+            "last_synced": fleet_agent.get("updated_at") if fleet_agent else None,
+        }
+    return payload
+
+
 @router.get("/v1/agents", tags=["discovery"])
-async def list_agents() -> dict:
+async def list_agents(request: Request) -> dict:
     """Quick auto-discovery of local AI agent configs (Claude Desktop, Cursor, Windsurf...).
     No CVE scan — instant results for the UI sidebar.
     """
     try:
-        from dataclasses import asdict
-
         from agent_bom.discovery import discover_all
         from agent_bom.parsers import extract_packages
 
@@ -41,9 +174,19 @@ async def list_agents() -> dict:
             for server in agent.mcp_servers:
                 if not server.packages:
                     server.packages = extract_packages(server)
+        tenant_id = _tenant_id(request)
+        scan_history_index = _build_scan_history_index(tenant_id)
+        gateway_index = _build_gateway_index(tenant_id)
 
         return {
-            "agents": [asdict(a) for a in agents],
+            "agents": [
+                _serialize_agent(
+                    a,
+                    scan_history_index=scan_history_index,
+                    gateway_index=gateway_index,
+                )
+                for a in agents
+            ],
             "count": len(agents),
             "warnings": [],
         }
@@ -56,8 +199,6 @@ async def list_agents() -> dict:
 async def get_agent_detail(request: Request, agent_name: str) -> dict:
     """Get detailed view of a single agent with cross-referenced scan data."""
     try:
-        from dataclasses import asdict
-
         from agent_bom.discovery import discover_all
         from agent_bom.parsers import extract_packages
 
@@ -96,8 +237,22 @@ async def get_agent_detail(request: Request, agent_name: str) -> dict:
             if sev in severity_counts:
                 severity_counts[sev] += 1
 
+        fleet_agent = None
+        tenant_id = _tenant_id(request)
+        for candidate in _get_fleet_store().list_by_tenant(tenant_id):
+            if candidate.name == agent_name:
+                fleet_agent = candidate.model_dump()
+                break
+        scan_history_index = _build_scan_history_index(tenant_id)
+        gateway_index = _build_gateway_index(tenant_id)
+
         return {
-            "agent": asdict(agent),
+            "agent": _serialize_agent(
+                agent,
+                fleet_agent=fleet_agent,
+                scan_history_index=scan_history_index,
+                gateway_index=gateway_index,
+            ),
             "summary": {
                 "total_servers": len(agent.mcp_servers),
                 "total_packages": total_packages,
@@ -108,6 +263,7 @@ async def get_agent_detail(request: Request, agent_name: str) -> dict:
             },
             "blast_radius": agent_blast,
             "credentials": all_credentials,
+            "fleet": fleet_agent,
         }
     except HTTPException:
         raise
@@ -307,8 +463,6 @@ async def get_agent_mesh(request: Request) -> dict:
     as an interactive graph.
     """
     try:
-        from dataclasses import asdict
-
         from agent_bom.discovery import discover_all
         from agent_bom.output.agent_mesh import build_agent_mesh
         from agent_bom.parsers import extract_packages
@@ -319,7 +473,10 @@ async def get_agent_mesh(request: Request) -> dict:
                 if not server.packages:
                     server.packages = extract_packages(server)
 
-        agents_data = [asdict(a) for a in agents]
+        tenant_id = _tenant_id(request)
+        scan_history_index = _build_scan_history_index(tenant_id)
+        gateway_index = _build_gateway_index(tenant_id)
+        agents_data = [_serialize_agent(a, scan_history_index=scan_history_index, gateway_index=gateway_index) for a in agents]
 
         # Gather blast radius from completed scans for vuln overlay
         all_blast: list[dict] = []

--- a/tests/test_api_agent_detail.py
+++ b/tests/test_api_agent_detail.py
@@ -4,8 +4,12 @@ from unittest.mock import patch
 
 from starlette.testclient import TestClient
 
+from agent_bom.api import stores as _stores
+from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState, InMemoryFleetStore
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
-from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 
 def _mock_agents():
@@ -15,6 +19,8 @@ def _mock_agents():
         command="npx",
         args=["-y", "test-server"],
         env={"API_KEY": "sk-test", "DEBUG": "1"},
+        transport=TransportType.SSE,
+        url="https://mcp.example.internal/sse",
         packages=[
             Package(name="express", version="4.18.2", ecosystem="npm"),
         ],
@@ -33,8 +39,59 @@ def _mock_agents():
     ]
 
 
+def _mock_fleet_store() -> InMemoryFleetStore:
+    store = InMemoryFleetStore()
+    store.put(
+        FleetAgent(
+            agent_id="fleet-1",
+            name="test-agent",
+            agent_type="claude_desktop",
+            config_path="/tmp/test-config.json",
+            lifecycle_state=FleetLifecycleState.APPROVED,
+            trust_score=87.5,
+            tenant_id="default",
+            last_discovery="2026-04-22T12:00:00Z",
+            last_scan="2026-04-22T12:05:00Z",
+            created_at="2026-04-22T12:00:00Z",
+            updated_at="2026-04-22T12:05:00Z",
+        )
+    )
+    return store
+
+
+def _mock_job_store() -> InMemoryJobStore:
+    store = InMemoryJobStore()
+    job = ScanJob(
+        job_id="job-1",
+        tenant_id="default",
+        status=JobStatus.DONE,
+        created_at="2026-04-22T11:58:00Z",
+        completed_at="2026-04-22T12:06:00Z",
+        request=ScanRequest(),
+    )
+    job.result = {
+        "scan_id": "scan-1",
+        "scan_sources": ["fleet_sync", "mcp_config"],
+        "agents": [
+            {
+                "name": "test-agent",
+                "servers": [
+                    {
+                        "name": "test-server",
+                        "url": "https://mcp.example.internal/sse",
+                        "transport": "sse",
+                    }
+                ],
+            }
+        ],
+    }
+    store.put(job)
+    return store
+
+
 @patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
-def test_agent_detail_found(_mock):
+@patch("agent_bom.api.routes.discovery._get_fleet_store", side_effect=_mock_fleet_store)
+def test_agent_detail_found(_fleet, _mock):
     """GET /v1/agents/{name} returns 200 with agent detail."""
     client = TestClient(app)
     resp = client.get("/v1/agents/test-agent")
@@ -46,6 +103,8 @@ def test_agent_detail_found(_mock):
     assert data["summary"]["total_credentials"] >= 1
     assert "blast_radius" in data
     assert "credentials" in data
+    assert data["fleet"]["lifecycle_state"] == "approved"
+    assert data["fleet"]["trust_score"] == 87.5
 
 
 @patch("agent_bom.discovery.discover_all", return_value=[])
@@ -94,6 +153,37 @@ def test_agent_detail_credential_detection(_mock):
     # API_KEY should be detected as credential, DEBUG should not
     assert "API_KEY" in data["credentials"]
     assert "DEBUG" not in data["credentials"]
+    server = data["agent"]["mcp_servers"][0]
+    assert server["command"] == "npx"
+    assert server["auth_mode"] == "env-credentials"
+
+
+@patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
+@patch("agent_bom.api.routes.discovery._get_fleet_store", side_effect=_mock_fleet_store)
+def test_agent_detail_exposes_server_provenance(_fleet, _mock):
+    prev_store = _stores._store
+    _stores._store = _mock_job_store()
+    try:
+        client = TestClient(app)
+        resp = client.get("/v1/agents/test-agent")
+        assert resp.status_code == 200
+        server = resp.json()["agent"]["mcp_servers"][0]
+        provenance = server["provenance"]
+        assert provenance["configured_locally"] is True
+        assert provenance["fleet_present"] is True
+        assert provenance["gateway_registered"] is True
+        assert provenance["runtime_observed"] is False
+        assert provenance["source_agents"] == ["test-agent"]
+        assert provenance["scan_sources"] == ["fleet_sync", "mcp_config"]
+        assert "local_discovery" in provenance["observed_via"]
+        assert "scan_result" in provenance["observed_via"]
+        assert "fleet_sync" in provenance["observed_via"]
+        assert "gateway_discovery" in provenance["observed_via"]
+        assert provenance["first_seen"] == "2026-04-22T11:58:00Z"
+        assert provenance["last_seen"] == "2026-04-22T12:00:00Z"
+        assert provenance["last_synced"] == "2026-04-22T12:05:00Z"
+    finally:
+        _stores._store = prev_store
 
 
 @patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -728,6 +728,11 @@ async def test_discovery_and_traces_are_tenant_scoped():
         with patch("agent_bom.parsers.extract_packages", return_value=[]):
             detail = await discovery_routes.get_agent_detail(req, "alpha")
             assert [item["vulnerability_id"] for item in detail["blast_radius"]] == ["CVE-alpha"]
+            server = detail["agent"]["mcp_servers"][0]
+            assert server["auth_mode"] == "local-stdio"
+            assert server["has_credentials"] is False
+            assert server["credential_env_vars"] == []
+            assert server["security_warnings"] == []
 
     def _parse(_body: dict) -> list:
         from agent_bom.otel_ingest import ToolCallTrace

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -34,10 +34,12 @@ import {
   Bug,
   ChevronDown,
   ChevronRight,
+  Clock3,
   Download,
   GitBranch,
   Key,
   KeyRound,
+  Link2,
   Loader2,
   Network,
   Package,
@@ -45,6 +47,7 @@ import {
   Server,
   Shield,
   ShieldAlert,
+  TerminalSquare,
   Wrench,
   X,
 } from "lucide-react";
@@ -504,7 +507,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
     );
   }
 
-  const { agent, summary, blast_radius, credentials } = data;
+  const { agent, summary, blast_radius, credentials, fleet } = data;
   const sev = summary.severity_breakdown;
 
   const toggleServer = (name: string) => {
@@ -553,6 +556,33 @@ function AgentDetail({ agentName }: { agentName: string }) {
       </div>
 
       <div className="max-w-7xl mx-auto px-6 py-6 space-y-6">
+        {fleet && (
+          <div className="rounded-xl border border-sky-900/60 bg-sky-950/20 p-4">
+            <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-sky-400">Observed state</p>
+            <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+              <div className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2">
+                <div className="text-zinc-500 text-xs">Lifecycle state</div>
+                <div className="mt-1 text-sm font-semibold text-zinc-100">{fleet.lifecycle_state}</div>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2">
+                <div className="text-zinc-500 text-xs">Trust score</div>
+                <div className="mt-1 text-sm font-semibold text-emerald-400">{fleet.trust_score.toFixed(1)}</div>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2">
+                <div className="text-zinc-500 text-xs">Last discovery</div>
+                <div className="mt-1 text-sm font-semibold text-zinc-100">{fleet.last_discovery || "not synced yet"}</div>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2">
+                <div className="text-zinc-500 text-xs">Last scan</div>
+                <div className="mt-1 text-sm font-semibold text-zinc-100">{fleet.last_scan || "not scanned yet"}</div>
+              </div>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2">
+                <div className="text-zinc-500 text-xs">Updated</div>
+                <div className="mt-1 text-sm font-semibold text-zinc-100">{fleet.updated_at || "unknown"}</div>
+              </div>
+            </div>
+          </div>
+        )}
         <div className="rounded-xl border border-emerald-900/60 bg-emerald-950/20 p-4">
           <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-emerald-400">Inventory-first view</p>
           <p className="mt-1 text-sm leading-6 text-zinc-400">
@@ -561,7 +591,6 @@ function AgentDetail({ agentName }: { agentName: string }) {
             using discovery and scan data alone: server transport, exposed tools, env-backed credentials, and attached package risk.
           </p>
         </div>
-
         {/* Summary Stats */}
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
           <StatCard icon={Server} label="MCP Servers" value={summary.total_servers} color="text-blue-400" />
@@ -635,6 +664,19 @@ function AgentDetail({ agentName }: { agentName: string }) {
                           {srv.credential_env_vars?.length ?? 0} credential env
                         </span>
                       )}
+                      {srv.auth_mode && (
+                        <span className="rounded border border-sky-800 bg-sky-950 px-1.5 py-0.5 text-[10px] font-mono text-sky-300">
+                          {srv.auth_mode}
+                        </span>
+                      )}
+                      {srv.provenance?.observed_via?.map((source) => (
+                        <span
+                          key={source}
+                          className="rounded border border-emerald-900 bg-emerald-950 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300"
+                        >
+                          {source}
+                        </span>
+                      ))}
                     </div>
                     <div className="flex items-center gap-3 text-xs text-zinc-500">
                       <span>{srvPkgs.length} pkgs</span>
@@ -646,6 +688,75 @@ function AgentDetail({ agentName }: { agentName: string }) {
                   </button>
                   {isExpanded && (
                     <div className="border-t border-zinc-800 px-4 py-3 space-y-3">
+                      <div className="grid gap-3 md:grid-cols-2">
+                        {srv.command && (
+                          <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-2">
+                            <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                              <TerminalSquare className="h-3.5 w-3.5" />
+                              Command
+                            </div>
+                            <div className="font-mono text-xs text-zinc-300 break-all">
+                              {[srv.command, ...(srv.args || [])].join(" ")}
+                            </div>
+                          </div>
+                        )}
+                        {srv.url && (
+                          <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-2">
+                            <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                              <Link2 className="h-3.5 w-3.5" />
+                              Remote URL
+                            </div>
+                            <div className="font-mono text-xs text-zinc-300 break-all">{srv.url}</div>
+                          </div>
+                        )}
+                      </div>
+                      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                        {srv.config_path && (
+                          <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-2">
+                            <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Config path</div>
+                            <div className="font-mono text-xs text-zinc-300 break-all">{srv.config_path}</div>
+                          </div>
+                        )}
+                        {srv.auth_mode && (
+                          <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-2">
+                            <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Auth mode</div>
+                            <div className="text-xs text-zinc-300">{srv.auth_mode}</div>
+                          </div>
+                        )}
+                        <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-2">
+                          <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                            <Clock3 className="h-3.5 w-3.5" />
+                            Discovery context
+                          </div>
+                          <div className="text-xs text-zinc-300">
+                            {fleet?.last_discovery ? `Seen in fleet sync at ${fleet.last_discovery}` : "Discovery-only, not synced through fleet yet"}
+                          </div>
+                        </div>
+                        {srv.provenance && (
+                          <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 px-3 py-2">
+                            <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Provenance</div>
+                            <div className="flex flex-wrap gap-1.5">
+                              {srv.provenance.observed_via.map((source) => (
+                                <span
+                                  key={source}
+                                  className="rounded border border-emerald-900 bg-emerald-950 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300"
+                                >
+                                  {source}
+                                </span>
+                              ))}
+                            </div>
+                            <div className="mt-2 space-y-1 text-[11px] text-zinc-400">
+                              {srv.provenance.last_seen && <div>Last seen: <span className="text-zinc-300">{srv.provenance.last_seen}</span></div>}
+                              {srv.provenance.last_synced && <div>Last synced: <span className="text-zinc-300">{srv.provenance.last_synced}</span></div>}
+                              {srv.provenance.source_agents.length > 0 && (
+                                <div>
+                                  Gateway sources: <span className="text-zinc-300">{srv.provenance.source_agents.join(", ")}</span>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        )}
+                      </div>
                       {/* Tools */}
                       {srvTools.length > 0 && (
                         <div>
@@ -655,6 +766,18 @@ function AgentDetail({ agentName }: { agentName: string }) {
                               <span key={t.name} className="bg-purple-950 border border-purple-800 text-purple-300 px-2 py-0.5 rounded text-xs">
                                 {t.name}
                               </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                      {(srv.security_warnings?.length ?? 0) > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-rose-400 mb-1">Security warnings</h4>
+                          <div className="space-y-1">
+                            {srv.security_warnings?.map((warning) => (
+                              <div key={warning} className="rounded border border-rose-900/60 bg-rose-950/20 px-3 py-2 text-xs text-rose-300">
+                                {warning}
+                              </div>
                             ))}
                           </div>
                         </div>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -216,7 +216,12 @@ export interface Agent {
 export interface MCPServer {
   name: string;
   command?: string;
+  args?: string[];
   transport?: string;
+  url?: string;
+  auth_mode?: string;
+  config_path?: string;
+  security_warnings?: string[];
   packages: Package[];
   tools?: Tool[];
   env?: Record<string, string>;
@@ -224,6 +229,21 @@ export interface MCPServer {
   has_credentials?: boolean;
   credential_env_vars?: string[];
   security_blocked?: boolean;
+  provenance?: MCPProvenance;
+}
+
+export interface MCPProvenance {
+  observed_via: string[];
+  observed_scopes: string[];
+  scan_sources: string[];
+  source_agents: string[];
+  configured_locally: boolean;
+  fleet_present: boolean;
+  gateway_registered: boolean;
+  runtime_observed: boolean;
+  first_seen?: string | null;
+  last_seen?: string | null;
+  last_synced?: string | null;
 }
 
 export interface Package {
@@ -835,6 +855,7 @@ export interface AgentDetailResponse {
   };
   blast_radius: BlastRadius[];
   credentials: string[];
+  fleet?: FleetAgent | null;
 }
 
 export interface AgentLifecycleResponse {


### PR DESCRIPTION
## Summary
- enrich the discovery API with canonical MCP provenance fields derived from local config, completed scan history, fleet sync state, and gateway upstream aggregation
- expose the new provenance/auth/credential metadata in the Agents detail UI instead of inferring source context client-side
- add focused API coverage for fleet, gateway, and scan-source provenance on MCP server detail responses

## Testing
- uv run pytest tests/test_api_agent_detail.py -q
- npm --prefix ui run lint
- npm --prefix ui run build

Closes #1692
Closes #1693
Refs #1697