### PR TITLE
docs(deploy): align EKS rollout to unified platform surfaces

### DIFF
--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -7,7 +7,7 @@ control-plane workflows?"
 This is a **reference rollout path** for self-hosted `agent-bom` on AWS:
 
 - the company platform team still owns the AWS account, VPC, EKS cluster, ingress, cert-manager, and shared controllers
-- `agent-bom` owns the product-specific baseline around that platform: Postgres, IRSA, backup bucket, auth secrets, Helm release, fleet onboarding, and optional gateway runtime
+- `agent-bom` owns the product-specific baseline around that platform: Postgres, IRSA, backup bucket, auth secrets, Helm release, fleet onboarding, gateway rollout, and proxy deployment patterns
 
 For the concrete runtime gateway discovery path after fleet and cluster scans
 have populated remote MCPs, see [Gateway Auto-Discovery From the Control
@@ -130,6 +130,20 @@ This is the clean ownership model:
 - **`agent-bom` installer** wires the product-specific AWS and Kubernetes pieces on top
 - **security/platform operators** onboard endpoints and selected MCP runtimes after the control plane is live
 
+## Product Surfaces In A Company EKS Rollout
+
+These are the product surfaces a real enterprise rollout usually cares about:
+
+- **control plane**: API, UI, auth, graph, findings, remediation, audit, policy
+- **scan and discovery**: repos, images, IaC, MCP configs, skills, cluster and cloud surfaces
+- **fleet**: endpoint and collector inventory pushed into the control plane
+- **gateway**: shared remote MCP traffic, policy, and audit in the cluster
+- **proxy**: laptop or sidecar runtime enforcement where inline MCP inspection is needed
+
+`gateway` and `proxy` are core features of the product. In practice they are
+deployed selectively by workload and traffic path, not to every process in the
+environment on day 1.
+
 ## Runtime Flow For Fleet, Proxy, And Gateway
 
 ```mermaid
@@ -171,8 +185,18 @@ What this means in practice:
 
 - developer endpoints can push fleet inventory and use `agent-bom proxy` as a local MCP wrapper
 - selected MCP workloads in-cluster can run with `agent-bom proxy` sidecars
-- the gateway is optional and centralizes policy/audit for shared upstreams
+- the gateway centralizes policy/audit for shared remote upstreams
 - the control plane persists findings, graph, fleet state, auth, and audit inside the customer's infrastructure
+
+## Scenario Matrix
+
+| Company need | Deploy | What becomes visible immediately |
+|---|---|---|
+| Know which MCPs employees are running | control plane + scans + fleet | endpoints, agents, MCP servers, transports, command or URL, declared tools, auth mode, credential-backed env vars |
+| Review risky MCP package exposure | control plane + scans + fleet | package context, vuln context, graph links, blast radius, exposed tools and credentials |
+| Govern shared remote MCP traffic | control plane + gateway | shared upstream MCP inventory, gateway policy/audit, remote MCP control plane surfaces |
+| Enforce inline on selected workloads | control plane + selected proxy deployment | workload-local runtime evidence, inline blocks, local audit push, selected sidecar/laptop inspection |
+| Run the full self-hosted platform | control plane + scans + fleet + selected gateway + selected proxy | one correlated operator plane across discovery, inventory, runtime, graph, findings, and audit |
 
 ## Recommended Rollout Sequence
 

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -8,7 +8,7 @@ Use this path when you want one operator-controlled system for:
 - scheduled scans and discovery
 - endpoint fleet inventory
 - selected live MCP proxy enforcement
-- central gateway policy management
+- central gateway policy management and shared remote MCP traffic
 - API, UI, findings, graph, and remediation in your own infra
 
 The recommended rollout is:
@@ -46,7 +46,11 @@ a split between:
 
 - a **control plane** for auth, graph, findings, fleet, audit, and remediation
 - **inventory paths** for scans and fleet ingest
-- **runtime paths** for proxy and gateway, added only where needed
+- **runtime paths** for proxy and gateway, deployed selectively where they are needed
+
+Both `proxy` and `gateway` are core `agent-bom` product surfaces. The question
+is not whether they exist in the product; it is where you deploy them for your
+actual MCP traffic and operating model.
 
 ### Deployment topology
 
@@ -99,6 +103,15 @@ Architecture](../architecture/self-hosted-product-architecture.md).*
 | **Shared remote MCP control** | inventory-first plus `gateway` | local proxy where stdio or sidecar enforcement is still needed |
 | **Full self-hosted platform** | control plane + scans + fleet + selected proxy + selected gateway | ClickHouse, Snowflake, stricter platform controls |
 
+### What each profile makes visible
+
+| Profile | What operators can already see | What is added later |
+|---|---|---|
+| **Inventory-first** | endpoints, agents, MCP servers, transports, command or URL, declared tools, auth mode, credential-backed env vars, package and vuln context | live runtime calls, inline blocks, runtime policy events |
+| **Runtime on selected workloads** | everything in inventory-first plus local runtime evidence for the chosen workloads | shared remote relay and central gateway-only surfaces |
+| **Shared remote MCP control** | everything in inventory-first plus shared upstream inventory and gateway policy/audit | workload-local proxy evidence where stdio or sidecar inspection is required |
+| **Full self-hosted platform** | one correlated plane across scans, fleet, gateway, proxy, graph, findings, and audit | longer-retention analytics and stricter platform controls |
+
 ## Which Agent-BOM Surface Runs Where
 
 | Surface | Where it runs | Why you deploy it |
@@ -106,8 +119,8 @@ Architecture](../architecture/self-hosted-product-architecture.md).*
 | **API + UI** | in-cluster or on self-hosted compute behind your ingress | one operator plane for findings, graph, fleet, audit, gateway, and remediation |
 | **Scan** | CronJob, CI runner, or one-off job | Kubernetes, container, package, MCP, cloud, and inventory scanning |
 | **Fleet** | pushed into the control plane from endpoints or collectors | persisted workstation and collector inventory in `/fleet` |
-| **Proxy / runtime** | only next to the MCP workloads you want inline enforcement on | live JSON-RPC inspection, allow/warn/deny, audit push |
-| **Gateway** | central service in-cluster | store and manage policies, and optionally front shared remote MCP traffic |
+| **Proxy / runtime** | next to the MCP workloads you want inline enforcement on | live JSON-RPC inspection, allow/warn/deny, audit push |
+| **Gateway** | central service in-cluster | shared remote MCP traffic plane, policy distribution, audit, and rate limiting |
 | **MCP server** | wherever you expose `agent-bom` itself as a tool server | assistant-facing tool access, separate from the proxy path |
 
 The important boundary is that `agent-bom proxy` is the inline runtime path,

--- a/tests/test_deploy_reference.py
+++ b/tests/test_deploy_reference.py
@@ -112,3 +112,29 @@ def test_verify_wrapper_script_exists_and_parses():
 
     assert script_path.exists()
     assert result.returncode == 0, result.stderr
+
+
+def test_install_reference_dry_run_gateway_summary_includes_gateway_verify(tmp_path: Path):
+    result = subprocess.run(
+        [
+            "bash",
+            str(ROOT / "scripts" / "deploy" / "install-eks-reference.sh"),
+            "--cluster-name",
+            "corp-ai",
+            "--region",
+            "us-east-1",
+            "--state-dir",
+            str(tmp_path),
+            "--dry-run",
+            "--enable-gateway",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = tmp_path / "corp-ai" / "generated" / "operator-summary.txt"
+    rendered = summary.read_text()
+    assert "--check-gateway" in rendered


### PR DESCRIPTION
## Summary
- tighten the EKS and AWS company rollout docs around the unified control-plane model
- make gateway and proxy explicit core product surfaces deployed selectively by workload and traffic path
- add clearer operator scenario matrices for inventory, fleet, gateway, and proxy outcomes
- extend deploy-reference coverage so the generated operator summary carries the gateway verify path

## Testing
- uv run pytest tests/test_deploy_reference.py -q
- uv run mkdocs build --strict
- bash -n scripts/deploy/install-eks-reference.sh
- bash -n scripts/deploy/verify-eks-reference.sh

Closes #1696
Refs #1691