### PR TITLE
docs(deploy): define retention and security-lake strategy

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,12 +103,14 @@ nav:
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
       - Control-Plane Data Model and Store Parity: deployment/control-plane-data-model.md
       - Audit Chain vs Compliance Signing: deployment/audit-and-compliance-verification.md
+      - Data Retention by Class: deployment/data-retention.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Runtime Operations: deployment/runtime-operations.md
       - Visual Leak Detection: deployment/visual-leak-detection.md
       - Worker and Scheduler Concurrency: deployment/worker-and-scheduler-concurrency.md
       - Gateway Auto-Discovery: deployment/gateway-auto-discovery.md
       - Backend Parity: deployment/backend-parity.md
+      - Backend and Security-Lake Strategy: deployment/backend-and-security-lakes.md
       - Snowflake-Native Backend: deployment/snowflake-backend.md
       - Docker: deployment/docker.md
       - Kubernetes: deployment/kubernetes.md

--- a/site-docs/deployment/backend-and-security-lakes.md
+++ b/site-docs/deployment/backend-and-security-lakes.md
@@ -1,0 +1,163 @@
+# Backend and Security-Lake Strategy
+
+`agent-bom` is one product, but not every backend does the same job.
+
+The backend strategy should stay simple:
+
+- `Postgres` is the transactional control-plane default
+- `ClickHouse` is the analytics scale-out tier
+- `Snowflake` is the warehouse-native governance and selected backend option
+- `S3` is the archive and evidence tier
+- `Databricks` is a future target only when code-backed
+
+This page explains how those stores fit together in a self-hosted deployment.
+
+## The product contract
+
+`agent-bom` should not require operators to choose between:
+
+- "good product semantics"
+- "warehouse compatibility"
+
+The right contract is:
+
+- one canonical control-plane model
+- multiple storage targets behind it
+- explicit parity boundaries
+
+That means:
+
+- findings, fleet state, policies, MCP inventory, runtime evidence, and graph
+  concepts should stay the same
+- storage choice changes scale, retention, and integration posture
+- storage choice should not silently rewrite the product model
+
+## Recommended roles by backend
+
+| Backend | Role | Use it for | Do not treat it as |
+|---|---|---|---|
+| `SQLite` | local persistence | laptop demos, local review, single-node testing | enterprise control plane |
+| `Postgres` / `Supabase` | transactional control plane | auth, policy, fleet, schedules, graph, recent scan state | long-range event lake |
+| `ClickHouse` | event and analytics tier | runtime history, trend queries, retained audit analytics | transactional API store |
+| `Snowflake` | warehouse-native governance and selected backend paths | governance joins, selected enterprise store paths, warehouse-centric orgs | universal parity until documented |
+| `S3` | archive and evidence tier | signed evidence bundles, backups, export archives | interactive operator query plane |
+| `Databricks` | future security-lake target | lakehouse export target when implemented | current shipped parity |
+
+## Recommended deployment shapes
+
+### 1. Default self-hosted control plane
+
+- `Postgres`
+- optional `S3`
+
+Use when you want:
+
+- the simplest reliable control-plane deployment
+- broadest route coverage
+- fast pilot-to-production path
+
+### 2. Enterprise control plane with analytics scale-out
+
+- `Postgres`
+- `ClickHouse`
+- optional `S3`
+
+Use when you want:
+
+- longer runtime history
+- analytics-heavy dashboards
+- retained trend queries without overloading `Postgres`
+
+### 3. Warehouse-native governance deployment
+
+- `Postgres` or selected `Snowflake` backend paths
+- `Snowflake`
+- optional `S3`
+
+Use when:
+
+- the customer already governs security data in `Snowflake`
+- they want warehouse-native joins and governance workflows
+- the documented Snowflake parity boundary is acceptable
+
+### 4. Future lakehouse export target
+
+- control plane on `Postgres`
+- exports or mirrored datasets to `Databricks`
+
+This should stay roadmap wording until code-backed. Do not market it as shipped
+parity before the implementation exists.
+
+## Snowflake and Databricks
+
+Both are valid security-lake destinations in real customer environments.
+
+The product posture should be:
+
+- `Snowflake` is part of the current interoperable backend story where parity is
+  already documented and implemented
+- `Databricks` is a supported direction for lakehouse export and governance once
+  the implementation exists
+
+That keeps the story accurate without understating how customers actually run
+security lakes.
+
+## What this means in EKS
+
+For a self-hosted AWS/EKS deployment, the clean shape is:
+
+- `agent-bom-api`
+- `agent-bom-ui`
+- scan and discovery workers
+- `agent-bom-gateway`
+- selected endpoint proxy rollout and sidecars
+- `Postgres` as the control-plane store
+- optional `ClickHouse`
+- optional `S3`
+- optional `Snowflake` integration
+
+That lets the product stay:
+
+- self-hosted
+- operator-controlled
+- easy to reason about
+- easy to extend with analytics or archive tiers
+
+## Why not put everything in one backend
+
+Because the system has different workload types:
+
+- transactional control-plane state
+- event-scale analytics
+- signed evidence and export archive
+- warehouse-native governance joins
+
+Trying to force one backend to do all of them creates drift or overclaiming.
+
+The healthier product stance is:
+
+- one model
+- several storage roles
+- explicit parity boundaries
+
+## CLI, UI, API, and MCP surface alignment
+
+This backend strategy should not create different products.
+
+The same semantics should hold across:
+
+- CLI
+- UI/API control plane
+- MCP server mode
+- Docker and Helm
+- CI/CD scan workflows
+
+What changes is where data is stored and how long it is retained, not what the
+finding, inventory object, or runtime event means.
+
+## Related docs
+
+- [Data Retention by Class](data-retention.md)
+- [Backend Parity](backend-parity.md)
+- [Snowflake-Native Backend](snowflake-backend.md)
+- [How Agent-BOM Works](../architecture/how-agent-bom-works.md)

--- a/site-docs/deployment/data-retention.md
+++ b/site-docs/deployment/data-retention.md
@@ -1,0 +1,122 @@
+# Data Retention by Class
+
+`agent-bom` should not feel like "whatever the backend keeps." Retention is a
+product contract.
+
+The design principle is:
+
+- keep the transactional control plane lean
+- persist the security evidence you actually need
+- push event-scale history into optional analytics or archive tiers when you
+  want longer retention
+
+This page defines the recommended retention model for a self-hosted deployment.
+
+## Retention classes
+
+| Data class | What it includes | Primary store | Recommended retention | Why |
+|---|---|---|---|---|
+| Control-plane state | tenants, policies, schedules, API keys, source registry, fleet state, graph state | `Postgres` / `Supabase` | keep current state + short operational history | transactional truth, not a data lake |
+| Scan jobs and results | submitted scans, summaries, attached result payloads | `Postgres` / `Supabase` | 14-90 days in the control plane | enough for operator review without turning the API DB into an archive |
+| Runtime operational evidence | proxy audit ingest, traces, OCSF ingest, gateway activity | `Postgres` for recent operational views, optional `ClickHouse` for longer history | 7-30 days in control plane, 30-365+ days in analytics | recent ops stay fast; history moves to analytics |
+| Compliance evidence | signed evidence bundles, exported reports, review packets | `S3` or customer archive store | match framework policy | this is evidence, not dashboard cache |
+| Security-lake / warehouse mirrors | analytics projections, governance joins, long-range history | `ClickHouse`, `Snowflake`, future `Databricks` target | customer-defined | lake and warehouse retention should be explicit and owned by the operator |
+
+## Product rule
+
+The control plane should stay good at:
+
+- answering "what is true right now?"
+- supporting operator workflows
+- serving recent scans, findings, fleet state, and runtime posture
+
+It should not silently become:
+
+- a multi-year event archive
+- a warehouse substitute
+- a compliance evidence bucket
+
+That is why the recommended shape is:
+
+- `Postgres` = transactional truth
+- `ClickHouse` / `Snowflake` = analytics and governance tier
+- `S3` = archive and evidence
+
+## Recommended defaults
+
+These are operator defaults, not enforced hard limits.
+
+| Deployment shape | Scan job retention in control plane | Runtime evidence retention in control plane | Analytics/archive recommendation |
+|---|---|---|---|
+| Local / small team | 14-30 days | 7-14 days | no extra tier unless you need it |
+| Enterprise pilot | 30-60 days | 14-30 days | add `ClickHouse` if runtime history matters |
+| Broader rollout | 30-90 days | 7-30 days | move retained event history to `ClickHouse`, `Snowflake`, or archive |
+
+## What stays in Postgres
+
+Keep these in `Postgres` or `Supabase` even if you add a lake:
+
+- tenant-scoped policy and auth state
+- schedules and active job coordination
+- fleet and source registry state
+- graph and remediation workflow state
+- recent operational views that need fast transactional reads
+
+This keeps the control plane predictable and fast.
+
+## What should move out of Postgres first
+
+If retention pressure or query drag increases, move these first:
+
+- long-range proxy and gateway audit history
+- traces and event-heavy ingest
+- trend and historical analytics reads
+- exported evidence packets and old signed bundles
+
+## Operator-visible retention
+
+The product should be clear about retention in three places:
+
+1. docs
+2. deployment values and env settings
+3. UI/runtime status surfaces
+
+If a tenant asks "how long do we keep this?", the answer should not require
+opening the database.
+
+## EKS guidance
+
+For the self-hosted EKS shape, the practical answer is:
+
+- keep the packaged control plane on `Postgres`
+- use `ClickHouse` only if retained runtime or trend analytics becomes heavy
+- archive signed evidence bundles and longer-lived exports to `S3`
+- mirror to `Snowflake` when governance or warehouse-native joins matter
+
+That gives you:
+
+- fast operator workflows
+- explicit retention boundaries
+- predictable storage cost
+- less pressure on the API database
+
+## Why this matters for trust
+
+Operators care about three things here:
+
+- how long sensitive telemetry lives in the control plane
+- where evidence goes for audits
+- whether long history forces them into an opaque hosted backend
+
+The product answer should stay:
+
+- self-hosted first
+- explicit retention by data class
+- customer-controlled analytics and archive tiers
+
+## Related docs
+
+- [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
+- [Backend Parity](backend-parity.md)
+- [Snowflake-Native Backend](snowflake-backend.md)
+- [AWS Company Rollout](aws-company-rollout.md)


### PR DESCRIPTION
Summary
- publish a data-retention-by-class contract for self-hosted deployments
- document backend and security-lake roles for Postgres, ClickHouse, Snowflake, S3, and future Databricks targets
- wire both docs into the deployment nav so the README can stay shorter and decision-oriented

Testing
- uv run mkdocs build --strict

Closes #1694
Closes #1695
Refs #1691