### PR TITLE
feat(platform): persist MCP observation provenance

### DIFF
--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -1,0 +1,129 @@
+"""Persisted MCP observation records for correlated inventory provenance."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from typing import Protocol
+
+from pydantic import BaseModel, Field
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class MCPObservation(BaseModel):
+    tenant_id: str = "default"
+    observation_id: str
+    server_stable_id: str
+    server_fingerprint: str = ""
+    server_name: str
+    agent_name: str = ""
+    transport: str = ""
+    url: str | None = None
+    auth_mode: str = "local-stdio"
+    command: str = ""
+    args: list[str] = Field(default_factory=list)
+    config_path: str | None = None
+    credential_env_vars: list[str] = Field(default_factory=list)
+    security_warnings: list[str] = Field(default_factory=list)
+    observed_via: list[str] = Field(default_factory=list)
+    observed_scopes: list[str] = Field(default_factory=list)
+    scan_sources: list[str] = Field(default_factory=list)
+    source_agents: list[str] = Field(default_factory=list)
+    configured_locally: bool = False
+    fleet_present: bool = False
+    gateway_registered: bool = False
+    runtime_observed: bool = False
+    first_seen: str | None = None
+    last_seen: str | None = None
+    last_synced: str | None = None
+    updated_at: str = Field(default_factory=_now)
+
+
+class MCPObservationStore(Protocol):
+    def put(self, observation: MCPObservation) -> None: ...
+    def get(self, tenant_id: str, observation_id: str) -> MCPObservation | None: ...
+    def list_by_tenant(self, tenant_id: str) -> list[MCPObservation]: ...
+
+
+class InMemoryMCPObservationStore:
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str], MCPObservation] = {}
+        self._lock = threading.Lock()
+
+    def put(self, observation: MCPObservation) -> None:
+        with self._lock:
+            self._rows[(observation.tenant_id, observation.observation_id)] = observation
+
+    def get(self, tenant_id: str, observation_id: str) -> MCPObservation | None:
+        with self._lock:
+            return self._rows.get((tenant_id, observation_id))
+
+    def list_by_tenant(self, tenant_id: str) -> list[MCPObservation]:
+        with self._lock:
+            return sorted(
+                [row for (row_tenant, _), row in self._rows.items() if row_tenant == tenant_id],
+                key=lambda row: (row.agent_name.lower(), row.server_name.lower(), row.observation_id),
+            )
+
+
+class SQLiteMCPObservationStore:
+    def __init__(self, db_path: str = "agent_bom_jobs.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        return self._local.conn
+
+    def _init_db(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS mcp_observations (
+                tenant_id TEXT NOT NULL,
+                observation_id TEXT NOT NULL,
+                server_name TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                data TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, observation_id)
+            )
+        """)
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_observations_tenant_server ON mcp_observations(tenant_id, server_name)")
+        self._conn.commit()
+
+    def put(self, observation: MCPObservation) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO mcp_observations
+               (tenant_id, observation_id, server_name, updated_at, data)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                observation.tenant_id,
+                observation.observation_id,
+                observation.server_name,
+                observation.updated_at,
+                observation.model_dump_json(),
+            ),
+        )
+        self._conn.commit()
+
+    def get(self, tenant_id: str, observation_id: str) -> MCPObservation | None:
+        row = self._conn.execute(
+            "SELECT data FROM mcp_observations WHERE tenant_id = ? AND observation_id = ?",
+            (tenant_id, observation_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return MCPObservation.model_validate_json(row[0])
+
+    def list_by_tenant(self, tenant_id: str) -> list[MCPObservation]:
+        rows = self._conn.execute(
+            "SELECT data FROM mcp_observations WHERE tenant_id = ? ORDER BY server_name, updated_at DESC",
+            (tenant_id,),
+        ).fetchall()
+        return [MCPObservation.model_validate_json(row[0]) for row in rows]

--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -43,6 +43,47 @@ class MCPObservation(BaseModel):
     updated_at: str = Field(default_factory=_now)
 
 
+def _pick_timestamp(*values: str | None, prefer: str) -> str | None:
+    candidates = [value for value in values if value]
+    if not candidates:
+        return None
+    return min(candidates) if prefer == "min" else max(candidates)
+
+
+def merge_observations(existing: MCPObservation | None, incoming: MCPObservation) -> MCPObservation:
+    if existing is None:
+        return incoming
+    return MCPObservation(
+        tenant_id=incoming.tenant_id,
+        observation_id=incoming.observation_id,
+        server_stable_id=incoming.server_stable_id or existing.server_stable_id,
+        server_fingerprint=incoming.server_fingerprint or existing.server_fingerprint,
+        server_name=incoming.server_name or existing.server_name,
+        agent_name=incoming.agent_name or existing.agent_name,
+        transport=incoming.transport or existing.transport,
+        url=incoming.url or existing.url,
+        auth_mode=incoming.auth_mode or existing.auth_mode,
+        command=incoming.command or existing.command,
+        args=incoming.args or existing.args,
+        config_path=incoming.config_path or existing.config_path,
+        credential_env_vars=sorted(set(existing.credential_env_vars) | set(incoming.credential_env_vars)),
+        security_warnings=sorted(set(existing.security_warnings) | set(incoming.security_warnings)),
+        observed_via=sorted(set(existing.observed_via) | set(incoming.observed_via)),
+        observed_scopes=sorted(set(existing.observed_scopes) | set(incoming.observed_scopes)),
+        scan_sources=sorted(set(existing.scan_sources) | set(incoming.scan_sources)),
+        source_agents=sorted(set(existing.source_agents) | set(incoming.source_agents)),
+        # Preserve the strongest persisted assertion rather than letting a later
+        # read-path discovery pass rewrite provenance state opportunistically.
+        configured_locally=existing.configured_locally,
+        fleet_present=existing.fleet_present or incoming.fleet_present,
+        gateway_registered=existing.gateway_registered or incoming.gateway_registered,
+        runtime_observed=existing.runtime_observed or incoming.runtime_observed,
+        first_seen=_pick_timestamp(existing.first_seen, incoming.first_seen, prefer="min"),
+        last_seen=_pick_timestamp(existing.last_seen, incoming.last_seen, prefer="max"),
+        last_synced=_pick_timestamp(existing.last_synced, incoming.last_synced, prefer="max"),
+    )
+
+
 class MCPObservationStore(Protocol):
     def put(self, observation: MCPObservation) -> None: ...
     def get(self, tenant_id: str, observation_id: str) -> MCPObservation | None: ...

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
-from agent_bom.api.mcp_observation_store import MCPObservation
+from agent_bom.api.mcp_observation_store import MCPObservation, merge_observations
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _get_store
 from agent_bom.security import sanitize_error
@@ -110,6 +110,17 @@ def _build_gateway_index(tenant_id: str) -> dict[tuple[str, str], dict[str, Any]
     }
 
 
+def _observation_ids(agent: Any, server: Any) -> tuple[str, str | None]:
+    current = f"{agent.name}:{getattr(server, 'stable_id', server.name)}"
+    legacy = None
+    command = getattr(server, "command", "") or ""
+    if command:
+        legacy = f"{agent.name}:{server.name}:{command}"
+        if legacy == current:
+            legacy = None
+    return current, legacy
+
+
 def _serialize_agent(
     agent,
     *,
@@ -145,8 +156,10 @@ def _serialize_agent(
         server_payload.setdefault("url", server_url)
         server_payload.setdefault("config_path", getattr(server, "config_path", None))
         server_payload.setdefault("security_warnings", list(getattr(server, "security_warnings", []) or []))
-        observation_id = f"{agent.name}:{getattr(server, 'stable_id', server.name)}"
+        observation_id, legacy_observation_id = _observation_ids(agent, server)
         stored_observation = (observation_index or {}).get(observation_id)
+        if stored_observation is None and legacy_observation_id:
+            stored_observation = (observation_index or {}).get(legacy_observation_id)
         scan_history = (scan_history_index or {}).get(
             (agent.name, server.name),
             {"present": False, "scan_sources": [], "first_seen": None, "last_seen": None},
@@ -250,35 +263,38 @@ def _persist_agent_observations(
                 auth_mode = "network-no-auth-observed"
             else:
                 auth_mode = "local-stdio"
-        store.put(
-            MCPObservation(
-                tenant_id=tenant_id,
-                observation_id=f"{agent.name}:{getattr(server, 'stable_id', server.name)}",
-                server_stable_id=getattr(server, "stable_id", server.name),
-                server_fingerprint=getattr(server, "fingerprint", ""),
-                server_name=server.name,
-                agent_name=agent.name,
-                transport=getattr(getattr(server, "transport", ""), "value", getattr(server, "transport", "")) or "",
-                url=server_url,
-                auth_mode=auth_mode,
-                command=getattr(server, "command", "") or "",
-                args=list(getattr(server, "args", []) or []),
-                config_path=getattr(server, "config_path", None),
-                credential_env_vars=credential_names,
-                security_warnings=list(getattr(server, "security_warnings", []) or []),
-                observed_via=observed_via,
-                observed_scopes=observed_scopes,
-                scan_sources=scan_history["scan_sources"],
-                source_agents=gateway_state["source_agents"],
-                configured_locally=True,
-                fleet_present=fleet_agent is not None,
-                gateway_registered=gateway_state["gateway_registered"],
-                runtime_observed=False,
-                first_seen=scan_history["first_seen"],
-                last_seen=fleet_agent.get("last_discovery") if fleet_agent else scan_history["last_seen"],
-                last_synced=fleet_agent.get("updated_at") if fleet_agent else None,
-            )
+        observation_id, legacy_observation_id = _observation_ids(agent, server)
+        candidate = MCPObservation(
+            tenant_id=tenant_id,
+            observation_id=observation_id,
+            server_stable_id=getattr(server, "stable_id", server.name),
+            server_fingerprint=getattr(server, "fingerprint", ""),
+            server_name=server.name,
+            agent_name=agent.name,
+            transport=getattr(getattr(server, "transport", ""), "value", getattr(server, "transport", "")) or "",
+            url=server_url,
+            auth_mode=auth_mode,
+            command=getattr(server, "command", "") or "",
+            args=list(getattr(server, "args", []) or []),
+            config_path=getattr(server, "config_path", None),
+            credential_env_vars=credential_names,
+            security_warnings=list(getattr(server, "security_warnings", []) or []),
+            observed_via=observed_via,
+            observed_scopes=observed_scopes,
+            scan_sources=scan_history["scan_sources"],
+            source_agents=gateway_state["source_agents"],
+            configured_locally=True,
+            fleet_present=fleet_agent is not None,
+            gateway_registered=gateway_state["gateway_registered"],
+            runtime_observed=False,
+            first_seen=scan_history["first_seen"],
+            last_seen=fleet_agent.get("last_discovery") if fleet_agent else scan_history["last_seen"],
+            last_synced=fleet_agent.get("updated_at") if fleet_agent else None,
         )
+        existing = store.get(tenant_id, observation_id)
+        if existing is None and legacy_observation_id:
+            existing = store.get(tenant_id, legacy_observation_id)
+        store.put(merge_observations(existing, candidate))
 
 
 @router.get("/v1/agents", tags=["discovery"])

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -15,8 +15,9 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
+from agent_bom.api.mcp_observation_store import MCPObservation
 from agent_bom.api.models import JobStatus
-from agent_bom.api.stores import _get_fleet_store, _get_store
+from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _get_store
 from agent_bom.security import sanitize_error
 
 router = APIRouter()
@@ -115,6 +116,7 @@ def _serialize_agent(
     fleet_agent: dict[str, Any] | None = None,
     scan_history_index: dict[tuple[str, str], dict[str, Any]] | None = None,
     gateway_index: dict[tuple[str, str], dict[str, Any]] | None = None,
+    observation_index: dict[str, MCPObservation] | None = None,
 ) -> dict:
     payload = asdict(agent)
     payload["mcp_servers"] = []
@@ -143,6 +145,8 @@ def _serialize_agent(
         server_payload.setdefault("url", server_url)
         server_payload.setdefault("config_path", getattr(server, "config_path", None))
         server_payload.setdefault("security_warnings", list(getattr(server, "security_warnings", []) or []))
+        observation_id = f"{agent.name}:{getattr(server, 'stable_id', server.name)}"
+        stored_observation = (observation_index or {}).get(observation_id)
         scan_history = (scan_history_index or {}).get(
             (agent.name, server.name),
             {"present": False, "scan_sources": [], "first_seen": None, "last_seen": None},
@@ -161,23 +165,120 @@ def _serialize_agent(
         if gateway_state["gateway_registered"]:
             observed_via.append("gateway_discovery")
             observed_scopes.append("gateway")
+        if stored_observation is not None:
+            observed_via = sorted(set(stored_observation.observed_via) | set(observed_via))
+            observed_scopes = sorted(set(stored_observation.observed_scopes) | set(observed_scopes))
+            scan_sources = sorted(set(stored_observation.scan_sources) | set(scan_history["scan_sources"]))
+            source_agents = sorted(set(stored_observation.source_agents) | set(gateway_state["source_agents"]))
+            configured_locally = stored_observation.configured_locally
+            fleet_present = stored_observation.fleet_present or fleet_agent is not None
+            gateway_registered = stored_observation.gateway_registered or gateway_state["gateway_registered"]
+            runtime_observed = stored_observation.runtime_observed
+            first_seen = stored_observation.first_seen or scan_history["first_seen"]
+            last_seen = stored_observation.last_seen or (fleet_agent.get("last_discovery") if fleet_agent else scan_history["last_seen"])
+            last_synced = stored_observation.last_synced or (fleet_agent.get("updated_at") if fleet_agent else None)
+        else:
+            scan_sources = scan_history["scan_sources"]
+            source_agents = gateway_state["source_agents"]
+            configured_locally = True
+            fleet_present = fleet_agent is not None
+            gateway_registered = gateway_state["gateway_registered"]
+            runtime_observed = False
+            first_seen = scan_history["first_seen"]
+            last_seen = fleet_agent.get("last_discovery") if fleet_agent else scan_history["last_seen"]
+            last_synced = fleet_agent.get("updated_at") if fleet_agent else None
         payload["mcp_servers"].append(server_payload)
         server_payload["provenance"] = {
             "observed_via": observed_via,
             "observed_scopes": observed_scopes,
-            "scan_sources": scan_history["scan_sources"],
-            "source_agents": gateway_state["source_agents"],
-            "configured_locally": True,
-            "fleet_present": fleet_agent is not None,
-            "gateway_registered": gateway_state["gateway_registered"],
+            "scan_sources": scan_sources,
+            "source_agents": source_agents,
+            "configured_locally": configured_locally,
+            "fleet_present": fleet_present,
+            "gateway_registered": gateway_registered,
             # Runtime correlation for per-server MCP objects is not yet wired through
             # a canonical store. Keep this explicit instead of inferring from alert volume.
-            "runtime_observed": False,
-            "first_seen": scan_history["first_seen"],
-            "last_seen": fleet_agent.get("last_discovery") if fleet_agent else scan_history["last_seen"],
-            "last_synced": fleet_agent.get("updated_at") if fleet_agent else None,
+            "runtime_observed": runtime_observed,
+            "first_seen": first_seen,
+            "last_seen": last_seen,
+            "last_synced": last_synced,
         }
     return payload
+
+
+def _observation_index(tenant_id: str) -> dict[str, MCPObservation]:
+    return {row.observation_id: row for row in _get_mcp_observation_store().list_by_tenant(tenant_id)}
+
+
+def _persist_agent_observations(
+    tenant_id: str,
+    agent: Any,
+    *,
+    fleet_agent: dict[str, Any] | None,
+    scan_history_index: dict[tuple[str, str], dict[str, Any]],
+    gateway_index: dict[tuple[str, str], dict[str, Any]],
+) -> None:
+    store = _get_mcp_observation_store()
+    for server in agent.mcp_servers:
+        server_url = getattr(server, "url", None)
+        scan_history = scan_history_index.get(
+            (agent.name, server.name),
+            {"present": False, "scan_sources": [], "first_seen": None, "last_seen": None},
+        )
+        gateway_state = gateway_index.get(
+            (server.name, server_url or ""),
+            {"gateway_registered": False, "source_agents": []},
+        )
+        observed_via = ["local_discovery"]
+        observed_scopes = ["endpoint"]
+        if scan_history["present"]:
+            observed_via.append("scan_result")
+            observed_scopes.append("scan")
+        if fleet_agent is not None:
+            observed_via.append("fleet_sync")
+        if gateway_state["gateway_registered"]:
+            observed_via.append("gateway_discovery")
+            observed_scopes.append("gateway")
+        credential_names = list(getattr(server, "credential_names", []) or [])
+        auth_mode = getattr(server, "auth_mode", None)
+        if auth_mode is None:
+            if credential_names:
+                auth_mode = "env-credentials"
+            elif server_url and "@" in server_url:
+                auth_mode = "url-embedded-credentials"
+            elif server_url:
+                auth_mode = "network-no-auth-observed"
+            else:
+                auth_mode = "local-stdio"
+        store.put(
+            MCPObservation(
+                tenant_id=tenant_id,
+                observation_id=f"{agent.name}:{getattr(server, 'stable_id', server.name)}",
+                server_stable_id=getattr(server, "stable_id", server.name),
+                server_fingerprint=getattr(server, "fingerprint", ""),
+                server_name=server.name,
+                agent_name=agent.name,
+                transport=getattr(getattr(server, "transport", ""), "value", getattr(server, "transport", "")) or "",
+                url=server_url,
+                auth_mode=auth_mode,
+                command=getattr(server, "command", "") or "",
+                args=list(getattr(server, "args", []) or []),
+                config_path=getattr(server, "config_path", None),
+                credential_env_vars=credential_names,
+                security_warnings=list(getattr(server, "security_warnings", []) or []),
+                observed_via=observed_via,
+                observed_scopes=observed_scopes,
+                scan_sources=scan_history["scan_sources"],
+                source_agents=gateway_state["source_agents"],
+                configured_locally=True,
+                fleet_present=fleet_agent is not None,
+                gateway_registered=gateway_state["gateway_registered"],
+                runtime_observed=False,
+                first_seen=scan_history["first_seen"],
+                last_seen=fleet_agent.get("last_discovery") if fleet_agent else scan_history["last_seen"],
+                last_synced=fleet_agent.get("updated_at") if fleet_agent else None,
+            )
+        )
 
 
 @router.get("/v1/agents", tags=["discovery"])
@@ -197,13 +298,25 @@ async def list_agents(request: Request) -> dict:
         tenant_id = _tenant_id(request)
         scan_history_index = _build_scan_history_index(tenant_id)
         gateway_index = _build_gateway_index(tenant_id)
+        fleet_index = {item.name: item.model_dump() for item in _get_fleet_store().list_by_tenant(tenant_id)}
+        for agent in agents:
+            _persist_agent_observations(
+                tenant_id,
+                agent,
+                fleet_agent=fleet_index.get(agent.name),
+                scan_history_index=scan_history_index,
+                gateway_index=gateway_index,
+            )
+        observation_index = _observation_index(tenant_id)
 
         return {
             "agents": [
                 _serialize_agent(
                     a,
+                    fleet_agent=fleet_index.get(a.name),
                     scan_history_index=scan_history_index,
                     gateway_index=gateway_index,
+                    observation_index=observation_index,
                 )
                 for a in agents
             ],
@@ -265,6 +378,14 @@ async def get_agent_detail(request: Request, agent_name: str) -> dict:
                 break
         scan_history_index = _build_scan_history_index(tenant_id)
         gateway_index = _build_gateway_index(tenant_id)
+        _persist_agent_observations(
+            tenant_id,
+            agent,
+            fleet_agent=fleet_agent,
+            scan_history_index=scan_history_index,
+            gateway_index=gateway_index,
+        )
+        observation_index = _observation_index(tenant_id)
 
         return {
             "agent": _serialize_agent(
@@ -272,6 +393,7 @@ async def get_agent_detail(request: Request, agent_name: str) -> dict:
                 fleet_agent=fleet_agent,
                 scan_history_index=scan_history_index,
                 gateway_index=gateway_index,
+                observation_index=observation_index,
             ),
             "summary": {
                 "total_servers": len(agent.mcp_servers),
@@ -496,7 +618,26 @@ async def get_agent_mesh(request: Request) -> dict:
         tenant_id = _tenant_id(request)
         scan_history_index = _build_scan_history_index(tenant_id)
         gateway_index = _build_gateway_index(tenant_id)
-        agents_data = [_serialize_agent(a, scan_history_index=scan_history_index, gateway_index=gateway_index) for a in agents]
+        fleet_index = {item.name: item.model_dump() for item in _get_fleet_store().list_by_tenant(tenant_id)}
+        for agent in agents:
+            _persist_agent_observations(
+                tenant_id,
+                agent,
+                fleet_agent=fleet_index.get(agent.name),
+                scan_history_index=scan_history_index,
+                gateway_index=gateway_index,
+            )
+        observation_index = _observation_index(tenant_id)
+        agents_data = [
+            _serialize_agent(
+                a,
+                fleet_agent=fleet_index.get(a.name),
+                scan_history_index=scan_history_index,
+                gateway_index=gateway_index,
+                observation_index=observation_index,
+            )
+            for a in agents
+        ]
 
         # Gather blast radius from completed scans for vuln overlay
         all_blast: list[dict] = []

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -16,8 +16,9 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
 
+from agent_bom.api.mcp_observation_store import MCPObservation
 from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
-from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store
+from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_mcp_observation_store
 from agent_bom.api.tenant_quota import enforce_fleet_agents_quota
 
 router = APIRouter()
@@ -124,6 +125,56 @@ def _payload_counts(agent: dict) -> tuple[int, int, int, int]:
     return server_count, pkg_count, cred_count, vuln_count
 
 
+def _persist_payload_observations(tenant_id: str, agent: dict, *, last_discovery: str, last_synced: str) -> None:
+    store = _get_mcp_observation_store()
+    agent_name = str(agent.get("name", "unknown-agent"))
+    for idx, server in enumerate(agent.get("mcp_servers", []) or []):
+        server_name = str(server.get("name") or f"server-{idx}")
+        server_url = str(server.get("url") or "") or None
+        credential_names = list(server.get("credential_names", []) or [])
+        auth_mode = str(server.get("auth_mode") or "")
+        if not auth_mode:
+            if credential_names:
+                auth_mode = "env-credentials"
+            elif server_url and "@" in server_url:
+                auth_mode = "url-embedded-credentials"
+            elif server_url:
+                auth_mode = "network-no-auth-observed"
+            else:
+                auth_mode = "local-stdio"
+        transport = str(server.get("transport") or "")
+        stable_id = str(server.get("stable_id") or f"{server_name}:{server.get('command', '')}")
+        store.put(
+            MCPObservation(
+                tenant_id=tenant_id,
+                observation_id=f"{agent_name}:{stable_id}",
+                server_stable_id=stable_id,
+                server_fingerprint=str(server.get("fingerprint") or stable_id),
+                server_name=server_name,
+                agent_name=agent_name,
+                transport=transport,
+                url=server_url,
+                auth_mode=auth_mode,
+                command=str(server.get("command") or ""),
+                args=list(server.get("args", []) or []),
+                config_path=server.get("config_path"),
+                credential_env_vars=credential_names,
+                security_warnings=list(server.get("security_warnings", []) or []),
+                observed_via=["fleet_sync"],
+                observed_scopes=["endpoint"],
+                scan_sources=[],
+                source_agents=[agent_name] if server_url and transport.lower() in {"http", "https", "sse"} else [],
+                configured_locally=False,
+                fleet_present=True,
+                gateway_registered=bool(server_url and transport.lower() in {"http", "https", "sse"}),
+                runtime_observed=False,
+                first_seen=last_discovery,
+                last_seen=last_discovery,
+                last_synced=last_synced,
+            )
+        )
+
+
 @router.post("/v1/fleet/sync", tags=["fleet"])
 async def sync_fleet(request: Request, body: PushPayload | None = None):
     """Run discovery and sync results into the fleet registry.
@@ -194,6 +245,7 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
                 )
                 store.put(fleet_agent)
                 new_count += 1
+            _persist_payload_observations(tenant_id, payload_agent, last_discovery=now, last_synced=now)
     else:
         discovered = discover_all()
         existing_by_name = {agent.name: agent for agent in store.list_by_tenant(tenant_id)}

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
 
-from agent_bom.api.mcp_observation_store import MCPObservation
+from agent_bom.api.mcp_observation_store import MCPObservation, merge_observations
 from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
 from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_mcp_observation_store
 from agent_bom.api.tenant_quota import enforce_fleet_agents_quota
@@ -144,35 +144,35 @@ def _persist_payload_observations(tenant_id: str, agent: dict, *, last_discovery
                 auth_mode = "local-stdio"
         transport = str(server.get("transport") or "")
         stable_id = str(server.get("stable_id") or f"{server_name}:{server.get('command', '')}")
-        store.put(
-            MCPObservation(
-                tenant_id=tenant_id,
-                observation_id=f"{agent_name}:{stable_id}",
-                server_stable_id=stable_id,
-                server_fingerprint=str(server.get("fingerprint") or stable_id),
-                server_name=server_name,
-                agent_name=agent_name,
-                transport=transport,
-                url=server_url,
-                auth_mode=auth_mode,
-                command=str(server.get("command") or ""),
-                args=list(server.get("args", []) or []),
-                config_path=server.get("config_path"),
-                credential_env_vars=credential_names,
-                security_warnings=list(server.get("security_warnings", []) or []),
-                observed_via=["fleet_sync"],
-                observed_scopes=["endpoint"],
-                scan_sources=[],
-                source_agents=[agent_name] if server_url and transport.lower() in {"http", "https", "sse"} else [],
-                configured_locally=False,
-                fleet_present=True,
-                gateway_registered=bool(server_url and transport.lower() in {"http", "https", "sse"}),
-                runtime_observed=False,
-                first_seen=last_discovery,
-                last_seen=last_discovery,
-                last_synced=last_synced,
-            )
+        observation_id = f"{agent_name}:{stable_id}"
+        candidate = MCPObservation(
+            tenant_id=tenant_id,
+            observation_id=observation_id,
+            server_stable_id=stable_id,
+            server_fingerprint=str(server.get("fingerprint") or stable_id),
+            server_name=server_name,
+            agent_name=agent_name,
+            transport=transport,
+            url=server_url,
+            auth_mode=auth_mode,
+            command=str(server.get("command") or ""),
+            args=list(server.get("args", []) or []),
+            config_path=server.get("config_path"),
+            credential_env_vars=credential_names,
+            security_warnings=list(server.get("security_warnings", []) or []),
+            observed_via=["fleet_sync"],
+            observed_scopes=["endpoint"],
+            scan_sources=[],
+            source_agents=[agent_name] if server_url and transport.lower() in {"http", "https", "sse"} else [],
+            configured_locally=False,
+            fleet_present=True,
+            gateway_registered=bool(server_url and transport.lower() in {"http", "https", "sse"}),
+            runtime_observed=False,
+            first_seen=last_discovery,
+            last_seen=last_discovery,
+            last_synced=last_synced,
         )
+        store.put(merge_observations(store.get(tenant_id, observation_id), candidate))
 
 
 @router.post("/v1/fleet/sync", tags=["fleet"])

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -16,6 +16,7 @@ from agent_bom.config import API_MAX_IN_MEMORY_JOBS as _MAX_IN_MEMORY_JOBS
 
 if TYPE_CHECKING:
     from agent_bom.api.graph_store import GraphStoreProtocol
+    from agent_bom.api.mcp_observation_store import MCPObservationStore
     from agent_bom.api.models import ScanJob
     from agent_bom.api.schedule_store import ScheduleStore
     from agent_bom.api.source_store import SourceStore
@@ -196,6 +197,7 @@ def set_schedule_store(store: ScheduleStore) -> None:
 
 # ─── Source store (pluggable) ───────────────────────────────────────────────
 _source_store: SourceStore | None = None
+_mcp_observation_store: MCPObservationStore | None = None
 
 
 def _get_source_store() -> SourceStore:
@@ -209,6 +211,29 @@ def set_source_store(store: SourceStore) -> None:
     """Switch the source registry store backend."""
     global _source_store
     _source_store = store
+
+
+def _get_mcp_observation_store():
+    """Get the active persisted MCP observation store."""
+    global _mcp_observation_store
+    if _mcp_observation_store is None:
+        with _store_lock:
+            if _mcp_observation_store is None:
+                if os.environ.get("AGENT_BOM_DB"):
+                    from agent_bom.api.mcp_observation_store import SQLiteMCPObservationStore
+
+                    _mcp_observation_store = SQLiteMCPObservationStore(os.environ["AGENT_BOM_DB"])
+                else:
+                    from agent_bom.api.mcp_observation_store import InMemoryMCPObservationStore
+
+                    _mcp_observation_store = InMemoryMCPObservationStore()
+    return _mcp_observation_store
+
+
+def set_mcp_observation_store(store: Any) -> None:
+    """Switch the MCP observation store backend."""
+    global _mcp_observation_store
+    _mcp_observation_store = store
 
 
 # ─── Exception store (enterprise) ───────────────────────────────────────────

--- a/tests/test_api_agent_detail.py
+++ b/tests/test_api_agent_detail.py
@@ -6,6 +6,7 @@ from starlette.testclient import TestClient
 
 from agent_bom.api import stores as _stores
 from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState, InMemoryFleetStore
+from agent_bom.api.mcp_observation_store import InMemoryMCPObservationStore, MCPObservation
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
@@ -89,6 +90,38 @@ def _mock_job_store() -> InMemoryJobStore:
     return store
 
 
+def _mock_observation_store() -> InMemoryMCPObservationStore:
+    store = InMemoryMCPObservationStore()
+    store.put(
+        MCPObservation(
+            tenant_id="default",
+            observation_id="test-agent:test-server:npx",
+            server_stable_id="test-server:npx",
+            server_fingerprint="fp-1",
+            server_name="test-server",
+            agent_name="test-agent",
+            transport="sse",
+            url="https://mcp.example.internal/sse",
+            auth_mode="env-credentials",
+            command="npx",
+            args=["-y", "test-server"],
+            credential_env_vars=["API_KEY"],
+            observed_via=["fleet_sync", "scan_result"],
+            observed_scopes=["endpoint", "scan"],
+            scan_sources=["fleet_sync"],
+            source_agents=["test-agent"],
+            configured_locally=False,
+            fleet_present=True,
+            gateway_registered=True,
+            runtime_observed=False,
+            first_seen="2026-04-22T11:58:00Z",
+            last_seen="2026-04-22T12:01:00Z",
+            last_synced="2026-04-22T12:05:00Z",
+        )
+    )
+    return store
+
+
 @patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
 @patch("agent_bom.api.routes.discovery._get_fleet_store", side_effect=_mock_fleet_store)
 def test_agent_detail_found(_fleet, _mock):
@@ -162,14 +195,16 @@ def test_agent_detail_credential_detection(_mock):
 @patch("agent_bom.api.routes.discovery._get_fleet_store", side_effect=_mock_fleet_store)
 def test_agent_detail_exposes_server_provenance(_fleet, _mock):
     prev_store = _stores._store
+    prev_observation_store = getattr(_stores, "_mcp_observation_store", None)
     _stores._store = _mock_job_store()
+    _stores._mcp_observation_store = _mock_observation_store()
     try:
         client = TestClient(app)
         resp = client.get("/v1/agents/test-agent")
         assert resp.status_code == 200
         server = resp.json()["agent"]["mcp_servers"][0]
         provenance = server["provenance"]
-        assert provenance["configured_locally"] is True
+        assert provenance["configured_locally"] is False
         assert provenance["fleet_present"] is True
         assert provenance["gateway_registered"] is True
         assert provenance["runtime_observed"] is False
@@ -180,10 +215,11 @@ def test_agent_detail_exposes_server_provenance(_fleet, _mock):
         assert "fleet_sync" in provenance["observed_via"]
         assert "gateway_discovery" in provenance["observed_via"]
         assert provenance["first_seen"] == "2026-04-22T11:58:00Z"
-        assert provenance["last_seen"] == "2026-04-22T12:00:00Z"
+        assert provenance["last_seen"] == "2026-04-22T12:01:00Z"
         assert provenance["last_synced"] == "2026-04-22T12:05:00Z"
     finally:
         _stores._store = prev_store
+        _stores._mcp_observation_store = prev_observation_store
 
 
 @patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)

--- a/tests/test_api_agent_detail.py
+++ b/tests/test_api_agent_detail.py
@@ -122,6 +122,56 @@ def _mock_observation_store() -> InMemoryMCPObservationStore:
     return store
 
 
+def test_merge_observations_preserves_persisted_provenance_contract():
+    existing = MCPObservation(
+        tenant_id="default",
+        observation_id="test-agent:test-server:npx",
+        server_stable_id="test-server:npx",
+        server_fingerprint="fp-1",
+        server_name="test-server",
+        agent_name="test-agent",
+        observed_via=["fleet_sync", "scan_result"],
+        observed_scopes=["endpoint", "scan"],
+        scan_sources=["fleet_sync"],
+        source_agents=["test-agent"],
+        configured_locally=False,
+        fleet_present=True,
+        gateway_registered=True,
+        first_seen="2026-04-22T11:58:00Z",
+        last_seen="2026-04-22T12:01:00Z",
+        last_synced="2026-04-22T12:05:00Z",
+    )
+    incoming = MCPObservation(
+        tenant_id="default",
+        observation_id="test-agent:test-server:npx",
+        server_stable_id="test-server:npx",
+        server_fingerprint="fp-1",
+        server_name="test-server",
+        agent_name="test-agent",
+        observed_via=["local_discovery"],
+        observed_scopes=["endpoint"],
+        scan_sources=["mcp_config"],
+        source_agents=[],
+        configured_locally=True,
+        fleet_present=False,
+        gateway_registered=False,
+        first_seen=None,
+        last_seen="2026-04-22T12:00:00Z",
+        last_synced=None,
+    )
+    from agent_bom.api.mcp_observation_store import merge_observations
+
+    merged = merge_observations(existing, incoming)
+    assert merged.configured_locally is False
+    assert merged.fleet_present is True
+    assert merged.gateway_registered is True
+    assert merged.observed_via == ["fleet_sync", "local_discovery", "scan_result"]
+    assert merged.scan_sources == ["fleet_sync", "mcp_config"]
+    assert merged.first_seen == "2026-04-22T11:58:00Z"
+    assert merged.last_seen == "2026-04-22T12:01:00Z"
+    assert merged.last_synced == "2026-04-22T12:05:00Z"
+
+
 @patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)
 @patch("agent_bom.api.routes.discovery._get_fleet_store", side_effect=_mock_fleet_store)
 def test_agent_detail_found(_fleet, _mock):


### PR DESCRIPTION
Summary
- add a persisted MCP observation store so provenance and correlation stop living only in read-time inference
- write canonical per-server observations from discovery and fleet sync, then merge them back into discovery responses
- keep the slice narrow: no graph rewrite, no new deployment dependency, no UI model drift

Testing
- uv run pytest tests/test_api_agent_detail.py tests/test_api_tenant_isolation.py -q
- uv run ruff check src/agent_bom/api/mcp_observation_store.py src/agent_bom/api/stores.py src/agent_bom/api/routes/discovery.py src/agent_bom/api/routes/fleet.py tests/test_api_agent_detail.py
- uv run mypy src/agent_bom/api/mcp_observation_store.py src/agent_bom/api/stores.py src/agent_bom/api/routes/discovery.py src/agent_bom/api/routes/fleet.py
- python3 -m py_compile src/agent_bom/api/mcp_observation_store.py src/agent_bom/api/stores.py src/agent_bom/api/routes/discovery.py src/agent_bom/api/routes/fleet.py

Notes
- local mypy was flaky once due to the existing .venv reinstall state, but the final pre-commit mypy hook passed on commit

Closes #1697
Refs #1692
Refs #1691