### PR TITLE
feat(graph): clarify snapshot and blast-radius semantics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - How Agent-BOM Works: architecture/how-agent-bom-works.md
       - Unified Platform Control Plane: architecture/unified-platform-control-plane.md
       - Self-Hosted Product Architecture: architecture/self-hosted-product-architecture.md
+      - Security Graph Model: architecture/security-graph-model.md
       - Hosted Product Control Plane: architecture/hosted-product-spec.md
       - AI Infrastructure Scanning: architecture/ai-infrastructure.md
       - Data Ingestion and Security: architecture/data-ingestion-and-security.md

--- a/site-docs/architecture/security-graph-model.md
+++ b/site-docs/architecture/security-graph-model.md
@@ -1,0 +1,172 @@
+# Security Graph Model
+
+Use this page when the question is not "how do I open the graph?" but "what is
+this graph actually storing, how should I read it, and what stays true when the
+snapshot gets large?"
+
+`agent-bom` persists the graph as a **snapshot-oriented control-plane view**:
+
+- **nodes** are canonical entities such as agents, MCP servers, tools,
+  packages, credentials, containers, cloud resources, vulnerabilities, and
+  misconfigurations
+- **edges** are typed relationships such as `uses`, `depends_on`,
+  `exposes_cred`, `affects`, `invoked`, and `lateral_path`
+- **attack paths** are precomputed fix-first exploit chains derived from the
+  persisted graph
+- **interaction risks** are runtime-oriented overlays that highlight where
+  agent behavior or shared control surfaces can expand blast radius
+
+This is not a best-effort browser-only canvas. It is a persisted graph snapshot
+loaded from the control plane.
+
+## What a snapshot means
+
+Each graph snapshot is identified by:
+
+- `scan_id`
+- `tenant_id`
+- `created_at`
+
+The snapshot captures:
+
+- the nodes present at that scan/control-plane save point
+- the edges between those nodes
+- the derived attack paths and interaction risks for that saved graph
+- aggregate counts used for graph headers, graph search, and UI summaries
+
+The important operator rule is:
+
+- **pagination changes the visible canvas**
+- **pagination does not change what the snapshot is**
+
+So when the graph page says `showing 1-500 of 3,200 nodes`, it is telling you
+how much of the persisted graph is on the current page, not that the rest of
+the graph disappeared.
+
+## IDs, timestamps, and evidence
+
+The graph uses stable identifiers wherever possible:
+
+- agents use canonical agent IDs
+- MCP servers use canonical server `stable_id`
+- tools, resources, and packages use their own stable IDs
+- graph nodes expose a `node_id` that the API and UI can round-trip
+
+That means operators can talk about:
+
+- one node across filters
+- one snapshot across pages
+- one server across repo scan, fleet sync, gateway discovery, and runtime
+
+Time fields have specific meaning:
+
+- `created_at` on the snapshot = when the graph snapshot was persisted
+- `first_seen` on a node = earliest observed timestamp for that entity in the
+  current correlated model
+- `last_seen` on a node = latest observed timestamp for that entity in the
+  current correlated model
+
+Those are different concepts. A snapshot is a saved graph view; `first_seen` and
+`last_seen` are entity lifecycle signals inside that view.
+
+## What the graph is for
+
+The graph is not meant to be a generic everything-map. It exists for three
+operator jobs:
+
+1. **blast radius**
+   Follow package or configuration risk into agents, credentials, tools, and
+   reachable runtime surfaces.
+2. **inventory correlation**
+   Show how repo, fleet, gateway, and runtime evidence point at the same MCP
+   server or agent surface.
+3. **fix-first triage**
+   Let operators collapse many exposed paths with one change instead of chasing
+   every finding separately.
+
+## Reading the graph in the UI
+
+The UI exposes three layers of interpretation:
+
+1. **snapshot metadata**
+   - scan ID
+   - captured time
+   - total nodes and edges
+   - current page window
+2. **topology filters**
+   - focused vs expanded view
+   - relationship scope
+   - runtime/static scope
+   - agent filters
+   - severity filters
+3. **node detail**
+   - node ID
+   - first seen / last seen
+   - incoming / outgoing edges
+   - sources and impact counts
+
+That split is intentional:
+
+- the header tells you what snapshot you are looking at
+- the filters tell you how you are slicing it
+- the detail panel tells you why one node matters
+
+## Scale and readability
+
+To keep the graph readable at larger sizes, `agent-bom` uses:
+
+- persisted snapshots rather than only transient browser layouts
+- paginated node windows
+- precomputed attack paths for shortlist triage
+- focused vs expanded topology modes
+- relationship-scope filters
+- node detail enrichment on demand
+
+The operator workflow should be:
+
+1. start with the focused graph or attack-path shortlist
+2. narrow by agent, severity, or relationship scope
+3. open node detail for IDs, timestamps, and impact
+4. page or expand only when the current slice is too narrow
+
+## Relationship categories
+
+At a high level the graph separates:
+
+- **inventory relationships**
+  - hosts
+  - uses
+  - depends_on
+  - provides_tool
+  - exposes_cred
+- **attack relationships**
+  - affects
+  - vulnerable_to
+  - exploitable_via
+  - remediates
+  - lateral_path
+- **runtime relationships**
+  - invoked
+  - accessed
+  - delegated_to
+- **governance relationships**
+  - manages
+  - owns
+  - part_of
+  - member_of
+
+This is why the graph page has relationship-scope filters. The same snapshot can
+be read as inventory, attack path, runtime context, or governance context
+without pretending those are all the same edge type.
+
+## What the graph is not
+
+The graph is not:
+
+- a replacement for the raw scan JSON
+- a guarantee that every runtime event is persisted forever
+- a substitute for the proxy or gateway itself
+- a live network map of traffic that never entered the control plane
+
+It is the persisted **operator model** that unifies inventory, findings,
+runtime evidence, and remediation.

--- a/ui/app/graph/page.tsx
+++ b/ui/app/graph/page.tsx
@@ -651,6 +651,16 @@ export default function GraphPage() {
     graphData && graphData.pagination.limit > 0
       ? Math.max(1, Math.ceil(graphData.pagination.total / graphData.pagination.limit))
       : 1;
+  const relationshipScopeLabel =
+    filters.relationshipScope === "all"
+      ? "all relationships"
+      : `${filters.relationshipScope} relationships`;
+  const runtimeModeLabel =
+    filters.runtimeMode === "all"
+      ? "static + runtime"
+      : filters.runtimeMode === "static"
+        ? "static only"
+        : "runtime only";
 
   if (loadingSnapshots) {
     return (
@@ -840,6 +850,41 @@ export default function GraphPage() {
               refreshing graph
             </span>
           )}
+        </div>
+
+        {activeSnapshot && graphData && (
+          <div className="mt-4 grid gap-3 lg:grid-cols-4">
+            <SnapshotMetaCard
+              label="Snapshot"
+              value={`${activeSnapshot.scan_id.slice(0, 12)}…`}
+              detail={`Persisted ${new Date(activeSnapshot.created_at).toLocaleString()}`}
+            />
+            <SnapshotMetaCard
+              label="Topology"
+              value={`${activeSnapshot.node_count} nodes · ${activeSnapshot.edge_count} edges`}
+              detail={`${graphData.attack_paths.length} attack paths on this page`}
+            />
+            <SnapshotMetaCard
+              label="Scope"
+              value={filters.agentName ? filters.agentName : "all agents"}
+              detail={`${relationshipScopeLabel} · ${runtimeModeLabel}`}
+            />
+            <SnapshotMetaCard
+              label="Window"
+              value={graphData.pagination.total > 0 ? `${pageStart}-${pageEnd} of ${graphData.pagination.total}` : "empty"}
+              detail={`page ${pageNumber} of ${totalPages} · depth ${filters.maxDepth}`}
+            />
+          </div>
+        )}
+
+        <div className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 text-xs text-zinc-400">
+          <div className="font-medium text-zinc-200">How to read this graph</div>
+          <ul className="mt-2 space-y-1.5">
+            <li>Each snapshot is a persisted control-plane view of entities, edges, attack paths, and relationship counts at one capture time.</li>
+            <li>Node IDs are stable identifiers inside the graph model; the detail panel shows the node ID, first seen, last seen, sources, and edge counts.</li>
+            <li>Pagination changes the visible canvas, not the persisted snapshot itself. Narrow the scope when the graph gets large; page when you need broader coverage.</li>
+            <li>Focused view is for operator triage. Expanded view is for topology review. Attack-path cards are the fix-first shortlist, not the whole graph.</li>
+          </ul>
         </div>
 
         <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
@@ -1084,6 +1129,24 @@ function PathTagList({
           </span>
         ))}
       </div>
+    </div>
+  );
+}
+
+function SnapshotMetaCard({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">{label}</p>
+      <p className="mt-1 font-mono text-sm text-zinc-100">{value}</p>
+      <p className="mt-1 text-[11px] text-zinc-500">{detail}</p>
     </div>
   );
 }

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -322,6 +322,13 @@ export function LineageDetailPanel({
           </div>
         )}
 
+        {typeof data.attributes?.node_id === "string" && data.attributes.node_id && (
+          <div className="space-y-2">
+            <Label>Identifier</Label>
+            <CodeBlock label="Node ID" value={String(data.attributes.node_id)} />
+          </div>
+        )}
+
         {(data.neighborCount != null ||
           data.sourceCount != null ||
           data.incomingEdgeCount != null ||


### PR DESCRIPTION
Summary
- make the persisted graph snapshot contract explicit in the UI with snapshot, scope, and window metadata
- surface node identifiers directly in the lineage detail panel
- add a dedicated security graph model doc covering snapshots, IDs, timestamps, attack paths, relationship scopes, and pagination

Testing
- npm --prefix ui run lint
- npm --prefix ui run build
- uv run mkdocs build --strict

Refs #1691