### PR TITLE
docs(release): tighten scale and runtime caveats

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,30 @@ gh pr create --base main            # or push + open PR on GitHub
 
 Branch naming: `feat/`, `fix/`, `docs/`, `chore/` prefixes. Always branch from and PR to `main`.
 
+### Important PR update rule
+
+Do **not** use GitHub's **Update branch** button on active PRs unless the PR is
+actually non-mergeable and you cannot refresh it locally.
+
+Preferred path:
+
+```bash
+git fetch origin main
+git rebase origin/main
+git push --force-with-lease
+```
+
+Why:
+
+- GitHub's synthetic merge head can leave PRs in a bad check state where
+  expected checks never attach cleanly
+- a real locally pushed head is more reliable for CI, branch protection, and
+  debugging
+
+If a PR ever shows "no checks reported", "expected" checks with no attached
+run, or obviously stale check-rollup state after an update, replace the branch
+head with a clean local rebase instead of retrying the GitHub button again.
+
 ---
 
 ## Tests

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -176,6 +176,41 @@ If any of these fail first:
 - overlapping scans: lengthen schedule or split scope
 - audit query drag: add retention boundaries and move analytics to `ClickHouse`
 
+## Security graph cardinality and windowing
+
+The security graph is one of the main operator surfaces, but it should be read
+as a persisted, filterable investigation view, not as a promise that every
+tenant should dump full topology into one browser canvas.
+
+Operationally important boundaries:
+
+- graph snapshots can contain many more nodes and edges than one page should
+  render at once
+- UI pagination, focus mode, search, and blast-radius drilldown are part of the
+  scaling model, not optional decoration
+- the operator workflow should narrow by tenant, snapshot, attack path, source,
+  or asset family before expecting one giant all-entity canvas to stay useful
+
+Recommended posture for larger tenants:
+
+1. keep graph investigation windowed by snapshot and page
+2. start from blast radius, focused graph, or asset search before expanding
+3. treat full-topology rendering as an exception path, not the default view
+4. benchmark the control plane with your expected snapshot size before calling
+   the graph production-ready at large scale
+
+What the product claims today:
+
+- persisted graph snapshots
+- stable node identifiers in the operator detail view
+- explicit snapshot metadata, scope, and timestamps
+- filterable graph investigation flows
+
+What it does not yet publish as a hard contract:
+
+- universal node/edge ceilings that apply to every tenant shape
+- a CI-enforced multi-tenant graph load harness
+
 ## Tenant quotas
 
 For multi-tenant or shared internal deployments, set explicit per-tenant quotas
@@ -223,6 +258,13 @@ Use that harness to validate:
 3. scaling behavior after enabling `HPA`
 4. the point where analytics should move to `ClickHouse`
 
+Current boundary:
+
+- the harness is shipped and operator-usable now
+- the harness is not yet a full multi-tenant performance gate in CI
+- published benchmark numbers should come from your environment until the repo
+  ships broader reference runs
+
 ## Minimal benchmark checklist
 
 Run these in your own environment before broader rollout:
@@ -258,6 +300,11 @@ starting point.
 
 `agent-bom` now ships the packaged control plane, pilot path, and operator
 defaults. What it still does not claim is:
+
+- one universal throughput number for every scan and tenant shape
+- one browser graph view that should render every tenant's full topology at once
+- CI-proven multi-tenant graph/load guarantees beyond the shipped focused
+  benchmark harness
 
 - fixed throughput guarantees
 - a bundled benchmark certification suite

--- a/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
+++ b/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
@@ -235,6 +235,34 @@ That is an intentional self-hosted shape:
 - `agent-bom` is the control plane and security layer
 - your surrounding platform still owns identity, secrets, and environment policy
 
+## Centralized admin boundary
+
+If you compare this to a more centralized managed MCP gateway model, the honest
+difference today is:
+
+- `agent-bom` is stronger on self-hosted inventory + scan + fleet + proxy/gateway correlation
+- `agent-bom` is less turnkey on managed connections, profiles, and centralized
+  per-user connection administration
+
+What ships now:
+
+- tenant-aware control plane
+- gateway policy storage and evaluation
+- inventory and provenance across scans, fleet, gateway, and persisted observations
+- environment-backed credential overlays for remote MCP upstreams
+
+What is still behind the more centralized SaaS-style admin model:
+
+- one-click managed connection setup for many enterprise integrations
+- centralized personal-vs-managed connection UX
+- broader identity-centric runtime administration beyond the current control-plane auth and RBAC surface
+
+That is a product-shape tradeoff, not hidden drift:
+
+- self-hosted first
+- customer-owned platform integrations
+- runtime governance close to the customer's infra
+
 ## EKS shape
 
 In a customer EKS deployment, the common split is:

--- a/site-docs/deployment/visual-leak-detection.md
+++ b/site-docs/deployment/visual-leak-detection.md
@@ -28,6 +28,12 @@ The OCR pass joins all image blocks in a single response into one stitched
 canvas, extracts words above the current confidence floor, and matches them
 against the shipped credential and PII pattern sets.
 
+Current boundary:
+
+- this is response-image OCR and redaction, not universal screenshot governance
+- it only runs where `proxy` or `gateway` are actually deployed
+- it is not yet a default-on redaction layer for every screenshot-heavy runtime path
+
 Current matching behavior:
 
 - single-word and short multi-word matches
@@ -155,6 +161,23 @@ Recommended rollout:
 | EKS sidecar proxy | required | image contents are fully operator-controlled |
 | Shared gateway pilot | best effort first | easier to validate OCR packaging and latency |
 | Shared gateway production | required | fail closed only after runtime support is proven |
+
+## What is real now vs still narrower
+
+Shipped now:
+
+- OCR-backed response inspection on image content blocks
+- credential and PII leak detection categories
+- proxy and gateway startup/readiness behavior
+- redaction of matched bounding boxes before the response reaches the client
+
+Still intentionally narrower:
+
+- always-on screenshot redaction across every deployment mode
+- request-side OCR inspection
+- a claim that visual redaction is already the default runtime posture everywhere
+
+That is why the feature stays opt-in and rollout-first in this release.
 
 ## Related guides
 


### PR DESCRIPTION
## Summary
- document graph cardinality and benchmark boundaries more explicitly
- make the current screenshot-redaction scope and rollout posture explicit
- clarify the current centralized admin / managed-connection boundary for proxy, gateway, and fleet
- add contributor guidance to avoid the GitHub Update branch synthetic-head CI freeze

## Testing
- uv run mkdocs build --strict

Refs #1691
Refs #1651
Refs #1677