### PR TITLE
chore(release): bump version to 0.81.1

### DIFF
--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
           if [ ! -f results.sarif ]; then
-            echo '{"version":"0.81.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.81.0"}},"results":[]}]}' > results.sarif
+            echo '{"version":"0.81.1","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.81.1"}},"results":[]}]}' > results.sarif
           fi
       # CVE freshness results are logged in workflow output.
       # We skip upload-sarif because this workflow only runs on schedule (not PRs),

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.81.0  # pinned — bump on each release
+        run: uv tool install agent-bom==0.81.1  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ Work targeting the next release.
 
 ---
 
+## [0.81.1] – 2026-04-22
+
+### Added
+- **Inventory-first MCP visibility** — the control plane now surfaces MCP command/URL, auth mode, credential-backed configuration, fleet timing, and provenance across scans, fleet sync, gateway discovery, and persisted observations instead of forcing operators to infer source context from summary badges.
+- **Operator feedback surface** — the shipped UI now includes in-product `Share feedback` and `Report bug` entry points with a copyable support bundle instead of relying on out-of-band issue filing alone.
+- **Runtime rollout packaging** — endpoint proxy bundles can now be rendered as `.pkg`, `.msi`, Homebrew, and MDM-oriented rollout assets, and Kubernetes deployments can opt into proxy sidecar auto-injection through the packaged mutating webhook path.
+
+### Changed
+- **Self-hosted runtime model clarity** — the product now documents `fleet`, `proxy`, and `gateway` as peer surfaces with explicit deployment/use guidance, tighter EKS rollout docs, clearer entrypoints, and an honest retention/security-lake model that matches the current code and storage backends.
+- **Security graph semantics** — the UI and docs now make snapshot identity, scope, timestamps, pagination, node identifiers, and blast-radius semantics explicit so graph investigation scales without inventing a second graph model in the operator workflow.
+- **Release-caveat guidance** — graph/load boundaries, screenshot-redaction scope, centralized managed-connection limits, and the contributor workflow around GitHub’s `Update branch` synthetic-head problem are now explicit in the shipped docs instead of living as tribal knowledge.
+
+### Fixed
+- **AWS/EKS operator path** — the reference installer now includes preflight checks and post-deploy verification so self-hosted rollout is not "install and guess" anymore.
+- **Skill-audit correlation gap** — skill-audit findings now feed the graph instead of landing as an orphan analysis surface outside the main inventory and blast-radius model.
+- **Runtime contract coverage** — gateway rate-limit behavior and inbound OCSF normalization now have explicit contract tests instead of relying on indirect coverage only.
+
+### Security
+- **Runtime hardening sweep** — middleware RBAC write-route coverage is closed, cached proxy policy bundles are Ed25519-signed and fail closed on mismatch, gateway policies can hot-reload without redeploy, and replay detection now uses a bounded long-window design instead of a short-lived exact-only cache.
+- **Deploy-time hardening** — the AWS/EKS rollout path now validates control-plane inputs before install, and packaged runtime operations document policy-signing rotation and cert-manager-backed webhook certificate renewal instead of leaving those as tribal knowledge.
+
+---
+
 ## [0.81.0] – 2026-04-21
 
 ### Added

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -171,7 +171,7 @@ Focused graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.81.0` | Current stable version (pinned) |
+| `0.81.1` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.81.0
+ARG VERSION=0.81.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ For published containers, the packaging model is:
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.81.0`) | CI/CD + SARIF |
+| GitHub Action (`uses: msaad00/agent-bom@v0.81.1`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
 | Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
@@ -381,7 +381,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.81.0
+- uses: msaad00/agent-bom@v0.81.1
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.81.0
+ARG VERSION=0.81.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.81.0
+ARG VERSION=0.81.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.81.0
+ARG VERSION=0.81.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.81.0
+ARG VERSION=0.81.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.81.0
+ARG VERSION=0.81.1
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for agentic infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
 version: 0.1.0
-appVersion: "0.81.0"
+appVersion: "0.81.1"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,16 +1,16 @@
 image:
   repository: agentbom/agent-bom
-  tag: "0.81.0"
+  tag: "0.81.1"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.81.0"
+  tag: "0.81.1"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.81.0"
+  tag: "0.81.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.81.0
+          image: agentbom/agent-bom:0.81.1
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.81.0
+          image: agentbom/agent-bom:0.81.1
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -124,7 +124,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.81.0
+- uses: msaad00/agent-bom@v0.81.1
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -23,7 +23,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.81.0
+- uses: msaad00/agent-bom@v0.81.1
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -41,21 +41,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.81.0
+- uses: msaad00/agent-bom@v0.81.1
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.81.0
+- uses: msaad00/agent-bom@v0.81.1
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.81.0
+- uses: msaad00/agent-bom@v0.81.1
   with:
     auto-update-db: false
     enrich: false
@@ -244,7 +244,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/root/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.81.0 agents --format json
+  agentbom/agent-bom:0.81.1 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -226,7 +226,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.81.0
+- uses: msaad00/agent-bom@v0.81.1
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-04-21",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-04-21`
-- Version: `0.81.0`
+- Version: `0.81.1`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.81.0"
+  --version "0.81.1"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -150,8 +150,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.81.0
-git push origin v0.81.0
+git tag v0.81.1
+git push origin v0.81.1
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.81.0
+TAG=v0.81.1
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.81.0`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.81.1`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.81.0 blast-radius demo
+# agent-bom v0.81.1 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.81.0",
+      "version": "0.81.1",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []
@@ -407,6 +407,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.81.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.81.1`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []
@@ -216,6 +216,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.81.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.81.1`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.81.0
+version: 0.81.1
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.81.0
+    docker: ghcr.io/msaad00/agent-bom:0.81.1
   openclaw:
     requires:
       bins: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.81.0"
+version = "0.81.1"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -282,7 +282,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.81.0 \
+  --version 0.81.1 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -318,7 +318,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.81.0 \
+  --version 0.81.1 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.81.0
+  uses: msaad00/agent-bom@v0.81.1
   with:
     policy: policy.json
     fail-on-violation: true

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.81.0"
+    __version__ = "0.81.1"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.81.0' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.81.1' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-bom"
-version = "0.81.0"
+version = "0.81.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump managed version surfaces from 0.81.0 to 0.81.1
- add the 0.81.1 changelog entry for the post-v0.81.0 sweep
- align Docker, Helm, registry, docs, and release-managed metadata on the patch version

## Testing
- python3 scripts/check_release_consistency.py
- uv run mkdocs build --strict
- npm --prefix ui run build

Closes #1677