### PR TITLE
feat(multitenancy): enforce tenant-scoped gateway routing

### DIFF
--- a/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
+++ b/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
@@ -108,6 +108,7 @@ agent-bom gateway serve \
 What `gateway` gives you today:
 
 - tenant-aware authentication at the gateway edge
+- tenant-scoped upstream routing keyed by the authenticated tenant, not just a global upstream name
 - inline policy evaluation for JSON-RPC requests
 - shared tenant rate limiting, including Postgres-backed multi-replica mode
 - audit logging back into the control plane

--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -53,6 +53,8 @@ def _pick_timestamp(*values: str | None, prefer: str) -> str | None:
 def merge_observations(existing: MCPObservation | None, incoming: MCPObservation) -> MCPObservation:
     if existing is None:
         return incoming
+    if existing.tenant_id != incoming.tenant_id:
+        raise ValueError("tenant mismatch in observation merge")
     return MCPObservation(
         tenant_id=incoming.tenant_id,
         observation_id=incoming.observation_id,

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -395,11 +395,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             request.state.tenant_id = tenant_id
             request.state.auth_method = auth_method
 
-        upstream = settings.registry.get(server_name)
+        upstream = settings.registry.get(server_name, tenant_id=tenant_id)
         if upstream is None:
             raise HTTPException(
                 status_code=404,
-                detail=f"unknown upstream {server_name!r}; known: {', '.join(settings.registry.names()) or '(none)'}",
+                detail=(
+                    f"unknown upstream {server_name!r} for tenant {tenant_id!r}; known: "
+                    f"{', '.join(settings.registry.names(tenant_id=tenant_id)) or '(none)'}"
+                ),
             )
 
         try:

--- a/src/agent_bom/gateway_upstreams.py
+++ b/src/agent_bom/gateway_upstreams.py
@@ -82,10 +82,15 @@ class UpstreamConfig:
         use and cached until ~60 s before expiry.
     headers:
         Additional static headers to inject on every upstream request.
+    tenant_id:
+        Optional tenant owner for this upstream. When set, the gateway must
+        only route requests from that tenant to this upstream. When unset, the
+        upstream is treated as a legacy/global entry for single-tenant deploys.
     """
 
     name: str
     url: str
+    tenant_id: str | None = None
     auth: str = "none"
     token_env: str | None = None
     oauth_token_url: str | None = None
@@ -175,11 +180,16 @@ class UpstreamRegistry:
     """Registry of upstream MCP servers the gateway can route to."""
 
     def __init__(self, upstreams: list[UpstreamConfig]) -> None:
-        self._by_name: dict[str, UpstreamConfig] = {}
+        self._by_name: dict[tuple[str | None, str], UpstreamConfig] = {}
+        self._tenant_presence_by_name: dict[str, set[str]] = {}
         for upstream in upstreams:
-            if upstream.name in self._by_name:
-                raise UpstreamConfigError(f"duplicate upstream name: {upstream.name!r}")
-            self._by_name[upstream.name] = upstream
+            key = (upstream.tenant_id, upstream.name)
+            if key in self._by_name:
+                tenant_label = upstream.tenant_id or "global"
+                raise UpstreamConfigError(f"duplicate upstream name for tenant {tenant_label!r}: {upstream.name!r}")
+            self._by_name[key] = upstream
+            if upstream.tenant_id:
+                self._tenant_presence_by_name.setdefault(upstream.name, set()).add(upstream.tenant_id)
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> "UpstreamRegistry":
@@ -212,7 +222,15 @@ class UpstreamRegistry:
         raw_upstreams = payload.get("upstreams") or []
         if not isinstance(raw_upstreams, list):
             raise UpstreamConfigError("discovery response must contain an 'upstreams' list")
-        upstreams = [_parse_upstream(raw, source="control-plane discovery") for raw in raw_upstreams]
+        response_tenant_id = payload.get("tenant_id")
+        upstreams = [
+            _parse_upstream(
+                raw,
+                source="control-plane discovery",
+                default_tenant_id=response_tenant_id if isinstance(response_tenant_id, str) and response_tenant_id else None,
+            )
+            for raw in raw_upstreams
+        ]
         logger.info("gateway: loaded %d upstreams from control-plane discovery", len(upstreams))
         return cls(upstreams)
 
@@ -223,24 +241,53 @@ class UpstreamRegistry:
         control plane AND the operator wants to override a subset (typically
         to attach bearer-token auth to an upstream discovery can't infer).
         """
-        merged: dict[str, UpstreamConfig] = dict(self._by_name)
-        for name, upstream in overlay._by_name.items():
-            merged[name] = upstream
+        merged: dict[tuple[str | None, str], UpstreamConfig] = dict(self._by_name)
+        for key, upstream in overlay._by_name.items():
+            merged[key] = upstream
         new = UpstreamRegistry.__new__(UpstreamRegistry)
         new._by_name = merged
+        new._tenant_presence_by_name = {}
+        for upstream in merged.values():
+            if upstream.tenant_id:
+                new._tenant_presence_by_name.setdefault(upstream.name, set()).add(upstream.tenant_id)
         return new
 
-    def get(self, name: str) -> UpstreamConfig | None:
-        return self._by_name.get(name)
+    def get(self, name: str, tenant_id: str | None = None) -> UpstreamConfig | None:
+        if tenant_id:
+            exact = self._by_name.get((tenant_id, name))
+            if exact is not None:
+                return exact
+            # Fail closed when this name has any tenant-bound entries. Falling
+            # back to a legacy/global entry here would let one tenant
+            # accidentally route into another tenant's administrative surface.
+            if tenant_id in self._tenant_presence_by_name.get(name, set()) or self._tenant_presence_by_name.get(name):
+                return None
+        global_match = self._by_name.get((None, name))
+        if global_match is not None:
+            return global_match
+        tenant_ids = self._tenant_presence_by_name.get(name, set())
+        if len(tenant_ids) == 1:
+            only_tenant = next(iter(tenant_ids))
+            return self._by_name.get((only_tenant, name))
+        return None
 
-    def names(self) -> list[str]:
-        return sorted(self._by_name.keys())
+    def names(self, tenant_id: str | None = None) -> list[str]:
+        if tenant_id:
+            names = {name for (entry_tenant, name) in self._by_name if entry_tenant == tenant_id}
+            # Only include global names when there is no tenant-bound variant
+            # for this name anywhere. That keeps single-tenant compatibility
+            # without silently advertising cross-tenant shared routes.
+            for (entry_tenant, name), _upstream in self._by_name.items():
+                if entry_tenant is None and name not in self._tenant_presence_by_name:
+                    names.add(name)
+            return sorted(names)
+        return sorted({name for (_tenant, name) in self._by_name})
 
     def __len__(self) -> int:
         return len(self._by_name)
 
     def __contains__(self, name: object) -> bool:
-        return isinstance(name, str) and name in self._by_name
+        return isinstance(name, str) and ((None, name) in self._by_name or name in self._tenant_presence_by_name)
 
 
 def fetch_discovered_upstreams(
@@ -271,7 +318,7 @@ def fetch_discovered_upstreams(
     return response.json()
 
 
-def _parse_upstream(raw: Any, *, source: str) -> UpstreamConfig:
+def _parse_upstream(raw: Any, *, source: str, default_tenant_id: str | None = None) -> UpstreamConfig:
     if not isinstance(raw, dict):
         raise UpstreamConfigError(f"{source}: every upstream entry must be a mapping, got {type(raw).__name__}")
 
@@ -297,9 +344,14 @@ def _parse_upstream(raw: Any, *, source: str) -> UpstreamConfig:
     if not isinstance(scopes_raw, list):
         raise UpstreamConfigError(f"{source}: upstream {name!r} scopes must be a list")
 
+    tenant_id = raw.get("tenant_id", default_tenant_id)
+    if tenant_id is not None and not isinstance(tenant_id, str):
+        raise UpstreamConfigError(f"{source}: upstream {name!r} tenant_id must be a string")
+
     return UpstreamConfig(
         name=name,
         url=url.rstrip("/"),
+        tenant_id=tenant_id,
         auth=auth,
         token_env=raw.get("token_env"),
         oauth_token_url=raw.get("oauth_token_url"),

--- a/tests/test_api_agent_detail.py
+++ b/tests/test_api_agent_detail.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api import stores as _stores
@@ -170,6 +171,25 @@ def test_merge_observations_preserves_persisted_provenance_contract():
     assert merged.first_seen == "2026-04-22T11:58:00Z"
     assert merged.last_seen == "2026-04-22T12:01:00Z"
     assert merged.last_synced == "2026-04-22T12:05:00Z"
+
+
+def test_merge_observations_rejects_tenant_mismatch():
+    existing = MCPObservation(
+        tenant_id="tenant-alpha",
+        observation_id="test-agent:test-server:npx",
+        server_stable_id="test-server:npx",
+        server_name="test-server",
+    )
+    incoming = MCPObservation(
+        tenant_id="tenant-beta",
+        observation_id="test-agent:test-server:npx",
+        server_stable_id="test-server:npx",
+        server_name="test-server",
+    )
+    from agent_bom.api.mcp_observation_store import merge_observations
+
+    with pytest.raises(ValueError, match="tenant mismatch"):
+        merge_observations(existing, incoming)
 
 
 @patch("agent_bom.discovery.discover_all", side_effect=_mock_agents)

--- a/tests/test_gateway_auth_tenant_e2e.py
+++ b/tests/test_gateway_auth_tenant_e2e.py
@@ -100,7 +100,7 @@ def _cp_client(tenant: str) -> TestClient:
     return c
 
 
-def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_fleet) -> None:
+def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_fleet, monkeypatch) -> None:
     """Walk the entire pilot flow — every seam guarded in one test."""
 
     # ── Stage 1: operator on tenant-alpha hits discovery, sees ONLY their MCPs
@@ -153,6 +153,17 @@ def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_
             upstream_calls.append({"upstream": upstream.name, "tool": message.get("params", {}).get("name"), "headers": extra_headers})
             return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
 
+        class _FakeKeyStore:
+            def has_keys(self) -> bool:
+                return True
+
+            def verify(self, raw_key: str):
+                if raw_key == "tenant-alpha-gateway-key":
+                    return type("ApiKey", (), {"tenant_id": "tenant-alpha"})()
+                return None
+
+        monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+
         gw_settings = GatewaySettings(
             registry=registry,
             policy=policy,
@@ -164,6 +175,7 @@ def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_
         # ── Stage 4: policy-blocked tool call — upstream must NOT be hit
         blocked = gw.post(
             "/mcp/jira",
+            headers={"X-API-Key": "tenant-alpha-gateway-key"},
             json={
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -184,6 +196,7 @@ def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_
         # ── Stage 5: allowed tool call — upstream hit, response returned
         allowed = gw.post(
             "/mcp/jira",
+            headers={"X-API-Key": "tenant-alpha-gateway-key"},
             json={
                 "jsonrpc": "2.0",
                 "id": 2,

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -308,6 +308,85 @@ def test_relay_accepts_control_plane_api_key_and_applies_tenant(monkeypatch) -> 
     assert audit_events[-1]["tenant_id"] == "tenant-alpha"
 
 
+def test_relay_routes_same_upstream_name_by_authenticated_tenant(monkeypatch) -> None:
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append({"tenant_id": upstream.tenant_id, "url": upstream.url, "name": upstream.name})
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "tenant-alpha-key":
+                return SimpleNamespace(tenant_id="tenant-alpha")
+            if raw_key == "tenant-beta-key":
+                return SimpleNamespace(tenant_id="tenant-beta")
+            return None
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+    registry = UpstreamRegistry(
+        [
+            UpstreamConfig(name="jira", tenant_id="tenant-alpha", url="https://alpha.example.com/mcp"),
+            UpstreamConfig(name="jira", tenant_id="tenant-beta", url="https://beta.example.com/mcp"),
+        ]
+    )
+    settings = GatewaySettings(registry=registry, policy={}, upstream_caller=fake_caller)
+    client = TestClient(create_gateway_app(settings))
+
+    alpha = client.post(
+        "/mcp/jira",
+        headers={"X-API-Key": "tenant-alpha-key"},
+        json=_json_rpc("tools/call", name="query_issues", arguments={"jql": "project = ALPHA"}),
+    )
+    beta = client.post(
+        "/mcp/jira",
+        headers={"X-API-Key": "tenant-beta-key"},
+        json=_json_rpc("tools/call", name="query_issues", arguments={"jql": "project = BETA"}),
+    )
+
+    assert alpha.status_code == 200
+    assert beta.status_code == 200
+    assert upstream_calls == [
+        {"tenant_id": "tenant-alpha", "url": "https://alpha.example.com/mcp", "name": "jira"},
+        {"tenant_id": "tenant-beta", "url": "https://beta.example.com/mcp", "name": "jira"},
+    ]
+
+
+def test_relay_fails_closed_when_tenant_has_no_matching_upstream(monkeypatch) -> None:
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "tenant-beta-key":
+                return SimpleNamespace(tenant_id="tenant-beta")
+            return None
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+    registry = UpstreamRegistry(
+        [
+            UpstreamConfig(name="jira", tenant_id="tenant-alpha", url="https://alpha.example.com/mcp"),
+            UpstreamConfig(name="jira", url="https://legacy-global.example.com/mcp"),
+        ]
+    )
+    settings = GatewaySettings(registry=registry, policy={}, upstream_caller=fake_caller)
+    client = TestClient(create_gateway_app(settings))
+
+    denied = client.post(
+        "/mcp/jira",
+        headers={"X-API-Key": "tenant-beta-key"},
+        json=_json_rpc("tools/call", name="query_issues", arguments={"jql": "project = BETA"}),
+    )
+    assert denied.status_code == 404
+    assert "tenant 'tenant-beta'" in denied.json()["detail"]
+
+
 def test_gateway_rate_limit_is_tenant_scoped(monkeypatch) -> None:
     class _FakeKeyStore:
         def has_keys(self) -> bool:

--- a/tests/test_gateway_upstreams.py
+++ b/tests/test_gateway_upstreams.py
@@ -238,6 +238,36 @@ def test_merged_with_overlay_adds_new_upstreams_not_in_discovery() -> None:
     assert sorted(merged.names()) == ["custom-internal", "jira"]
 
 
+def test_tenant_scoped_registry_routes_same_name_to_tenant_specific_upstream() -> None:
+    registry = UpstreamRegistry(
+        [
+            UpstreamConfig(name="jira", tenant_id="tenant-alpha", url="https://alpha.example.com/mcp"),
+            UpstreamConfig(name="jira", tenant_id="tenant-beta", url="https://beta.example.com/mcp"),
+        ]
+    )
+    alpha = registry.get("jira", tenant_id="tenant-alpha")
+    beta = registry.get("jira", tenant_id="tenant-beta")
+    assert alpha is not None
+    assert beta is not None
+    assert alpha.url == "https://alpha.example.com/mcp"
+    assert beta.url == "https://beta.example.com/mcp"
+    assert registry.names(tenant_id="tenant-alpha") == ["jira"]
+    assert registry.names(tenant_id="tenant-beta") == ["jira"]
+
+
+def test_tenant_scoped_registry_fails_closed_on_cross_tenant_fallback() -> None:
+    registry = UpstreamRegistry(
+        [
+            UpstreamConfig(name="jira", tenant_id="tenant-alpha", url="https://alpha.example.com/mcp"),
+            UpstreamConfig(name="jira", url="https://legacy-global.example.com/mcp"),
+        ]
+    )
+    assert registry.get("jira", tenant_id="tenant-alpha") is not None
+    # A different tenant must not silently fall through to the global route
+    # once a tenant-bound upstream exists for this name.
+    assert registry.get("jira", tenant_id="tenant-beta") is None
+
+
 # ─── OAuth2 client-credentials ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- enforce tenant-scoped gateway upstream routing keyed by the authenticated tenant
- fail closed when a tenant tries to route to an upstream that only exists for another tenant
- reject MCP observation merges that try to overwrite `tenant_id`
- clarify the tenant-scoped gateway behavior in the deployment docs

## Why

`agent-bom` already had strong tenant scoping in the control plane and storage layers, but the highest-value remaining multi-tenant hardening seam was the shared gateway/runtime surface. This change makes the relay path tenant-aware end to end and closes the silent observation-merge seam the latest audit identified.

## Impact

- tenant A and tenant B can reuse the same upstream name without collisions
- shared gateways no longer fall through to another tenant's upstream config
- observation provenance merges fail fast on tenant mismatch instead of silently rewriting ownership
- single-tenant discovery compatibility is preserved for non-relay registry reads

## Validation

- `.venv/bin/python -m pytest tests/test_gateway_upstreams.py tests/test_gateway_server.py tests/test_gateway_auth_tenant_e2e.py tests/test_gateway_upstream_discovery_route.py tests/test_api_agent_detail.py -q`
- `uv run ruff check src/agent_bom/gateway_upstreams.py src/agent_bom/gateway_server.py src/agent_bom/api/mcp_observation_store.py tests/test_gateway_upstreams.py tests/test_gateway_server.py tests/test_gateway_auth_tenant_e2e.py tests/test_api_agent_detail.py`
- `uv run mypy src/agent_bom/api/mcp_observation_store.py src/agent_bom/gateway_upstreams.py src/agent_bom/gateway_server.py`
- `uv run mkdocs build --strict`
