### PR TITLE
docs(multitenancy): tighten self-hosted tenancy boundary

### DIFF
--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -234,6 +234,10 @@ Use two layers.
 That keeps scan, fleet, runtime enforcement, and gateway policy aligned
 without pretending every workload needs the same enforcement model.
 
+For the current boundary between strong self-hosted tenant isolation and
+provider-style MSSP multi-tenancy, see
+[When To Use Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md).
+
 ## Helm Knobs That Matter
 
 | Value | Why it matters |

--- a/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
+++ b/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
@@ -248,6 +248,7 @@ difference today is:
 What ships now:
 
 - tenant-aware control plane
+- tenant-scoped gateway upstream routing keyed by the authenticated tenant
 - gateway policy storage and evaluation
 - inventory and provenance across scans, fleet, gateway, and persisted observations
 - environment-backed credential overlays for remote MCP upstreams
@@ -263,6 +264,23 @@ That is a product-shape tradeoff, not hidden drift:
 - self-hosted first
 - customer-owned platform integrations
 - runtime governance close to the customer's infra
+
+## What It Is Not Yet
+
+- **Managed SaaS**: no hosted vendor control plane; the supported model today
+  is self-hosted and customer-operated.
+- **MSSP-grade multi-tenancy**: tenant isolation is real in the control plane,
+  stores, audit, fleet, and shared gateway routing, but `agent-bom` is not yet
+  a turnkey "one provider serving many customer orgs" platform. The main gaps
+  are tenant lifecycle automation, richer per-tenant delegation/templates, and
+  stronger provider-style quota and admin surfaces.
+- **Auto-injected runtime sidecars everywhere**: proxy and gateway are
+  productized, but broad operator-driven sidecar attachment is still selective,
+  not a universal default rollout.
+- **Streaming SIEM product surface**: audit is durable, signed, and exportable,
+  but not yet a first-class Kafka or Splunk HEC style streaming experience.
+- **First-party IDE plugin ecosystem**: MCP server mode works with existing AI
+  clients, but dedicated editor plugins are not the primary distribution model.
 
 ## EKS shape
 


### PR DESCRIPTION
## Summary

- make the current self-hosted multi-tenant boundary explicit in the docs
- document that tenant isolation is already real across the control plane, stores, audit, fleet, and shared gateway routing
- spell out what is still not turnkey MSSP-grade multi-tenancy today
- link the EKS deployment guide back to the runtime/fleet/tenancy boundary guide

## Why

The current product shape is strong on self-hosted tenant isolation, but the public boundary between "secure multi-tenant self-hosting" and "turnkey provider-style MSSP multi-tenancy" was still too implicit. This PR makes that distinction explicit so the score-up is honest and reviewable.

## Impact

- clearer operator expectation setting for self-hosted customers
- clearer explanation of where `agent-bom` is already strong on tenancy
- no hidden overclaim that current self-hosted multi-tenancy is the same thing as a provider-run SaaS or MSSP control plane

## Validation

- `uv run mkdocs build --strict`
