### PR TITLE
fix(release): close audit followups

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ sequenceDiagram
 
     CLI->>BlastRadius: Vulns + topology
     BlastRadius->>BlastRadius: CVE → package → server → agent → creds → tools
-    BlastRadius->>BlastRadius: Tag 15 compliance frameworks
+    BlastRadius->>BlastRadius: Tag 14 compliance frameworks
     BlastRadius-->>CLI: Scored + tagged findings
 
     CLI->>Reporter: Full results
@@ -147,7 +147,7 @@ graph LR
 
 ## 4. Compliance Tagging
 
-Every finding is tagged against 15 frameworks, grouped into four families.
+Every finding is tagged against 14 frameworks, grouped into four families.
 
 ```mermaid
 graph LR

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -152,7 +152,7 @@ agent-bom agents --enforce    # + static tool poisoning analysis
 agent-bom agents --gpu-scan   # + GPU containers, CUDA versions, DCGM exposure
 ```
 
-Outputs: blast radius tree, compliance mapping (15 frameworks), posture score, SARIF/CycloneDX/SPDX/HTML.
+Outputs: blast radius tree, compliance mapping (14 frameworks), posture score, SARIF/CycloneDX/SPDX/HTML.
 
 ### 4.2 Proxy mode
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -140,7 +140,7 @@ If engaging a third-party auditor, the recommended scope:
 
 ### Compliance Framework Mapping
 
-agent-bom **maps findings TO compliance controls** across 15 frameworks:
+agent-bom **maps findings TO compliance controls** across 14 frameworks:
 
 OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10,
 EU AI Act, NIST AI RMF, NIST CSF, ISO 27001, SOC 2, CIS Controls,

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="138" class="item-label" fill="#fb7185">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">15 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
   <rect x="422" y="144" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="162" class="item-label" fill="#fb7185">Policy engine</text>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="138" class="item-label" fill="#e11d48">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">15 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
   <rect x="422" y="144" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="162" class="item-label" fill="#e11d48">Policy engine</text>

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -294,27 +294,23 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     async def _reload_policy_if_changed(force: bool = False) -> bool:
         if settings.policy_path is None:
             return False
-        try:
-            stat = settings.policy_path.stat()
-        except OSError as exc:
-            async with policy_lock:
-                policy_state["last_error"] = str(exc)
-            logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
-            return False
-
-        mtime = stat.st_mtime
-        if not force and policy_state["last_mtime"] == mtime:
-            return False
-
-        try:
-            next_policy = _load_policy_file(settings.policy_path)
-        except Exception as exc:  # noqa: BLE001
-            async with policy_lock:
-                policy_state["last_error"] = str(exc)
-            logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
-            return False
 
         async with policy_lock:
+            try:
+                stat = settings.policy_path.stat()
+                mtime = stat.st_mtime
+                if not force and policy_state["last_mtime"] == mtime:
+                    return False
+                next_policy = _load_policy_file(settings.policy_path)
+            except FileNotFoundError as exc:
+                policy_state["last_error"] = str(exc)
+                logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
+                return False
+            except Exception as exc:  # noqa: BLE001
+                policy_state["last_error"] = str(exc)
+                logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
+                return False
+
             policy_state["policy"] = next_policy
             policy_state["last_loaded_at"] = time.time()
             policy_state["last_error"] = None

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -546,6 +546,33 @@ def test_gateway_hot_reload_updates_policy_without_restart(tmp_path: Path) -> No
         assert allowed.json()["result"]["ok"] is True
 
 
+def test_gateway_hot_reload_tolerates_policy_file_removed_mid_reload(tmp_path: Path) -> None:
+    policy_path = tmp_path / "gateway-policy.json"
+    policy_path.write_text(json.dumps({"rules": []}))
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+        policy_path=policy_path,
+        policy_reload_interval_seconds=1,
+    )
+    with TestClient(create_gateway_app(settings)) as client:
+        healthy = client.get("/healthz")
+        assert healthy.status_code == 200
+        assert healthy.json()["policy_runtime"]["last_error"] is None
+
+        policy_path.unlink()
+        time.sleep(1.2)
+
+        reloaded = client.get("/healthz")
+        assert reloaded.status_code == 200
+        assert "No such file or directory" in (reloaded.json()["policy_runtime"]["last_error"] or "")
+
+
 # ─── Error cases ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- fix the gateway file-backed policy hot-reload race so a transient delete/truncate does not crash the reload path
- add a regression test covering the file-removed-mid-reload case
- align the remaining compliance-framework count claims in docs/assets with the code-backed count of 14

## Why

The latest audit found two release-worthy followups on `main`: a docs claim drift (`15 frameworks` vs `14` in code) and a hot-reload stat/read race in the gateway policy loop. This PR closes both without changing the product model or deployment shape.

## Impact

- gateway hot-reload stays fail-safe on transient file replacement/removal instead of crashing the loop
- docs and diagrams stay provable against `COMPLIANCE_FRAMEWORK_COUNT`
- no change to CLI/API surface area

## Validation

- `.venv/bin/python -m pytest tests/test_gateway_server.py -q`
- `uv run ruff check src/agent_bom/gateway_server.py tests/test_gateway_server.py`
- `uv run mypy src/agent_bom/gateway_server.py`
- `uv run mkdocs build --strict`
