### PR TITLE
docs(deploy): clarify official deployment paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ agent-bom image nginx:latest                  # container image scan
 agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC scan, optionally `--k8s-live`
 ```
 
-Self-hosted pilot:
+Recommended pilot on one workstation:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
@@ -85,7 +85,17 @@ docker compose -f docker-compose.pilot.yml up -d
 # Dashboard -> http://localhost:3000
 ```
 
-Production chart from a checked-out repo:
+Recommended full self-hosted path in your own AWS / EKS:
+
+```bash
+scripts/deploy/install-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --hostname agent-bom.internal.example.com \
+  --enable-gateway
+```
+
+Advanced/manual path from a checked-out repo:
 
 ```bash
 helm upgrade --install agent-bom deploy/helm/agent-bom \
@@ -246,7 +256,18 @@ start with a runtime rollout.
 Users should not think about that split directly:
 
 - **pilot**: one Compose file
-- **production**: one Helm chart
+- **full self-hosted**: one reference installer
+- **advanced/manual**: one Helm chart
+
+Official deployment entrypoints:
+
+- **pilot on one machine**:
+  [deploy/docker-compose.pilot.yml](deploy/docker-compose.pilot.yml)
+- **full self-hosted in your own AWS / EKS**:
+  [scripts/deploy/install-eks-reference.sh](scripts/deploy/install-eks-reference.sh)
+
+Other Compose files in `deploy/` are advanced or component-specific examples,
+not the primary recommended deployment path.
 
 ## Local vs self-hosted
 
@@ -254,7 +275,7 @@ Users should not think about that split directly:
 |---|---|---|
 | `agent-bom agents -p .` on your laptop | local repo, local MCP configs, local manifests, local endpoint context | cluster-only resources unless you pass credentials or run from that environment |
 | `agent-bom serve` on one machine | scans and UI workflows for paths that machine can access | another developer laptop's local files or cluster-internal services it cannot reach |
-| Helm / Compose control plane in your infra | scan jobs, fleet sync, graph, audit, remediation, API/UI workflows | endpoint-local stdio traffic unless proxy is deployed there |
+| Helm / scripted control plane in your infra | scan jobs, fleet sync, graph, audit, remediation, API/UI workflows | endpoint-local stdio traffic unless proxy is deployed there |
 | `agent-bom proxy` on an endpoint or sidecar | that workload's live MCP traffic | shared remote MCP traffic that never passes through that proxy |
 | `agent-bom gateway serve` in cluster | shared remote MCP traffic routed through it | local stdio MCP sessions that stay on endpoints |
 

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -18,7 +18,7 @@ Plane](gateway-auto-discovery.md).
 - `agentbom/agent-bom` for scanner, API, jobs, proxy, gateway, and workers
 - `agentbom/agent-bom-ui` for the browser dashboard
 
-## Reference Entry Points
+## Official Entry Points
 
 Pilot on one workstation:
 
@@ -27,7 +27,7 @@ curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docke
 docker compose -f docker-compose.pilot.yml up -d
 ```
 
-Reference AWS/EKS rollout:
+Recommended full self-hosted AWS / EKS rollout:
 
 ```bash
 scripts/deploy/install-eks-reference.sh \
@@ -38,7 +38,7 @@ scripts/deploy/install-eks-reference.sh \
   --enable-gateway
 ```
 
-If the company already has an EKS platform, reuse it:
+If the company already has an EKS platform, reuse it with the same installer:
 
 ```bash
 scripts/deploy/install-eks-reference.sh \

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -19,6 +19,21 @@ docker compose -f docker-compose.pilot.yml up -d
 The UI image does not replace the API image. A self-hosted browser deployment
 still needs the API/control-plane service from `agentbom/agent-bom`.
 
+## Recommended vs advanced Docker paths
+
+Use these in this order:
+
+| Path | Status | Use when |
+|---|---|---|
+| `deploy/docker-compose.pilot.yml` | recommended | fastest one-machine pilot with the shipped images |
+| `deploy/docker-compose.fullstack.yml` | advanced local example | you want a fuller single-machine compose setup and are comfortable editing local compose files |
+| `deploy/docker-compose.platform.yml` | component example | you are focusing on the control-plane/platform layer only |
+| `deploy/docker-compose.runtime.yml` | component example | you are focusing on proxy/runtime behavior only |
+
+If you want the full self-hosted deployment path for your own infrastructure,
+use `scripts/deploy/install-eks-reference.sh` instead of trying to stretch a
+Compose file into production.
+
 ## Quick scan
 
 ```bash

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -20,6 +20,16 @@ docker compose -f docker-compose.pilot.yml up -d
 Production in your own cluster from a checked-out repo:
 
 ```bash
+scripts/deploy/install-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region us-east-1 \
+  --hostname agent-bom.internal.example.com \
+  --enable-gateway
+```
+
+Advanced/manual chart install from a checked-out repo:
+
+```bash
 helm upgrade --install agent-bom deploy/helm/agent-bom \
   --namespace agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -55,6 +65,23 @@ That is not a downgrade of runtime. It is a cleaner adoption model:
 
 - **inventory and discovery** should already be useful on day 1
 - **proxy and gateway** deepen that into live runtime control on day 2
+
+## Official deployment entrypoints
+
+Use these first:
+
+| Goal | Recommended entrypoint | Why |
+|---|---|---|
+| One-machine pilot | `deploy/docker-compose.pilot.yml` | fastest path to API + UI with the shipped images |
+| Full self-hosted deployment in your own AWS / EKS | `scripts/deploy/install-eks-reference.sh` | creates or targets EKS, wires the AWS baseline, installs Helm, and prints verify/next-step commands |
+
+Use these only when you are intentionally going off the paved path:
+
+| Entry point | Use when |
+|---|---|
+| `helm upgrade --install ... -f deploy/helm/agent-bom/examples/eks-production-values.yaml` | you already manage your own Helm layering and do not want the reference installer |
+| `deploy/docker-compose.fullstack.yml` | you want a fuller local compose example on one machine, not the recommended production path |
+| `deploy/docker-compose.platform.yml` / `deploy/docker-compose.runtime.yml` | you are developing or demonstrating one part of the product surface, not doing the standard install |
 
 ## Deployment modes
 

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -165,11 +165,13 @@ data to a vendor-hosted control plane.
 
 These are the maintained building blocks for this model:
 
+- recommended full self-hosted entrypoint:
+  [scripts/deploy/install-eks-reference.sh](https://github.com/msaad00/agent-bom/blob/main/scripts/deploy/install-eks-reference.sh)
 - control plane:
   [deploy/helm/agent-bom](https://github.com/msaad00/agent-bom/tree/main/deploy/helm/agent-bom)
 - AWS baseline module:
   [deploy/terraform/aws/baseline](https://github.com/msaad00/agent-bom/tree/main/deploy/terraform/aws/baseline)
-- Compose references:
+- advanced local Compose references, not the primary production path:
   [deploy/docker-compose.platform.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.platform.yml)
   and
   [deploy/docker-compose.runtime.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.runtime.yml)
@@ -185,6 +187,11 @@ These are the maintained building blocks for this model:
   [eks-production-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-production-values.yaml)
 - focused pilot values example:
   [eks-mcp-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml)
+
+If you want one official answer to "what is the full deployment path?", use the
+reference installer first. Drop to the raw Helm examples only when you
+intentionally want to manage the AWS baseline, secrets, and values layering
+yourself.
 
 For teams that want Terraform to own the AWS baseline around the chart, use the
 [Terraform AWS Baseline](terraform-aws-baseline.md) module for RDS, IRSA,
@@ -233,10 +240,6 @@ Use two layers.
 
 That keeps scan, fleet, runtime enforcement, and gateway policy aligned
 without pretending every workload needs the same enforcement model.
-
-For the current boundary between strong self-hosted tenant isolation and
-provider-style MSSP multi-tenancy, see
-[When To Use Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md).
 
 ## Helm Knobs That Matter
 


### PR DESCRIPTION
## Summary

- clarify the official deployment entrypoints in the README and deployment docs
- make the local, pilot, full self-hosted, proxy, and gateway paths more explicit
- reduce overlap between deployment-mode explanations so operators can see the recommended path faster
- keep the deeper architecture detail in docs instead of overloading the front page

## Why

`agent-bom` now has multiple strong deployment surfaces, but the docs were still easy to read as "many equivalent ways to do the same thing." This PR makes the recommended path clearer per deployment goal without changing runtime behavior.

## Validation

- `uv run mkdocs build --strict`
