### PR TITLE
docs(trust): define customer data and support boundary

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - Packaged API + UI Control Plane: deployment/control-plane-helm.md
       - Control-Plane Data Model and Store Parity: deployment/control-plane-data-model.md
       - Audit Chain vs Compliance Signing: deployment/audit-and-compliance-verification.md
+      - Customer Data and Support Boundary: deployment/customer-data-and-support-boundary.md
       - Data Retention by Class: deployment/data-retention.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Runtime Operations: deployment/runtime-operations.md

--- a/site-docs/architecture/auth-and-session-model.md
+++ b/site-docs/architecture/auth-and-session-model.md
@@ -80,6 +80,9 @@ That fallback is intentionally narrow:
 - it does not make the browser a trust anchor
 - the API still verifies the key and role on every request
 
+For the self-hosted data-ownership and support-sharing contract around these
+sessions, see [Customer Data and Support Boundary](../deployment/customer-data-and-support-boundary.md).
+
 ## Recommended self-hosted browser path
 
 For the cleanest enterprise deployment, use:

--- a/site-docs/deployment/customer-data-and-support-boundary.md
+++ b/site-docs/deployment/customer-data-and-support-boundary.md
@@ -1,0 +1,127 @@
+# Customer Data and Support Boundary
+
+This page defines the default self-hosted trust boundary for `agent-bom`.
+
+The short version:
+
+- customer findings, runtime events, audit, fleet, graph, and tenant data stay
+  in customer-controlled infrastructure by default
+- customer operators can review their own tenant-scoped logs, audit, and events
+  through the UI and API when their role allows it
+- `agent-bom` maintainers do **not** get silent access to customer content in
+  self-hosted deployments
+- outbound telemetry and support sharing are explicit operator choices, not
+  hidden defaults
+
+## What customer users can see
+
+For an authenticated user inside the customer tenant, the normal control-plane
+experience can include:
+
+- audit trail and auth/debug history
+- scan jobs and scan results
+- findings, graph, remediation, and compliance state
+- fleet inventory and MCP provenance
+- proxy and gateway audit, alerts, and runtime health
+- traces and pushed runtime results where those paths are enabled
+
+That access is still role-scoped:
+
+- `viewer` stays read-only
+- `analyst` can run and review operational workflows
+- `admin` can manage keys, policies, and other protected control-plane actions
+
+The UI may hide or disable actions for clarity, but the API remains the source
+of truth for what each role is allowed to read or mutate.
+
+## What stays customer-owned by default
+
+In the self-hosted model, these data classes stay in the customer's own control
+plane and storage tier unless the operator explicitly exports them elsewhere:
+
+- findings and remediation state
+- runtime events and runtime audit
+- fleet inventory and endpoint posture
+- graph nodes, edges, and correlated evidence
+- tenant-scoped auth and audit history
+- generated reports and compliance exports
+
+That is true whether the customer keeps the data in:
+
+- Postgres
+- ClickHouse
+- S3
+- Snowflake
+- OTEL / SIEM destinations they control
+
+## What `agent-bom` maintainers do not see by default
+
+In self-hosted deployments, `agent-bom` maintainers should not see customer
+tenant content by default.
+
+That includes:
+
+- findings payloads
+- prompts or tool arguments
+- audit contents
+- fleet inventories
+- tenant business data
+- credential-backed configuration details
+
+Self-hosted means the customer operates the control plane and owns the data
+plane. There is no silent vendor backhaul.
+
+## Minimal product-health telemetry
+
+If a customer later wants to share narrow product-health telemetry, the safest
+default is a minimal, opt-in set such as:
+
+- auth success or failure counts
+- error classes and crash reports
+- request IDs and trace IDs
+- anonymized session IDs
+- product version and deployment mode
+- component health and route-level latency classes
+
+This is product-health telemetry, not customer content telemetry.
+
+## Optional exports and interoperability
+
+`agent-bom` is designed so the customer can send their own data to the systems
+they already trust.
+
+Common export paths include:
+
+- OTEL collectors
+- Splunk
+- Elastic
+- Datadog
+- Snowflake
+- ClickHouse
+- customer-managed archive and evidence stores
+
+Those exports are customer-controlled integrations. They are not hidden vendor
+telemetry.
+
+## Support access and support bundles
+
+The safe support model is:
+
+- support access is explicit
+- support sharing is revocable
+- support access is auditable
+- support data is customer-selected
+
+Today the product already supports a redaction-friendly support bundle flow in
+the UI help surface. That gives operators a copyable bundle for debugging and
+bug reports without sending hidden telemetry automatically.
+
+If a customer needs deeper support later, the recommended model is:
+
+- customer-generated support bundle
+- explicit export to the destination they choose
+- time-bounded break-glass access only when the operator approves it
+
+## One-sentence policy
+
+`Customers own their findings, audit, runtime events, fleet data, and exports; agent-bom owners should only see minimal product-health telemetry when the customer explicitly opts in or shares support data.`

--- a/site-docs/deployment/enterprise-auth-and-tenancy.md
+++ b/site-docs/deployment/enterprise-auth-and-tenancy.md
@@ -16,6 +16,10 @@ resolve onto the same control-plane model.
 For the browser-to-API trust split inside the self-hosted control plane, see
 [UI, API, Auth, and Session Model](../architecture/auth-and-session-model.md).
 
+For the default self-hosted contract on who can see tenant logs, audit, and
+support data, see
+[Customer Data and Support Boundary](customer-data-and-support-boundary.md).
+
 ## What is especially strong
 
 - **Tenant context is not UI-only.**

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -126,6 +126,9 @@ For the post-install maintenance path around proxy policy-signing key rotation
 and cert-manager-backed webhook certificate renewal, see
 [Runtime Operations](runtime-operations.md).
 
+For the default self-hosted data-ownership and support-sharing boundary, see
+[Customer Data and Support Boundary](customer-data-and-support-boundary.md).
+
 ## How the surfaces connect
 
 | Path | Starts from | Ends at | Purpose |
@@ -148,6 +151,10 @@ remediation output, and proxy audit data stay inside the customer's
 infrastructure. External egress only happens when the operator explicitly enables
 it for catalog refresh, enrichment, registry lookups, SIEM export, OTLP, or
 webhooks.
+
+That same self-hosted boundary also means `agent-bom` maintainers do not get
+silent access to tenant data. For the full operator-facing contract, see
+[Customer Data and Support Boundary](customer-data-and-support-boundary.md).
 
 ## Which Service Does What
 


### PR DESCRIPTION
## Summary
- add one operator-facing page for the self-hosted customer-data, telemetry, and support-sharing boundary
- clarify what customer tenant users can see, what stays customer-owned by default, and what agent-bom maintainers do not see by default
- link the boundary from deployment and auth docs without repeating the full policy text in multiple places

## Testing
- uv run mkdocs build --strict
