### PR TITLE
feat(runtime): harden optional monitor daemonset

### DIFF
--- a/deploy/helm/agent-bom/templates/_helpers.tpl
+++ b/deploy/helm/agent-bom/templates/_helpers.tpl
@@ -38,6 +38,17 @@ Gateway service account name.
 {{- end }}
 
 {{/*
+Monitor service account name.
+*/}}
+{{- define "agent-bom.monitorServiceAccountName" -}}
+{{- if .Values.monitor.serviceAccount.create }}
+{{- default (printf "%s-monitor" (include "agent-bom.name" .)) .Values.monitor.serviceAccount.name }}
+{{- else }}
+{{- default (include "agent-bom.serviceAccountName" .) .Values.monitor.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Sidecar injector full name.
 */}}
 {{- define "agent-bom.sidecarInjectorName" -}}

--- a/deploy/helm/agent-bom/templates/daemonset.yaml
+++ b/deploy/helm/agent-bom/templates/daemonset.yaml
@@ -22,7 +22,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ include "agent-bom.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      serviceAccountName: {{ include "agent-bom.monitorServiceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/agent-bom/templates/serviceaccount.yaml
+++ b/deploy/helm/agent-bom/templates/serviceaccount.yaml
@@ -32,6 +32,22 @@ metadata:
   {{- end }}
 {{- end }}
 
+{{- if and .Values.monitor.enabled .Values.monitor.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-bom.monitorServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitor
+  {{- with .Values.monitor.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
 {{- if and .Values.scanner.enabled .Values.scanner.serviceAccount.create }}
 ---
 apiVersion: v1

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -46,6 +46,10 @@ monitor:
   enabled: false
   mode: http
   port: 8423
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
   service:
     enabled: true
     type: ClusterIP

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -17,10 +17,11 @@ spec:
         app.kubernetes.io/name: agent-bom
         app.kubernetes.io/component: monitor
     spec:
+      automountServiceAccountToken: false
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.81.0
+          image: agentbom/agent-bom:0.81.1
           command: ["agent-bom"]
           args:
             - "protect"

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -46,7 +46,8 @@ When you set `controlPlane.enabled=true`, the Helm chart can package:
 - UI Deployment + Service
 - same-origin Ingress that routes API paths to the API service and `/` to the UI
 - scanner CronJob
-- optional runtime monitor DaemonSet
+- optional runtime monitor DaemonSet with a dedicated service account and no
+  automounted service-account token by default
 
 The image split is intentional:
 
@@ -109,6 +110,9 @@ The chart packages the control plane, but it does not quietly weaken the
 runtime model.
 
 - API and UI pods run with `automountServiceAccountToken: false`
+- the optional monitor DaemonSet now also runs with
+  `automountServiceAccountToken: false` and its own service-account path instead
+  of inheriting the shared chart identity
 - the discovery service account and IRSA path stay attached to the scanner
 - the API still refuses non-loopback startup without `AGENT_BOM_API_KEY`,
   OIDC, SAML-issued session keys, or an explicit insecure override

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -9,7 +9,7 @@ Located in `deploy/k8s/`:
 | `namespace.yaml` | `agent-bom` namespace |
 | `rbac.yaml` | ServiceAccount + ClusterRole (pod/namespace read) |
 | `cronjob.yaml` | Scheduled scan every 6 hours |
-| `daemonset.yaml` | Runtime protection on every node |
+| `daemonset.yaml` | Optional node-wide runtime monitor |
 | `sidecar-example.yaml` | Proxy sidecar alongside an MCP server |
 | `proxy-sidecar-pilot.yaml` | Focused EKS pilot sidecar pattern for selected MCP workloads |
 
@@ -60,7 +60,7 @@ agent-bom iac . --k8s-live --k8s-all-namespaces
 helm install agent-bom deploy/helm/agent-bom/ \
   -n agent-bom --create-namespace
 
-# Enable runtime monitoring
+# Enable the optional node-wide runtime monitor
 helm install agent-bom deploy/helm/agent-bom/ \
   -n agent-bom --create-namespace \
   --set monitor.enabled=true
@@ -86,8 +86,9 @@ helm install agent-bom deploy/helm/agent-bom/ \
 | `scanner.allNamespaces` | `true` | Scan all namespaces |
 | `scanner.extraArgs` | `[]` | Add scan flags like `--k8s-mcp`, `--enforce`, or `--introspect` |
 | `scanner.env` | `[]` | Extra environment variables for the scanner CronJob |
-| `monitor.enabled` | `false` | Deploy DaemonSet monitor |
+| `monitor.enabled` | `false` | Deploy the optional node-wide monitor DaemonSet |
 | `monitor.port` | `8423` | HTTP port for protect endpoint |
+| `monitor.serviceAccount.create` | `true` | Create a dedicated monitor service account instead of reusing the shared chart identity |
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments and Services |
 | `controlPlane.ingress.enabled` | `false` | Add same-origin ingress routing for UI + API |
 | `controlPlane.ui.env` | `NEXT_PUBLIC_API_URL=\"\"` | Blank by default so the browser uses same-origin paths |
@@ -98,6 +99,14 @@ helm install agent-bom deploy/helm/agent-bom/ \
 
 For the full control-plane topology and secret wiring, see
 [Packaged API + UI Control Plane](control-plane-helm.md).
+
+Use the monitor only when you explicitly want node-wide runtime coverage. The
+default secure path remains:
+
+- agentless scans
+- fleet sync
+- gateway for shared remote MCPs
+- selected sidecar proxies where inline enforcement matters
 
 For the narrower MCP and agents pilot, see
 [Focused EKS MCP Pilot](eks-mcp-pilot.md).

--- a/site-docs/deployment/runtime-monitoring.md
+++ b/site-docs/deployment/runtime-monitoring.md
@@ -19,7 +19,15 @@ The runtime proxy (`agent-bom proxy`) intercepts MCP JSON-RPC messages between c
 | Local sidecar | `agent-bom proxy -- npx server` | Dev/testing |
 | Docker sidecar | See [Docker](docker.md) | Production |
 | K8s sidecar | See [Kubernetes](kubernetes.md) | Fleet |
+| Optional node-wide monitor | Helm `monitor.enabled=true` | Broad runtime coverage only when a team explicitly accepts a DaemonSet |
 | Config watcher | `agent-bom watch` | Drift alerting |
+
+The node-wide monitor is:
+
+- optional
+- off by default
+- not required for scan/discovery, fleet, gateway, or selected sidecar proxy rollout
+- the highest-trust runtime shape, so it should be enabled only when the operator wants per-node runtime coverage
 
 ## Alert routing
 


### PR DESCRIPTION
## Summary
- give the optional monitor DaemonSet its own service-account path instead of inheriting the shared chart identity
- disable automounted service-account tokens on the monitor by default
- clarify in the runtime/kubernetes/control-plane docs that the monitor is optional, off by default, and not required for scan/discovery, gateway, or selected sidecar proxy rollout
- align the static DaemonSet manifest with the current image tag and token-mount hardening

## Testing
- uv run mkdocs build --strict
- template validation by inspection (Helm CLI not available in this environment)

Closes #1717
