### PR TITLE
docs(deploy): simplify official entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ Backend defaults:
 |---|---|
 | fastest local pilot | [Deployment Overview](site-docs/deployment/overview.md) |
 | self-host in your AWS / EKS | [Deploy In Your Own AWS / EKS Infrastructure](site-docs/deployment/own-infra-eks.md) |
-| reference AWS rollout from cluster creation onward | [AWS Company Rollout](site-docs/deployment/aws-company-rollout.md) |
 | endpoint inventory and laptop rollout | [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md) |
 | proxy and gateway runtime operations | [Runtime Operations](site-docs/deployment/runtime-operations.md) |
 | trust model, auth, tenant isolation | [ENTERPRISE_SECURITY_PLAYBOOK.md](docs/ENTERPRISE_SECURITY_PLAYBOOK.md) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,16 +92,16 @@ nav:
   - Deployment:
       - Overview: deployment/overview.md
       - Deployment Modes and Alignment: deployment/deployment-modes-and-alignment.md
-      - AWS Company Rollout: deployment/aws-company-rollout.md
+      - AWS Company Rollout (Reference): deployment/aws-company-rollout.md
       - Enterprise Auth and Tenancy: deployment/enterprise-auth-and-tenancy.md
       - Enterprise MCP / Endpoint Pilot: deployment/enterprise-pilot.md
       - Endpoint Fleet: deployment/endpoint-fleet.md
       - Proxy vs Gateway vs Fleet: deployment/proxy-vs-gateway-vs-fleet.md
       - Focused EKS MCP Pilot: deployment/eks-mcp-pilot.md
       - Your Own AWS / EKS: deployment/own-infra-eks.md
-      - Terraform AWS Baseline: deployment/terraform-aws-baseline.md
-      - Postgres Provisioning Workflow: deployment/postgres-provisioning.md
-      - Packaged API + UI Control Plane: deployment/control-plane-helm.md
+      - Terraform AWS Baseline (Reference): deployment/terraform-aws-baseline.md
+      - Postgres Provisioning Workflow (Reference): deployment/postgres-provisioning.md
+      - Packaged API + UI Control Plane (Reference): deployment/control-plane-helm.md
       - Control-Plane Data Model and Store Parity: deployment/control-plane-data-model.md
       - Audit Chain vs Compliance Signing: deployment/audit-and-compliance-verification.md
       - Customer Data and Support Boundary: deployment/customer-data-and-support-boundary.md
@@ -114,11 +114,11 @@ nav:
       - Backend Parity: deployment/backend-parity.md
       - Backend and Security-Lake Strategy: deployment/backend-and-security-lakes.md
       - Snowflake-Native Backend: deployment/snowflake-backend.md
-      - Docker: deployment/docker.md
-      - Kubernetes: deployment/kubernetes.md
+      - Docker (Reference): deployment/docker.md
+      - Kubernetes (Reference): deployment/kubernetes.md
       - SIEM Integration: deployment/siem-integration.md
-      - Runtime Monitoring: deployment/runtime-monitoring.md
-      - Grafana Dashboard: deployment/grafana.md
+      - Runtime Monitoring (Optional): deployment/runtime-monitoring.md
+      - Grafana Dashboard (Reference): deployment/grafana.md
   - Architecture:
       - Overview: architecture/overview.md
       - How Agent-BOM Works: architecture/how-agent-bom-works.md

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -18,7 +18,12 @@ Plane](gateway-auto-discovery.md).
 - `agentbom/agent-bom` for scanner, API, jobs, proxy, gateway, and workers
 - `agentbom/agent-bom-ui` for the browser dashboard
 
-## Official Entry Points
+Use [Deployment Overview](overview.md) first if you still need to choose a
+path. Use [Deploy In Your Own AWS / EKS Infrastructure](own-infra-eks.md) for
+the paved production rollout. This page is the deeper AWS reference once that
+decision is already made.
+
+## Reference Entry Points
 
 Pilot on one workstation:
 
@@ -27,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docke
 docker compose -f docker-compose.pilot.yml up -d
 ```
 
-Recommended full self-hosted AWS / EKS rollout:
+Reference full self-hosted AWS / EKS rollout:
 
 ```bash
 scripts/deploy/install-eks-reference.sh \

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -4,6 +4,10 @@
 and dashboard inside their own Kubernetes environment instead of running custom
 Deployment manifests by hand.
 
+If you still need to choose a path, start with [Deployment Overview](overview.md).
+Use this page after you already know you want the chart itself, either through
+the reference installer or your own Helm layering.
+
 This is the right path when you want:
 
 - the API and UI in your own cluster

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -3,6 +3,10 @@
 Use this page for containerized entrypoints. `agent-bom` is one product with
 two deployable images:
 
+If you still need to choose a deployment path, start with
+[Deployment Overview](overview.md). This page is Docker-specific reference
+material after that decision, not the primary production rollout guide.
+
 - `agentbom/agent-bom` = the main runtime image for CLI scans, the API,
   scanner jobs, gateway, MCP server mode, and other non-browser entrypoints
 - `agentbom/agent-bom-ui` = the standalone browser UI image used when the

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -8,6 +8,10 @@ open-source control plane for:
 - gateway policy management
 - selected inline proxy enforcement
 
+If you still need to choose between pilot and production rollout paths, start
+with [Deployment Overview](overview.md). This page is the narrower pilot guide
+once you have already chosen that shape.
+
 It is intentionally not an EDR-style managed agent product. The current
 contract is opt-in endpoint scans plus self-hosted control-plane and proxy
 surfaces.

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -1,5 +1,9 @@
 # Kubernetes Deployment
 
+If you still need to choose a rollout path, start with
+[Deployment Overview](overview.md). This page is Kubernetes reference material
+for teams that already know they want raw manifests or direct chart controls.
+
 ## Pre-built manifests
 
 Located in `deploy/k8s/`:

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -4,6 +4,10 @@ Use this page when the question is not "how do I install `agent-bom`?" but
 "what should I deploy first, what does that give me, and when do I add runtime
 enforcement?"
 
+Treat this as the primary deployment chooser. The rest of the deployment docs
+either deepen one of these supported paths or act as reference material for
+teams intentionally diverging from them.
+
 `agent-bom` is one product with two deployable images:
 
 - `agentbom/agent-bom` for scanner, API, jobs, gateway, proxy, and other non-browser runtimes
@@ -75,13 +79,24 @@ Use these first:
 | One-machine pilot | `deploy/docker-compose.pilot.yml` | fastest path to API + UI with the shipped images |
 | Full self-hosted deployment in your own AWS / EKS | `scripts/deploy/install-eks-reference.sh` | creates or targets EKS, wires the AWS baseline, installs Helm, and prints verify/next-step commands |
 
-Use these only when you are intentionally going off the paved path:
+Everything else is either advanced or specialized:
 
 | Entry point | Use when |
 |---|---|
 | `helm upgrade --install ... -f deploy/helm/agent-bom/examples/eks-production-values.yaml` | you already manage your own Helm layering and do not want the reference installer |
 | `deploy/docker-compose.fullstack.yml` | you want a fuller local compose example on one machine, not the recommended production path |
 | `deploy/docker-compose.platform.yml` / `deploy/docker-compose.runtime.yml` | you are developing or demonstrating one part of the product surface, not doing the standard install |
+
+## Supported path map
+
+Use these pages in this order:
+
+| If you need... | Read this first | Then use... |
+|---|---|---|
+| the fastest pilot | this page | `deploy/docker-compose.pilot.yml` |
+| the paved production rollout | this page | [Deploy In Your Own AWS / EKS Infrastructure](own-infra-eks.md) |
+| a focused endpoint + MCP pilot | this page | [Enterprise MCP / Endpoint Pilot](enterprise-pilot.md) |
+| raw Helm, Docker, Terraform, or Kubernetes details | this page | the matching reference page only after you know you are leaving the paved path |
 
 ## Deployment modes
 


### PR DESCRIPTION
Summary
- make the paved pilot and production entrypoints the only primary starts across README and deployment docs
- demote Docker, Kubernetes, raw Helm, and the AWS company rollout to explicit reference material
- label the deployment nav so advanced and optional pages stop reading like equal starting points

Testing
- uv run mkdocs build --strict

Closes #1715
Refs #1719