### PR TITLE
docs(deploy): separate self-hosted and MSSP maturity

### DIFF
--- a/site-docs/deployment/customer-data-and-support-boundary.md
+++ b/site-docs/deployment/customer-data-and-support-boundary.md
@@ -85,6 +85,20 @@ default is a minimal, opt-in set such as:
 
 This is product-health telemetry, not customer content telemetry.
 
+## Self-hosted boundary vs provider operations
+
+This page describes the self-hosted default:
+
+- customer operators use the product inside their own infra
+- customer tenants see their own data by role
+- `agent-bom` maintainers do not silently inherit access
+
+That is intentionally different from a future provider-style or MSSP operating
+model where one operator plane serves many customer organizations. If that
+product track expands later, it should still preserve explicit access,
+auditable support flows, and least-privilege defaults instead of weakening the
+self-hosted trust boundary described here.
+
 ## Optional exports and interoperability
 
 `agent-bom` is designed so the customer can send their own data to the systems

--- a/site-docs/deployment/enterprise-auth-and-tenancy.md
+++ b/site-docs/deployment/enterprise-auth-and-tenancy.md
@@ -52,7 +52,8 @@ support data, see
 - **Current multi-tenancy is strong for self-hosted teams, not yet turnkey MSSP.**
   Tenant isolation is enforced in auth, stores, audit, fleet, and now shared
   gateway routing, but provider-style tenant lifecycle automation and richer
-  delegation/admin surfaces are still later work.
+  delegation/admin surfaces are still later work. That is a separate maturity
+  track, not something the self-hosted deployment story is trying to imply.
 
 ## Auth modes
 
@@ -267,6 +268,25 @@ That means:
 For the full architecture contract, including request integrity, audit, and the
 recommended hosted/session evolution path, see
 [UI, API, Auth, and Session Model](../architecture/auth-and-session-model.md).
+
+## Self-hosted teams vs provider-style operators
+
+The supported strength today is:
+
+- a company or platform team running one self-hosted control plane for its own
+  organization
+- tenant-scoped auth, RBAC, audit, fleet, stores, and shared gateway routing
+- customer-owned data, storage, and telemetry choices
+
+That is not the same claim as:
+
+- a provider operating one control plane for many customer organizations
+- turnkey tenant onboarding lifecycle APIs
+- richer per-tenant delegation templates and quota surfaces
+- provider-style admin UX and support workflows
+
+Those provider/MSSP surfaces are a later product track. They should not be
+inferred from current self-hosted auth and tenancy strength.
 
 ## Honest security claim
 

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -141,6 +141,18 @@ This self-hosted shape is designed around a few explicit operating principles:
 - **Cheap by default**: scan workers scale to zero, offline vuln DB reduces repeated network lookups, ClickHouse stays optional
 - **Interoperable**: one shared graph and policy model spans scanner, proxy, gateway, fleet, and API/UI
 
+## Self-hosted now, provider track later
+
+The supported strength today is the self-hosted enterprise path:
+
+- one organization running `agent-bom` in its own infrastructure
+- strong tenant-aware auth, RBAC, audit, fleet, graph, and gateway routing
+- customer-owned storage, telemetry, and support-sharing decisions
+
+That should not be read as a hidden claim of turnkey MSSP maturity. Provider
+surfaces such as tenant lifecycle automation, richer delegation templates, and
+provider-style admin operations remain a separate product track.
+
 ## Enterprise Self-Hosted Diagrams
 
 Use two diagrams, not one overloaded graph:

--- a/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
+++ b/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
@@ -273,7 +273,8 @@ That is a product-shape tradeoff, not hidden drift:
   stores, audit, fleet, and shared gateway routing, but `agent-bom` is not yet
   a turnkey "one provider serving many customer orgs" platform. The main gaps
   are tenant lifecycle automation, richer per-tenant delegation/templates, and
-  stronger provider-style quota and admin surfaces.
+  stronger provider-style quota and admin surfaces. That provider maturity is a
+  separate track from the current self-hosted platform story.
 - **Auto-injected runtime sidecars everywhere**: proxy and gateway are
   productized, but broad operator-driven sidecar attachment is still selective,
   not a universal default rollout.


### PR DESCRIPTION
Summary
- make the self-hosted enterprise story explicitly distinct from provider-style MSSP maturity
- clarify in auth, deployment, and runtime docs that current tenant strength is for customer-operated control planes
- keep provider lifecycle, delegation, and admin surfaces framed as a separate product track

Testing
- uv run mkdocs build --strict

Closes #1716
Refs #1719