### PR TITLE
docs(deploy): sharpen Snowflake parity boundaries

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -12,7 +12,7 @@ product split.
 | `focused-pilot` | `eks-mcp-pilot-values.yaml` | Narrow EKS pilot with control plane, scanner, and tightened ingress |
 | `production` | `eks-production-values.yaml` | Postgres-backed production EKS rollout with autoscaling, backup, and ExternalSecrets |
 | `mesh-hardening` | `eks-istio-kyverno-values.yaml` | Overlay for Istio mTLS/authz and Kyverno policy-controller packaging |
-| `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake-backed analytics/export deployments |
+| `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake governance and selected store parity, not a claim of full control-plane replacement |
 | `gateway-runtime` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` | Focused pilot plus central gateway rendering for shared MCP relay/policy |
 
 ## Validate the shipped profiles
@@ -63,4 +63,5 @@ python scripts/install_helm_profile.py production \
 - Use `sqlite-pilot` only for demos or single-node packaged pilots.
 - Move to `production` once Postgres, ingress, and backup ownership are real.
 - Treat `mesh-hardening` and `snowflake-backend` as overlays, not separate products.
+- Treat `snowflake-backend` as a warehouse-native deployment mode with explicit parity boundaries, not the default production path.
 - Gateway remains an optional runtime surface layered onto the control plane, not a mandatory chokepoint.

--- a/site-docs/deployment/backend-and-security-lakes.md
+++ b/site-docs/deployment/backend-and-security-lakes.md
@@ -80,6 +80,10 @@ Use when:
 - they want warehouse-native joins and governance workflows
 - the documented Snowflake parity boundary is acceptable
 
+This should be read as a supported security-lake and governance mode, not as a
+claim that every transactional control-plane surface has already reached
+Snowflake parity.
+
 ### 4. Future lakehouse export target
 
 - control plane on `Postgres`
@@ -98,6 +102,13 @@ The product posture should be:
   already documented and implemented
 - `Databricks` is a supported direction for lakehouse export and governance once
   the implementation exists
+
+The operator rule stays simple:
+
+- default to `Postgres` for the control plane
+- add `ClickHouse` for event-scale analytics
+- choose `Snowflake` when warehouse-native governance or selected store parity
+  is the actual goal
 
 That keeps the story accurate without understating how customers actually run
 security lakes.

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -54,6 +54,32 @@ The key distinction is:
 
 These are related, but not interchangeable.
 
+## Snowflake parity target
+
+The Snowflake story should be read in three layers:
+
+1. **Current shipped parity**
+   - `scan_jobs`
+   - `fleet_agents`
+   - `gateway_policies`
+   - `policy_audit_log`
+   - governance and activity discovery routes
+2. **Current explicit non-parity**
+   - source registry
+   - exceptions
+   - API keys and RBAC persistence
+   - schedules
+   - graph persistence
+   - trend and baseline state
+   - full HMAC-chained `audit_log`
+3. **Next parity targets, if warehouse-native control-plane coverage expands**
+   - source registry
+   - schedules
+   - selected baseline/trend state
+
+That means Snowflake is already a real backend mode, but it is still not the
+same claim as “full transactional replacement for Postgres.”
+
 For the exact logical entity → table/store mapping, see
 [Control-Plane Data Model and Store Parity](control-plane-data-model.md).
 
@@ -111,6 +137,18 @@ Current limitations:
 
 That makes Snowflake viable for selected control-plane paths, but not yet a full transactional replacement for Postgres.
 
+Recommended fit:
+
+- teams already governed around Snowflake
+- warehouse-native inventory, policy, and fleet history
+- governance-heavy deployments where Snowflake is already the source of record
+
+Not the best fit:
+
+- broad control-plane admin workflows
+- API-key-heavy operational setups
+- graph-first operator workflows that expect backend-complete parity today
+
 ### 3. Warehouse-native governance mode
 
 Use when the primary goal is:
@@ -124,6 +162,12 @@ This mode is compatible with:
 - local CLI scans
 - API/UI deployments
 - hybrid control planes where the warehouse is the authoritative governance data source
+
+The practical shape is:
+
+- `Postgres` remains the easiest full control-plane default
+- `Snowflake` can be the warehouse-native governance and selected-store backend
+- customers can still export or mirror data without locking the product model to one backend
 
 ## Recommended Selection
 

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -11,6 +11,16 @@ chain) have not been ported to `SnowflakeStore` yet. See
 [backend-parity.md](backend-parity.md) for the current capability
 matrix.
 
+The safest way to think about this mode is:
+
+- **real and supported**
+- **warehouse-native**
+- **not universal parity**
+
+It is the right answer for teams that want Snowflake-native inventory, fleet,
+policy, and governance workflows. It is not the default answer for every
+self-hosted control-plane deployment.
+
 ---
 
 ## When Snowflake is the right fit
@@ -47,6 +57,44 @@ Pick Postgres when you want broad API surface coverage and the fastest
 possible install, and you're comfortable adding ClickHouse only if
 audit/event volume justifies it. Pick Snowflake when you'd rather
 collapse both into one unified stack.
+
+## Supported Snowflake deployment modes
+
+### 1. Snowflake governance mode
+
+Use when you mainly want:
+
+- governance discovery
+- activity and observability joins
+- warehouse-native reporting and investigations
+
+In this mode, Snowflake is primarily the governance and security-lake system of
+record, while the rest of the control plane can remain on the default backend.
+
+### 2. Snowflake selected control-plane mode
+
+Use when you want these persisted in Snowflake:
+
+- scan jobs
+- fleet inventory
+- gateway policies
+- gateway policy audit
+
+This is the current partial-control-plane mode backed by
+`SnowflakeJobStore`, `SnowflakeFleetStore`, and `SnowflakePolicyStore`.
+
+### 3. Hybrid self-hosted control plane
+
+Use when you want:
+
+- `Postgres` for the broadest transactional control-plane coverage
+- `Snowflake` for governance, warehouse joins, and selected mirrored or
+  warehouse-native paths
+- optional `ClickHouse` only if event analytics scale justifies it
+
+This is often the cleanest enterprise answer because it keeps the default
+control-plane semantics broad while still respecting warehouse-centric data
+governance.
 
 ## Auth — zero-credential model
 
@@ -158,3 +206,11 @@ applies here. Snowflake-specific signals worth alerting on:
   ([`src/agent_bom/cloud/snowflake.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/cloud/snowflake.py)).
 - Time Travel + Fail-safe provide durability, but configure a retention
   window that matches your compliance retention policy.
+
+## Honest operator summary
+
+`Snowflake` is already a valid warehouse-native backend mode for governance,
+scan inventory, fleet state, and gateway policy paths. `Postgres` remains the
+default full control-plane answer. Use Snowflake when that warehouse-native
+shape is the goal, not because the product is pretending all backend roles are
+already identical.


### PR DESCRIPTION
Summary
- define the current Snowflake parity target and explicit non-parity areas
- document supported Snowflake deployment modes for governance, selected store parity, and hybrid self-hosted control planes
- align the security-lake and Helm profile docs so Snowflake reads as a real bounded mode, not a universal backend overclaim

Testing
- uv run mkdocs build --strict

Refs #1366