### PR TITLE
fix(runtime): harden shield concurrency and rate limiting

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -8,6 +8,7 @@ import logging
 import os
 import secrets
 import sys
+import threading
 import time
 import uuid
 from functools import lru_cache
@@ -102,34 +103,37 @@ class InMemoryRateLimitStore:
         self._window = window_seconds
         self._hits: dict[str, list[float]] = {}
         self._last_cleanup = time.time()
+        self._lock = threading.RLock()
 
     def _cleanup(self, now: float) -> None:
         """Prune stale entries to prevent unbounded memory growth."""
-        if now - self._last_cleanup < self._window:
-            return
-        self._last_cleanup = now
-        stale = [k for k, v in self._hits.items() if not v or v[-1] < now - self._window]
-        for k in stale:
-            del self._hits[k]
-        if len(self._hits) > self._MAX_ENTRIES:
-            overflow = len(self._hits) - self._MAX_ENTRIES
-            oldest_keys = sorted(self._hits, key=lambda key: self._hits[key][-1] if self._hits[key] else 0.0)[:overflow]
-            for key in oldest_keys:
-                del self._hits[key]
-            _logger.warning(
-                "In-memory rate limiter pruned %s oldest buckets to stay under %s entries",
-                overflow,
-                self._MAX_ENTRIES,
-            )
+        with self._lock:
+            if now - self._last_cleanup < self._window:
+                return
+            self._last_cleanup = now
+            stale = [k for k, v in self._hits.items() if not v or v[-1] < now - self._window]
+            for k in stale:
+                del self._hits[k]
+            if len(self._hits) > self._MAX_ENTRIES:
+                overflow = len(self._hits) - self._MAX_ENTRIES
+                oldest_keys = sorted(self._hits, key=lambda key: self._hits[key][-1] if self._hits[key] else 0.0)[:overflow]
+                for key in oldest_keys:
+                    del self._hits[key]
+                _logger.warning(
+                    "In-memory rate limiter pruned %s oldest buckets to stay under %s entries",
+                    overflow,
+                    self._MAX_ENTRIES,
+                )
 
     def hit(self, key: str, now: float) -> tuple[int, int]:
         """Record a request and return (hit_count, reset_epoch)."""
-        self._cleanup(now)
-        timestamps = [t for t in self._hits.get(key, []) if now - t < self._window]
-        timestamps.append(now)
-        self._hits[key] = timestamps
-        reset_at = int((timestamps[0] if timestamps else now) + self._window)
-        return len(timestamps), reset_at
+        with self._lock:
+            self._cleanup(now)
+            timestamps = [t for t in self._hits.get(key, []) if now - t < self._window]
+            timestamps.append(now)
+            self._hits[key] = timestamps
+            reset_at = int((timestamps[0] if timestamps else now) + self._window)
+            return len(timestamps), reset_at
 
 
 class PostgresRateLimitStore:

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -251,3 +251,11 @@ MCP_CALLER_RATE_LIMIT = _int("AGENT_BOM_MCP_CALLER_RATE_LIMIT", 120)
 MCP_CALLER_WINDOW_SECONDS = _float("AGENT_BOM_MCP_CALLER_WINDOW_SECONDS", 60.0)
 MCP_MAX_CALLER_STATES = _int("AGENT_BOM_MCP_MAX_CALLER_STATES", 256)
 MCP_MAX_REQUEST_TRACES = _int("AGENT_BOM_MCP_MAX_REQUEST_TRACES", 256)
+
+
+# ── Shield async bridge limits ───────────────────────────────────────────
+# The synchronous Shield SDK can be called from inside a running event loop.
+# Use a small shared pool for that bridge instead of spawning a fresh unbounded
+# executor per call.
+
+SHIELD_ASYNC_BRIDGE_MAX_WORKERS = _int("AGENT_BOM_SHIELD_ASYNC_BRIDGE_MAX_WORKERS", 4)

--- a/src/agent_bom/shield.py
+++ b/src/agent_bom/shield.py
@@ -24,6 +24,10 @@ Zero external dependencies beyond agent-bom itself.
 
 from __future__ import annotations
 
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+from agent_bom.config import SHIELD_ASYNC_BRIDGE_MAX_WORKERS
 from agent_bom.runtime.detectors import (
     CredentialLeakDetector,
 )
@@ -32,6 +36,23 @@ from agent_bom.runtime.protection import (
     ShieldAssessment,
     ThreatLevel,
 )
+
+_SHIELD_ASYNC_BRIDGE = ThreadPoolExecutor(
+    max_workers=max(SHIELD_ASYNC_BRIDGE_MAX_WORKERS, 1),
+    thread_name_prefix="agent-bom-shield",
+)
+
+
+def _run_async_bridge(coro):
+    """Run a Shield coroutine from sync code, even inside an active event loop."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        return _SHIELD_ASYNC_BRIDGE.submit(asyncio.run, coro).result()
+    return asyncio.run(coro)
 
 
 class Shield:
@@ -82,23 +103,7 @@ class Shield:
         Runs all request-path detectors: argument analysis, rate limiting,
         sequence analysis. Returns alert dicts for any findings.
         """
-        import asyncio
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            # Already in async context — create task
-            import concurrent.futures
-
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                return pool.submit(
-                    asyncio.run,
-                    self._engine.process_tool_call(tool_name, arguments),
-                ).result()
-        return asyncio.run(self._engine.process_tool_call(tool_name, arguments))
+        return _run_async_bridge(self._engine.process_tool_call(tool_name, arguments))
 
     def check_response(self, tool_name: str, response_text: str) -> list[dict]:
         """Check a tool response for credential leaks, injection, cloaking.
@@ -106,41 +111,11 @@ class Shield:
         Runs all response-path detectors: credential leak, PII detection,
         response inspection, vector DB injection.
         """
-        import asyncio
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            import concurrent.futures
-
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                return pool.submit(
-                    asyncio.run,
-                    self._engine.process_tool_response(tool_name, response_text),
-                ).result()
-        return asyncio.run(self._engine.process_tool_response(tool_name, response_text))
+        return _run_async_bridge(self._engine.process_tool_response(tool_name, response_text))
 
     def check_drift(self, current_tools: list[str]) -> list[dict]:
         """Check for tool drift (new tools appearing after baseline)."""
-        import asyncio
-
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            import concurrent.futures
-
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                return pool.submit(
-                    asyncio.run,
-                    self._engine.check_tool_drift(current_tools),
-                ).result()
-        return asyncio.run(self._engine.check_tool_drift(current_tools))
+        return _run_async_bridge(self._engine.check_tool_drift(current_tools))
 
     @staticmethod
     def redact(text: str) -> str:

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -616,6 +617,22 @@ def test_in_memory_rate_limit_store_prunes_oldest_entries_instead_of_clearing_al
     assert count == 2
     assert "important" in store._hits
     assert len(store._hits) <= store._MAX_ENTRIES
+
+
+def test_in_memory_rate_limit_store_is_thread_safe_for_same_bucket():
+    """Concurrent hits on one bucket should not lose updates."""
+    store = InMemoryRateLimitStore(window_seconds=60)
+    now = time.time()
+
+    def _hit() -> int:
+        count, _ = store.hit("shared-bucket", now)
+        return count
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        counts = list(pool.map(lambda _: _hit(), range(64)))
+
+    assert len(store._hits["shared-bucket"]) == 64
+    assert max(counts) == 64
 
 
 def test_max_body_size_middleware():

--- a/tests/test_shield.py
+++ b/tests/test_shield.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+from agent_bom.shield import Shield
+
+
+def test_shield_check_tool_call_uses_async_bridge_in_running_loop(monkeypatch):
+    shield = Shield()
+
+    async def fake_process_tool_call(tool_name: str, arguments: dict) -> list[dict]:
+        return [{"tool": tool_name, "arguments": arguments}]
+
+    class _Future:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self):
+            return self._value
+
+    submitted = {}
+
+    class _Executor:
+        def submit(self, fn, coro):
+            submitted["fn"] = fn
+            submitted["coro"] = coro
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                return _Future(pool.submit(fn, coro).result())
+
+    monkeypatch.setattr(shield._engine, "process_tool_call", fake_process_tool_call)
+    monkeypatch.setattr("agent_bom.shield._SHIELD_ASYNC_BRIDGE", _Executor())
+
+    async def _run():
+        return shield.check_tool_call("read_file", {"path": "/tmp/demo"})
+
+    result = asyncio.run(_run())
+
+    assert submitted["fn"] is asyncio.run
+    assert result == [{"tool": "read_file", "arguments": {"path": "/tmp/demo"}}]
+
+
+def test_shield_check_response_runs_without_async_loop(monkeypatch):
+    shield = Shield()
+
+    async def fake_process_tool_response(tool_name: str, response_text: str) -> list[dict]:
+        return [{"tool": tool_name, "response": response_text}]
+
+    monkeypatch.setattr(shield._engine, "process_tool_response", fake_process_tool_response)
+
+    result = shield.check_response("read_file", "ok")
+
+    assert result == [{"tool": "read_file", "response": "ok"}]


### PR DESCRIPTION
Summary
- replace per-call Shield ThreadPoolExecutor creation with a small shared async bridge
- add a bounded config knob for Shield async bridge workers
- make the in-memory API rate limiter explicitly thread-safe and add focused concurrency coverage

Testing
- .venv/bin/python -m pytest tests/test_shield.py tests/test_api_hardening.py -q
- uv run ruff check src/agent_bom/shield.py src/agent_bom/api/middleware.py tests/test_shield.py tests/test_api_hardening.py
- uv run mypy src/agent_bom/shield.py src/agent_bom/api/middleware.py