### PR TITLE
feat(auth): add UI session and capability contract

### DIFF
--- a/site-docs/architecture/auth-and-session-model.md
+++ b/site-docs/architecture/auth-and-session-model.md
@@ -96,6 +96,7 @@ That maps to the current runtime status surfaced by:
 
 - `GET /v1/auth/policy`
 - `GET /v1/auth/debug`
+- `GET /v1/auth/me`
 
 The current auth-policy endpoint already tells operators which UI mode is
 recommended:
@@ -155,8 +156,19 @@ The UI should use backend-provided auth/runtime state to drive experience:
 - current auth mode
 - resolved tenant
 - role
+- contributor/admin/viewer display semantics
 - allowed actions
 - current runtime policy mode
+
+The current UI-facing session contract now lives at:
+
+- `GET /v1/auth/me`
+
+That endpoint exists so the browser does not need to infer:
+
+- whether `analyst` should render as a contributor-level role in the UI
+- which actions should be enabled or disabled
+- what the current actor can see, do, and not do in the active tenant
 
 The browser may render a softer UX:
 

--- a/site-docs/deployment/enterprise-auth-and-tenancy.md
+++ b/site-docs/deployment/enterprise-auth-and-tenancy.md
@@ -80,9 +80,24 @@ and the route minimum-role map lives in
 Operationally:
 
 - `admin` can manage keys, policies, fleet writes, and configuration
-- `analyst` can run scans, push observability/runtime data, and create
+- `analyst` is the current backend role that the UI should present as a
+  **contributor** operator role; it can run scans, push observability/runtime data, and create
   exceptions
 - `viewer` is read-only
+
+The UI/session contract for that mapping now comes from:
+
+- `GET /v1/auth/me`
+
+That endpoint returns:
+
+- the authenticated actor and active tenant
+- the backend role (`admin` / `analyst` / `viewer`)
+- the UI role label (`admin` / `contributor` / `viewer`)
+- capability and access summaries the browser can use to explain:
+  - what the actor can see
+  - what the actor can do
+  - what remains blocked server-side
 
 ## Tenant propagation
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -334,6 +334,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("GET", "/v1/compliance", "viewer"),
         ("GET", "/v1/posture", "viewer"),
         ("GET", "/v1/auth/debug", "viewer"),
+        ("GET", "/v1/auth/me", "viewer"),
         ("GET", "/v1/auth/policy", "admin"),
         ("GET", "/v1/auth/keys", "admin"),
         ("POST", "/v1/auth/keys", "admin"),

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -50,6 +50,44 @@ router = APIRouter()
 _logger = logging.getLogger(__name__)
 
 
+def _auth_session_state(request: Request) -> dict:
+    """Build the current request's auth/session state without leaking secrets."""
+    from agent_bom.api.middleware import get_auth_runtime_status
+    from agent_bom.rbac import summarize_role
+
+    method = getattr(request.state, "auth_method", None)
+    subject = getattr(request.state, "api_key_name", None)
+    role = getattr(request.state, "api_key_role", None)
+    tenant_id = getattr(request.state, "tenant_id", None) or "default"
+    request_id = getattr(request.state, "request_id", None)
+    trace_id = getattr(request.state, "trace_id", None)
+    span_id = getattr(request.state, "span_id", None)
+    issuer = getattr(request.state, "auth_issuer", None)
+    key_id = getattr(request.state, "api_key_id", None)
+    key_id_prefix = key_id[:8] if isinstance(key_id, str) else None
+
+    authenticated = bool(method and role)
+    auth_runtime = get_auth_runtime_status()
+    role_summary = summarize_role(role)
+
+    return {
+        "authenticated": authenticated,
+        "auth_required": auth_runtime["auth_required"],
+        "configured_modes": auth_runtime["configured_modes"],
+        "recommended_ui_mode": auth_runtime["recommended_ui_mode"],
+        "auth_method": method,
+        "subject": subject,
+        "role": role,
+        "tenant_id": tenant_id,
+        "oidc_issuer_suffix": issuer,
+        "api_key_id_prefix": key_id_prefix,
+        "request_id": request_id,
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "role_summary": role_summary,
+    }
+
+
 # ── API Key Management (RBAC) ───────────────────────────────────────────────
 
 
@@ -243,35 +281,55 @@ async def auth_debug(request: Request) -> dict:
     non-secret identifying attributes (name, key_id prefix, role, tenant,
     auth method) so the endpoint is safe to log.
     """
-    from agent_bom.api.middleware import get_auth_runtime_status
-
-    method = getattr(request.state, "auth_method", None)
-    subject = getattr(request.state, "api_key_name", None)
-    role = getattr(request.state, "api_key_role", None)
-    tenant_id = getattr(request.state, "tenant_id", None) or "default"
-    request_id = getattr(request.state, "request_id", None)
-    trace_id = getattr(request.state, "trace_id", None)
-    span_id = getattr(request.state, "span_id", None)
-    issuer = getattr(request.state, "auth_issuer", None)
-    key_id = getattr(request.state, "api_key_id", None)
-    key_id_prefix = key_id[:8] if isinstance(key_id, str) else None
-
-    authenticated = bool(method and role)
-    auth_runtime = get_auth_runtime_status()
+    state = _auth_session_state(request)
     return {
-        "authenticated": authenticated,
-        "auth_required": auth_runtime["auth_required"],
-        "configured_modes": auth_runtime["configured_modes"],
-        "recommended_ui_mode": auth_runtime["recommended_ui_mode"],
-        "auth_method": method,
-        "subject": subject,
-        "role": role,
-        "tenant_id": tenant_id,
-        "oidc_issuer_suffix": issuer,
-        "api_key_id_prefix": key_id_prefix,
-        "request_id": request_id,
-        "trace_id": trace_id,
-        "span_id": span_id,
+        "authenticated": state["authenticated"],
+        "auth_required": state["auth_required"],
+        "configured_modes": state["configured_modes"],
+        "recommended_ui_mode": state["recommended_ui_mode"],
+        "auth_method": state["auth_method"],
+        "subject": state["subject"],
+        "role": state["role"],
+        "tenant_id": state["tenant_id"],
+        "oidc_issuer_suffix": state["oidc_issuer_suffix"],
+        "api_key_id_prefix": state["api_key_id_prefix"],
+        "request_id": state["request_id"],
+        "trace_id": state["trace_id"],
+        "span_id": state["span_id"],
+    }
+
+
+@router.get("/v1/auth/me", tags=["enterprise"])
+async def auth_me(request: Request) -> dict:
+    """Return the current UI-facing actor/session contract for the active tenant."""
+    state = _auth_session_state(request)
+    role_summary = state["role_summary"]
+    memberships = []
+    if role_summary is not None:
+        memberships.append(
+            {
+                "tenant_id": state["tenant_id"],
+                "role": role_summary["role"],
+                "ui_role": role_summary["ui_role"],
+                "display_name": role_summary["display_name"],
+                "active": True,
+            }
+        )
+
+    return {
+        "authenticated": state["authenticated"],
+        "auth_required": state["auth_required"],
+        "configured_modes": state["configured_modes"],
+        "recommended_ui_mode": state["recommended_ui_mode"],
+        "auth_method": state["auth_method"],
+        "subject": state["subject"],
+        "tenant_id": state["tenant_id"],
+        "role": state["role"],
+        "role_summary": role_summary,
+        "memberships": memberships,
+        "request_id": state["request_id"],
+        "trace_id": state["trace_id"],
+        "span_id": state["span_id"],
     }
 
 

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from dataclasses import dataclass
 from enum import Enum
 from typing import Callable
 
@@ -47,6 +48,128 @@ _PERMISSIONS: dict[str, set[Role]] = {
     "sla_write": {Role.ADMIN},
     "sla_read": {Role.ADMIN, Role.ANALYST, Role.VIEWER},
     "config": {Role.ADMIN},
+}
+
+
+@dataclass(frozen=True)
+class CapabilityDefinition:
+    id: str
+    label: str
+    description: str
+    minimum_role: Role
+
+
+_ROLE_HIERARCHY: dict[Role, int] = {
+    Role.ADMIN: 3,
+    Role.ANALYST: 2,
+    Role.VIEWER: 1,
+}
+
+_ROLE_DISPLAY_NAMES: dict[Role, str] = {
+    Role.ADMIN: "Admin",
+    Role.ANALYST: "Contributor",
+    Role.VIEWER: "Viewer",
+}
+
+_ROLE_UI_NAMES: dict[Role, str] = {
+    Role.ADMIN: "admin",
+    Role.ANALYST: "contributor",
+    Role.VIEWER: "viewer",
+}
+
+_ROLE_DESCRIPTIONS: dict[Role, str] = {
+    Role.ADMIN: "Full control-plane administration, protected writes, and tenant-scoped key/policy/fleet management.",
+    Role.ANALYST: "Contributor-level operator access for scans, source management, runtime ingest, and exception workflows.",
+    Role.VIEWER: "Read-only operator access to inventory, findings, graph, remediation, audit, and posture surfaces.",
+}
+
+_CAPABILITY_DEFINITIONS: tuple[CapabilityDefinition, ...] = (
+    CapabilityDefinition(
+        id="inventory.read",
+        label="View inventory, findings, graph, and audit",
+        description="See agents, fleet, findings, posture, compliance, graph, governance, and audit state.",
+        minimum_role=Role.VIEWER,
+    ),
+    CapabilityDefinition(
+        id="scan.run",
+        label="Run scans and imports",
+        description="Start scans, compare baselines, and push approved result or trace data into the control plane.",
+        minimum_role=Role.ANALYST,
+    ),
+    CapabilityDefinition(
+        id="sources.manage",
+        label="Manage sources and schedules",
+        description="Create, run, test, update, and schedule control-plane sources and collection jobs.",
+        minimum_role=Role.ANALYST,
+    ),
+    CapabilityDefinition(
+        id="exceptions.manage",
+        label="Create and manage exception workflows",
+        description="Create false-positive and exception records and drive remediation-related control-plane actions.",
+        minimum_role=Role.ANALYST,
+    ),
+    CapabilityDefinition(
+        id="runtime.ingest",
+        label="Push runtime evidence and evaluate policy",
+        description="Push traces, runtime events, proxy audit, OCSF, and gateway evaluations into the tenant control plane.",
+        minimum_role=Role.ANALYST,
+    ),
+    CapabilityDefinition(
+        id="keys.manage",
+        label="Manage API keys and auth policy",
+        description="Create, rotate, and revoke service keys and review auth/runtime policy configuration.",
+        minimum_role=Role.ADMIN,
+    ),
+    CapabilityDefinition(
+        id="fleet.manage",
+        label="Manage fleet writes and sync operations",
+        description="Run fleet sync and perform protected fleet mutations that affect tenant inventory state.",
+        minimum_role=Role.ADMIN,
+    ),
+    CapabilityDefinition(
+        id="policy.manage",
+        label="Manage protected policy and break-glass actions",
+        description="Change gateway policy, SIEM tests, shield state, and other protected control-plane administration.",
+        minimum_role=Role.ADMIN,
+    ),
+)
+
+_ROLE_ACCESS_SUMMARY: dict[Role, dict[str, list[str]]] = {
+    Role.ADMIN: {
+        "can_see": [
+            "All tenant inventory, findings, graph, fleet, runtime, and audit surfaces",
+            "Auth policy, API key lifecycle, and protected admin controls",
+        ],
+        "can_do": [
+            "Run scans, manage sources and schedules, and push runtime evidence",
+            "Manage API keys, gateway policy, fleet sync, and other protected control-plane writes",
+        ],
+        "cannot_do": [],
+    },
+    Role.ANALYST: {
+        "can_see": [
+            "Inventory, findings, fleet, graph, remediation, audit, and governance surfaces",
+            "Source registry and schedule state for the active tenant",
+        ],
+        "can_do": [
+            "Run scans, manage sources and schedules, and create exception workflows",
+            "Push runtime evidence and evaluate policy within the active tenant",
+        ],
+        "cannot_do": [
+            "Create, rotate, or revoke API keys",
+            "Change protected admin policy, fleet writes, or break-glass state",
+        ],
+    },
+    Role.VIEWER: {
+        "can_see": [
+            "Read-only inventory, findings, fleet, graph, remediation, governance, posture, and audit surfaces",
+        ],
+        "can_do": [],
+        "cannot_do": [
+            "Run scans or schedule collection jobs",
+            "Create or update sources, exceptions, keys, policy, or fleet state",
+        ],
+    },
 }
 
 # API key → role mapping (loaded from env or config)
@@ -132,6 +255,55 @@ def check_permission(role: Role, action: str) -> bool:
         logger.warning("Unknown action %r — denying by default", action)
         return False
     return role in allowed
+
+
+def role_rank(role: Role) -> int:
+    """Return the numeric rank for a role."""
+    return _ROLE_HIERARCHY.get(role, 0)
+
+
+def normalize_role(value: Role | str | None) -> Role | None:
+    """Normalize a role-like value into a Role enum when possible."""
+    if value is None:
+        return None
+    if isinstance(value, Role):
+        return value
+    try:
+        return Role(str(value).lower())
+    except ValueError:
+        return None
+
+
+def summarize_role(value: Role | str | None) -> dict | None:
+    """Return UI-facing role, capability, and access summary data."""
+    role = normalize_role(value)
+    if role is None:
+        return None
+
+    allowed_capabilities = [cap.id for cap in _CAPABILITY_DEFINITIONS if role_rank(role) >= role_rank(cap.minimum_role)]
+    capability_matrix = [
+        {
+            "id": cap.id,
+            "label": cap.label,
+            "description": cap.description,
+            "minimum_role": cap.minimum_role.value,
+            "minimum_role_label": _ROLE_DISPLAY_NAMES[cap.minimum_role],
+            "allowed": role_rank(role) >= role_rank(cap.minimum_role),
+        }
+        for cap in _CAPABILITY_DEFINITIONS
+    ]
+    summary = _ROLE_ACCESS_SUMMARY[role]
+    return {
+        "role": role.value,
+        "ui_role": _ROLE_UI_NAMES[role],
+        "display_name": _ROLE_DISPLAY_NAMES[role],
+        "description": _ROLE_DESCRIPTIONS[role],
+        "capabilities": allowed_capabilities,
+        "capability_matrix": capability_matrix,
+        "can_see": summary["can_see"],
+        "can_do": summary["can_do"],
+        "cannot_do": summary["cannot_do"],
+    }
 
 
 def require_permission(action: str) -> Callable:

--- a/tests/test_api_auth_me.py
+++ b/tests/test_api_auth_me.py
@@ -1,0 +1,87 @@
+"""Tests for GET /v1/auth/me — UI-facing auth/session contract."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+
+def test_auth_me_returns_zero_state_without_auth() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/auth/me")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["authenticated"] is False
+    assert body["auth_method"] is None
+    assert body["role"] is None
+    assert body["tenant_id"] == "default"
+    assert body["role_summary"] is None
+    assert body["memberships"] == []
+
+
+def test_auth_me_reports_contributor_capabilities_for_analyst() -> None:
+    from agent_bom.api.routes.enterprise import auth_me
+
+    class _FakeState:
+        auth_method = "oidc"
+        api_key_name = "alice@example.com"
+        api_key_role = "analyst"
+        tenant_id = "tenant-alpha"
+        request_id = "req-123"
+        trace_id = "trace-abc"
+        span_id = "span-456"
+        auth_issuer = "example.com"
+        api_key_id = None
+
+    class _FakeRequest:
+        state = _FakeState()
+
+    body = asyncio.run(auth_me(_FakeRequest()))  # type: ignore[arg-type]
+    assert body["authenticated"] is True
+    assert body["role"] == "analyst"
+    assert body["tenant_id"] == "tenant-alpha"
+    assert body["role_summary"]["ui_role"] == "contributor"
+    assert body["role_summary"]["display_name"] == "Contributor"
+    assert "scan.run" in body["role_summary"]["capabilities"]
+    assert "keys.manage" not in body["role_summary"]["capabilities"]
+    assert "Create, rotate, or revoke API keys" in body["role_summary"]["cannot_do"]
+    assert body["memberships"] == [
+        {
+            "tenant_id": "tenant-alpha",
+            "role": "analyst",
+            "ui_role": "contributor",
+            "display_name": "Contributor",
+            "active": True,
+        }
+    ]
+
+
+def test_auth_me_never_leaks_raw_key_or_token() -> None:
+    from agent_bom.api.routes.enterprise import auth_me
+
+    secret = "sk-live-super-secret-123456789"
+
+    class _FakeState:
+        auth_method = "api_key"
+        api_key_name = "ci-bot"
+        api_key_role = "admin"
+        tenant_id = "tenant-alpha"
+        request_id = "req-123"
+        trace_id = "trace-abc"
+        span_id = "span-456"
+        auth_issuer = None
+        api_key_id = "deadbeef01234567"
+        raw_api_key = secret
+        jwt_token = secret
+        api_key_hash = secret
+
+    class _FakeRequest:
+        state = _FakeState()
+
+    body = asyncio.run(auth_me(_FakeRequest()))  # type: ignore[arg-type]
+    serialized = json.dumps(body)
+    assert secret not in serialized


### PR DESCRIPTION
## Summary
- add `GET /v1/auth/me` as the UI-facing session contract
- expose contributor/admin/viewer role summaries and capability matrices from the backend
- document that the UI should render analyst as the contributor role while the API remains authoritative

## Testing
- `.venv/bin/python -m pytest tests/test_api_auth_debug.py tests/test_api_auth_me.py tests/test_enterprise_gaps.py -q`
- `uv run ruff check src/agent_bom/rbac.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/middleware.py tests/test_api_auth_me.py`
- `uv run mypy src/agent_bom/rbac.py src/agent_bom/api/routes/enterprise.py`
- `uv run mkdocs build --strict`