### PR TITLE
feat(ui): gate control-plane actions by auth capabilities

### DIFF
--- a/ui/app/audit/page.tsx
+++ b/ui/app/audit/page.tsx
@@ -22,6 +22,7 @@ import {
   CheckCircle2,
   Filter,
 } from "lucide-react";
+import { useAuthState } from "@/components/auth-provider";
 import { KeyLifecyclePanel } from "@/components/key-lifecycle-panel";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -42,6 +43,7 @@ const PAGE_SIZE = 50;
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 export default function AuditLogPage() {
+  const { session, loading: authSessionLoading, hasCapability } = useAuthState();
   const [entries, setEntries] = useState<AuditEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [integrity, setIntegrity] = useState<AuditIntegrityResponse | null>(null);
@@ -57,6 +59,8 @@ export default function AuditLogPage() {
   const [actionFilter, setActionFilter] = useState<string>("");
   const [resourceFilter, setResourceFilter] = useState<string>("");
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const roleLabel = session?.role_summary?.display_name ?? session?.role ?? "Unknown";
+  const canManageKeys = hasCapability("keys.manage");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -82,8 +86,18 @@ export default function AuditLogPage() {
   }, [actionFilter, resourceFilter, page]);
 
   const loadAdmin = useCallback(async () => {
+    if (authSessionLoading) {
+      return;
+    }
     setAdminLoading(true);
     setAdminError(null);
+    if (!canManageKeys) {
+      setAuthPolicy(null);
+      setKeys([]);
+      setAdminError(`${roleLabel} access can review audit state but cannot manage API keys or auth policy.`);
+      setAdminLoading(false);
+      return;
+    }
     try {
       const [policy, keyList] = await Promise.all([api.getAuthPolicy(), api.listKeys()]);
       setAuthPolicy(policy);
@@ -93,15 +107,17 @@ export default function AuditLogPage() {
     } finally {
       setAdminLoading(false);
     }
-  }, []);
+  }, [authSessionLoading, canManageKeys, roleLabel]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
       void load();
-      void loadAdmin();
+      if (!authSessionLoading) {
+        void loadAdmin();
+      }
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [load, loadAdmin]);
+  }, [authSessionLoading, load, loadAdmin]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
@@ -145,6 +161,7 @@ export default function AuditLogPage() {
         policy={authPolicy}
         keys={keys}
         onRefresh={loadAdmin}
+        roleLabel={roleLabel}
       />
 
       {/* Integrity banner + stats */}

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import Script from "next/script";
 import "./globals.css";
 import { AuthGate } from "@/components/auth-gate";
+import { AuthProvider } from "@/components/auth-provider";
 import { Nav } from "@/components/nav";
 
 // Local fonts — no network fetch at build time (works in air-gapped environments)
@@ -53,15 +54,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Script id="theme-bootstrap" strategy="beforeInteractive">
           {themeBootstrap}
         </Script>
-        <Nav />
-        {/* Main content — offset by sidebar width on desktop, offset by top bar on mobile */}
-        <AuthGate>
-          <main id="main-content" className="lg:pl-[240px] pt-14 lg:pt-0 min-h-screen transition-[padding-left] duration-200">
-            <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
-              {children}
-            </div>
-          </main>
-        </AuthGate>
+        <AuthProvider>
+          <Nav />
+          {/* Main content — offset by sidebar width on desktop, offset by top bar on mobile */}
+          <AuthGate>
+            <main id="main-content" className="lg:pl-[240px] pt-14 lg:pt-0 min-h-screen transition-[padding-left] duration-200">
+              <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
+                {children}
+              </div>
+            </main>
+          </AuthGate>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/ui/app/sources/page.tsx
+++ b/ui/app/sources/page.tsx
@@ -19,13 +19,13 @@ import {
 
 import {
   api,
-  type AuthDebugResponse,
   type ConnectorHealthResponse,
   type ScanSchedule,
   type SourceCreateRequest,
   type SourceKind,
   type SourceRecord,
 } from "@/lib/api";
+import { useAuthState } from "@/components/auth-provider";
 
 type IngestMode = "Direct scan" | "Read-only connector" | "Pushed ingest" | "Runtime" | "Imported artifact";
 
@@ -217,7 +217,7 @@ function toneForStatus(status: string): string {
 }
 
 export default function SourcesPage() {
-  const [authDebug, setAuthDebug] = useState<AuthDebugResponse | null>(null);
+  const { session, loading: authLoading, hasCapability } = useAuthState();
   const [connectorHealth, setConnectorHealth] = useState<ConnectorHealthResponse[]>([]);
   const [schedules, setSchedules] = useState<ScanSchedule[]>([]);
   const [sources, setSources] = useState<SourceRecord[]>([]);
@@ -265,6 +265,11 @@ export default function SourcesPage() {
     }
     return counts;
   }, [schedules]);
+  const roleSummary = session?.role_summary ?? null;
+  const roleLabel = roleSummary?.display_name ?? session?.role ?? "Unknown";
+  const canManageSources = hasCapability("sources.manage");
+  const canRunScans = hasCapability("scan.run");
+  const canManageFleet = hasCapability("fleet.manage");
 
   function updateForm<K extends keyof FormState>(field: K, value: FormState[K]) {
     setFormState((current) => ({ ...current, [field]: value }));
@@ -279,16 +284,11 @@ export default function SourcesPage() {
     setError(null);
 
     try {
-      const [authResult, connectorsResult, schedulesResult, sourcesResult] = await Promise.allSettled([
-        api.getAuthDebug(),
+      const [connectorsResult, schedulesResult, sourcesResult] = await Promise.allSettled([
         api.listConnectors(),
         api.listSchedules(),
         api.listSources(),
       ]);
-
-      if (authResult.status === "fulfilled") {
-        setAuthDebug(authResult.value);
-      }
 
       if (sourcesResult.status === "fulfilled") {
         setSources(sourcesResult.value.sources);
@@ -317,10 +317,10 @@ export default function SourcesPage() {
         setConnectorHealth([]);
       }
 
-      const failures = [authResult, connectorsResult, schedulesResult, sourcesResult].filter(
+      const failures = [connectorsResult, schedulesResult, sourcesResult].filter(
         (result) => result.status === "rejected"
       );
-      if (failures.length === 4) {
+      if (failures.length === 3) {
         setError("Failed to load control-plane source state.");
       }
     } finally {
@@ -494,7 +494,7 @@ export default function SourcesPage() {
             </button>
             <button
               onClick={handleFleetSync}
-              disabled={syncingFleet}
+              disabled={syncingFleet || !canManageFleet}
               className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Activity className="h-4 w-4" />
@@ -507,10 +507,10 @@ export default function SourcesPage() {
           <MetricCard
             icon={ShieldCheck}
             label="Auth mode"
-            value={authDebug?.auth_method ?? (loading ? "Loading…" : "Unknown")}
+            value={session?.auth_method ?? (authLoading ? "Loading…" : "Unknown")}
             detail={
-              authDebug
-                ? `${authDebug.role ?? "no role"} · tenant ${authDebug.tenant_id} · ${authDebug.recommended_ui_mode}`
+              session
+                ? `${roleLabel} · tenant ${session.tenant_id} · ${session.recommended_ui_mode}`
                 : "API/control plane owns auth and tenant scope"
             }
           />
@@ -538,6 +538,26 @@ export default function SourcesPage() {
         {formMessage ? <p className="mt-2 text-sm text-emerald-400">{formMessage}</p> : null}
         {error ? <p className="mt-2 text-sm text-red-400">{error}</p> : null}
       </section>
+
+      {roleSummary ? (
+        <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
+          <div className="flex items-start gap-3">
+            <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
+              <Shield className="h-5 w-5 text-emerald-400" />
+            </span>
+            <div>
+              <h2 className="text-base font-semibold text-[var(--foreground)]">{roleSummary.display_name} access in this tenant</h2>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">{roleSummary.description}</p>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-4 lg:grid-cols-3">
+            <AccessList title="Can see" items={roleSummary.can_see} tone="text-sky-300" />
+            <AccessList title="Can do" items={roleSummary.can_do} tone="text-emerald-300" />
+            <AccessList title="Blocked from" items={roleSummary.cannot_do} tone="text-amber-300" />
+          </div>
+        </section>
+      ) : null}
 
       <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
         <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
@@ -600,21 +620,21 @@ export default function SourcesPage() {
                     <div className="mt-4 flex flex-wrap gap-2">
                       <button
                         onClick={() => runSourceAction(source.source_id, "test")}
-                        disabled={isBusy}
+                        disabled={isBusy || !canManageSources}
                         className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         {isBusy ? "Working…" : "Test"}
                       </button>
                       <button
                         onClick={() => runSourceAction(source.source_id, "run")}
-                        disabled={isBusy || !source.enabled}
+                        disabled={isBusy || !source.enabled || !canRunScans}
                         className="rounded-xl bg-emerald-500 px-3 py-2 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         Run now
                       </button>
                       <button
                         onClick={() => runSourceAction(source.source_id, "delete")}
-                        disabled={isBusy}
+                        disabled={isBusy || !canManageSources}
                         className="rounded-xl border border-red-900/60 bg-red-950/20 px-3 py-2 text-xs font-medium text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         Delete
@@ -715,7 +735,7 @@ export default function SourcesPage() {
 
               <button
                 type="submit"
-                disabled={submitting}
+                disabled={submitting || !canManageSources}
                 className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <Plus className="h-4 w-4" />
@@ -817,7 +837,7 @@ export default function SourcesPage() {
                   </p>
                   <button
                     type="submit"
-                    disabled={submittingSchedule || schedulableSources.length === 0}
+                    disabled={submittingSchedule || schedulableSources.length === 0 || !canManageSources}
                     className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <CalendarClock className="h-4 w-4" />
@@ -860,14 +880,14 @@ export default function SourcesPage() {
                     <div className="mt-4 flex flex-wrap gap-2">
                       <button
                         onClick={() => runScheduleAction(schedule.schedule_id, "toggle")}
-                        disabled={isBusy}
+                        disabled={isBusy || !canManageSources}
                         className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         {isBusy ? "Working…" : schedule.enabled ? "Pause" : "Enable"}
                       </button>
                       <button
                         onClick={() => runScheduleAction(schedule.schedule_id, "delete")}
-                        disabled={isBusy}
+                        disabled={isBusy || !canManageSources}
                         className="rounded-xl border border-red-900/60 bg-red-950/20 px-3 py-2 text-xs font-medium text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         Delete
@@ -948,6 +968,23 @@ function MetricCard({
         </div>
       </div>
       <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">{detail}</p>
+    </div>
+  );
+}
+
+function AccessList({ title, items, tone }: { title: string; items: string[]; tone: string }) {
+  return (
+    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <p className={`text-xs uppercase tracking-[0.18em] ${tone}`}>{title}</p>
+      {items.length === 0 ? (
+        <p className="mt-3 text-sm text-[var(--text-secondary)]">No additional access in this category.</p>
+      ) : (
+        <ul className="mt-3 space-y-2 text-sm text-[var(--text-secondary)]">
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { KeyRound, Loader2, Lock, ShieldCheck } from "lucide-react";
 
-import { api, type AuthDebugResponse } from "@/lib/api";
+import { useAuthState } from "@/components/auth-provider";
 import { clearSessionApiKey, getSessionApiKey, setSessionApiKey } from "@/lib/auth";
 
 function isAuthFailure(message: string): boolean {
@@ -12,32 +12,14 @@ function isAuthFailure(message: string): boolean {
 }
 
 export function AuthGate({ children }: { children: React.ReactNode }) {
-  const [status, setStatus] = useState<AuthDebugResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { session, loading, error, refresh } = useAuthState();
   const [apiKey, setApiKey] = useState("");
-
-  const refresh = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const next = await api.getAuthDebug();
-      setStatus(next);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to determine auth status";
-      setStatus(null);
-      setError(message);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   useEffect(() => {
     const stored = getSessionApiKey();
     if (stored) {
       setApiKey(stored);
     }
-    void refresh();
   }, []);
 
   if (loading) {
@@ -48,7 +30,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     );
   }
 
-  if (status && (!status.auth_required || status.authenticated)) {
+  if (session && (!session.auth_required || session.authenticated)) {
     return <>{children}</>;
   }
 
@@ -116,10 +98,10 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
                 </button>
                 <button
                   type="button"
-                  onClick={() => {
+                  onClick={async () => {
                     clearSessionApiKey();
                     setApiKey("");
-                    setError(null);
+                    await refresh();
                   }}
                   className="rounded-xl border border-zinc-700 px-4 py-2 text-sm text-zinc-300 transition hover:bg-zinc-900"
                 >

--- a/ui/components/auth-provider.tsx
+++ b/ui/components/auth-provider.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+import { api, type AuthMeResponse } from "@/lib/api";
+
+interface AuthContextValue {
+  session: AuthMeResponse | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  hasCapability: (capability: string) => boolean;
+}
+
+const defaultContext: AuthContextValue = {
+  session: null,
+  loading: true,
+  error: null,
+  refresh: async () => {},
+  hasCapability: () => false,
+};
+
+const AuthContext = createContext<AuthContextValue>(defaultContext);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<AuthMeResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await api.getAuthMe();
+      setSession(next);
+    } catch (nextError) {
+      setSession(null);
+      setError(nextError instanceof Error ? nextError.message : "Failed to load auth session");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      session,
+      loading,
+      error,
+      refresh,
+      hasCapability: (capability: string) => Boolean(session?.role_summary?.capabilities.includes(capability)),
+    }),
+    [error, loading, refresh, session]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthState(): AuthContextValue {
+  return useContext(AuthContext);
+}

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -72,12 +72,14 @@ export function KeyLifecyclePanel({
   policy,
   keys,
   onRefresh,
+  roleLabel,
 }: {
   loading: boolean;
   error: string | null;
   policy: AuthPolicyResponse | null;
   keys: ApiKeyRecord[];
   onRefresh: () => Promise<void> | void;
+  roleLabel?: string | null;
 }) {
   const [busyKeyId, setBusyKeyId] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<"create" | "rotate" | "revoke" | null>(null);
@@ -384,6 +386,11 @@ export function KeyLifecyclePanel({
             <div>
               <p className="text-sm font-semibold text-amber-200">Admin access is required for key lifecycle operations</p>
               <p className="mt-1 text-sm text-amber-100/80">{error}</p>
+              {roleLabel ? (
+                <p className="mt-2 text-xs text-amber-100/70">
+                  Current role: {roleLabel}. Contributors and viewers can review audit state, but only admins can manage service keys.
+                </p>
+              ) : null}
             </div>
           </div>
         </div>

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -30,6 +30,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { api } from "@/lib/api";
+import { useAuthState } from "@/components/auth-provider";
 import { BrandMark } from "@/components/brand-mark";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
@@ -142,6 +143,7 @@ export function Nav() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const { counts } = useDeploymentContext();
+  const { session, loading: authLoading } = useAuthState();
 
   // Close mobile on route change
   useEffect(() => {
@@ -441,6 +443,7 @@ export function Nav() {
       {/* Bottom section */}
       <div className={`border-t border-[color:var(--border-subtle)] ${collapsed ? "px-2 py-3" : "px-3 py-3"}`}>
         <div className="space-y-2">
+          <SessionStatus collapsed={collapsed} loading={authLoading} session={session} />
           <Link
             href={`/help?from=${encodeURIComponent(path ?? "/")}`}
             className={`flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[12px] text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)] ${collapsed ? "justify-center px-2" : ""}`}
@@ -508,6 +511,57 @@ export function Nav() {
         />
       )}
     </>
+  );
+}
+
+function SessionStatus({
+  collapsed,
+  loading,
+  session,
+}: {
+  collapsed: boolean;
+  loading: boolean;
+  session: ReturnType<typeof useAuthState>["session"];
+}) {
+  if (collapsed) {
+    if (loading) {
+      return <div className="mx-auto h-2 w-2 rounded-full bg-zinc-500 animate-pulse" title="Checking session" />;
+    }
+    if (session?.authenticated) {
+      return (
+        <div
+          className="mx-auto h-2 w-2 rounded-full bg-emerald-500"
+          title={`${session.role_summary?.display_name ?? session.role ?? "Authenticated"} · tenant ${session.tenant_id}`}
+        />
+      );
+    }
+    return <div className="mx-auto h-2 w-2 rounded-full bg-amber-500" title="Authentication required" />;
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[12px] text-[color:var(--text-secondary)]">
+        Checking session…
+      </div>
+    );
+  }
+
+  if (!session?.authenticated) {
+    return (
+      <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 px-3 py-2 text-[12px] text-amber-300">
+        Sign-in required for protected control-plane actions
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Signed in</p>
+      <p className="mt-1 truncate text-[12px] font-medium text-[color:var(--foreground)]">{session.subject ?? "Authenticated user"}</p>
+      <p className="mt-1 text-[11px] text-[color:var(--text-secondary)]">
+        {session.role_summary?.display_name ?? session.role ?? "Unknown"} · tenant {session.tenant_id}
+      </p>
+    </div>
   );
 }
 

--- a/ui/e2e/scan-export.spec.ts
+++ b/ui/e2e/scan-export.spec.ts
@@ -78,7 +78,7 @@ test("scan flow reaches result view and exports graph JSON", async ({ page }) =>
     });
   });
 
-  await page.route("**/v1/auth/debug", async (route) => {
+  await page.route("**/v1/auth/me", async (route) => {
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
@@ -89,9 +89,9 @@ test("scan flow reaches result view and exports graph JSON", async ({ page }) =>
         auth_method: null,
         subject: null,
         role: null,
+        role_summary: null,
         tenant_id: "default",
-        oidc_issuer_suffix: null,
-        api_key_id_prefix: null,
+        memberships: [],
         request_id: "req-e2e",
         trace_id: "trace-e2e",
         span_id: "span-e2e",

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -487,6 +487,51 @@ export interface AuthDebugResponse {
   span_id: string | null;
 }
 
+export interface AuthRoleCapability {
+  id: string;
+  label: string;
+  description: string;
+  minimum_role: string;
+  minimum_role_label: string;
+  allowed: boolean;
+}
+
+export interface AuthRoleSummary {
+  role: string;
+  ui_role: string;
+  display_name: string;
+  description: string;
+  capabilities: string[];
+  capability_matrix: AuthRoleCapability[];
+  can_see: string[];
+  can_do: string[];
+  cannot_do: string[];
+}
+
+export interface AuthMembership {
+  tenant_id: string;
+  role: string;
+  ui_role: string;
+  display_name: string;
+  active: boolean;
+}
+
+export interface AuthMeResponse {
+  authenticated: boolean;
+  auth_required: boolean;
+  configured_modes: string[];
+  recommended_ui_mode: string;
+  auth_method: string | null;
+  subject: string | null;
+  tenant_id: string;
+  role: string | null;
+  role_summary: AuthRoleSummary | null;
+  memberships: AuthMembership[];
+  request_id: string | null;
+  trace_id: string | null;
+  span_id: string | null;
+}
+
 export interface AuthPolicyResponse {
   api_key: {
     default_ttl_seconds: number;
@@ -1089,6 +1134,7 @@ async function getBlob(path: string): Promise<Blob> {
 export const api = {
   health: () => get<HealthResponse>("/health"),
   version: () => get<VersionInfo>("/version"),
+  getAuthMe: () => get<AuthMeResponse>("/v1/auth/me"),
   getAuthDebug: () => get<AuthDebugResponse>("/v1/auth/debug"),
   getAuthPolicy: () => get<AuthPolicyResponse>("/v1/auth/policy"),
   listKeys: () => get<ListKeysResponse>("/v1/auth/keys"),

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach } from "vitest";
 
 import { AuthGate } from "@/components/auth-gate";
+import { AuthProvider } from "@/components/auth-provider";
 import { clearSessionApiKey, setSessionApiKey } from "@/lib/auth";
 
 const originalFetch = global.fetch;
@@ -27,8 +28,8 @@ describe("AuthGate", () => {
         subject: null,
         role: null,
         tenant_id: "default",
-        oidc_issuer_suffix: null,
-        api_key_id_prefix: null,
+        role_summary: null,
+        memberships: [],
         request_id: null,
         trace_id: null,
         span_id: null,
@@ -36,9 +37,11 @@ describe("AuthGate", () => {
     }) as typeof fetch;
 
     render(
-      <AuthGate>
-        <div>protected surface</div>
-      </AuthGate>,
+      <AuthProvider>
+        <AuthGate>
+          <div>protected surface</div>
+        </AuthGate>
+      </AuthProvider>,
     );
 
     await waitFor(() => expect(screen.getByText("protected surface")).toBeInTheDocument());
@@ -54,9 +57,11 @@ describe("AuthGate", () => {
     }) as typeof fetch;
 
     render(
-      <AuthGate>
-        <div>protected surface</div>
-      </AuthGate>,
+      <AuthProvider>
+        <AuthGate>
+          <div>protected surface</div>
+        </AuthGate>
+      </AuthProvider>,
     );
 
     await waitFor(() => expect(screen.getByText("Control-plane authentication required")).toBeInTheDocument());

--- a/ui/tests/sources-page.test.tsx
+++ b/ui/tests/sources-page.test.tsx
@@ -5,7 +5,6 @@ import SourcesPage from "@/app/sources/page";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: {
-    getAuthDebug: vi.fn(),
     listConnectors: vi.fn(),
     getConnectorHealth: vi.fn(),
     listSchedules: vi.fn(),
@@ -25,26 +24,46 @@ vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
 }));
 
+vi.mock("@/components/auth-provider", () => ({
+  useAuthState: () => ({
+    session: {
+      authenticated: true,
+      auth_required: true,
+      configured_modes: ["oidc"],
+      recommended_ui_mode: "browser_oidc",
+      auth_method: "oidc",
+      subject: "user@example.com",
+      tenant_id: "tenant-acme",
+      role: "analyst",
+      role_summary: {
+        role: "analyst",
+        ui_role: "contributor",
+        display_name: "Contributor",
+        description: "Contributor-level operator access.",
+        capabilities: ["inventory.read", "scan.run", "sources.manage", "exceptions.manage", "runtime.ingest"],
+        capability_matrix: [],
+        can_see: ["Inventory, findings, fleet, graph, remediation, audit, and governance surfaces"],
+        can_do: ["Run scans, manage sources and schedules, and create exception workflows"],
+        cannot_do: ["Create, rotate, or revoke API keys"],
+      },
+      memberships: [],
+      request_id: "req-1",
+      trace_id: "trace-1",
+      span_id: "span-1",
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    hasCapability: (capability: string) =>
+      ["inventory.read", "scan.run", "sources.manage", "exceptions.manage", "runtime.ingest"].includes(capability),
+  }),
+}));
+
 vi.mock("@/lib/api", () => ({
   api: apiMock,
 }));
 
 function primeApi() {
-  apiMock.getAuthDebug.mockResolvedValue({
-    authenticated: true,
-    auth_required: true,
-    configured_modes: ["oidc"],
-    recommended_ui_mode: "browser_oidc",
-    auth_method: "oidc",
-    subject: "user@example.com",
-    role: "admin",
-    tenant_id: "tenant-acme",
-    oidc_issuer_suffix: "issuer.example.com",
-    api_key_id_prefix: null,
-    request_id: "req-1",
-    trace_id: "trace-1",
-    span_id: "span-1",
-  });
   apiMock.listConnectors.mockResolvedValue({ connectors: ["jira"] });
   apiMock.getConnectorHealth.mockResolvedValue({
     connector: "jira",


### PR DESCRIPTION
## Summary
- bootstrap the browser from `GET /v1/auth/me` via a shared auth provider
- surface signed-in role and tenant state in the shell and auth gate
- gate sources and audit control-plane actions by backend-provided capabilities so contributor/viewer/admin behavior is explicit in the UI

Depends on #1727 for the backend session contract.

## Testing
- `npm --prefix ui run test -- --run tests/auth-gate.test.tsx tests/sources-page.test.tsx tests/nav.test.tsx`
- `npm --prefix ui run lint`
- `npm --prefix ui run build`