### PR TITLE
fix(platform): enforce tenant and time invariants

### DIFF
--- a/site-docs/architecture/data-ingestion-and-security.md
+++ b/site-docs/architecture/data-ingestion-and-security.md
@@ -11,6 +11,18 @@ The product should support four honest intake modes:
 
 Those are not the same thing, and the security model is different for each.
 
+## Platform record invariants
+
+Regardless of intake mode, the persisted platform record should keep a few
+stable invariants:
+
+- `tenant_id` is normalized server-side and never trusted from ad hoc UI state
+- timestamps are stored in UTC ISO-8601 form for correlation, graph windows, and audit
+- collectors may differ, but the canonical model stays the same across fleet, gateway, runtime, and findings
+
+That contract matters because graph slices, fleet rollups, runtime evidence, and
+audit trails all depend on consistent tenant and time semantics.
+
 ## The four intake modes
 
 | Mode | What agent-bom does | Typical examples | Security posture |

--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import os
 import sqlite3
 import threading
-from datetime import datetime, timezone
 from enum import Enum
 from typing import Protocol
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
 
 # ─── Models ──────────────────────────────────────────────────────────────────
 
@@ -36,9 +37,9 @@ class FleetAgent(BaseModel):
     lifecycle_state: FleetLifecycleState = FleetLifecycleState.DISCOVERED
     owner: str | None = None
     environment: str | None = None
-    tags: list[str] = []
+    tags: list[str] = Field(default_factory=list)
     trust_score: float = 0.0
-    trust_factors: dict = {}
+    trust_factors: dict = Field(default_factory=dict)
     server_count: int = 0
     package_count: int = 0
     credential_count: int = 0
@@ -49,6 +50,24 @@ class FleetAgent(BaseModel):
     created_at: str = ""
     updated_at: str = ""
     notes: str = ""
+
+    @field_validator("tenant_id", mode="before")
+    @classmethod
+    def _normalize_tenant_id(cls, value: str | None) -> str:
+        return normalize_tenant_id(value)
+
+    @field_validator("last_discovery", "last_scan", "created_at", "updated_at", mode="before")
+    @classmethod
+    def _normalize_timestamps(cls, value: str | None) -> str | None:
+        return normalize_timestamp(value)
+
+    @model_validator(mode="after")
+    def _apply_defaults(self) -> FleetAgent:
+        if not self.created_at:
+            self.created_at = now_utc_iso()
+        if not self.updated_at:
+            self.updated_at = self.created_at
+        return self
 
 
 # ─── Protocol ────────────────────────────────────────────────────────────────
@@ -80,8 +99,9 @@ class InMemoryFleetStore:
         self._lock = threading.Lock()
 
     def put(self, agent: FleetAgent) -> None:
+        normalized = FleetAgent.model_validate(agent.model_dump())
         with self._lock:
-            self._agents[agent.agent_id] = agent
+            self._agents[normalized.agent_id] = normalized
 
     def get(self, agent_id: str) -> FleetAgent | None:
         with self._lock:
@@ -135,14 +155,15 @@ class InMemoryFleetStore:
             if agent is None:
                 return False
             agent.lifecycle_state = state
-            agent.updated_at = datetime.now(timezone.utc).isoformat()
+            agent.updated_at = now_utc_iso()
             return True
 
     def batch_put(self, agents: list[FleetAgent]) -> int:
         """Upsert multiple agents at once."""
         with self._lock:
             for agent in agents:
-                self._agents[agent.agent_id] = agent
+                normalized = FleetAgent.model_validate(agent.model_dump())
+                self._agents[normalized.agent_id] = normalized
             return len(agents)
 
 
@@ -185,17 +206,18 @@ class SQLiteFleetStore:
         self._conn.commit()
 
     def put(self, agent: FleetAgent) -> None:
+        normalized = FleetAgent.model_validate(agent.model_dump())
         self._conn.execute(
             """INSERT OR REPLACE INTO fleet_agents
                (agent_id, name, lifecycle_state, trust_score, updated_at, data)
                VALUES (?, ?, ?, ?, ?, ?)""",
             (
-                agent.agent_id,
-                agent.name,
-                agent.lifecycle_state.value,
-                agent.trust_score,
-                agent.updated_at,
-                agent.model_dump_json(),
+                normalized.agent_id,
+                normalized.name,
+                normalized.lifecycle_state.value,
+                normalized.trust_score,
+                normalized.updated_at,
+                normalized.model_dump_json(),
             ),
         )
         self._conn.commit()
@@ -253,7 +275,7 @@ class SQLiteFleetStore:
         return [{"tenant_id": r[0], "agent_count": r[1]} for r in rows]
 
     def update_state(self, agent_id: str, state: FleetLifecycleState) -> bool:
-        now = datetime.now(timezone.utc).isoformat()
+        now = now_utc_iso()
         agent = self.get(agent_id)
         if agent is None:
             return False

--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 import sqlite3
 import threading
-from datetime import datetime, timezone
 from typing import Protocol
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
-
-def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()
+from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
 
 
 class MCPObservation(BaseModel):
@@ -40,7 +37,17 @@ class MCPObservation(BaseModel):
     first_seen: str | None = None
     last_seen: str | None = None
     last_synced: str | None = None
-    updated_at: str = Field(default_factory=_now)
+    updated_at: str = Field(default_factory=now_utc_iso)
+
+    @field_validator("tenant_id", mode="before")
+    @classmethod
+    def _normalize_tenant_id(cls, value: str | None) -> str:
+        return normalize_tenant_id(value)
+
+    @field_validator("first_seen", "last_seen", "last_synced", "updated_at", mode="before")
+    @classmethod
+    def _normalize_timestamp(cls, value: str | None) -> str | None:
+        return normalize_timestamp(value)
 
 
 def _pick_timestamp(*values: str | None, prefer: str) -> str | None:
@@ -98,8 +105,9 @@ class InMemoryMCPObservationStore:
         self._lock = threading.Lock()
 
     def put(self, observation: MCPObservation) -> None:
+        normalized = MCPObservation.model_validate(observation.model_dump())
         with self._lock:
-            self._rows[(observation.tenant_id, observation.observation_id)] = observation
+            self._rows[(normalized.tenant_id, normalized.observation_id)] = normalized
 
     def get(self, tenant_id: str, observation_id: str) -> MCPObservation | None:
         with self._lock:
@@ -141,16 +149,17 @@ class SQLiteMCPObservationStore:
         self._conn.commit()
 
     def put(self, observation: MCPObservation) -> None:
+        normalized = MCPObservation.model_validate(observation.model_dump())
         self._conn.execute(
             """INSERT OR REPLACE INTO mcp_observations
                (tenant_id, observation_id, server_name, updated_at, data)
                VALUES (?, ?, ?, ?, ?)""",
             (
-                observation.tenant_id,
-                observation.observation_id,
-                observation.server_name,
-                observation.updated_at,
-                observation.model_dump_json(),
+                normalized.tenant_id,
+                normalized.observation_id,
+                normalized.server_name,
+                normalized.updated_at,
+                normalized.model_dump_json(),
             ),
         )
         self._conn.commit()

--- a/src/agent_bom/platform_invariants.py
+++ b/src/agent_bom/platform_invariants.py
@@ -1,0 +1,40 @@
+"""Shared platform record invariants.
+
+These helpers keep tenant- and time-bearing records consistent across fleet,
+gateway/discovery provenance, and later graph/event consumers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def now_utc_iso() -> str:
+    """Return the current UTC timestamp as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalize_tenant_id(value: str | None) -> str:
+    """Return a canonical tenant id, falling back to ``default``."""
+    tenant_id = (value or "").strip()
+    return tenant_id or "default"
+
+
+def normalize_timestamp(value: str | None) -> str | None:
+    """Return a canonical UTC ISO-8601 timestamp.
+
+    Blank values stay ``None``. Naive timestamps are treated as UTC.
+    """
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed.isoformat()

--- a/src/agent_bom/platform_invariants.py
+++ b/src/agent_bom/platform_invariants.py
@@ -37,4 +37,7 @@ def normalize_timestamp(value: str | None) -> str | None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     else:
         parsed = parsed.astimezone(timezone.utc)
-    return parsed.isoformat()
+    normalized = parsed.isoformat()
+    if normalized.endswith("+00:00"):
+        return f"{normalized[:-6]}Z"
+    return normalized

--- a/tests/test_fleet_store.py
+++ b/tests/test_fleet_store.py
@@ -95,6 +95,34 @@ def test_update_state_missing():
     assert store.update_state("nope", FleetLifecycleState.APPROVED) is False
 
 
+def test_fleet_agent_normalizes_tenant_and_timestamps():
+    agent = FleetAgent(
+        agent_id="a-1",
+        name="test-agent",
+        agent_type="claude-desktop",
+        tenant_id=" tenant-a ",
+        created_at="2026-04-23T11:00:00Z",
+        updated_at="2026-04-23T07:05:00-04:00",
+        last_discovery="2026-04-23T11:10:00",
+    )
+    assert agent.tenant_id == "tenant-a"
+    assert agent.created_at == "2026-04-23T11:00:00+00:00"
+    assert agent.updated_at == "2026-04-23T11:05:00+00:00"
+    assert agent.last_discovery == "2026-04-23T11:10:00+00:00"
+
+
+def test_fleet_store_revalidates_agent_before_write():
+    store = InMemoryFleetStore()
+    agent = _make()
+    agent.tenant_id = " tenant-a "
+    agent.updated_at = "2026-04-23T11:05:00"
+    store.put(agent)
+    stored = store.get("a-1")
+    assert stored is not None
+    assert stored.tenant_id == "tenant-a"
+    assert stored.updated_at == "2026-04-23T11:05:00+00:00"
+
+
 # ── SQLiteFleetStore ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_fleet_store.py
+++ b/tests/test_fleet_store.py
@@ -106,9 +106,9 @@ def test_fleet_agent_normalizes_tenant_and_timestamps():
         last_discovery="2026-04-23T11:10:00",
     )
     assert agent.tenant_id == "tenant-a"
-    assert agent.created_at == "2026-04-23T11:00:00+00:00"
-    assert agent.updated_at == "2026-04-23T11:05:00+00:00"
-    assert agent.last_discovery == "2026-04-23T11:10:00+00:00"
+    assert agent.created_at == "2026-04-23T11:00:00Z"
+    assert agent.updated_at == "2026-04-23T11:05:00Z"
+    assert agent.last_discovery == "2026-04-23T11:10:00Z"
 
 
 def test_fleet_store_revalidates_agent_before_write():
@@ -120,7 +120,7 @@ def test_fleet_store_revalidates_agent_before_write():
     stored = store.get("a-1")
     assert stored is not None
     assert stored.tenant_id == "tenant-a"
-    assert stored.updated_at == "2026-04-23T11:05:00+00:00"
+    assert stored.updated_at == "2026-04-23T11:05:00Z"
 
 
 # ── SQLiteFleetStore ──────────────────────────────────────────────────────────

--- a/tests/test_mcp_observation_store.py
+++ b/tests/test_mcp_observation_store.py
@@ -1,0 +1,75 @@
+"""Tests for agent_bom.api.mcp_observation_store invariants."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api.mcp_observation_store import (
+    InMemoryMCPObservationStore,
+    MCPObservation,
+    SQLiteMCPObservationStore,
+    merge_observations,
+)
+
+
+def _make_observation(**overrides) -> MCPObservation:
+    base = {
+        "observation_id": "obs-1",
+        "server_stable_id": "stable-1",
+        "server_name": "sqlite-mcp",
+        "tenant_id": "tenant-a",
+        "first_seen": "2026-04-23T11:00:00Z",
+        "last_seen": "2026-04-23T11:05:00-04:00",
+        "last_synced": "2026-04-23T15:06:00",
+    }
+    base.update(overrides)
+    return MCPObservation(**base)
+
+
+def _sqlite_store() -> tuple[SQLiteMCPObservationStore, Path]:
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    return SQLiteMCPObservationStore(tmp.name), Path(tmp.name)
+
+
+def test_observation_normalizes_tenant_and_timestamps() -> None:
+    observation = _make_observation(tenant_id="  tenant-a  ")
+    assert observation.tenant_id == "tenant-a"
+    assert observation.first_seen == "2026-04-23T11:00:00+00:00"
+    assert observation.last_seen == "2026-04-23T15:05:00+00:00"
+    assert observation.last_synced == "2026-04-23T15:06:00+00:00"
+
+
+def test_merge_rejects_tenant_mismatch() -> None:
+    existing = _make_observation(tenant_id="tenant-a")
+    incoming = _make_observation(tenant_id="tenant-b")
+    with pytest.raises(ValueError, match="tenant mismatch"):
+        merge_observations(existing, incoming)
+
+
+def test_inmemory_store_revalidates_observation_before_write() -> None:
+    store = InMemoryMCPObservationStore()
+    observation = _make_observation()
+    observation.tenant_id = "  tenant-a  "
+    observation.last_seen = "2026-04-23T11:05:00"
+    store.put(observation)
+    stored = store.get("tenant-a", "obs-1")
+    assert stored is not None
+    assert stored.tenant_id == "tenant-a"
+    assert stored.last_seen == "2026-04-23T11:05:00+00:00"
+
+
+def test_sqlite_store_revalidates_observation_before_write() -> None:
+    store, path = _sqlite_store()
+    try:
+        observation = _make_observation(tenant_id=" tenant-a ", updated_at="2026-04-23T12:00:00Z")
+        store.put(observation)
+        stored = store.get("tenant-a", "obs-1")
+        assert stored is not None
+        assert stored.tenant_id == "tenant-a"
+        assert stored.updated_at == "2026-04-23T12:00:00+00:00"
+    finally:
+        path.unlink(missing_ok=True)

--- a/tests/test_mcp_observation_store.py
+++ b/tests/test_mcp_observation_store.py
@@ -38,9 +38,9 @@ def _sqlite_store() -> tuple[SQLiteMCPObservationStore, Path]:
 def test_observation_normalizes_tenant_and_timestamps() -> None:
     observation = _make_observation(tenant_id="  tenant-a  ")
     assert observation.tenant_id == "tenant-a"
-    assert observation.first_seen == "2026-04-23T11:00:00+00:00"
-    assert observation.last_seen == "2026-04-23T15:05:00+00:00"
-    assert observation.last_synced == "2026-04-23T15:06:00+00:00"
+    assert observation.first_seen == "2026-04-23T11:00:00Z"
+    assert observation.last_seen == "2026-04-23T15:05:00Z"
+    assert observation.last_synced == "2026-04-23T15:06:00Z"
 
 
 def test_merge_rejects_tenant_mismatch() -> None:
@@ -59,7 +59,7 @@ def test_inmemory_store_revalidates_observation_before_write() -> None:
     stored = store.get("tenant-a", "obs-1")
     assert stored is not None
     assert stored.tenant_id == "tenant-a"
-    assert stored.last_seen == "2026-04-23T11:05:00+00:00"
+    assert stored.last_seen == "2026-04-23T11:05:00Z"
 
 
 def test_sqlite_store_revalidates_observation_before_write() -> None:
@@ -70,6 +70,6 @@ def test_sqlite_store_revalidates_observation_before_write() -> None:
         stored = store.get("tenant-a", "obs-1")
         assert stored is not None
         assert stored.tenant_id == "tenant-a"
-        assert stored.updated_at == "2026-04-23T12:00:00+00:00"
+        assert stored.updated_at == "2026-04-23T12:00:00Z"
     finally:
         path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- normalize fleet and MCP observation tenant IDs and timestamps at the model layer
- revalidate persisted fleet and observation records on store writes
- document the canonical tenant/time invariant for ingest, fleet, gateway, and graph consumers

## Testing
- .venv/bin/python -m pytest tests/test_fleet_store.py tests/test_mcp_observation_store.py -q
- uv run ruff check src/agent_bom/platform_invariants.py src/agent_bom/api/fleet_store.py src/agent_bom/api/mcp_observation_store.py tests/test_fleet_store.py tests/test_mcp_observation_store.py
- uv run mypy src/agent_bom/platform_invariants.py src/agent_bom/api/fleet_store.py src/agent_bom/api/mcp_observation_store.py
- uv run mkdocs build --strict

Closes #1729