### PR TITLE
feat(endpoint): add enrollment bundle contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Work targeting the next release.
 
 ### Changed
 - **Graph search and slice filtering** — the control plane now uses indexed graph-node search paths with server-side entity, severity, compliance-prefix, and data-source filters so larger tenant snapshots do not fall back to broad client-side graph scans.
+- **Endpoint onboarding bundles** — managed endpoint rollout bundles now carry a machine-readable enrollment manifest plus optional stable fleet `source_id` wiring so Jamf, Intune, and Kandji pushes can keep one explicit endpoint identity contract instead of only raw install scripts.
 
 ---
 

--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -53,6 +53,36 @@ Important boundary:
 - there is no MDM or quarantine control channel today
 - the pilot model is explicit local execution on a schedule you control
 
+## Managed rollout-ready bundle contract
+
+`agent-bom proxy-bootstrap` now emits more than install scripts. The bundle also
+ships:
+
+- `endpoint-enrollment.json` — machine-readable rollout metadata for IT
+- `endpoint-onboarding-summary.json` — operator-facing bundle summary
+- optional stable `source_id` wiring via `AGENT_BOM_PUSH_SOURCE_ID`
+
+That means Jamf, Intune, or Kandji rollout can keep one explicit endpoint
+identity contract without pretending `agent-bom` is already a bidirectional
+managed agent.
+
+Example:
+
+```bash
+agent-bom proxy-bootstrap \
+  --bundle-dir ./bundle \
+  --control-plane-url https://agent-bom.internal.example.com \
+  --push-url https://agent-bom.internal.example.com/v1/fleet/sync \
+  --push-api-key "$AGENT_BOM_PUSH_API_KEY" \
+  --source-id device-acme-001 \
+  --enrollment-name corp-laptop-rollout \
+  --owner platform-security \
+  --environment production \
+  --tag developer-endpoint \
+  --tag mdm \
+  --mdm-provider jamf
+```
+
 ## Endpoint service templates
 
 Shipped templates:

--- a/site-docs/deployment/runtime-operations.md
+++ b/site-docs/deployment/runtime-operations.md
@@ -67,7 +67,9 @@ environment/config through the same managed path used for initial install:
 agent-bom proxy-bootstrap \
   --bundle-dir ./bundle \
   --control-plane-url https://agent-bom.internal.example.com \
-  --control-plane-token "$CONTROL_PLANE_TOKEN"
+  --control-plane-token "$CONTROL_PLANE_TOKEN" \
+  --enrollment-name corp-laptop-rollout \
+  --mdm-provider jamf
 ```
 
 ### Break-glass recovery

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -325,6 +325,17 @@ def proxy_configure_cmd(
 )
 @click.option("--push-url", default=None, help="Optional fleet sync endpoint to write into managed endpoint artifacts")
 @click.option("--push-api-key", default=None, help="Optional fleet sync API key to write into managed endpoint artifacts")
+@click.option("--source-id", default=None, help="Optional stable endpoint source ID to embed in the rollout bundle")
+@click.option("--enrollment-name", default=None, help="Optional rollout or enrollment name to stamp into the bundle manifest")
+@click.option("--owner", default=None, help="Optional owning team or operator for the endpoint rollout manifest")
+@click.option("--environment", default=None, help="Optional environment label to stamp into the endpoint rollout manifest")
+@click.option("--tag", "tags", multiple=True, help="Optional repeated tag to stamp into the endpoint rollout manifest")
+@click.option(
+    "--mdm-provider",
+    type=click.Choice(["jamf", "intune", "kandji"], case_sensitive=False),
+    default=None,
+    help="Optional primary MDM provider label for the endpoint rollout manifest",
+)
 @click.option("--policy", type=click.Path(exists=True), default=None, help="Policy JSON file to pass to each proxy instance")
 @click.option(
     "--log-dir",
@@ -363,6 +374,12 @@ def proxy_bootstrap_cmd(
     control_plane_token,
     push_url,
     push_api_key,
+    source_id,
+    enrollment_name,
+    owner,
+    environment,
+    tags,
+    mdm_provider,
     policy,
     log_dir,
     secure_defaults,
@@ -407,6 +424,12 @@ def proxy_bootstrap_cmd(
         block_undeclared=block_undeclared,
         push_url=push_url,
         push_api_key=push_api_key,
+        source_id=source_id,
+        enrollment_name=enrollment_name,
+        owner=owner,
+        environment=environment,
+        tags=list(tags),
+        mdm_provider=mdm_provider,
     )
     con.print(f"[green]✓[/green] Wrote endpoint onboarding bundle to [bold]{bundle_path}[/bold]")
     for name, artifact_path in artifacts.items():

--- a/src/agent_bom/endpoint_onboarding.py
+++ b/src/agent_bom/endpoint_onboarding.py
@@ -7,6 +7,8 @@ import os
 import stat
 from pathlib import Path
 
+from agent_bom import __version__
+
 
 def _write_text(path: Path, body: str, mode: int) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -97,11 +99,13 @@ New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 """
 
 
-def render_fleet_sync_env(push_url: str, push_api_key: str | None) -> str:
+def render_fleet_sync_env(push_url: str, push_api_key: str | None, source_id: str | None = None) -> str:
     """Render a fleet-sync env file for the shipped timer/service assets."""
     lines = [f'AGENT_BOM_PUSH_URL="{push_url}"']
     if push_api_key:
         lines.append(f'AGENT_BOM_PUSH_API_KEY="{push_api_key}"')
+    if source_id:
+        lines.append(f'AGENT_BOM_PUSH_SOURCE_ID="{source_id}"')
     return "\n".join(lines) + "\n"
 
 
@@ -153,13 +157,20 @@ exit 1
 """
 
 
-def render_launch_agent_plist(push_url: str, push_api_key: str | None) -> str:
+def render_launch_agent_plist(push_url: str, push_api_key: str | None, source_id: str | None = None) -> str:
     """Render a launchd plist with concrete fleet-sync values."""
     token_xml = (
         f"""    <key>AGENT_BOM_PUSH_API_KEY</key>
     <string>{push_api_key}</string>
 """
         if push_api_key
+        else ""
+    )
+    source_xml = (
+        f"""    <key>AGENT_BOM_PUSH_SOURCE_ID</key>
+    <string>{source_id}</string>
+"""
+        if source_id
         else ""
     )
     return f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -178,7 +189,7 @@ def render_launch_agent_plist(push_url: str, push_api_key: str | None) -> str:
   <dict>
     <key>AGENT_BOM_PUSH_URL</key>
     <string>{push_url}</string>
-{token_xml}  </dict>
+{token_xml}{source_xml}  </dict>
   <key>RunAtLoad</key>
   <true/>
   <key>StartInterval</key>
@@ -190,6 +201,58 @@ def render_launch_agent_plist(push_url: str, push_api_key: str | None) -> str:
 </dict>
 </plist>
 """
+
+
+def render_endpoint_enrollment_manifest(
+    *,
+    control_plane_url: str,
+    push_url: str | None,
+    source_id: str | None,
+    enrollment_name: str | None,
+    owner: str | None,
+    environment: str | None,
+    tags: list[str],
+    mdm_provider: str | None,
+    policy_refresh_seconds: int,
+    audit_push_interval: int,
+    log_dir: str,
+    secure_defaults: bool,
+    detect_credentials: bool,
+    block_undeclared: bool,
+) -> dict:
+    """Render machine-readable endpoint rollout metadata for IT-owned deployment."""
+    normalized_tags = sorted({tag.strip() for tag in tags if tag and tag.strip()})
+    return {
+        "agent_bom_version": __version__,
+        "enrollment_name": enrollment_name or "agent-bom-endpoint-rollout",
+        "owner": owner or "",
+        "environment": environment or "",
+        "tags": normalized_tags,
+        "mdm_provider": mdm_provider or "",
+        "device_identity": {
+            "source_id": source_id or "",
+            "source_id_strategy": "configured" if source_id else "hostname_sha256",
+            "source_id_env": "AGENT_BOM_PUSH_SOURCE_ID",
+        },
+        "control_plane": {
+            "url": control_plane_url,
+            "fleet_sync_url": push_url or "",
+        },
+        "runtime_defaults": {
+            "log_dir": log_dir,
+            "policy_refresh_seconds": policy_refresh_seconds,
+            "audit_push_interval": audit_push_interval,
+            "secure_defaults": secure_defaults,
+            "detect_credentials": detect_credentials,
+            "block_undeclared": block_undeclared,
+        },
+        "rollout_contract": {
+            "managed_agent": False,
+            "batch_fleet_sync": bool(push_url),
+            "local_proxy_bootstrap": True,
+            "mdm_wrapper_bundle": True,
+        },
+    }
 
 
 def write_endpoint_onboarding_bundle(
@@ -206,6 +269,12 @@ def write_endpoint_onboarding_bundle(
     block_undeclared: bool,
     push_url: str | None,
     push_api_key: str | None,
+    source_id: str | None = None,
+    enrollment_name: str | None = None,
+    owner: str | None = None,
+    environment: str | None = None,
+    tags: list[str] | None = None,
+    mdm_provider: str | None = None,
 ) -> dict[str, str]:
     """Write packaged endpoint onboarding artifacts to *bundle_dir*."""
     command = build_proxy_configure_command(
@@ -221,6 +290,7 @@ def write_endpoint_onboarding_bundle(
         apply=True,
     )
     artifacts: dict[str, str] = {}
+    normalized_tags = sorted({tag.strip() for tag in (tags or []) if tag and tag.strip()})
     shell_path = _write_text(
         bundle_dir / "install-agent-bom-endpoint.sh",
         render_shell_bootstrap_script(command),
@@ -265,18 +335,42 @@ def write_endpoint_onboarding_bundle(
     if push_url:
         env_path = _write_text(
             bundle_dir / "fleet-sync.env",
-            render_fleet_sync_env(push_url, push_api_key),
+            render_fleet_sync_env(push_url, push_api_key, source_id=source_id),
             stat.S_IRUSR | stat.S_IWUSR,
         )
         artifacts["fleet_sync_env"] = str(env_path)
         plist_path = _write_text(
             bundle_dir / "com.agentbom.fleet-sync.plist",
-            render_launch_agent_plist(push_url, push_api_key),
+            render_launch_agent_plist(push_url, push_api_key, source_id=source_id),
             stat.S_IRUSR | stat.S_IWUSR,
         )
         artifacts["launch_agent_plist"] = str(plist_path)
 
+    enrollment_manifest = render_endpoint_enrollment_manifest(
+        control_plane_url=control_plane_url,
+        push_url=push_url,
+        source_id=source_id,
+        enrollment_name=enrollment_name,
+        owner=owner,
+        environment=environment,
+        tags=normalized_tags,
+        mdm_provider=mdm_provider,
+        policy_refresh_seconds=policy_refresh_seconds,
+        audit_push_interval=audit_push_interval,
+        log_dir=log_dir,
+        secure_defaults=secure_defaults,
+        detect_credentials=detect_credentials,
+        block_undeclared=block_undeclared,
+    )
+    enrollment_path = _write_text(
+        bundle_dir / "endpoint-enrollment.json",
+        json.dumps(enrollment_manifest, indent=2),
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    artifacts["enrollment_manifest"] = str(enrollment_path)
+
     summary = {
+        "agent_bom_version": __version__,
         "control_plane_url": control_plane_url,
         "log_dir": log_dir,
         "policy_path": policy_path,
@@ -285,6 +379,13 @@ def write_endpoint_onboarding_bundle(
         "secure_defaults": secure_defaults,
         "detect_credentials": detect_credentials,
         "block_undeclared": block_undeclared,
+        "source_id": source_id or "",
+        "source_id_strategy": "configured" if source_id else "hostname_sha256",
+        "enrollment_name": enrollment_name or "",
+        "owner": owner or "",
+        "environment": environment or "",
+        "tags": normalized_tags,
+        "mdm_provider": mdm_provider or "",
         "artifacts": artifacts,
     }
     summary_path = _write_text(

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -12,6 +12,7 @@ import asyncio
 import copy
 import hashlib
 import logging
+import os
 import platform
 import uuid
 
@@ -22,6 +23,9 @@ logger = logging.getLogger(__name__)
 
 def generate_source_id() -> str:
     """Generate a stable machine identifier (hostname SHA256[:12])."""
+    configured = os.environ.get("AGENT_BOM_PUSH_SOURCE_ID", "").strip()
+    if configured:
+        return configured
     hostname = platform.node() or "unknown"
     return hashlib.sha256(hostname.encode()).hexdigest()[:12]
 

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -224,6 +224,20 @@ def test_proxy_bootstrap_writes_bundle(tmp_path):
             "https://agent-bom.internal.example.com/v1/fleet/sync",
             "--push-api-key",
             "fleet-key",
+            "--source-id",
+            "device-acme-001",
+            "--enrollment-name",
+            "corp-rollout",
+            "--owner",
+            "platform-security",
+            "--environment",
+            "production",
+            "--tag",
+            "developer-endpoint",
+            "--tag",
+            "mdm",
+            "--mdm-provider",
+            "jamf",
         ],
     )
     assert result.exit_code == 0
@@ -235,6 +249,7 @@ def test_proxy_bootstrap_writes_bundle(tmp_path):
     assert (tmp_path / "intune" / "detect-agent-bom-endpoint.ps1").exists()
     assert (tmp_path / "kandji" / "install-agent-bom-endpoint.sh").exists()
     assert (tmp_path / "endpoint-onboarding-summary.json").exists()
+    assert (tmp_path / "endpoint-enrollment.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_endpoint_onboarding.py
+++ b/tests/test_endpoint_onboarding.py
@@ -40,6 +40,12 @@ def test_write_endpoint_onboarding_bundle_writes_artifacts(tmp_path):
         block_undeclared=False,
         push_url="https://agent-bom.internal.example.com/v1/fleet/sync",
         push_api_key="fleet-key",
+        source_id="device-acme-001",
+        enrollment_name="corp-laptop-rollout",
+        owner="platform-security",
+        environment="production",
+        tags=["mdm", "developer-endpoint"],
+        mdm_provider="jamf",
     )
     assert set(artifacts) >= {
         "shell_bootstrap",
@@ -50,6 +56,7 @@ def test_write_endpoint_onboarding_bundle_writes_artifacts(tmp_path):
         "intune_detect",
         "fleet_sync_env",
         "launch_agent_plist",
+        "enrollment_manifest",
         "summary",
     }
     shell_script = Path(artifacts["shell_bootstrap"]).read_text()
@@ -58,10 +65,20 @@ def test_write_endpoint_onboarding_bundle_writes_artifacts(tmp_path):
     env_file = Path(artifacts["fleet_sync_env"]).read_text()
     assert "AGENT_BOM_PUSH_URL" in env_file
     assert "AGENT_BOM_PUSH_API_KEY" in env_file
+    assert 'AGENT_BOM_PUSH_SOURCE_ID="device-acme-001"' in env_file
     jamf_script = Path(artifacts["jamf_install"]).read_text()
     assert "install-agent-bom-endpoint.sh" in jamf_script
     intune_script = Path(artifacts["intune_install"]).read_text()
     assert "install-agent-bom-endpoint.ps1" in intune_script
+    enrollment = json.loads(Path(artifacts["enrollment_manifest"]).read_text())
+    assert enrollment["enrollment_name"] == "corp-laptop-rollout"
+    assert enrollment["owner"] == "platform-security"
+    assert enrollment["environment"] == "production"
+    assert enrollment["mdm_provider"] == "jamf"
+    assert enrollment["device_identity"]["source_id"] == "device-acme-001"
+    assert enrollment["device_identity"]["source_id_strategy"] == "configured"
     summary = json.loads(Path(artifacts["summary"]).read_text())
     assert summary["control_plane_url"] == "https://agent-bom.internal.example.com"
+    assert summary["source_id"] == "device-acme-001"
+    assert summary["mdm_provider"] == "jamf"
     assert summary["artifacts"]["shell_bootstrap"] == artifacts["shell_bootstrap"]

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -18,6 +18,10 @@ from agent_bom.push import (
 
 
 class TestGenerateSourceId:
+    def test_env_override_takes_priority(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_PUSH_SOURCE_ID", "device-acme-001")
+        assert generate_source_id() == "device-acme-001"
+
     def test_stable(self):
         """Same machine produces same source_id."""
         id1 = generate_source_id()


### PR DESCRIPTION
## Summary
- add a machine-readable endpoint enrollment manifest to the proxy-bootstrap bundle
- support optional stable fleet source IDs in managed endpoint rollout artifacts
- document the MDM-ready bundle contract for Jamf, Intune, and Kandji rollout

## Testing
- uv run --python 3.12 pytest tests/test_endpoint_onboarding.py tests/test_cli_runtime.py tests/test_push.py -q
- uv run ruff check src/agent_bom/endpoint_onboarding.py src/agent_bom/push.py src/agent_bom/cli/_runtime.py tests/test_endpoint_onboarding.py tests/test_cli_runtime.py tests/test_push.py
- uv run mkdocs build --strict

Progresses #1469