### PR TITLE
feat(snowflake): add schedule store parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 Work targeting the next release.
 
 ### Changed
+- **Snowflake schedule parity** — warehouse-native deployments now persist recurring scan schedules in Snowflake and wire `/v1/schedules*` through the same backend-selection path as jobs, fleet, and gateway policy stores.
 - **Graph search and slice filtering** — the control plane now uses indexed graph-node search paths with server-side entity, severity, compliance-prefix, and data-source filters so larger tenant snapshots do not fall back to broad client-side graph scans.
 
 ---

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -173,7 +173,7 @@ For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated
 
 For horizontally scaled control-plane APIs, shared rate limiting is mandatory. `agent-bom` now fails closed when `AGENT_BOM_CONTROL_PLANE_REPLICAS > 1` (or `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1`) and no PostgreSQL-backed limiter is configured via `AGENT_BOM_POSTGRES_URL`.
 
-**Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, schedules, graph state, and trend history.
+**Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, graph state, and trend history.
 
 Use the backend story this way:
 

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -22,7 +22,7 @@ This page documents what is wired today, not what might exist as a class on disk
 | Source registry persistence | Yes | Yes | No | No |
 | Exception workflow persistence | No default API wiring | Yes | No | No |
 | API key persistence / RBAC store | No default API wiring | Yes | No | No |
-| Schedule persistence | Yes | Yes | No | No |
+| Schedule persistence | Yes | Yes | No | Yes |
 | Trend / baseline persistence | Yes | Yes | No | No |
 | Graph persistence | Yes | Yes | No | No |
 | Analytics / OLAP writes | No | No | Yes | No |
@@ -42,7 +42,7 @@ backend?"
 | `/v1/audit*` primary trail | Yes | Yes | No | Partial; Snowflake policy audit exists, but it is not the full transactional audit replacement |
 | `/v1/auth/keys*` | No default API wiring | Yes | No | No |
 | `/v1/exceptions*` | No default API wiring | Yes | No | No |
-| `/v1/schedules*` | Yes | Yes | No | No |
+| `/v1/schedules*` | Yes | Yes | No | Yes |
 | `/v1/traces`, `/v1/proxy/audit`, `/v1/ocsf/ingest` analytics writes | No | No | Yes | No |
 | Snowflake governance/account discovery routes | No | No | No | Yes |
 
@@ -68,13 +68,11 @@ The Snowflake story should be read in three layers:
    - source registry
    - exceptions
    - API keys and RBAC persistence
-   - schedules
    - graph persistence
    - trend and baseline state
    - full HMAC-chained `audit_log`
 3. **Next parity targets, if warehouse-native control-plane coverage expands**
    - source registry
-   - schedules
    - selected baseline/trend state
 
 That means Snowflake is already a real backend mode, but it is still not the
@@ -129,7 +127,6 @@ Use when you want:
 
 Current limitations:
 
-- schedules do not persist to Snowflake
 - graph persistence does not persist to Snowflake
 - exceptions do not persist to Snowflake
 - API keys do not persist to Snowflake

--- a/site-docs/deployment/control-plane-data-model.md
+++ b/site-docs/deployment/control-plane-data-model.md
@@ -63,7 +63,7 @@ The main operator rule is:
 | Source registry | `sources` | `control_plane_sources` | No | No |
 | API keys / RBAC | No default API wiring | `api_keys` | No | No |
 | Exceptions | No default API wiring | `exceptions` | No | No |
-| Schedules | `scan_schedules` | `scan_schedules` | No | No |
+| Schedules | `scan_schedules` | `scan_schedules` | No | `scan_schedules` |
 | Audit chain | `audit_log` | `audit_log` | denormalized analytics copy only | No full transactional replacement |
 | Graph / attack path | SQLite graph tables | Postgres graph tables | No | No |
 | Trend / baseline | local control-plane tables | `trend_history` and related control-plane tables | analytics/event aggregation only | No |
@@ -128,8 +128,8 @@ use:
 - SQLite and Postgres `api_rate_limits` in the shared rate-limit path
 - Postgres `gateway_policies`, `policy_audit_log`, `scan_schedules`,
   `control_plane_sources`
-- Snowflake `scan_jobs`, `fleet_agents`, `gateway_policies`,
-  `policy_audit_log`
+- Snowflake `scan_jobs`, `fleet_agents`, `scan_schedules`,
+  `gateway_policies`, `policy_audit_log`
 
 This is why "table exists in SQL" and "route is fully supported on this
 backend" are different questions.
@@ -182,9 +182,9 @@ Use for:
 
 Current transactional parity boundary:
 
-- supported: `scan_jobs`, `fleet_agents`, `gateway_policies`,
-  `policy_audit_log`
-- not supported: source registry, API keys, exceptions, schedules,
+- supported: `scan_jobs`, `fleet_agents`, `scan_schedules`,
+  `gateway_policies`, `policy_audit_log`
+- not supported: source registry, API keys, exceptions,
   graph, trend/baseline, full audit-chain replacement
 
 ## Recommended selection

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -1,12 +1,12 @@
 # Snowflake-native backend
 
 `agent-bom` runs against Snowflake as the primary store for scan jobs,
-fleet agents, gateway policies, and the policy audit trail. Use this
+fleet agents, schedules, gateway policies, and the policy audit trail. Use this
 mode when your organisation already governs data in Snowflake and you
 want selected control-plane persistence to land in the same warehouse.
 
 The parity boundary is explicit — some API surfaces (source registry,
-exceptions, API keys, schedules, trend, graph, and the full audit
+exceptions, API keys, trend, graph, and the full audit
 chain) have not been ported to `SnowflakeStore` yet. See
 [backend-parity.md](backend-parity.md) for the current capability
 matrix.
@@ -77,11 +77,13 @@ Use when you want these persisted in Snowflake:
 
 - scan jobs
 - fleet inventory
+- schedules
 - gateway policies
 - gateway policy audit
 
 This is the current partial-control-plane mode backed by
-`SnowflakeJobStore`, `SnowflakeFleetStore`, and `SnowflakePolicyStore`.
+`SnowflakeJobStore`, `SnowflakeFleetStore`, `SnowflakeScheduleStore`,
+and `SnowflakePolicyStore`.
 
 ### 3. Hybrid self-hosted control plane
 
@@ -161,7 +163,7 @@ The example file configures:
 
 ## Schema bootstrap
 
-`SnowflakeJobStore` / `SnowflakeFleetStore` / `SnowflakePolicyStore`
+`SnowflakeJobStore` / `SnowflakeFleetStore` / `SnowflakeScheduleStore` / `SnowflakePolicyStore`
 create their tables on first connect with `CREATE TABLE IF NOT EXISTS`.
 The schema lives in the database + schema you set via
 `SNOWFLAKE_DATABASE` / `SNOWFLAKE_SCHEMA`.
@@ -197,7 +199,7 @@ applies here. Snowflake-specific signals worth alerting on:
 
 ## Caveats
 
-- Source registry, exceptions, API-key persistence, scheduler, trend,
+- Source registry, exceptions, API-key persistence, trend,
   graph, and the full HMAC-chained `audit_log` are not yet on
   `SnowflakeStore`. Run Postgres alongside for these, or wait for
   parity.
@@ -210,7 +212,7 @@ applies here. Snowflake-specific signals worth alerting on:
 ## Honest operator summary
 
 `Snowflake` is already a valid warehouse-native backend mode for governance,
-scan inventory, fleet state, and gateway policy paths. `Postgres` remains the
+scan inventory, fleet state, schedules, and gateway policy paths. `Postgres` remains the
 default full control-plane answer. Use Snowflake when that warehouse-native
 shape is the goal, not because the product is pretending all backend roles are
 already identical.

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -179,6 +179,7 @@ async def _lifespan(app_instance: FastAPI):
             SnowflakeFleetStore,
             SnowflakeJobStore,
             SnowflakePolicyStore,
+            SnowflakeScheduleStore,
             build_connection_params,
         )
 
@@ -189,6 +190,8 @@ async def _lifespan(app_instance: FastAPI):
             set_fleet_store(SnowflakeFleetStore(sf))
         if _stores._policy_store is None:
             set_policy_store(SnowflakePolicyStore(sf))
+        if _stores._schedule_store is None:
+            set_schedule_store(SnowflakeScheduleStore(sf))
     elif os.environ.get("AGENT_BOM_POSTGRES_URL"):
         from agent_bom.api import audit_log as _audit_log_mod
         from agent_bom.api import auth as _auth

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -1,8 +1,9 @@
 """Snowflake-backed storage backends for agent-bom.
 
-Provides pluggable Snowflake persistence for all three store protocols:
+Provides pluggable Snowflake persistence for all four store protocols:
 - ``SnowflakeJobStore``    — scan job persistence
 - ``SnowflakeFleetStore``  — fleet agent lifecycle
+- ``SnowflakeScheduleStore`` — recurring scan schedules
 - ``SnowflakePolicyStore`` — gateway policies + audit log
 
 Requires ``pip install 'agent-bom[snowflake]'``.
@@ -363,6 +364,100 @@ class SnowflakeFleetStore:
             total += len(batch)
 
         return total
+
+
+# ─── Schedule Store ───────────────────────────────────────────────────────────
+
+
+class SnowflakeScheduleStore:
+    """Snowflake-backed recurring scan schedule persistence."""
+
+    def __init__(self, connection_params: dict) -> None:
+        self._conn_params = connection_params
+        self._init_tables()
+
+    def _connect(self):  # type: ignore[no-untyped-def]
+        return _sf_connect(**self._conn_params)
+
+    def _init_tables(self) -> None:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS scan_schedules (
+                    schedule_id VARCHAR PRIMARY KEY,
+                    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                    next_run VARCHAR,
+                    tenant_id VARCHAR NOT NULL DEFAULT 'default',
+                    data VARIANT NOT NULL
+                )
+            """)
+            cur.execute("ALTER TABLE scan_schedules ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+            cur.execute("CREATE INDEX IF NOT EXISTS idx_sched_tenant_due ON scan_schedules(tenant_id, enabled, next_run)")
+
+    def put(self, schedule) -> None:
+        with self._connect() as conn:
+            conn.cursor().execute(
+                """MERGE INTO scan_schedules t USING (SELECT %s AS schedule_id) s
+                   ON t.schedule_id = s.schedule_id
+                   WHEN MATCHED THEN UPDATE SET
+                     enabled = %s, next_run = %s, tenant_id = %s, data = PARSE_JSON(%s)
+                   WHEN NOT MATCHED THEN INSERT
+                     (schedule_id, enabled, next_run, tenant_id, data)
+                     VALUES (%s, %s, %s, %s, PARSE_JSON(%s))""",
+                (
+                    schedule.schedule_id,
+                    schedule.enabled,
+                    schedule.next_run,
+                    schedule.tenant_id,
+                    schedule.model_dump_json(),
+                    schedule.schedule_id,
+                    schedule.enabled,
+                    schedule.next_run,
+                    schedule.tenant_id,
+                    schedule.model_dump_json(),
+                ),
+            )
+
+    def get(self, schedule_id: str):
+        from .schedule_store import ScanSchedule
+
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT data FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return ScanSchedule.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
+
+    def delete(self, schedule_id: str) -> bool:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            return (cur.rowcount or 0) > 0
+
+    def list_all(self, tenant_id: str | None = None) -> list:
+        from .schedule_store import ScanSchedule
+
+        with self._connect() as conn:
+            cur = conn.cursor()
+            if tenant_id is None:
+                cur.execute("SELECT data FROM scan_schedules ORDER BY schedule_id")
+            else:
+                cur.execute("SELECT data FROM scan_schedules WHERE tenant_id = %s ORDER BY schedule_id", (tenant_id,))
+            return [ScanSchedule.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+
+    def list_due(self, now_iso: str) -> list:
+        from .schedule_store import ScanSchedule
+
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """SELECT data
+                   FROM scan_schedules
+                   WHERE enabled = TRUE AND next_run IS NOT NULL AND next_run <= %s""",
+                (now_iso,),
+            )
+            return [ScanSchedule.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
 
 
 # ─── Policy Store ─────────────────────────────────────────────────────────────

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -653,6 +653,95 @@ class TestSnowflakePolicyStore:
         assert any("tenant_id = %s" in call for call in sql_calls)
 
 
+# ─── SnowflakeScheduleStore ──────────────────────────────────────────────────
+
+
+class TestSnowflakeScheduleStore:
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def _make_store(self, mock_connect):
+        mock_connect.return_value = _mock_connection()
+        from agent_bom.api.snowflake_store import SnowflakeScheduleStore
+
+        return SnowflakeScheduleStore(SF_PARAMS)
+
+    def _make_schedule(self, schedule_id="sched-1", tenant_id="default", enabled=True, next_run="2025-01-01T00:00:00Z"):
+        from agent_bom.api.schedule_store import ScanSchedule
+
+        return ScanSchedule(
+            schedule_id=schedule_id,
+            name="nightly-scan",
+            cron_expression="0 */6 * * *",
+            scan_config={"images": ["nginx:latest"]},
+            enabled=enabled,
+            next_run=next_run,
+            created_at="2025-01-01T00:00:00Z",
+            updated_at="2025-01-01T00:00:00Z",
+            tenant_id=tenant_id,
+        )
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_init_creates_table(self, mock_connect):
+        conn = _mock_connection()
+        mock_connect.return_value = conn
+        from agent_bom.api.snowflake_store import SnowflakeScheduleStore
+
+        SnowflakeScheduleStore(SF_PARAMS)
+        create_call = conn.cursor().execute.call_args_list[0]
+        assert "CREATE TABLE IF NOT EXISTS scan_schedules" in create_call[0][0]
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_put(self, mock_connect):
+        conn = _mock_connection()
+        mock_connect.return_value = conn
+        store = self._make_store()
+        store.put(self._make_schedule())
+        calls = conn.cursor().execute.call_args_list
+        merge_call = [c for c in calls if "MERGE INTO scan_schedules" in str(c)]
+        assert len(merge_call) > 0
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_get_found(self, mock_connect):
+        schedule = self._make_schedule()
+        cur = _mock_cursor(fetchone_val=(schedule.model_dump_json(),))
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        result = store.get("sched-1")
+        assert result is not None
+        assert result.schedule_id == "sched-1"
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_list_all_tenant_filtered(self, mock_connect):
+        s1 = self._make_schedule("sched-1", tenant_id="tenant-a")
+        s2 = self._make_schedule("sched-2", tenant_id="tenant-a")
+        cur = _mock_cursor(fetchall_val=[(s1.model_dump_json(),), (s2.model_dump_json(),)])
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        result = store.list_all(tenant_id="tenant-a")
+        assert len(result) == 2
+        assert all(item.tenant_id == "tenant-a" for item in result)
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_list_due(self, mock_connect):
+        schedule = self._make_schedule("sched-due", enabled=True, next_run="2025-01-01T00:00:00Z")
+        cur = _mock_cursor(fetchall_val=[(schedule.model_dump_json(),)])
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        result = store.list_due("2025-06-01T00:00:00Z")
+        assert len(result) == 1
+        assert result[0].schedule_id == "sched-due"
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_delete_found(self, mock_connect):
+        cur = _mock_cursor(rowcount=1)
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        assert store.delete("sched-1") is True
+
+
 # ─── Server lifespan auto-detection ──────────────────────────────────────────
 
 
@@ -675,6 +764,7 @@ class TestServerLifespanAutoDetect:
         st._store = None
         st._fleet_store = None
         st._policy_store = None
+        st._schedule_store = None
 
         import asyncio
 
@@ -688,13 +778,16 @@ class TestServerLifespanAutoDetect:
             SnowflakeFleetStore,
             SnowflakeJobStore,
             SnowflakePolicyStore,
+            SnowflakeScheduleStore,
         )
 
         assert isinstance(st._store, SnowflakeJobStore)
         assert isinstance(st._fleet_store, SnowflakeFleetStore)
         assert isinstance(st._policy_store, SnowflakePolicyStore)
+        assert isinstance(st._schedule_store, SnowflakeScheduleStore)
 
         # Cleanup
         st._store = None
         st._fleet_store = None
         st._policy_store = None
+        st._schedule_store = None


### PR DESCRIPTION
## Summary
- add a Snowflake-backed schedule store and wire it into backend auto-detection
- extend Snowflake store coverage to `/v1/schedules*` for warehouse-native deployments
- update parity and deployment docs to reflect the new bounded control-plane support

## Testing
- uv run --python 3.12 pytest tests/test_snowflake_stores.py -q
- uv run ruff check src/agent_bom/api/snowflake_store.py src/agent_bom/api/server.py tests/test_snowflake_stores.py
- uv run mypy src/agent_bom/api/snowflake_store.py src/agent_bom/api/server.py
- uv run mkdocs build --strict

Progresses #1366