### PR TITLE
fix(auth): enforce key scopes and scrub gateway 404s

### DIFF
--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -103,6 +103,23 @@ class ApiKey:
         """Check if this key's role meets or exceeds the required role."""
         return _ROLE_HIERARCHY.get(self.role, 0) >= _ROLE_HIERARCHY.get(required, 0)
 
+    def has_scope(self, required_scope: str | None) -> bool:
+        """Check whether this key's scopes allow the requested action."""
+        if not required_scope:
+            return True
+        if not self.scopes:
+            return True
+        if any(scope in {"saml-session", "browser-session", "oidc-session"} for scope in self.scopes):
+            return True
+        for scope in self.scopes:
+            if scope == "*" or scope == required_scope:
+                return True
+            if scope.endswith(":*") and required_scope.startswith(scope[:-1]):
+                return True
+            if scope.endswith(".*") and required_scope.startswith(scope[:-1]):
+                return True
+        return False
+
     def to_dict(self) -> dict:
         current = datetime.now(timezone.utc)
         overlap_remaining_seconds = None

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -374,6 +374,29 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("PUT", "/v1/sources/", "analyst"),
     )
 
+    _SCOPE_RULES: tuple[tuple[str, str, str], ...] = (
+        ("GET", "/v1/auth/keys", "auth.keys:read"),
+        ("POST", "/v1/auth/keys", "auth.keys:write"),
+        ("POST", "/v1/auth/keys/", "auth.keys:write"),
+        ("DELETE", "/v1/auth/keys/", "auth.keys:write"),
+        ("GET", "/v1/gateway/policies", "gateway.policy:read"),
+        ("POST", "/v1/gateway/policies", "gateway.policy:write"),
+        ("PUT", "/v1/gateway/policies/", "gateway.policy:write"),
+        ("DELETE", "/v1/gateway/policies/", "gateway.policy:write"),
+        ("GET", "/v1/gateway/audit", "audit:read"),
+        ("POST", "/v1/fleet/sync", "fleet:write"),
+        ("POST", "/v1/scan", "scan:write"),
+        ("DELETE", "/v1/scan/", "scan:delete"),
+        ("POST", "/v1/schedules", "schedule:write"),
+        ("DELETE", "/v1/schedules/", "schedule:write"),
+        ("PUT", "/v1/schedules/", "schedule:write"),
+        ("POST", "/v1/graph/presets", "graph.preset:write"),
+        ("DELETE", "/v1/graph/presets/", "graph.preset:write"),
+        ("POST", "/v1/exceptions", "exception:write"),
+        ("PUT", "/v1/exceptions/", "exception:write"),
+        ("DELETE", "/v1/exceptions/", "exception:write"),
+    )
+
     def __init__(self, app: ASGIApp, api_key: str) -> None:
         super().__init__(app)
         self._api_key = api_key
@@ -388,6 +411,13 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             if method == m and path.startswith(p):
                 return role
         return "viewer"
+
+    def _required_scope(self, method: str, path: str) -> str | None:
+        """Determine the optional scope required for a request."""
+        for m, p, scope in self._SCOPE_RULES:
+            if method == m and path.startswith(p):
+                return scope
+        return None
 
     async def dispatch(self, request: StarletteRequest, call_next):
         if request.url.path in self._EXEMPT_PATHS:
@@ -468,10 +498,17 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                         status_code=403,
                         content={"detail": f"Forbidden — requires {required} role, you have {api_key.role.value}"},
                     )
+                required_scope = self._required_scope(request.method, request.url.path)
+                if not api_key.has_scope(required_scope):
+                    return JSONResponse(
+                        status_code=403,
+                        content={"detail": f"Forbidden — requires scope {required_scope}"},
+                    )
                 request.state.api_key_name = api_key.name
                 request.state.api_key_role = api_key.role.value
                 request.state.tenant_id = api_key.tenant_id
                 request.state.api_key_id = api_key.key_id
+                request.state.api_key_scopes = list(api_key.scopes)
                 # SAML-minted keys are named "saml:<subject>" — surface that
                 # as a distinct auth method so operators can trace who came
                 # in via which IdP path even after the key has been issued.

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -393,13 +393,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
         upstream = settings.registry.get(server_name, tenant_id=tenant_id)
         if upstream is None:
-            raise HTTPException(
-                status_code=404,
-                detail=(
-                    f"unknown upstream {server_name!r} for tenant {tenant_id!r}; known: "
-                    f"{', '.join(settings.registry.names(tenant_id=tenant_id)) or '(none)'}"
-                ),
-            )
+            raise HTTPException(status_code=404, detail=f"unknown upstream {server_name!r}")
 
         try:
             body = await request.json()

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -318,6 +318,55 @@ def test_api_key_middleware_graph_preset_mutation_requires_analyst_role():
         set_key_store(original_store)
 
 
+def test_api_key_middleware_enforces_scopes_when_present():
+    """Scoped keys should be denied when the route needs a missing scope."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    original_store = get_key_store()
+    store = KeyStore()
+    raw_key, analyst = create_api_key("analyst", Role.ANALYST, tenant_id="tenant-alpha", scopes=["graph.preset:write"])
+    store.add(analyst)
+    set_key_store(store)
+    try:
+        test_app = Starlette(routes=[Route("/v1/scan", dummy, methods=["POST"])])
+        test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+        client = TestClient(test_app)
+        resp = client.post("/v1/scan", headers={"Authorization": f"Bearer {raw_key}"})
+        assert resp.status_code == 403
+        assert "requires scope scan:write" in resp.json()["detail"]
+    finally:
+        set_key_store(original_store)
+
+
+def test_api_key_middleware_empty_scopes_keep_legacy_access():
+    """Keys without scopes should preserve the legacy unrestricted behavior."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    original_store = get_key_store()
+    store = KeyStore()
+    raw_key, analyst = create_api_key("analyst", Role.ANALYST, tenant_id="tenant-alpha")
+    store.add(analyst)
+    set_key_store(store)
+    try:
+        test_app = Starlette(routes=[Route("/v1/scan", dummy, methods=["POST"])])
+        test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+        client = TestClient(test_app)
+        resp = client.post("/v1/scan", headers={"Authorization": f"Bearer {raw_key}"})
+        assert resp.status_code == 200
+    finally:
+        set_key_store(original_store)
+
+
 def test_api_key_middleware_oidc_sets_tenant_from_custom_claim():
     """OIDC tenant scoping should honor AGENT_BOM_OIDC_TENANT_CLAIM semantics."""
     from starlette.applications import Starlette

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -384,7 +384,7 @@ def test_relay_fails_closed_when_tenant_has_no_matching_upstream(monkeypatch) ->
         json=_json_rpc("tools/call", name="query_issues", arguments={"jql": "project = BETA"}),
     )
     assert denied.status_code == 404
-    assert "tenant 'tenant-beta'" in denied.json()["detail"]
+    assert denied.json()["detail"] == "unknown upstream 'jira'"
 
 
 def test_gateway_rate_limit_is_tenant_scoped(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- enforce API key scopes on the routes that already expose scoped authorization surfaces
- preserve legacy unrestricted behavior for empty-scope keys and browser/session-style keys
- scrub tenant-specific upstream details from gateway 404 responses

## Testing
- uv run --python 3.12 pytest tests/test_api_hardening.py tests/test_gateway_server.py tests/test_auth.py -q
- uv run ruff check src/agent_bom/api/auth.py src/agent_bom/api/middleware.py src/agent_bom/gateway_server.py tests/test_api_hardening.py tests/test_gateway_server.py tests/test_auth.py
- uv run mypy src/agent_bom/api/auth.py src/agent_bom/api/middleware.py src/agent_bom/gateway_server.py

Hardens auth scope enforcement and gateway tenant isolation.
