### PR TITLE
docs: add safe PR refresh helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,12 +88,15 @@ Branch naming: `feat/`, `fix/`, `docs/`, `chore/` prefixes. Always branch from a
 Do **not** use GitHub's **Update branch** button on active PRs unless the PR is
 actually non-mergeable and you cannot refresh it locally.
 
+If GitHub only says **"This branch is out-of-date with the base branch"**, that
+does **not** automatically mean there is a conflict. In this repo, that banner
+is informational unless merge protection explicitly blocks on being current with
+`main`.
+
 Preferred path:
 
 ```bash
-git fetch origin main
-git rebase origin/main
-git push --force-with-lease
+scripts/refresh-pr-branch.sh your-branch
 ```
 
 Why:
@@ -106,6 +109,15 @@ Why:
 If a PR ever shows "no checks reported", "expected" checks with no attached
 run, or obviously stale check-rollup state after an update, replace the branch
 head with a clean local rebase instead of retrying the GitHub button again.
+
+Manual equivalent:
+
+```bash
+git fetch origin
+git checkout your-branch
+git rebase origin/main
+git push --force-with-lease origin your-branch
+```
 
 ---
 

--- a/scripts/refresh-pr-branch.sh
+++ b/scripts/refresh-pr-branch.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required" >&2
+  exit 1
+fi
+
+BRANCH="${1:-$(git branch --show-current)}"
+BASE_REF="${2:-origin/main}"
+
+if [[ -z "${BRANCH}" ]]; then
+  echo "usage: scripts/refresh-pr-branch.sh <branch> [base-ref]" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "working tree is not clean; commit or stash changes first" >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+
+cleanup() {
+  if [[ -n "${CURRENT_BRANCH}" && "$(git branch --show-current)" != "${CURRENT_BRANCH}" ]]; then
+    git checkout "${CURRENT_BRANCH}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "Fetching latest refs..."
+git fetch origin
+
+echo "Checking out ${BRANCH}..."
+git checkout "${BRANCH}"
+
+echo "Rebasing ${BRANCH} onto ${BASE_REF}..."
+git rebase "${BASE_REF}"
+
+echo "Pushing refreshed head with force-with-lease..."
+git push --force-with-lease origin "${BRANCH}"
+
+echo
+echo "Safe refresh complete."
+echo "- branch: ${BRANCH}"
+echo "- base: ${BASE_REF}"
+echo "- new head: $(git rev-parse HEAD)"
+echo
+echo "Do not click GitHub 'Update branch' after this push."


### PR DESCRIPTION
## Summary
- add a safe local PR refresh helper script
- document that GitHub's "out-of-date" banner is not the same thing as a merge conflict
- point contributors to local rebase + force-with-lease instead of GitHub's `Update branch` button

## Testing
- bash -n scripts/refresh-pr-branch.sh

Prevents the repeated synthetic-head / detached-check issue on active PRs.
