### PR TITLE
feat(snowflake): add exception store parity

### DIFF
--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -20,7 +20,7 @@ This page documents what is wired today, not what might exist as a class on disk
 | Gateway policy persistence | Yes | Yes | No | Yes |
 | Audit log persistence | Yes | Yes | No | Yes, via `SnowflakePolicyStore` |
 | Source registry persistence | Yes | Yes | No | No |
-| Exception workflow persistence | No default API wiring | Yes | No | No |
+| Exception workflow persistence | No default API wiring | Yes | No | Yes |
 | API key persistence / RBAC store | No default API wiring | Yes | No | No |
 | Schedule persistence | Yes | Yes | No | Yes |
 | Trend / baseline persistence | Yes | Yes | No | No |
@@ -41,7 +41,7 @@ backend?"
 | `/v1/sources*` source registry | Yes | Yes | No | No |
 | `/v1/audit*` primary trail | Yes | Yes | No | Partial; Snowflake policy audit exists, but it is not the full transactional audit replacement |
 | `/v1/auth/keys*` | No default API wiring | Yes | No | No |
-| `/v1/exceptions*` | No default API wiring | Yes | No | No |
+| `/v1/exceptions*` | No default API wiring | Yes | No | Yes |
 | `/v1/schedules*` | Yes | Yes | No | Yes |
 | `/v1/traces`, `/v1/proxy/audit`, `/v1/ocsf/ingest` analytics writes | No | No | Yes | No |
 | Snowflake governance/account discovery routes | No | No | No | Yes |
@@ -63,10 +63,10 @@ The Snowflake story should be read in three layers:
    - `fleet_agents`
    - `gateway_policies`
    - `policy_audit_log`
+   - `exceptions`
    - governance and activity discovery routes
 2. **Current explicit non-parity**
    - source registry
-   - exceptions
    - API keys and RBAC persistence
    - graph persistence
    - trend and baseline state
@@ -128,7 +128,7 @@ Use when you want:
 Current limitations:
 
 - graph persistence does not persist to Snowflake
-- exceptions do not persist to Snowflake
+- exceptions persist to Snowflake
 - API keys do not persist to Snowflake
 - baseline/trend storage does not persist to Snowflake
 

--- a/site-docs/deployment/control-plane-data-model.md
+++ b/site-docs/deployment/control-plane-data-model.md
@@ -62,7 +62,7 @@ The main operator rule is:
 | Gateway policy audit | `policy_audit_log` | `policy_audit_log` | No | `policy_audit_log` |
 | Source registry | `sources` | `control_plane_sources` | No | No |
 | API keys / RBAC | No default API wiring | `api_keys` | No | No |
-| Exceptions | No default API wiring | `exceptions` | No | No |
+| Exceptions | No default API wiring | `exceptions` | No | `exceptions` |
 | Schedules | `scan_schedules` | `scan_schedules` | No | `scan_schedules` |
 | Audit chain | `audit_log` | `audit_log` | denormalized analytics copy only | No full transactional replacement |
 | Graph / attack path | SQLite graph tables | Postgres graph tables | No | No |
@@ -183,8 +183,8 @@ Use for:
 Current transactional parity boundary:
 
 - supported: `scan_jobs`, `fleet_agents`, `scan_schedules`,
-  `gateway_policies`, `policy_audit_log`
-- not supported: source registry, API keys, exceptions,
+  `gateway_policies`, `policy_audit_log`, `exceptions`
+- not supported: source registry, API keys,
   graph, trend/baseline, full audit-chain replacement
 
 ## Recommended selection

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -1,12 +1,12 @@
 # Snowflake-native backend
 
 `agent-bom` runs against Snowflake as the primary store for scan jobs,
-fleet agents, schedules, gateway policies, and the policy audit trail. Use this
+fleet agents, schedules, gateway policies, vulnerability exceptions, and the policy audit trail. Use this
 mode when your organisation already governs data in Snowflake and you
 want selected control-plane persistence to land in the same warehouse.
 
 The parity boundary is explicit — some API surfaces (source registry,
-exceptions, API keys, trend, graph, and the full audit
+API keys, trend, graph, and the full audit
 chain) have not been ported to `SnowflakeStore` yet. See
 [backend-parity.md](backend-parity.md) for the current capability
 matrix.
@@ -79,11 +79,12 @@ Use when you want these persisted in Snowflake:
 - fleet inventory
 - schedules
 - gateway policies
+- vulnerability exceptions
 - gateway policy audit
 
 This is the current partial-control-plane mode backed by
 `SnowflakeJobStore`, `SnowflakeFleetStore`, `SnowflakeScheduleStore`,
-and `SnowflakePolicyStore`.
+`SnowflakeExceptionStore`, and `SnowflakePolicyStore`.
 
 ### 3. Hybrid self-hosted control plane
 
@@ -163,7 +164,7 @@ The example file configures:
 
 ## Schema bootstrap
 
-`SnowflakeJobStore` / `SnowflakeFleetStore` / `SnowflakeScheduleStore` / `SnowflakePolicyStore`
+`SnowflakeJobStore` / `SnowflakeFleetStore` / `SnowflakeScheduleStore` / `SnowflakeExceptionStore` / `SnowflakePolicyStore`
 create their tables on first connect with `CREATE TABLE IF NOT EXISTS`.
 The schema lives in the database + schema you set via
 `SNOWFLAKE_DATABASE` / `SNOWFLAKE_SCHEMA`.
@@ -199,7 +200,7 @@ applies here. Snowflake-specific signals worth alerting on:
 
 ## Caveats
 
-- Source registry, exceptions, API-key persistence, trend,
+- Source registry, API-key persistence, trend,
   graph, and the full HMAC-chained `audit_log` are not yet on
   `SnowflakeStore`. Run Postgres alongside for these, or wait for
   parity.

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -176,6 +176,7 @@ async def _lifespan(app_instance: FastAPI):
     # Priority: Snowflake > Postgres > SQLite > InMemory (lazy default)
     if os.environ.get("SNOWFLAKE_ACCOUNT"):
         from agent_bom.api.snowflake_store import (
+            SnowflakeExceptionStore,
             SnowflakeFleetStore,
             SnowflakeJobStore,
             SnowflakePolicyStore,
@@ -192,6 +193,8 @@ async def _lifespan(app_instance: FastAPI):
             set_policy_store(SnowflakePolicyStore(sf))
         if _stores._schedule_store is None:
             set_schedule_store(SnowflakeScheduleStore(sf))
+        if _stores._exception_store is None:
+            set_exception_store(SnowflakeExceptionStore(sf))
     elif os.environ.get("AGENT_BOM_POSTGRES_URL"):
         from agent_bom.api import audit_log as _audit_log_mod
         from agent_bom.api import auth as _auth

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -22,6 +22,7 @@ import os
 import warnings
 from datetime import datetime, timezone
 
+from .exception_store import ExceptionStatus, VulnException
 from .fleet_store import FleetAgent, FleetLifecycleState
 from .policy_store import GatewayPolicy, PolicyAuditEntry
 from .server import ScanJob
@@ -458,6 +459,116 @@ class SnowflakeScheduleStore:
                 (now_iso,),
             )
             return [ScanSchedule.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in cur.fetchall()]
+
+
+# ─── Exception Store ─────────────────────────────────────────────────────────
+
+
+class SnowflakeExceptionStore:
+    """Snowflake-backed vulnerability exception persistence."""
+
+    def __init__(self, connection_params: dict) -> None:
+        self._conn_params = connection_params
+        self._init_tables()
+
+    def _connect(self):  # type: ignore[no-untyped-def]
+        return _sf_connect(**self._conn_params)
+
+    def _init_tables(self) -> None:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS exceptions (
+                    exception_id VARCHAR PRIMARY KEY,
+                    vuln_id VARCHAR NOT NULL,
+                    package_name VARCHAR NOT NULL,
+                    server_name VARCHAR NOT NULL DEFAULT '',
+                    status VARCHAR NOT NULL DEFAULT 'pending',
+                    created_at TIMESTAMP_TZ NOT NULL,
+                    expires_at VARCHAR NOT NULL DEFAULT '',
+                    tenant_id VARCHAR NOT NULL DEFAULT 'default',
+                    data VARIANT NOT NULL
+                )
+            """)
+            cur.execute("ALTER TABLE exceptions ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+
+    def put(self, exc: VulnException) -> None:
+        with self._connect() as conn:
+            conn.cursor().execute(
+                """MERGE INTO exceptions t USING (SELECT %s AS exception_id) s
+                   ON t.exception_id = s.exception_id
+                   WHEN MATCHED THEN UPDATE SET
+                     vuln_id = %s, package_name = %s, server_name = %s,
+                     status = %s, created_at = %s, expires_at = %s, tenant_id = %s,
+                     data = PARSE_JSON(%s)
+                   WHEN NOT MATCHED THEN INSERT
+                     (exception_id, vuln_id, package_name, server_name, status, created_at, expires_at, tenant_id, data)
+                     VALUES (%s, %s, %s, %s, %s, %s, %s, %s, PARSE_JSON(%s))""",
+                (
+                    exc.exception_id,
+                    exc.vuln_id,
+                    exc.package_name,
+                    exc.server_name,
+                    exc.status.value,
+                    exc.created_at,
+                    exc.expires_at,
+                    exc.tenant_id,
+                    json.dumps(exc.to_dict(), sort_keys=True),
+                    exc.exception_id,
+                    exc.vuln_id,
+                    exc.package_name,
+                    exc.server_name,
+                    exc.status.value,
+                    exc.created_at,
+                    exc.expires_at,
+                    exc.tenant_id,
+                    json.dumps(exc.to_dict(), sort_keys=True),
+                ),
+            )
+
+    def get(self, exception_id: str) -> VulnException | None:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT data FROM exceptions WHERE exception_id = %s", (exception_id,))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            payload = row[0] if isinstance(row[0], str) else json.dumps(row[0])
+            data = json.loads(payload)
+            data["status"] = ExceptionStatus(data.get("status", ExceptionStatus.PENDING.value))
+            return VulnException(**data)
+
+    def delete(self, exception_id: str) -> bool:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM exceptions WHERE exception_id = %s", (exception_id,))
+            return (cur.rowcount or 0) > 0
+
+    def list_all(self, status: str | None = None, tenant_id: str = "default") -> list[VulnException]:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            sql = "SELECT data FROM exceptions WHERE tenant_id = %s"
+            params: list[object] = [tenant_id]
+            if status:
+                sql += " AND status = %s"
+                params.append(status)
+            sql += " ORDER BY created_at DESC"
+            cur.execute(sql, tuple(params))
+            results: list[VulnException] = []
+            for row in cur.fetchall():
+                payload = row[0] if isinstance(row[0], str) else json.dumps(row[0])
+                data = json.loads(payload)
+                data["status"] = ExceptionStatus(data.get("status", ExceptionStatus.PENDING.value))
+                results.append(VulnException(**data))
+            return results
+
+    def find_matching(self, vuln_id: str, package_name: str, server_name: str = "", tenant_id: str = "default") -> VulnException | None:
+        exceptions = self.list_all(status=ExceptionStatus.ACTIVE.value, tenant_id=tenant_id)
+        exceptions += self.list_all(status=ExceptionStatus.APPROVED.value, tenant_id=tenant_id)
+        for exc in exceptions:
+            if exc.matches(vuln_id, package_name, server_name):
+                return exc
+        return None
 
 
 # ─── Policy Store ─────────────────────────────────────────────────────────────

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -742,6 +742,99 @@ class TestSnowflakeScheduleStore:
         assert store.delete("sched-1") is True
 
 
+# ─── SnowflakeExceptionStore ─────────────────────────────────────────────────
+
+
+class TestSnowflakeExceptionStore:
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def _make_store(self, mock_connect):
+        mock_connect.return_value = _mock_connection()
+        from agent_bom.api.snowflake_store import SnowflakeExceptionStore
+
+        return SnowflakeExceptionStore(SF_PARAMS)
+
+    def _make_exception(self, exception_id="exc-1", tenant_id="default", status="pending"):
+        from agent_bom.api.exception_store import ExceptionStatus, VulnException
+
+        return VulnException(
+            exception_id=exception_id,
+            vuln_id="CVE-2026-0001",
+            package_name="express",
+            server_name="filesystem",
+            reason="accepted temporary risk",
+            requested_by="alice@example.com",
+            approved_by="bob@example.com" if status != "pending" else "",
+            status=ExceptionStatus(status),
+            created_at="2026-01-01T00:00:00Z",
+            expires_at="2026-06-01T00:00:00Z",
+            tenant_id=tenant_id,
+        )
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_init_creates_table(self, mock_connect):
+        conn = _mock_connection()
+        mock_connect.return_value = conn
+        from agent_bom.api.snowflake_store import SnowflakeExceptionStore
+
+        SnowflakeExceptionStore(SF_PARAMS)
+        create_call = conn.cursor().execute.call_args_list[0]
+        assert "CREATE TABLE IF NOT EXISTS exceptions" in create_call[0][0]
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_put(self, mock_connect):
+        conn = _mock_connection()
+        mock_connect.return_value = conn
+        store = self._make_store()
+        store.put(self._make_exception())
+        calls = conn.cursor().execute.call_args_list
+        merge_call = [c for c in calls if "MERGE INTO exceptions" in str(c)]
+        assert len(merge_call) > 0
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_get_found(self, mock_connect):
+        exc = self._make_exception()
+        cur = _mock_cursor(fetchone_val=(json.dumps(exc.to_dict()),))
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        result = store.get("exc-1")
+        assert result is not None
+        assert result.exception_id == "exc-1"
+        assert result.tenant_id == "default"
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_list_all_tenant_filtered(self, mock_connect):
+        exc = self._make_exception("exc-1", tenant_id="tenant-a", status="approved")
+        cur = _mock_cursor(fetchall_val=[(json.dumps(exc.to_dict()),)])
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        result = store.list_all(status="approved", tenant_id="tenant-a")
+        assert len(result) == 1
+        assert result[0].tenant_id == "tenant-a"
+        assert result[0].status.value == "approved"
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_find_matching_uses_approved_and_active(self, mock_connect):
+        approved = self._make_exception("exc-approved", tenant_id="tenant-a", status="approved")
+        active = self._make_exception("exc-active", tenant_id="tenant-a", status="active")
+        cur = _mock_cursor(fetchall_val=[(json.dumps(approved.to_dict()),), (json.dumps(active.to_dict()),)])
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        result = store.find_matching("CVE-2026-0001", "express", "filesystem", tenant_id="tenant-a")
+        assert result is not None
+        assert result.exception_id in {"exc-approved", "exc-active"}
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_delete_found(self, mock_connect):
+        cur = _mock_cursor(rowcount=1)
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        assert store.delete("exc-1") is True
+
+
 # ─── Server lifespan auto-detection ──────────────────────────────────────────
 
 
@@ -765,6 +858,7 @@ class TestServerLifespanAutoDetect:
         st._fleet_store = None
         st._policy_store = None
         st._schedule_store = None
+        st._exception_store = None
 
         import asyncio
 
@@ -775,6 +869,7 @@ class TestServerLifespanAutoDetect:
         asyncio.run(_run())
 
         from agent_bom.api.snowflake_store import (
+            SnowflakeExceptionStore,
             SnowflakeFleetStore,
             SnowflakeJobStore,
             SnowflakePolicyStore,
@@ -785,9 +880,11 @@ class TestServerLifespanAutoDetect:
         assert isinstance(st._fleet_store, SnowflakeFleetStore)
         assert isinstance(st._policy_store, SnowflakePolicyStore)
         assert isinstance(st._schedule_store, SnowflakeScheduleStore)
+        assert isinstance(st._exception_store, SnowflakeExceptionStore)
 
         # Cleanup
         st._store = None
         st._fleet_store = None
         st._policy_store = None
         st._schedule_store = None
+        st._exception_store = None


### PR DESCRIPTION
Part of #1366

## Summary
- add Snowflake-backed exception persistence
- wire Snowflake exception store into API backend selection
- update Snowflake parity docs to reflect exceptions as a shipped surface

## Validation
- uv run --python 3.12 pytest tests/test_snowflake_stores.py -q
- uv run mypy src/agent_bom/api/snowflake_store.py src/agent_bom/api/server.py
- uv run mkdocs build --strict