### PR TITLE
feat(endpoint): persist enrolled fleet identity

### DIFF
--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -61,6 +61,12 @@ ships:
 - `endpoint-enrollment.json` — machine-readable rollout metadata for IT
 - `endpoint-onboarding-summary.json` — operator-facing bundle summary
 - optional stable `source_id` wiring via `AGENT_BOM_PUSH_SOURCE_ID`
+- optional enrolled endpoint metadata wiring via:
+  - `AGENT_BOM_PUSH_ENROLLMENT_NAME`
+  - `AGENT_BOM_PUSH_OWNER`
+  - `AGENT_BOM_PUSH_ENVIRONMENT`
+  - `AGENT_BOM_PUSH_TAGS`
+  - `AGENT_BOM_PUSH_MDM_PROVIDER`
 
 That means Jamf, Intune, or Kandji rollout can keep one explicit endpoint
 identity contract without pretending `agent-bom` is already a bidirectional
@@ -96,6 +102,7 @@ The wrapper script expects:
 
 - `AGENT_BOM_PUSH_URL`
 - optionally `AGENT_BOM_PUSH_API_KEY`
+- optionally the rollout metadata env vars listed above
 
 ## Linux systemd example
 
@@ -108,6 +115,12 @@ Example env file:
 ```bash
 AGENT_BOM_PUSH_URL=https://agent-bom.internal.example.com/v1/fleet/sync
 AGENT_BOM_PUSH_API_KEY=replace-me
+AGENT_BOM_PUSH_SOURCE_ID=device-acme-001
+AGENT_BOM_PUSH_ENROLLMENT_NAME=corp-laptop-rollout
+AGENT_BOM_PUSH_OWNER=platform-security
+AGENT_BOM_PUSH_ENVIRONMENT=production
+AGENT_BOM_PUSH_TAGS=developer-endpoint,mdm
+AGENT_BOM_PUSH_MDM_PROVIDER=jamf
 ```
 
 4. install the unit files:

--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -34,6 +34,9 @@ class FleetAgent(BaseModel):
     name: str
     agent_type: str
     config_path: str = ""
+    source_id: str = ""
+    enrollment_name: str = ""
+    mdm_provider: str = ""
     lifecycle_state: FleetLifecycleState = FleetLifecycleState.DISCOVERED
     owner: str | None = None
     environment: str | None = None

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -125,6 +125,10 @@ def _payload_counts(agent: dict) -> tuple[int, int, int, int]:
     return server_count, pkg_count, cred_count, vuln_count
 
 
+def _payload_tags(agent: dict) -> list[str]:
+    return sorted({str(tag).strip() for tag in list(agent.get("tags", []) or []) if str(tag).strip()})
+
+
 def _persist_payload_observations(tenant_id: str, agent: dict, *, last_discovery: str, last_synced: str) -> None:
     store = _get_mcp_observation_store()
     agent_name = str(agent.get("name", "unknown-agent"))
@@ -212,6 +216,12 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
             server_count, pkg_count, cred_count, vuln_count = _payload_counts(payload_agent)
             score = float(payload_agent.get("trust_score", 0.0) or 0.0)
             factors = dict(payload_agent.get("trust_factors", {}) or {})
+            payload_source_id = str(payload_agent.get("source_id") or source_id or "")
+            payload_enrollment_name = str(payload_agent.get("enrollment_name") or "")
+            payload_mdm_provider = str(payload_agent.get("mdm_provider") or "")
+            payload_owner = payload_agent.get("owner")
+            payload_environment = payload_agent.get("environment")
+            payload_tags = _payload_tags(payload_agent)
             if existing:
                 existing.server_count = server_count
                 existing.package_count = pkg_count
@@ -223,6 +233,15 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
                 existing.updated_at = now
                 existing.config_path = ""
                 existing.agent_type = str(payload_agent.get("agent_type", existing.agent_type))
+                existing.source_id = payload_source_id or existing.source_id
+                existing.enrollment_name = payload_enrollment_name or existing.enrollment_name
+                existing.mdm_provider = payload_mdm_provider or existing.mdm_provider
+                if payload_owner is not None:
+                    existing.owner = str(payload_owner or "")
+                if payload_environment is not None:
+                    existing.environment = str(payload_environment or "")
+                if payload_tags:
+                    existing.tags = payload_tags
                 store.put(existing)
                 updated_count += 1
             else:
@@ -231,7 +250,13 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
                     name=name,
                     agent_type=str(payload_agent.get("agent_type", "unknown")),
                     config_path="",
+                    source_id=payload_source_id,
+                    enrollment_name=payload_enrollment_name,
+                    mdm_provider=payload_mdm_provider,
                     lifecycle_state=FleetLifecycleState.DISCOVERED,
+                    owner=str(payload_owner or "") or None,
+                    environment=str(payload_environment or "") or None,
+                    tags=payload_tags,
                     trust_score=score,
                     trust_factors=factors,
                     server_count=server_count,

--- a/src/agent_bom/endpoint_onboarding.py
+++ b/src/agent_bom/endpoint_onboarding.py
@@ -99,13 +99,34 @@ New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 """
 
 
-def render_fleet_sync_env(push_url: str, push_api_key: str | None, source_id: str | None = None) -> str:
+def render_fleet_sync_env(
+    push_url: str,
+    push_api_key: str | None,
+    *,
+    source_id: str | None = None,
+    enrollment_name: str | None = None,
+    owner: str | None = None,
+    environment: str | None = None,
+    tags: list[str] | None = None,
+    mdm_provider: str | None = None,
+) -> str:
     """Render a fleet-sync env file for the shipped timer/service assets."""
     lines = [f'AGENT_BOM_PUSH_URL="{push_url}"']
     if push_api_key:
         lines.append(f'AGENT_BOM_PUSH_API_KEY="{push_api_key}"')
     if source_id:
         lines.append(f'AGENT_BOM_PUSH_SOURCE_ID="{source_id}"')
+    if enrollment_name:
+        lines.append(f'AGENT_BOM_PUSH_ENROLLMENT_NAME="{enrollment_name}"')
+    if owner:
+        lines.append(f'AGENT_BOM_PUSH_OWNER="{owner}"')
+    if environment:
+        lines.append(f'AGENT_BOM_PUSH_ENVIRONMENT="{environment}"')
+    normalized_tags = sorted({tag.strip() for tag in (tags or []) if tag and tag.strip()})
+    if normalized_tags:
+        lines.append(f'AGENT_BOM_PUSH_TAGS="{",".join(normalized_tags)}"')
+    if mdm_provider:
+        lines.append(f'AGENT_BOM_PUSH_MDM_PROVIDER="{mdm_provider}"')
     return "\n".join(lines) + "\n"
 
 
@@ -157,7 +178,17 @@ exit 1
 """
 
 
-def render_launch_agent_plist(push_url: str, push_api_key: str | None, source_id: str | None = None) -> str:
+def render_launch_agent_plist(
+    push_url: str,
+    push_api_key: str | None,
+    *,
+    source_id: str | None = None,
+    enrollment_name: str | None = None,
+    owner: str | None = None,
+    environment: str | None = None,
+    tags: list[str] | None = None,
+    mdm_provider: str | None = None,
+) -> str:
     """Render a launchd plist with concrete fleet-sync values."""
     token_xml = (
         f"""    <key>AGENT_BOM_PUSH_API_KEY</key>
@@ -171,6 +202,42 @@ def render_launch_agent_plist(push_url: str, push_api_key: str | None, source_id
     <string>{source_id}</string>
 """
         if source_id
+        else ""
+    )
+    enrollment_xml = (
+        f"""    <key>AGENT_BOM_PUSH_ENROLLMENT_NAME</key>
+    <string>{enrollment_name}</string>
+"""
+        if enrollment_name
+        else ""
+    )
+    owner_xml = (
+        f"""    <key>AGENT_BOM_PUSH_OWNER</key>
+    <string>{owner}</string>
+"""
+        if owner
+        else ""
+    )
+    environment_xml = (
+        f"""    <key>AGENT_BOM_PUSH_ENVIRONMENT</key>
+    <string>{environment}</string>
+"""
+        if environment
+        else ""
+    )
+    normalized_tags = sorted({tag.strip() for tag in (tags or []) if tag and tag.strip()})
+    tags_xml = (
+        f"""    <key>AGENT_BOM_PUSH_TAGS</key>
+    <string>{",".join(normalized_tags)}</string>
+"""
+        if normalized_tags
+        else ""
+    )
+    mdm_xml = (
+        f"""    <key>AGENT_BOM_PUSH_MDM_PROVIDER</key>
+    <string>{mdm_provider}</string>
+"""
+        if mdm_provider
         else ""
     )
     return f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -189,7 +256,7 @@ def render_launch_agent_plist(push_url: str, push_api_key: str | None, source_id
   <dict>
     <key>AGENT_BOM_PUSH_URL</key>
     <string>{push_url}</string>
-{token_xml}{source_xml}  </dict>
+{token_xml}{source_xml}{enrollment_xml}{owner_xml}{environment_xml}{tags_xml}{mdm_xml}  </dict>
   <key>RunAtLoad</key>
   <true/>
   <key>StartInterval</key>
@@ -335,13 +402,31 @@ def write_endpoint_onboarding_bundle(
     if push_url:
         env_path = _write_text(
             bundle_dir / "fleet-sync.env",
-            render_fleet_sync_env(push_url, push_api_key, source_id=source_id),
+            render_fleet_sync_env(
+                push_url,
+                push_api_key,
+                source_id=source_id,
+                enrollment_name=enrollment_name,
+                owner=owner,
+                environment=environment,
+                tags=normalized_tags,
+                mdm_provider=mdm_provider,
+            ),
             stat.S_IRUSR | stat.S_IWUSR,
         )
         artifacts["fleet_sync_env"] = str(env_path)
         plist_path = _write_text(
             bundle_dir / "com.agentbom.fleet-sync.plist",
-            render_launch_agent_plist(push_url, push_api_key, source_id=source_id),
+            render_launch_agent_plist(
+                push_url,
+                push_api_key,
+                source_id=source_id,
+                enrollment_name=enrollment_name,
+                owner=owner,
+                environment=environment,
+                tags=normalized_tags,
+                mdm_provider=mdm_provider,
+            ),
             stat.S_IRUSR | stat.S_IWUSR,
         )
         artifacts["launch_agent_plist"] = str(plist_path)

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -21,6 +21,24 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
+def _csv_env(name: str) -> list[str]:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _endpoint_identity_from_env() -> dict[str, str | list[str]]:
+    return {
+        "source_id": generate_source_id(),
+        "enrollment_name": os.environ.get("AGENT_BOM_PUSH_ENROLLMENT_NAME", "").strip(),
+        "owner": os.environ.get("AGENT_BOM_PUSH_OWNER", "").strip(),
+        "environment": os.environ.get("AGENT_BOM_PUSH_ENVIRONMENT", "").strip(),
+        "mdm_provider": os.environ.get("AGENT_BOM_PUSH_MDM_PROVIDER", "").strip(),
+        "tags": _csv_env("AGENT_BOM_PUSH_TAGS"),
+    }
+
+
 def generate_source_id() -> str:
     """Generate a stable machine identifier (hostname SHA256[:12])."""
     configured = os.environ.get("AGENT_BOM_PUSH_SOURCE_ID", "").strip()
@@ -39,6 +57,8 @@ def sanitize_results(results: dict) -> dict:
     """
     sanitized = copy.deepcopy(results)
 
+    endpoint_identity = _endpoint_identity_from_env()
+
     # Strip config_path from agents
     for agent in sanitized.get("agents", []):
         agent.pop("config_path", None)
@@ -47,9 +67,16 @@ def sanitize_results(results: dict) -> dict:
         for key, val in list(meta.items()):
             if isinstance(val, str) and _looks_like_secret(key):
                 meta[key] = "***REDACTED***"
+        for key in ("source_id", "enrollment_name", "owner", "environment", "mdm_provider"):
+            value = endpoint_identity.get(key, "")
+            if value and not agent.get(key):
+                agent[key] = value
+        tags = endpoint_identity.get("tags", [])
+        if tags and not agent.get("tags"):
+            agent["tags"] = tags
 
     # Add source identifier
-    sanitized["source_id"] = generate_source_id()
+    sanitized["source_id"] = str(endpoint_identity["source_id"])
     sanitized["idempotency_key"] = str(uuid.uuid4())
 
     return sanitized

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -190,6 +190,38 @@ def test_sync_accepts_endpoint_push_payload():
     assert agents[0].vuln_count == 2
 
 
+def test_sync_persists_endpoint_identity_metadata():
+    client, store = _fresh_client()
+    resp = client.post(
+        "/v1/fleet/sync",
+        json={
+            "source_id": "device-acme-001",
+            "agents": [
+                {
+                    "name": "cursor",
+                    "agent_type": "cursor",
+                    "source_id": "device-acme-001",
+                    "enrollment_name": "corp-laptop-rollout",
+                    "owner": "platform-security",
+                    "environment": "production",
+                    "tags": ["developer-endpoint", "mdm"],
+                    "mdm_provider": "jamf",
+                    "trust_score": 82.5,
+                    "mcp_servers": [],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    agent = store.list_all()[0]
+    assert agent.source_id == "device-acme-001"
+    assert agent.enrollment_name == "corp-laptop-rollout"
+    assert agent.owner == "platform-security"
+    assert agent.environment == "production"
+    assert agent.tags == ["developer-endpoint", "mdm"]
+    assert agent.mdm_provider == "jamf"
+
+
 def test_sync_endpoint_push_is_idempotent():
     client, store = _fresh_client()
     payload = {

--- a/tests/test_endpoint_onboarding.py
+++ b/tests/test_endpoint_onboarding.py
@@ -66,10 +66,18 @@ def test_write_endpoint_onboarding_bundle_writes_artifacts(tmp_path):
     assert "AGENT_BOM_PUSH_URL" in env_file
     assert "AGENT_BOM_PUSH_API_KEY" in env_file
     assert 'AGENT_BOM_PUSH_SOURCE_ID="device-acme-001"' in env_file
+    assert 'AGENT_BOM_PUSH_ENROLLMENT_NAME="corp-laptop-rollout"' in env_file
+    assert 'AGENT_BOM_PUSH_OWNER="platform-security"' in env_file
+    assert 'AGENT_BOM_PUSH_ENVIRONMENT="production"' in env_file
+    assert 'AGENT_BOM_PUSH_TAGS="developer-endpoint,mdm"' in env_file
+    assert 'AGENT_BOM_PUSH_MDM_PROVIDER="jamf"' in env_file
     jamf_script = Path(artifacts["jamf_install"]).read_text()
     assert "install-agent-bom-endpoint.sh" in jamf_script
     intune_script = Path(artifacts["intune_install"]).read_text()
     assert "install-agent-bom-endpoint.ps1" in intune_script
+    plist = Path(artifacts["launch_agent_plist"]).read_text()
+    assert "AGENT_BOM_PUSH_ENROLLMENT_NAME" in plist
+    assert "AGENT_BOM_PUSH_MDM_PROVIDER" in plist
     enrollment = json.loads(Path(artifacts["enrollment_manifest"]).read_text())
     assert enrollment["enrollment_name"] == "corp-laptop-rollout"
     assert enrollment["owner"] == "platform-security"

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -104,6 +104,23 @@ class TestSanitizeResults:
         assert sanitized["summary"] == "ok"
         assert "source_id" in sanitized
 
+    def test_adds_endpoint_identity_metadata_from_env(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_PUSH_SOURCE_ID", "device-acme-001")
+        monkeypatch.setenv("AGENT_BOM_PUSH_ENROLLMENT_NAME", "corp-laptop-rollout")
+        monkeypatch.setenv("AGENT_BOM_PUSH_OWNER", "platform-security")
+        monkeypatch.setenv("AGENT_BOM_PUSH_ENVIRONMENT", "production")
+        monkeypatch.setenv("AGENT_BOM_PUSH_MDM_PROVIDER", "jamf")
+        monkeypatch.setenv("AGENT_BOM_PUSH_TAGS", "developer-endpoint, mdm")
+        results = {"agents": [{"name": "cursor"}]}
+        sanitized = sanitize_results(results)
+        agent = sanitized["agents"][0]
+        assert agent["source_id"] == "device-acme-001"
+        assert agent["enrollment_name"] == "corp-laptop-rollout"
+        assert agent["owner"] == "platform-security"
+        assert agent["environment"] == "production"
+        assert agent["mdm_provider"] == "jamf"
+        assert agent["tags"] == ["developer-endpoint", "mdm"]
+
 
 # ─── _looks_like_secret ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
Part of #1469

## Summary
- carry enrolled endpoint metadata from onboarding bundles into fleet sync env
- attach endpoint identity metadata during push sanitization
- persist source, enrollment, owner, environment, tags, and MDM provider on fleet agents

## Validation
- uv run --python 3.12 pytest tests/test_api_fleet.py tests/test_endpoint_onboarding.py tests/test_push.py -q
- uv run mypy src/agent_bom/api/fleet_store.py src/agent_bom/api/routes/fleet.py src/agent_bom/endpoint_onboarding.py src/agent_bom/push.py
- uv run mkdocs build --strict