### PR TITLE
fix(platform): harden audit and graph query paths

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -545,6 +545,7 @@ class SQLiteGraphStore:
         if conn is None:
             return [], 0
         try:
+            conn_ro: sqlite3.Connection = conn
             effective_scan_id = scan_id or sqlite_graph_store.latest_snapshot_id(conn, tenant_id=tenant_id)
             if not effective_scan_id:
                 return [], 0
@@ -554,33 +555,63 @@ class SQLiteGraphStore:
                 "gns.scan_id = ?",
             ]
             params: list[Any] = [tenant_id, effective_scan_id]
-            if fts_query and self._should_use_fts(query):
-                search_where.append("gns.graph_node_search MATCH ?")
-                params.append(fts_query)
-            else:
-                search_where.append("gns.search_text LIKE ? ESCAPE '\\'")
-                params.append(f"%{_escape_like_query(query.lower())}%")
-            if entity_types:
-                placeholders = ",".join("?" for _ in entity_types)
-                search_where.append(f"gn.entity_type IN ({placeholders})")
-                params.extend(sorted(entity_types))
-            if min_severity_rank:
-                search_where.append("gn.severity_id >= ?")
-                params.append(min_severity_rank)
-            if compliance_prefixes:
-                prefix_filters = []
-                for prefix in sorted(compliance_prefixes):
-                    clause, clause_params = self._compliance_prefix_filter("gns.compliance_tags", prefix)
-                    prefix_filters.append(clause)
-                    params.extend(clause_params)
-                search_where.append("(" + " OR ".join(prefix_filters) + ")")
-            if data_sources:
-                source_filters = []
-                for source in sorted(data_sources):
-                    clause, clause_params = self._space_token_filter("gns.data_sources", source)
-                    source_filters.append(clause)
-                    params.extend(clause_params)
-                search_where.append("(" + " OR ".join(source_filters) + ")")
+            like_query = f"%{_escape_like_query(query.lower())}%"
+
+            def _run_search(*, use_fts: bool) -> tuple[list[UnifiedNode], int]:
+                local_where = list(search_where)
+                local_params = list(params)
+                if use_fts:
+                    local_where.append("gns.graph_node_search MATCH ?")
+                    local_params.append(fts_query)
+                else:
+                    local_where.append("gns.search_text LIKE ? ESCAPE '\\'")
+                    local_params.append(like_query)
+                if entity_types:
+                    placeholders = ",".join("?" for _ in entity_types)
+                    local_where.append(f"gn.entity_type IN ({placeholders})")
+                    local_params.extend(sorted(entity_types))
+                if min_severity_rank:
+                    local_where.append("gn.severity_id >= ?")
+                    local_params.append(min_severity_rank)
+                if compliance_prefixes:
+                    prefix_filters = []
+                    for prefix in sorted(compliance_prefixes):
+                        clause, clause_params = self._compliance_prefix_filter("gns.compliance_tags", prefix)
+                        prefix_filters.append(clause)
+                        local_params.extend(clause_params)
+                    local_where.append("(" + " OR ".join(prefix_filters) + ")")
+                if data_sources:
+                    source_filters = []
+                    for source in sorted(data_sources):
+                        clause, clause_params = self._space_token_filter("gns.data_sources", source)
+                        source_filters.append(clause)
+                        local_params.extend(clause_params)
+                    local_where.append("(" + " OR ".join(source_filters) + ")")
+
+                where_sql = " AND ".join(local_where)
+                total = int(
+                    conn_ro.execute(
+                        "SELECT COUNT(*) " + from_clause + " WHERE " + where_sql,
+                        local_params,
+                    ).fetchone()[0]
+                    or 0
+                )
+                if total == 0:
+                    return [], 0
+                rows = conn_ro.execute(
+                    """
+                    SELECT
+                        gn.id, gn.entity_type, gn.label, gn.category_uid, gn.class_uid, gn.type_uid,
+                        gn.status, gn.risk_score, gn.severity, gn.severity_id, gn.first_seen, gn.last_seen,
+                        gn.attributes, gn.compliance_tags, gn.data_sources, gn.dimensions
+                    """
+                    + from_clause
+                    + " WHERE "
+                    + where_sql
+                    + " ORDER BY gn.severity_id DESC, gn.risk_score DESC, gn.label ASC, gn.id ASC LIMIT ? OFFSET ?",
+                    [*local_params, limit, offset],
+                ).fetchall()
+                return [self._node_from_row(row) for row in rows], total
 
             from_clause = """
                 FROM graph_node_search gns
@@ -589,30 +620,13 @@ class SQLiteGraphStore:
                  AND gn.scan_id = gns.scan_id
                  AND gn.tenant_id = gns.tenant_id
             """
-            where_sql = " AND ".join(search_where)
-            total = int(
-                conn.execute(
-                    "SELECT COUNT(*) " + from_clause + " WHERE " + where_sql,
-                    params,
-                ).fetchone()[0]
-                or 0
-            )
-            if total == 0:
-                return [], 0
-            rows = conn.execute(
-                """
-                SELECT
-                    gn.id, gn.entity_type, gn.label, gn.category_uid, gn.class_uid, gn.type_uid,
-                    gn.status, gn.risk_score, gn.severity, gn.severity_id, gn.first_seen, gn.last_seen,
-                    gn.attributes, gn.compliance_tags, gn.data_sources, gn.dimensions
-                """
-                + from_clause
-                + " WHERE "
-                + where_sql
-                + " ORDER BY gn.severity_id DESC, gn.risk_score DESC, gn.label ASC, gn.id ASC LIMIT ? OFFSET ?",
-                [*params, limit, offset],
-            ).fetchall()
-            return [self._node_from_row(row) for row in rows], total
+            use_fts = bool(fts_query and self._should_use_fts(query))
+            try:
+                return _run_search(use_fts=use_fts)
+            except sqlite3.OperationalError:
+                if not use_fts:
+                    raise
+                return _run_search(use_fts=False)
         finally:
             conn.close()
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -561,13 +561,13 @@ async def get_exception(request: Request, exception_id: str) -> dict:
 
 
 @router.put("/v1/exceptions/{exception_id}/approve", tags=["enterprise"])
-async def approve_exception(request: Request, exception_id: str, approved_by: str = "") -> dict:
+async def approve_exception(request: Request, exception_id: str) -> dict:
     """Approve a pending exception (admin only)."""
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.exception_store import ExceptionStatus
 
     tenant_id = getattr(request.state, "tenant_id", "default")
-    actor = approved_by or getattr(request.state, "api_key_name", "")
+    actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
     exc = store.get(exception_id)
     if exc is None or exc.tenant_id != tenant_id:
@@ -583,13 +583,13 @@ async def approve_exception(request: Request, exception_id: str, approved_by: st
 
 
 @router.put("/v1/exceptions/{exception_id}/revoke", tags=["enterprise"])
-async def revoke_exception(request: Request, exception_id: str, revoked_by: str = "") -> dict:
+async def revoke_exception(request: Request, exception_id: str) -> dict:
     """Revoke an active exception."""
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.exception_store import ExceptionStatus
 
     tenant_id = getattr(request.state, "tenant_id", "default")
-    actor = revoked_by or getattr(request.state, "api_key_name", "")
+    actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
     exc = store.get(exception_id)
     if exc is None or exc.tenant_id != tenant_id:

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -17,6 +17,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Literal, Optional
 
@@ -64,6 +65,11 @@ def _page_meta(total: int, offset: int, limit: int) -> dict:
         "limit": limit,
         "has_more": offset + limit < total,
     }
+
+
+async def _graph_store_call(fn, /, *args, **kwargs):
+    """Run sync graph store methods off the event loop."""
+    return await asyncio.to_thread(fn, *args, **kwargs)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -182,7 +188,7 @@ async def get_graph(
     graph_store = _get_graph_store_or_503()
     requested_scan_id = scan_id or ""
 
-    if not requested_scan_id and not graph_store.latest_snapshot_id(tenant_id=tenant):
+    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
 
     et_set: set[str] | None = None
@@ -194,7 +200,8 @@ async def get_graph(
         min_rank = SEVERITY_RANK.get(min_severity.lower(), 0)
 
     if relationships or static_only or dynamic_only:
-        graph = graph_store.load_graph(
+        graph = await _graph_store_call(
+            graph_store.load_graph,
             scan_id=requested_scan_id,
             tenant_id=tenant,
             entity_types=et_set,
@@ -238,7 +245,8 @@ async def get_graph(
             "pagination": pagination,
         }
 
-    effective_scan_id, created_at, paged_nodes, total = graph_store.page_nodes(
+    effective_scan_id, created_at, paged_nodes, total = await _graph_store_call(
+        graph_store.page_nodes,
         scan_id=requested_scan_id,
         tenant_id=tenant,
         entity_types=et_set,
@@ -247,7 +255,8 @@ async def get_graph(
         limit=limit,
     )
     paged_ids = {n.id for n in paged_nodes}
-    paged_edges = graph_store.edges_for_node_ids(
+    paged_edges = await _graph_store_call(
+        graph_store.edges_for_node_ids,
         scan_id=effective_scan_id,
         tenant_id=tenant,
         node_ids=paged_ids,
@@ -260,7 +269,8 @@ async def get_graph(
         "edges": [e.to_dict() for e in paged_edges],
         "attack_paths": [],
         "interaction_risks": [],
-        "stats": graph_store.snapshot_stats(
+        "stats": await _graph_store_call(
+            graph_store.snapshot_stats,
             scan_id=effective_scan_id,
             tenant_id=tenant,
             entity_types=et_set,
@@ -277,7 +287,7 @@ async def get_graph_diff(
     new: str = Query(..., description="New scan ID"),
 ) -> dict:
     """Diff two scan snapshots — nodes/edges added, removed, changed."""
-    return _get_graph_store_or_503().diff_snapshots(old, new, tenant_id=_tenant(request))
+    return await _graph_store_call(_get_graph_store_or_503().diff_snapshots, old, new, tenant_id=_tenant(request))
 
 
 @router.get("/v1/graph/paths", tags=["graph"])
@@ -290,7 +300,7 @@ async def get_graph_paths(
     limit: int = Query(100, ge=1, le=1000, description="Max paths"),
 ) -> dict:
     """Find all attack paths from a source node via BFS."""
-    graph = _get_graph_store_or_503().load_graph(scan_id=scan_id or "", tenant_id=_tenant(request))
+    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
     if not graph.has_node(source):
         raise HTTPException(status_code=404, detail=f"Node '{source}' not found in graph")
 
@@ -317,7 +327,7 @@ async def get_graph_impact(
     max_depth: int = Query(4, ge=1, le=10, description="Maximum reverse BFS depth"),
 ) -> dict:
     """Compute blast radius of a node — what depends on it?"""
-    graph = _get_graph_store_or_503().load_graph(scan_id=scan_id or "", tenant_id=_tenant(request))
+    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
     if not graph.has_node(node):
         raise HTTPException(status_code=404, detail=f"Node '{node}' not found")
     return graph.impact_of(node, max_depth=max_depth)
@@ -340,7 +350,8 @@ async def search_graph(
     min_rank = SEVERITY_RANK.get(min_severity.lower(), 0) if min_severity else 0
     prefix_filters = {value.strip().upper() for value in compliance_prefixes.split(",") if value.strip()} if compliance_prefixes else None
     data_source_filters = {value.strip() for value in data_sources.split(",") if value.strip()} if data_sources else None
-    results, total = _get_graph_store_or_503().search_nodes(
+    results, total = await _graph_store_call(
+        _get_graph_store_or_503().search_nodes,
         scan_id=scan_id or "",
         tenant_id=_tenant(request),
         query=q,
@@ -374,7 +385,7 @@ async def search_graph(
 async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
     """Run a bounded programmable traversal over the canonical graph."""
 
-    graph = _get_graph_store_or_503().load_graph(scan_id=body.scan_id or "", tenant_id=_tenant(request))
+    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=body.scan_id or "", tenant_id=_tenant(request))
     missing_roots = [root for root in body.roots if not graph.has_node(root)]
     if missing_roots:
         raise HTTPException(status_code=404, detail={"message": "Root nodes not found", "missing_roots": missing_roots})
@@ -439,7 +450,7 @@ async def get_graph_node(
     scan_id: Optional[str] = Query(None, description="Scan ID"),
 ) -> dict:
     """Get a single node with its edges, neighbors, and impact stats."""
-    graph = _get_graph_store_or_503().load_graph(scan_id=scan_id or "", tenant_id=_tenant(request))
+    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
     node = graph.get_node(node_id)
     if not node:
         raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
@@ -460,7 +471,7 @@ async def get_graph_snapshots(
     limit: int = Query(50, ge=1, le=500, description="Max snapshots"),
 ) -> list[dict]:
     """List persisted scan snapshots ordered by creation time."""
-    return _get_graph_store_or_503().list_snapshots(tenant_id=_tenant(request), limit=limit)
+    return await _graph_store_call(_get_graph_store_or_503().list_snapshots, tenant_id=_tenant(request), limit=limit)
 
 
 @router.get("/v1/graph/compliance", tags=["graph"])
@@ -476,7 +487,7 @@ async def get_graph_compliance(
     """
     from collections import defaultdict
 
-    graph = _get_graph_store_or_503().load_graph(scan_id=scan_id or "", tenant_id=_tenant(request))
+    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
 
     framework_stats: dict[str, dict] = defaultdict(
         lambda: {
@@ -545,7 +556,8 @@ async def create_preset(request: Request, body: PresetCreate) -> dict:
     from agent_bom.graph.util import _now_iso
 
     tenant = _tenant(request)
-    _get_graph_store_or_503().save_preset(
+    await _graph_store_call(
+        _get_graph_store_or_503().save_preset,
         tenant_id=tenant,
         name=body.name,
         description=body.description,
@@ -558,13 +570,13 @@ async def create_preset(request: Request, body: PresetCreate) -> dict:
 @router.get("/v1/graph/presets", tags=["graph"])
 async def list_presets(request: Request) -> list[dict]:
     """List saved filter presets for the current tenant."""
-    return _get_graph_store_or_503().list_presets(tenant_id=_tenant(request))
+    return await _graph_store_call(_get_graph_store_or_503().list_presets, tenant_id=_tenant(request))
 
 
 @router.delete("/v1/graph/presets/{name}", tags=["graph"])
 async def delete_preset(request: Request, name: str) -> dict:
     """Delete a saved filter preset."""
-    deleted = _get_graph_store_or_503().delete_preset(tenant_id=_tenant(request), name=name)
+    deleted = await _graph_store_call(_get_graph_store_or_503().delete_preset, tenant_id=_tenant(request), name=name)
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Preset '{name}' not found")
     return {"name": name, "status": "deleted"}

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -208,7 +208,10 @@ def verify_hmac_entries(log: AuditLog, sign_key: str) -> tuple[int, int]:
             hashlib.sha256,
         ).hexdigest()
         # Compare constant-time
-        if hmac.compare_digest(expected, hmac_entry.hmac_sha256[:64]):
+        if len(hmac_entry.hmac_sha256) != 64:
+            failed += 1
+            continue
+        if hmac.compare_digest(expected, hmac_entry.hmac_sha256):
             verified += 1
         else:
             failed += 1

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -10,7 +10,7 @@ from fastapi import HTTPException
 
 from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog, get_audit_log, set_audit_log
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
-from agent_bom.api.exception_store import InMemoryExceptionStore, VulnException
+from agent_bom.api.exception_store import ExceptionStatus, InMemoryExceptionStore, VulnException
 from agent_bom.api.models import CreateKeyRequest, JobStatus, RotateKeyRequest, ScanJob, ScanRequest
 from agent_bom.api.routes import enterprise
 from agent_bom.api.store import InMemoryJobStore
@@ -166,6 +166,17 @@ async def test_approve_exception_uses_request_actor_and_tenant(isolated_exceptio
 
     assert approved["approved_by"] == "alice-admin"
     assert approved["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_revoke_exception_uses_authenticated_actor(isolated_exception_store):
+    exc = VulnException(vuln_id="CVE-1", package_name="pkg", tenant_id="tenant-alpha")
+    exc.status = ExceptionStatus.ACTIVE
+    isolated_exception_store.put(exc)
+
+    revoked = await enterprise.revoke_exception(_request("tenant-alpha", "alice-admin"), exc.exception_id)
+
+    assert revoked["status"] == "revoked"
 
 
 @pytest.mark.asyncio

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -419,6 +419,16 @@ def test_verify_hmac_mismatch():
     assert failed == 1
 
 
+def test_verify_hmac_rejects_short_hmac():
+    log = AuditLog(
+        tool_calls=[ToolCallEntry(ts="", tool="t", policy="allowed", reason="", agent_id="", args={}, payload_sha256="abc", message_id=1)],
+        hmac_entries=[ResponseHMACEntry(ts="", message_id=1, hmac_sha256="deadbeef")],
+    )
+    verified, failed = verify_hmac_entries(log, "secret")
+    assert verified == 0
+    assert failed == 1
+
+
 def test_verify_hash_chain_passes_for_valid_records():
     p = _write_log(_chained([TOOL_CALL, BLOCKED_CALL]))
     verified, tampered = verify_hash_chain(p)

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -10,6 +10,7 @@ from starlette.testclient import TestClient
 
 from agent_bom.api import stores as api_stores
 from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.api.routes import graph as graph_routes
 from agent_bom.api.server import app
 from agent_bom.api.stores import set_graph_store
 from agent_bom.db.graph_store import _init_db, load_graph, save_graph
@@ -300,6 +301,19 @@ class TestGraphEndpointLogic:
         assert underscore_total == 1
         assert [node.id for node in underscore_results] == ["dataset:underscore"]
 
+    def test_sqlite_graph_store_search_falls_back_when_fts_match_errors(self, tmp_path, monkeypatch):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="search-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="server:vector", entity_type=EntityType.SERVER, label="Vector Service"))
+        store.save_graph(graph)
+
+        monkeypatch.setattr(SQLiteGraphStore, "_search_query_expression", staticmethod(lambda query: '"'))
+
+        results, total = store.search_nodes(tenant_id="default", query="vector", offset=0, limit=10)
+
+        assert total == 1
+        assert [node.id for node in results] == ["server:vector"]
+
 
 class TestBackendDirectionality:
     """Regression: graph_backend must respect edge direction from unified graph."""
@@ -517,6 +531,25 @@ class TestGraphStoreBackendSelection:
         assert response.json()["results"][0]["id"] == "server:a"
         assert any(call[0] == "search_nodes" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_graph_routes_offload_store_calls_to_thread(self, recording_graph_store, monkeypatch):
+        client = TestClient(app)
+        helper_calls: list[str] = []
+
+        async def _fake_graph_store_call(fn, /, *args, **kwargs):
+            helper_calls.append(fn.__name__)
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(graph_routes, "_graph_store_call", _fake_graph_store_call)
+
+        graph_response = client.get("/v1/graph")
+        search_response = client.get("/v1/graph/search", params={"q": "agent"})
+
+        assert graph_response.status_code == 200
+        assert search_response.status_code == 200
+        assert "latest_snapshot_id" in helper_calls
+        assert "page_nodes" in helper_calls
+        assert "search_nodes" in helper_calls
 
     def test_graph_search_forwards_slice_filters(self, recording_graph_store):
         recording_graph_store.graph.add_node(


### PR DESCRIPTION
## Summary
- remove user-controlled actor overrides from exception approve/revoke audit records
- move sync graph store calls off the FastAPI event loop with a shared thread helper
- add SQLite graph search fallback when FTS MATCH expressions error and reject short audit HMACs

## Notes
- current main already had SQL filter pushdown for graph search, stripped empty query-param values, and lock coverage in _jobs_put, so those stale audit items are intentionally not included here
- current scheduler.py no longer contains the cited requests.post callback path

## Validation
- uv run --python 3.12 pytest tests/test_api_enterprise_tenant.py tests/test_graph_api.py tests/test_audit_replay.py -q
- uv run mypy src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/graph.py src/agent_bom/api/graph_store.py src/agent_bom/audit_replay.py
- uv run ruff check src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/graph.py src/agent_bom/api/graph_store.py src/agent_bom/audit_replay.py tests/test_api_enterprise_tenant.py tests/test_graph_api.py tests/test_audit_replay.py