### PR TITLE
fix(snowflake): scope store lookups by tenant

### DIFF
--- a/src/agent_bom/api/exception_store.py
+++ b/src/agent_bom/api/exception_store.py
@@ -93,8 +93,8 @@ class VulnException:
 
 class ExceptionStore(Protocol):
     def put(self, exc: VulnException) -> None: ...
-    def get(self, exception_id: str) -> VulnException | None: ...
-    def delete(self, exception_id: str) -> bool: ...
+    def get(self, exception_id: str, tenant_id: str | None = None) -> VulnException | None: ...
+    def delete(self, exception_id: str, tenant_id: str | None = None) -> bool: ...
     def list_all(self, status: str | None = None, tenant_id: str = "default") -> list[VulnException]: ...
     def find_matching(self, vuln_id: str, package_name: str, server_name: str = "", tenant_id: str = "default") -> VulnException | None: ...
 
@@ -108,12 +108,23 @@ class InMemoryExceptionStore:
         with self._lock:
             self._store[exc.exception_id] = exc
 
-    def get(self, exception_id: str) -> VulnException | None:
-        return self._store.get(exception_id)
+    def get(self, exception_id: str, tenant_id: str | None = None) -> VulnException | None:
+        exc = self._store.get(exception_id)
+        if exc is None:
+            return None
+        if tenant_id is not None and exc.tenant_id != tenant_id:
+            return None
+        return exc
 
-    def delete(self, exception_id: str) -> bool:
+    def delete(self, exception_id: str, tenant_id: str | None = None) -> bool:
         with self._lock:
-            return self._store.pop(exception_id, None) is not None
+            exc = self._store.get(exception_id)
+            if exc is None:
+                return False
+            if tenant_id is not None and exc.tenant_id != tenant_id:
+                return False
+            self._store.pop(exception_id, None)
+            return True
 
     def list_all(self, status: str | None = None, tenant_id: str = "default") -> list[VulnException]:
         with self._lock:
@@ -188,13 +199,21 @@ class SQLiteExceptionStore:
         )
         self._conn.commit()
 
-    def get(self, exception_id: str) -> VulnException | None:
-        row = self._conn.execute(
-            "SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, "
-            "approved_by, status, created_at, expires_at, approved_at, revoked_at, tenant_id "
-            "FROM exceptions WHERE exception_id = ?",
-            (exception_id,),
-        ).fetchone()
+    def get(self, exception_id: str, tenant_id: str | None = None) -> VulnException | None:
+        if tenant_id is None:
+            row = self._conn.execute(
+                "SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, "
+                "approved_by, status, created_at, expires_at, approved_at, revoked_at, tenant_id "
+                "FROM exceptions WHERE exception_id = ?",
+                (exception_id,),
+            ).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, "
+                "approved_by, status, created_at, expires_at, approved_at, revoked_at, tenant_id "
+                "FROM exceptions WHERE exception_id = ? AND tenant_id = ?",
+                (exception_id, tenant_id),
+            ).fetchone()
         if not row:
             return None
         return VulnException(
@@ -213,8 +232,14 @@ class SQLiteExceptionStore:
             tenant_id=row[12],
         )
 
-    def delete(self, exception_id: str) -> bool:
-        cursor = self._conn.execute("DELETE FROM exceptions WHERE exception_id = ?", (exception_id,))
+    def delete(self, exception_id: str, tenant_id: str | None = None) -> bool:
+        if tenant_id is None:
+            cursor = self._conn.execute("DELETE FROM exceptions WHERE exception_id = ?", (exception_id,))
+        else:
+            cursor = self._conn.execute(
+                "DELETE FROM exceptions WHERE exception_id = ? AND tenant_id = ?",
+                (exception_id, tenant_id),
+            )
         self._conn.commit()
         return cursor.rowcount > 0
 

--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -80,9 +80,9 @@ class FleetStore(Protocol):
     """Protocol for fleet agent persistence."""
 
     def put(self, agent: FleetAgent) -> None: ...
-    def get(self, agent_id: str) -> FleetAgent | None: ...
+    def get(self, agent_id: str, tenant_id: str | None = None) -> FleetAgent | None: ...
     def get_by_name(self, name: str) -> FleetAgent | None: ...
-    def delete(self, agent_id: str) -> bool: ...
+    def delete(self, agent_id: str, tenant_id: str | None = None) -> bool: ...
     def list_all(self) -> list[FleetAgent]: ...
     def list_summary(self) -> list[dict]: ...
     def list_by_tenant(self, tenant_id: str) -> list[FleetAgent]: ...
@@ -106,9 +106,14 @@ class InMemoryFleetStore:
         with self._lock:
             self._agents[normalized.agent_id] = normalized
 
-    def get(self, agent_id: str) -> FleetAgent | None:
+    def get(self, agent_id: str, tenant_id: str | None = None) -> FleetAgent | None:
         with self._lock:
-            return self._agents.get(agent_id)
+            agent = self._agents.get(agent_id)
+            if agent is None:
+                return None
+            if tenant_id is not None and agent.tenant_id != tenant_id:
+                return None
+            return agent
 
     def get_by_name(self, name: str) -> FleetAgent | None:
         with self._lock:
@@ -117,11 +122,15 @@ class InMemoryFleetStore:
                     return a
             return None
 
-    def delete(self, agent_id: str) -> bool:
+    def delete(self, agent_id: str, tenant_id: str | None = None) -> bool:
         with self._lock:
-            if agent_id in self._agents:
-                del self._agents[agent_id]
-                return True
+            agent = self._agents.get(agent_id)
+            if agent is None:
+                return False
+            if tenant_id is not None and agent.tenant_id != tenant_id:
+                return False
+            del self._agents[agent_id]
+            return True
             return False
 
     def list_all(self) -> list[FleetAgent]:
@@ -225,8 +234,14 @@ class SQLiteFleetStore:
         )
         self._conn.commit()
 
-    def get(self, agent_id: str) -> FleetAgent | None:
-        row = self._conn.execute("SELECT data FROM fleet_agents WHERE agent_id = ?", (agent_id,)).fetchone()
+    def get(self, agent_id: str, tenant_id: str | None = None) -> FleetAgent | None:
+        if tenant_id is None:
+            row = self._conn.execute("SELECT data FROM fleet_agents WHERE agent_id = ?", (agent_id,)).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT data FROM fleet_agents WHERE agent_id = ? AND json_extract(data, '$.tenant_id') = ?",
+                (agent_id, tenant_id),
+            ).fetchone()
         if row is None:
             return None
         return FleetAgent.model_validate_json(row[0])
@@ -237,8 +252,14 @@ class SQLiteFleetStore:
             return None
         return FleetAgent.model_validate_json(row[0])
 
-    def delete(self, agent_id: str) -> bool:
-        cursor = self._conn.execute("DELETE FROM fleet_agents WHERE agent_id = ?", (agent_id,))
+    def delete(self, agent_id: str, tenant_id: str | None = None) -> bool:
+        if tenant_id is None:
+            cursor = self._conn.execute("DELETE FROM fleet_agents WHERE agent_id = ?", (agent_id,))
+        else:
+            cursor = self._conn.execute(
+                "DELETE FROM fleet_agents WHERE agent_id = ? AND json_extract(data, '$.tenant_id') = ?",
+                (agent_id, tenant_id),
+            )
         self._conn.commit()
         return cursor.rowcount > 0
 

--- a/src/agent_bom/api/postgres_access.py
+++ b/src/agent_bom/api/postgres_access.py
@@ -316,20 +316,35 @@ class PostgresExceptionStore:
             )
             conn.commit()
 
-    def get(self, exception_id: str) -> VulnException | None:
+    def get(self, exception_id: str, tenant_id: str | None = None) -> VulnException | None:
         with _tenant_connection(self._pool) as conn:
-            row = conn.execute(
-                """SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, approved_by,
-                          status, created_at, expires_at, approved_at, revoked_at, team_id
-                   FROM exceptions
-                   WHERE exception_id = %s""",
-                (exception_id,),
-            ).fetchone()
+            if tenant_id is None:
+                row = conn.execute(
+                    """SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, approved_by,
+                              status, created_at, expires_at, approved_at, revoked_at, team_id
+                       FROM exceptions
+                       WHERE exception_id = %s""",
+                    (exception_id,),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    """SELECT exception_id, vuln_id, package_name, server_name, reason, requested_by, approved_by,
+                              status, created_at, expires_at, approved_at, revoked_at, team_id
+                       FROM exceptions
+                       WHERE exception_id = %s AND team_id = %s""",
+                    (exception_id, tenant_id),
+                ).fetchone()
             return self._row_to_exception(row) if row else None
 
-    def delete(self, exception_id: str) -> bool:
+    def delete(self, exception_id: str, tenant_id: str | None = None) -> bool:
         with _tenant_connection(self._pool) as conn:
-            cursor = conn.execute("DELETE FROM exceptions WHERE exception_id = %s", (exception_id,))
+            if tenant_id is None:
+                cursor = conn.execute("DELETE FROM exceptions WHERE exception_id = %s", (exception_id,))
+            else:
+                cursor = conn.execute(
+                    "DELETE FROM exceptions WHERE exception_id = %s AND team_id = %s",
+                    (exception_id, tenant_id),
+                )
             conn.commit()
             return cursor.rowcount > 0
 

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -229,19 +229,31 @@ class PostgresScheduleStore:
             )
             conn.commit()
 
-    def get(self, schedule_id: str):
+    def get(self, schedule_id: str, tenant_id: str | None = None):
         from .schedule_store import ScanSchedule
 
         with _tenant_connection(self._pool) as conn:
-            row = conn.execute("SELECT data FROM scan_schedules WHERE schedule_id = %s", (schedule_id,)).fetchone()
+            if tenant_id is None:
+                row = conn.execute("SELECT data FROM scan_schedules WHERE schedule_id = %s", (schedule_id,)).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT data FROM scan_schedules WHERE schedule_id = %s AND tenant_id = %s",
+                    (schedule_id, tenant_id),
+                ).fetchone()
             if row is None:
                 return None
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return ScanSchedule.model_validate_json(raw)
 
-    def delete(self, schedule_id: str) -> bool:
+    def delete(self, schedule_id: str, tenant_id: str | None = None) -> bool:
         with _tenant_connection(self._pool) as conn:
-            cursor = conn.execute("DELETE FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            if tenant_id is None:
+                cursor = conn.execute("DELETE FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            else:
+                cursor = conn.execute(
+                    "DELETE FROM scan_schedules WHERE schedule_id = %s AND tenant_id = %s",
+                    (schedule_id, tenant_id),
+                )
             conn.commit()
             return cursor.rowcount > 0
 

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -95,19 +95,31 @@ class PostgresJobStore:
             )
             conn.commit()
 
-    def get(self, job_id: str):
+    def get(self, job_id: str, tenant_id: str | None = None):
         from .server import ScanJob
 
         with _tenant_connection(self._pool) as conn:
-            row = conn.execute("SELECT data FROM scan_jobs WHERE job_id = %s", (job_id,)).fetchone()
+            if tenant_id is None:
+                row = conn.execute("SELECT data FROM scan_jobs WHERE job_id = %s", (job_id,)).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT data FROM scan_jobs WHERE job_id = %s AND team_id = %s",
+                    (job_id, tenant_id),
+                ).fetchone()
             if row is None:
                 return None
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return ScanJob.model_validate_json(raw)
 
-    def delete(self, job_id: str) -> bool:
+    def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
         with _tenant_connection(self._pool) as conn:
-            cursor = conn.execute("DELETE FROM scan_jobs WHERE job_id = %s", (job_id,))
+            if tenant_id is None:
+                cursor = conn.execute("DELETE FROM scan_jobs WHERE job_id = %s", (job_id,))
+            else:
+                cursor = conn.execute(
+                    "DELETE FROM scan_jobs WHERE job_id = %s AND team_id = %s",
+                    (job_id, tenant_id),
+                )
             conn.commit()
             return cursor.rowcount > 0
 
@@ -209,11 +221,17 @@ class PostgresFleetStore:
             )
             conn.commit()
 
-    def get(self, agent_id: str):
+    def get(self, agent_id: str, tenant_id: str | None = None):
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
-            row = conn.execute("SELECT data FROM fleet_agents WHERE agent_id = %s", (agent_id,)).fetchone()
+            if tenant_id is None:
+                row = conn.execute("SELECT data FROM fleet_agents WHERE agent_id = %s", (agent_id,)).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT data FROM fleet_agents WHERE agent_id = %s AND tenant_id = %s",
+                    (agent_id, tenant_id),
+                ).fetchone()
             if row is None:
                 return None
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
@@ -229,9 +247,15 @@ class PostgresFleetStore:
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return FleetAgent.model_validate_json(raw)
 
-    def delete(self, agent_id: str) -> bool:
+    def delete(self, agent_id: str, tenant_id: str | None = None) -> bool:
         with _tenant_connection(self._pool) as conn:
-            cursor = conn.execute("DELETE FROM fleet_agents WHERE agent_id = %s", (agent_id,))
+            if tenant_id is None:
+                cursor = conn.execute("DELETE FROM fleet_agents WHERE agent_id = %s", (agent_id,))
+            else:
+                cursor = conn.execute(
+                    "DELETE FROM fleet_agents WHERE agent_id = %s AND tenant_id = %s",
+                    (agent_id, tenant_id),
+                )
             conn.commit()
             return cursor.rowcount > 0
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -554,8 +554,8 @@ async def list_exceptions(request: Request, status: str | None = None) -> dict:
 async def get_exception(request: Request, exception_id: str) -> dict:
     """Get a specific exception."""
     tenant_id = getattr(request.state, "tenant_id", "default")
-    exc = _get_exception_store().get(exception_id)
-    if exc is None or exc.tenant_id != tenant_id:
+    exc = _get_exception_store().get(exception_id, tenant_id=tenant_id)
+    if exc is None:
         raise HTTPException(status_code=404, detail=f"Exception {exception_id} not found")
     return exc.to_dict()
 
@@ -569,8 +569,8 @@ async def approve_exception(request: Request, exception_id: str) -> dict:
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
-    exc = store.get(exception_id)
-    if exc is None or exc.tenant_id != tenant_id:
+    exc = store.get(exception_id, tenant_id=tenant_id)
+    if exc is None:
         raise HTTPException(status_code=404, detail=f"Exception {exception_id} not found")
     if exc.status != ExceptionStatus.PENDING:
         raise HTTPException(status_code=409, detail=f"Cannot approve exception in {exc.status.value} state")
@@ -591,8 +591,8 @@ async def revoke_exception(request: Request, exception_id: str) -> dict:
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
-    exc = store.get(exception_id)
-    if exc is None or exc.tenant_id != tenant_id:
+    exc = store.get(exception_id, tenant_id=tenant_id)
+    if exc is None:
         raise HTTPException(status_code=404, detail=f"Exception {exception_id} not found")
     exc.status = ExceptionStatus.REVOKED
     exc.revoked_at = datetime.now(timezone.utc).isoformat()
@@ -609,10 +609,10 @@ async def delete_exception(request: Request, exception_id: str) -> None:
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
-    exc = store.get(exception_id)
-    if exc is None or exc.tenant_id != tenant_id:
+    exc = store.get(exception_id, tenant_id=tenant_id)
+    if exc is None:
         raise HTTPException(status_code=404, detail=f"Exception {exception_id} not found")
-    ok = store.delete(exception_id)
+    ok = store.delete(exception_id, tenant_id=tenant_id)
     if not ok:
         raise HTTPException(status_code=404, detail=f"Exception {exception_id} not found")
     log_action("exception_delete", actor=actor, resource=f"exception/{exception_id}", tenant_id=tenant_id)
@@ -630,11 +630,11 @@ async def compare_baseline(request: Request, previous_job_id: str = "", current_
     store = _get_store()
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
-    prev_job = store.get(previous_job_id) if previous_job_id else None
-    curr_job = store.get(current_job_id) if current_job_id else None
-    if previous_job_id and (prev_job is None or prev_job.tenant_id != tenant_id):
+    prev_job = store.get(previous_job_id, tenant_id=tenant_id) if previous_job_id else None
+    curr_job = store.get(current_job_id, tenant_id=tenant_id) if current_job_id else None
+    if previous_job_id and prev_job is None:
         raise HTTPException(status_code=404, detail="Previous job not found")
-    if current_job_id and (curr_job is None or curr_job.tenant_id != tenant_id):
+    if current_job_id and curr_job is None:
         raise HTTPException(status_code=404, detail="Current job not found")
 
     prev_report = prev_job.result if prev_job and prev_job.result else {}
@@ -854,10 +854,10 @@ async def remove_false_positive(request: Request, fp_id: str) -> None:
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
-    exc = store.get(fp_id)
-    if exc is None or exc.tenant_id != tenant_id or not exc.reason.startswith("[false_positive]"):
+    exc = store.get(fp_id, tenant_id=tenant_id)
+    if exc is None or not exc.reason.startswith("[false_positive]"):
         raise HTTPException(status_code=404, detail=f"False positive {fp_id} not found")
-    ok = store.delete(fp_id)
+    ok = store.delete(fp_id, tenant_id=tenant_id)
     if not ok:
         raise HTTPException(status_code=404, detail=f"False positive {fp_id} not found")
     log_action("findings.false_positive_removed", actor=actor, resource=f"fp/{fp_id}", tenant_id=tenant_id)

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -97,9 +97,9 @@ async def fleet_stats(request: Request):
 @router.get("/v1/fleet/{agent_id}", tags=["fleet"])
 async def get_fleet_agent(request: Request, agent_id: str):
     """Get a single fleet agent with trust score breakdown."""
-    agent = _get_fleet_store().get(agent_id)
     tenant_id = getattr(request.state, "tenant_id", "default")
-    if agent is None or agent.tenant_id != tenant_id:
+    agent = _get_fleet_store().get(agent_id, tenant_id=tenant_id)
+    if agent is None:
         raise HTTPException(status_code=404, detail="Fleet agent not found")
     return agent.model_dump()
 
@@ -356,8 +356,8 @@ async def update_fleet_state(request: Request, agent_id: str, body: StateUpdate)
     store = _get_fleet_store()
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
-    agent = store.get(agent_id)
-    if agent is None or agent.tenant_id != tenant_id:
+    agent = store.get(agent_id, tenant_id=tenant_id)
+    if agent is None:
         raise HTTPException(status_code=404, detail="Fleet agent not found")
     store.update_state(agent_id, new_state)
     log_action(
@@ -376,10 +376,10 @@ async def update_fleet_agent(request: Request, agent_id: str, body: FleetAgentUp
     from agent_bom.api.audit_log import log_action
 
     store = _get_fleet_store()
-    agent = store.get(agent_id)
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
-    if agent is None or agent.tenant_id != tenant_id:
+    agent = store.get(agent_id, tenant_id=tenant_id)
+    if agent is None:
         raise HTTPException(status_code=404, detail="Fleet agent not found")
     if body.owner is not None:
         agent.owner = body.owner

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -147,8 +147,8 @@ def _job_for_request(request: Request, job_id: str) -> ScanJob:
     in_mem = _jobs_get(job_id)
     if in_mem is not None and _visible_to_tenant(in_mem, tenant_id):
         return in_mem
-    job = _get_store().get(job_id)
-    if job is None or not _visible_to_tenant(job, tenant_id):
+    job = _get_store().get(job_id, tenant_id=tenant_id)
+    if job is None:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
     return job
 
@@ -445,7 +445,7 @@ async def delete_scan(request: Request, job_id: str) -> None:
     """Discard a job record."""
     job = _job_for_request(request, job_id)
     in_memory = _jobs_pop(job_id) if _visible_to_tenant(job, _tenant_id(request)) else None
-    in_store = _get_store().delete(job_id)
+    in_store = _get_store().delete(job_id, tenant_id=_tenant_id(request))
     if not in_memory and not in_store:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 

--- a/src/agent_bom/api/routes/schedules.py
+++ b/src/agent_bom/api/routes/schedules.py
@@ -70,9 +70,9 @@ async def list_schedules(request: Request) -> list[dict]:
 @router.get("/v1/schedules/{schedule_id}", tags=["schedules"])
 async def get_schedule(request: Request, schedule_id: str) -> dict:
     """Get a specific schedule."""
-    s = _get_schedule_store().get(schedule_id)
     tenant_id = getattr(request.state, "tenant_id", "default")
-    if s is None or s.tenant_id != tenant_id:
+    s = _get_schedule_store().get(schedule_id, tenant_id=tenant_id)
+    if s is None:
         raise HTTPException(status_code=404, detail=f"Schedule {schedule_id} not found")
     return s.model_dump()
 
@@ -82,12 +82,12 @@ async def delete_schedule(request: Request, schedule_id: str):
     """Delete a schedule."""
     from agent_bom.api.audit_log import log_action
 
-    s = _get_schedule_store().get(schedule_id)
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
-    if s is None or s.tenant_id != tenant_id:
+    s = _get_schedule_store().get(schedule_id, tenant_id=tenant_id)
+    if s is None:
         raise HTTPException(status_code=404, detail=f"Schedule {schedule_id} not found")
-    _get_schedule_store().delete(schedule_id)
+    _get_schedule_store().delete(schedule_id, tenant_id=tenant_id)
     log_action("schedule.delete", actor=actor, resource=f"schedule/{schedule_id}", tenant_id=tenant_id)
 
 
@@ -96,10 +96,10 @@ async def toggle_schedule(request: Request, schedule_id: str) -> dict:
     """Enable or disable a schedule."""
     from agent_bom.api.audit_log import log_action
 
-    s = _get_schedule_store().get(schedule_id)
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
-    if s is None or s.tenant_id != tenant_id:
+    s = _get_schedule_store().get(schedule_id, tenant_id=tenant_id)
+    if s is None:
         raise HTTPException(status_code=404, detail=f"Schedule {schedule_id} not found")
     s.enabled = not s.enabled
     s.updated_at = datetime.now(timezone.utc).isoformat()

--- a/src/agent_bom/api/schedule_store.py
+++ b/src/agent_bom/api/schedule_store.py
@@ -32,8 +32,8 @@ class ScheduleStore(Protocol):
     """Protocol for schedule persistence."""
 
     def put(self, schedule: ScanSchedule) -> None: ...
-    def get(self, schedule_id: str) -> ScanSchedule | None: ...
-    def delete(self, schedule_id: str) -> bool: ...
+    def get(self, schedule_id: str, tenant_id: str | None = None) -> ScanSchedule | None: ...
+    def delete(self, schedule_id: str, tenant_id: str | None = None) -> bool: ...
     def list_all(self, tenant_id: str | None = None) -> list[ScanSchedule]: ...
     def list_due(self, now_iso: str) -> list[ScanSchedule]: ...
 
@@ -47,13 +47,22 @@ class InMemoryScheduleStore:
     def put(self, schedule: ScanSchedule) -> None:
         self._schedules[schedule.schedule_id] = schedule
 
-    def get(self, schedule_id: str) -> ScanSchedule | None:
-        return self._schedules.get(schedule_id)
+    def get(self, schedule_id: str, tenant_id: str | None = None) -> ScanSchedule | None:
+        schedule = self._schedules.get(schedule_id)
+        if schedule is None:
+            return None
+        if tenant_id is not None and schedule.tenant_id != tenant_id:
+            return None
+        return schedule
 
-    def delete(self, schedule_id: str) -> bool:
-        if schedule_id in self._schedules:
-            del self._schedules[schedule_id]
-            return True
+    def delete(self, schedule_id: str, tenant_id: str | None = None) -> bool:
+        schedule = self._schedules.get(schedule_id)
+        if schedule is None:
+            return False
+        if tenant_id is not None and schedule.tenant_id != tenant_id:
+            return False
+        del self._schedules[schedule_id]
+        return True
         return False
 
     def list_all(self, tenant_id: str | None = None) -> list[ScanSchedule]:
@@ -107,14 +116,26 @@ class SQLiteScheduleStore:
         )
         self._conn.commit()
 
-    def get(self, schedule_id: str) -> ScanSchedule | None:
-        row = self._conn.execute("SELECT data FROM schedules WHERE schedule_id = ?", (schedule_id,)).fetchone()
+    def get(self, schedule_id: str, tenant_id: str | None = None) -> ScanSchedule | None:
+        if tenant_id is None:
+            row = self._conn.execute("SELECT data FROM schedules WHERE schedule_id = ?", (schedule_id,)).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT data FROM schedules WHERE schedule_id = ? AND tenant_id = ?",
+                (schedule_id, tenant_id),
+            ).fetchone()
         if row is None:
             return None
         return ScanSchedule.model_validate_json(row[0])
 
-    def delete(self, schedule_id: str) -> bool:
-        cursor = self._conn.execute("DELETE FROM schedules WHERE schedule_id = ?", (schedule_id,))
+    def delete(self, schedule_id: str, tenant_id: str | None = None) -> bool:
+        if tenant_id is None:
+            cursor = self._conn.execute("DELETE FROM schedules WHERE schedule_id = ?", (schedule_id,))
+        else:
+            cursor = self._conn.execute(
+                "DELETE FROM schedules WHERE schedule_id = ? AND tenant_id = ?",
+                (schedule_id, tenant_id),
+            )
         self._conn.commit()
         return cursor.rowcount > 0
 

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -119,19 +119,25 @@ class SnowflakeJobStore:
                 ),
             )
 
-    def get(self, job_id: str) -> ScanJob | None:
+    def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT data FROM scan_jobs WHERE job_id = %s", (job_id,))
+            if tenant_id is None:
+                cur.execute("SELECT data FROM scan_jobs WHERE job_id = %s", (job_id,))
+            else:
+                cur.execute("SELECT data FROM scan_jobs WHERE job_id = %s AND tenant_id = %s", (job_id, tenant_id))
             row = cur.fetchone()
             if row is None:
                 return None
             return ScanJob.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
 
-    def delete(self, job_id: str) -> bool:
+    def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("DELETE FROM scan_jobs WHERE job_id = %s", (job_id,))
+            if tenant_id is None:
+                cur.execute("DELETE FROM scan_jobs WHERE job_id = %s", (job_id,))
+            else:
+                cur.execute("DELETE FROM scan_jobs WHERE job_id = %s AND tenant_id = %s", (job_id, tenant_id))
             return (cur.rowcount or 0) > 0
 
     def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
@@ -245,10 +251,13 @@ class SnowflakeFleetStore:
                 ),
             )
 
-    def get(self, agent_id: str) -> FleetAgent | None:
+    def get(self, agent_id: str, tenant_id: str | None = None) -> FleetAgent | None:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT data FROM fleet_agents WHERE agent_id = %s", (agent_id,))
+            if tenant_id is None:
+                cur.execute("SELECT data FROM fleet_agents WHERE agent_id = %s", (agent_id,))
+            else:
+                cur.execute("SELECT data FROM fleet_agents WHERE agent_id = %s AND tenant_id = %s", (agent_id, tenant_id))
             row = cur.fetchone()
             if row is None:
                 return None
@@ -263,10 +272,13 @@ class SnowflakeFleetStore:
                 return None
             return FleetAgent.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
 
-    def delete(self, agent_id: str) -> bool:
+    def delete(self, agent_id: str, tenant_id: str | None = None) -> bool:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("DELETE FROM fleet_agents WHERE agent_id = %s", (agent_id,))
+            if tenant_id is None:
+                cur.execute("DELETE FROM fleet_agents WHERE agent_id = %s", (agent_id,))
+            else:
+                cur.execute("DELETE FROM fleet_agents WHERE agent_id = %s AND tenant_id = %s", (agent_id, tenant_id))
             return (cur.rowcount or 0) > 0
 
     def list_all(self) -> list[FleetAgent]:
@@ -419,21 +431,27 @@ class SnowflakeScheduleStore:
                 ),
             )
 
-    def get(self, schedule_id: str):
+    def get(self, schedule_id: str, tenant_id: str | None = None):
         from .schedule_store import ScanSchedule
 
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT data FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            if tenant_id is None:
+                cur.execute("SELECT data FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            else:
+                cur.execute("SELECT data FROM scan_schedules WHERE schedule_id = %s AND tenant_id = %s", (schedule_id, tenant_id))
             row = cur.fetchone()
             if row is None:
                 return None
             return ScanSchedule.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
 
-    def delete(self, schedule_id: str) -> bool:
+    def delete(self, schedule_id: str, tenant_id: str | None = None) -> bool:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("DELETE FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            if tenant_id is None:
+                cur.execute("DELETE FROM scan_schedules WHERE schedule_id = %s", (schedule_id,))
+            else:
+                cur.execute("DELETE FROM scan_schedules WHERE schedule_id = %s AND tenant_id = %s", (schedule_id, tenant_id))
             return (cur.rowcount or 0) > 0
 
     def list_all(self, tenant_id: str | None = None) -> list:
@@ -526,10 +544,13 @@ class SnowflakeExceptionStore:
                 ),
             )
 
-    def get(self, exception_id: str) -> VulnException | None:
+    def get(self, exception_id: str, tenant_id: str | None = None) -> VulnException | None:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT data FROM exceptions WHERE exception_id = %s", (exception_id,))
+            if tenant_id is None:
+                cur.execute("SELECT data FROM exceptions WHERE exception_id = %s", (exception_id,))
+            else:
+                cur.execute("SELECT data FROM exceptions WHERE exception_id = %s AND tenant_id = %s", (exception_id, tenant_id))
             row = cur.fetchone()
             if row is None:
                 return None
@@ -538,10 +559,13 @@ class SnowflakeExceptionStore:
             data["status"] = ExceptionStatus(data.get("status", ExceptionStatus.PENDING.value))
             return VulnException(**data)
 
-    def delete(self, exception_id: str) -> bool:
+    def delete(self, exception_id: str, tenant_id: str | None = None) -> bool:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("DELETE FROM exceptions WHERE exception_id = %s", (exception_id,))
+            if tenant_id is None:
+                cur.execute("DELETE FROM exceptions WHERE exception_id = %s", (exception_id,))
+            else:
+                cur.execute("DELETE FROM exceptions WHERE exception_id = %s AND tenant_id = %s", (exception_id, tenant_id))
             return (cur.rowcount or 0) > 0
 
     def list_all(self, status: str | None = None, tenant_id: str = "default") -> list[VulnException]:

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -21,8 +21,8 @@ class JobStore(Protocol):
     """Protocol for scan job persistence."""
 
     def put(self, job: ScanJob) -> None: ...
-    def get(self, job_id: str) -> ScanJob | None: ...
-    def delete(self, job_id: str) -> bool: ...
+    def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None: ...
+    def delete(self, job_id: str, tenant_id: str | None = None) -> bool: ...
     def list_all(self, tenant_id: str | None = None) -> list[ScanJob]: ...
     def list_summary(self, tenant_id: str | None = None) -> list[dict]: ...
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int: ...
@@ -39,15 +39,24 @@ class InMemoryJobStore:
         with self._lock:
             self._jobs[job.job_id] = job
 
-    def get(self, job_id: str) -> ScanJob | None:
+    def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None:
         with self._lock:
-            return self._jobs.get(job_id)
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            if tenant_id is not None and job.tenant_id != tenant_id:
+                return None
+            return job
 
-    def delete(self, job_id: str) -> bool:
+    def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
         with self._lock:
-            if job_id in self._jobs:
-                del self._jobs[job_id]
-                return True
+            job = self._jobs.get(job_id)
+            if job is None:
+                return False
+            if tenant_id is not None and job.tenant_id != tenant_id:
+                return False
+            del self._jobs[job_id]
+            return True
             return False
 
     def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
@@ -145,14 +154,26 @@ class SQLiteJobStore:
         )
         self._conn.commit()
 
-    def get(self, job_id: str) -> ScanJob | None:
-        row = self._conn.execute("SELECT data FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
+    def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None:
+        if tenant_id is None:
+            row = self._conn.execute("SELECT data FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT data FROM jobs WHERE job_id = ? AND tenant_id = ?",
+                (job_id, tenant_id),
+            ).fetchone()
         if row is None:
             return None
         return self._deserialize(row[0])
 
-    def delete(self, job_id: str) -> bool:
-        cursor = self._conn.execute("DELETE FROM jobs WHERE job_id = ?", (job_id,))
+    def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
+        if tenant_id is None:
+            cursor = self._conn.execute("DELETE FROM jobs WHERE job_id = ?", (job_id,))
+        else:
+            cursor = self._conn.execute(
+                "DELETE FROM jobs WHERE job_id = ? AND tenant_id = ?",
+                (job_id, tenant_id),
+            )
         self._conn.commit()
         return cursor.rowcount > 0
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -9,7 +9,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from agent_bom import __version__
-from agent_bom.api.server import _jobs, app, set_job_store
+from agent_bom.api.server import JobStatus, ScanJob, ScanRequest, _jobs, app, set_job_store
 from agent_bom.api.store import InMemoryJobStore
 
 
@@ -257,6 +257,105 @@ def test_delete_scan_not_found():
     client, _ = _fresh_client()
     resp = client.delete("/v1/scan/nonexistent")
     assert resp.status_code == 404
+
+
+def test_get_scan_passes_tenant_to_store():
+    import agent_bom.api.stores as api_stores
+
+    class RecordingJobStore:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str | None]] = []
+
+        def put(self, job) -> None:
+            raise NotImplementedError
+
+        def get(self, job_id: str, tenant_id: str | None = None):
+            self.calls.append((job_id, tenant_id))
+            return ScanJob(
+                job_id=job_id,
+                tenant_id=tenant_id or "default",
+                status=JobStatus.PENDING,
+                created_at="2026-01-01T00:00:00Z",
+                request=ScanRequest(),
+            )
+
+        def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
+            raise NotImplementedError
+
+        def list_all(self, tenant_id: str | None = None):
+            return []
+
+        def list_summary(self, tenant_id: str | None = None):
+            return []
+
+        def cleanup_expired(self, ttl_seconds: int = 3600) -> int:
+            return 0
+
+    store = RecordingJobStore()
+    original = api_stores._store
+    try:
+        set_job_store(store)
+        _jobs.clear()
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.get("/v1/scan/job-tenant-check")
+
+        assert resp.status_code == 200
+        assert store.calls == [("job-tenant-check", "default")]
+    finally:
+        set_job_store(original)
+        _jobs.clear()
+
+
+def test_delete_scan_passes_tenant_to_store():
+    import agent_bom.api.stores as api_stores
+
+    class RecordingJobStore:
+        def __init__(self) -> None:
+            self.get_calls: list[tuple[str, str | None]] = []
+            self.delete_calls: list[tuple[str, str | None]] = []
+
+        def put(self, job) -> None:
+            raise NotImplementedError
+
+        def get(self, job_id: str, tenant_id: str | None = None):
+            self.get_calls.append((job_id, tenant_id))
+            return ScanJob(
+                job_id=job_id,
+                tenant_id=tenant_id or "default",
+                status=JobStatus.PENDING,
+                created_at="2026-01-01T00:00:00Z",
+                request=ScanRequest(),
+            )
+
+        def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
+            self.delete_calls.append((job_id, tenant_id))
+            return True
+
+        def list_all(self, tenant_id: str | None = None):
+            return []
+
+        def list_summary(self, tenant_id: str | None = None):
+            return []
+
+        def cleanup_expired(self, ttl_seconds: int = 3600) -> int:
+            return 0
+
+    store = RecordingJobStore()
+    original = api_stores._store
+    try:
+        set_job_store(store)
+        _jobs.clear()
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.delete("/v1/scan/job-tenant-delete")
+
+        assert resp.status_code == 204
+        assert store.get_calls == [("job-tenant-delete", "default")]
+        assert store.delete_calls == [("job-tenant-delete", "default")]
+    finally:
+        set_job_store(original)
+        _jobs.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -216,6 +216,42 @@ async def test_delete_exception_audit_logs_actor_and_tenant(isolated_exception_s
 
 
 @pytest.mark.asyncio
+async def test_delete_exception_passes_tenant_to_store(monkeypatch):
+    class RecordingExceptionStore:
+        def __init__(self) -> None:
+            self.get_calls: list[tuple[str, str | None]] = []
+            self.delete_calls: list[tuple[str, str | None]] = []
+            self.exc = VulnException(vuln_id="CVE-1", package_name="pkg", tenant_id="tenant-alpha")
+
+        def put(self, exc: VulnException) -> None:
+            self.exc = exc
+
+        def get(self, exception_id: str, tenant_id: str | None = None) -> VulnException | None:
+            self.get_calls.append((exception_id, tenant_id))
+            if exception_id != self.exc.exception_id or tenant_id != self.exc.tenant_id:
+                return None
+            return self.exc
+
+        def delete(self, exception_id: str, tenant_id: str | None = None) -> bool:
+            self.delete_calls.append((exception_id, tenant_id))
+            return exception_id == self.exc.exception_id and tenant_id == self.exc.tenant_id
+
+        def list_all(self, status: str | None = None, tenant_id: str = "default"):
+            return []
+
+        def find_matching(self, vuln_id: str, package_name: str, server_name: str = "", tenant_id: str = "default"):
+            return None
+
+    store = RecordingExceptionStore()
+    monkeypatch.setattr(enterprise, "_get_exception_store", lambda: store)
+
+    await enterprise.delete_exception(_request("tenant-alpha", "alice-admin"), store.exc.exception_id)
+
+    assert store.get_calls == [(store.exc.exception_id, "tenant-alpha")]
+    assert store.delete_calls == [(store.exc.exception_id, "tenant-alpha")]
+
+
+@pytest.mark.asyncio
 async def test_create_jira_ticket_requires_header_token(monkeypatch):
     req = enterprise.JiraTicketRequest(
         jira_url="https://example.atlassian.net",

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -122,6 +122,34 @@ def test_get_agent_not_found():
     assert resp.status_code == 404
 
 
+def test_get_agent_passes_tenant_to_store():
+    import agent_bom.api.stores as api_stores
+
+    class RecordingFleetStore:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str | None]] = []
+
+        def get(self, agent_id: str, tenant_id: str | None = None):
+            self.calls.append((agent_id, tenant_id))
+            return _make(agent_id=agent_id, name="alpha", tenant_id=tenant_id or "default")
+
+        def list_by_tenant(self, tenant_id: str):
+            return []
+
+    store = RecordingFleetStore()
+    original = api_stores._fleet_store
+    try:
+        set_fleet_store(store)
+        client = TestClient(app)
+
+        resp = client.get("/v1/fleet/a-tenant-check")
+
+        assert resp.status_code == 200
+        assert store.calls == [("a-tenant-check", "default")]
+    finally:
+        set_fleet_store(original)
+
+
 # ── Sync ──────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -241,9 +241,11 @@ class TestSnowflakeJobStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        result = store.get("j1")
+        result = store.get("j1", tenant_id="default")
         assert result is not None
         assert result.job_id == "j1"
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "WHERE job_id = %s AND tenant_id = %s" in sql
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_get_not_found(self, mock_connect):
@@ -272,7 +274,9 @@ class TestSnowflakeJobStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        assert store.delete("j1") is True
+        assert store.delete("j1", tenant_id="default") is True
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "DELETE FROM scan_jobs WHERE job_id = %s AND tenant_id = %s" in sql
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_delete_not_found(self, mock_connect):
@@ -366,9 +370,11 @@ class TestSnowflakeFleetStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        result = store.get("a1")
+        result = store.get("a1", tenant_id="tenant-alpha")
         assert result is not None
         assert result.agent_id == "a1"
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "WHERE agent_id = %s AND tenant_id = %s" in sql
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_get_not_found(self, mock_connect):
@@ -395,7 +401,9 @@ class TestSnowflakeFleetStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        assert store.delete("a1") is True
+        assert store.delete("a1", tenant_id="tenant-alpha") is True
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "DELETE FROM fleet_agents WHERE agent_id = %s AND tenant_id = %s" in sql
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_list_all(self, mock_connect):
@@ -706,9 +714,11 @@ class TestSnowflakeScheduleStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        result = store.get("sched-1")
+        result = store.get("sched-1", tenant_id="default")
         assert result is not None
         assert result.schedule_id == "sched-1"
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "WHERE schedule_id = %s AND tenant_id = %s" in sql
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_list_all_tenant_filtered(self, mock_connect):
@@ -739,7 +749,9 @@ class TestSnowflakeScheduleStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        assert store.delete("sched-1") is True
+        assert store.delete("sched-1", tenant_id="default") is True
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "DELETE FROM scan_schedules WHERE schedule_id = %s AND tenant_id = %s" in sql
 
 
 # ─── SnowflakeExceptionStore ─────────────────────────────────────────────────
@@ -797,10 +809,12 @@ class TestSnowflakeExceptionStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        result = store.get("exc-1")
+        result = store.get("exc-1", tenant_id="default")
         assert result is not None
         assert result.exception_id == "exc-1"
         assert result.tenant_id == "default"
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "WHERE exception_id = %s AND tenant_id = %s" in sql
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_list_all_tenant_filtered(self, mock_connect):
@@ -832,7 +846,9 @@ class TestSnowflakeExceptionStore:
         conn = _mock_connection(cursor=cur)
         mock_connect.return_value = conn
         store = self._make_store()
-        assert store.delete("exc-1") is True
+        assert store.delete("exc-1", tenant_id="default") is True
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "DELETE FROM exceptions WHERE exception_id = %s AND tenant_id = %s" in sql
 
 
 # ─── Server lifespan auto-detection ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- scope job, fleet, schedule, and exception store get/delete calls by tenant
- pass tenant-aware lookups through scan, fleet, schedules, and enterprise routes
- add Snowflake SQL and route passthrough regression tests

## Validation
- uv run --python 3.12 pytest tests/test_snowflake_stores.py tests/test_api_endpoints.py tests/test_api_fleet.py tests/test_api_enterprise_tenant.py -q
- uv run ruff check src/agent_bom/api/store.py src/agent_bom/api/fleet_store.py src/agent_bom/api/schedule_store.py src/agent_bom/api/exception_store.py src/agent_bom/api/postgres_store.py src/agent_bom/api/postgres_policy.py src/agent_bom/api/postgres_access.py src/agent_bom/api/snowflake_store.py src/agent_bom/api/routes/scan.py src/agent_bom/api/routes/fleet.py src/agent_bom/api/routes/schedules.py src/agent_bom/api/routes/enterprise.py tests/test_snowflake_stores.py tests/test_api_endpoints.py tests/test_api_fleet.py tests/test_api_enterprise_tenant.py
- uv run mypy src/agent_bom/api/store.py src/agent_bom/api/fleet_store.py src/agent_bom/api/schedule_store.py src/agent_bom/api/exception_store.py src/agent_bom/api/postgres_store.py src/agent_bom/api/postgres_policy.py src/agent_bom/api/postgres_access.py src/agent_bom/api/snowflake_store.py src/agent_bom/api/routes/scan.py src/agent_bom/api/routes/fleet.py src/agent_bom/api/routes/schedules.py src/agent_bom/api/routes/enterprise.py