### PR TITLE
docs(deploy): tighten graph and runtime guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ Runtime choices:
 | **Workload-local inline enforcement** | selected `agent-bom proxy` sidecars or local wrappers |
 | **Node-wide runtime coverage** | optional monitor only if your platform team explicitly wants a DaemonSet |
 
+Current graph scale boundary:
+
+- the graph is strong for pilot and mid-market investigation flows, but larger tenants should stay windowed by snapshot, page, search, and blast-radius drilldown instead of expecting one giant browser canvas to stay smooth
+- operator sizing guidance and the shipped benchmark harness live in [Performance, Sizing, and Benchmarks](site-docs/deployment/performance-and-sizing.md)
+
 Backend defaults:
 
 | Layer | Default | Add later only if needed |
@@ -243,6 +248,12 @@ With scans and fleet sync alone, teams can already see:
 - credential-backed environment variables
 - last seen and last synced state
 - package, image, IaC, and related finding context
+
+### Discovery confidence boundaries
+
+- configured MCP clients, transports, declared tools, command paths, URLs, auth mode, and credential-backed environment references are high-confidence inventory surfaces
+- source-code agent and tool extraction still mixes static parsing and heuristics, so indirect or runtime-only registrations can under-report today
+- inventory is a strong operator baseline now, not a claim that every dynamic framework registration path is fully captured already
 
 ### What each surface owns
 

--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -47,6 +47,12 @@ That gives you:
 - sanitized fleet sync to the self-hosted control plane
 - the same fleet/mesh/gateway review path as cluster-discovered MCPs
 
+Inventory confidence on this path:
+
+- MCP client presence, config paths, transports, command or URL targets, declared tools, auth mode, and credential-backed environment references are the strongest endpoint-fleet signals today
+- source-code-derived agent and tool extraction can still miss indirect or runtime-only registrations in some frameworks, so treat those as strong heuristic inventory rather than a claim of perfect dynamic coverage
+- if a rollout decision depends on one framework family, validate that family with a focused fixture or pilot before claiming full discovery coverage
+
 Important boundary:
 
 - this is not a managed endpoint agent

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -27,6 +27,19 @@ Recommended defaults for this path:
 - **node-wide runtime coverage**: optional monitor only when your platform team explicitly wants that tradeoff
 - **advanced storage**: add ClickHouse or Snowflake only when the default Postgres-first path is no longer enough
 
+## Operator defaults at a glance
+
+| Concern | Recommended default | Change when |
+|---|---|---|
+| **control-plane backend** | `Postgres` | retained analytics or warehouse-native requirements justify `ClickHouse` or selected Snowflake parity surfaces |
+| **ingress + auth** | same-origin ingress with OIDC or SAML in front of the control plane | you already run a different enterprise ingress/auth split and intentionally want to diverge |
+| **runtime rollout** | scans + fleet first, then selected `proxy` or `gateway` | live runtime enforcement is worth the extra operational surface |
+| **remote MCP traffic** | `gateway` | the traffic is actually local stdio or workload-local sidecar traffic instead |
+| **workload-local enforcement** | selected `proxy` sidecars or endpoint-local wrappers | you do not need inline runtime enforcement on that workload yet |
+| **node-wide coverage** | keep the monitor off | your platform team explicitly accepts a DaemonSet tradeoff for node-wide runtime visibility |
+| **graph operations** | investigate by snapshot, page, search, and blast radius | you have benchmarked your expected tenant size and know a wider graph window is safe |
+| **production sizing** | start from the packaged production values and benchmark before broad rollout | your endpoint/runtime volume exceeds the published pilot and initial-enterprise guidance |
+
 If you want the narrower pilot shape first, start with
 [Focused EKS MCP Pilot](eks-mcp-pilot.md). If you want the broader rollout that
 also covers developer endpoints, pair this page with
@@ -36,6 +49,9 @@ If you need the fastest packaged control-plane demo before standing up
 Postgres, there is now a single-node SQLite preset at
 [eks-control-plane-sqlite-pilot-values.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml).
 Use it only for pilots and demos; multi-replica EKS still belongs on Postgres.
+
+For sizing bands, graph investigation boundaries, and the shipped load-test
+harness, see [Performance, Sizing, and Benchmarks](performance-and-sizing.md).
 
 ## What This EKS Shape Is Optimized For
 

--- a/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
+++ b/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
@@ -19,6 +19,15 @@ These are all core product surfaces. They are not three different products.
 | **Proxy** | local stdio MCPs and sidecar enforcement | laptop, workstation, or selected workload | inline policy evaluation, detector chain, audit push, signed cached policy bundles, workload-local runtime visibility | shared remote MCP relay |
 | **Gateway** | shared remote MCP traffic over `http` / `sse` | cluster or shared service tier | remote MCP relay, shared policy surface, tenant auth, shared rate limits, audit, upstream discovery overlay | local stdio or every endpoint runtime path |
 
+## Recommended deployment matrix
+
+| If your goal is... | Deploy | Why |
+|---|---|---|
+| **inventory only** | scans + fleet | lowest-friction way to prove MCP exposure, findings, graph, and provenance |
+| **shared remote MCP control** | inventory-first plus `gateway` | best fit for governed remote `http` / `sse` MCP traffic |
+| **workload-local inline enforcement** | inventory-first plus selected `proxy` sidecars or local wrappers | best fit for local stdio MCPs and workload-local enforcement |
+| **node-wide runtime visibility** | optional monitor on selected clusters only | only when your platform team explicitly wants a higher-trust DaemonSet path |
+
 ## What each surface is for
 
 ### Fleet
@@ -51,6 +60,12 @@ What `fleet` is not:
 - not an always-on endpoint daemon product
 - not inline MCP enforcement
 - not a replacement for `proxy` or `gateway`
+
+Discovery confidence:
+
+- endpoint inventory, MCP config paths, transports, declared tools, auth mode, and credential-backed environment references are high-confidence surfaces
+- source-code agent and tool extraction still includes heuristic/static paths, so indirect or runtime-only registrations can under-report today
+- that is why `fleet` is the inventory wedge first, with deeper runtime or framework-specific validation layered on later when needed
 
 ### Proxy
 


### PR DESCRIPTION
## Summary\n- surface the current graph scale boundary in the README and point operators to the sizing/benchmark guide\n- add a concise self-hosted EKS defaults table for ingress/auth, runtime choices, graph operations, and sizing\n- add runtime/deployment matrix and discovery-confidence wording for fleet, gateway, and proxy docs\n\n## Validation\n- uv run mkdocs build --strict\n