### PR TITLE
feat(graph): add cursor pagination for graph overview

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -8,6 +8,7 @@ provide the same contract for multi-tenant API deployments.
 
 from __future__ import annotations
 
+import base64
 import json
 import re
 import sqlite3
@@ -62,6 +63,28 @@ def _node_search_text(node: UnifiedNode) -> str:
     return " ".join(part for part in parts if part).lower()
 
 
+def _node_sort_key(node: UnifiedNode) -> tuple[int, float, str, str]:
+    return (int(node.severity_id or 0), float(node.risk_score or 0.0), node.label or "", node.id)
+
+
+def encode_graph_cursor(node: UnifiedNode) -> str:
+    payload = json.dumps(list(_node_sort_key(node)), separators=(",", ":"), ensure_ascii=True).encode()
+    return base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+
+def decode_graph_cursor(cursor: str) -> tuple[int, float, str, str]:
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        values = json.loads(raw)
+        if not isinstance(values, list) or len(values) != 4:
+            raise ValueError
+        severity_id, risk_score, label, node_id = values
+        return int(severity_id), float(risk_score), str(label), str(node_id)
+    except Exception as exc:  # pragma: no cover - normalized into ValueError for route handling
+        raise ValueError("Invalid graph cursor") from exc
+
+
 class GraphStoreProtocol(Protocol):
     """Shared graph store contract used by the API pipeline and routes."""
 
@@ -100,9 +123,10 @@ class GraphStoreProtocol(Protocol):
         scan_id: str = "",
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 500,
-    ) -> tuple[str, str, list[UnifiedNode], int]: ...
+    ) -> tuple[str, str, list[UnifiedNode], int, str | None]: ...
 
     def edges_for_node_ids(
         self,
@@ -122,9 +146,10 @@ class GraphStoreProtocol(Protocol):
         min_severity_rank: int = 0,
         compliance_prefixes: set[str] | None = None,
         data_sources: set[str] | None = None,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 50,
-    ) -> tuple[list[UnifiedNode], int]: ...
+    ) -> tuple[list[UnifiedNode], int, str | None]: ...
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict[str, Any], created_at: str) -> None: ...
 
@@ -437,16 +462,17 @@ class SQLiteGraphStore:
         scan_id: str = "",
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 500,
-    ) -> tuple[str, str, list[UnifiedNode], int]:
+    ) -> tuple[str, str, list[UnifiedNode], int, str | None]:
         conn = self._open_ro_conn()
         if conn is None:
-            return scan_id, "", [], 0
+            return scan_id, "", [], 0, None
         try:
             effective_scan_id, created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
             if not effective_scan_id:
-                return scan_id, "", [], 0
+                return scan_id, "", [], 0, None
             where = ["tenant_id = ?", "scan_id = ?"]
             params: list[Any] = [tenant_id, effective_scan_id]
             if entity_types:
@@ -464,6 +490,21 @@ class SQLiteGraphStore:
                 ).fetchone()[0]
                 or 0
             )
+            row_params = list(params)
+            cursor_clause = ""
+            if cursor:
+                severity_id, risk_score, label, node_id = decode_graph_cursor(cursor)
+                cursor_clause = """
+                AND (
+                    severity_id < ?
+                    OR (severity_id = ? AND risk_score < ?)
+                    OR (severity_id = ? AND risk_score = ? AND label > ?)
+                    OR (severity_id = ? AND risk_score = ? AND label = ? AND id > ?)
+                )
+                """
+                row_params.extend(
+                    [severity_id, severity_id, risk_score, severity_id, risk_score, label, severity_id, risk_score, label, node_id]
+                )
             rows = conn.execute(
                 f"""
                 SELECT
@@ -472,12 +513,17 @@ class SQLiteGraphStore:
                     attributes, compliance_tags, data_sources, dimensions
                 FROM graph_nodes
                 WHERE {where_sql}
+                {cursor_clause}
                 ORDER BY severity_id DESC, risk_score DESC, label ASC, id ASC
                 LIMIT ? OFFSET ?
                 """,  # nosec B608 - where_sql is built from static clause fragments
-                [*params, limit, offset],
+                [*row_params, limit + 1 if cursor else limit, 0 if cursor else offset],
             ).fetchall()
-            return effective_scan_id, created_at, [self._node_from_row(row) for row in rows], total
+            has_more = len(rows) > limit if cursor else offset + limit < total
+            rows = rows[:limit]
+            nodes = [self._node_from_row(row) for row in rows]
+            next_cursor = encode_graph_cursor(nodes[-1]) if has_more and nodes else None
+            return effective_scan_id, created_at, nodes, total, next_cursor
         finally:
             conn.close()
 
@@ -538,17 +584,18 @@ class SQLiteGraphStore:
         min_severity_rank: int = 0,
         compliance_prefixes: set[str] | None = None,
         data_sources: set[str] | None = None,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 50,
-    ) -> tuple[list[UnifiedNode], int]:
+    ) -> tuple[list[UnifiedNode], int, str | None]:
         conn = self._open_ro_conn()
         if conn is None:
-            return [], 0
+            return [], 0, None
         try:
             conn_ro: sqlite3.Connection = conn
             effective_scan_id = scan_id or sqlite_graph_store.latest_snapshot_id(conn, tenant_id=tenant_id)
             if not effective_scan_id:
-                return [], 0
+                return [], 0, None
             fts_query = self._search_query_expression(query)
             search_where = [
                 "gns.tenant_id = ?",
@@ -557,7 +604,7 @@ class SQLiteGraphStore:
             params: list[Any] = [tenant_id, effective_scan_id]
             like_query = f"%{_escape_like_query(query.lower())}%"
 
-            def _run_search(*, use_fts: bool) -> tuple[list[UnifiedNode], int]:
+            def _run_search(*, use_fts: bool) -> tuple[list[UnifiedNode], int, str | None]:
                 local_where = list(search_where)
                 local_params = list(params)
                 if use_fts:
@@ -587,6 +634,21 @@ class SQLiteGraphStore:
                         source_filters.append(clause)
                         local_params.extend(clause_params)
                     local_where.append("(" + " OR ".join(source_filters) + ")")
+                row_params = list(local_params)
+                cursor_clause = ""
+                if cursor:
+                    severity_id, risk_score, label, node_id = decode_graph_cursor(cursor)
+                    cursor_clause = """
+                    AND (
+                        gn.severity_id < ?
+                        OR (gn.severity_id = ? AND gn.risk_score < ?)
+                        OR (gn.severity_id = ? AND gn.risk_score = ? AND gn.label > ?)
+                        OR (gn.severity_id = ? AND gn.risk_score = ? AND gn.label = ? AND gn.id > ?)
+                    )
+                    """
+                    row_params.extend(
+                        [severity_id, severity_id, risk_score, severity_id, risk_score, label, severity_id, risk_score, label, node_id]
+                    )
 
                 where_sql = " AND ".join(local_where)
                 total = int(
@@ -597,7 +659,7 @@ class SQLiteGraphStore:
                     or 0
                 )
                 if total == 0:
-                    return [], 0
+                    return [], 0, None
                 rows = conn_ro.execute(
                     """
                     SELECT
@@ -608,10 +670,15 @@ class SQLiteGraphStore:
                     + from_clause
                     + " WHERE "
                     + where_sql
+                    + cursor_clause
                     + " ORDER BY gn.severity_id DESC, gn.risk_score DESC, gn.label ASC, gn.id ASC LIMIT ? OFFSET ?",
-                    [*local_params, limit, offset],
+                    [*row_params, limit + 1 if cursor else limit, 0 if cursor else offset],
                 ).fetchall()
-                return [self._node_from_row(row) for row in rows], total
+                has_more = len(rows) > limit if cursor else offset + limit < total
+                rows = rows[:limit]
+                nodes = [self._node_from_row(row) for row in rows]
+                next_cursor = encode_graph_cursor(nodes[-1]) if has_more and nodes else None
+                return nodes, total, next_cursor
 
             from_clause = """
                 FROM graph_node_search gns

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
-from agent_bom.api.graph_store import _escape_like_query, _node_search_text
+from agent_bom.api.graph_store import _escape_like_query, _node_search_text, decode_graph_cursor, encode_graph_cursor
 
 from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
 
@@ -725,12 +725,13 @@ class PostgresGraphStore:
         scan_id: str = "",
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 500,
-    ) -> tuple[str, str, list[Any], int]:
+    ) -> tuple[str, str, list[Any], int, str | None]:
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
-            return scan_id, "", [], 0
+            return scan_id, "", [], 0, None
         with _tenant_connection(self._pool) as conn:
             created_row = conn.execute(
                 "SELECT created_at FROM graph_snapshots WHERE scan_id = %s AND tenant_id = %s",
@@ -753,6 +754,21 @@ class PostgresGraphStore:
                 ).fetchone()[0]
                 or 0
             )
+            row_params = list(params)
+            cursor_clause = ""
+            if cursor:
+                severity_id, risk_score, label, node_id = decode_graph_cursor(cursor)
+                cursor_clause = """
+                AND (
+                    severity_id < %s
+                    OR (severity_id = %s AND risk_score < %s)
+                    OR (severity_id = %s AND risk_score = %s AND label > %s)
+                    OR (severity_id = %s AND risk_score = %s AND label = %s AND id > %s)
+                )
+                """
+                row_params.extend(
+                    [severity_id, severity_id, risk_score, severity_id, risk_score, label, severity_id, risk_score, label, node_id]
+                )
             rows = conn.execute(
                 f"""
                 SELECT
@@ -761,12 +777,17 @@ class PostgresGraphStore:
                     attributes, compliance_tags, data_sources, dimensions
                 FROM graph_nodes
                 WHERE {where_sql}
+                {cursor_clause}
                 ORDER BY severity_id DESC, risk_score DESC, label ASC, id ASC
                 LIMIT %s OFFSET %s
                 """,  # nosec B608 - where_sql is built from static clause fragments
-                [*params, limit, offset],
+                [*row_params, limit + 1 if cursor else limit, 0 if cursor else offset],
             ).fetchall()
-            return effective_scan_id, str(created_row[0]) if created_row else "", [self._node_from_row(row) for row in rows], total
+            has_more = len(rows) > limit if cursor else offset + limit < total
+            rows = rows[:limit]
+            nodes = [self._node_from_row(row) for row in rows]
+            next_cursor = encode_graph_cursor(nodes[-1]) if has_more and nodes else None
+            return effective_scan_id, str(created_row[0]) if created_row else "", nodes, total, next_cursor
 
     def edges_for_node_ids(
         self,
@@ -820,12 +841,13 @@ class PostgresGraphStore:
         min_severity_rank: int = 0,
         compliance_prefixes: set[str] | None = None,
         data_sources: set[str] | None = None,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 50,
     ):
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
-            return [], 0
+            return [], 0, None
 
         with _tenant_connection(self._pool) as conn:
             search_where = [
@@ -865,7 +887,22 @@ class PostgresGraphStore:
             where_sql = " AND ".join(search_where)
             total = int(conn.execute("SELECT COUNT(*) " + from_clause + " WHERE " + where_sql, params).fetchone()[0] or 0)
             if total == 0:
-                return [], 0
+                return [], 0, None
+            row_params = list(params)
+            cursor_clause = ""
+            if cursor:
+                severity_id, risk_score, label, node_id = decode_graph_cursor(cursor)
+                cursor_clause = """
+                AND (
+                    gn.severity_id < %s
+                    OR (gn.severity_id = %s AND gn.risk_score < %s)
+                    OR (gn.severity_id = %s AND gn.risk_score = %s AND gn.label > %s)
+                    OR (gn.severity_id = %s AND gn.risk_score = %s AND gn.label = %s AND gn.id > %s)
+                )
+                """
+                row_params.extend(
+                    [severity_id, severity_id, risk_score, severity_id, risk_score, label, severity_id, risk_score, label, node_id]
+                )
             rows = conn.execute(
                 """
                 SELECT
@@ -876,10 +913,15 @@ class PostgresGraphStore:
                 + from_clause
                 + " WHERE "
                 + where_sql
+                + cursor_clause
                 + " ORDER BY gn.severity_id DESC, gn.risk_score DESC, gn.label ASC, gn.id ASC LIMIT %s OFFSET %s",
-                [*params, limit, offset],
+                [*row_params, limit + 1 if cursor else limit, 0 if cursor else offset],
             ).fetchall()
-            return [self._node_from_row(row) for row in rows], total
+            has_more = len(rows) > limit if cursor else offset + limit < total
+            rows = rows[:limit]
+            nodes = [self._node_from_row(row) for row in rows]
+            next_cursor = encode_graph_cursor(nodes[-1]) if has_more and nodes else None
+            return nodes, total, next_cursor
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict[str, Any], created_at: str) -> None:
         with _tenant_connection(self._pool) as conn:

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -58,12 +58,14 @@ def _paginate(items: list, offset: int, limit: int) -> tuple[list, dict]:
     }
 
 
-def _page_meta(total: int, offset: int, limit: int) -> dict:
+def _page_meta(total: int, offset: int, limit: int, *, cursor: str | None = None, next_cursor: str | None = None) -> dict:
     return {
         "total": total,
         "offset": offset,
         "limit": limit,
-        "has_more": offset + limit < total,
+        "cursor": cursor or "",
+        "next_cursor": next_cursor or "",
+        "has_more": bool(next_cursor) if cursor else offset + limit < total,
     }
 
 
@@ -174,6 +176,7 @@ async def get_graph(
     static_only: bool = Query(False, description="Exclude runtime edges"),
     dynamic_only: bool = Query(False, description="Only runtime edges"),
     max_depth: Optional[int] = Query(None, ge=1, le=20, description="Max traversal depth"),
+    cursor: Optional[str] = Query(None, description="Opaque cursor for keyset node pagination"),
     offset: int = Query(0, ge=0, description="Pagination offset for nodes"),
     limit: int = Query(500, ge=1, le=5000, description="Max nodes to return"),
 ) -> dict:
@@ -245,15 +248,19 @@ async def get_graph(
             "pagination": pagination,
         }
 
-    effective_scan_id, created_at, paged_nodes, total = await _graph_store_call(
-        graph_store.page_nodes,
-        scan_id=requested_scan_id,
-        tenant_id=tenant,
-        entity_types=et_set,
-        min_severity_rank=min_rank,
-        offset=offset,
-        limit=limit,
-    )
+    try:
+        effective_scan_id, created_at, paged_nodes, total, next_cursor = await _graph_store_call(
+            graph_store.page_nodes,
+            scan_id=requested_scan_id,
+            tenant_id=tenant,
+            entity_types=et_set,
+            min_severity_rank=min_rank,
+            cursor=cursor,
+            offset=offset,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     paged_ids = {n.id for n in paged_nodes}
     paged_edges = await _graph_store_call(
         graph_store.edges_for_node_ids,
@@ -276,7 +283,7 @@ async def get_graph(
             entity_types=et_set,
             min_severity_rank=min_rank,
         ),
-        "pagination": _page_meta(total, offset, limit),
+        "pagination": _page_meta(total, offset, limit, cursor=cursor, next_cursor=next_cursor),
     }
 
 
@@ -342,6 +349,7 @@ async def search_graph(
     min_severity: Optional[str] = Query(None, description="Minimum severity (critical/high/medium/low)"),
     compliance_prefixes: Optional[str] = Query(None, description="Comma-separated compliance prefixes"),
     data_sources: Optional[str] = Query(None, description="Comma-separated data sources"),
+    cursor: Optional[str] = Query(None, description="Opaque cursor for keyset search pagination"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
     limit: int = Query(50, ge=1, le=500, description="Max results"),
 ) -> dict:
@@ -350,18 +358,22 @@ async def search_graph(
     min_rank = SEVERITY_RANK.get(min_severity.lower(), 0) if min_severity else 0
     prefix_filters = {value.strip().upper() for value in compliance_prefixes.split(",") if value.strip()} if compliance_prefixes else None
     data_source_filters = {value.strip() for value in data_sources.split(",") if value.strip()} if data_sources else None
-    results, total = await _graph_store_call(
-        _get_graph_store_or_503().search_nodes,
-        scan_id=scan_id or "",
-        tenant_id=_tenant(request),
-        query=q,
-        entity_types=entity_type_filters,
-        min_severity_rank=min_rank,
-        compliance_prefixes=prefix_filters,
-        data_sources=data_source_filters,
-        offset=offset,
-        limit=limit,
-    )
+    try:
+        results, total, next_cursor = await _graph_store_call(
+            _get_graph_store_or_503().search_nodes,
+            scan_id=scan_id or "",
+            tenant_id=_tenant(request),
+            query=q,
+            entity_types=entity_type_filters,
+            min_severity_rank=min_rank,
+            compliance_prefixes=prefix_filters,
+            data_sources=data_source_filters,
+            cursor=cursor,
+            offset=offset,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {
         "query": q,
         "filters": {
@@ -376,7 +388,9 @@ async def search_graph(
             "total": total,
             "offset": offset,
             "limit": limit,
-            "has_more": offset + limit < total,
+            "cursor": cursor or "",
+            "next_cursor": next_cursor or "",
+            "has_more": bool(next_cursor) if cursor else offset + limit < total,
         },
     }
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -241,10 +241,11 @@ class TestGraphEndpointLogic:
         )
         store.save_graph(graph)
 
-        results, total = store.search_nodes(tenant_id="default", query="vector", offset=0, limit=10)
+        results, total, next_cursor = store.search_nodes(tenant_id="default", query="vector", offset=0, limit=10)
 
         assert total == 1
         assert [node.id for node in results] == ["server:acme:vector"]
+        assert next_cursor is None
 
     def test_sqlite_graph_store_search_applies_slice_filters(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
@@ -271,7 +272,7 @@ class TestGraphEndpointLogic:
         )
         store.save_graph(graph)
 
-        results, total = store.search_nodes(
+        results, total, next_cursor = store.search_nodes(
             tenant_id="default",
             query="vector",
             entity_types={"server"},
@@ -284,6 +285,7 @@ class TestGraphEndpointLogic:
 
         assert total == 1
         assert [node.id for node in results] == ["server:prod:vector"]
+        assert next_cursor is None
 
     def test_sqlite_graph_store_search_escapes_like_wildcards(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
@@ -293,8 +295,8 @@ class TestGraphEndpointLogic:
         graph.add_node(UnifiedNode(id="agent:plain", entity_type=EntityType.AGENT, label="plain agent"))
         store.save_graph(graph)
 
-        percent_results, percent_total = store.search_nodes(tenant_id="default", query="%", offset=0, limit=10)
-        underscore_results, underscore_total = store.search_nodes(tenant_id="default", query="_", offset=0, limit=10)
+        percent_results, percent_total, _ = store.search_nodes(tenant_id="default", query="%", offset=0, limit=10)
+        underscore_results, underscore_total, _ = store.search_nodes(tenant_id="default", query="_", offset=0, limit=10)
 
         assert percent_total == 1
         assert [node.id for node in percent_results] == ["server:percent"]
@@ -309,7 +311,7 @@ class TestGraphEndpointLogic:
 
         monkeypatch.setattr(SQLiteGraphStore, "_search_query_expression", staticmethod(lambda query: '"'))
 
-        results, total = store.search_nodes(tenant_id="default", query="vector", offset=0, limit=10)
+        results, total, _ = store.search_nodes(tenant_id="default", query="vector", offset=0, limit=10)
 
         assert total == 1
         assert [node.id for node in results] == ["server:vector"]
@@ -394,16 +396,49 @@ class _RecordingGraphStore:
         scan_id: str = "",
         entity_types=None,
         min_severity_rank: int = 0,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 500,
     ):
-        self.calls.append(("page_nodes", tenant_id, scan_id, entity_types, min_severity_rank, offset, limit))
-        nodes = list(self.graph.nodes.values())
+        self.calls.append(("page_nodes", tenant_id, scan_id, entity_types, min_severity_rank, cursor, offset, limit))
+        nodes = sorted(
+            self.graph.nodes.values(),
+            key=lambda node: (-node.severity_id, -(node.risk_score or 0.0), node.label, node.id),
+        )
         if entity_types:
             nodes = [node for node in nodes if node.entity_type.value in entity_types]
         if min_severity_rank:
             nodes = [node for node in nodes if node.severity_id >= min_severity_rank]
-        return self.graph.scan_id, self.graph.created_at, nodes[offset : offset + limit], len(nodes)
+        full_total = len(nodes)
+        if cursor:
+            from agent_bom.api.graph_store import decode_graph_cursor, encode_graph_cursor
+
+            severity_id, risk_score, label, node_id = decode_graph_cursor(cursor)
+            nodes = [
+                node
+                for node in nodes
+                if (
+                    node.severity_id < severity_id
+                    or (node.severity_id == severity_id and (node.risk_score or 0.0) < risk_score)
+                    or (node.severity_id == severity_id and (node.risk_score or 0.0) == risk_score and node.label > label)
+                    or (
+                        node.severity_id == severity_id
+                        and (node.risk_score or 0.0) == risk_score
+                        and node.label == label
+                        and node.id > node_id
+                    )
+                )
+            ]
+            page = nodes[:limit]
+            next_cursor = encode_graph_cursor(page[-1]) if len(nodes) > limit and page else None
+            return self.graph.scan_id, self.graph.created_at, page, full_total, next_cursor
+        page = nodes[offset : offset + limit]
+        next_cursor = None
+        if offset + limit < full_total and page:
+            from agent_bom.api.graph_store import encode_graph_cursor
+
+            next_cursor = encode_graph_cursor(page[-1])
+        return self.graph.scan_id, self.graph.created_at, page, full_total, next_cursor
 
     def edges_for_node_ids(self, *, tenant_id: str = "", scan_id: str = "", node_ids: set[str]):
         self.calls.append(("edges_for_node_ids", tenant_id, scan_id, tuple(sorted(node_ids))))
@@ -419,6 +454,7 @@ class _RecordingGraphStore:
         min_severity_rank: int = 0,
         compliance_prefixes=None,
         data_sources=None,
+        cursor: str | None = None,
         offset: int = 0,
         limit: int = 50,
     ):
@@ -432,6 +468,7 @@ class _RecordingGraphStore:
                 min_severity_rank,
                 compliance_prefixes,
                 data_sources,
+                cursor,
                 offset,
                 limit,
             )
@@ -451,7 +488,37 @@ class _RecordingGraphStore:
             ]
         if data_sources:
             matches = [node for node in matches if set(node.data_sources).intersection(data_sources)]
-        return matches[offset : offset + limit], len(matches)
+        matches = sorted(matches, key=lambda node: (-node.severity_id, -(node.risk_score or 0.0), node.label, node.id))
+        full_total = len(matches)
+        if cursor:
+            from agent_bom.api.graph_store import decode_graph_cursor, encode_graph_cursor
+
+            severity_id, risk_score, label, node_id = decode_graph_cursor(cursor)
+            matches = [
+                node
+                for node in matches
+                if (
+                    node.severity_id < severity_id
+                    or (node.severity_id == severity_id and (node.risk_score or 0.0) < risk_score)
+                    or (node.severity_id == severity_id and (node.risk_score or 0.0) == risk_score and node.label > label)
+                    or (
+                        node.severity_id == severity_id
+                        and (node.risk_score or 0.0) == risk_score
+                        and node.label == label
+                        and node.id > node_id
+                    )
+                )
+            ]
+            page = matches[:limit]
+            next_cursor = encode_graph_cursor(page[-1]) if len(matches) > limit and page else None
+            return page, full_total, next_cursor
+        page = matches[offset : offset + limit]
+        next_cursor = None
+        if offset + limit < full_total and page:
+            from agent_bom.api.graph_store import encode_graph_cursor
+
+            next_cursor = encode_graph_cursor(page[-1])
+        return page, full_total, next_cursor
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict, created_at: str) -> None:
         self.calls.append(("save_preset", tenant_id, name))
@@ -612,9 +679,50 @@ class TestGraphStoreBackendSelection:
             4,
             {"CIS"},
             {"runtime-proxy"},
+            None,
             0,
             50,
         ) in recording_graph_store.calls
+
+    def test_graph_overview_supports_cursor_pagination(self, recording_graph_store):
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="server:b", entity_type=EntityType.SERVER, label="server-b", severity="high", severity_id=4)
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="server:c", entity_type=EntityType.SERVER, label="server-c", severity="high", severity_id=4)
+        )
+        client = TestClient(app)
+
+        first = client.get("/v1/graph", params={"entity_types": "agent,server", "limit": 2})
+        assert first.status_code == 200
+        next_cursor = first.json()["pagination"]["next_cursor"]
+        assert next_cursor
+
+        second = client.get("/v1/graph", params={"entity_types": "agent,server", "limit": 2, "cursor": next_cursor})
+        assert second.status_code == 200
+        assert second.json()["pagination"]["cursor"] == next_cursor
+        assert second.json()["pagination"]["offset"] == 0
+
+    def test_graph_search_supports_cursor_pagination(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:b", entity_type=EntityType.SERVER, label="agent-b server"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:c", entity_type=EntityType.SERVER, label="agent-c server"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:d", entity_type=EntityType.SERVER, label="agent-d server"))
+        client = TestClient(app)
+
+        first = client.get("/v1/graph/search", params={"q": "server", "limit": 2})
+        assert first.status_code == 200
+        next_cursor = first.json()["pagination"]["next_cursor"]
+        assert next_cursor
+
+        second = client.get("/v1/graph/search", params={"q": "server", "limit": 2, "cursor": next_cursor})
+        assert second.status_code == 200
+        assert second.json()["pagination"]["cursor"] == next_cursor
+
+    def test_graph_cursor_rejects_invalid_values(self, recording_graph_store):
+        client = TestClient(app)
+        response = client.get("/v1/graph", params={"cursor": "not-a-real-cursor"})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid graph cursor"
 
     def test_graph_paths_reachable_nodes_follow_traversable_edges_only(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")


### PR DESCRIPTION
## Summary
- add cursor pagination support to the store-backed graph overview and search paths
- return store-level totals with next_cursor while keeping offset pagination compatibility
- cover SQLite/Postgres store behavior and invalid cursor handling in graph API tests

## Validation
- uv run --python 3.12 pytest tests/test_graph_api.py -q
- uv run mypy src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py src/agent_bom/api/routes/graph.py
- uv run ruff check src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py src/agent_bom/api/routes/graph.py tests/test_graph_api.py