### PR TITLE
docs(perf): publish graph and control-plane baselines

### DIFF
--- a/deploy/loadtest/README.md
+++ b/deploy/loadtest/README.md
@@ -7,6 +7,7 @@ control-plane and proxy-ingest paths that matter for enterprise rollout.
 ## What is covered
 
 - control-plane API health and authenticated fleet reads
+- graph overview and graph search operator reads
 - proxy audit ingest writes
 
 ## Prerequisites
@@ -59,14 +60,36 @@ What it hits:
 
 - `POST /v1/proxy/audit`
 
+## Graph operator baseline
+
+```bash
+k6 run deploy/loadtest/k6-graph-api.js
+```
+
+Optional overrides:
+
+- `AGENT_BOM_BASE_URL`
+- `AGENT_BOM_API_TOKEN`
+- `AGENT_BOM_GRAPH_SCAN_ID`
+- `AGENT_BOM_GRAPH_QUERY`
+- `AGENT_BOM_GRAPH_ENTITY_TYPES`
+- `K6_VUS`
+- `K6_DURATION`
+
+What it hits:
+
+- `GET /v1/graph`
+- `GET /v1/graph/search`
+
 ## How to use the results
 
 Use these runs to answer four operator questions:
 
 1. Are API replicas sized correctly for steady-state reads?
-2. Does proxy audit ingest stay healthy under expected concurrency?
-3. At what point should `HPA` thresholds be widened?
-4. At what point should analytics move from `Postgres`-only to
+2. Does graph overview/search stay within the target operator latency budget?
+3. Does proxy audit ingest stay healthy under expected concurrency?
+4. At what point should `HPA` thresholds be widened?
+5. At what point should analytics move from `Postgres`-only to
    `Postgres + ClickHouse`?
 
 Do not treat one green run as a certification. Re-run after:

--- a/deploy/loadtest/k6-graph-api.js
+++ b/deploy/loadtest/k6-graph-api.js
@@ -1,0 +1,54 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const baseUrl = (__ENV.AGENT_BOM_BASE_URL || "http://127.0.0.1:8422").replace(/\/$/, "");
+const token = __ENV.AGENT_BOM_API_TOKEN || "";
+const graphScanId = __ENV.AGENT_BOM_GRAPH_SCAN_ID || "";
+const graphSearch = __ENV.AGENT_BOM_GRAPH_QUERY || "agent";
+const graphEntityTypes = __ENV.AGENT_BOM_GRAPH_ENTITY_TYPES || "agent,server";
+
+export const options = {
+  vus: Number(__ENV.K6_VUS || 10),
+  duration: __ENV.K6_DURATION || "60s",
+  thresholds: {
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<1000"],
+  },
+};
+
+function authHeaders() {
+  const headers = { Accept: "application/json" };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+function graphParams(extra = {}) {
+  const params = new URLSearchParams({
+    limit: "100",
+    entity_types: graphEntityTypes,
+    ...extra,
+  });
+  if (graphScanId) {
+    params.set("scan_id", graphScanId);
+  }
+  return params.toString();
+}
+
+export default function () {
+  const overview = http.get(`${baseUrl}/v1/graph?${graphParams()}`, { headers: authHeaders() });
+  check(overview, {
+    "graph overview returns 200": (r) => r.status === 200,
+  });
+
+  const search = http.get(
+    `${baseUrl}/v1/graph/search?${graphParams({ q: graphSearch, limit: "25" })}`,
+    { headers: authHeaders() }
+  );
+  check(search, {
+    "graph search returns 200": (r) => r.status === 200,
+  });
+
+  sleep(1);
+}

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -1,9 +1,10 @@
-# Performance Benchmarks
+# Performance Benchmarks and Target SLOs
 
 Measured numbers for the agent-bom scanner hot paths that matter at
 pilot scale. Run on a MacBook Pro (M-series, 2026) with Python 3.13.
 Your infra will vary — treat these as the reference curve, not the
-SLO.
+contract. The target SLOs below are the operator envelope we use for
+pilot and production readiness decisions.
 
 Run them yourself:
 
@@ -11,6 +12,14 @@ Run them yourself:
 pip install 'agent-bom[dev]'
 pytest tests/benchmarks/ --benchmark-only --benchmark-columns=min,mean,max,stddev,ops
 AGENT_BOM_BENCH_FULL=1 pytest tests/benchmarks/ --benchmark-only -k 50k  # heaviest
+```
+
+For control-plane and graph API baselines against a running deployment:
+
+```bash
+k6 run deploy/loadtest/k6-control-plane-api.js
+k6 run deploy/loadtest/k6-graph-api.js
+k6 run deploy/loadtest/k6-proxy-audit.js
 ```
 
 ---
@@ -125,6 +134,45 @@ team runs against during pilot smoke-testing. Run
 | `/v1/compliance/{framework}/report` at 50k findings | < 500 ms p99 | < 1 s p99 |
 | jsonl bundle streaming (first byte) | < 50 ms | < 100 ms |
 
+## Graph and control-plane operator targets
+
+These are the target envelopes for the main operator flows after the
+0.81.x store-backed graph improvements. They are not yet universal
+guarantees for every tenant shape; they are the thresholds we expect a
+healthy self-hosted rollout to validate with the bundled k6 harness.
+
+| Operation | Baseline path | Target (pilot) | Target (production) |
+|---|---|---:|---:|
+| `GET /v1/graph?limit=100` | store-backed overview page | < 300 ms p95 | < 500 ms p95 |
+| `GET /v1/graph/search?q=agent&limit=25` | store-backed search page | < 250 ms p95 | < 400 ms p95 |
+| `GET /v1/fleet?limit=25` | authenticated fleet read | < 200 ms p95 | < 350 ms p95 |
+| `GET /v1/fleet/stats` | fleet summary read | < 150 ms p95 | < 300 ms p95 |
+| `POST /v1/proxy/audit` | proxy audit ingest batch | < 300 ms p95 | < 500 ms p95 |
+
+### How to measure the operator targets
+
+Run against the deployment you actually intend to operate:
+
+```bash
+export AGENT_BOM_BASE_URL=https://agent-bom.internal.example.com
+export AGENT_BOM_API_TOKEN=replace-me
+export AGENT_BOM_GRAPH_SCAN_ID=$(curl -s -H "Authorization: Bearer $AGENT_BOM_API_TOKEN" \
+  "$AGENT_BOM_BASE_URL/v1/graph/snapshots?limit=1" | jq -r '.[0].scan_id')
+
+k6 run deploy/loadtest/k6-control-plane-api.js
+k6 run deploy/loadtest/k6-graph-api.js
+k6 run deploy/loadtest/k6-proxy-audit.js
+```
+
+Interpretation:
+
+- if graph overview/search breaches target first, keep the graph windowed by
+  snapshot and page size before widening runtime rollout
+- if fleet reads breach target first, tune API HPA and database size before
+  assuming the graph is the bottleneck
+- if proxy audit ingest breaches target first, adjust batch size, retention,
+  or analytics backend before widening sidecar/gateway deployment
+
 Latency budget for a bundle export at 50k findings on Postgres:
 
 - `_tenant_jobs` store read: ~10 ms (index on tenant_id)
@@ -149,6 +197,14 @@ Pilot-default Helm values ([`eks-mcp-pilot-values.yaml`](../deploy/helm/agent-bo
 Scale-out signal: `agent_bom_rate_limit_hits_total` hitting a tenant
 bucket for > 10 minutes, OR `p95` on `/v1/compliance/*` above 800 ms.
 Both show up on the shipped Grafana dashboard.
+
+For graph/runtime-heavy rollouts, treat these as the next scale-out
+signals too:
+
+- `/v1/graph` `p95` consistently above `500 ms`
+- `/v1/graph/search` `p95` consistently above `400 ms`
+- `POST /v1/proxy/audit` `p95` consistently above `500 ms`
+- rising queueing or timeout behavior during the bundled k6 graph/control-plane runs
 
 ---
 

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -249,14 +249,16 @@ The repo now ships a small benchmark harness under:
 
 - [deploy/loadtest/README.md](https://github.com/msaad00/agent-bom/blob/main/deploy/loadtest/README.md)
 - [k6-control-plane-api.js](https://github.com/msaad00/agent-bom/blob/main/deploy/loadtest/k6-control-plane-api.js)
+- [k6-graph-api.js](https://github.com/msaad00/agent-bom/blob/main/deploy/loadtest/k6-graph-api.js)
 - [k6-proxy-audit.js](https://github.com/msaad00/agent-bom/blob/main/deploy/loadtest/k6-proxy-audit.js)
 
 Use that harness to validate:
 
 1. authenticated control-plane read paths
-2. proxy audit ingest write paths
-3. scaling behavior after enabling `HPA`
-4. the point where analytics should move to `ClickHouse`
+2. graph overview and graph search operator paths
+3. proxy audit ingest write paths
+4. scaling behavior after enabling `HPA`
+5. the point where analytics should move to `ClickHouse`
 
 Current boundary:
 
@@ -270,12 +272,29 @@ Current boundary:
 Run these in your own environment before broader rollout:
 
 1. Baseline the API with the control-plane script at low and medium concurrency.
-2. Baseline proxy audit ingest with realistic batch sizes.
-3. Repeat both runs with `HPA` enabled.
-4. Repeat with `ClickHouse` disabled, then enabled if your rollout expects high
+2. Baseline graph overview/search with the graph script against a representative snapshot.
+3. Baseline proxy audit ingest with realistic batch sizes.
+4. Repeat all runs with `HPA` enabled.
+5. Repeat with `ClickHouse` disabled, then enabled if your rollout expects high
    retained analytics volume.
-5. Record your chosen replica floor, resource requests, and retention policy in
+6. Record your chosen replica floor, resource requests, and retention policy in
    your operator runbook.
+
+## Target operator latency envelope
+
+These are the current target thresholds for self-hosted rollouts using the
+bundled k6 harness:
+
+| Flow | Target (pilot) | Target (production) |
+|---|---:|---:|
+| Graph overview `GET /v1/graph?limit=100` | < 300 ms p95 | < 500 ms p95 |
+| Graph search `GET /v1/graph/search?q=agent&limit=25` | < 250 ms p95 | < 400 ms p95 |
+| Fleet read `GET /v1/fleet?limit=25` | < 200 ms p95 | < 350 ms p95 |
+| Fleet stats `GET /v1/fleet/stats` | < 150 ms p95 | < 300 ms p95 |
+| Proxy audit ingest `POST /v1/proxy/audit` | < 300 ms p95 | < 500 ms p95 |
+
+These are not universal guarantees for every tenant shape. They are the
+thresholds operators should validate before calling a rollout production-ready.
 
 ## Publish your own benchmark numbers
 


### PR DESCRIPTION
## Summary
- add a graph-focused k6 benchmark harness for store-backed overview and search paths
- publish graph/control-plane/proxy target p95 envelopes in the benchmark and sizing docs
- wire the existing load-test harness and benchmark docs together so operators can reproduce the baseline

## Validation
- uv run mkdocs build --strict