### PR TITLE
fix(cli): clarify mesh scope and local auth mode

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -167,7 +167,7 @@ Users can restrict or bypass auto-discovery entirely:
 |------|--------|
 | `--dry-run` | Shows exactly which files, APIs, and data would be accessed, then exits without reading anything |
 | `--inventory <file>` | Scans only the agents/packages defined in a JSON inventory file — skips all config discovery |
-| `--project <dir>` | Scans only MCP configs in a specific project directory |
+| `--project <dir>` | Restricts discovery to MCP configs in a specific project directory (does not include machine-wide configs) |
 | `--config-dir <dir>` | Reads MCP configs from a single custom directory only |
 | `--no-skill` | Disables skill/instruction file scanning |
 | `--skill-only` | Runs only skill scanning, skips all agent/package/CVE analysis |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -54,7 +54,8 @@ def main():
       agent-bom agents                               discover + scan local agents and MCP servers
       agent-bom agents -p .                          scan project manifests plus agent/MCP context
       agent-bom where                                show MCP discovery paths checked on this machine
-      agent-bom mesh --project .                     show the live agent/MCP topology
+      agent-bom mesh                                 show the live machine-wide agent/MCP topology
+      agent-bom mesh --project .                     show project-local topology only
       agent-bom skills scan .                        scan skills and instruction files
       agent-bom skills rescan                        revisit previously cataloged skills
       agent-bom check flask@2.0.0 --ecosystem pypi  pre-install CVE gate

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -284,7 +284,7 @@ def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool)
     "project_dir",
     type=click.Path(exists=True, file_okay=False),
     default=None,
-    help="Discover agents relative to a project directory.",
+    help="Restrict discovery to a project directory (replaces machine-wide discovery).",
 )
 @click.option(
     "--format",
@@ -303,7 +303,7 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
     \b
     Examples:
       agent-bom mesh
-      agent-bom mesh --project .
+      agent-bom mesh --project .   # project-local discovery only
       agent-bom mesh report.json --format json --output mesh.json
     """
     from agent_bom.output.agent_mesh import build_agent_mesh
@@ -317,7 +317,10 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
         raise SystemExit(1) from exc
 
     if not agents_data:
-        con.print("[yellow]No agents discovered.[/yellow]")
+        if project_dir:
+            con.print("[yellow]No project-local agents discovered.[/yellow] Try [bold]agent-bom mesh[/bold] for machine-wide discovery.")
+        else:
+            con.print("[yellow]No agents discovered.[/yellow]")
         return
 
     mesh = build_agent_mesh(agents_data, blast_radius)

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -181,7 +181,9 @@ def serve_cmd(
         import uvicorn  # noqa: F401
     except ImportError:
         click.echo(
-            "ERROR: FastAPI + Uvicorn are required for `agent-bom serve`.\nInstall them with:  pip install 'agent-bom[ui]'",
+            "ERROR: FastAPI + Uvicorn are required for `agent-bom serve`.\n"
+            "Install them with:  uv pip install 'agent-bom[ui]'  "
+            "(or: pip install 'agent-bom[ui]')",
             err=True,
         )
         sys.exit(1)
@@ -222,6 +224,8 @@ def serve_cmd(
         click.echo("  Auth:       OIDC bearer token required")
     elif allow_insecure_no_auth and not _is_loopback_host(host):
         click.echo("  Auth:       disabled by explicit override (--allow-insecure-no-auth)")
+    else:
+        click.echo("  Auth:       local unauthenticated mode (loopback only); set --api-key or OIDC for authenticated access")
     if resolved_backend == "clickhouse":
         mode = "buffered" if analytics_buffered else "direct"
         click.echo(f"  Analytics:  ClickHouse ({mode}, batch={max(1, analytics_max_batch)}, flush={analytics_flush_interval:.2f}s)")
@@ -243,7 +247,12 @@ def serve_cmd(
 
 
 @click.command("api")
-@click.option("--host", default="127.0.0.1", show_default=True, help="Host to bind to (use 0.0.0.0 for LAN access)")
+@click.option(
+    "--host",
+    default="127.0.0.1",
+    show_default=True,
+    help="Host to bind to (non-loopback requires --api-key / OIDC or --allow-insecure-no-auth).",
+)
 @click.option("--port", default=8422, show_default=True, help="Port to listen on")
 @click.option("--reload", is_flag=True, help="Auto-reload on code changes (development mode)")
 @click.option("--workers", default=1, show_default=True, help="Number of worker processes")
@@ -360,7 +369,7 @@ def api_cmd(
     \b
     Usage:
       agent-bom api                           # local dev: http://127.0.0.1:8422
-      agent-bom api --host 0.0.0.0            # expose on LAN
+      agent-bom api --host 0.0.0.0 --api-key <key>  # expose on LAN with auth
       agent-bom api --port 9000               # custom port
       agent-bom api --reload                  # dev mode
     """
@@ -372,7 +381,9 @@ def api_cmd(
         import uvicorn
     except ImportError:
         click.echo(
-            "ERROR: uvicorn is required for `agent-bom api`.\nInstall it with:  pip install 'agent-bom[api]'",
+            "ERROR: uvicorn is required for `agent-bom api`.\n"
+            "Install it with:  uv pip install 'agent-bom[api]'  "
+            "(or: pip install 'agent-bom[api]')",
             err=True,
         )
         sys.exit(1)
@@ -420,6 +431,8 @@ def api_cmd(
         click.echo("  Auth:         OIDC bearer token required")
     elif allow_insecure_no_auth and not _is_loopback_host(host):
         click.echo("  Auth:         disabled by explicit override (--allow-insecure-no-auth)")
+    else:
+        click.echo("  Auth:         local unauthenticated mode (loopback only); set --api-key or OIDC for authenticated access")
     if pg_url and not persist:
         click.echo("  Storage:      PostgreSQL")
     elif persist:

--- a/tests/test_cli_analysis.py
+++ b/tests/test_cli_analysis.py
@@ -312,6 +312,17 @@ def test_mesh_cmd_quiet_suppresses_summary_heading():
         assert "filesystem" in result.output
 
 
+def test_mesh_cmd_project_scope_empty_message():
+    runner = CliRunner()
+
+    with patch("agent_bom.discovery.discover_all", return_value=[]):
+        result = runner.invoke(mesh_cmd, ["--project", "."])
+
+    assert result.exit_code == 0
+    assert "No project-local agents discovered." in result.output
+    assert "agent-bom mesh" in result.output
+
+
 # ---------------------------------------------------------------------------
 # dashboard_cmd
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -62,6 +62,7 @@ def test_api_cmd_missing_uvicorn():
         result = runner.invoke(api_cmd, [])
         assert result.exit_code == 1
         assert "uvicorn" in result.output.lower()
+        assert "uv pip install 'agent-bom[api]'" in result.output
 
 
 def test_api_cmd_rejects_unauthenticated_non_loopback_bind():
@@ -87,6 +88,18 @@ def test_api_cmd_allows_non_loopback_bind_with_api_key():
     mock_configure.assert_called_once()
     mock_run.assert_called_once()
     assert "API key required" in result.output
+
+
+def test_api_cmd_loopback_no_auth_warns_local_mode():
+    runner = CliRunner()
+
+    with patch("agent_bom.api.server.configure_api") as mock_configure, patch("uvicorn.run") as mock_run:
+        result = runner.invoke(api_cmd, [])
+
+    assert result.exit_code == 0
+    mock_configure.assert_called_once()
+    mock_run.assert_called_once()
+    assert "local unauthenticated mode" in result.output
 
 
 def test_api_cmd_enables_clickhouse_analytics():
@@ -151,6 +164,18 @@ def test_serve_cmd_configures_api_auth():
     mock_configure.assert_called_once()
     mock_run.assert_called_once()
     assert "API key required" in result.output
+
+
+def test_serve_cmd_loopback_no_auth_warns_local_mode():
+    runner = CliRunner()
+
+    with patch("agent_bom.api.server.configure_api") as mock_configure, patch("uvicorn.run") as mock_run:
+        result = runner.invoke(serve_cmd, [])
+
+    assert result.exit_code == 0
+    mock_configure.assert_called_once()
+    mock_run.assert_called_once()
+    assert "local unauthenticated mode" in result.output
 
 
 def test_serve_cmd_enables_clickhouse_analytics():


### PR DESCRIPTION
## Summary
- clarify that `mesh --project` is project-local scope, not machine-wide discovery
- show a clearer message when project-local mesh discovery returns nothing
- make API/serve help and startup output explicit about local unauthenticated loopback mode and non-loopback auth requirements
- make missing-api-extras install hints uv-friendly

## Validation
- uv run --python 3.12 pytest tests/test_cli_analysis.py tests/test_cli_server.py -q
- uv run ruff check src/agent_bom/cli/__init__.py src/agent_bom/cli/_analysis.py src/agent_bom/cli/_server.py tests/test_cli_analysis.py tests/test_cli_server.py
- uv run mypy src/agent_bom/cli/_analysis.py src/agent_bom/cli/_server.py