### PR TITLE
feat(graph): store-backed traversal for graph query APIs

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from agent_bom.db import graph_store as sqlite_graph_store
-from agent_bom.graph import EntityType, NodeDimensions, NodeStatus, UnifiedGraph, UnifiedNode
+from agent_bom.graph import AttackPath, EntityType, NodeDimensions, NodeStatus, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
 
 _CREATE_PRESET_TABLE_SQLITE = """\
 CREATE TABLE IF NOT EXISTS graph_filter_presets (
@@ -85,6 +85,13 @@ def decode_graph_cursor(cursor: str) -> tuple[int, float, str, str]:
         raise ValueError("Invalid graph cursor") from exc
 
 
+_DYNAMIC_RELATIONSHIP_VALUES = {
+    RelationshipType.INVOKED.value,
+    RelationshipType.ACCESSED.value,
+    RelationshipType.DELEGATED_TO.value,
+}
+
+
 class GraphStoreProtocol(Protocol):
     """Shared graph store contract used by the API pipeline and routes."""
 
@@ -150,6 +157,57 @@ class GraphStoreProtocol(Protocol):
         offset: int = 0,
         limit: int = 50,
     ) -> tuple[list[UnifiedNode], int, str | None]: ...
+
+    def nodes_by_ids(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_ids: set[str],
+    ) -> list[UnifiedNode]: ...
+
+    def bfs_paths(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        source: str,
+        max_depth: int = 4,
+        traversable_only: bool = True,
+    ) -> tuple[list[list[str]], set[str]]: ...
+
+    def impact_of(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_id: str,
+        max_depth: int = 4,
+    ) -> dict[str, Any] | None: ...
+
+    def traverse_subgraph(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        roots: list[str],
+        direction: str = "forward",
+        max_depth: int = 4,
+        max_nodes: int = 500,
+        traversable_only: bool = False,
+        relationship_types: set[RelationshipType] | None = None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+        include_roots: bool = True,
+    ) -> tuple[UnifiedGraph, dict[str, int], bool]: ...
+
+    def attack_paths_for_sources(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        source_ids: set[str],
+    ) -> list[AttackPath]: ...
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict[str, Any], created_at: str) -> None: ...
 
@@ -280,6 +338,375 @@ class SQLiteGraphStore:
             data_sources=json.loads(row["data_sources"]),
             dimensions=NodeDimensions.from_dict(json.loads(row["dimensions"])),
         )
+
+    @staticmethod
+    def _edge_from_row(row: sqlite3.Row) -> UnifiedEdge:
+        return UnifiedEdge(
+            source=row["source_id"],
+            target=row["target_id"],
+            relationship=RelationshipType(row["relationship"]),
+            direction=row["direction"],
+            weight=row["weight"],
+            traversable=bool(row["traversable"]),
+            first_seen=row["first_seen"],
+            last_seen=row["last_seen"],
+            evidence=json.loads(row["evidence"]),
+            activity_id=row["activity_id"],
+        )
+
+    def _filtered_edge_rows(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        scan_id: str,
+        frontier: set[str],
+        traversable_only: bool = False,
+        relationship_types: set[RelationshipType] | None = None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+    ) -> list[sqlite3.Row]:
+        if not frontier:
+            return []
+        placeholders = ",".join("?" for _ in frontier)
+        where = [
+            "tenant_id = ?",
+            "scan_id = ?",
+            f"(source_id IN ({placeholders}) OR target_id IN ({placeholders}))",
+        ]
+        params: list[Any] = [tenant_id, scan_id, *frontier, *frontier]
+        if traversable_only:
+            where.append("traversable = 1")
+        if relationship_types:
+            rel_values = sorted(rel.value if isinstance(rel, RelationshipType) else str(rel) for rel in relationship_types)
+            rel_placeholders = ",".join("?" for _ in rel_values)
+            where.append(f"relationship IN ({rel_placeholders})")
+            params.extend(rel_values)
+        if static_only:
+            dynamic_placeholders = ",".join("?" for _ in _DYNAMIC_RELATIONSHIP_VALUES)
+            where.append(f"relationship NOT IN ({dynamic_placeholders})")
+            params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+        if dynamic_only:
+            dynamic_placeholders = ",".join("?" for _ in _DYNAMIC_RELATIONSHIP_VALUES)
+            where.append(f"relationship IN ({dynamic_placeholders})")
+            params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+        return conn.execute(
+            f"""
+            SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
+            FROM graph_edges
+            WHERE {" AND ".join(where)}
+            """,  # nosec B608 - clause fragments and placeholders are generated internally
+            params,
+        ).fetchall()
+
+    def nodes_by_ids(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_ids: set[str],
+    ) -> list[UnifiedNode]:
+        if not node_ids:
+            return []
+        conn = self._open_ro_conn()
+        if conn is None:
+            return []
+        try:
+            effective_scan_id, _created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+            if not effective_scan_id:
+                return []
+            placeholders = ",".join("?" for _ in node_ids)
+            rows = conn.execute(
+                f"""
+                SELECT
+                    id, entity_type, label, category_uid, class_uid, type_uid,
+                    status, risk_score, severity, severity_id, first_seen, last_seen,
+                    attributes, compliance_tags, data_sources, dimensions
+                FROM graph_nodes
+                WHERE tenant_id = ? AND scan_id = ? AND id IN ({placeholders})
+                """,  # nosec B608 - placeholders are generated internally
+                [tenant_id, effective_scan_id, *node_ids],
+            ).fetchall()
+            return [self._node_from_row(row) for row in rows]
+        finally:
+            conn.close()
+
+    def _walk_graph(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        tenant_id: str,
+        scan_id: str,
+        roots: list[str],
+        direction: str,
+        max_depth: int,
+        max_nodes: int,
+        traversable_only: bool,
+        relationship_types: set[RelationshipType] | None,
+        static_only: bool,
+        dynamic_only: bool,
+        include_roots: bool,
+    ) -> tuple[str, str, set[str], dict[str, int], dict[tuple[str, str, str], UnifiedEdge], dict[str, str], list[str], bool]:
+        effective_scan_id, created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+        if not effective_scan_id:
+            return scan_id, "", set(), {}, {}, {}, [], False
+
+        existing_roots = {node.id for node in self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=set(roots))}
+        visited: set[str] = set()
+        depth_by_node: dict[str, int] = {}
+        traversed_edges: dict[tuple[str, str, str], UnifiedEdge] = {}
+        parent_by_node: dict[str, str] = {}
+        discovery_order: list[str] = []
+        truncated = False
+
+        queue: list[tuple[str, int]] = []
+        for root in roots:
+            if root not in existing_roots:
+                continue
+            queue.append((root, 0))
+            depth_by_node[root] = 0
+            if include_roots:
+                visited.add(root)
+
+        index = 0
+        while index < len(queue):
+            current, depth = queue[index]
+            index += 1
+            if depth >= max_depth:
+                continue
+            for row in self._filtered_edge_rows(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=effective_scan_id,
+                frontier={current},
+                traversable_only=traversable_only,
+                relationship_types=relationship_types,
+                static_only=static_only,
+                dynamic_only=dynamic_only,
+            ):
+                edge = self._edge_from_row(row)
+                candidates: list[str] = []
+                if direction in {"forward", "both"}:
+                    if edge.source == current:
+                        candidates.append(edge.target)
+                    elif edge.is_bidirectional and edge.target == current:
+                        candidates.append(edge.source)
+                if direction in {"reverse", "both"}:
+                    if edge.target == current:
+                        candidates.append(edge.source)
+                    elif edge.is_bidirectional and edge.source == current:
+                        candidates.append(edge.target)
+                if not candidates:
+                    continue
+
+                rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+                traversed_edges.setdefault((edge.source, edge.target, rel), edge)
+
+                for neighbor in candidates:
+                    if neighbor in visited:
+                        continue
+                    if len(visited) >= max_nodes:
+                        truncated = True
+                        continue
+                    visited.add(neighbor)
+                    depth_by_node[neighbor] = depth + 1
+                    parent_by_node.setdefault(neighbor, current)
+                    discovery_order.append(neighbor)
+                    queue.append((neighbor, depth + 1))
+
+        if include_roots:
+            visited.update(existing_roots)
+
+        return effective_scan_id, created_at, visited, depth_by_node, traversed_edges, parent_by_node, discovery_order, truncated
+
+    def bfs_paths(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        source: str,
+        max_depth: int = 4,
+        traversable_only: bool = True,
+    ) -> tuple[list[list[str]], set[str]]:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return [], set()
+        try:
+            (
+                _effective_scan_id,
+                _created_at,
+                visited,
+                _depth_by_node,
+                _edges,
+                parent_by_node,
+                discovery_order,
+                _truncated,
+            ) = self._walk_graph(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                roots=[source],
+                direction="forward",
+                max_depth=max_depth,
+                max_nodes=5000,
+                traversable_only=traversable_only,
+                relationship_types=None,
+                static_only=False,
+                dynamic_only=False,
+                include_roots=True,
+            )
+            if source not in visited:
+                return [], set()
+
+            paths: list[list[str]] = []
+            for node_id in discovery_order:
+                if node_id == source:
+                    continue
+                path = [node_id]
+                current = node_id
+                while current in parent_by_node:
+                    current = parent_by_node[current]
+                    path.append(current)
+                path.reverse()
+                if path and path[0] == source:
+                    paths.append(path)
+            reachable = set(visited)
+            reachable.discard(source)
+            return paths, reachable
+        finally:
+            conn.close()
+
+    def impact_of(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_id: str,
+        max_depth: int = 4,
+    ) -> dict[str, Any] | None:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return None
+        try:
+            effective_scan_id, _created_at, visited, depth_by_node, _edges, _parents, _order, _truncated = self._walk_graph(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                roots=[node_id],
+                direction="reverse",
+                max_depth=max_depth,
+                max_nodes=5000,
+                traversable_only=False,
+                relationship_types=None,
+                static_only=False,
+                dynamic_only=False,
+                include_roots=True,
+            )
+            if not effective_scan_id or node_id not in visited:
+                return None
+
+            affected_nodes = sorted(node for node in visited if node != node_id)
+            affected_node_rows = self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=set(affected_nodes))
+            affected_by_type: dict[str, int] = {}
+            for node in affected_node_rows:
+                entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+                affected_by_type[entity_type] = affected_by_type.get(entity_type, 0) + 1
+
+            return {
+                "node_id": node_id,
+                "affected_nodes": affected_nodes,
+                "affected_by_type": affected_by_type,
+                "affected_count": len(affected_nodes),
+                "max_depth_reached": max((depth_by_node.get(node, 0) for node in affected_nodes), default=0),
+            }
+        finally:
+            conn.close()
+
+    def traverse_subgraph(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        roots: list[str],
+        direction: str = "forward",
+        max_depth: int = 4,
+        max_nodes: int = 500,
+        traversable_only: bool = False,
+        relationship_types: set[RelationshipType] | None = None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+        include_roots: bool = True,
+    ) -> tuple[UnifiedGraph, dict[str, int], bool]:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id), {}, False
+        try:
+            effective_scan_id, created_at, visited, depth_by_node, traversed_edges, _parents, _order, truncated = self._walk_graph(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                roots=roots,
+                direction=direction,
+                max_depth=max_depth,
+                max_nodes=max_nodes,
+                traversable_only=traversable_only,
+                relationship_types=relationship_types,
+                static_only=static_only,
+                dynamic_only=dynamic_only,
+                include_roots=include_roots,
+            )
+            graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=created_at)
+            if not effective_scan_id:
+                return graph, {}, False
+            node_rows = self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=visited)
+            for node in node_rows:
+                graph.add_node(node)
+            for edge in traversed_edges.values():
+                if edge.source in graph.nodes and edge.target in graph.nodes:
+                    graph.add_edge(edge)
+            return graph, depth_by_node, truncated
+        finally:
+            conn.close()
+
+    def attack_paths_for_sources(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        source_ids: set[str],
+    ) -> list[AttackPath]:
+        if not source_ids:
+            return []
+        conn = self._open_ro_conn()
+        if conn is None:
+            return []
+        try:
+            effective_scan_id, _created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+            if not effective_scan_id:
+                return []
+            placeholders = ",".join("?" for _ in source_ids)
+            rows = conn.execute(
+                f"""
+                SELECT source_node, target_node, path_nodes, path_edges, composite_risk, credential_exposure, vuln_ids
+                FROM attack_paths
+                WHERE tenant_id = ? AND scan_id = ? AND source_node IN ({placeholders})
+                """,  # nosec B608 - placeholders are generated internally
+                [tenant_id, effective_scan_id, *source_ids],
+            ).fetchall()
+            return [
+                AttackPath(
+                    source=row["source_node"],
+                    target=row["target_node"],
+                    hops=json.loads(row["path_nodes"]),
+                    edges=json.loads(row["path_edges"]),
+                    composite_risk=row["composite_risk"],
+                    credential_exposure=json.loads(row["credential_exposure"]),
+                    vuln_ids=json.loads(row["vuln_ids"]),
+                )
+                for row in rows
+            ]
+        finally:
+            conn.close()
 
     def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
         conn = self._open_ro_conn()

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -548,6 +548,92 @@ class PostgresGraphStore:
 
             return graph
 
+    def nodes_by_ids(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_ids: set[str],
+    ) -> list[Any]:
+        if not node_ids:
+            return []
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        return [node for node_id, node in graph.nodes.items() if node_id in node_ids]
+
+    def bfs_paths(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        source: str,
+        max_depth: int = 4,
+        traversable_only: bool = True,
+    ) -> tuple[list[list[str]], set[str]]:
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        if not graph.has_node(source):
+            return [], set()
+        paths = graph.bfs(source, max_depth=max_depth, traversable_only=traversable_only)
+        reachable = graph.reachable_from(
+            source,
+            max_depth=max_depth,
+            traversable_only=traversable_only,
+            include_source=False,
+        )
+        return paths, reachable
+
+    def impact_of(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_id: str,
+        max_depth: int = 4,
+    ) -> dict[str, Any] | None:
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        if not graph.has_node(node_id):
+            return None
+        return graph.impact_of(node_id, max_depth=max_depth)
+
+    def traverse_subgraph(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        roots: list[str],
+        direction: str = "forward",
+        max_depth: int = 4,
+        max_nodes: int = 500,
+        traversable_only: bool = False,
+        relationship_types=None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+        include_roots: bool = True,
+    ) -> tuple[Any, dict[str, int], bool]:
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        return graph.traverse_subgraph(
+            roots,
+            direction=direction,
+            max_depth=max_depth,
+            max_nodes=max_nodes,
+            traversable_only=traversable_only,
+            relationship_types=relationship_types,
+            static_only=static_only,
+            dynamic_only=dynamic_only,
+            include_roots=include_roots,
+        )
+
+    def attack_paths_for_sources(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        source_ids: set[str],
+    ) -> list[Any]:
+        if not source_ids:
+            return []
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        return [attack_path for attack_path in graph.attack_paths if attack_path.source in source_ids]
+
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
         with _tenant_connection(self._pool) as conn:
             old_nodes = {

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -307,13 +307,26 @@ async def get_graph_paths(
     limit: int = Query(100, ge=1, le=1000, description="Max paths"),
 ) -> dict:
     """Find all attack paths from a source node via BFS."""
-    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
-    if not graph.has_node(source):
+    graph_store = _get_graph_store_or_503()
+    source_nodes = await _graph_store_call(graph_store.nodes_by_ids, scan_id=scan_id or "", tenant_id=_tenant(request), node_ids={source})
+    if not source_nodes:
         raise HTTPException(status_code=404, detail=f"Node '{source}' not found in graph")
 
-    all_paths = graph.bfs(source, max_depth=max_depth, traversable_only=True)
+    all_paths, reachable = await _graph_store_call(
+        graph_store.bfs_paths,
+        scan_id=scan_id or "",
+        tenant_id=_tenant(request),
+        source=source,
+        max_depth=max_depth,
+        traversable_only=True,
+    )
     paged_paths, pagination = _paginate(all_paths, offset, limit)
-    reachable = graph.reachable_from(source, max_depth=max_depth, traversable_only=True, include_source=False)
+    attack_paths = await _graph_store_call(
+        graph_store.attack_paths_for_sources,
+        scan_id=scan_id or "",
+        tenant_id=_tenant(request),
+        source_ids={source},
+    )
 
     return {
         "source": source,
@@ -321,7 +334,7 @@ async def get_graph_paths(
         "reachable_count": len(reachable),
         "reachable_nodes": sorted(reachable),
         "paths": [{"target": p[-1], "hops": p, "depth": len(p) - 1} for p in paged_paths],
-        "attack_paths": [ap.to_dict() for ap in graph.attack_paths if ap.source == source],
+        "attack_paths": [ap.to_dict() for ap in attack_paths if ap.source == source],
         "pagination": pagination,
     }
 
@@ -334,10 +347,16 @@ async def get_graph_impact(
     max_depth: int = Query(4, ge=1, le=10, description="Maximum reverse BFS depth"),
 ) -> dict:
     """Compute blast radius of a node — what depends on it?"""
-    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
-    if not graph.has_node(node):
+    impact = await _graph_store_call(
+        _get_graph_store_or_503().impact_of,
+        scan_id=scan_id or "",
+        tenant_id=_tenant(request),
+        node_id=node,
+        max_depth=max_depth,
+    )
+    if impact is None:
         raise HTTPException(status_code=404, detail=f"Node '{node}' not found")
-    return graph.impact_of(node, max_depth=max_depth)
+    return impact
 
 
 @router.get("/v1/graph/search", tags=["graph"])
@@ -398,15 +417,24 @@ async def search_graph(
 @router.post("/v1/graph/query", tags=["graph"])
 async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
     """Run a bounded programmable traversal over the canonical graph."""
-
-    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=body.scan_id or "", tenant_id=_tenant(request))
-    missing_roots = [root for root in body.roots if not graph.has_node(root)]
+    graph_store = _get_graph_store_or_503()
+    root_nodes = await _graph_store_call(
+        graph_store.nodes_by_ids,
+        scan_id=body.scan_id or "",
+        tenant_id=_tenant(request),
+        node_ids=set(body.roots),
+    )
+    known_roots = {node.id for node in root_nodes}
+    missing_roots = [root for root in body.roots if root not in known_roots]
     if missing_roots:
         raise HTTPException(status_code=404, detail={"message": "Root nodes not found", "missing_roots": missing_roots})
 
     rel_types = {RelationshipType(rel) for rel in body.relationship_types} if body.relationship_types else None
-    traversal_graph, depth_by_node, truncated = graph.traverse_subgraph(
-        body.roots,
+    traversal_graph, depth_by_node, truncated = await _graph_store_call(
+        graph_store.traverse_subgraph,
+        scan_id=body.scan_id or "",
+        tenant_id=_tenant(request),
+        roots=body.roots,
         direction=body.direction,
         max_depth=body.max_depth,
         max_nodes=body.max_nodes,
@@ -428,8 +456,14 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
 
     attack_paths = []
     if body.include_attack_paths:
+        root_attack_paths = await _graph_store_call(
+            graph_store.attack_paths_for_sources,
+            scan_id=body.scan_id or "",
+            tenant_id=_tenant(request),
+            source_ids=set(body.roots),
+        )
         attack_paths = [
-            ap.to_dict() for ap in graph.attack_paths if ap.source in body.roots and all(hop in filtered_graph.nodes for hop in ap.hops)
+            ap.to_dict() for ap in root_attack_paths if ap.source in body.roots and all(hop in filtered_graph.nodes for hop in ap.hops)
         ]
 
     return {

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -316,6 +316,59 @@ class TestGraphEndpointLogic:
         assert total == 1
         assert [node.id for node in results] == ["server:vector"]
 
+    def test_sqlite_graph_store_bfs_paths_uses_persisted_edges(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="traversal-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        graph.add_node(UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"))
+        graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True))
+        graph.add_edge(UnifiedEdge(source="server:s", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO, traversable=True))
+        store.save_graph(graph)
+
+        paths, reachable = store.bfs_paths(tenant_id="default", scan_id="traversal-scan", source="agent:a", max_depth=3)
+
+        assert reachable == {"server:s", "vuln:cve"}
+        assert paths == [["agent:a", "server:s"], ["agent:a", "server:s", "vuln:cve"]]
+
+    def test_sqlite_graph_store_impact_of_uses_reverse_edges(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="impact-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        store.save_graph(graph)
+
+        impact = store.impact_of(tenant_id="default", scan_id="impact-scan", node_id="server:s", max_depth=3)
+
+        assert impact is not None
+        assert impact["affected_nodes"] == ["agent:a"]
+        assert impact["affected_by_type"] == {"agent": 1}
+
+    def test_sqlite_graph_store_attack_paths_for_sources_returns_persisted_paths(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="attack-path-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        graph.add_node(UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"))
+        graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        graph.add_edge(UnifiedEdge(source="server:s", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO))
+        graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:cve",
+                hops=["agent:a", "server:s", "vuln:cve"],
+                edges=["uses", "vulnerable_to"],
+                composite_risk=9.8,
+            )
+        )
+        store.save_graph(graph)
+
+        attack_paths = store.attack_paths_for_sources(tenant_id="default", scan_id="attack-path-scan", source_ids={"agent:a"})
+
+        assert len(attack_paths) == 1
+        assert attack_paths[0].target == "vuln:cve"
+
 
 class TestBackendDirectionality:
     """Regression: graph_backend must respect edge direction from unified graph."""
@@ -519,6 +572,69 @@ class _RecordingGraphStore:
 
             next_cursor = encode_graph_cursor(page[-1])
         return page, full_total, next_cursor
+
+    def nodes_by_ids(self, *, tenant_id: str = "", scan_id: str = "", node_ids: set[str]):
+        self.calls.append(("nodes_by_ids", tenant_id, scan_id, tuple(sorted(node_ids))))
+        return [node for node_id, node in self.graph.nodes.items() if node_id in node_ids]
+
+    def bfs_paths(self, *, tenant_id: str = "", scan_id: str = "", source: str, max_depth: int = 4, traversable_only: bool = True):
+        self.calls.append(("bfs_paths", tenant_id, scan_id, source, max_depth, traversable_only))
+        paths = self.graph.bfs(source, max_depth=max_depth, traversable_only=traversable_only)
+        reachable = self.graph.reachable_from(source, max_depth=max_depth, traversable_only=traversable_only, include_source=False)
+        return paths, reachable
+
+    def impact_of(self, *, tenant_id: str = "", scan_id: str = "", node_id: str, max_depth: int = 4):
+        self.calls.append(("impact_of", tenant_id, scan_id, node_id, max_depth))
+        if not self.graph.has_node(node_id):
+            return None
+        return self.graph.impact_of(node_id, max_depth=max_depth)
+
+    def traverse_subgraph(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        roots: list[str],
+        direction: str = "forward",
+        max_depth: int = 4,
+        max_nodes: int = 500,
+        traversable_only: bool = False,
+        relationship_types=None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+        include_roots: bool = True,
+    ):
+        self.calls.append(
+            (
+                "traverse_subgraph",
+                tenant_id,
+                scan_id,
+                tuple(roots),
+                direction,
+                max_depth,
+                max_nodes,
+                traversable_only,
+                relationship_types,
+                static_only,
+                dynamic_only,
+                include_roots,
+            )
+        )
+        return self.graph.traverse_subgraph(
+            roots,
+            direction=direction,
+            max_depth=max_depth,
+            max_nodes=max_nodes,
+            traversable_only=traversable_only,
+            relationship_types=relationship_types,
+            static_only=static_only,
+            dynamic_only=dynamic_only,
+            include_roots=include_roots,
+        )
+
+    def attack_paths_for_sources(self, *, tenant_id: str = "", scan_id: str = "", source_ids: set[str]):
+        self.calls.append(("attack_paths_for_sources", tenant_id, scan_id, tuple(sorted(source_ids))))
+        return [ap for ap in self.graph.attack_paths if ap.source in source_ids]
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict, created_at: str) -> None:
         self.calls.append(("save_preset", tenant_id, name))
@@ -744,6 +860,26 @@ class TestGraphStoreBackendSelection:
         assert body["reachable_count"] == 1
         assert body["reachable_nodes"] == ["server:s"]
         assert [path["target"] for path in body["paths"]] == ["server:s"]
+        assert any(call[0] == "bfs_paths" for call in recording_graph_store.calls)
+        assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_graph_impact_uses_store_native_traversal(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/impact", params={"node": "server:s", "max_depth": 4})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["node_id"] == "server:s"
+        assert body["affected_nodes"] == ["agent:a"]
+        assert any(call[0] == "impact_of" for call in recording_graph_store.calls)
+        assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
     def test_graph_query_returns_bounded_directional_subgraph(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
@@ -804,6 +940,8 @@ class TestGraphStoreBackendSelection:
             ("server:s", "vuln:CVE-2026-1"),
         }
         assert body["attack_paths"][0]["target"] == "vuln:CVE-2026-1"
+        assert any(call[0] == "traverse_subgraph" for call in recording_graph_store.calls)
+        assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
     def test_graph_query_filters_by_compliance_and_source(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")


### PR DESCRIPTION
## Summary
- switch `/v1/graph/paths`, `/v1/graph/impact`, and `/v1/graph/query` from full `load_graph()` reads to store-native traversal helpers
- add persisted graph-store traversal primitives for node lookup, BFS paths, reverse impact, bounded subgraph walks, and attack path fetches
- cover the new behavior with route-level backend-selection tests and direct SQLite store traversal tests

## Why
`#1748` is aimed at making large-tenant graph queries scale without materializing the full graph snapshot for common traversal endpoints. This PR moves the highest-traffic traversal APIs onto store-backed access paths while preserving the existing response shape.

## Validation
- `pytest -q tests/test_graph_api.py tests/test_graph_backend.py -q`
- `ruff check src/agent_bom/api/graph_store.py src/agent_bom/api/routes/graph.py tests/test_graph_api.py`
- commit hooks: `ruff`, `ruff-format`, `mypy`, `bandit`
