### PR TITLE
feat(graph): store-back node and compliance views

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -12,6 +12,7 @@ import base64
 import json
 import re
 import sqlite3
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -209,6 +210,22 @@ class GraphStoreProtocol(Protocol):
         source_ids: set[str],
     ) -> list[AttackPath]: ...
 
+    def node_context(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_id: str,
+    ) -> dict[str, Any] | None: ...
+
+    def compliance_summary(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        framework: str = "",
+    ) -> dict[str, Any]: ...
+
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict[str, Any], created_at: str) -> None: ...
 
     def list_presets(self, *, tenant_id: str) -> list[dict[str, Any]]: ...
@@ -352,6 +369,21 @@ class SQLiteGraphStore:
             last_seen=row["last_seen"],
             evidence=json.loads(row["evidence"]),
             activity_id=row["activity_id"],
+        )
+
+    @staticmethod
+    def _reverse_edge(edge: UnifiedEdge) -> UnifiedEdge:
+        return UnifiedEdge(
+            source=edge.target,
+            target=edge.source,
+            relationship=edge.relationship,
+            direction=edge.direction,
+            weight=edge.weight,
+            traversable=edge.traversable,
+            first_seen=edge.first_seen,
+            last_seen=edge.last_seen,
+            evidence=edge.evidence,
+            activity_id=edge.activity_id,
         )
 
     def _filtered_edge_rows(
@@ -705,6 +737,148 @@ class SQLiteGraphStore:
                 )
                 for row in rows
             ]
+        finally:
+            conn.close()
+
+    def node_context(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_id: str,
+    ) -> dict[str, Any] | None:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return None
+        try:
+            effective_scan_id, _created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+            if not effective_scan_id:
+                return None
+            nodes = self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids={node_id})
+            if not nodes:
+                return None
+            rows = conn.execute(
+                """
+                SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
+                FROM graph_edges
+                WHERE tenant_id = ? AND scan_id = ? AND (source_id = ? OR target_id = ?)
+                ORDER BY source_id ASC, target_id ASC, relationship ASC
+                """,
+                [tenant_id, effective_scan_id, node_id, node_id],
+            ).fetchall()
+
+            edges_out: list[UnifiedEdge] = []
+            edges_in: list[UnifiedEdge] = []
+            neighbors: list[str] = []
+            sources: list[str] = []
+
+            for row in rows:
+                edge = self._edge_from_row(row)
+                if edge.source == node_id:
+                    edges_out.append(edge)
+                    neighbors.append(edge.target)
+                    if edge.is_bidirectional:
+                        reverse = self._reverse_edge(edge)
+                        edges_in.append(reverse)
+                        sources.append(edge.target)
+                if edge.target == node_id:
+                    edges_in.append(edge)
+                    sources.append(edge.source)
+                    if edge.is_bidirectional:
+                        reverse = self._reverse_edge(edge)
+                        edges_out.append(reverse)
+                        neighbors.append(edge.source)
+
+            return {
+                "node": nodes[0],
+                "edges_out": edges_out,
+                "edges_in": edges_in,
+                "neighbors": neighbors,
+                "sources": sources,
+                "impact": self.impact_of(tenant_id=tenant_id, scan_id=effective_scan_id, node_id=node_id),
+            }
+        finally:
+            conn.close()
+
+    def compliance_summary(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        framework: str = "",
+    ) -> dict[str, Any]:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return {
+                "scan_id": scan_id,
+                "framework_count": 0,
+                "total_tagged_findings": 0,
+                "frameworks": {},
+            }
+        try:
+            effective_scan_id, _created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+            if not effective_scan_id:
+                return {
+                    "scan_id": scan_id,
+                    "framework_count": 0,
+                    "total_tagged_findings": 0,
+                    "frameworks": {},
+                }
+
+            rows = conn.execute(
+                """
+                SELECT id, entity_type, severity, compliance_tags
+                FROM graph_nodes
+                WHERE tenant_id = ? AND scan_id = ? AND json_array_length(compliance_tags) > 0
+                ORDER BY id ASC
+                """,
+                [tenant_id, effective_scan_id],
+            ).fetchall()
+
+            framework_filter = framework.upper()
+            framework_stats: dict[str, dict[str, Any]] = defaultdict(
+                lambda: {
+                    "total_findings": 0,
+                    "by_severity": defaultdict(int),
+                    "by_entity_type": defaultdict(int),
+                    "tags": set(),
+                    "node_ids": [],
+                }
+            )
+
+            for row in rows:
+                tags = json.loads(row["compliance_tags"])
+                if not tags:
+                    continue
+                for tag in tags:
+                    prefix = tag.split("-")[0].upper() if "-" in tag else tag.upper()
+                    if framework_filter and framework_filter != prefix:
+                        continue
+                    stats = framework_stats[prefix]
+                    stats["total_findings"] += 1
+                    stats["by_severity"][row["severity"] or "unknown"] += 1
+                    stats["by_entity_type"][row["entity_type"]] += 1
+                    stats["tags"].add(tag)
+                    if row["id"] not in stats["node_ids"]:
+                        stats["node_ids"].append(row["id"])
+
+            frameworks: dict[str, Any] = {}
+            for name, stats in sorted(framework_stats.items()):
+                frameworks[name] = {
+                    "total_findings": stats["total_findings"],
+                    "by_severity": dict(stats["by_severity"]),
+                    "by_entity_type": dict(stats["by_entity_type"]),
+                    "tags": sorted(stats["tags"]),
+                    "node_count": len(stats["node_ids"]),
+                    "node_ids": stats["node_ids"][:100],
+                }
+
+            return {
+                "scan_id": effective_scan_id,
+                "framework_count": len(frameworks),
+                "total_tagged_findings": sum(stats["total_findings"] for stats in frameworks.values()),
+                "frameworks": frameworks,
+            }
         finally:
             conn.close()
 

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -634,6 +634,80 @@ class PostgresGraphStore:
         graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
         return [attack_path for attack_path in graph.attack_paths if attack_path.source in source_ids]
 
+    def node_context(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        node_id: str,
+    ) -> dict[str, Any] | None:
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        node = graph.get_node(node_id)
+        if not node:
+            return None
+        return {
+            "node": node,
+            "edges_out": graph.edges_from(node_id),
+            "edges_in": graph.edges_to(node_id),
+            "neighbors": graph.neighbors(node_id),
+            "sources": graph.sources_of(node_id),
+            "impact": graph.impact_of(node_id),
+        }
+
+    def compliance_summary(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        framework: str = "",
+    ) -> dict[str, Any]:
+        from collections import defaultdict
+
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        framework_stats: dict[str, dict[str, Any]] = defaultdict(
+            lambda: {
+                "total_findings": 0,
+                "by_severity": defaultdict(int),
+                "by_entity_type": defaultdict(int),
+                "tags": set(),
+                "node_ids": [],
+            }
+        )
+
+        for node in graph.nodes.values():
+            if not node.compliance_tags:
+                continue
+            for tag in node.compliance_tags:
+                prefix = tag.split("-")[0].upper() if "-" in tag else tag.upper()
+                if framework and framework.upper() != prefix:
+                    continue
+                stats = framework_stats[prefix]
+                stats["total_findings"] += 1
+                stats["by_severity"][node.severity or "unknown"] += 1
+                entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else node.entity_type
+                stats["by_entity_type"][entity_type] += 1
+                stats["tags"].add(tag)
+                if node.id not in stats["node_ids"]:
+                    stats["node_ids"].append(node.id)
+
+        frameworks: dict[str, Any] = {}
+        for name, stats in sorted(framework_stats.items()):
+            frameworks[name] = {
+                "total_findings": stats["total_findings"],
+                "by_severity": dict(stats["by_severity"]),
+                "by_entity_type": dict(stats["by_entity_type"]),
+                "tags": sorted(stats["tags"]),
+                "node_count": len(stats["node_ids"]),
+                "node_ids": stats["node_ids"][:100],
+            }
+
+        return {
+            "scan_id": graph.scan_id,
+            "framework_count": len(frameworks),
+            "total_tagged_findings": sum(stats["total_findings"] for stats in frameworks.values()),
+            "frameworks": frameworks,
+        }
+
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
         with _tenant_connection(self._pool) as conn:
             old_nodes = {

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -498,18 +498,22 @@ async def get_graph_node(
     scan_id: Optional[str] = Query(None, description="Scan ID"),
 ) -> dict:
     """Get a single node with its edges, neighbors, and impact stats."""
-    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
-    node = graph.get_node(node_id)
-    if not node:
+    node_context = await _graph_store_call(
+        _get_graph_store_or_503().node_context,
+        scan_id=scan_id or "",
+        tenant_id=_tenant(request),
+        node_id=node_id,
+    )
+    if node_context is None:
         raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
 
     return {
-        "node": node.to_dict(),
-        "edges_out": [e.to_dict() for e in graph.edges_from(node_id)],
-        "edges_in": [e.to_dict() for e in graph.edges_to(node_id)],
-        "neighbors": graph.neighbors(node_id),
-        "sources": graph.sources_of(node_id),
-        "impact": graph.impact_of(node_id),
+        "node": node_context["node"].to_dict(),
+        "edges_out": [edge.to_dict() for edge in node_context["edges_out"]],
+        "edges_in": [edge.to_dict() for edge in node_context["edges_in"]],
+        "neighbors": node_context["neighbors"],
+        "sources": node_context["sources"],
+        "impact": node_context["impact"],
     }
 
 
@@ -533,53 +537,12 @@ async def get_graph_compliance(
     Returns per-framework finding counts, severity breakdown, affected entity
     counts, and the list of tagged findings. Filter by framework to drill down.
     """
-    from collections import defaultdict
-
-    graph = await _graph_store_call(_get_graph_store_or_503().load_graph, scan_id=scan_id or "", tenant_id=_tenant(request))
-
-    framework_stats: dict[str, dict] = defaultdict(
-        lambda: {
-            "total_findings": 0,
-            "by_severity": defaultdict(int),
-            "by_entity_type": defaultdict(int),
-            "tags": set(),
-            "node_ids": [],
-        }
+    return await _graph_store_call(
+        _get_graph_store_or_503().compliance_summary,
+        scan_id=scan_id or "",
+        tenant_id=_tenant(request),
+        framework=framework or "",
     )
-
-    for node in graph.nodes.values():
-        if not node.compliance_tags:
-            continue
-        for tag in node.compliance_tags:
-            prefix = tag.split("-")[0].upper() if "-" in tag else tag.upper()
-            if framework and framework.upper() != prefix:
-                continue
-            stats = framework_stats[prefix]
-            stats["total_findings"] += 1
-            stats["by_severity"][node.severity or "unknown"] += 1
-            et = node.entity_type.value if hasattr(node.entity_type, "value") else node.entity_type
-            stats["by_entity_type"][et] += 1
-            stats["tags"].add(tag)
-            if node.id not in stats["node_ids"]:
-                stats["node_ids"].append(node.id)
-
-    result = {}
-    for fw, stats in sorted(framework_stats.items()):
-        result[fw] = {
-            "total_findings": stats["total_findings"],
-            "by_severity": dict(stats["by_severity"]),
-            "by_entity_type": dict(stats["by_entity_type"]),
-            "tags": sorted(stats["tags"]),
-            "node_count": len(stats["node_ids"]),
-            "node_ids": stats["node_ids"][:100],
-        }
-
-    return {
-        "scan_id": graph.scan_id,
-        "framework_count": len(result),
-        "total_tagged_findings": sum(s["total_findings"] for s in result.values()),
-        "frameworks": result,
-    }
 
 
 @router.get("/v1/graph/legend", tags=["graph"])

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -369,6 +369,62 @@ class TestGraphEndpointLogic:
         assert len(attack_paths) == 1
         assert attack_paths[0].target == "vuln:cve"
 
+    def test_sqlite_graph_store_node_context_preserves_bidirectional_neighbors(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="node-context-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        graph.add_node(UnifiedNode(id="agent:b", entity_type=EntityType.AGENT, label="agent-b"))
+        graph.add_edge(
+            UnifiedEdge(
+                source="agent:a",
+                target="agent:b",
+                relationship=RelationshipType.SHARES_SERVER,
+                direction="bidirectional",
+            )
+        )
+        store.save_graph(graph)
+
+        node_context = store.node_context(tenant_id="default", scan_id="node-context-scan", node_id="agent:b")
+
+        assert node_context is not None
+        assert node_context["neighbors"] == ["agent:a"]
+        assert node_context["sources"] == ["agent:a"]
+        assert node_context["edges_out"][0].target == "agent:a"
+        assert node_context["edges_in"][0].source == "agent:a"
+
+    def test_sqlite_graph_store_compliance_summary_aggregates_frameworks_without_loading_graph(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="compliance-scan", tenant_id="default")
+        graph.add_node(
+            UnifiedNode(
+                id="vuln:cve",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-1",
+                severity="critical",
+                severity_id=5,
+                compliance_tags=["CIS-5.4.1", "OWASP-A01"],
+            )
+        )
+        graph.add_node(
+            UnifiedNode(
+                id="agent:a",
+                entity_type=EntityType.AGENT,
+                label="agent-a",
+                severity="high",
+                severity_id=4,
+                compliance_tags=["CIS-6.2"],
+            )
+        )
+        store.save_graph(graph)
+
+        summary = store.compliance_summary(tenant_id="default", scan_id="compliance-scan")
+
+        assert summary["framework_count"] == 2
+        assert summary["total_tagged_findings"] == 3
+        assert summary["frameworks"]["CIS"]["total_findings"] == 2
+        assert summary["frameworks"]["CIS"]["node_count"] == 2
+        assert summary["frameworks"]["OWASP"]["total_findings"] == 1
+
 
 class TestBackendDirectionality:
     """Regression: graph_backend must respect edge direction from unified graph."""
@@ -635,6 +691,62 @@ class _RecordingGraphStore:
     def attack_paths_for_sources(self, *, tenant_id: str = "", scan_id: str = "", source_ids: set[str]):
         self.calls.append(("attack_paths_for_sources", tenant_id, scan_id, tuple(sorted(source_ids))))
         return [ap for ap in self.graph.attack_paths if ap.source in source_ids]
+
+    def node_context(self, *, tenant_id: str = "", scan_id: str = "", node_id: str):
+        self.calls.append(("node_context", tenant_id, scan_id, node_id))
+        node = self.graph.get_node(node_id)
+        if not node:
+            return None
+        return {
+            "node": node,
+            "edges_out": self.graph.edges_from(node_id),
+            "edges_in": self.graph.edges_to(node_id),
+            "neighbors": self.graph.neighbors(node_id),
+            "sources": self.graph.sources_of(node_id),
+            "impact": self.graph.impact_of(node_id),
+        }
+
+    def compliance_summary(self, *, tenant_id: str = "", scan_id: str = "", framework: str = ""):
+        self.calls.append(("compliance_summary", tenant_id, scan_id, framework))
+        frameworks: dict[str, dict] = {}
+        for node in self.graph.nodes.values():
+            for tag in node.compliance_tags:
+                prefix = tag.split("-")[0].upper() if "-" in tag else tag.upper()
+                if framework and framework.upper() != prefix:
+                    continue
+                stats = frameworks.setdefault(
+                    prefix,
+                    {
+                        "total_findings": 0,
+                        "by_severity": {},
+                        "by_entity_type": {},
+                        "tags": set(),
+                        "node_ids": [],
+                    },
+                )
+                stats["total_findings"] += 1
+                stats["by_severity"][node.severity or "unknown"] = stats["by_severity"].get(node.severity or "unknown", 0) + 1
+                entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+                stats["by_entity_type"][entity_type] = stats["by_entity_type"].get(entity_type, 0) + 1
+                stats["tags"].add(tag)
+                if node.id not in stats["node_ids"]:
+                    stats["node_ids"].append(node.id)
+        return {
+            "scan_id": self.graph.scan_id,
+            "framework_count": len(frameworks),
+            "total_tagged_findings": sum(stats["total_findings"] for stats in frameworks.values()),
+            "frameworks": {
+                name: {
+                    "total_findings": stats["total_findings"],
+                    "by_severity": stats["by_severity"],
+                    "by_entity_type": stats["by_entity_type"],
+                    "tags": sorted(stats["tags"]),
+                    "node_count": len(stats["node_ids"]),
+                    "node_ids": stats["node_ids"][:100],
+                }
+                for name, stats in sorted(frameworks.items())
+            },
+        }
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict, created_at: str) -> None:
         self.calls.append(("save_preset", tenant_id, name))
@@ -941,6 +1053,47 @@ class TestGraphStoreBackendSelection:
         }
         assert body["attack_paths"][0]["target"] == "vuln:CVE-2026-1"
         assert any(call[0] == "traverse_subgraph" for call in recording_graph_store.calls)
+        assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_graph_node_uses_store_native_context(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/node/server:s")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["node"]["id"] == "server:s"
+        assert body["sources"] == ["agent:a"]
+        assert any(call[0] == "node_context" for call in recording_graph_store.calls)
+        assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_graph_compliance_uses_store_native_summary(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:cve",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-1",
+                severity="critical",
+                severity_id=5,
+                compliance_tags=["CIS-5.4.1", "OWASP-A01"],
+            )
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/compliance", params={"framework": "CIS"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["framework_count"] == 1
+        assert body["frameworks"]["CIS"]["total_findings"] == 1
+        assert any(call[0] == "compliance_summary" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
     def test_graph_query_filters_by_compliance_and_source(self, recording_graph_store):


### PR DESCRIPTION
## Summary
- move `/v1/graph/node/{id}` onto a store-native node-context helper instead of loading the full graph snapshot
- move `/v1/graph/compliance` onto a store-native compliance-summary helper that scans tagged nodes directly
- add route/backend-selection tests plus direct SQLite store tests for node context, bidirectional edge parity, and compliance aggregation

## Why
This is the follow-up slice for `#1748` after the traversal PR. It removes two more `load_graph()` callers from the graph API surface so large snapshots do not need to be fully materialized for node-detail and compliance-summary requests.

## Validation
- `pytest -q tests/test_graph_api.py tests/test_graph_backend.py -q`
- `ruff check src/agent_bom/api/graph_store.py src/agent_bom/api/routes/graph.py tests/test_graph_api.py`
- commit hooks: `ruff`, `ruff-format`, `mypy`, `bandit`
