### PR TITLE
feat(deploy): wire gateway helm control plane settings

### DIFF
--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -43,9 +43,30 @@ spec:
             - "0.0.0.0:8090"
             - --upstreams
             - /etc/agent-bom/gateway/upstreams.yaml
+            {{- if .Values.gateway.controlPlaneDiscovery.url }}
+            - --from-control-plane
+            - {{ .Values.gateway.controlPlaneDiscovery.url | quote }}
+            {{- end }}
             {{- if .Values.gateway.policyPath }}
             - --policy
             - {{ .Values.gateway.policyPath }}
+            {{- end }}
+            {{- if gt (int (.Values.gateway.policyReloadSeconds | default 0)) 0 }}
+            - --policy-reload-seconds
+            - {{ .Values.gateway.policyReloadSeconds | quote }}
+            {{- end }}
+            {{- if gt (int (.Values.gateway.runtimeRateLimitPerTenantPerMinute | default 0)) 0 }}
+            - --runtime-rate-limit-per-tenant-per-minute
+            - {{ .Values.gateway.runtimeRateLimitPerTenantPerMinute | quote }}
+            {{- end }}
+            {{- if .Values.gateway.requireSharedRateLimit }}
+            - --require-shared-rate-limit
+            {{- end }}
+            {{- if .Values.gateway.detectVisualLeaks }}
+            - --detect-visual-leaks
+            {{- end }}
+            {{- if .Values.gateway.allowVisualLeakBestEffort }}
+            - --allow-visual-leak-best-effort
             {{- end }}
           ports:
             - name: http

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -79,11 +79,14 @@ monitor:
 #
 # See docs/design/MULTI_MCP_GATEWAY.md for the full design + rollout plan.
 #
-# ── Operator must provide (no auto-discovery): ───────────────────────────────
-#   1. gateway.upstreamsYaml — the list of MCP servers the gateway should
+# ── Operator must provide at least one upstream source: ──────────────────────
+#   1. gateway.upstreamsYaml — a static list of MCP servers the gateway should
 #      route to. Start from deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
 #      and customise; pass via --set-file gateway.upstreamsYaml=./my-upstreams.yaml.
-#   2. A Kubernetes Secret exposing any bearer tokens referenced by
+#   2. gateway.controlPlaneDiscovery.url — optional control-plane discovery
+#      source for live remote MCP inventory. Use env/envFrom to provide
+#      AGENT_BOM_CONTROL_PLANE_TOKEN when the control plane requires auth.
+#   3. A Kubernetes Secret exposing any bearer tokens referenced by
 #      `token_env` in upstreamsYaml (e.g. SNOWFLAKE_JIRA_MCP_TOKEN,
 #      GITHUB_MCP_TOKEN). Point gateway.envFrom at it:
 #
@@ -92,7 +95,7 @@ monitor:
 #            - secretRef:
 #                name: agent-bom-gateway-upstream-tokens
 #
-#   3. An ingress (same cluster as controlPlane) pointing at the
+#   4. An ingress (same cluster as controlPlane) pointing at the
 #      agent-bom-{release}-gateway Service on port 8090.
 # ─────────────────────────────────────────────────────────────────────────────
 gateway:
@@ -116,8 +119,22 @@ gateway:
   # until you redeploy with a populated list.
   upstreamsYaml: |
     upstreams: []
+  controlPlaneDiscovery:
+    # Optional URL for --from-control-plane discovery.
+    # Example: https://agent-bom.internal.example.com
+    url: ""
   # Optional runtime policy JSON path (mounted via extraVolumes + extraVolumeMounts).
   policyPath: ""
+  # In-process policy file reload interval; requires policyPath when > 0.
+  policyReloadSeconds: 0
+  # Tenant-scoped runtime request limit for gateway relay traffic (0 disables).
+  runtimeRateLimitPerTenantPerMinute: 0
+  # Fail closed unless runtime rate limiting uses a shared backend.
+  requireSharedRateLimit: false
+  # OCR-scan image responses for leaked credentials/PII.
+  detectVisualLeaks: false
+  # Allow startup to continue when OCR runtime support is unavailable.
+  allowVisualLeakBestEffort: false
   # Typical deploy-time auth/runtime wiring:
   #   env:
   #     - name: AGENT_BOM_GATEWAY_DETECT_VISUAL_LEAKS
@@ -128,6 +145,7 @@ gateway:
   #
   # Where `agent-bom-gateway-auth` contains:
   #   AGENT_BOM_GATEWAY_BEARER_TOKEN=<token for incoming gateway clients>
+  #   AGENT_BOM_CONTROL_PLANE_TOKEN=<token for gateway control-plane discovery>
   env: []
   envFrom: []
   serviceAccount:

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -422,10 +422,37 @@ def test_helm_control_plane_backup_defaults():
 def test_helm_gateway_service_account_defaults():
     """Gateway service account knobs stay explicit for IRSA-style rollout."""
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
-    sa = doc["gateway"]["serviceAccount"]
+    gateway = doc["gateway"]
+    sa = gateway["serviceAccount"]
     assert sa["create"] is True
     assert sa["name"] == ""
     assert sa["annotations"] == {}
+    assert gateway["controlPlaneDiscovery"]["url"] == ""
+    assert gateway["policyReloadSeconds"] == 0
+    assert gateway["runtimeRateLimitPerTenantPerMinute"] == 0
+    assert gateway["requireSharedRateLimit"] is False
+    assert gateway["detectVisualLeaks"] is False
+    assert gateway["allowVisualLeakBestEffort"] is False
+
+
+def test_helm_gateway_template_wires_control_plane_and_runtime_flags():
+    """Gateway deployment should expose the CLI's deploy-time control knobs."""
+    template = (HELM_DIR / "templates" / "gateway-deployment.yaml").read_text()
+    assert "--from-control-plane" in template
+    assert ".Values.gateway.controlPlaneDiscovery.url" in template
+    assert "--policy-reload-seconds" in template
+    assert ".Values.gateway.policyReloadSeconds" in template
+    assert "--runtime-rate-limit-per-tenant-per-minute" in template
+    assert ".Values.gateway.runtimeRateLimitPerTenantPerMinute" in template
+    assert "--require-shared-rate-limit" in template
+    assert "--detect-visual-leaks" in template
+    assert "--allow-visual-leak-best-effort" in template
+
+
+def test_helm_examples_do_not_ship_duplicate_sqlite_pilot_profile():
+    """Packaged Helm example profiles should have one canonical sqlite pilot file."""
+    duplicate = HELM_DIR / "examples" / "eks-control-plane-sqlite-pilot-values 2.yaml"
+    assert not duplicate.exists()
 
 
 def test_helm_gateway_autoscaling_defaults():


### PR DESCRIPTION
## Summary
- add Helm values for gateway control-plane discovery, policy reload, runtime rate limiting, and visual leak detection flags
- wire those values into the gateway deployment template so operators can turn on existing CLI/runtime capabilities from Helm
- extend deploy manifest tests to cover the new gateway knobs and enforce one canonical sqlite pilot example surface

## Why
The gateway CLI already supported several important EKS/operator controls, but the Helm chart did not expose them. That forced manual template patching or ad hoc manifests for control-plane-driven gateway rollouts, which is exactly the kind of deploy drift we want to eliminate.

## Validation
- `pytest -q tests/test_deploy_manifests.py tests/test_deploy_profiles.py -q`
- `python3 scripts/validate_helm_profiles.py --list`
- commit hooks: `check yaml`, `ruff`, `ruff-format`
