### PR TITLE
feat(runtime): surface gateway policy rollout state

### DIFF
--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -165,6 +165,7 @@ def serve_cmd(
         UpstreamRegistry,
         fetch_discovered_upstreams,
     )
+    from agent_bom.proxy_policy import summarize_policy_bundle
     from agent_bom.runtime.visual_leak_detector import require_visual_leak_runtime
 
     registry: UpstreamRegistry | None = None
@@ -225,6 +226,7 @@ def serve_cmd(
         policy_reload_interval_seconds=max(policy_reload_seconds, 0),
     )
     app = create_gateway_app(settings)
+    policy_summary = summarize_policy_bundle(policy)
 
     # Binding to 0.0.0.0 is intentional for containerized deploys — ingress /
     # service mesh terminates external traffic in front of this pod. Set
@@ -244,6 +246,14 @@ def serve_cmd(
                 "Disabled by explicit override (--allow-insecure-no-auth)"
                 if allow_insecure_no_auth
                 else "Loopback-only without transport auth; add --bearer-token before exposing remotely"
+            ),
+        ),
+        (
+            "Policy",
+            (
+                f"{policy_summary['summary']} "
+                f"Rules={policy_summary['total_rules']} "
+                f"(block={policy_summary['blocking_rules']}, warn={policy_summary['advisory_rules']})"
             ),
         ),
     ]

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -47,6 +47,7 @@ from agent_bom.api.middleware import InMemoryRateLimitStore, PostgresRateLimitSt
 from agent_bom.api.tracing import get_tracer, inject_trace_headers, make_request_trace
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc
+from agent_bom.proxy_policy import summarize_policy_bundle
 
 logger = logging.getLogger(__name__)
 _GATEWAY_TRACER = get_tracer("agent_bom.gateway")
@@ -346,12 +347,15 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     @app.get("/healthz")
     async def healthz() -> dict[str, Any]:
         async with policy_lock:
+            policy_summary = summarize_policy_bundle(policy_state["policy"])
             policy_runtime = {
                 "source": policy_state["source"],
+                "source_kind": "file" if settings.policy_path else "inline",
                 "reload_enabled": bool(settings.policy_path and settings.policy_reload_interval_seconds > 0),
                 "reload_interval_seconds": settings.policy_reload_interval_seconds,
                 "last_loaded_at": policy_state["last_loaded_at"],
                 "last_error": policy_state["last_error"],
+                **policy_summary,
             }
         health: dict[str, Any] = {
             "status": "ok",

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -150,6 +150,77 @@ def resolve_rate_limit_threshold(policy: dict) -> int | None:
     return min(limits) if limits else None
 
 
+def summarize_policy_bundle(policy: dict) -> dict[str, object]:
+    """Summarize rollout posture and major controls for a runtime policy bundle."""
+    raw_rules = policy.get("rules", [])
+    rules = raw_rules if isinstance(raw_rules, list) else []
+
+    total_rules = len(rules)
+    blocking_rules = 0
+    advisory_rules = 0
+    allowlist_rules = 0
+    default_deny_rules = 0
+    read_only_rules = 0
+    secret_path_rules = 0
+    unknown_egress_rules = 0
+    denied_tool_classes: set[str] = set()
+
+    for raw_rule in rules:
+        rule = raw_rule if isinstance(raw_rule, dict) else {}
+        action = str(rule.get("action", "warn")).lower()
+        is_blocking = action in ("block", "fail")
+        if is_blocking:
+            blocking_rules += 1
+        else:
+            advisory_rules += 1
+        if str(rule.get("mode", "")).lower() == "allowlist":
+            allowlist_rules += 1
+            if is_blocking:
+                default_deny_rules += 1
+        if rule.get("read_only"):
+            read_only_rules += 1
+        if rule.get("block_secret_paths"):
+            secret_path_rules += 1
+        if rule.get("block_unknown_egress"):
+            unknown_egress_rules += 1
+        denied_tool_classes.update(str(item).lower() for item in rule.get("deny_tool_classes", []) if item)
+
+    if total_rules == 0:
+        rollout_mode = "disabled"
+        summary = "No runtime policy rules configured."
+    elif blocking_rules == 0:
+        rollout_mode = "advisory_only"
+        summary = "Policy matches are advisory only; runtime will not block."
+    elif blocking_rules > 0 and advisory_rules > 0:
+        rollout_mode = "mixed"
+        summary = "Mixed rollout: some rules block while others remain advisory."
+    elif default_deny_rules > 0:
+        rollout_mode = "default_deny"
+        summary = "Blocking allowlist enforcement is active for matched policy scope."
+    else:
+        rollout_mode = "blocking"
+        summary = "Blocking runtime enforcement is active."
+
+    return {
+        "rollout_mode": rollout_mode,
+        "summary": summary,
+        "total_rules": total_rules,
+        "blocking_rules": blocking_rules,
+        "advisory_rules": advisory_rules,
+        "allowlist_rules": allowlist_rules,
+        "default_deny_rules": default_deny_rules,
+        "read_only_rules": read_only_rules,
+        "secret_path_rules": secret_path_rules,
+        "unknown_egress_rules": unknown_egress_rules,
+        "denied_tool_classes": sorted(denied_tool_classes),
+        "blocks_requests": blocking_rules > 0,
+        "advisory_only": total_rules > 0 and blocking_rules == 0,
+        "default_deny": default_deny_rules > 0,
+        "protects_secret_paths": secret_path_rules > 0,
+        "restricts_unknown_egress": unknown_egress_rules > 0,
+    }
+
+
 def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, str]:
     """Evaluate runtime policy against a tools/call request."""
     rules = policy.get("rules", [])

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -315,6 +315,7 @@ def test_gateway_serve_allows_non_loopback_bind_with_bearer_token(tmp_path):
     assert "token required" in result.output
     assert "Upstreams" in result.output
     assert "Bind" in result.output
+    assert "No runtime policy rules configured." in result.output
     mock_run.assert_called_once()
 
 
@@ -408,6 +409,36 @@ def test_gateway_serve_passes_policy_reload_settings(tmp_path):
     assert settings.policy_path == policy
     assert settings.policy_reload_interval_seconds == 5
     assert "Policy hot reload: enabled every 5s" in result.output
+    mock_run.assert_called_once()
+
+
+def test_gateway_serve_reports_advisory_only_policy_summary(tmp_path):
+    runner = CliRunner()
+    upstreams = tmp_path / "upstreams.yaml"
+    policy = tmp_path / "policy.json"
+    upstreams.write_text("upstreams:\n  - name: jira\n    url: https://jira.example.com/mcp\n")
+    policy.write_text('{"rules":[{"id":"warn-secret","block_secret_paths":true}]}')
+
+    with (
+        patch("agent_bom.gateway_server.create_gateway_app") as mock_create_app,
+        patch("uvicorn.run") as mock_run,
+    ):
+        mock_create_app.return_value = object()
+        result = runner.invoke(
+            gateway_serve_cmd,
+            [
+                "--bind",
+                "127.0.0.1:8090",
+                "--upstreams",
+                str(upstreams),
+                "--policy",
+                str(policy),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Policy matches are advisory only; runtime will not block." in result.output
+    assert "Rules=1 (block=0, warn=1)" in result.output
     mock_run.assert_called_once()
 
 

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -72,10 +72,27 @@ def test_healthz_lists_configured_upstreams() -> None:
         },
         "policy_runtime": {
             "source": "inline",
+            "source_kind": "inline",
             "reload_enabled": False,
             "reload_interval_seconds": 0,
             "last_loaded_at": None,
             "last_error": None,
+            "rollout_mode": "disabled",
+            "summary": "No runtime policy rules configured.",
+            "total_rules": 0,
+            "blocking_rules": 0,
+            "advisory_rules": 0,
+            "allowlist_rules": 0,
+            "default_deny_rules": 0,
+            "read_only_rules": 0,
+            "secret_path_rules": 0,
+            "unknown_egress_rules": 0,
+            "denied_tool_classes": [],
+            "blocks_requests": False,
+            "advisory_only": False,
+            "default_deny": False,
+            "protects_secret_paths": False,
+            "restricts_unknown_egress": False,
         },
     }
 
@@ -94,10 +111,40 @@ def test_healthz_reports_policy_reload_runtime(tmp_path: Path) -> None:
         assert resp.status_code == 200
         runtime = resp.json()["policy_runtime"]
         assert runtime["source"] == str(policy_path)
+        assert runtime["source_kind"] == "file"
         assert runtime["reload_enabled"] is True
         assert runtime["reload_interval_seconds"] == 2
         assert runtime["last_loaded_at"] is not None
         assert runtime["last_error"] is None
+        assert runtime["rollout_mode"] == "disabled"
+
+
+def test_healthz_reports_policy_rollout_summary_for_advisory_rules() -> None:
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={"rules": [{"id": "warn-secret", "block_secret_paths": True}]},
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.get("/healthz")
+    runtime = resp.json()["policy_runtime"]
+    assert runtime["rollout_mode"] == "advisory_only"
+    assert runtime["blocks_requests"] is False
+    assert runtime["advisory_only"] is True
+    assert runtime["protects_secret_paths"] is True
+
+
+def test_healthz_reports_policy_rollout_summary_for_default_deny() -> None:
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={"rules": [{"id": "allow-read", "mode": "allowlist", "action": "block", "allow_tools": ["read_file"]}]},
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.get("/healthz")
+    runtime = resp.json()["policy_runtime"]
+    assert runtime["rollout_mode"] == "default_deny"
+    assert runtime["blocks_requests"] is True
+    assert runtime["default_deny"] is True
+    assert runtime["allowlist_rules"] == 1
 
 
 def test_healthz_reports_visual_leak_readiness_when_enabled(monkeypatch) -> None:

--- a/tests/test_proxy_policy.py
+++ b/tests/test_proxy_policy.py
@@ -11,6 +11,7 @@ from agent_bom.proxy import (
     compute_response_hmac,
     set_gateway_evaluator,
 )
+from agent_bom.proxy_policy import summarize_policy_bundle
 
 # ---------------------------------------------------------------------------
 # compute_payload_hash
@@ -239,6 +240,47 @@ def test_check_policy_blocks_non_allowlisted_host():
     allowed, reason = check_policy(policy, "web_fetch", {"endpoint": "https://evil.example/api"})
     assert allowed is False
     assert "allowlisted" in reason.lower()
+
+
+def test_summarize_policy_bundle_disabled():
+    summary = summarize_policy_bundle({})
+    assert summary["rollout_mode"] == "disabled"
+    assert summary["blocks_requests"] is False
+    assert summary["total_rules"] == 0
+
+
+def test_summarize_policy_bundle_advisory_only():
+    summary = summarize_policy_bundle(
+        {
+            "rules": [
+                {"id": "warn-exec", "action": "warn", "deny_tool_classes": ["execute"]},
+                {"id": "warn-secret", "block_secret_paths": True},
+            ]
+        }
+    )
+    assert summary["rollout_mode"] == "advisory_only"
+    assert summary["advisory_only"] is True
+    assert summary["blocking_rules"] == 0
+    assert summary["advisory_rules"] == 2
+    assert summary["denied_tool_classes"] == ["execute"]
+    assert summary["protects_secret_paths"] is True
+
+
+def test_summarize_policy_bundle_default_deny():
+    summary = summarize_policy_bundle(
+        {
+            "rules": [
+                {"id": "allow-read", "mode": "allowlist", "action": "block", "allow_tools": ["read_file"]},
+                {"id": "no-egress", "action": "block", "block_unknown_egress": True, "allowed_hosts": ["api.openai.com"]},
+            ]
+        }
+    )
+    assert summary["rollout_mode"] == "default_deny"
+    assert summary["blocks_requests"] is True
+    assert summary["default_deny"] is True
+    assert summary["allowlist_rules"] == 1
+    assert summary["default_deny_rules"] == 1
+    assert summary["restricts_unknown_egress"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
- add a reusable runtime policy bundle summary helper for advisory-only, mixed, blocking, and default-deny posture
- expose that rollout state on gateway `/healthz` so operators can see active rule counts and major controls without inspecting JSON files manually
- surface the same policy posture in `agent-bom gateway serve` startup output
- add regression coverage for the summary helper, gateway health runtime, and CLI output

Why
Part of #1767. The policy engine and reload path already exist, but operators still had to infer whether a gateway was advisory-only or actively blocking. This PR improves visibility without changing enforcement behavior.

Validation
- `pytest -q tests/test_proxy_policy.py tests/test_gateway_server.py tests/test_cli_server.py -q`
- `uv run ruff check src/agent_bom/proxy_policy.py src/agent_bom/gateway_server.py src/agent_bom/cli/_gateway.py tests/test_proxy_policy.py tests/test_gateway_server.py tests/test_cli_server.py`
