### PR TITLE
feat(runtime): surface gateway rollout posture in dashboard

### DIFF
--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -344,13 +344,22 @@ async def discovered_upstreams(request: Request) -> dict:
 @router.get("/v1/gateway/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
 async def gateway_stats(request: Request):
     """Gateway-wide statistics."""
+    from agent_bom.gateway import summarize_gateway_policies
+
     tenant_id = getattr(request.state, "tenant_id", "default")
     policies = _get_policy_store().list_policies(tenant_id=tenant_id)
     audit = _get_policy_store().list_audit_entries(limit=10000, tenant_id=tenant_id)
-    enforce_count = sum(1 for p in policies if p.mode.value == "enforce" and p.enabled)
-    audit_count = sum(1 for p in policies if p.mode.value == "audit" and p.enabled)
+    active_policies = [p for p in policies if p.enabled]
+    enforce_count = sum(1 for p in active_policies if p.mode.value == "enforce")
+    audit_count = sum(1 for p in active_policies if p.mode.value == "audit")
     blocked = sum(1 for e in audit if e.action_taken == "blocked")
     alerted = sum(1 for e in audit if e.action_taken == "alerted")
+    policy_runtime = {
+        "source": "control_plane",
+        "source_kind": "policy_store",
+        "enabled_policies": len(active_policies),
+        **summarize_gateway_policies(active_policies),
+    }
     return {
         "total_policies": len(policies),
         "enforce_count": enforce_count,
@@ -360,4 +369,5 @@ async def gateway_stats(request: Request):
         "audit_entries": len(audit),
         "blocked_count": blocked,
         "alerted_count": alerted,
+        "policy_runtime": policy_runtime,
     }

--- a/src/agent_bom/gateway.py
+++ b/src/agent_bom/gateway.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from agent_bom.proxy import check_policy
+from agent_bom.proxy_policy import summarize_policy_bundle
 
 if TYPE_CHECKING:
     from agent_bom.api.policy_store import GatewayPolicy
@@ -47,6 +48,31 @@ def gateway_policy_to_proxy_format(policy: "GatewayPolicy") -> dict:
             d["rate_limit"] = rule.rate_limit
         rules.append(d)
     return {"rules": rules}
+
+
+def gateway_policies_to_proxy_bundle(policies: list["GatewayPolicy"]) -> dict:
+    """Convert enabled gateway policies into an effective proxy policy bundle.
+
+    Audit-mode policies are translated to advisory-only rules so any rollout
+    summary reflects actual runtime behavior rather than raw stored rule
+    actions.
+    """
+    rules: list[dict] = []
+    for policy in policies:
+        if not policy.enabled:
+            continue
+        proxy_fmt = gateway_policy_to_proxy_format(policy)
+        for rule in proxy_fmt["rules"]:
+            effective_rule = dict(rule)
+            if policy.mode.value != "enforce" and effective_rule.get("action", "block") in ("block", "fail"):
+                effective_rule["action"] = "warn"
+            rules.append(effective_rule)
+    return {"rules": rules}
+
+
+def summarize_gateway_policies(policies: list["GatewayPolicy"]) -> dict[str, object]:
+    """Summarize the effective runtime posture of control-plane gateway policies."""
+    return summarize_policy_bundle(gateway_policies_to_proxy_bundle(policies))
 
 
 def evaluate_gateway_policies(

--- a/tests/test_api_gateway.py
+++ b/tests/test_api_gateway.py
@@ -282,6 +282,27 @@ def test_stats_empty():
     data = resp.json()
     assert data["total_policies"] == 0
     assert data["blocked_count"] == 0
+    assert data["policy_runtime"] == {
+        "source": "control_plane",
+        "source_kind": "policy_store",
+        "enabled_policies": 0,
+        "rollout_mode": "disabled",
+        "summary": "No runtime policy rules configured.",
+        "total_rules": 0,
+        "blocking_rules": 0,
+        "advisory_rules": 0,
+        "allowlist_rules": 0,
+        "default_deny_rules": 0,
+        "read_only_rules": 0,
+        "secret_path_rules": 0,
+        "unknown_egress_rules": 0,
+        "denied_tool_classes": [],
+        "blocks_requests": False,
+        "advisory_only": False,
+        "default_deny": False,
+        "protects_secret_paths": False,
+        "restricts_unknown_egress": False,
+    }
 
 
 def test_stats_populated():
@@ -307,3 +328,42 @@ def test_stats_populated():
     assert data["enforce_count"] == 1
     assert data["audit_count"] == 1
     assert data["blocked_count"] == 1
+    assert data["policy_runtime"]["enabled_policies"] == 2
+    assert data["policy_runtime"]["rollout_mode"] == "mixed"
+    assert data["policy_runtime"]["blocking_rules"] == 1
+    assert data["policy_runtime"]["advisory_rules"] == 1
+
+
+def test_stats_reflect_protective_controls():
+    client, store = _fresh_client()
+    ts = _now()
+    store.put_policy(
+        GatewayPolicy(
+            policy_id="p-protect",
+            name="protective-controls",
+            mode=PolicyMode.ENFORCE,
+            rules=[
+                GatewayRule(
+                    id="r-protect",
+                    action="block",
+                    block_tools=["fetch_url"],
+                    description="Protect secrets and outbound egress",
+                    block_secret_paths=True,
+                    block_unknown_egress=True,
+                    allowed_hosts=["api.openai.com"],
+                    deny_tool_classes=["network"],
+                )
+            ],
+            created_at=ts,
+            updated_at=ts,
+            tenant_id="default",
+        )
+    )
+
+    resp = client.get("/v1/gateway/stats")
+    data = resp.json()["policy_runtime"]
+    assert data["rollout_mode"] == "blocking"
+    assert data["blocking_rules"] == 1
+    assert data["protects_secret_paths"] is True
+    assert data["restricts_unknown_egress"] is True
+    assert data["denied_tool_classes"] == ["network"]

--- a/ui/app/gateway/page.tsx
+++ b/ui/app/gateway/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import {
   api,
   type GatewayPolicy,
+  type GatewayPolicyRuntimeSummary,
   type GatewayStatsResponse,
   type PolicyAuditEntry,
   type PolicyMode,
@@ -38,6 +39,14 @@ import {
 const MODE_COLORS: Record<PolicyMode, string> = {
   audit: "bg-blue-950 text-blue-300 border-blue-800",
   enforce: "bg-red-950 text-red-300 border-red-800",
+};
+
+const RUNTIME_COLORS: Record<GatewayPolicyRuntimeSummary["rollout_mode"], string> = {
+  disabled: "bg-zinc-900 text-zinc-300 border-zinc-700",
+  advisory_only: "bg-blue-950 text-blue-300 border-blue-800",
+  mixed: "bg-amber-950 text-amber-300 border-amber-800",
+  default_deny: "bg-red-950 text-red-300 border-red-800",
+  blocking: "bg-emerald-950 text-emerald-300 border-emerald-800",
 };
 
 // ─── Page ───────────────────────────────────────────────────────────────────
@@ -161,12 +170,15 @@ export default function GatewayPage() {
 
       {/* Stats */}
       {stats && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <StatCard label="Total Policies" value={stats.total_policies} icon={Lock} color="text-zinc-400" />
-          <StatCard label="Enforce Mode" value={stats.enforce_count} icon={ShieldAlert} color="text-red-400" />
-          <StatCard label="Audit Mode" value={stats.audit_count} icon={ShieldCheck} color="text-blue-400" />
-          <StatCard label="Blocked" value={stats.blocked_count} icon={ShieldAlert} color="text-orange-400" />
-        </div>
+        <>
+          <RuntimePostureCard runtime={stats.policy_runtime} />
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <StatCard label="Total Policies" value={stats.total_policies} icon={Lock} color="text-zinc-400" />
+            <StatCard label="Enforce Mode" value={stats.enforce_count} icon={ShieldAlert} color="text-red-400" />
+            <StatCard label="Audit Mode" value={stats.audit_count} icon={ShieldCheck} color="text-blue-400" />
+            <StatCard label="Blocked" value={stats.blocked_count} icon={ShieldAlert} color="text-orange-400" />
+          </div>
+        </>
       )}
 
       {/* Tabs */}
@@ -531,6 +543,53 @@ function StatCard({
       <Icon className={`w-4 h-4 mb-2 ${color}`} />
       <div className="text-2xl font-bold font-mono">{value}</div>
       <div className="text-xs text-zinc-500 mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+function RuntimePostureCard({ runtime }: { runtime: GatewayPolicyRuntimeSummary }) {
+  const highlights = [
+    { label: "Enabled policies", value: String(runtime.enabled_policies) },
+    { label: "Blocking rules", value: String(runtime.blocking_rules) },
+    { label: "Advisory rules", value: String(runtime.advisory_rules) },
+    { label: "Allowlist rules", value: String(runtime.allowlist_rules) },
+  ];
+
+  if (runtime.protects_secret_paths) {
+    highlights.push({ label: "Secret path guard", value: "On" });
+  }
+  if (runtime.restricts_unknown_egress) {
+    highlights.push({ label: "Unknown egress guard", value: "On" });
+  }
+
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(9,9,11,0.98))] p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+              Runtime posture
+            </span>
+            <span className={`rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] ${RUNTIME_COLORS[runtime.rollout_mode]}`}>
+              {runtime.rollout_mode.replaceAll("_", " ")}
+            </span>
+          </div>
+          <p className="max-w-2xl text-sm text-zinc-300">{runtime.summary}</p>
+          {runtime.denied_tool_classes.length > 0 && (
+            <p className="text-xs text-zinc-500">
+              Denied tool classes: {runtime.denied_tool_classes.join(", ")}
+            </p>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {highlights.map((item) => (
+            <div key={item.label} className="rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-zinc-600">{item.label}</div>
+              <div className="mt-1 text-sm font-semibold text-zinc-100">{item.value}</div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1038,6 +1038,29 @@ export interface GatewayStatsResponse {
   audit_entries: number;
   blocked_count: number;
   alerted_count: number;
+  policy_runtime: GatewayPolicyRuntimeSummary;
+}
+
+export interface GatewayPolicyRuntimeSummary {
+  source: string;
+  source_kind: string;
+  enabled_policies: number;
+  rollout_mode: "disabled" | "advisory_only" | "mixed" | "default_deny" | "blocking";
+  summary: string;
+  total_rules: number;
+  blocking_rules: number;
+  advisory_rules: number;
+  allowlist_rules: number;
+  default_deny_rules: number;
+  read_only_rules: number;
+  secret_path_rules: number;
+  unknown_egress_rules: number;
+  denied_tool_classes: string[];
+  blocks_requests: boolean;
+  advisory_only: boolean;
+  default_deny: boolean;
+  protects_secret_paths: boolean;
+  restricts_unknown_egress: boolean;
 }
 
 export interface EvaluateResult {

--- a/ui/tests/gateway-page.test.tsx
+++ b/ui/tests/gateway-page.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import GatewayPage from "@/app/gateway/page";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    listGatewayPolicies: vi.fn(),
+    getGatewayStats: vi.fn(),
+    listGatewayAudit: vi.fn(),
+    createGatewayPolicy: vi.fn(),
+    deleteGatewayPolicy: vi.fn(),
+    updateGatewayPolicy: vi.fn(),
+    evaluateGateway: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: apiMock,
+  };
+});
+
+describe("GatewayPage", () => {
+  beforeEach(() => {
+    Object.values(apiMock).forEach((mockFn) => mockFn.mockReset());
+    apiMock.listGatewayPolicies.mockResolvedValue({ policies: [], count: 0 });
+    apiMock.listGatewayAudit.mockResolvedValue({ entries: [], count: 0 });
+    apiMock.getGatewayStats.mockResolvedValue({
+      total_policies: 2,
+      enforce_count: 1,
+      audit_count: 1,
+      enabled_count: 2,
+      total_rules: 3,
+      audit_entries: 4,
+      blocked_count: 2,
+      alerted_count: 1,
+      policy_runtime: {
+        source: "control_plane",
+        source_kind: "policy_store",
+        enabled_policies: 2,
+        rollout_mode: "mixed",
+        summary: "Mixed rollout: some rules block while others remain advisory.",
+        total_rules: 3,
+        blocking_rules: 1,
+        advisory_rules: 2,
+        allowlist_rules: 0,
+        default_deny_rules: 0,
+        read_only_rules: 0,
+        secret_path_rules: 1,
+        unknown_egress_rules: 1,
+        denied_tool_classes: ["network"],
+        blocks_requests: true,
+        advisory_only: false,
+        default_deny: false,
+        protects_secret_paths: true,
+        restricts_unknown_egress: true,
+      },
+    });
+  });
+
+  it("surfaces runtime rollout posture and protective controls", async () => {
+    render(<GatewayPage />);
+
+    await waitFor(() => expect(screen.getByText("Runtime posture")).toBeInTheDocument());
+    expect(screen.getByText("mixed")).toBeInTheDocument();
+    expect(screen.getByText("Mixed rollout: some rules block while others remain advisory.")).toBeInTheDocument();
+    expect(screen.getByText("Enabled policies")).toBeInTheDocument();
+    expect(screen.getByText("Secret path guard")).toBeInTheDocument();
+    expect(screen.getByText("Unknown egress guard")).toBeInTheDocument();
+    expect(screen.getByText("Denied tool classes: network")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Summary
- derive effective gateway rollout posture from enabled control-plane policies using the same advisory-vs-blocking semantics as runtime evaluation
- expose that posture on /v1/gateway/stats and surface it in the Next.js gateway dashboard with clearer visual separation of rollout mode and major controls
- add backend and UI coverage for the new policy_runtime contract

Why
- Closes #1767
- The runtime policy rollout summary from #1771 was visible in gateway healthz and CLI output, but the control-plane stats API and dashboard still showed only raw counts. This PR makes the operator-facing UI and API contract consistent with actual runtime behavior.

Validation
- pytest -q tests/test_api_gateway.py
- uv run ruff check src/agent_bom/gateway.py src/agent_bom/api/routes/gateway.py tests/test_api_gateway.py
- uv run mypy src/agent_bom/gateway.py src/agent_bom/api/routes/gateway.py --ignore-missing-imports --disable-error-code import-untyped
- npm test -- --run tests/gateway-page.test.tsx tests/api.test.ts
- npx eslint app/gateway/page.tsx tests/gateway-page.test.tsx lib/api.ts