### PR TITLE
docs: clarify canonical dashboard visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ pip install 'agent-bom[ui]' && agent-bom serve                    # API + bundle
 ## Product views
 
 These come from the live product path, using the built-in demo data pushed through the API. See [`docs/CAPTURE.md`](docs/CAPTURE.md) for the canonical capture protocol.
+They are captured from the packaged Next.js dashboard served by `agent-bom serve`, not from the Snowflake Streamlit compatibility path.
 
 ### Dashboard — Risk overview
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -7,6 +7,10 @@ the resulting graph is actually informative. PR #1445 regressed
 (`claude-code`) had no servers in the local data — this protocol exists so
 that does not happen again.
 
+The canonical published web UI is the packaged Next.js dashboard served by
+`agent-bom serve`. Do not publish README or docs screenshots from archived
+pre-Next.js views or from the Snowflake Streamlit compatibility surface.
+
 ## Canonical capture environment
 
 1. Clean checkout on the release tag.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -362,9 +362,10 @@ Resources:
 ## ❄️ Snowflake Integration
 
 > **Note**: agent-bom integrates with Snowflake for **scanning Cortex Agents,
-> CoCo skills, and Snowpark resources** — not as a deployed Native App.
-> The architecture below is a proposed reference pattern for enterprise
-> teams that want to run agent-bom inside Snowflake infrastructure.
+> CoCo skills, Snowpark resources, and Snowflake-hosted app surfaces**.
+> The primary shipped web UI remains the packaged Next.js dashboard. The
+> Streamlit path below is a Snowflake-specific compatibility / native-view
+> option, not the default product dashboard.
 
 ### Reference Architecture
 
@@ -402,7 +403,7 @@ Resources:
    Enterprise networks can use the same proxy and custom-CA contract as the other maintained images:
    `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, and `PIP_CERT`.
 
-3. **Deploy SiS dashboard** — upload `deploy/snowflake/streamlit_app.py` and `deploy/snowflake/environment.yml` via the Snowflake web UI (Streamlit > + Streamlit App).
+3. **Optional: deploy the Snowflake-native Streamlit view** — upload `deploy/snowflake/streamlit_app.py` and `deploy/snowflake/environment.yml` via the Snowflake web UI (Streamlit > + Streamlit App).
 
 ### Authentication
 

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -3,6 +3,10 @@
 Three media, used deliberately. Picking the right one keeps the README
 readable, mobile-friendly, and easy to keep in sync with code.
 
+For product screenshots, the source of truth is the packaged Next.js
+dashboard. Snowflake Streamlit views may still exist for Snowflake-native
+deployments, but they are not the primary product visuals for README or docs.
+
 ## SVG — for hero visuals + dense product imagery
 
 Use when:
@@ -23,7 +27,7 @@ Current SVG inventory:
 | `engine-internals-{light,dark}.svg` | Inside the scanner | "How a scan moves" |
 | `topology-{light,dark}.svg` | Focused graph view (start scoped, expand) | "How a scan moves" |
 | `compliance-{light,dark}.svg` | Finding → control → evidence packet | Compliance section |
-| `dashboard-live.png` `dashboard-paths-live.png` `mesh-live.png` `remediation-live.png` | Live UI screenshots | Product views |
+| `dashboard-live.png` `dashboard-paths-live.png` `mesh-live.png` `remediation-live.png` | Live packaged Next.js dashboard screenshots | Product views |
 | `demo-latest.gif` | Terminal demo (1.04MB after compression) | "Try the demo" |
 
 ## Mermaid — for code-true flows that evolve

--- a/docs/skills/ai-bom-generator.md
+++ b/docs/skills/ai-bom-generator.md
@@ -72,7 +72,7 @@ agent-bom scan --aws --aws-region us-east-1 \
   --aws-include-lambda --aws-include-eks --aws-include-step-functions \
   --enrich -f json -o ai-bom-aws.json
 
-# Snowflake — Cortex Agents, MCP Servers, Search, Snowpark, Streamlit
+# Snowflake — Cortex Agents, MCP Servers, Search, Snowpark, optional Streamlit-native surfaces
 agent-bom scan --snowflake --enrich -f json -o ai-bom-snowflake.json
 
 # Azure AI Foundry + Container Apps


### PR DESCRIPTION
Summary
- clarify in README and capture guidance that published product screenshots come from the packaged Next.js dashboard served by agent-bom
- update visual-language docs so Snowflake Streamlit is treated as a compatibility surface, not the canonical product UI
- tighten Snowflake deployment and skill docs to describe the Streamlit path as optional and Snowflake-specific

Why
- Closes #1765
- The repo already had current live screenshots, but some docs still left room for Streamlit-era ambiguity about which UI is primary.

Validation
- git diff --check
- manual doc review in README.md, docs/CAPTURE.md, docs/VISUAL_LANGUAGE.md, docs/DEPLOYMENT.md, and docs/skills/ai-bom-generator.md