### PR TITLE
test(docs): codify Snowflake backend parity

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -185,16 +185,19 @@ is deliberately cross-tenant and reserved for admin surfaces.
 
 Warehouse-native deployment for governance-heavy customers. Today it
 persists `scan_jobs`, `fleet_agents`, `gateway_policies`, and
-`policy_audit_log` with Snowflake-specific column types. It is not yet
-at full control-plane parity:
+`policy_audit_log` with Snowflake-specific column types. It also supports
+`scan_schedules` and `exceptions`, so the warehouse-native contract is
+broader than the original jobs/fleet/policy slice. It is not yet at full
+control-plane parity:
 
 - no source registry persistence
 - no API-key / RBAC persistence
-- no exceptions persistence
-- no schedule persistence
 - no graph persistence
 - no trend/baseline persistence
 - no full `audit_log` transactional replacement
+
+For the operator-facing backend matrix and current parity boundaries, see
+`site-docs/deployment/backend-parity.md`.
 
 ### Deployment-context posture contract — `GET /v1/posture/counts`
 

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -80,6 +80,17 @@ The Snowflake story should be read in three layers:
 That means Snowflake is already a real backend mode, but it is still not the
 same claim as “full transactional replacement for Postgres.”
 
+## CI-Backed Snowflake Contract Coverage
+
+The documented Snowflake parity slice is enforced in CI with mocked
+connector-based tests:
+
+- `tests/test_snowflake_stores.py` covers the store-layer contracts for jobs,
+  fleet, gateway policies, schedules, and exceptions.
+- `tests/test_snowflake_backend_contract.py` covers the API-advertised backend
+  contract for health reporting and the supported schedule / exception routes
+  in warehouse-native mode.
+
 For the exact logical entity → table/store mapping, see
 [Control-Plane Data Model and Store Parity](control-plane-data-model.md).
 

--- a/tests/test_snowflake_backend_contract.py
+++ b/tests/test_snowflake_backend_contract.py
@@ -1,0 +1,99 @@
+"""Contract tests for the advertised Snowflake control-plane slice.
+
+These tests do not use a live Snowflake account. They prove the API wiring and
+health contract against the mocked Snowflake store implementations that CI can
+run deterministically.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as api_stores
+from agent_bom.api.server import app
+
+
+def _mock_cursor(fetchone_val=None, fetchall_val=None, rowcount=0):
+    cur = MagicMock()
+    cur.fetchone.return_value = fetchone_val
+    cur.fetchall.return_value = fetchall_val or []
+    cur.rowcount = rowcount
+    cur.execute.return_value = cur
+    return cur
+
+
+def _mock_connection(cursor=None):
+    conn = MagicMock()
+    conn.cursor.return_value = cursor or _mock_cursor()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+def _clear_store_globals() -> None:
+    api_stores._store = None
+    api_stores._fleet_store = None
+    api_stores._policy_store = None
+    api_stores._source_store = None
+    api_stores._schedule_store = None
+    api_stores._exception_store = None
+    api_stores._trend_store = None
+    api_stores._graph_store = None
+    api_stores._analytics_store = None
+
+
+@patch("agent_bom.api.snowflake_store._sf_connect")
+def test_health_reports_supported_snowflake_control_plane_slice(mock_connect, monkeypatch):
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct")
+    monkeypatch.setenv("SNOWFLAKE_USER", "user")
+    monkeypatch.setenv("SNOWFLAKE_PRIVATE_KEY_PATH", "/keys/test.p8")
+    monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+    mock_connect.return_value = _mock_connection()
+    monkeypatch.setattr("agent_bom.api.server._cleanup_loop", lambda: _async_noop())
+    monkeypatch.setattr("agent_bom.api.scheduler.scheduler_loop", lambda store, fn: _async_noop())
+
+    _clear_store_globals()
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/health")
+            assert resp.status_code == 200
+            storage = resp.json()["storage"]
+            assert storage["control_plane_backend"] == "snowflake"
+            assert storage["job_store"] == "snowflake"
+            assert storage["fleet_store"] == "snowflake"
+            assert storage["policy_store"] == "snowflake"
+            assert storage["schedule_store"] == "snowflake"
+            assert storage["exception_store"] == "snowflake"
+    finally:
+        _clear_store_globals()
+
+
+@patch("agent_bom.api.snowflake_store._sf_connect")
+def test_supported_snowflake_routes_remain_wired(mock_connect, monkeypatch):
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct")
+    monkeypatch.setenv("SNOWFLAKE_USER", "user")
+    monkeypatch.setenv("SNOWFLAKE_PRIVATE_KEY_PATH", "/keys/test.p8")
+    monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+    mock_connect.return_value = _mock_connection()
+    monkeypatch.setattr("agent_bom.api.server._cleanup_loop", lambda: _async_noop())
+    monkeypatch.setattr("agent_bom.api.scheduler.scheduler_loop", lambda store, fn: _async_noop())
+
+    _clear_store_globals()
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            schedules = client.get("/v1/schedules")
+            exceptions = client.get("/v1/exceptions")
+
+            assert schedules.status_code == 200
+            assert schedules.json() == []
+
+            assert exceptions.status_code == 200
+            assert exceptions.json() == {"exceptions": [], "total": 0}
+    finally:
+        _clear_store_globals()
+
+
+async def _async_noop() -> None:
+    return None


### PR DESCRIPTION
Summary
- correct the Snowflake parity description in the data-model docs so schedules and exceptions are listed as supported warehouse-native stores
- add explicit CI-backed contract coverage for the Snowflake health/storage contract and the supported schedules/exceptions API slice
- document the test locations directly in the backend parity guide

Why
- Closes #1769
- The repo already had Snowflake schedule and exception stores plus unit coverage, but one of the parity docs still claimed they were unsupported and there was no explicit API-facing contract test for the advertised warehouse-native slice.

Validation
- pytest -q tests/test_snowflake_backend_contract.py tests/test_snowflake_stores.py
- git diff --check