### PR TITLE
feat(auth): surface enterprise identity status and quota usage

### DIFF
--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -212,7 +212,7 @@ async def list_keys(request: Request) -> dict:
 
 
 @router.get("/v1/auth/policy", tags=["enterprise"])
-async def auth_policy() -> dict:
+async def auth_policy(request: Request) -> dict:
     """Report API key and rate-limit key rotation policy + status.
 
     Operators surface this in dashboards and runbooks to confirm that
@@ -225,6 +225,7 @@ async def auth_policy() -> dict:
         get_rate_limit_key_status,
         get_rate_limit_runtime_status,
     )
+    from agent_bom.api.tenant_quota import get_tenant_quota_runtime
     from agent_bom.config import (
         API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT,
         API_MAX_FLEET_AGENTS_PER_TENANT,
@@ -236,6 +237,7 @@ async def auth_policy() -> dict:
     rl_status = get_rate_limit_key_status()
     rl_runtime = get_rate_limit_runtime_status()
     auth_runtime = get_auth_runtime_status()
+    tenant_id = getattr(request.state, "tenant_id", "default")
     return {
         "api_key": {
             "default_ttl_seconds": api_policy.default_ttl_seconds,
@@ -263,6 +265,27 @@ async def auth_policy() -> dict:
             "retained_scan_jobs": API_MAX_RETAINED_JOBS_PER_TENANT,
             "fleet_agents": API_MAX_FLEET_AGENTS_PER_TENANT,
             "schedules": API_MAX_SCHEDULES_PER_TENANT,
+        },
+        "tenant_quota_runtime": get_tenant_quota_runtime(tenant_id),
+        "identity_provisioning": {
+            "scim": {
+                "supported": False,
+                "configured": False,
+                "status": "not_implemented",
+                "message": (
+                    "SCIM provisioning is not implemented yet. User and group lifecycle still depends on the upstream "
+                    "identity provider, reverse proxy, or manual API-key administration."
+                ),
+            },
+            "session_revocation": {
+                "service_keys": "API key revocation takes effect immediately at the control-plane auth layer.",
+                "session_api_key": (
+                    "The browser fallback key is scoped to the current browser session and disappears when that local session is cleared."
+                ),
+                "browser_sessions": (
+                    "OIDC or reverse-proxy browser sessions must be terminated at the upstream identity provider or trusted proxy."
+                ),
+            },
         },
     }
 

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from fastapi import HTTPException
 
 from agent_bom.api.audit_log import log_action
@@ -112,3 +114,49 @@ def enforce_schedule_quota(tenant_id: str, attempted: int = 1) -> None:
             current=current,
             attempted=attempted,
         )
+
+
+def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
+    """Return operator-facing quota status for a tenant.
+
+    Quotas are process-wide configuration today. This surface makes that
+    explicit while still showing the tenant's current usage so the UI can
+    explain whether an operator is close to the enforced limits.
+    """
+
+    def _entry(limit: int, current: int) -> dict[str, int | bool | None]:
+        return {
+            "limit": limit,
+            "current": current,
+            "remaining": None if limit <= 0 else max(limit - current, 0),
+            "enforced": limit > 0,
+        }
+
+    def _safe_count(fn: Callable[[], int]) -> int:
+        try:
+            return fn()
+        except RuntimeError:
+            # Operator status should stay readable during partial startup and tests
+            # even if optional stores are not initialized yet.
+            return 0
+
+    active_jobs = _safe_count(
+        lambda: sum(1 for job in _get_store().list_all(tenant_id=tenant_id) if job.status in (JobStatus.PENDING, JobStatus.RUNNING))
+    )
+    retained_jobs = _safe_count(lambda: len(_get_store().list_all(tenant_id=tenant_id)))
+    fleet_agents = _safe_count(lambda: len(_get_fleet_store().list_by_tenant(tenant_id)))
+    schedules = _safe_count(lambda: len(_get_schedule_store().list_all(tenant_id=tenant_id)))
+
+    return {
+        "source": "static_process_config",
+        "per_tenant_overrides": False,
+        "message": (
+            "Tenant quotas are enforced from control-plane configuration today. Per-tenant override management is not yet exposed."
+        ),
+        "usage": {
+            "active_scan_jobs": _entry(API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT, active_jobs),
+            "retained_scan_jobs": _entry(API_MAX_RETAINED_JOBS_PER_TENANT, retained_jobs),
+            "fleet_agents": _entry(API_MAX_FLEET_AGENTS_PER_TENANT, fleet_agents),
+            "schedules": _entry(API_MAX_SCHEDULES_PER_TENANT, schedules),
+        },
+    }

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -136,6 +136,13 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["tenant_quotas"]["retained_scan_jobs"] >= 1
     assert body["tenant_quotas"]["fleet_agents"] >= 1
     assert body["tenant_quotas"]["schedules"] >= 1
+    assert body["tenant_quota_runtime"]["source"] == "static_process_config"
+    assert body["tenant_quota_runtime"]["per_tenant_overrides"] is False
+    assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["current"] >= 0
+    assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["limit"] >= 1
+    assert body["identity_provisioning"]["scim"]["status"] == "not_implemented"
+    assert body["identity_provisioning"]["scim"]["supported"] is False
+    assert "service_keys" in body["identity_provisioning"]["session_revocation"]
 
 
 def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -144,10 +144,10 @@ export function KeyLifecyclePanel({
     () =>
       policy
         ? [
-            ["Active scan jobs", policy.tenant_quotas.active_scan_jobs],
-            ["Retained scan jobs", policy.tenant_quotas.retained_scan_jobs],
-            ["Fleet agents", policy.tenant_quotas.fleet_agents],
-            ["Schedules", policy.tenant_quotas.schedules],
+            ["Active scan jobs", policy.tenant_quota_runtime.usage.active_scan_jobs],
+            ["Retained scan jobs", policy.tenant_quota_runtime.usage.retained_scan_jobs],
+            ["Fleet agents", policy.tenant_quota_runtime.usage.fleet_agents],
+            ["Schedules", policy.tenant_quota_runtime.usage.schedules],
           ]
         : [],
     [policy]
@@ -480,31 +480,57 @@ export function KeyLifecyclePanel({
 
             <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
               <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Tenant guardrails</p>
+              <p className="mt-3 text-sm text-zinc-300">{policy.tenant_quota_runtime.message}</p>
+              <div className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Quota source</p>
+                <p className="mt-2 text-sm font-semibold text-zinc-100">
+                  {policy.tenant_quota_runtime.source}
+                  {policy.tenant_quota_runtime.per_tenant_overrides ? " · tenant overrides enabled" : " · global defaults only"}
+                </p>
+              </div>
               <div className="mt-3 grid grid-cols-2 gap-3">
                 {quotaCards.map(([label, value]) => (
                   <div key={label} className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
                     <p className="text-[11px] uppercase tracking-[0.16em] text-zinc-500">{label}</p>
-                    <p className="mt-2 text-lg font-semibold text-zinc-100">{value}</p>
+                    <p className="mt-2 text-lg font-semibold text-zinc-100">{value.limit}</p>
+                    <p className="mt-1 text-xs text-zinc-400">
+                      Current {value.current}
+                      {value.remaining != null ? ` · Remaining ${value.remaining}` : " · Unlimited"}
+                    </p>
                   </div>
                 ))}
               </div>
             </section>
           </div>
 
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Identity lifecycle</p>
+            <div className="mt-3 grid gap-3 lg:grid-cols-2">
+              <BoundaryCard
+                title="SCIM provisioning"
+                body={policy.identity_provisioning.scim.message}
+              />
+              <BoundaryCard
+                title="Provisioning posture"
+                body={`${policy.identity_provisioning.scim.status.replaceAll("_", " ")}${policy.identity_provisioning.scim.configured ? " · configured" : " · not configured yet"}`}
+              />
+            </div>
+          </section>
+
           <section className="rounded-2xl border border-amber-900/40 bg-amber-950/10 p-4">
             <p className="text-xs uppercase tracking-[0.18em] text-amber-200/70">Revocation boundaries</p>
             <div className="mt-3 grid gap-3 lg:grid-cols-3">
               <BoundaryCard
                 title="Service keys"
-                body="Revoke stops that key at the API auth layer immediately. Rotation overlap is explicit and bounded by policy."
+                body={policy.identity_provisioning.session_revocation.service_keys}
               />
               <BoundaryCard
                 title="Session API key fallback"
-                body="The browser-only fallback lives in sessionStorage for the current tab or browser session. Clearing the session removes it locally."
+                body={policy.identity_provisioning.session_revocation.session_api_key}
               />
               <BoundaryCard
                 title="Reverse-proxy or OIDC sessions"
-                body="Cookie or IdP session invalidation happens at the upstream proxy or identity provider. This panel does not force-log-out existing browser sessions."
+                body={policy.identity_provisioning.session_revocation.browser_sessions}
               />
             </div>
           </section>

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -62,6 +62,10 @@ function stateLabel(state: ApiKeyRecord["state"]): string {
   }
 }
 
+type TenantQuotaUsageEntry =
+  AuthPolicyResponse["tenant_quota_runtime"]["usage"][keyof AuthPolicyResponse["tenant_quota_runtime"]["usage"]];
+type QuotaCard = readonly [label: string, value: TenantQuotaUsageEntry];
+
 function isSessionKey(key: ApiKeyRecord): boolean {
   return key.name.startsWith("saml:") || key.scopes.includes("saml-session");
 }
@@ -140,7 +144,7 @@ export function KeyLifecyclePanel({
     }, {});
   }, [keys]);
 
-  const quotaCards = useMemo(
+  const quotaCards = useMemo<QuotaCard[]>(
     () =>
       policy
         ? [

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -571,6 +571,33 @@ export interface AuthPolicyResponse {
     fleet_agents: number;
     schedules: number;
   };
+  tenant_quota_runtime: {
+    source: string;
+    per_tenant_overrides: boolean;
+    message: string;
+    usage: Record<
+      "active_scan_jobs" | "retained_scan_jobs" | "fleet_agents" | "schedules",
+      {
+        limit: number;
+        current: number;
+        remaining: number | null;
+        enforced: boolean;
+      }
+    >;
+  };
+  identity_provisioning: {
+    scim: {
+      supported: boolean;
+      configured: boolean;
+      status: string;
+      message: string;
+    };
+    session_revocation: {
+      service_keys: string;
+      session_api_key: string;
+      browser_sessions: string;
+    };
+  };
 }
 
 export type ApiKeyLifecycleState = "active" | "rotation_overlap" | "rotated" | "revoked" | "expired";

--- a/ui/tests/key-lifecycle-panel.test.tsx
+++ b/ui/tests/key-lifecycle-panel.test.tsx
@@ -41,6 +41,30 @@ const policy: AuthPolicyResponse = {
     fleet_agents: 5000,
     schedules: 25,
   },
+  tenant_quota_runtime: {
+    source: "static_process_config",
+    per_tenant_overrides: false,
+    message: "Tenant quotas are enforced from control-plane configuration today.",
+    usage: {
+      active_scan_jobs: { limit: 10, current: 2, remaining: 8, enforced: true },
+      retained_scan_jobs: { limit: 100, current: 12, remaining: 88, enforced: true },
+      fleet_agents: { limit: 5000, current: 48, remaining: 4952, enforced: true },
+      schedules: { limit: 25, current: 3, remaining: 22, enforced: true },
+    },
+  },
+  identity_provisioning: {
+    scim: {
+      supported: false,
+      configured: false,
+      status: "not_implemented",
+      message: "SCIM provisioning is not implemented yet.",
+    },
+    session_revocation: {
+      service_keys: "API key revocation takes effect immediately at the control-plane auth layer.",
+      session_api_key: "The browser fallback key is scoped to the current browser session.",
+      browser_sessions: "OIDC or reverse-proxy browser sessions must be terminated at the upstream identity provider or trusted proxy.",
+    },
+  },
 };
 
 const keys: ApiKeyRecord[] = [
@@ -80,7 +104,10 @@ describe("KeyLifecyclePanel", () => {
     expect(screen.getByText("Tenant guardrails")).toBeInTheDocument();
     expect(screen.getByText("Active scan jobs")).toBeInTheDocument();
     expect(screen.getByText("5000")).toBeInTheDocument();
+    expect(screen.getByText("Current 48 · Remaining 4952")).toBeInTheDocument();
+    expect(screen.getByText("Identity lifecycle")).toBeInTheDocument();
+    expect(screen.getByText("SCIM provisioning")).toBeInTheDocument();
     expect(screen.getByText("Revocation boundaries")).toBeInTheDocument();
-    expect(screen.getByText("Reverse-proxy or OIDC sessions")).toBeInTheDocument();
+    expect(screen.getByText("OIDC or reverse-proxy browser sessions must be terminated at the upstream identity provider or trusted proxy.")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Summary
- expose operator-facing tenant quota runtime usage and source details in /v1/auth/policy
- report honest enterprise identity lifecycle status for SCIM and browser session revocation boundaries
- wire the key lifecycle panel to the new policy fields so backend and UI stay aligned

Why
Part of #1750. This tightens the enterprise auth/operator surface without overstating SCIM support or per-tenant quota management that is not implemented yet.

Validation
- pytest -q tests/test_api_operator_policy.py
- npm test -- --run tests/key-lifecycle-panel.test.tsx tests/api.test.ts
- uv run ruff check src/agent_bom/api/tenant_quota.py src/agent_bom/api/routes/enterprise.py tests/test_api_operator_policy.py
- uv run mypy src/agent_bom/api/tenant_quota.py src/agent_bom/api/routes/enterprise.py --ignore-missing-imports --disable-error-code import-untyped
- npx eslint components/key-lifecycle-panel.tsx lib/api.ts tests/key-lifecycle-panel.test.tsx