### PR TITLE
ci: add merge queue workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   # 1. Security Scanning

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '30 1 * * 1'  # Weekly on Monday at 01:30 UTC
 

--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -8,6 +8,8 @@ name: PR Security Gate
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Summary
- add `merge_group` triggers to the main CI workflow, CodeQL workflow, and PR security gate
- keep the existing pull request and push behavior unchanged while allowing merge queue runs to report the same checks

Why
Part of #1780. GitHub merge queue will not report required checks unless the workflows also listen for `merge_group` events.

Validation
- python3 -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/ci.yml','.github/workflows/codeql.yml','.github/workflows/pr-security-gate.yml']]; print('yaml-ok')"
- git diff --check