### PR TITLE
feat(auth): surface audit and signing posture

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -38,8 +38,8 @@ def _env_enabled(name: str) -> bool:
 # per-process key is generated — signatures verify within the same process
 # but provide no cross-restart integrity.  Production deployments MUST set
 # AGENT_BOM_AUDIT_HMAC_KEY for meaningful tamper detection.
-_HMAC_ENV_KEY = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY")
-if _HMAC_ENV_KEY is not None:
+_HMAC_ENV_KEY = (os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") or "").strip()
+if _HMAC_ENV_KEY:
     _HMAC_KEY = _HMAC_ENV_KEY.encode()
 else:
     if _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC"):
@@ -113,6 +113,36 @@ class AuditEntry:
 def sign_export_payload(payload: bytes) -> str:
     """Sign an exported audit payload so downstream consumers can verify it."""
     return hmac.new(_HMAC_KEY, payload, hashlib.sha256).hexdigest()
+
+
+def describe_audit_hmac_status() -> dict[str, object]:
+    """Return operator-facing audit HMAC posture for auth/policy surfaces."""
+    required = _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC")
+    if _HMAC_ENV_KEY:
+        return {
+            "status": "configured",
+            "configured": True,
+            "required": required,
+            "source": "AGENT_BOM_AUDIT_HMAC_KEY",
+            "persists_across_restart": True,
+            "rotation_tracking_supported": False,
+            "message": (
+                "Audit log tamper detection uses a configured shared secret. "
+                "Signatures remain verifiable across restarts as long as the same key stays in place."
+            ),
+        }
+    return {
+        "status": "ephemeral",
+        "configured": False,
+        "required": required,
+        "source": "process_ephemeral",
+        "persists_across_restart": False,
+        "rotation_tracking_supported": False,
+        "message": (
+            "Audit log tamper detection is using an in-process ephemeral secret. "
+            "Integrity checks work only for this process lifetime and reset after restart."
+        ),
+    }
 
 
 class AuditLogStore(Protocol):

--- a/src/agent_bom/api/compliance_signing.py
+++ b/src/agent_bom/api/compliance_signing.py
@@ -166,3 +166,41 @@ def current_key_id() -> str | None:
     """Return the Ed25519 key_id, or None when only HMAC is configured."""
     signer = _load_ed25519_signer()
     return signer.key_id if signer is not None else None
+
+
+def describe_signing_posture() -> dict[str, object]:
+    """Return operator-facing compliance bundle signing posture."""
+    signer = _load_ed25519_signer()
+    if signer is not None:
+        return {
+            "algorithm": "Ed25519",
+            "mode": "asymmetric_public_key",
+            "configured": True,
+            "key_id": signer.key_id,
+            "public_key_endpoint": "/v1/compliance/verification-key",
+            "auditor_distributable": True,
+            "uses_audit_hmac_secret": False,
+            "persists_across_restart": True,
+            "message": (
+                "Compliance evidence bundles are signed with Ed25519. "
+                "External verifiers only need the public key, not shared secret material."
+            ),
+        }
+
+    from agent_bom.api.audit_log import describe_audit_hmac_status
+
+    audit_hmac = describe_audit_hmac_status()
+    return {
+        "algorithm": "HMAC-SHA256",
+        "mode": "shared_secret",
+        "configured": bool(audit_hmac["configured"]),
+        "key_id": None,
+        "public_key_endpoint": None,
+        "auditor_distributable": False,
+        "uses_audit_hmac_secret": True,
+        "persists_across_restart": bool(audit_hmac["persists_across_restart"]),
+        "message": (
+            "Compliance evidence bundles are signed with the same shared secret family as the audit export path. "
+            "For auditor-distributable verification, switch to Ed25519."
+        ),
+    }

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -219,7 +219,9 @@ async def auth_policy(request: Request) -> dict:
     rotation cadence is enforced and that no fingerprint key has aged
     past the configured maximum.
     """
+    from agent_bom.api.audit_log import describe_audit_hmac_status
     from agent_bom.api.auth import get_api_key_policy
+    from agent_bom.api.compliance_signing import describe_signing_posture
     from agent_bom.api.middleware import (
         get_auth_runtime_status,
         get_rate_limit_key_status,
@@ -260,6 +262,10 @@ async def auth_policy(request: Request) -> dict:
             ),
         },
         "rate_limit_runtime": rl_runtime,
+        "secret_integrity": {
+            "audit_hmac": describe_audit_hmac_status(),
+            "compliance_signing": describe_signing_posture(),
+        },
         "tenant_quotas": {
             "active_scan_jobs": API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT,
             "retained_scan_jobs": API_MAX_RETAINED_JOBS_PER_TENANT,

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -25,6 +25,15 @@ from agent_bom.api.server import app
 # ─── Rate-limit key status ────────────────────────────────────────────────────
 
 
+@pytest.fixture(autouse=True)
+def _restore_runtime_modules():
+    yield
+    _reload_config()
+    importlib.reload(audit_log_module)
+    importlib.reload(compliance_signing_module)
+    compliance_signing_module.reset_signer_cache_for_tests()
+
+
 def _clear_rate_limit_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AGENT_BOM_RATE_LIMIT_KEY", raising=False)
     monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_KEY", raising=False)

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -8,11 +8,16 @@ Covers:
 
 from __future__ import annotations
 
+import importlib
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from starlette.testclient import TestClient
 
+from agent_bom.api import audit_log as audit_log_module
+from agent_bom.api import compliance_signing as compliance_signing_module
 from agent_bom.api import server as _server_mod
 from agent_bom.api.middleware import APIKeyMiddleware, get_rate_limit_key_status, get_rate_limit_runtime_status
 from agent_bom.api.server import app
@@ -114,6 +119,8 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_rate_limit_env(monkeypatch)
     monkeypatch.setenv("AGENT_BOM_RATE_LIMIT_KEY", "secret-key")
     _reload_config()
+    importlib.reload(audit_log_module)
+    compliance_signing_module.reset_signer_cache_for_tests()
 
     client = TestClient(app)
     resp = client.get("/v1/auth/policy")
@@ -132,6 +139,8 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "shared_across_replicas" in body["rate_limit_runtime"]
     assert "configured_api_replicas" in body["rate_limit_runtime"]
     assert "fail_closed" in body["rate_limit_runtime"]
+    assert body["secret_integrity"]["audit_hmac"]["status"] in {"configured", "ephemeral"}
+    assert body["secret_integrity"]["compliance_signing"]["algorithm"] in {"HMAC-SHA256", "Ed25519"}
     assert body["tenant_quotas"]["active_scan_jobs"] >= 1
     assert body["tenant_quotas"]["retained_scan_jobs"] >= 1
     assert body["tenant_quotas"]["fleet_agents"] >= 1
@@ -143,6 +152,41 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["identity_provisioning"]["scim"]["status"] == "not_implemented"
     assert body["identity_provisioning"]["scim"]["supported"] is False
     assert "service_keys" in body["identity_provisioning"]["session_revocation"]
+
+
+def test_auth_policy_reports_secret_integrity_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "audit-secret")
+    private_key = Ed25519PrivateKey.generate()
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", pem)
+    _reload_config()
+    importlib.reload(audit_log_module)
+    importlib.reload(compliance_signing_module)
+    compliance_signing_module.reset_signer_cache_for_tests()
+
+    client = TestClient(app)
+    body = client.get("/v1/auth/policy").json()
+
+    assert body["secret_integrity"]["audit_hmac"] == {
+        "status": "configured",
+        "configured": True,
+        "required": False,
+        "source": "AGENT_BOM_AUDIT_HMAC_KEY",
+        "persists_across_restart": True,
+        "rotation_tracking_supported": False,
+        "message": (
+            "Audit log tamper detection uses a configured shared secret. "
+            "Signatures remain verifiable across restarts as long as the same key stays in place."
+        ),
+    }
+    assert body["secret_integrity"]["compliance_signing"]["algorithm"] == "Ed25519"
+    assert body["secret_integrity"]["compliance_signing"]["mode"] == "asymmetric_public_key"
+    assert body["secret_integrity"]["compliance_signing"]["public_key_endpoint"] == "/v1/compliance/verification-key"
 
 
 def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_compliance_signing.py
+++ b/tests/test_compliance_signing.py
@@ -22,6 +22,7 @@ from starlette.testclient import TestClient
 from agent_bom.api import stores as _stores
 from agent_bom.api.compliance_signing import (
     describe_current_signer,
+    describe_signing_posture,
     reset_signer_cache_for_tests,
     sign_compliance_bundle,
 )
@@ -179,3 +180,15 @@ def test_malformed_pem_falls_back_to_hmac(monkeypatch: pytest.MonkeyPatch, clean
     assert algorithm == "HMAC-SHA256"
     assert key_id is None
     assert pem is None
+
+
+def test_describe_signing_posture_reports_ed25519(monkeypatch: pytest.MonkeyPatch, clean_signer_env: None) -> None:
+    pem, _ = _generate_ed25519_pem()
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", pem)
+    reset_signer_cache_for_tests()
+
+    posture = describe_signing_posture()
+    assert posture["algorithm"] == "Ed25519"
+    assert posture["mode"] == "asymmetric_public_key"
+    assert posture["auditor_distributable"] is True
+    assert posture["public_key_endpoint"] == "/v1/compliance/verification-key"

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -508,6 +508,28 @@ export function KeyLifecyclePanel({
           </div>
 
           <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Secret and integrity posture</p>
+            <div className="mt-3 grid gap-3 lg:grid-cols-2">
+              <BoundaryCard
+                title="Audit HMAC"
+                body={policy.secret_integrity.audit_hmac.message}
+                accent="teal"
+                detail={`${policy.secret_integrity.audit_hmac.status.replaceAll("_", " ")} · ${policy.secret_integrity.audit_hmac.source}${
+                  policy.secret_integrity.audit_hmac.persists_across_restart ? " · survives restart" : " · resets on restart"
+                }`}
+              />
+              <BoundaryCard
+                title="Compliance evidence signing"
+                body={policy.secret_integrity.compliance_signing.message}
+                accent="teal"
+                detail={`${policy.secret_integrity.compliance_signing.algorithm} · ${policy.secret_integrity.compliance_signing.mode.replaceAll("_", " ")}${
+                  policy.secret_integrity.compliance_signing.key_id ? ` · key ${policy.secret_integrity.compliance_signing.key_id}` : ""
+                }${policy.secret_integrity.compliance_signing.public_key_endpoint ? ` · ${policy.secret_integrity.compliance_signing.public_key_endpoint}` : ""}`}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
             <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Identity lifecycle</p>
             <div className="mt-3 grid gap-3 lg:grid-cols-2">
               <BoundaryCard
@@ -653,11 +675,34 @@ function MetricCard({ label, value, hint }: { label: string; value: string; hint
   );
 }
 
-function BoundaryCard({ title, body }: { title: string; body: string }) {
+function BoundaryCard({
+  title,
+  body,
+  detail,
+  accent = "amber",
+}: {
+  title: string;
+  body: string;
+  detail?: string;
+  accent?: "amber" | "teal";
+}) {
+  const tone =
+    accent === "teal"
+      ? {
+          border: "border-teal-900/30",
+          title: "text-teal-100",
+          detail: "text-teal-200/70",
+        }
+      : {
+          border: "border-amber-900/30",
+          title: "text-amber-100",
+          detail: "text-amber-200/70",
+        };
   return (
-    <div className="rounded-xl border border-amber-900/30 bg-zinc-950/50 p-3">
-      <p className="text-sm font-semibold text-amber-100">{title}</p>
+    <div className={`rounded-xl border bg-zinc-950/50 p-3 ${tone.border}`}>
+      <p className={`text-sm font-semibold ${tone.title}`}>{title}</p>
       <p className="mt-1 text-xs leading-5 text-zinc-300">{body}</p>
+      {detail ? <p className={`mt-2 text-[11px] uppercase tracking-[0.14em] ${tone.detail}`}>{detail}</p> : null}
     </div>
   );
 }

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -565,6 +565,28 @@ export interface AuthPolicyResponse {
     fail_closed: boolean;
     message: string;
   };
+  secret_integrity: {
+    audit_hmac: {
+      status: string;
+      configured: boolean;
+      required: boolean;
+      source: string;
+      persists_across_restart: boolean;
+      rotation_tracking_supported: boolean;
+      message: string;
+    };
+    compliance_signing: {
+      algorithm: string;
+      mode: string;
+      configured: boolean;
+      key_id: string | null;
+      public_key_endpoint: string | null;
+      auditor_distributable: boolean;
+      uses_audit_hmac_secret: boolean;
+      persists_across_restart: boolean;
+      message: string;
+    };
+  };
   tenant_quotas: {
     active_scan_jobs: number;
     retained_scan_jobs: number;

--- a/ui/tests/key-lifecycle-panel.test.tsx
+++ b/ui/tests/key-lifecycle-panel.test.tsx
@@ -35,6 +35,28 @@ const policy: AuthPolicyResponse = {
     fail_closed: true,
     message: "Shared rate limiting is enabled across replicas.",
   },
+  secret_integrity: {
+    audit_hmac: {
+      status: "configured",
+      configured: true,
+      required: false,
+      source: "AGENT_BOM_AUDIT_HMAC_KEY",
+      persists_across_restart: true,
+      rotation_tracking_supported: false,
+      message: "Audit log tamper detection uses a configured shared secret.",
+    },
+    compliance_signing: {
+      algorithm: "Ed25519",
+      mode: "asymmetric_public_key",
+      configured: true,
+      key_id: "deadbeefcafebabe",
+      public_key_endpoint: "/v1/compliance/verification-key",
+      auditor_distributable: true,
+      uses_audit_hmac_secret: false,
+      persists_across_restart: true,
+      message: "Compliance evidence bundles are signed with Ed25519.",
+    },
+  },
   tenant_quotas: {
     active_scan_jobs: 10,
     retained_scan_jobs: 100,
@@ -105,6 +127,12 @@ describe("KeyLifecyclePanel", () => {
     expect(screen.getByText("Active scan jobs")).toBeInTheDocument();
     expect(screen.getByText("5000")).toBeInTheDocument();
     expect(screen.getByText("Current 48 · Remaining 4952")).toBeInTheDocument();
+    expect(screen.getByText("Secret and integrity posture")).toBeInTheDocument();
+    expect(screen.getByText("Audit HMAC")).toBeInTheDocument();
+    expect(screen.getByText("Compliance evidence signing")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ed25519 · asymmetric public key · key deadbeefcafebabe · /v1/compliance/verification-key")
+    ).toBeInTheDocument();
     expect(screen.getByText("Identity lifecycle")).toBeInTheDocument();
     expect(screen.getByText("SCIM provisioning")).toBeInTheDocument();
     expect(screen.getByText("Revocation boundaries")).toBeInTheDocument();


### PR DESCRIPTION
Summary
- surface audit HMAC posture and compliance bundle signing posture through `/v1/auth/policy`
- add a dedicated secret/integrity section to the key lifecycle panel so operators can see whether integrity survives restart and whether evidence signing is auditor-distributable
- harden audit HMAC env handling so blank `AGENT_BOM_AUDIT_HMAC_KEY` values are treated as unset instead of as a configured empty secret

Why
The auth/operator surface already covered API keys, rate limiting, quotas, and identity status, but it did not expose the remaining integrity-critical pieces operators need to reason about: audit HMAC durability and compliance signing mode. That left a real visibility gap in the enterprise auth and runtime story.

Impact
- operators can distinguish configured audit integrity from ephemeral process-local integrity
- operators can see whether compliance evidence is signed with shared-secret HMAC or auditor-safe Ed25519
- the UI and API now describe these trust boundaries consistently

Validation
- pytest -q tests/test_api_operator_policy.py tests/test_compliance_signing.py -q
- npm test -- --run tests/key-lifecycle-panel.test.tsx
- uv run ruff check src/agent_bom/api/audit_log.py src/agent_bom/api/compliance_signing.py src/agent_bom/api/routes/enterprise.py tests/test_api_operator_policy.py tests/test_compliance_signing.py

Issue
- Part of #1750
