### PR TITLE
feat(auth): surface identity provider posture

### DIFF
--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -384,6 +384,11 @@ def oidc_enabled_from_env() -> bool:
     return bool(os.environ.get("AGENT_BOM_OIDC_ISSUER", "").strip() or os.environ.get("AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON", "").strip())
 
 
+def _issuer_host(value: str) -> str:
+    parsed = urlparse(value)
+    return parsed.netloc or parsed.path or value
+
+
 # ── OIDCConfig helper ──────────────────────────────────────────────────────────
 
 
@@ -590,3 +595,69 @@ class OIDCConfig:
                 providers[normalized_tenant] = provider
             return cls(tenant_providers=providers)
         return cls()
+
+
+def describe_oidc_posture() -> dict[str, object]:
+    """Return operator-facing OIDC posture for auth policy surfaces."""
+    try:
+        config = OIDCConfig.from_env()
+    except OIDCError as exc:
+        return {
+            "supported": True,
+            "configured": False,
+            "mode": "invalid",
+            "issuer_hosts": [],
+            "provider_count": 0,
+            "audience_configured": False,
+            "role_claim": None,
+            "tenant_claim": None,
+            "require_role_claim": False,
+            "require_tenant_claim": False,
+            "allow_default_tenant": False,
+            "required_nonce": False,
+            "message": str(exc),
+        }
+
+    if not config.enabled:
+        return {
+            "supported": True,
+            "configured": False,
+            "mode": "disabled",
+            "issuer_hosts": [],
+            "provider_count": 0,
+            "audience_configured": False,
+            "role_claim": None,
+            "tenant_claim": None,
+            "require_role_claim": False,
+            "require_tenant_claim": False,
+            "allow_default_tenant": False,
+            "required_nonce": False,
+            "message": (
+                "OIDC bearer auth is not configured. For browser access, the preferred production posture remains "
+                "same-origin reverse-proxy OIDC with trusted header injection."
+            ),
+        }
+
+    providers = list(config.tenant_providers.values()) if config.tenant_providers else [config]
+    primary = providers[0]
+    mode = "tenant_bound" if config.tenant_providers else "single_issuer"
+    issuer_hosts = sorted({_issuer_host(provider.issuer) for provider in providers if provider.issuer})
+    return {
+        "supported": True,
+        "configured": True,
+        "mode": mode,
+        "issuer_hosts": issuer_hosts,
+        "provider_count": len(providers),
+        "audience_configured": all(bool(provider.audience) for provider in providers),
+        "role_claim": primary.role_claim,
+        "tenant_claim": primary.tenant_claim,
+        "require_role_claim": any(provider.require_role_claim for provider in providers),
+        "require_tenant_claim": all(provider.require_tenant_claim for provider in providers),
+        "allow_default_tenant": any(provider.allow_default_tenant for provider in providers),
+        "required_nonce": any(bool(provider.required_nonce) for provider in providers),
+        "message": (
+            "OIDC bearer auth is enabled with tenant-bound issuers and fail-closed tenant routing."
+            if config.tenant_providers
+            else "OIDC bearer auth is enabled for a single issuer."
+        ),
+    }

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -228,6 +228,8 @@ async def auth_policy(request: Request) -> dict:
         get_rate_limit_key_status,
         get_rate_limit_runtime_status,
     )
+    from agent_bom.api.oidc import describe_oidc_posture
+    from agent_bom.api.saml import describe_saml_posture
     from agent_bom.api.tenant_quota import default_tenant_quotas, get_tenant_quota_runtime
 
     api_policy = get_api_key_policy()
@@ -265,6 +267,8 @@ async def auth_policy(request: Request) -> dict:
         "tenant_quotas": defaults,
         "tenant_quota_runtime": get_tenant_quota_runtime(tenant_id),
         "identity_provisioning": {
+            "oidc": describe_oidc_posture(),
+            "saml": describe_saml_posture(),
             "scim": {
                 "supported": False,
                 "configured": False,

--- a/src/agent_bom/api/saml.py
+++ b/src/agent_bom/api/saml.py
@@ -241,3 +241,40 @@ class SAMLConfig:
     @classmethod
     def from_env(cls) -> "SAMLConfig":
         return cls()
+
+
+def describe_saml_posture() -> dict[str, object]:
+    """Return operator-facing SAML posture for auth policy surfaces."""
+    config = SAMLConfig.from_env()
+    if not config.enabled:
+        return {
+            "supported": True,
+            "configured": False,
+            "metadata_endpoint": "/v1/auth/saml/metadata",
+            "acs_path": None,
+            "idp_host": None,
+            "role_attribute": config.role_attribute,
+            "tenant_attribute": config.tenant_attribute,
+            "require_role_attribute": config.require_role_attribute,
+            "require_tenant_attribute": config.require_tenant_attribute,
+            "session_ttl_seconds": config.session_ttl_seconds,
+            "message": (
+                "SAML assertion exchange is not configured. When enabled, agent-bom verifies the IdP assertion and mints "
+                "a short-lived session API key for the UI."
+            ),
+        }
+
+    acs = urlparse(config.sp_acs_url)
+    return {
+        "supported": True,
+        "configured": True,
+        "metadata_endpoint": "/v1/auth/saml/metadata",
+        "acs_path": acs.path or "/v1/auth/saml/login",
+        "idp_host": urlparse(config.idp_sso_url).netloc or config.idp_sso_url,
+        "role_attribute": config.role_attribute,
+        "tenant_attribute": config.tenant_attribute,
+        "require_role_attribute": config.require_role_attribute,
+        "require_tenant_attribute": config.require_tenant_attribute,
+        "session_ttl_seconds": config.session_ttl_seconds,
+        "message": "SAML assertion exchange is enabled and mints short-lived session API keys after IdP verification.",
+    }

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -165,6 +165,8 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["limit"] >= 1
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["source"] == "global_default"
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["override_limit"] is None
+    assert body["identity_provisioning"]["oidc"]["mode"] == "disabled"
+    assert body["identity_provisioning"]["saml"]["configured"] is False
     assert body["identity_provisioning"]["scim"]["status"] == "not_implemented"
     assert body["identity_provisioning"]["scim"]["supported"] is False
     assert "service_keys" in body["identity_provisioning"]["session_revocation"]
@@ -239,6 +241,33 @@ def test_auth_quota_update_persists_tenant_override(monkeypatch: pytest.MonkeyPa
         assert policy["tenant_quota_runtime"]["usage"]["schedules"]["limit"] == 3
     finally:
         _stores._tenant_quota_store = original_store
+
+
+def test_auth_policy_reports_identity_provider_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_OIDC_ISSUER", "https://login.example.com")
+    monkeypatch.setenv("AGENT_BOM_OIDC_AUDIENCE", "agent-bom")
+    monkeypatch.setenv("AGENT_BOM_OIDC_REQUIRE_ROLE_CLAIM", "1")
+    monkeypatch.setenv("AGENT_BOM_SAML_IDP_ENTITY_ID", "https://idp.example.com/metadata")
+    monkeypatch.setenv("AGENT_BOM_SAML_IDP_SSO_URL", "https://idp.example.com/sso")
+    monkeypatch.setenv("AGENT_BOM_SAML_IDP_X509_CERT", "-----BEGIN CERTIFICATE-----test-----END CERTIFICATE-----")
+    monkeypatch.setenv("AGENT_BOM_SAML_SP_ENTITY_ID", "https://agent-bom.example.com/saml/metadata")
+    monkeypatch.setenv("AGENT_BOM_SAML_SP_ACS_URL", "https://agent-bom.example.com/v1/auth/saml/login")
+    monkeypatch.setenv("AGENT_BOM_SAML_SESSION_TTL_SECONDS", "1800")
+
+    client = TestClient(app)
+    body = client.get("/v1/auth/policy").json()
+
+    assert body["identity_provisioning"]["oidc"]["configured"] is True
+    assert body["identity_provisioning"]["oidc"]["mode"] == "single_issuer"
+    assert body["identity_provisioning"]["oidc"]["issuer_hosts"] == ["login.example.com"]
+    assert body["identity_provisioning"]["oidc"]["provider_count"] == 1
+    assert body["identity_provisioning"]["oidc"]["require_role_claim"] is True
+    assert body["identity_provisioning"]["oidc"]["require_tenant_claim"] is True
+    assert body["identity_provisioning"]["saml"]["configured"] is True
+    assert body["identity_provisioning"]["saml"]["metadata_endpoint"] == "/v1/auth/saml/metadata"
+    assert body["identity_provisioning"]["saml"]["acs_path"] == "/v1/auth/saml/login"
+    assert body["identity_provisioning"]["saml"]["idp_host"] == "idp.example.com"
+    assert body["identity_provisioning"]["saml"]["session_ttl_seconds"] == 1800
 
 
 def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -643,7 +643,21 @@ export function KeyLifecyclePanel({
 
           <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
             <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Identity lifecycle</p>
-            <div className="mt-3 grid gap-3 lg:grid-cols-2">
+            <div className="mt-3 grid gap-3 lg:grid-cols-3">
+              <BoundaryCard
+                title="OIDC browser / bearer"
+                body={policy.identity_provisioning.oidc.message}
+                detail={`${formatModeLabel(policy.identity_provisioning.oidc.mode)} · ${policy.identity_provisioning.oidc.provider_count} issuer${
+                  policy.identity_provisioning.oidc.provider_count === 1 ? "" : "s"
+                } · ${policy.identity_provisioning.oidc.require_tenant_claim ? "tenant claim required" : "default tenant allowed"}`}
+              />
+              <BoundaryCard
+                title="SAML assertion exchange"
+                body={policy.identity_provisioning.saml.message}
+                detail={`${policy.identity_provisioning.saml.metadata_endpoint}${
+                  policy.identity_provisioning.saml.acs_path ? ` · ${policy.identity_provisioning.saml.acs_path}` : ""
+                } · ${formatSeconds(policy.identity_provisioning.saml.session_ttl_seconds)} session`}
+              />
               <BoundaryCard
                 title="SCIM provisioning"
                 body={policy.identity_provisioning.scim.message}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -614,6 +614,34 @@ export interface AuthPolicyResponse {
     >;
   };
   identity_provisioning: {
+    oidc: {
+      supported: boolean;
+      configured: boolean;
+      mode: string;
+      issuer_hosts: string[];
+      provider_count: number;
+      audience_configured: boolean;
+      role_claim: string | null;
+      tenant_claim: string | null;
+      require_role_claim: boolean;
+      require_tenant_claim: boolean;
+      allow_default_tenant: boolean;
+      required_nonce: boolean;
+      message: string;
+    };
+    saml: {
+      supported: boolean;
+      configured: boolean;
+      metadata_endpoint: string;
+      acs_path: string | null;
+      idp_host: string | null;
+      role_attribute: string;
+      tenant_attribute: string;
+      require_role_attribute: boolean;
+      require_tenant_attribute: boolean;
+      session_ttl_seconds: number;
+      message: string;
+    };
     scim: {
       supported: boolean;
       configured: boolean;

--- a/ui/tests/key-lifecycle-panel.test.tsx
+++ b/ui/tests/key-lifecycle-panel.test.tsx
@@ -78,6 +78,34 @@ const policy: AuthPolicyResponse = {
     },
   },
   identity_provisioning: {
+    oidc: {
+      supported: true,
+      configured: true,
+      mode: "single_issuer",
+      issuer_hosts: ["login.example.com"],
+      provider_count: 1,
+      audience_configured: true,
+      role_claim: "agent_bom_role",
+      tenant_claim: "tenant_id",
+      require_role_claim: true,
+      require_tenant_claim: true,
+      allow_default_tenant: false,
+      required_nonce: false,
+      message: "OIDC bearer auth is enabled for a single issuer.",
+    },
+    saml: {
+      supported: true,
+      configured: true,
+      metadata_endpoint: "/v1/auth/saml/metadata",
+      acs_path: "/v1/auth/saml/login",
+      idp_host: "idp.example.com",
+      role_attribute: "agent_bom_role",
+      tenant_attribute: "tenant_id",
+      require_role_attribute: false,
+      require_tenant_attribute: false,
+      session_ttl_seconds: 3600,
+      message: "SAML assertion exchange is enabled and mints short-lived session API keys after IdP verification.",
+    },
     scim: {
       supported: false,
       configured: false,
@@ -141,6 +169,8 @@ describe("KeyLifecyclePanel", () => {
       screen.getByText("Ed25519 · asymmetric public key · key deadbeefcafebabe · /v1/compliance/verification-key")
     ).toBeInTheDocument();
     expect(screen.getByText("Identity lifecycle")).toBeInTheDocument();
+    expect(screen.getByText("OIDC browser / bearer")).toBeInTheDocument();
+    expect(screen.getByText("SAML assertion exchange")).toBeInTheDocument();
     expect(screen.getByText("SCIM provisioning")).toBeInTheDocument();
     expect(screen.getByText("Revocation boundaries")).toBeInTheDocument();
     expect(screen.getByText("OIDC or reverse-proxy browser sessions must be terminated at the upstream identity provider or trusted proxy.")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- expose operator-facing OIDC posture in `/v1/auth/policy`, including mode, issuer count, claim requirements, and tenant-routing stance
- expose operator-facing SAML posture in `/v1/auth/policy`, including metadata/ACS paths, attribute mapping, and session TTL
- extend the key lifecycle panel to show the active OIDC and SAML identity paths alongside SCIM and revocation boundaries

## Why
The auth surface already explained revocation and SCIM status, but it still hid the actual identity providers and claim posture that are doing the work today. This closes the remaining identity-visibility gap in `#1750` without overstating SCIM support.

## Validation
- `pytest -q tests/test_api_operator_policy.py tests/test_api_oidc.py tests/test_api_saml.py -q`
- `uv run ruff check src/agent_bom/api/oidc.py src/agent_bom/api/saml.py src/agent_bom/api/routes/enterprise.py tests/test_api_operator_policy.py`
- `npm test -- --run tests/key-lifecycle-panel.test.tsx`
- `npm run build`

## Issue
Part of #1750
