### PR TITLE
feat(auth): add scim configuration posture

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -336,6 +336,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("GET", "/v1/auth/debug", "viewer"),
         ("GET", "/v1/auth/me", "viewer"),
         ("GET", "/v1/auth/policy", "admin"),
+        ("GET", "/v1/auth/scim/config", "admin"),
         ("GET", "/v1/auth/quota", "admin"),
         ("GET", "/v1/auth/keys", "admin"),
         ("PUT", "/v1/auth/quota", "admin"),
@@ -379,6 +380,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
     _SCOPE_RULES: tuple[tuple[str, str, str], ...] = (
         ("GET", "/v1/auth/keys", "auth.keys:read"),
+        ("GET", "/v1/auth/scim/config", "auth.scim:read"),
         ("GET", "/v1/auth/quota", "auth.quota:read"),
         ("POST", "/v1/auth/keys", "auth.keys:write"),
         ("POST", "/v1/auth/keys/", "auth.keys:write"),

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -230,6 +230,7 @@ async def auth_policy(request: Request) -> dict:
     )
     from agent_bom.api.oidc import describe_oidc_posture
     from agent_bom.api.saml import describe_saml_posture
+    from agent_bom.api.scim import describe_scim_posture
     from agent_bom.api.tenant_quota import default_tenant_quotas, get_tenant_quota_runtime
 
     api_policy = get_api_key_policy()
@@ -269,15 +270,7 @@ async def auth_policy(request: Request) -> dict:
         "identity_provisioning": {
             "oidc": describe_oidc_posture(),
             "saml": describe_saml_posture(),
-            "scim": {
-                "supported": False,
-                "configured": False,
-                "status": "not_implemented",
-                "message": (
-                    "SCIM provisioning is not implemented yet. User and group lifecycle still depends on the upstream "
-                    "identity provider, reverse proxy, or manual API-key administration."
-                ),
-            },
+            "scim": describe_scim_posture(),
             "session_revocation": {
                 "service_keys": "API key revocation takes effect immediately at the control-plane auth layer.",
                 "session_api_key": (
@@ -289,6 +282,14 @@ async def auth_policy(request: Request) -> dict:
             },
         },
     }
+
+
+@router.get("/v1/auth/scim/config", tags=["enterprise"])
+async def auth_scim_config() -> dict:
+    """Return the operator-facing SCIM configuration posture."""
+    from agent_bom.api.scim import describe_scim_posture
+
+    return describe_scim_posture()
 
 
 @router.get("/v1/auth/quota", tags=["enterprise"])

--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -1,0 +1,44 @@
+"""SCIM configuration posture for enterprise auth surfaces."""
+
+from __future__ import annotations
+
+import os
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def describe_scim_posture() -> dict[str, object]:
+    """Return operator-facing SCIM configuration posture.
+
+    This is intentionally a control-plane posture surface, not a claim that
+    full SCIM provisioning is implemented end to end.
+    """
+
+    token = os.environ.get("AGENT_BOM_SCIM_BEARER_TOKEN", "").strip()
+    base_path = os.environ.get("AGENT_BOM_SCIM_BASE_PATH", "").strip() or "/scim/v2"
+    role_attribute = os.environ.get("AGENT_BOM_SCIM_ROLE_ATTRIBUTE", "").strip() or "agent_bom_role"
+    tenant_attribute = os.environ.get("AGENT_BOM_SCIM_TENANT_ATTRIBUTE", "").strip() or "tenant_id"
+    external_id_attribute = os.environ.get("AGENT_BOM_SCIM_EXTERNAL_ID_ATTRIBUTE", "").strip() or "externalId"
+    groups_required = _env_flag("AGENT_BOM_SCIM_REQUIRE_GROUPS")
+
+    configured = bool(token)
+    return {
+        "supported": True,
+        "configured": configured,
+        "status": "configured" if configured else "disabled",
+        "base_path": base_path,
+        "token_configured": configured,
+        "external_id_attribute": external_id_attribute,
+        "role_attribute": role_attribute,
+        "tenant_attribute": tenant_attribute,
+        "groups_required": groups_required,
+        "message": (
+            "SCIM provisioning bootstrap is configured. Control-plane posture now exposes the expected token and attribute "
+            "mapping contract, but full user and group lifecycle enforcement is still a follow-on."
+            if configured
+            else "SCIM provisioning is not configured. User and group lifecycle still depends on the upstream identity "
+            "provider, reverse proxy, or manual API-key administration."
+        ),
+    }

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -167,8 +167,10 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["override_limit"] is None
     assert body["identity_provisioning"]["oidc"]["mode"] == "disabled"
     assert body["identity_provisioning"]["saml"]["configured"] is False
-    assert body["identity_provisioning"]["scim"]["status"] == "not_implemented"
-    assert body["identity_provisioning"]["scim"]["supported"] is False
+    assert body["identity_provisioning"]["scim"]["status"] == "disabled"
+    assert body["identity_provisioning"]["scim"]["supported"] is True
+    assert body["identity_provisioning"]["scim"]["base_path"] == "/scim/v2"
+    assert body["identity_provisioning"]["scim"]["token_configured"] is False
     assert "service_keys" in body["identity_provisioning"]["session_revocation"]
 
 
@@ -270,6 +272,27 @@ def test_auth_policy_reports_identity_provider_posture(monkeypatch: pytest.Monke
     assert body["identity_provisioning"]["saml"]["session_ttl_seconds"] == 1800
 
 
+def test_auth_policy_reports_scim_configuration_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "super-secret")
+    monkeypatch.setenv("AGENT_BOM_SCIM_BASE_PATH", "/scim/v2")
+    monkeypatch.setenv("AGENT_BOM_SCIM_ROLE_ATTRIBUTE", "roles")
+    monkeypatch.setenv("AGENT_BOM_SCIM_TENANT_ATTRIBUTE", "organization_id")
+    monkeypatch.setenv("AGENT_BOM_SCIM_EXTERNAL_ID_ATTRIBUTE", "employeeNumber")
+    monkeypatch.setenv("AGENT_BOM_SCIM_REQUIRE_GROUPS", "1")
+
+    client = TestClient(app)
+    body = client.get("/v1/auth/policy").json()
+
+    assert body["identity_provisioning"]["scim"]["configured"] is True
+    assert body["identity_provisioning"]["scim"]["status"] == "configured"
+    assert body["identity_provisioning"]["scim"]["base_path"] == "/scim/v2"
+    assert body["identity_provisioning"]["scim"]["token_configured"] is True
+    assert body["identity_provisioning"]["scim"]["role_attribute"] == "roles"
+    assert body["identity_provisioning"]["scim"]["tenant_attribute"] == "organization_id"
+    assert body["identity_provisioning"]["scim"]["external_id_attribute"] == "employeeNumber"
+    assert body["identity_provisioning"]["scim"]["groups_required"] is True
+
+
 def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://example/test")
     monkeypatch.setenv("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT", "1")
@@ -305,6 +328,7 @@ def test_rate_limit_runtime_reports_single_replica_process_local_backend(monkeyp
 def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
     middleware = APIKeyMiddleware(app, api_key="static-secret")
     assert middleware._required_role("GET", "/v1/auth/policy") == "admin"
+    assert middleware._required_role("GET", "/v1/auth/scim/config") == "admin"
     assert middleware._required_role("PUT", "/v1/auth/quota") == "admin"
     assert middleware._required_role("DELETE", "/v1/auth/quota") == "admin"
     assert middleware._required_role("GET", "/v1/auth/debug") == "viewer"

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -661,10 +661,15 @@ export function KeyLifecyclePanel({
               <BoundaryCard
                 title="SCIM provisioning"
                 body={policy.identity_provisioning.scim.message}
+                detail={`${policy.identity_provisioning.scim.status.replaceAll("_", " ")} · ${policy.identity_provisioning.scim.base_path} · ${
+                  policy.identity_provisioning.scim.token_configured ? "token configured" : "token missing"
+                }`}
               />
               <BoundaryCard
                 title="Provisioning posture"
-                body={`${policy.identity_provisioning.scim.status.replaceAll("_", " ")}${policy.identity_provisioning.scim.configured ? " · configured" : " · not configured yet"}`}
+                body={`Role ${policy.identity_provisioning.scim.role_attribute} · tenant ${policy.identity_provisioning.scim.tenant_attribute} · external ID ${policy.identity_provisioning.scim.external_id_attribute}${
+                  policy.identity_provisioning.scim.groups_required ? " · groups required" : ""
+                }`}
               />
             </div>
           </section>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -646,6 +646,12 @@ export interface AuthPolicyResponse {
       supported: boolean;
       configured: boolean;
       status: string;
+      base_path: string;
+      token_configured: boolean;
+      external_id_attribute: string;
+      role_attribute: string;
+      tenant_attribute: string;
+      groups_required: boolean;
       message: string;
     };
     session_revocation: {

--- a/ui/tests/key-lifecycle-panel.test.tsx
+++ b/ui/tests/key-lifecycle-panel.test.tsx
@@ -107,10 +107,16 @@ const policy: AuthPolicyResponse = {
       message: "SAML assertion exchange is enabled and mints short-lived session API keys after IdP verification.",
     },
     scim: {
-      supported: false,
-      configured: false,
-      status: "not_implemented",
-      message: "SCIM provisioning is not implemented yet.",
+      supported: true,
+      configured: true,
+      status: "configured",
+      base_path: "/scim/v2",
+      token_configured: true,
+      external_id_attribute: "externalId",
+      role_attribute: "agent_bom_role",
+      tenant_attribute: "tenant_id",
+      groups_required: false,
+      message: "SCIM provisioning bootstrap is configured.",
     },
     session_revocation: {
       service_keys: "API key revocation takes effect immediately at the control-plane auth layer.",
@@ -172,6 +178,8 @@ describe("KeyLifecyclePanel", () => {
     expect(screen.getByText("OIDC browser / bearer")).toBeInTheDocument();
     expect(screen.getByText("SAML assertion exchange")).toBeInTheDocument();
     expect(screen.getByText("SCIM provisioning")).toBeInTheDocument();
+    expect(screen.getByText("configured · /scim/v2 · token configured")).toBeInTheDocument();
+    expect(screen.getByText("Role agent_bom_role · tenant tenant_id · external ID externalId")).toBeInTheDocument();
     expect(screen.getByText("Revocation boundaries")).toBeInTheDocument();
     expect(screen.getByText("OIDC or reverse-proxy browser sessions must be terminated at the upstream identity provider or trusted proxy.")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add a dedicated SCIM posture helper that reports configured token/path/attribute state without leaking secrets
- expose that SCIM posture through `/v1/auth/policy` and a new admin endpoint at `/v1/auth/scim/config`
- update the key lifecycle panel to show the active SCIM bootstrap contract instead of a hardcoded placeholder

## Why
`#1750` still had SCIM represented as a fixed "not implemented" placeholder even after the broader auth/operator surfaces matured. This makes the SCIM story explicit and testable without overstating that full user/group provisioning is already complete.

## Validation
- `pytest -q tests/test_api_operator_policy.py -q`
- `uv run ruff check src/agent_bom/api/scim.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/middleware.py tests/test_api_operator_policy.py`
- `npm test -- --run tests/key-lifecycle-panel.test.tsx`
- `npm run build`

## Issue
Part of #1750
