### PR TITLE
feat(auth): surface secret rotation posture

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -34,6 +34,106 @@ def _env_enabled(name: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _env_int(name: str) -> int | None:
+    value = (os.environ.get(name) or "").strip()
+    if not value:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _describe_rotation_posture(
+    *,
+    configured: bool,
+    last_rotated_env: str,
+    rotation_days_env: str,
+    max_age_days_env: str,
+    subject: str,
+    not_configured_status: str,
+    not_configured_message: str,
+) -> dict[str, object]:
+    rotation_days = _env_int(rotation_days_env)
+    max_age_days = _env_int(max_age_days_env)
+    raw_last_rotated = (os.environ.get(last_rotated_env) or "").strip()
+
+    if not configured:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": not_configured_status,
+            "rotation_method": "env_swap_and_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": None,
+            "age_days": None,
+            "rotation_message": not_configured_message,
+        }
+
+    if not raw_last_rotated:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": "unknown_age",
+            "rotation_method": "env_swap_and_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": None,
+            "age_days": None,
+            "rotation_message": (
+                f"{subject} is configured but {last_rotated_env} is unset. Record an ISO-8601 rotation timestamp "
+                "to expose key age in operator surfaces."
+            ),
+        }
+
+    try:
+        rotated = datetime.fromisoformat(raw_last_rotated)
+    except ValueError:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": "unknown_age",
+            "rotation_method": "env_swap_and_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": raw_last_rotated,
+            "age_days": None,
+            "rotation_message": (
+                f"{last_rotated_env} is set but is not a valid ISO-8601 timestamp. Use a value like '2026-04-17T00:00:00+00:00'."
+            ),
+        }
+
+    if rotated.tzinfo is None:
+        rotated = rotated.replace(tzinfo=timezone.utc)
+    age_days = max(0, int((datetime.now(timezone.utc) - rotated).total_seconds() // 86400))
+
+    if max_age_days is not None and age_days >= max_age_days:
+        status = "max_age_exceeded"
+        message = (
+            f"{subject} is {age_days} days old, exceeding the configured maximum ({max_age_days} days). Rotate the "
+            "secret, restart the control plane, and update the recorded rotation timestamp."
+        )
+    elif rotation_days is not None and age_days >= rotation_days:
+        status = "rotation_due"
+        message = f"{subject} is {age_days} days old, past the configured rotation interval ({rotation_days} days)."
+    else:
+        status = "ok"
+        if rotation_days is not None:
+            message = f"{subject} is {age_days} days old; configured rotation interval is {rotation_days} days."
+        else:
+            message = f"{subject} is {age_days} days old. No explicit rotation interval is configured."
+
+    return {
+        "rotation_tracking_supported": True,
+        "rotation_status": status,
+        "rotation_method": "env_swap_and_restart",
+        "rotation_days": rotation_days,
+        "max_age_days": max_age_days,
+        "last_rotated": rotated.isoformat(),
+        "age_days": age_days,
+        "rotation_message": message,
+    }
+
+
 # HMAC key for audit log tamper detection.  When unset, an ephemeral
 # per-process key is generated — signatures verify within the same process
 # but provide no cross-restart integrity.  Production deployments MUST set
@@ -118,18 +218,30 @@ def sign_export_payload(payload: bytes) -> str:
 def describe_audit_hmac_status() -> dict[str, object]:
     """Return operator-facing audit HMAC posture for auth/policy surfaces."""
     required = _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC")
-    if _HMAC_ENV_KEY:
+    configured = bool(_HMAC_ENV_KEY)
+    rotation = _describe_rotation_posture(
+        configured=configured,
+        last_rotated_env="AGENT_BOM_AUDIT_HMAC_LAST_ROTATED",
+        rotation_days_env="AGENT_BOM_AUDIT_HMAC_ROTATION_DAYS",
+        max_age_days_env="AGENT_BOM_AUDIT_HMAC_MAX_AGE_DAYS",
+        subject="Audit HMAC secret",
+        not_configured_status="ephemeral",
+        not_configured_message=(
+            "Audit integrity is currently backed by a process-ephemeral secret, so there is no stable rotation history to track."
+        ),
+    )
+    if configured:
         return {
             "status": "configured",
             "configured": True,
             "required": required,
             "source": "AGENT_BOM_AUDIT_HMAC_KEY",
             "persists_across_restart": True,
-            "rotation_tracking_supported": False,
             "message": (
                 "Audit log tamper detection uses a configured shared secret. "
                 "Signatures remain verifiable across restarts as long as the same key stays in place."
             ),
+            **rotation,
         }
     return {
         "status": "ephemeral",
@@ -137,11 +249,11 @@ def describe_audit_hmac_status() -> dict[str, object]:
         "required": required,
         "source": "process_ephemeral",
         "persists_across_restart": False,
-        "rotation_tracking_supported": False,
         "message": (
             "Audit log tamper detection is using an in-process ephemeral secret. "
             "Integrity checks work only for this process lifetime and reset after restart."
         ),
+        **rotation,
     }
 
 

--- a/src/agent_bom/api/compliance_signing.py
+++ b/src/agent_bom/api/compliance_signing.py
@@ -32,6 +32,7 @@ import hashlib
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Final
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,86 @@ class _Ed25519Signer:
 
 _signer_cache: _Ed25519Signer | None = None
 _signer_init_error: str | None = None
+
+
+def _env_int(name: str) -> int | None:
+    value = (os.environ.get(name) or "").strip()
+    if not value:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _describe_rotation_posture() -> dict[str, object]:
+    rotation_days = _env_int("AGENT_BOM_COMPLIANCE_SIGNING_ROTATION_DAYS")
+    max_age_days = _env_int("AGENT_BOM_COMPLIANCE_SIGNING_MAX_AGE_DAYS")
+    raw_last_rotated = (os.environ.get("AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED") or "").strip()
+
+    if not raw_last_rotated:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": "unknown_age",
+            "rotation_method": "env_swap_and_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": None,
+            "age_days": None,
+            "rotation_message": (
+                "Compliance signing is configured but AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED is unset. "
+                "Record an ISO-8601 rotation timestamp to expose key age in operator surfaces."
+            ),
+        }
+
+    try:
+        rotated = datetime.fromisoformat(raw_last_rotated)
+    except ValueError:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": "unknown_age",
+            "rotation_method": "env_swap_and_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": raw_last_rotated,
+            "age_days": None,
+            "rotation_message": (
+                "AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED is set but is not a valid ISO-8601 timestamp. "
+                "Use a value like '2026-04-17T00:00:00+00:00'."
+            ),
+        }
+
+    if rotated.tzinfo is None:
+        rotated = rotated.replace(tzinfo=timezone.utc)
+    age_days = max(0, int((datetime.now(timezone.utc) - rotated).total_seconds() // 86400))
+
+    if max_age_days is not None and age_days >= max_age_days:
+        status = "max_age_exceeded"
+        message = (
+            f"Compliance signing key is {age_days} days old, exceeding the configured maximum ({max_age_days} days). "
+            "Rotate the signing key, redeploy, and update the recorded rotation timestamp."
+        )
+    elif rotation_days is not None and age_days >= rotation_days:
+        status = "rotation_due"
+        message = f"Compliance signing key is {age_days} days old, past the configured rotation interval ({rotation_days} days)."
+    else:
+        status = "ok"
+        if rotation_days is not None:
+            message = f"Compliance signing key is {age_days} days old; configured rotation interval is {rotation_days} days."
+        else:
+            message = f"Compliance signing key is {age_days} days old. No explicit rotation interval is configured."
+
+    return {
+        "rotation_tracking_supported": True,
+        "rotation_status": status,
+        "rotation_method": "env_swap_and_restart",
+        "rotation_days": rotation_days,
+        "max_age_days": max_age_days,
+        "last_rotated": rotated.isoformat(),
+        "age_days": age_days,
+        "rotation_message": message,
+    }
 
 
 def _load_ed25519_signer() -> _Ed25519Signer | None:
@@ -185,6 +266,7 @@ def describe_signing_posture() -> dict[str, object]:
                 "Compliance evidence bundles are signed with Ed25519. "
                 "External verifiers only need the public key, not shared secret material."
             ),
+            **_describe_rotation_posture(),
         }
 
     from agent_bom.api.audit_log import describe_audit_hmac_status
@@ -202,5 +284,15 @@ def describe_signing_posture() -> dict[str, object]:
         "message": (
             "Compliance evidence bundles are signed with the same shared secret family as the audit export path. "
             "For auditor-distributable verification, switch to Ed25519."
+        ),
+        "rotation_tracking_supported": bool(audit_hmac["rotation_tracking_supported"]),
+        "rotation_status": audit_hmac["rotation_status"],
+        "rotation_method": audit_hmac["rotation_method"],
+        "rotation_days": audit_hmac["rotation_days"],
+        "max_age_days": audit_hmac["max_age_days"],
+        "last_rotated": audit_hmac["last_rotated"],
+        "age_days": audit_hmac["age_days"],
+        "rotation_message": (
+            "Compliance evidence currently inherits audit HMAC rotation posture because HMAC signing reuses the audit secret family."
         ),
     }

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -41,6 +41,12 @@ def _clear_rate_limit_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AGENT_BOM_RATE_LIMIT_KEY", raising=False)
     monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_KEY", raising=False)
     monkeypatch.delenv("AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_LAST_ROTATED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_ROTATION_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_MAX_AGE_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_ROTATION_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_MAX_AGE_DAYS", raising=False)
 
 
 def _reload_config() -> None:
@@ -152,7 +158,23 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "configured_api_replicas" in body["rate_limit_runtime"]
     assert "fail_closed" in body["rate_limit_runtime"]
     assert body["secret_integrity"]["audit_hmac"]["status"] in {"configured", "ephemeral"}
+    assert body["secret_integrity"]["audit_hmac"]["rotation_tracking_supported"] is True
+    assert body["secret_integrity"]["audit_hmac"]["rotation_status"] in {
+        "ok",
+        "unknown_age",
+        "ephemeral",
+        "rotation_due",
+        "max_age_exceeded",
+    }
     assert body["secret_integrity"]["compliance_signing"]["algorithm"] in {"HMAC-SHA256", "Ed25519"}
+    assert body["secret_integrity"]["compliance_signing"]["rotation_tracking_supported"] is True
+    assert body["secret_integrity"]["compliance_signing"]["rotation_status"] in {
+        "ok",
+        "unknown_age",
+        "ephemeral",
+        "rotation_due",
+        "max_age_exceeded",
+    }
     assert body["tenant_quotas"]["active_scan_jobs"] >= 1
     assert body["tenant_quotas"]["retained_scan_jobs"] >= 1
     assert body["tenant_quotas"]["fleet_agents"] >= 1
@@ -175,6 +197,14 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_auth_policy_reports_secret_integrity_posture(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_rate_limit_env(monkeypatch)
     monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "audit-secret")
+    audit_rotated = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    compliance_rotated = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_LAST_ROTATED", audit_rotated)
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_ROTATION_DAYS", "30")
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_MAX_AGE_DAYS", "90")
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED", compliance_rotated)
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_SIGNING_ROTATION_DAYS", "30")
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_SIGNING_MAX_AGE_DAYS", "180")
     private_key = Ed25519PrivateKey.generate()
     pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -190,21 +220,31 @@ def test_auth_policy_reports_secret_integrity_posture(monkeypatch: pytest.Monkey
     client = TestClient(app)
     body = client.get("/v1/auth/policy").json()
 
-    assert body["secret_integrity"]["audit_hmac"] == {
-        "status": "configured",
-        "configured": True,
-        "required": False,
-        "source": "AGENT_BOM_AUDIT_HMAC_KEY",
-        "persists_across_restart": True,
-        "rotation_tracking_supported": False,
-        "message": (
-            "Audit log tamper detection uses a configured shared secret. "
-            "Signatures remain verifiable across restarts as long as the same key stays in place."
-        ),
-    }
-    assert body["secret_integrity"]["compliance_signing"]["algorithm"] == "Ed25519"
-    assert body["secret_integrity"]["compliance_signing"]["mode"] == "asymmetric_public_key"
-    assert body["secret_integrity"]["compliance_signing"]["public_key_endpoint"] == "/v1/compliance/verification-key"
+    audit_hmac = body["secret_integrity"]["audit_hmac"]
+    assert audit_hmac["status"] == "configured"
+    assert audit_hmac["configured"] is True
+    assert audit_hmac["required"] is False
+    assert audit_hmac["source"] == "AGENT_BOM_AUDIT_HMAC_KEY"
+    assert audit_hmac["persists_across_restart"] is True
+    assert audit_hmac["rotation_tracking_supported"] is True
+    assert audit_hmac["rotation_status"] == "ok"
+    assert audit_hmac["rotation_method"] == "env_swap_and_restart"
+    assert audit_hmac["rotation_days"] == 30
+    assert audit_hmac["max_age_days"] == 90
+    assert audit_hmac["last_rotated"] == audit_rotated
+    assert audit_hmac["age_days"] == 10
+
+    signing = body["secret_integrity"]["compliance_signing"]
+    assert signing["algorithm"] == "Ed25519"
+    assert signing["mode"] == "asymmetric_public_key"
+    assert signing["public_key_endpoint"] == "/v1/compliance/verification-key"
+    assert signing["rotation_tracking_supported"] is True
+    assert signing["rotation_status"] == "rotation_due"
+    assert signing["rotation_method"] == "env_swap_and_restart"
+    assert signing["rotation_days"] == 30
+    assert signing["max_age_days"] == 180
+    assert signing["last_rotated"] == compliance_rotated
+    assert signing["age_days"] == 40
 
 
 def test_auth_quota_update_persists_tenant_override(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_compliance_signing.py
+++ b/tests/test_compliance_signing.py
@@ -12,7 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -73,6 +73,9 @@ def _seed_tagged_scan(tenant_id: str = "tenant-alpha") -> InMemoryJobStore:
 @pytest.fixture
 def clean_signer_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_ROTATION_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_MAX_AGE_DAYS", raising=False)
     reset_signer_cache_for_tests()
     yield
     reset_signer_cache_for_tests()
@@ -185,6 +188,10 @@ def test_malformed_pem_falls_back_to_hmac(monkeypatch: pytest.MonkeyPatch, clean
 def test_describe_signing_posture_reports_ed25519(monkeypatch: pytest.MonkeyPatch, clean_signer_env: None) -> None:
     pem, _ = _generate_ed25519_pem()
     monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", pem)
+    rotated = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED", rotated)
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_SIGNING_ROTATION_DAYS", "30")
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_SIGNING_MAX_AGE_DAYS", "180")
     reset_signer_cache_for_tests()
 
     posture = describe_signing_posture()
@@ -192,3 +199,10 @@ def test_describe_signing_posture_reports_ed25519(monkeypatch: pytest.MonkeyPatc
     assert posture["mode"] == "asymmetric_public_key"
     assert posture["auditor_distributable"] is True
     assert posture["public_key_endpoint"] == "/v1/compliance/verification-key"
+    assert posture["rotation_tracking_supported"] is True
+    assert posture["rotation_status"] == "rotation_due"
+    assert posture["rotation_method"] == "env_swap_and_restart"
+    assert posture["rotation_days"] == 30
+    assert posture["max_age_days"] == 180
+    assert posture["last_rotated"] == rotated
+    assert posture["age_days"] == 45

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -110,6 +110,48 @@ function quotaInputValue(value: number | null | undefined): string {
   return value == null ? "" : String(value);
 }
 
+function formatStatusLabel(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function formatCadence(rotationDays: number | null, maxAgeDays: number | null): string | null {
+  const parts = [];
+  if (rotationDays != null) parts.push(`rotate ${rotationDays}d`);
+  if (maxAgeDays != null) parts.push(`max ${maxAgeDays}d`);
+  return parts.length ? parts.join(" · ") : null;
+}
+
+function formatRotationDetail(posture: {
+  rotation_status: string;
+  rotation_method: string;
+  last_rotated: string | null;
+  age_days: number | null;
+  rotation_days: number | null;
+  max_age_days: number | null;
+}): string {
+  return [
+    formatStatusLabel(posture.rotation_status),
+    posture.last_rotated ? `rotated ${formatDate(posture.last_rotated)}` : "timestamp unset",
+    posture.age_days != null ? `${posture.age_days}d old` : null,
+    formatCadence(posture.rotation_days, posture.max_age_days),
+    posture.rotation_method.replaceAll("_", " "),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function formatRateLimitRotationDetail(rateLimit: AuthPolicyResponse["rate_limit_key"]): string {
+  return [
+    formatStatusLabel(rateLimit.status),
+    rateLimit.last_rotated ? `rotated ${formatDate(rateLimit.last_rotated)}` : "timestamp unset",
+    rateLimit.age_days != null ? `${rateLimit.age_days}d old` : null,
+    formatCadence(rateLimit.rotation_days ?? null, rateLimit.max_age_days ?? null),
+    rateLimit.fallback_source ? `fallback ${rateLimit.fallback_source}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
 export function KeyLifecyclePanel({
   loading,
   error,
@@ -637,6 +679,32 @@ export function KeyLifecyclePanel({
                 detail={`${policy.secret_integrity.compliance_signing.algorithm} · ${policy.secret_integrity.compliance_signing.mode.replaceAll("_", " ")}${
                   policy.secret_integrity.compliance_signing.key_id ? ` · key ${policy.secret_integrity.compliance_signing.key_id}` : ""
                 }${policy.secret_integrity.compliance_signing.public_key_endpoint ? ` · ${policy.secret_integrity.compliance_signing.public_key_endpoint}` : ""}`}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Rotation posture</p>
+            <div className="mt-3 grid gap-3 lg:grid-cols-2 xl:grid-cols-4">
+              <BoundaryCard
+                title="Service API keys"
+                body="Service keys rotate through an overlap-aware replacement flow so callers can roll without downtime."
+                detail={`enforced · ${formatSeconds(policy.api_key.default_overlap_seconds)} default overlap · ${policy.api_key.rotation_endpoint}`}
+              />
+              <BoundaryCard
+                title="Rate-limit key"
+                body={policy.rate_limit_key.message ?? "Rate-limit fingerprint rotation posture is not available."}
+                detail={formatRateLimitRotationDetail(policy.rate_limit_key)}
+              />
+              <BoundaryCard
+                title="Audit HMAC rotation"
+                body={policy.secret_integrity.audit_hmac.rotation_message}
+                detail={formatRotationDetail(policy.secret_integrity.audit_hmac)}
+              />
+              <BoundaryCard
+                title="Compliance signing rotation"
+                body={policy.secret_integrity.compliance_signing.rotation_message}
+                detail={formatRotationDetail(policy.secret_integrity.compliance_signing)}
               />
             </div>
           </section>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -545,6 +545,9 @@ export interface AuthPolicyResponse {
     status: string;
     last_rotated: string | null;
     age_days: number | null;
+    rotation_days?: number | null;
+    max_age_days?: number | null;
+    message?: string;
     fallback_source?: string | null;
     [key: string]: unknown;
   };
@@ -573,6 +576,13 @@ export interface AuthPolicyResponse {
       source: string;
       persists_across_restart: boolean;
       rotation_tracking_supported: boolean;
+      rotation_status: string;
+      rotation_method: string;
+      rotation_days: number | null;
+      max_age_days: number | null;
+      last_rotated: string | null;
+      age_days: number | null;
+      rotation_message: string;
       message: string;
     };
     compliance_signing: {
@@ -584,6 +594,14 @@ export interface AuthPolicyResponse {
       auditor_distributable: boolean;
       uses_audit_hmac_secret: boolean;
       persists_across_restart: boolean;
+      rotation_tracking_supported: boolean;
+      rotation_status: string;
+      rotation_method: string;
+      rotation_days: number | null;
+      max_age_days: number | null;
+      last_rotated: string | null;
+      age_days: number | null;
+      rotation_message: string;
       message: string;
     };
   };

--- a/ui/tests/key-lifecycle-panel.test.tsx
+++ b/ui/tests/key-lifecycle-panel.test.tsx
@@ -15,8 +15,11 @@ const policy: AuthPolicyResponse = {
   },
   rate_limit_key: {
     status: "ok",
-    last_rotated: null,
-    age_days: null,
+    last_rotated: "2026-04-20T00:00:00Z",
+    age_days: 4,
+    rotation_days: 30,
+    max_age_days: 90,
+    message: "Rate-limit key is 4 days old; rotation interval is 30 days.",
   },
   ui: {
     recommended_mode: "reverse_proxy_oidc",
@@ -42,7 +45,14 @@ const policy: AuthPolicyResponse = {
       required: false,
       source: "AGENT_BOM_AUDIT_HMAC_KEY",
       persists_across_restart: true,
-      rotation_tracking_supported: false,
+      rotation_tracking_supported: true,
+      rotation_status: "ok",
+      rotation_method: "env_swap_and_restart",
+      rotation_days: 90,
+      max_age_days: 180,
+      last_rotated: "2026-04-01T00:00:00Z",
+      age_days: 23,
+      rotation_message: "Audit HMAC secret is 23 days old; configured rotation interval is 90 days.",
       message: "Audit log tamper detection uses a configured shared secret.",
     },
     compliance_signing: {
@@ -54,6 +64,14 @@ const policy: AuthPolicyResponse = {
       auditor_distributable: true,
       uses_audit_hmac_secret: false,
       persists_across_restart: true,
+      rotation_tracking_supported: true,
+      rotation_status: "rotation_due",
+      rotation_method: "env_swap_and_restart",
+      rotation_days: 30,
+      max_age_days: 180,
+      last_rotated: "2026-03-10T00:00:00Z",
+      age_days: 45,
+      rotation_message: "Compliance signing key is 45 days old, past the configured rotation interval (30 days).",
       message: "Compliance evidence bundles are signed with Ed25519.",
     },
   },
@@ -168,6 +186,18 @@ describe("KeyLifecyclePanel", () => {
     expect(
       screen.getByText("Ed25519 · asymmetric public key · key deadbeefcafebabe · /v1/compliance/verification-key")
     ).toBeInTheDocument();
+    expect(screen.getByText("Rotation posture")).toBeInTheDocument();
+    expect(screen.getByText("Service API keys")).toBeInTheDocument();
+    expect(screen.getByText("Rate-limit key")).toBeInTheDocument();
+    expect(screen.getByText("Audit HMAC rotation")).toBeInTheDocument();
+    expect(screen.getByText("Compliance signing rotation")).toBeInTheDocument();
+    expect(screen.getByText("enforced · 15m default overlap · /v1/auth/keys/{key_id}/rotate")).toBeInTheDocument();
+    expect(screen.getByText("Rate-limit key is 4 days old; rotation interval is 30 days.")).toBeInTheDocument();
+    expect(screen.getByText("Audit HMAC secret is 23 days old; configured rotation interval is 90 days.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Compliance signing key is 45 days old, past the configured rotation interval (30 days).")
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/env swap and restart/).length).toBeGreaterThan(0);
     expect(screen.getByText("Identity lifecycle")).toBeInTheDocument();
     expect(screen.getByText("OIDC browser / bearer")).toBeInTheDocument();
     expect(screen.getByText("SAML assertion exchange")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- expose structured rotation posture for audit HMAC and compliance signing in `/v1/auth/policy`
- add a dedicated rotation posture section to the key lifecycle panel for service keys, rate-limit keys, audit HMAC, and compliance signing
- support optional manual rotation timestamps and age thresholds so operators can see `ok`, `rotation_due`, or `max_age_exceeded` instead of guessing from prose

## Why
`#1750` still had a real operator UX gap around secret rotation. The control plane already surfaced API-key rotation, rate-limit key state, audit integrity posture, and signing mode, but it did not expose machine-readable rotation status for the integrity-critical secrets themselves. This PR closes that gap without pretending to automate secret rotation.

## Validation
- `pytest -q tests/test_api_operator_policy.py tests/test_compliance_signing.py -q`
- `uv run ruff check src/agent_bom/api/audit_log.py src/agent_bom/api/compliance_signing.py tests/test_api_operator_policy.py tests/test_compliance_signing.py`
- `npm test -- --run tests/key-lifecycle-panel.test.tsx`
- `npm run build`

## Issue
Part of #1750
