### PR TITLE
Reduce duplicate PR check runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
   merge_group:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
   merge_group:

--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -7,7 +7,7 @@ name: PR Security Gate
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
   merge_group:


### PR DESCRIPTION
## Summary

Reduces duplicate PR check noise introduced by running full CI, CodeQL, and PR Security Gate on every branch push and on `pull_request` for the same commit.

This keeps the important gates on:

- `pull_request` to `main`
- merge queue via `merge_group`
- post-merge `push` to `main`

A PR branch update already emits the `pull_request` synchronize event, so the branch-wide push trigger is redundant for same-repo and Dependabot PRs and doubles the visible checks.

## Validation

- workflow YAML parsed for `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, and `.github/workflows/pr-security-gate.yml`
- `git diff --check`
- pre-commit hooks: yaml/json/toml checks, EOF, whitespace, private key detection, case conflict, merge conflict, mixed line ending

`actionlint` is not installed in this local environment.
