### PR TITLE
Docs: add enterprise procurement readiness packet

### DIFF
--- a/.github/workflows/airgap-image-bundle.yml
+++ b/.github/workflows/airgap-image-bundle.yml
@@ -1,0 +1,48 @@
+name: Air-gapped image bundle
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version or tag suffix, for example 0.81.3 or v0.81.3
+        required: true
+        type: string
+      platform:
+        description: Image platform to bundle
+        required: true
+        default: linux/amd64
+        type: choice
+        options:
+          - linux/amd64
+          - linux/arm64
+
+permissions:
+  contents: read
+
+jobs:
+  bundle:
+    name: Build air-gapped image bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Build bundle
+        env:
+          BUNDLE_VERSION: ${{ inputs.version }}
+          BUNDLE_PLATFORM: ${{ inputs.platform }}
+        run: |
+          scripts/release/build-airgap-image-bundle.sh \
+            --version "$BUNDLE_VERSION" \
+            --platform "$BUNDLE_PLATFORM" \
+            --output-dir dist/airgap
+
+      - name: Upload bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agent-bom-airgap-${{ inputs.version }}
+          path: dist/airgap/agent-bom-airgap-*.tar.gz
+          if-no-files-found: error
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Backend defaults:
 | endpoint inventory and laptop rollout | [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md) |
 | proxy and gateway runtime operations | [Runtime Operations](site-docs/deployment/runtime-operations.md) |
 | trust model, auth, tenant isolation | [ENTERPRISE_SECURITY_PLAYBOOK.md](docs/ENTERPRISE_SECURITY_PLAYBOOK.md) |
+| procurement security posture | [ENTERPRISE_SECURITY_POSTURE.md](docs/ENTERPRISE_SECURITY_POSTURE.md) |
+| SOC 2 / ISO / CIS control mapping | [CONTROL_MAPPING.md](docs/CONTROL_MAPPING.md) |
 
 <details>
 <summary><b>Advanced deployment notes</b></summary>
@@ -297,7 +299,7 @@ agent-bom is a **read-only scanner**. It never writes configs, never executes MC
 | `verify` | Package + version | PyPI / npm integrity endpoints | don't run `verify` |
 | Optional integrations | Finding summaries | Slack / Jira / Vanta / Drata | don't pass those flags |
 
-Full trust model: [SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) · [PERMISSIONS.md](docs/PERMISSIONS.md) · [SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md) · [RELEASE_VERIFICATION.md](docs/RELEASE_VERIFICATION.md).
+Full trust model: [SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) · [PERMISSIONS.md](docs/PERMISSIONS.md) · [SUPPLY_CHAIN.md](docs/SUPPLY_CHAIN.md) · [RELEASE_VERIFICATION.md](docs/RELEASE_VERIFICATION.md) · [ENTERPRISE_SECURITY_POSTURE.md](docs/ENTERPRISE_SECURITY_POSTURE.md) · [CONTROL_MAPPING.md](docs/CONTROL_MAPPING.md).
 
 ## Compliance
 

--- a/docs/CONTROL_MAPPING.md
+++ b/docs/CONTROL_MAPPING.md
@@ -1,0 +1,84 @@
+# Enterprise Control Mapping
+
+This page maps common procurement and audit questions to implemented
+`agent-bom` controls. It is an evidence index, not a certification claim.
+Auditors should validate the linked code, tests, workflows, and deployment
+settings in the customer environment.
+
+## How To Use This Map
+
+1. Confirm the deployed mode: scan-only, API/UI control plane, gateway, proxy,
+   or full self-hosted EKS.
+2. Collect the evidence links listed below from the exact release tag in use.
+3. Export tenant-scoped evidence from the API when applicable.
+4. Attach operator-owned controls such as IdP policy, cloud KMS policy,
+   network policy, backup retention, and support process.
+
+## Evidence Collection
+
+| Evidence | Product path | Primary implementation |
+|---|---|---|
+| Tenant-scoped audit export | `GET /v1/audit/export` | `src/agent_bom/api/routes/enterprise.py`, `src/agent_bom/api/audit_log.py` |
+| Audit chain verification | `POST /v1/audit/verify` | `src/agent_bom/api/audit_log.py` |
+| Compliance report | `GET /v1/compliance/{framework}/report` | `src/agent_bom/api/routes/compliance.py` |
+| Evidence bundle signing posture | `GET /v1/compliance/signing/status` | `src/agent_bom/api/compliance_signing.py` |
+| Auth and secret posture | `GET /v1/auth/policy` | `src/agent_bom/api/routes/auth.py`, `src/agent_bom/api/audit_log.py` |
+| Release artifact verification | GitHub Release assets | `docs/RELEASE_VERIFICATION.md`, `.github/workflows/release.yml` |
+| Dependency and image audit | CI artifacts and release SBOM | `docs/SUPPLY_CHAIN.md`, `.github/workflows/pr-security-gate.yml`, `.github/workflows/extras-audit.yml` |
+| Backup restore proof | CI workflow and operator runbook | `.github/workflows/backup-restore.yml`, `deploy/ops/restore-postgres-backup.sh` |
+
+## SOC 2 Common Criteria
+
+| Control family | How agent-bom supports it | Evidence |
+|---|---|---|
+| CC6.1 logical access | API keys, OIDC, SAML metadata, trusted proxy mode, route-level RBAC | `src/agent_bom/api/middleware.py`, `src/agent_bom/rbac.py`, `docs/ENTERPRISE.md` |
+| CC6.2 least privilege | Admin, analyst, and viewer capabilities are enforced by middleware before route handlers | `src/agent_bom/rbac.py`, `tests/test_api_operator_policy.py`, `tests/test_rbac.py` |
+| CC6.3 access changes | API key creation, revocation, and rotation are explicit API operations with audit events | `src/agent_bom/api/auth.py`, `src/agent_bom/api/routes/auth.py` |
+| CC6.6 transmission boundaries | TLS terminates at customer ingress; gateway/proxy policy can fail closed for runtime traffic | `deploy/helm/agent-bom/templates/controlplane-ingress.yaml`, `src/agent_bom/gateway_server.py` |
+| CC6.7 data access restriction | Tenant propagation, Postgres RLS, ClickHouse tenant filters, and cross-tenant tests | `src/agent_bom/api/middleware.py`, `src/agent_bom/api/postgres_common.py`, `tests/test_cross_tenant_leakage.py` |
+| CC7.2 monitoring | Prometheus metrics, client error telemetry, audit events, and SIEM integration | `src/agent_bom/api/routes/observability.py`, `site-docs/deployment/siem-integration.md` |
+| CC7.3 incident response | Private security advisory intake, disclosure SLA, pentest scope, and runtime break-glass guidance | `SECURITY.md`, `docs/PENTEST_READINESS.md`, `site-docs/deployment/runtime-operations.md` |
+| CC8.1 change management | Release consistency checks, pinned actions, lockfiles, dependency review, and release provenance | `scripts/check_release_consistency.py`, `docs/SUPPLY_CHAIN.md`, `.github/workflows/release.yml` |
+
+## ISO 27001:2022 Annex A
+
+| Annex A control | How agent-bom supports it | Evidence |
+|---|---|---|
+| A.5.15 Access control | RBAC, OIDC tenant claims, API-key lifecycle, trusted proxy headers | `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`, `src/agent_bom/api/auth.py` |
+| A.5.16 Identity management | External IdP integration, SAML metadata, tenant-bound OIDC providers | `src/agent_bom/api/oidc.py`, `src/agent_bom/api/saml.py` |
+| A.5.17 Authentication information | API-key hashing, bearer-token verification, browser cookie signing, CSRF protection | `src/agent_bom/api/auth.py`, `src/agent_bom/api/browser_session.py` |
+| A.5.23 Cloud services | Self-hosted deployment guidance, customer-managed storage, cloud read-only roles | `site-docs/deployment/own-infra-eks.md`, `scripts/provision/README.md` |
+| A.5.30 ICT readiness | Backup restore workflow, HPA/PDB chart controls, runtime operations runbook | `.github/workflows/backup-restore.yml`, `deploy/helm/agent-bom/templates/controlplane-pdb.yaml` |
+| A.8.8 Technical vulnerabilities | OSV, NVD, EPSS, CISA KEV enrichment, dependency scans, image scans | `src/agent_bom/enrichment.py`, `.github/workflows/pr-security-gate.yml`, `.github/workflows/container-rescan.yml` |
+| A.8.9 Configuration management | Helm values, pinned deployment examples, release consistency guard | `deploy/helm/agent-bom/values.yaml`, `scripts/check_release_consistency.py` |
+| A.8.12 Data leakage prevention | Credential and PII detectors in proxy, gateway, Shield, and visual leak detection | `src/agent_bom/runtime/detectors.py`, `src/agent_bom/runtime/visual_leak_detector.py` |
+| A.8.15 Logging | HMAC-chained audit log and tenant-scoped export | `src/agent_bom/api/audit_log.py`, `src/agent_bom/api/postgres_audit.py` |
+| A.8.24 Cryptography | HMAC audit chains, Ed25519 evidence signing, KMS-backed backup encryption | `src/agent_bom/api/compliance_signing.py`, `deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml` |
+
+## CIS Controls v8
+
+| CIS control | How agent-bom supports it | Evidence |
+|---|---|---|
+| 1 Inventory and control of enterprise assets | Fleet sync and endpoint inventory | `src/agent_bom/api/routes/fleet.py`, `site-docs/deployment/endpoint-fleet.md` |
+| 2 Inventory and control of software assets | Package, MCP, container, OS package, and SBOM scanning | `src/agent_bom/discovery`, `src/agent_bom/parsers`, `src/agent_bom/scanners` |
+| 3 Data protection | Tenant-scoped data model, signed evidence bundles, backup encryption knobs | `docs/DATA_MODEL.md`, `docs/COMPLIANCE_SIGNING.md`, `deploy/helm/agent-bom/values.yaml` |
+| 4 Secure configuration | IaC and cloud benchmark scanning, Kubernetes and Helm guidance | `src/agent_bom/iac`, `src/agent_bom/cloud`, `site-docs/deployment/kubernetes.md` |
+| 5 Account management | API-key expiry, rotation overlap, revocation, and OIDC/SAML integrations | `src/agent_bom/api/auth.py`, `src/agent_bom/api/routes/auth.py` |
+| 6 Access control management | RBAC matrix and middleware-enforced route permissions | `src/agent_bom/rbac.py`, `docs/ENTERPRISE.md` |
+| 7 Continuous vulnerability management | Dependency audits, CVE freshness, image rescans, Dependabot | `.github/workflows/cve-freshness.yml`, `.github/workflows/extras-audit.yml` |
+| 8 Audit log management | HMAC chain, export, verification, SIEM push | `src/agent_bom/api/audit_log.py`, `site-docs/deployment/siem-integration.md` |
+| 12 Network infrastructure management | Gateway/proxy egress controls and SSRF hardening | `src/agent_bom/security.py`, `src/agent_bom/gateway_upstreams.py` |
+| 16 Application software security | CodeQL, fuzzing, dependency review, release provenance | `.github/workflows/codeql.yml`, `.github/workflows/cflite-pr.yml`, `.github/workflows/release.yml` |
+
+## Customer-Owned Evidence
+
+These controls depend on the operator's environment and should be attached by
+the customer during procurement review:
+
+- IdP MFA policy and conditional access rules
+- ingress TLS certificate policy and private DNS design
+- KMS key policy, rotation evidence, and separation of duties
+- S3 object-lock, retention, versioning, replication, and lifecycle policy
+- Postgres backup retention and restore drill records
+- SIEM routing, alert ownership, and incident response records
+- DPA, subprocessor, and support-access procedures

--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -1,0 +1,148 @@
+# Enterprise Security Posture
+
+This is the procurement-facing security posture for self-hosted `agent-bom`.
+It summarizes what the product does, where trust boundaries sit, and what an
+enterprise buyer must configure in its own environment.
+
+## Executive Summary
+
+`agent-bom` is designed for customer-controlled deployment. The recommended
+enterprise posture runs the API, UI, jobs, gateway, Postgres, optional
+ClickHouse, and backup archive inside the customer's infrastructure. There is
+no mandatory vendor-hosted control plane and no mandatory telemetry path.
+
+The product security model is defense in depth:
+
+- read-only discovery by default
+- explicit runtime enforcement only where proxy or gateway is deployed
+- API authentication through API keys, OIDC, SAML metadata, or trusted proxy
+  headers
+- middleware-enforced RBAC and tenant propagation
+- tenant-scoped stores and export paths
+- HMAC-chained audit logs and Ed25519-signed compliance evidence
+- pinned release artifacts, lockfiles, dependency review, and image scanning
+- restore-tested Postgres backup path for the packaged control plane
+
+## Trust Boundaries
+
+| Boundary | Trust level | Controls |
+|---|---|---|
+| Browser to UI/API | authenticated enterprise user | ingress TLS, OIDC/proxy auth, httpOnly same-origin session cookie, CSRF protection |
+| API to stores | trusted service path | tenant propagation, Postgres RLS, parameterized stores, bounded connection pools |
+| Scanner to local files | local user trust boundary | read-only config parsing, path validation, redaction of credential values |
+| Scanner to public vuln APIs | untrusted external data | HTTPS, defensive parsers, no code execution from responses |
+| Gateway/proxy to upstream MCPs | untrusted upstream | policy evaluation, credential/PII leak detectors, SSRF/private egress blocking |
+| API to SIEM/webhook/export targets | operator-approved egress | scheme and private-network validation before outbound push |
+| Release artifacts to operator | public supply chain | Sigstore, SLSA provenance, SBOMs, dependency review, image scan gates |
+
+## Data Classification
+
+| Data class | Examples | Default handling |
+|---|---|---|
+| Inventory metadata | packages, MCP server names, tool names, endpoint IDs | stored in customer-owned Postgres or export files |
+| Findings | CVEs, risky permissions, policy hits, blast radius | tenant-scoped API and store paths |
+| Audit records | actor, action, resource, tenant, details digest | HMAC-chained per tenant, exportable and verifiable |
+| Credentials | API keys, OAuth client secrets, cloud tokens | values are not stored in scan output; deployment secrets live in operator secret stores |
+| Compliance evidence | signed bundles, verification keys, audit export | Ed25519 preferred for auditor-distributable verification |
+| Telemetry | Prometheus metrics, traces, client error reports | self-hosted endpoints; no mandatory vendor telemetry |
+
+## Encryption And Signing Matrix
+
+| Surface | In transit | At rest | Integrity |
+|---|---|---|---|
+| Browser/API traffic | customer ingress TLS | Postgres/customer store | request ID, audit entry |
+| API keys | HTTPS/TLS at ingress | scrypt-hashed or stored key metadata only | rotation and revocation audit |
+| Browser session cookie | same-origin secure cookie in production | signed token payload, no JS-readable bearer token needed | HMAC signature with configured or ephemeral key |
+| Audit log | API transport | Postgres or configured audit store | per-tenant HMAC chain |
+| Compliance bundle | API transport | operator archive | Ed25519 signature, HMAC fallback |
+| Postgres backup | S3/TLS | S3 SSE-S3 or SSE-KMS | restore drill and checksum verification |
+| Release artifacts | GitHub/Docker registry TLS | operator artifact store | Sigstore, SLSA, SBOM, image signatures |
+
+## Identity And Access
+
+The self-hosted control plane supports:
+
+- API keys with expiry, rotation overlap, and revocation
+- OIDC bearer validation with tenant claim enforcement
+- SAML SP metadata for enterprise IdP wiring
+- trusted reverse-proxy identity headers when a customer-owned proxy handles
+  authentication
+- admin, analyst, and viewer RBAC enforced in API middleware
+
+Browser authentication can use same-origin httpOnly cookies for the dashboard
+while keeping bearer-token support for CLI and service clients.
+
+## Tenant Isolation
+
+Tenant isolation is enforced across API middleware, stores, audit export,
+fleet routes, ClickHouse analytics, and shared gateway routing. The control
+plane test suite includes cross-tenant matrix and concurrent-write leakage
+coverage. Operators should still deploy separate environments for separate
+legal entities when regulatory or contractual requirements prohibit shared
+infrastructure.
+
+## Secrets Lifecycle
+
+Recommended production posture:
+
+- source API, OIDC, OAuth2, audit HMAC, Ed25519, Postgres, and webhook secrets
+  from the customer's secret manager
+- mount Kubernetes secrets through External Secrets or equivalent CSI/IRSA
+  controls
+- set rotation timestamps for audit HMAC and compliance signing keys so posture
+  endpoints can expose key age
+- rotate API keys through the API rather than replacing all clients at once
+- restart API/gateway workloads after rotating mounted signing or OAuth client
+  secrets
+
+`agent-bom` does not replace the customer's KMS, Vault, IdP, or privileged
+access management system. The product exposes posture and supports rotation
+paths; the operator owns secret authority, approval workflow, and key custody.
+
+## Logging, Monitoring, And Incident Response
+
+Relevant security signals:
+
+- authenticated `/metrics` for Prometheus scraping
+- SIEM integration for audit and finding export
+- client error telemetry for dashboard failures
+- HMAC audit export and verification endpoints
+- PrometheusRule defaults for high-risk runtime and control-plane alerts
+- private vulnerability reporting through GitHub Security Advisories
+
+Incident response ownership remains with the self-hosting organization. The
+published security policy defines maintainer disclosure SLAs for product
+vulnerabilities; customer deployment incidents follow customer process.
+
+## Availability, Backup, And Restore
+
+The Helm chart includes an optional Postgres backup CronJob that writes custom
+format `pg_dump` artifacts to S3-compatible storage. The restore script is
+tested in CI through a MinIO-backed round trip. Production deployments should
+set real RPO/RTO targets, bucket retention, KMS keys, object lock where needed,
+and restore-drill cadence.
+
+See `site-docs/deployment/backup-restore.md` for the operator runbook.
+
+## Procurement Package
+
+A procurement packet should include:
+
+- this security posture
+- `docs/CONTROL_MAPPING.md`
+- `docs/SECURITY_ARCHITECTURE.md`
+- `docs/THREAT_MODEL.md`
+- `docs/SUPPLY_CHAIN.md`
+- `docs/RELEASE_VERIFICATION.md`
+- `docs/PENTEST_READINESS.md`
+- `site-docs/deployment/customer-data-and-support-boundary.md`
+- customer-owned DPA, subprocessors, support-access policy, and retention
+  schedule
+
+## Current Boundaries
+
+The self-hosted enterprise posture is ready for teams operating the product
+behind their own identity, network, storage, and monitoring controls. Turnkey
+external multi-tenant SaaS procurement still needs separate hosted-service
+controls such as data-subject automation, provider-style tenant lifecycle
+operations, and formal legal templates owned by the service provider.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,11 @@ Keep top-level `docs/` focused on operator-facing and externally useful material
 Canonical docs here:
 
 - `ARCHITECTURE.md`
+- `CONTROL_MAPPING.md`
 - `DEPLOYMENT.md`
 - `ENTERPRISE.md`
 - `ENTERPRISE_DEPLOYMENT.md`
+- `ENTERPRISE_SECURITY_POSTURE.md`
 - `MCP_CLIENT_GUIDES.md`
 - `MCP_SERVER.md`
 - `PERMISSIONS.md`

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -138,6 +138,7 @@ This is the public verification path. Release trust is not hidden inside CI.
 - [Threat Model](THREAT_MODEL.md)
 - [Release Verification](RELEASE_VERIFICATION.md)
 - [Permissions and Trust](PERMISSIONS.md)
+- [Air-Gapped Image Bundle](../site-docs/deployment/airgapped-image-bundle.md)
 
 ## Operational guidance
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,8 @@ nav:
       - Audit Chain vs Compliance Signing: deployment/audit-and-compliance-verification.md
       - Customer Data and Support Boundary: deployment/customer-data-and-support-boundary.md
       - Data Retention by Class: deployment/data-retention.md
+      - Backup and Restore Runbook: deployment/backup-restore.md
+      - Air-Gapped Image Bundle: deployment/airgapped-image-bundle.md
       - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
       - Runtime Operations: deployment/runtime-operations.md
       - Visual Leak Detection: deployment/visual-leak-detection.md

--- a/scripts/release/build-airgap-image-bundle.sh
+++ b/scripts/release/build-airgap-image-bundle.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: build-airgap-image-bundle.sh --version VERSION [--platform PLATFORM] [--output-dir DIR] [--no-verify]
+
+Builds a portable tarball containing the public agent-bom runtime images,
+checksums, and a load script for disconnected registries or clusters.
+
+Required:
+  --version VERSION        Release version or tag suffix, for example 0.81.3 or v0.81.3
+
+Optional:
+  --platform PLATFORM     Image platform to pull and archive (default: linux/amd64)
+  --output-dir DIR         Directory for bundle output (default: dist/airgap)
+  --no-verify             Skip cosign image signature verification
+
+Environment:
+  VERIFY_SIGNATURES=0      Same as --no-verify
+USAGE
+}
+
+version=""
+platform="linux/amd64"
+output_dir="dist/airgap"
+verify_signatures="${VERIFY_SIGNATURES:-1}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --platform)
+      platform="${2:-}"
+      shift 2
+      ;;
+    --no-verify)
+      verify_signatures=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$version" ]]; then
+  echo "--version is required" >&2
+  usage
+  exit 2
+fi
+
+version="${version#v}"
+case "$version" in
+  *[!A-Za-z0-9._-]*|"")
+    echo "version may only contain letters, numbers, dot, underscore, and dash" >&2
+    exit 2
+    ;;
+esac
+
+case "$platform" in
+  *[!A-Za-z0-9._/-]*|"")
+    echo "platform may only contain letters, numbers, dot, underscore, dash, and slash" >&2
+    exit 2
+    ;;
+esac
+
+command -v docker >/dev/null || {
+  echo "docker is required" >&2
+  exit 1
+}
+
+if [[ "$verify_signatures" != "0" ]]; then
+  command -v cosign >/dev/null || {
+    echo "cosign is required unless --no-verify or VERIFY_SIGNATURES=0 is set" >&2
+    exit 1
+  }
+fi
+
+safe_platform="$(printf '%s' "$platform" | tr '/:' '__')"
+bundle_root="${output_dir%/}/agent-bom-airgap-${version}-${safe_platform}"
+images_dir="${bundle_root}/images"
+manifest_dir="${bundle_root}/manifests"
+rm -rf "$bundle_root"
+mkdir -p "$images_dir" "$manifest_dir"
+
+images=(
+  "agentbom/agent-bom:${version}"
+  "agentbom/agent-bom-ui:${version}"
+)
+
+identity_regexp='https://github.com/msaad00/agent-bom/.github/workflows/release.yml@.*'
+
+for image in "${images[@]}"; do
+  echo "Pulling ${image} for ${platform}"
+  docker pull --platform "$platform" "$image"
+
+  if [[ "$verify_signatures" != "0" ]]; then
+    echo "Verifying ${image} signature"
+    cosign verify "$image" \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      --certificate-identity-regexp "$identity_regexp" \
+      >/dev/null
+  fi
+
+  safe_name="$(printf '%s' "$image" | tr '/:' '__')"
+  tar_path="${images_dir}/${safe_name}.tar"
+  docker save "$image" -o "$tar_path"
+  printf '%s\n' "$image" >> "${manifest_dir}/images.txt"
+done
+
+(
+  cd "$bundle_root"
+  find images -type f -name '*.tar' -print0 | sort -z | xargs -0 sha256sum > manifests/sha256sums.txt
+)
+
+cat > "${bundle_root}/load-images.sh" <<'LOAD'
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$bundle_dir"
+sha256sum -c manifests/sha256sums.txt
+find images -type f -name '*.tar' -print0 | sort -z | while IFS= read -r -d '' image_tar; do
+  docker load -i "$image_tar"
+done
+LOAD
+chmod +x "${bundle_root}/load-images.sh"
+
+cat > "${bundle_root}/README.md" <<README
+# agent-bom air-gapped image bundle ${version}
+
+Contents:
+
+- platform: \`${platform}\`
+- \`images/*.tar\`: Docker image archives for \`agentbom/agent-bom:${version}\` and \`agentbom/agent-bom-ui:${version}\`
+- \`manifests/images.txt\`: source image references
+- \`manifests/sha256sums.txt\`: archive checksums
+- \`load-images.sh\`: checksum verification and \`docker load\`
+
+Load on the disconnected host:
+
+\`\`\`bash
+tar -xzf agent-bom-airgap-${version}-${safe_platform}.tar.gz
+cd agent-bom-airgap-${version}-${safe_platform}
+./load-images.sh
+\`\`\`
+README
+
+(
+  cd "${output_dir%/}"
+  tar -czf "agent-bom-airgap-${version}-${safe_platform}.tar.gz" "agent-bom-airgap-${version}-${safe_platform}"
+)
+
+echo "Wrote ${output_dir%/}/agent-bom-airgap-${version}-${safe_platform}.tar.gz"

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -1,0 +1,87 @@
+# Air-Gapped Image Bundle
+
+Use this workflow when a customer must import release images into a disconnected
+registry or cluster. The bundle contains the API/runtime image, the UI image,
+checksums, and a loader script. Bundles are platform-specific; produce one for
+`linux/amd64` and another for `linux/arm64` when your disconnected estate runs
+both architectures.
+
+## Build A Bundle
+
+From an internet-connected build host:
+
+```bash
+scripts/release/build-airgap-image-bundle.sh \
+  --version 0.81.3 \
+  --platform linux/amd64 \
+  --output-dir dist/airgap
+```
+
+The script:
+
+1. pulls `agentbom/agent-bom:<version>` and `agentbom/agent-bom-ui:<version>` for the requested platform
+2. verifies image signatures with cosign by default
+3. saves both images as Docker archives
+4. writes `manifests/images.txt`
+5. writes `manifests/sha256sums.txt`
+6. packages everything as `agent-bom-airgap-<version>.tar.gz`
+
+If your build host cannot install cosign, use `--no-verify` only after
+verifying the release through `docs/RELEASE_VERIFICATION.md` on a trusted
+machine.
+
+## Import On The Disconnected Host
+
+```bash
+tar -xzf agent-bom-airgap-0.81.3-linux_amd64.tar.gz
+cd agent-bom-airgap-0.81.3-linux_amd64
+./load-images.sh
+```
+
+The loader verifies archive checksums before running `docker load`.
+
+## Push To An Internal Registry
+
+```bash
+VERSION=0.81.3
+REGISTRY=registry.internal.example.com/security
+
+docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
+docker tag "agentbom/agent-bom-ui:${VERSION}" "${REGISTRY}/agent-bom-ui:${VERSION}"
+
+docker push "${REGISTRY}/agent-bom:${VERSION}"
+docker push "${REGISTRY}/agent-bom-ui:${VERSION}"
+```
+
+Then point Helm at the internal registry:
+
+```yaml
+image:
+  repository: registry.internal.example.com/security/agent-bom
+  tag: "0.81.3"
+
+controlPlane:
+  ui:
+    image:
+      repository: registry.internal.example.com/security/agent-bom-ui
+      tag: "0.81.3"
+```
+
+## GitHub Actions Bundle Job
+
+Maintainers can also generate the same artifact from GitHub Actions through
+the manual "Air-gapped image bundle" workflow. Choose `linux/amd64` or
+`linux/arm64` explicitly. Treat the uploaded artifact as a transfer package;
+the receiving environment should still verify checksums after download and
+before import.
+
+## Audit Record
+
+For regulated imports, retain:
+
+- source release tag and commit SHA
+- output of `cosign verify` for both images
+- `manifests/images.txt`
+- `manifests/sha256sums.txt`
+- internal registry digest after push
+- operator, approver, import time, and target environment

--- a/site-docs/deployment/backup-restore.md
+++ b/site-docs/deployment/backup-restore.md
@@ -1,0 +1,127 @@
+# Backup And Restore Runbook
+
+This runbook covers the packaged Postgres backup path for self-hosted control
+planes. It applies when `controlPlane.backup.enabled=true` in the Helm chart.
+Snowflake-native deployments use the warehouse durability and recovery model
+instead.
+
+## What Is Backed Up
+
+The backup CronJob runs `pg_dump --format=custom` against
+`AGENT_BOM_POSTGRES_URL` and uploads the resulting dump to S3-compatible
+storage.
+
+Packaged implementation:
+
+- Helm template: `deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml`
+- values: `deploy/helm/agent-bom/values.yaml`
+- restore script: `deploy/ops/restore-postgres-backup.sh`
+- CI proof: `.github/workflows/backup-restore.yml`
+
+## Production Prerequisites
+
+Before enabling the CronJob:
+
+1. Create a dedicated backup bucket with public access blocked.
+2. Enable bucket versioning and retention appropriate for your RPO/RTO.
+3. Use SSE-KMS for regulated environments.
+4. Attach a least-privilege IRSA or workload-identity role to the backup
+   service account.
+5. Confirm `pg_dump` and `pg_restore` major versions match the Postgres major
+   version.
+6. Store `AGENT_BOM_POSTGRES_URL` in your secret manager, not inline values.
+
+## Helm Values
+
+Minimal shape:
+
+```yaml
+controlPlane:
+  backup:
+    enabled: true
+    schedule: "0 3 * * *"
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/agent-bom-backup
+    destination:
+      bucket: agent-bom-prod-backups
+      prefix: agent-bom/postgres
+      bucketRegion: "<your-backup-bucket-region>"
+      encryption:
+        enabled: true
+        mode: "aws:kms"
+        kmsKeyId: alias/agent-bom-backups
+```
+
+Keep `bucketRegion` explicit. Do not rely on example regions for production.
+
+## Manual Backup Check
+
+Confirm the latest backup object exists:
+
+```bash
+export AWS_REGION="<your-backup-bucket-region>"
+aws s3 ls "s3://agent-bom-prod-backups/agent-bom/postgres/" \
+  --region "$AWS_REGION" \
+  --recursive \
+  --human-readable \
+  --summarize
+```
+
+Check the CronJob:
+
+```bash
+kubectl -n agent-bom get cronjob agent-bom-control-plane-backup
+kubectl -n agent-bom get jobs -l app.kubernetes.io/component=control-plane-backup
+```
+
+## Restore Drill
+
+Restore into a staging database first. Do not restore directly over production
+until incident command has approved the data-loss window.
+
+```bash
+export AWS_REGION="<your-backup-bucket-region>"
+export BACKUP_URI="s3://agent-bom-prod-backups/agent-bom/postgres/agent-bom-YYYYMMDDTHHMMSSZ.dump"
+export RESTORE_POSTGRES_URL="postgresql://agent_bom:REDACTED@staging-postgres:5432/agent_bom"
+
+deploy/ops/restore-postgres-backup.sh \
+  "$BACKUP_URI" \
+  "$RESTORE_POSTGRES_URL" \
+  "$AWS_REGION"
+```
+
+Verify tenant-aware tables after restore:
+
+```bash
+psql "$RESTORE_POSTGRES_URL" -c "select count(*) from audit_log;"
+psql "$RESTORE_POSTGRES_URL" -c "select team_id, count(*) from audit_log group by team_id order by team_id;"
+```
+
+Then run the control-plane smoke checks against the restored environment:
+
+```bash
+scripts/deploy/verify-eks-reference.sh \
+  --cluster-name corp-ai \
+  --region "$AWS_REGION" \
+  --namespace agent-bom
+```
+
+## Production Restore Checklist
+
+- Freeze scan schedules and external pushes before restore.
+- Snapshot the current database if it is still reachable.
+- Restore to a new database or schema first when time allows.
+- Verify row counts, tenant distribution, audit export, and auth key state.
+- Point the API deployment at the restored database.
+- Restart API, worker, gateway, and UI deployments.
+- Re-run health, metrics, and signed compliance evidence checks.
+- Record the backup URI, operator, approval, start time, end time, and data
+  loss window in the incident record.
+
+## CI Guardrail
+
+The backup workflow seeds synthetic tenant data, dumps it, wipes the database,
+restores through the production restore script, and verifies row counts plus
+tenant distribution. It runs on backup-script/template changes and weekly to
+catch upstream image drift.

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -307,6 +307,7 @@ You still own:
 - keep `controlPlane.backup.destination.encryption.enabled=true`; the default is `AES256`, and production should set `mode=aws:kms` with a dedicated `kmsKeyId`
 - restore drills should use [`deploy/ops/restore-postgres-backup.sh`](https://github.com/msaad00/agent-bom/blob/main/deploy/ops/restore-postgres-backup.sh):
   `./deploy/ops/restore-postgres-backup.sh s3://bucket/key.dump "$AGENT_BOM_POSTGRES_URL" REPLACE_ME_BUCKET_REGION`
+- use [Backup and Restore Runbook](backup-restore.md) for the full operator checklist
 - expose `GET /v1/auth/saml/metadata` to your IdP admins and keep
   `POST /v1/auth/saml/login` behind the same ingress hostname as the API
 - enable PDBs when you are running multi-replica workloads


### PR DESCRIPTION
Summary
- adds procurement-facing enterprise security posture and SOC 2 / ISO 27001 / CIS evidence mapping
- adds Postgres backup/restore runbook and links it from Helm operations docs
- adds signed, checksumed air-gapped image bundle script plus manual workflow for amd64/arm64 bundle generation

Validation
- bash -n scripts/release/build-airgap-image-bundle.sh
- workflow YAML parse for all .github/workflows/*.yml
- git diff --check
- uv run mkdocs build --strict
