### PR TITLE
Scale fleet and graph operator paths

### DIFF
--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -205,6 +205,8 @@ What the product claims today:
 - stable node identifiers in the operator detail view
 - explicit snapshot metadata, scope, and timestamps
 - filterable graph investigation flows
+- paginated agent-node selectors through `GET /v1/graph/agents`
+- bounded fleet list windows through `GET /v1/fleet?limit=...&offset=...`
 
 What it does not yet publish as a hard contract:
 
@@ -242,6 +244,13 @@ Recommended starting posture:
 - keep retained jobs bounded to match your retention expectations
 - keep fleet-agent quotas aligned to your actual endpoint/runtime rollout size
 - keep schedule quotas low unless you deliberately expose scheduled scans to many tenants
+
+For large tenants with thousands of agents, do not drive dashboards from a full
+fleet dump. Use server-side fleet search and pagination, graph agent selectors,
+and node-context drilldown. The UI should show a readable working set first,
+then let the operator expand by search, lifecycle state, environment, or graph
+neighborhood. Treat the exact fleet size as an operator sizing input, not a
+fixed product ceiling.
 
 ## Benchmark before production rollout
 

--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -86,6 +86,18 @@ class FleetStore(Protocol):
     def list_all(self) -> list[FleetAgent]: ...
     def list_summary(self) -> list[dict]: ...
     def list_by_tenant(self, tenant_id: str) -> list[FleetAgent]: ...
+    def query_by_tenant(
+        self,
+        tenant_id: str,
+        *,
+        state: str | None = None,
+        environment: str | None = None,
+        min_trust: float | None = None,
+        search: str | None = None,
+        include_quarantined: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetAgent], int]: ...
     def list_tenants(self) -> list[dict]: ...
     def update_state(self, agent_id: str, state: FleetLifecycleState) -> bool: ...
     def batch_put(self, agents: list[FleetAgent]) -> int: ...
@@ -154,6 +166,41 @@ class InMemoryFleetStore:
         with self._lock:
             return [a for a in self._agents.values() if a.tenant_id == tenant_id]
 
+    def query_by_tenant(
+        self,
+        tenant_id: str,
+        *,
+        state: str | None = None,
+        environment: str | None = None,
+        min_trust: float | None = None,
+        search: str | None = None,
+        include_quarantined: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetAgent], int]:
+        agents = self.list_by_tenant(tenant_id)
+        if not include_quarantined and state is None:
+            agents = [a for a in agents if a.lifecycle_state.value not in ("quarantined", "decommissioned")]
+        if state:
+            agents = [a for a in agents if a.lifecycle_state.value == state]
+        if environment:
+            agents = [a for a in agents if a.environment == environment]
+        if min_trust is not None:
+            agents = [a for a in agents if (a.trust_score or 0.0) >= min_trust]
+        if search:
+            needle = search.lower()
+            agents = [
+                a
+                for a in agents
+                if needle in a.name.lower()
+                or needle in (a.owner or "").lower()
+                or needle in (a.environment or "").lower()
+                or any(needle in tag.lower() for tag in a.tags)
+            ]
+        agents = sorted(agents, key=lambda a: (a.name.lower(), a.agent_id))
+        total = len(agents)
+        return agents[offset : offset + limit], total
+
     def list_tenants(self) -> list[dict]:
         with self._lock:
             counts: dict[str, int] = {}
@@ -215,6 +262,7 @@ class SQLiteFleetStore:
         """)
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_name ON fleet_agents(name)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state ON fleet_agents(lifecycle_state)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state_trust_name ON fleet_agents(lifecycle_state, trust_score DESC, name)")
         self._conn.commit()
 
     def put(self, agent: FleetAgent) -> None:
@@ -288,6 +336,41 @@ class SQLiteFleetStore:
             (tenant_id,),
         ).fetchall()
         return [FleetAgent.model_validate_json(r[0]) for r in rows]
+
+    def query_by_tenant(
+        self,
+        tenant_id: str,
+        *,
+        state: str | None = None,
+        environment: str | None = None,
+        min_trust: float | None = None,
+        search: str | None = None,
+        include_quarantined: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[FleetAgent], int]:
+        agents = self.list_by_tenant(tenant_id)
+        if not include_quarantined and state is None:
+            agents = [a for a in agents if a.lifecycle_state.value not in ("quarantined", "decommissioned")]
+        if state:
+            agents = [a for a in agents if a.lifecycle_state.value == state]
+        if environment:
+            agents = [a for a in agents if a.environment == environment]
+        if min_trust is not None:
+            agents = [a for a in agents if (a.trust_score or 0.0) >= min_trust]
+        if search:
+            needle = search.lower()
+            agents = [
+                a
+                for a in agents
+                if needle in a.name.lower()
+                or needle in (a.owner or "").lower()
+                or needle in (a.environment or "").lower()
+                or any(needle in tag.lower() for tag in a.tags)
+            ]
+        agents = sorted(agents, key=lambda a: (a.name.lower(), a.agent_id))
+        total = len(agents)
+        return agents[offset : offset + limit], total
 
     def list_tenants(self) -> list[dict]:
         rows = self._conn.execute(

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -202,6 +202,18 @@ class PostgresFleetStore:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_name ON fleet_agents(name)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state ON fleet_agents(lifecycle_state)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_tenant ON fleet_agents(tenant_id)")
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_fleet_tenant_state_trust_name
+                ON fleet_agents(tenant_id, lifecycle_state, trust_score DESC, name)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_fleet_tenant_name_lower
+                ON fleet_agents(tenant_id, lower(name))
+                """
+            )
             _ensure_tenant_rls(conn, "fleet_agents", "tenant_id")
             conn.commit()
 
@@ -278,6 +290,62 @@ class PostgresFleetStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT data FROM fleet_agents WHERE tenant_id = %s ORDER BY name", (tenant_id,)).fetchall()
             return [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
+
+    def query_by_tenant(
+        self,
+        tenant_id: str,
+        *,
+        state: str | None = None,
+        environment: str | None = None,
+        min_trust: float | None = None,
+        search: str | None = None,
+        include_quarantined: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list, int]:
+        from .fleet_store import FleetAgent
+
+        clauses = ["tenant_id = %s"]
+        params: list[object] = [tenant_id]
+        if not include_quarantined and state is None:
+            clauses.append("lifecycle_state NOT IN ('quarantined', 'decommissioned')")
+        if state:
+            clauses.append("lifecycle_state = %s")
+            params.append(state)
+        if min_trust is not None:
+            clauses.append("trust_score >= %s")
+            params.append(float(min_trust))
+        if environment:
+            clauses.append("data->>'environment' = %s")
+            params.append(environment)
+        if search:
+            needle = f"%{search.lower()}%"
+            clauses.append(
+                """
+                (
+                    lower(name) LIKE %s
+                    OR lower(COALESCE(data->>'owner', '')) LIKE %s
+                    OR lower(COALESCE(data->>'environment', '')) LIKE %s
+                    OR lower(COALESCE(data->>'tags', '')) LIKE %s
+                )
+                """
+            )
+            params.extend([needle, needle, needle, needle])
+        where = " AND ".join(clauses)
+        with _tenant_connection(self._pool) as conn:
+            total_row = conn.execute(f"SELECT COUNT(*) FROM fleet_agents WHERE {where}", tuple(params)).fetchone()  # nosec B608 - clauses are static
+            rows = conn.execute(
+                f"""
+                SELECT data
+                FROM fleet_agents
+                WHERE {where}
+                ORDER BY name, agent_id
+                LIMIT %s OFFSET %s
+                """,  # nosec B608 - clauses are static
+                (*params, int(limit), int(offset)),
+            ).fetchall()
+            agents = [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
+            return agents, int(total_row[0] if total_row else 0)
 
     def list_tenants(self) -> list[dict]:
         with _tenant_connection(self._pool) as conn:

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -24,6 +24,50 @@ from agent_bom.api.tenant_quota import enforce_fleet_agents_quota
 router = APIRouter()
 
 
+def _state_value(agent) -> str:
+    state = getattr(agent, "lifecycle_state", "")
+    return str(getattr(state, "value", state) or "")
+
+
+def _agent_text(value) -> str:
+    return str(value or "").lower()
+
+
+def _query_fleet_fallback(
+    agents: list,
+    *,
+    state: str | None,
+    environment: str | None,
+    min_trust: float | None,
+    search: str | None,
+    include_quarantined: bool,
+    limit: int,
+    offset: int,
+) -> tuple[list, int]:
+    filtered = list(agents)
+    if not include_quarantined and state is None:
+        filtered = [a for a in filtered if _state_value(a) not in ("quarantined", "decommissioned")]
+    if state:
+        filtered = [a for a in filtered if _state_value(a) == state]
+    if environment:
+        filtered = [a for a in filtered if getattr(a, "environment", None) == environment]
+    if min_trust is not None:
+        filtered = [a for a in filtered if float(getattr(a, "trust_score", 0.0) or 0.0) >= min_trust]
+    if search:
+        needle = search.lower()
+        filtered = [
+            a
+            for a in filtered
+            if needle in _agent_text(getattr(a, "name", ""))
+            or needle in _agent_text(getattr(a, "owner", ""))
+            or needle in _agent_text(getattr(a, "environment", ""))
+            or any(needle in _agent_text(tag) for tag in getattr(a, "tags", []) or [])
+        ]
+    filtered = sorted(filtered, key=lambda a: (_agent_text(getattr(a, "name", "")), str(getattr(a, "agent_id", ""))))
+    total = len(filtered)
+    return filtered[offset : offset + limit], total
+
+
 def _request_header(request: Request, key: str) -> str:
     headers = getattr(request, "headers", None)
     if headers is None:
@@ -37,6 +81,7 @@ async def list_fleet(
     state: str | None = None,
     environment: str | None = None,
     min_trust: float | None = None,
+    search: str | None = None,
     include_quarantined: bool = False,
     limit: int = 50,
     offset: int = 0,
@@ -50,24 +95,42 @@ async def list_fleet(
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
     tenant_id = getattr(request.state, "tenant_id", "default")
-    agents = _get_fleet_store().list_by_tenant(tenant_id)
-    if not include_quarantined:
-        agents = [a for a in agents if a.lifecycle_state.value not in ("quarantined", "decommissioned")]
-    if state:
-        agents = [a for a in agents if a.lifecycle_state.value == state]
-    if environment:
-        agents = [a for a in agents if a.environment == environment]
-    if min_trust is not None:
-        _threshold = float(min_trust)
-        agents = [a for a in agents if (a.trust_score or 0.0) >= _threshold]
-    total = len(agents)
-    page = agents[offset : offset + limit]
+    min_trust_value = float(min_trust) if min_trust is not None else None
+    search_value = (search or "").strip() or None
+    store = _get_fleet_store()
+    result = None
+    query_by_tenant = getattr(store, "query_by_tenant", None)
+    if callable(query_by_tenant):
+        result = query_by_tenant(
+            tenant_id,
+            state=state,
+            environment=environment,
+            min_trust=min_trust_value,
+            search=search_value,
+            include_quarantined=include_quarantined,
+            limit=limit,
+            offset=offset,
+        )
+    if isinstance(result, tuple) and len(result) == 2:
+        page, total = result
+    else:
+        page, total = _query_fleet_fallback(
+            store.list_by_tenant(tenant_id),
+            state=state,
+            environment=environment,
+            min_trust=min_trust_value,
+            search=search_value,
+            include_quarantined=include_quarantined,
+            limit=limit,
+            offset=offset,
+        )
     return {
         "agents": [a.model_dump() for a in page],
         "count": len(page),
         "total": total,
         "limit": limit,
         "offset": offset,
+        "has_more": offset + len(page) < total,
     }
 
 

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -6,6 +6,7 @@ Endpoints:
   GET  /v1/graph/paths          — attack paths from a source node
   GET  /v1/graph/impact         — blast radius of a node (reverse BFS)
   GET  /v1/graph/search         — full-text graph search
+  GET  /v1/graph/agents         — paginated agent node selector
   POST /v1/graph/query          — programmable traversal query
   GET  /v1/graph/node/{id}      — single node detail with edges + impact
   GET  /v1/graph/snapshots      — list persisted scan snapshots
@@ -412,6 +413,63 @@ async def search_graph(
             "next_cursor": next_cursor or "",
             "has_more": bool(next_cursor) if cursor else offset + limit < total,
         },
+    }
+
+
+@router.get("/v1/graph/agents", tags=["graph"])
+async def list_graph_agents(
+    request: Request,
+    q: str = Query("", description="Optional agent label/id search"),
+    scan_id: Optional[str] = Query(None, description="Scan ID"),
+    cursor: Optional[str] = Query(None, description="Opaque cursor for keyset pagination"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    limit: int = Query(100, ge=1, le=500, description="Max agents"),
+) -> dict:
+    """List agent nodes for large-graph selectors without loading the full graph."""
+    graph_store = _get_graph_store_or_503()
+    tenant_id = _tenant(request)
+    query = q.strip()
+    if query:
+        agents, total, next_cursor = await _graph_store_call(
+            graph_store.search_nodes,
+            scan_id=scan_id or "",
+            tenant_id=tenant_id,
+            query=query,
+            entity_types={"agent"},
+            cursor=cursor,
+            offset=offset,
+            limit=limit,
+        )
+        effective_scan_id = scan_id or await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant_id)
+        created_at = ""
+    else:
+        effective_scan_id, created_at, agents, total, next_cursor = await _graph_store_call(
+            graph_store.page_nodes,
+            scan_id=scan_id or "",
+            tenant_id=tenant_id,
+            entity_types={"agent"},
+            cursor=cursor,
+            offset=offset,
+            limit=limit,
+        )
+    return {
+        "scan_id": effective_scan_id,
+        "tenant_id": tenant_id,
+        "created_at": created_at,
+        "agents": [
+            {
+                "id": node.id,
+                "label": node.label,
+                "risk_score": node.risk_score,
+                "severity": node.severity,
+                "status": node.status.value if hasattr(node.status, "value") else str(node.status),
+                "data_sources": node.data_sources,
+                "first_seen": node.first_seen,
+                "last_seen": node.last_seen,
+            }
+            for node in agents
+        ],
+        "pagination": _page_meta(total, offset, limit, cursor=cursor, next_cursor=next_cursor),
     }
 
 

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -105,6 +105,77 @@ def test_list_filter_min_trust():
     assert data["agents"][0]["agent_id"] == "a-2"
 
 
+def test_list_uses_server_side_search_and_pagination():
+    client, store = _fresh_client()
+    for idx in range(12):
+        store.put(
+            _make(
+                agent_id=f"a-{idx:02d}",
+                name=f"agent-{idx:02d}",
+                owner="platform" if idx % 2 == 0 else "security",
+                environment="prod" if idx % 3 == 0 else "dev",
+                tags=["critical"] if idx == 10 else [],
+            )
+        )
+
+    resp = client.get("/v1/fleet?search=platform&limit=3&offset=3")
+    data = resp.json()
+
+    assert resp.status_code == 200
+    assert data["count"] == 3
+    assert data["total"] == 6
+    assert data["limit"] == 3
+    assert data["offset"] == 3
+    assert data["has_more"] is False
+    assert [agent["name"] for agent in data["agents"]] == ["agent-06", "agent-08", "agent-10"]
+
+
+def test_list_falls_back_for_legacy_fleet_store_without_query_api():
+    import agent_bom.api.stores as api_stores
+
+    class LegacyFleetStore:
+        def __init__(self) -> None:
+            self.agents = [
+                _make(agent_id="a-1", name="agent-01", owner="platform", environment="prod"),
+                _make(agent_id="a-2", name="agent-02", owner="security", environment="prod"),
+                _make(agent_id="a-3", name="agent-03", owner="platform", environment="dev"),
+                _make(agent_id="a-4", name="agent-04", owner="platform", environment="prod"),
+            ]
+
+        def list_by_tenant(self, tenant_id: str):
+            return [agent for agent in self.agents if agent.tenant_id == tenant_id]
+
+    store = LegacyFleetStore()
+    original = api_stores._fleet_store
+    try:
+        set_fleet_store(store)
+        client = TestClient(app)
+
+        resp = client.get("/v1/fleet?search=platform&limit=2&offset=1")
+        data = resp.json()
+
+        assert resp.status_code == 200
+        assert data["count"] == 2
+        assert data["total"] == 3
+        assert data["has_more"] is False
+        assert [agent["agent_id"] for agent in data["agents"]] == ["a-3", "a-4"]
+    finally:
+        set_fleet_store(original)
+
+
+def test_list_explicit_quarantined_state_is_not_hidden_by_default_exclusion():
+    client, store = _fresh_client()
+    store.put(_make(agent_id="a-1", state=FleetLifecycleState.QUARANTINED))
+    store.put(_make(agent_id="a-2", state=FleetLifecycleState.APPROVED))
+
+    all_resp = client.get("/v1/fleet")
+    quarantined_resp = client.get("/v1/fleet?state=quarantined")
+
+    assert all_resp.json()["total"] == 1
+    assert quarantined_resp.json()["total"] == 1
+    assert quarantined_resp.json()["agents"][0]["lifecycle_state"] == "quarantined"
+
+
 # ── Get ───────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -287,6 +287,29 @@ class TestGraphEndpointLogic:
         assert [node.id for node in results] == ["server:prod:vector"]
         assert next_cursor is None
 
+    def test_graph_agents_endpoint_lists_agent_nodes_without_full_graph_load(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="agent-selector-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="agent:alpha", entity_type=EntityType.AGENT, label="Alpha Agent", risk_score=8.0))
+        graph.add_node(UnifiedNode(id="agent:beta", entity_type=EntityType.AGENT, label="Beta Agent", risk_score=2.0))
+        graph.add_node(UnifiedNode(id="server:alpha:fs", entity_type=EntityType.SERVER, label="Filesystem Server"))
+        store.save_graph(graph)
+        original_store = api_stores._graph_store
+        try:
+            set_graph_store(store)
+            client = TestClient(app)
+
+            response = client.get("/v1/graph/agents?scan_id=agent-selector-scan&limit=1")
+
+            assert response.status_code == 200
+            body = response.json()
+            assert body["pagination"]["total"] == 2
+            assert body["pagination"]["has_more"] is True
+            assert len(body["agents"]) == 1
+            assert body["agents"][0]["id"].startswith("agent:")
+        finally:
+            set_graph_store(original_store)
+
     def test_sqlite_graph_store_search_escapes_like_wildcards(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
         graph = UnifiedGraph(scan_id="search-scan", tenant_id="default")

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   api,
   type FleetAgent,
@@ -73,6 +73,8 @@ const TRANSITIONS: Record<FleetLifecycleState, FleetLifecycleState[]> = {
   decommissioned: [],
 };
 
+const FLEET_PAGE_SIZE = 100;
+
 function trustColor(score: number): string {
   if (score >= 80) return "bg-emerald-500";
   if (score >= 50) return "bg-yellow-500";
@@ -96,6 +98,8 @@ export default function FleetPage() {
   const [syncing, setSyncing] = useState(false);
   const [stateFilter, setStateFilter] = useState<string>("all");
   const [search, setSearch] = useState("");
+  const [fleetTotal, setFleetTotal] = useState(0);
+  const [fleetOffset, setFleetOffset] = useState(0);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [trustThreshold, setTrustThreshold] = useState(50);
   const [autoQuarantine, setAutoQuarantine] = useState(false);
@@ -106,16 +110,25 @@ export default function FleetPage() {
     [agents, trustThreshold]
   );
 
-  const load = () => {
+  const load = useCallback(() => {
     setLoading(true);
     setError(null);
     setWarning(null);
-    Promise.allSettled([api.listFleet(), api.getFleetStats()])
+    const filters = {
+      state: stateFilter === "all" ? undefined : stateFilter,
+      search: search.trim() || undefined,
+      include_quarantined: stateFilter !== "all",
+      limit: FLEET_PAGE_SIZE,
+      offset: fleetOffset,
+    };
+    Promise.allSettled([api.listFleet(filters), api.getFleetStats()])
       .then(([fleetResult, statsResult]) => {
         if (fleetResult.status === "fulfilled") {
           setAgents(fleetResult.value.agents);
+          setFleetTotal(fleetResult.value.total);
         } else {
           setAgents([]);
+          setFleetTotal(0);
         }
 
         if (statsResult.status === "fulfilled") {
@@ -139,9 +152,15 @@ export default function FleetPage() {
         }
       })
       .finally(() => setLoading(false));
-  };
+  }, [fleetOffset, search, stateFilter]);
 
-  useEffect(load, []);
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    setFleetOffset(0);
+  }, [search, stateFilter]);
 
   const handleSync = async () => {
     setSyncing(true);
@@ -168,17 +187,11 @@ export default function FleetPage() {
     });
   };
 
-  const filtered = agents
-    .filter((a) => stateFilter === "all" || a.lifecycle_state === stateFilter)
-    .filter((a) => {
-      if (!search) return true;
-      const q = search.toLowerCase();
-      return (
-        a.name.toLowerCase().includes(q) ||
-        (a.owner ?? "").toLowerCase().includes(q) ||
-        (a.environment ?? "").toLowerCase().includes(q)
-      );
-    });
+  const filtered = agents;
+  const pageStart = fleetTotal > 0 ? fleetOffset + 1 : 0;
+  const pageEnd = fleetTotal > 0 ? Math.min(fleetOffset + agents.length, fleetTotal) : 0;
+  const pageNumber = Math.floor(fleetOffset / FLEET_PAGE_SIZE) + 1;
+  const totalPages = Math.max(1, Math.ceil(fleetTotal / FLEET_PAGE_SIZE));
 
   return (
     <div className="space-y-6">
@@ -311,15 +324,27 @@ export default function FleetPage() {
       })()}
 
       {/* Search + Filter tabs */}
-      <div className="relative w-full sm:w-72">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-600" />
-        <input
-          type="text"
-          placeholder="Search by name, owner, environment…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-full bg-zinc-900 border border-zinc-700 rounded-lg pl-8 pr-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
-        />
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="relative w-full sm:w-96">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-600" />
+          <input
+            type="text"
+            placeholder="Search by name, owner, environment, or tag..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg pl-8 pr-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+          />
+        </div>
+        <div className="text-xs text-zinc-500">
+          {fleetTotal > 0 ? (
+            <span>
+              Showing <span className="font-mono text-zinc-300">{pageStart}-{pageEnd}</span> of{" "}
+              <span className="font-mono text-zinc-300">{fleetTotal}</span> agents
+            </span>
+          ) : (
+            <span>No matching agents</span>
+          )}
+        </div>
       </div>
 
       <div className="flex gap-1.5 flex-wrap">
@@ -483,6 +508,33 @@ export default function FleetPage() {
               </div>
             );
           })}
+        </div>
+      )}
+
+      {!loading && fleetTotal > FLEET_PAGE_SIZE && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-zinc-800 bg-zinc-900 px-4 py-3">
+          <div className="text-xs text-zinc-500">
+            Page <span className="font-mono text-zinc-300">{pageNumber}</span> of{" "}
+            <span className="font-mono text-zinc-300">{totalPages}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setFleetOffset((current) => Math.max(0, current - FLEET_PAGE_SIZE))}
+              disabled={fleetOffset === 0}
+              className="rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              onClick={() => setFleetOffset((current) => current + FLEET_PAGE_SIZE)}
+              disabled={fleetOffset + agents.length >= fleetTotal}
+              className="rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/ui/components/agent-topology.tsx
+++ b/ui/components/agent-topology.tsx
@@ -17,6 +17,9 @@ import "@xyflow/react/dist/style.css";
 import { Lock, Network, Package, Server, ShieldAlert, Wrench } from "lucide-react";
 import type { Agent } from "@/lib/api";
 
+const MAX_RENDERED_AGENTS = 75;
+const MAX_RENDERED_SERVERS = 220;
+
 // ─── Custom Node Components with proper Handles ─────────────────────────────
 
 function AgentNode({ data }: { data: { label: string; type: string; serverCount: number; vulnCount: number } }) {
@@ -248,6 +251,31 @@ export function AgentTopology({ agents, direction = "LR" }: { agents: Agent[]; d
       credentialedServers,
     };
   }, [agents]);
+  const displayAgents = useMemo(() => {
+    let renderedServers = 0;
+    return [...agents]
+      .sort((left, right) => {
+        const leftServers = left.mcp_servers ?? [];
+        const rightServers = right.mcp_servers ?? [];
+        const leftVulns = leftServers.reduce(
+          (total, server) => total + (server.packages ?? []).reduce((sum, pkg) => sum + (pkg.vulnerabilities?.length ?? 0), 0),
+          0,
+        );
+        const rightVulns = rightServers.reduce(
+          (total, server) => total + (server.packages ?? []).reduce((sum, pkg) => sum + (pkg.vulnerabilities?.length ?? 0), 0),
+          0,
+        );
+        return rightVulns - leftVulns || rightServers.length - leftServers.length || left.name.localeCompare(right.name);
+      })
+      .filter((agent) => {
+        if (renderedServers >= MAX_RENDERED_SERVERS) return false;
+        renderedServers += agent.mcp_servers?.length ?? 0;
+        return true;
+      })
+      .slice(0, MAX_RENDERED_AGENTS);
+  }, [agents]);
+  const hiddenAgentCount = Math.max(0, agents.length - displayAgents.length);
+  const hiddenServerCount = Math.max(0, summary.servers - displayAgents.flatMap((agent) => agent.mcp_servers ?? []).length);
 
   const handleAgentClick = useCallback(
     (name: string) => {
@@ -290,9 +318,16 @@ export function AgentTopology({ agents, direction = "LR" }: { agents: Agent[]; d
           </div>
         </div>
       </div>
+      {(hiddenAgentCount > 0 || hiddenServerCount > 0) && (
+        <div className="border-b border-zinc-800/80 bg-zinc-950/70 px-4 py-2 text-xs text-zinc-400">
+          Showing the highest-risk {displayAgents.length} agents and{" "}
+          {displayAgents.flatMap((agent) => agent.mcp_servers ?? []).length} servers to keep the canvas responsive. Use Fleet search or the
+          Security Graph for the remaining {hiddenAgentCount} agents and {hiddenServerCount} servers.
+        </div>
+      )}
       <div className="px-2 pb-2 pt-1" style={{ height: 400 }}>
         <ReactFlowProvider>
-          <TopologyFlow agents={agents} onAgentClick={handleAgentClick} direction={direction} />
+          <TopologyFlow agents={displayAgents} onAgentClick={handleAgentClick} direction={direction} />
         </ReactFlowProvider>
       </div>
     </div>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -101,6 +101,8 @@ export interface GraphPagination {
   offset: number;
   limit: number;
   has_more: boolean;
+  cursor?: string;
+  next_cursor?: string;
 }
 
 export interface GraphSnapshot {
@@ -135,6 +137,25 @@ export interface GraphNodeDetailResponse {
 export interface GraphSearchResponse {
   query: string;
   results: UnifiedNode[];
+  pagination: GraphPagination;
+}
+
+export interface GraphAgentSelectorItem {
+  id: string;
+  label: string;
+  risk_score: number;
+  severity: string;
+  status: string;
+  data_sources: string[];
+  first_seen: string;
+  last_seen: string;
+}
+
+export interface GraphAgentsResponse {
+  scan_id: string;
+  tenant_id: string;
+  created_at: string;
+  agents: GraphAgentSelectorItem[];
   pagination: GraphPagination;
 }
 
@@ -1060,6 +1081,10 @@ export interface FleetAgent {
 export interface FleetResponse {
   agents: FleetAgent[];
   count: number;
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
 }
 
 export interface FleetStatsResponse {
@@ -1408,6 +1433,18 @@ export const api = {
     return get<GraphSearchResponse>(`/v1/graph/search?${params.toString()}`);
   },
 
+  /** List agent nodes for large graph selectors without loading the full graph */
+  listGraphAgents: (filters?: { query?: string; scanId?: string; offset?: number; limit?: number; cursor?: string }) => {
+    const params = new URLSearchParams();
+    if (filters?.query) params.set("q", filters.query);
+    if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.cursor) params.set("cursor", filters.cursor);
+    const qs = params.toString();
+    return get<GraphAgentsResponse>(`/v1/graph/agents${qs ? `?${qs}` : ""}`);
+  },
+
   /** Load one graph node plus impact and neighbor context */
   getGraphNode: (nodeId: string, scanId?: string) => {
     const params = new URLSearchParams();
@@ -1458,11 +1495,23 @@ export const api = {
     get<ComplianceNarrativeResponse>(`/v1/compliance/narrative/${encodeURIComponent(framework)}`),
 
   /** Fleet management */
-  listFleet: (filters?: { state?: string; environment?: string; min_trust?: number }) => {
+  listFleet: (filters?: {
+    state?: string;
+    environment?: string;
+    min_trust?: number;
+    search?: string;
+    include_quarantined?: boolean;
+    limit?: number;
+    offset?: number;
+  }) => {
     const params = new URLSearchParams();
     if (filters?.state) params.set("state", filters.state);
     if (filters?.environment) params.set("environment", filters.environment);
     if (filters?.min_trust != null) params.set("min_trust", String(filters.min_trust));
+    if (filters?.search) params.set("search", filters.search);
+    if (filters?.include_quarantined) params.set("include_quarantined", "true");
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
     const qs = params.toString();
     return get<FleetResponse>(`/v1/fleet${qs ? `?${qs}` : ""}`);
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "bundle:check": "node scripts/check-bundle-budget.mjs",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "lock:normalize": "npm install --package-lock-only --ignore-scripts",
     "test:e2e": "playwright test",


### PR DESCRIPTION
Summary
- Moves fleet listing to server-side filtering and pagination for large tenants instead of loading/filtering whole fleet dumps in the UI.
- Adds Postgres fleet indexes and a query_by_tenant store path for tenant/state/trust/search windows.
- Adds GET /v1/graph/agents for paginated agent-node selectors without loading the full security graph.
- Caps the dashboard topology preview to a readable highest-risk working set and points operators to Fleet search / Security Graph for the rest.
- Adds a UI typecheck script so local and CI validation use the locked TypeScript dependency instead of accidental npx package resolution.
- Updates the performance guide to frame large/thousands-of-agents fleets as a bounded-window design, not a fixed product ceiling.

Why
Teams may have thousands of agents and large MCP/package/call/vulnerability graphs. Operator workflows need bounded DB reads, paginated graph selectors, and UI canvases that stay readable and responsive.

Validation
- uv run ruff check src/agent_bom/api/fleet_store.py src/agent_bom/api/postgres_store.py src/agent_bom/api/routes/fleet.py src/agent_bom/api/routes/graph.py tests/test_api_fleet.py tests/test_graph_api.py
- uv run pytest tests/test_api_fleet.py tests/test_graph_api.py -q
- cd ui && npm ci
- cd ui && npm run lint
- cd ui && npm run typecheck
- uv run mkdocs build --strict
- git diff --check origin/main...HEAD
