### PR TITLE
fix: redact OIDC posture config errors

### DIFF
--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -602,6 +602,9 @@ def describe_oidc_posture() -> dict[str, object]:
     try:
         config = OIDCConfig.from_env()
     except OIDCError as exc:
+        from agent_bom.security import sanitize_error
+
+        logger.warning("OIDC posture config is invalid: %s", sanitize_error(exc))
         return {
             "supported": True,
             "configured": False,
@@ -615,7 +618,7 @@ def describe_oidc_posture() -> dict[str, object]:
             "require_tenant_claim": False,
             "allow_default_tenant": False,
             "required_nonce": False,
-            "message": str(exc),
+            "message": "OIDC configuration is invalid. Check control-plane logs and OIDC environment settings.",
         }
 
     if not config.enabled:

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -198,6 +198,21 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "service_keys" in body["identity_provisioning"]["session_revocation"]
 
 
+def test_auth_policy_redacts_oidc_config_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON", '{"tenant-secret":')
+
+    client = TestClient(app)
+    resp = client.get("/v1/auth/policy")
+
+    assert resp.status_code == 200
+    oidc = resp.json()["identity_provisioning"]["oidc"]
+    assert oidc["mode"] == "invalid"
+    assert oidc["message"] == "OIDC configuration is invalid. Check control-plane logs and OIDC environment settings."
+    assert "tenant-secret" not in oidc["message"]
+    assert "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON" not in oidc["message"]
+
+
 def test_auth_policy_reports_secret_integrity_posture(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_rate_limit_env(monkeypatch)
     monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "audit-secret")


### PR DESCRIPTION
Summary
- Fixes CodeQL alert #1569 by preventing OIDC configuration exception text from being returned by /v1/auth/policy.
- Logs a sanitized server-side diagnostic while returning a stable invalid-config message to API clients.
- Adds a regression test proving tenant/env details are not exposed in the auth policy response.

Validation
- uv run ruff check src/agent_bom/api/oidc.py tests/test_api_operator_policy.py
- uv run pytest tests/test_api_operator_policy.py::test_auth_policy_redacts_oidc_config_errors tests/test_api_operator_policy.py::test_auth_policy_surface_shape -q
- uv run pytest tests/test_api_operator_policy.py -q
- git diff --check