### PR TITLE
feat: add SCIM lifecycle provisioning

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -31,6 +31,8 @@ controlPlane:
         value: "5000"
       - name: AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT
         value: "250"
+      - name: AGENT_BOM_REQUIRE_SHARED_SCIM_STORE
+        value: "1"
     autoscaling:
       enabled: true
       minReplicas: 2
@@ -96,6 +98,14 @@ controlPlane:
             remoteRef:
               key: REPLACE_ME_AUTH_SECRET_PATH
               property: REPLACE_ME_OIDC_AUDIENCE_PROPERTY
+          - secretKey: AGENT_BOM_SCIM_BEARER_TOKEN
+            remoteRef:
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SCIM_BEARER_TOKEN_PROPERTY
+          - secretKey: AGENT_BOM_SCIM_TENANT_ID
+            remoteRef:
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SCIM_TENANT_ID_PROPERTY
           - secretKey: AGENT_BOM_SAML_IDP_ENTITY_ID
             remoteRef:
               key: REPLACE_ME_AUTH_SECRET_PATH

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -394,6 +394,8 @@ controlPlane:
         apiPaths:
           - path: /v1
             pathType: Prefix
+          - path: /scim
+            pathType: Prefix
           - path: /health
             pathType: Prefix
           - path: /docs

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -10,6 +10,7 @@ It exists for a simple reason: the controls are real, but they should not requir
 
 - API key auth with ordered RBAC route rules
 - optional OIDC bearer auth with fail-closed tenant claims
+- dedicated SCIM user/group provisioning for enterprise IdPs
 - PostgreSQL-backed multi-tenant stores with row-level security
 - HMAC-chained audit logging
 - request tracing and `/health` observability contracts
@@ -22,6 +23,7 @@ It exists for a simple reason: the controls are real, but they should not requir
 | API key auth + RBAC | API keys carry `admin` / `analyst` / `viewer` roles and are checked per route prefix | `src/agent_bom/api/auth.py`, `src/agent_bom/api/middleware.py` |
 | OIDC / SSO | Any standard OIDC provider can issue bearer tokens for API access | `src/agent_bom/api/oidc.py`, `src/agent_bom/api/middleware.py` |
 | Fail-closed tenant claims | Missing tenant claims now fail closed by default; `AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT=1` is the explicit single-tenant compatibility override | `src/agent_bom/api/oidc.py` |
+| SCIM lifecycle provisioning | IdPs can create, list, patch, deactivate, and group users through a dedicated SCIM bearer surface | `src/agent_bom/api/routes/scim.py`, `src/agent_bom/api/scim_store.py`, `src/agent_bom/api/postgres_scim.py` |
 | Postgres tenant isolation | The authenticated tenant is pushed into the DB session as `app.tenant_id` before request handling | `src/agent_bom/api/middleware.py`, `src/agent_bom/api/postgres_store.py` |
 | PostgreSQL row-level security | Tenant-bearing tables have RLS policies keyed off the current tenant | `deploy/supabase/postgres/init.sql`, `src/agent_bom/api/postgres_store.py` |
 | API keys persisted in Postgres | Keys move from in-memory to transactional storage when `AGENT_BOM_POSTGRES_URL` is set | `src/agent_bom/api/server.py`, `src/agent_bom/api/postgres_store.py`, `src/agent_bom/api/auth.py` |
@@ -39,6 +41,10 @@ The API middleware uses ordered route rules. Narrower enterprise routes win over
 | Method | Route prefix | Minimum role |
 |---|---|---|
 | `GET` | `/v1/auth/keys` | `admin` |
+| `GET` | `/scim/v2` | `admin` |
+| `POST` | `/scim/v2` | `admin` |
+| `PATCH` | `/scim/v2` | `admin` |
+| `DELETE` | `/scim/v2` | `admin` |
 | `POST` | `/v1/auth/keys` | `admin` |
 | `POST` | `/v1/auth/keys/` | `admin` |
 | `DELETE` | `/v1/auth/keys/` | `admin` |
@@ -71,7 +77,7 @@ Implementation source: `src/agent_bom/api/middleware.py`
 
 ## Authentication Contract
 
-`agent-bom api` and `agent-bom serve` support three runtime postures:
+`agent-bom api` and `agent-bom serve` support four runtime postures:
 
 1. Loopback development
    - localhost binds are allowed without remote auth
@@ -88,6 +94,12 @@ Implementation source: `src/agent_bom/api/middleware.py`
    - missing tenant claims fail closed by default
    - opt into single-tenant default mode only with `AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT=1`
    - optionally set `AGENT_BOM_OIDC_REQUIRED_NONCE` when your IdP flow includes a nonce claim
+4. SCIM lifecycle provisioning
+   - set `AGENT_BOM_SCIM_BEARER_TOKEN` to enable `/scim/v2/Users`, `/scim/v2/Groups`, and `/scim/v2/ServiceProviderConfig`
+   - set `AGENT_BOM_SCIM_TENANT_ID` to bind all inbound SCIM lifecycle writes to one tenant; tenant IDs supplied by the IdP payload are ignored
+   - set `AGENT_BOM_SCIM_BASE_PATH` before API startup if your IdP requires a different SCIM path
+   - use PostgreSQL or Supabase for clustered, multi-node, or EKS deployments; SQLite is only for single-node pilots
+   - SCIM traffic uses the dedicated SCIM bearer token only and does not accept dashboard sessions or general API keys
 
 Rate limiting also follows an explicit fail-closed contract for scaled control planes:
 
@@ -105,7 +117,7 @@ Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oid
 |---|---|---|
 | PostgreSQL | Full transactional control-plane backend | team and enterprise API deployments |
 | Supabase | Full transactional control-plane backend because it is PostgreSQL | managed Postgres deployments |
-| SQLite | single-node / local persistence | local or small deployments |
+| SQLite | single-node / local persistence | local or small deployments; not for clustered SCIM identity state |
 | ClickHouse | analytics backend | high-volume scan and posture analytics |
 | Snowflake | selected enterprise stores, not full transactional parity | governance / warehouse-native environments |
 

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -169,9 +169,21 @@ export AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON='{
 
 At startup, `agent-bom` treats `AGENT_BOM_OIDC_ISSUER` and `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON` as mutually exclusive. Mixed configuration now fails closed instead of silently choosing one mode.
 
+For SCIM-backed enterprise identity provisioning, use the dedicated SCIM token and tenant binding:
+
+```bash
+export AGENT_BOM_SCIM_BEARER_TOKEN="replace-with-idp-scim-token"
+export AGENT_BOM_SCIM_TENANT_ID="tenant-alpha"
+# export AGENT_BOM_SCIM_BASE_PATH="/scim/v2"
+```
+
+SCIM lifecycle traffic is available under `/scim/v2/Users`, `/scim/v2/Groups`, `/scim/v2/ServiceProviderConfig`, `/scim/v2/Schemas`, and `/scim/v2/ResourceTypes`. These routes require `AGENT_BOM_SCIM_BEARER_TOKEN`; dashboard sessions and general API keys are not accepted. The tenant is always taken from `AGENT_BOM_SCIM_TENANT_ID`, so tenant fields in the IdP payload cannot steer writes into another tenant.
+
 For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated tenant into the database session (`app.tenant_id`) so Postgres row-level security can enforce the same tenant boundary for fleet and schedule data. Internal scheduler work uses an explicit trusted bypass rather than silently reading across tenants.
 
 For horizontally scaled control-plane APIs, shared rate limiting is mandatory. `agent-bom` now fails closed when `AGENT_BOM_CONTROL_PLANE_REPLICAS > 1` (or `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1`) and no PostgreSQL-backed limiter is configured via `AGENT_BOM_POSTGRES_URL`.
+
+For horizontally scaled SCIM, shared identity storage is also mandatory. Set `AGENT_BOM_POSTGRES_URL` for EKS or any multi-replica control plane, and keep `AGENT_BOM_REQUIRE_SHARED_SCIM_STORE=1` enabled in production values. SQLite is acceptable only for a single-node pilot.
 
 **Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, graph state, and trend history.
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -69,6 +69,7 @@ def configure_auth_runtime(
     api_key_configured: bool,
     oidc_enabled: bool,
     trusted_proxy_enabled: bool,
+    scim_enabled: bool = False,
 ) -> None:
     """Track the active auth modes for operator/UI introspection surfaces."""
     configured_modes: list[str] = []
@@ -78,6 +79,8 @@ def configure_auth_runtime(
         configured_modes.append("oidc_bearer")
     if api_key_configured:
         configured_modes.append("api_key")
+    if scim_enabled:
+        configured_modes.append("scim_provisioning")
 
     recommended_ui_mode = "no_auth"
     if trusted_proxy_enabled:
@@ -345,6 +348,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("GET", "/v1/auth/me", "viewer"),
         ("GET", "/v1/auth/policy", "admin"),
         ("GET", "/v1/auth/scim/config", "admin"),
+        ("GET", "/scim/v2", "admin"),
+        ("POST", "/scim/v2", "admin"),
+        ("PATCH", "/scim/v2", "admin"),
+        ("PUT", "/scim/v2", "admin"),
+        ("DELETE", "/scim/v2", "admin"),
         ("GET", "/v1/auth/quota", "admin"),
         ("GET", "/v1/auth/keys", "admin"),
         ("GET", "/v1/tenant/", "admin"),
@@ -391,6 +399,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     _SCOPE_RULES: tuple[tuple[str, str, str], ...] = (
         ("GET", "/v1/auth/keys", "auth.keys:read"),
         ("GET", "/v1/auth/scim/config", "auth.scim:read"),
+        ("GET", "/scim/v2", "auth.scim:read"),
+        ("POST", "/scim/v2", "auth.scim:write"),
+        ("PATCH", "/scim/v2", "auth.scim:write"),
+        ("PUT", "/scim/v2", "auth.scim:write"),
+        ("DELETE", "/scim/v2", "auth.scim:write"),
         ("GET", "/v1/auth/quota", "auth.quota:read"),
         ("GET", "/v1/tenant/", "privacy.data:read"),
         ("POST", "/v1/auth/keys", "auth.keys:write"),
@@ -442,6 +455,9 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: StarletteRequest, call_next):
         if request.url.path in self._EXEMPT_PATHS:
             return await call_next(request)
+
+        if self._is_scim_path(request.url.path):
+            return await self._try_scim_bearer_auth(request, call_next)
 
         session_token = request.cookies.get(SESSION_COOKIE_NAME, "")
         if session_token:
@@ -545,6 +561,37 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             status_code=401,
             content={"detail": "Unauthorized — invalid API key"},
         )
+
+    def _is_scim_path(self, path: str) -> bool:
+        from agent_bom.api.scim import scim_base_path
+
+        base = scim_base_path()
+        return path == base or path.startswith(base + "/")
+
+    async def _try_scim_bearer_auth(self, request: StarletteRequest, call_next):
+        """Authenticate dedicated SCIM provisioning traffic.
+
+        SCIM uses its own bearer token and tenant binding so IdP lifecycle
+        traffic cannot be hijacked through dashboard sessions or general API
+        keys, and tenant routing cannot be supplied by the inbound payload.
+        """
+        configured = os.environ.get("AGENT_BOM_SCIM_BEARER_TOKEN", "").strip()
+        auth = request.headers.get("authorization", "")
+        raw_key = auth[7:] if auth.startswith("Bearer ") else ""
+        if not configured or not raw_key or not secrets.compare_digest(raw_key, configured):
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized — SCIM bearer token required"},
+            )
+
+        from agent_bom.api.scim import scim_tenant_id_from_env
+
+        request.state.api_key_name = "scim-provisioner"
+        request.state.api_key_role = "admin"
+        request.state.tenant_id = scim_tenant_id_from_env()
+        request.state.api_key_scopes = ["auth.scim:read", "auth.scim:write"]
+        request.state.auth_method = "scim_bearer"
+        return await self._call_with_tenant_context(request, call_next)
 
     async def _try_browser_session_auth(self, request: StarletteRequest, call_next, token: str):
         from agent_bom.api.auth import _ROLE_HIERARCHY, Role, get_key_store

--- a/src/agent_bom/api/postgres_scim.py
+++ b/src/agent_bom/api/postgres_scim.py
@@ -1,0 +1,174 @@
+"""Postgres-backed SCIM lifecycle store."""
+
+from __future__ import annotations
+
+import json
+
+from agent_bom.api.postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.scim_store import SCIMGroup, SCIMUser
+from agent_bom.platform_invariants import normalize_tenant_id, now_utc_iso
+
+
+class PostgresSCIMStore:
+    """Shared SCIM store for clustered self-hosted deployments."""
+
+    def __init__(self, pool=None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS scim_users (
+                    tenant_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    external_id TEXT,
+                    user_name TEXT NOT NULL,
+                    active BOOLEAN NOT NULL DEFAULT TRUE,
+                    updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+                    data JSONB NOT NULL,
+                    PRIMARY KEY (tenant_id, user_id)
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_scim_users_lookup ON scim_users(tenant_id, user_name, external_id)")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS scim_groups (
+                    tenant_id TEXT NOT NULL,
+                    group_id TEXT NOT NULL,
+                    external_id TEXT,
+                    display_name TEXT NOT NULL,
+                    updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+                    data JSONB NOT NULL,
+                    PRIMARY KEY (tenant_id, group_id)
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_scim_groups_lookup ON scim_groups(tenant_id, display_name, external_id)")
+            _ensure_tenant_rls(conn, "scim_users", "tenant_id")
+            _ensure_tenant_rls(conn, "scim_groups", "tenant_id")
+            conn.commit()
+
+    def put_user(self, user: SCIMUser) -> SCIMUser:
+        user.updated_at = now_utc_iso()
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO scim_users (tenant_id, user_id, external_id, user_name, active, updated_at, data)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, user_id) DO UPDATE SET
+                    external_id = EXCLUDED.external_id,
+                    user_name = EXCLUDED.user_name,
+                    active = EXCLUDED.active,
+                    updated_at = EXCLUDED.updated_at,
+                    data = EXCLUDED.data
+                """,
+                (
+                    user.tenant_id,
+                    user.user_id,
+                    user.external_id,
+                    user.user_name,
+                    user.active,
+                    user.updated_at,
+                    json.dumps(user.model_dump(mode="json"), sort_keys=True),
+                ),
+            )
+            conn.commit()
+        return user
+
+    def get_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM scim_users WHERE tenant_id = %s AND user_id = %s",
+                (normalize_tenant_id(tenant_id), user_id),
+            ).fetchone()
+        return _load_user(row[0]) if row else None
+
+    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]:
+        tenant = normalize_tenant_id(tenant_id)
+        query = "SELECT data FROM scim_users WHERE tenant_id = %s ORDER BY user_name ASC, user_id ASC"
+        params: tuple[object, ...] = (tenant,)
+        if filter_attr == "userName":
+            query = "SELECT data FROM scim_users WHERE tenant_id = %s AND user_name = %s ORDER BY user_name ASC, user_id ASC"
+            params = (tenant, filter_value)
+        elif filter_attr == "externalId":
+            query = "SELECT data FROM scim_users WHERE tenant_id = %s AND external_id = %s ORDER BY user_name ASC, user_id ASC"
+            params = (tenant, filter_value)
+        elif filter_attr == "id":
+            query = "SELECT data FROM scim_users WHERE tenant_id = %s AND user_id = %s ORDER BY user_name ASC, user_id ASC"
+            params = (tenant, filter_value)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [_load_user(row[0]) for row in rows]
+
+    def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
+        user = self.get_user(tenant_id, user_id)
+        if user is None:
+            return None
+        user.active = False
+        return self.put_user(user)
+
+    def put_group(self, group: SCIMGroup) -> SCIMGroup:
+        group.updated_at = now_utc_iso()
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO scim_groups (tenant_id, group_id, external_id, display_name, updated_at, data)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, group_id) DO UPDATE SET
+                    external_id = EXCLUDED.external_id,
+                    display_name = EXCLUDED.display_name,
+                    updated_at = EXCLUDED.updated_at,
+                    data = EXCLUDED.data
+                """,
+                (
+                    group.tenant_id,
+                    group.group_id,
+                    group.external_id,
+                    group.display_name,
+                    group.updated_at,
+                    json.dumps(group.model_dump(mode="json"), sort_keys=True),
+                ),
+            )
+            conn.commit()
+        return group
+
+    def get_group(self, tenant_id: str, group_id: str) -> SCIMGroup | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM scim_groups WHERE tenant_id = %s AND group_id = %s",
+                (normalize_tenant_id(tenant_id), group_id),
+            ).fetchone()
+        return _load_group(row[0]) if row else None
+
+    def list_groups(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMGroup]:
+        tenant = normalize_tenant_id(tenant_id)
+        query = "SELECT data FROM scim_groups WHERE tenant_id = %s ORDER BY display_name ASC, group_id ASC"
+        params: tuple[object, ...] = (tenant,)
+        if filter_attr == "displayName":
+            query = "SELECT data FROM scim_groups WHERE tenant_id = %s AND display_name = %s ORDER BY display_name ASC, group_id ASC"
+            params = (tenant, filter_value)
+        elif filter_attr == "externalId":
+            query = "SELECT data FROM scim_groups WHERE tenant_id = %s AND external_id = %s ORDER BY display_name ASC, group_id ASC"
+            params = (tenant, filter_value)
+        elif filter_attr == "id":
+            query = "SELECT data FROM scim_groups WHERE tenant_id = %s AND group_id = %s ORDER BY display_name ASC, group_id ASC"
+            params = (tenant, filter_value)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [_load_group(row[0]) for row in rows]
+
+    def delete_group(self, tenant_id: str, group_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "DELETE FROM scim_groups WHERE tenant_id = %s AND group_id = %s",
+                (normalize_tenant_id(tenant_id), group_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+
+def _load_user(raw: object) -> SCIMUser:
+    return SCIMUser(**(raw if isinstance(raw, dict) else json.loads(str(raw))))
+
+
+def _load_group(raw: object) -> SCIMGroup:
+    return SCIMGroup(**(raw if isinstance(raw, dict) else json.loads(str(raw))))

--- a/src/agent_bom/api/routes/scim.py
+++ b/src/agent_bom/api/routes/scim.py
@@ -1,0 +1,501 @@
+"""SCIM 2.0 lifecycle endpoints for enterprise identity provisioning."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+
+from agent_bom.api.audit_log import log_action
+from agent_bom.api.scim import scim_base_path
+from agent_bom.api.scim_store import SCIMGroup, SCIMUser
+from agent_bom.api.stores import _get_scim_store
+from agent_bom.platform_invariants import now_utc_iso
+
+SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
+SCIM_GROUP_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Group"
+SCIM_LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+SCIM_SERVICE_PROVIDER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+SCIM_SCHEMA_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Schema"
+SCIM_RESOURCE_TYPE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+router = APIRouter(prefix=scim_base_path(), tags=["scim"])
+_FILTER_RE = re.compile(r'^\s*(userName|displayName|externalId|id)\s+eq\s+"([^"]{1,512})"\s*$')
+
+
+def _tenant_id(request: Request) -> str:
+    return str(getattr(request.state, "tenant_id", "") or "default")
+
+
+def _actor(request: Request) -> str:
+    return str(getattr(request.state, "api_key_name", None) or "scim-provisioner")
+
+
+def _require_scim(request: Request) -> None:
+    if getattr(request.state, "auth_method", None) != "scim_bearer":
+        raise HTTPException(status_code=401, detail="SCIM bearer token required")
+
+
+def _parse_filter(raw: str | None) -> tuple[str | None, str | None]:
+    if not raw:
+        return None, None
+    match = _FILTER_RE.match(raw)
+    if not match:
+        raise HTTPException(status_code=400, detail="Unsupported SCIM filter")
+    return match.group(1), match.group(2)
+
+
+def _paginate(items: list[Any], start_index: int, count: int) -> list[Any]:
+    offset = max(start_index, 1) - 1
+    return items[offset : offset + max(min(count, 500), 0)]
+
+
+def _location(request: Request, kind: str, resource_id: str) -> str:
+    return str(request.url_for(f"scim_get_{kind}", **{f"{kind}_id": resource_id}))
+
+
+def _optional_str(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _user_from_payload(tenant_id: str, body: dict[str, Any], *, existing: SCIMUser | None = None) -> SCIMUser:
+    user_name = str(body.get("userName") or (existing.user_name if existing else "")).strip()
+    if not user_name:
+        raise HTTPException(status_code=400, detail="userName is required")
+    display_name = str(body.get("displayName") or "").strip()
+    if not display_name and isinstance(body.get("name"), dict):
+        display_name = str(body["name"].get("formatted") or "").strip()
+    if existing and not display_name:
+        display_name = existing.display_name
+    emails = body.get("emails", existing.emails if existing else [])
+    if not isinstance(emails, list):
+        raise HTTPException(status_code=400, detail="emails must be a list")
+    groups = [str(group.get("value", "")).strip() for group in body.get("groups", []) if isinstance(group, dict) and group.get("value")]
+    external_id = _optional_str(body.get("externalId"))
+    if external_id is None and existing is not None:
+        external_id = existing.external_id
+    return SCIMUser(
+        tenant_id=tenant_id,
+        user_id=existing.user_id if existing else str(body.get("id") or uuid.uuid4()),
+        external_id=external_id,
+        user_name=user_name,
+        display_name=display_name,
+        active=bool(body.get("active", existing.active if existing else True)),
+        emails=[entry for entry in emails if isinstance(entry, dict)],
+        groups=groups or (existing.groups if existing else []),
+        raw=dict(body),
+        created_at=existing.created_at if existing else now_utc_iso(),
+        updated_at=now_utc_iso(),
+    )
+
+
+def _group_from_payload(tenant_id: str, body: dict[str, Any], *, existing: SCIMGroup | None = None) -> SCIMGroup:
+    display_name = str(body.get("displayName") or (existing.display_name if existing else "")).strip()
+    if not display_name:
+        raise HTTPException(status_code=400, detail="displayName is required")
+    members = body.get("members", existing.members if existing else [])
+    if not isinstance(members, list):
+        raise HTTPException(status_code=400, detail="members must be a list")
+    external_id = _optional_str(body.get("externalId"))
+    if external_id is None and existing is not None:
+        external_id = existing.external_id
+    return SCIMGroup(
+        tenant_id=tenant_id,
+        group_id=existing.group_id if existing else str(body.get("id") or uuid.uuid4()),
+        external_id=external_id,
+        display_name=display_name,
+        members=[entry for entry in members if isinstance(entry, dict)],
+        raw=dict(body),
+        created_at=existing.created_at if existing else now_utc_iso(),
+        updated_at=now_utc_iso(),
+    )
+
+
+def _user_to_scim(user: SCIMUser, request: Request) -> dict[str, Any]:
+    return {
+        "schemas": [SCIM_USER_SCHEMA],
+        "id": user.user_id,
+        "externalId": user.external_id,
+        "userName": user.user_name,
+        "displayName": user.display_name,
+        "active": user.active,
+        "emails": user.emails,
+        "groups": [{"value": group_id} for group_id in user.groups],
+        "meta": {
+            "resourceType": "User",
+            "created": user.created_at,
+            "lastModified": user.updated_at,
+            "location": _location(request, "user", user.user_id),
+        },
+    }
+
+
+def _group_to_scim(group: SCIMGroup, request: Request) -> dict[str, Any]:
+    return {
+        "schemas": [SCIM_GROUP_SCHEMA],
+        "id": group.group_id,
+        "externalId": group.external_id,
+        "displayName": group.display_name,
+        "members": group.members,
+        "meta": {
+            "resourceType": "Group",
+            "created": group.created_at,
+            "lastModified": group.updated_at,
+            "location": _location(request, "group", group.group_id),
+        },
+    }
+
+
+def _apply_user_patch(user: SCIMUser, body: dict[str, Any]) -> SCIMUser:
+    operations = body.get("Operations", [])
+    if not isinstance(operations, list):
+        raise HTTPException(status_code=400, detail="Operations must be a list")
+    for operation in operations:
+        if not isinstance(operation, dict):
+            continue
+        op = str(operation.get("op", "replace")).lower()
+        path = str(operation.get("path", "")).strip()
+        value = operation.get("value")
+        if op not in {"add", "replace"}:
+            raise HTTPException(status_code=400, detail="Only add and replace patch operations are supported")
+        if isinstance(value, dict) and not path:
+            if "active" in value:
+                user.active = bool(value["active"])
+            if "displayName" in value:
+                user.display_name = str(value["displayName"]).strip()
+            if "userName" in value:
+                user.user_name = str(value["userName"]).strip()
+            if "emails" in value and isinstance(value["emails"], list):
+                user.emails = [entry for entry in value["emails"] if isinstance(entry, dict)]
+            continue
+        if path == "active":
+            user.active = bool(value)
+        elif path == "displayName":
+            user.display_name = str(value or "").strip()
+        elif path == "userName":
+            user.user_name = str(value or "").strip()
+        elif path == "emails" and isinstance(value, list):
+            user.emails = [entry for entry in value if isinstance(entry, dict)]
+        else:
+            raise HTTPException(status_code=400, detail="Unsupported user patch path")
+    if not user.user_name:
+        raise HTTPException(status_code=400, detail="userName is required")
+    user.updated_at = now_utc_iso()
+    return user
+
+
+def _apply_group_patch(group: SCIMGroup, body: dict[str, Any]) -> SCIMGroup:
+    operations = body.get("Operations", [])
+    if not isinstance(operations, list):
+        raise HTTPException(status_code=400, detail="Operations must be a list")
+    for operation in operations:
+        if not isinstance(operation, dict):
+            continue
+        op = str(operation.get("op", "replace")).lower()
+        path = str(operation.get("path", "")).strip()
+        value = operation.get("value")
+        if op not in {"add", "replace", "remove"}:
+            raise HTTPException(status_code=400, detail="Only add, replace, and remove patch operations are supported")
+        if op == "remove" and path.startswith("members"):
+            group.members = []
+        elif path == "displayName":
+            group.display_name = str(value or "").strip()
+        elif path == "members" and isinstance(value, list):
+            group.members = [entry for entry in value if isinstance(entry, dict)]
+        elif isinstance(value, dict) and not path:
+            if "displayName" in value:
+                group.display_name = str(value["displayName"]).strip()
+            if "members" in value and isinstance(value["members"], list):
+                group.members = [entry for entry in value["members"] if isinstance(entry, dict)]
+        else:
+            raise HTTPException(status_code=400, detail="Unsupported group patch path")
+    if not group.display_name:
+        raise HTTPException(status_code=400, detail="displayName is required")
+    group.updated_at = now_utc_iso()
+    return group
+
+
+@router.get("/ServiceProviderConfig", name="scim_service_provider_config")
+async def service_provider_config(request: Request) -> dict[str, Any]:
+    _require_scim(request)
+    return {
+        "schemas": [SCIM_SERVICE_PROVIDER_SCHEMA],
+        "patch": {"supported": True},
+        "bulk": {"supported": False, "maxOperations": 0, "maxPayloadSize": 0},
+        "filter": {"supported": True, "maxResults": 500},
+        "changePassword": {"supported": False},
+        "sort": {"supported": False},
+        "etag": {"supported": False},
+        "authenticationSchemes": [{"type": "oauthbearertoken", "name": "Bearer", "primary": True}],
+    }
+
+
+@router.get("/Schemas", name="scim_schemas")
+async def schemas(request: Request) -> dict[str, Any]:
+    _require_scim(request)
+    resources = [
+        {
+            "schemas": [SCIM_SCHEMA_SCHEMA],
+            "id": SCIM_USER_SCHEMA,
+            "name": "User",
+            "description": "Agent BOM provisioned user",
+            "attributes": [
+                {"name": "userName", "type": "string", "required": True, "mutability": "readWrite"},
+                {"name": "displayName", "type": "string", "required": False, "mutability": "readWrite"},
+                {"name": "active", "type": "boolean", "required": False, "mutability": "readWrite"},
+                {"name": "emails", "type": "complex", "multiValued": True, "required": False, "mutability": "readWrite"},
+                {"name": "groups", "type": "complex", "multiValued": True, "required": False, "mutability": "readOnly"},
+            ],
+        },
+        {
+            "schemas": [SCIM_SCHEMA_SCHEMA],
+            "id": SCIM_GROUP_SCHEMA,
+            "name": "Group",
+            "description": "Agent BOM provisioned group",
+            "attributes": [
+                {"name": "displayName", "type": "string", "required": True, "mutability": "readWrite"},
+                {"name": "members", "type": "complex", "multiValued": True, "required": False, "mutability": "readWrite"},
+            ],
+        },
+    ]
+    return {
+        "schemas": [SCIM_LIST_SCHEMA],
+        "totalResults": len(resources),
+        "startIndex": 1,
+        "itemsPerPage": len(resources),
+        "Resources": resources,
+    }
+
+
+@router.get("/ResourceTypes", name="scim_resource_types")
+async def resource_types(request: Request) -> dict[str, Any]:
+    _require_scim(request)
+    resources = [
+        {
+            "schemas": [SCIM_RESOURCE_TYPE_SCHEMA],
+            "id": "User",
+            "name": "User",
+            "endpoint": "/Users",
+            "schema": SCIM_USER_SCHEMA,
+        },
+        {
+            "schemas": [SCIM_RESOURCE_TYPE_SCHEMA],
+            "id": "Group",
+            "name": "Group",
+            "endpoint": "/Groups",
+            "schema": SCIM_GROUP_SCHEMA,
+        },
+    ]
+    return {
+        "schemas": [SCIM_LIST_SCHEMA],
+        "totalResults": len(resources),
+        "startIndex": 1,
+        "itemsPerPage": len(resources),
+        "Resources": resources,
+    }
+
+
+@router.get("/Users", name="scim_list_users")
+async def list_users(
+    request: Request,
+    scim_filter: str | None = Query(default=None, alias="filter"),
+    start_index: int = Query(default=1, alias="startIndex", ge=1),
+    count: int = Query(default=100, ge=0, le=500),
+) -> dict[str, Any]:
+    _require_scim(request)
+    attr, value = _parse_filter(scim_filter)
+    users = _get_scim_store().list_users(_tenant_id(request), filter_attr=attr, filter_value=value)
+    page = _paginate(users, start_index, count)
+    return {
+        "schemas": [SCIM_LIST_SCHEMA],
+        "totalResults": len(users),
+        "startIndex": start_index,
+        "itemsPerPage": len(page),
+        "Resources": [_user_to_scim(user, request) for user in page],
+    }
+
+
+@router.post("/Users", status_code=201, name="scim_create_user")
+async def create_user(request: Request, body: dict[str, Any]) -> dict[str, Any]:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    store = _get_scim_store()
+    user = _user_from_payload(tenant_id, body)
+    if store.list_users(tenant_id, filter_attr="userName", filter_value=user.user_name):
+        raise HTTPException(status_code=409, detail="User already exists")
+    if user.external_id and store.list_users(tenant_id, filter_attr="externalId", filter_value=user.external_id):
+        raise HTTPException(status_code=409, detail="User already exists")
+    saved = store.put_user(user)
+    log_action(
+        "scim.user_created",
+        actor=_actor(request),
+        resource=f"scim/user/{saved.user_id}",
+        tenant_id=tenant_id,
+        user_name=saved.user_name,
+    )
+    return _user_to_scim(saved, request)
+
+
+@router.get("/Users/{user_id}", name="scim_get_user")
+async def get_user(request: Request, user_id: str) -> dict[str, Any]:
+    _require_scim(request)
+    user = _get_scim_store().get_user(_tenant_id(request), user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return _user_to_scim(user, request)
+
+
+@router.patch("/Users/{user_id}", name="scim_patch_user")
+async def patch_user(request: Request, user_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    store = _get_scim_store()
+    user = store.get_user(tenant_id, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    saved = store.put_user(_apply_user_patch(user, body))
+    log_action(
+        "scim.user_patched",
+        actor=_actor(request),
+        resource=f"scim/user/{saved.user_id}",
+        tenant_id=tenant_id,
+        user_name=saved.user_name,
+    )
+    return _user_to_scim(saved, request)
+
+
+@router.put("/Users/{user_id}", name="scim_replace_user")
+async def replace_user(request: Request, user_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    store = _get_scim_store()
+    existing = store.get_user(tenant_id, user_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    saved = store.put_user(_user_from_payload(tenant_id, body, existing=existing))
+    log_action(
+        "scim.user_replaced",
+        actor=_actor(request),
+        resource=f"scim/user/{saved.user_id}",
+        tenant_id=tenant_id,
+        user_name=saved.user_name,
+    )
+    return _user_to_scim(saved, request)
+
+
+@router.delete("/Users/{user_id}", status_code=204, name="scim_delete_user")
+async def delete_user(request: Request, user_id: str) -> Response:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    user = _get_scim_store().deactivate_user(tenant_id, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    log_action(
+        "scim.user_deactivated",
+        actor=_actor(request),
+        resource=f"scim/user/{user.user_id}",
+        tenant_id=tenant_id,
+        user_name=user.user_name,
+    )
+    return Response(status_code=204)
+
+
+@router.get("/Groups", name="scim_list_groups")
+async def list_groups(
+    request: Request,
+    scim_filter: str | None = Query(default=None, alias="filter"),
+    start_index: int = Query(default=1, alias="startIndex", ge=1),
+    count: int = Query(default=100, ge=0, le=500),
+) -> dict[str, Any]:
+    _require_scim(request)
+    attr, value = _parse_filter(scim_filter)
+    groups = _get_scim_store().list_groups(_tenant_id(request), filter_attr=attr, filter_value=value)
+    page = _paginate(groups, start_index, count)
+    return {
+        "schemas": [SCIM_LIST_SCHEMA],
+        "totalResults": len(groups),
+        "startIndex": start_index,
+        "itemsPerPage": len(page),
+        "Resources": [_group_to_scim(group, request) for group in page],
+    }
+
+
+@router.post("/Groups", status_code=201, name="scim_create_group")
+async def create_group(request: Request, body: dict[str, Any]) -> dict[str, Any]:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    store = _get_scim_store()
+    group = _group_from_payload(tenant_id, body)
+    if store.list_groups(tenant_id, filter_attr="displayName", filter_value=group.display_name):
+        raise HTTPException(status_code=409, detail="Group already exists")
+    if group.external_id and store.list_groups(tenant_id, filter_attr="externalId", filter_value=group.external_id):
+        raise HTTPException(status_code=409, detail="Group already exists")
+    saved = store.put_group(group)
+    log_action(
+        "scim.group_created",
+        actor=_actor(request),
+        resource=f"scim/group/{saved.group_id}",
+        tenant_id=tenant_id,
+        display_name=saved.display_name,
+    )
+    return _group_to_scim(saved, request)
+
+
+@router.get("/Groups/{group_id}", name="scim_get_group")
+async def get_group(request: Request, group_id: str) -> dict[str, Any]:
+    _require_scim(request)
+    group = _get_scim_store().get_group(_tenant_id(request), group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    return _group_to_scim(group, request)
+
+
+@router.patch("/Groups/{group_id}", name="scim_patch_group")
+async def patch_group(request: Request, group_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    store = _get_scim_store()
+    group = store.get_group(tenant_id, group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    saved = store.put_group(_apply_group_patch(group, body))
+    log_action(
+        "scim.group_patched",
+        actor=_actor(request),
+        resource=f"scim/group/{saved.group_id}",
+        tenant_id=tenant_id,
+        display_name=saved.display_name,
+    )
+    return _group_to_scim(saved, request)
+
+
+@router.put("/Groups/{group_id}", name="scim_replace_group")
+async def replace_group(request: Request, group_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    store = _get_scim_store()
+    existing = store.get_group(tenant_id, group_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    saved = store.put_group(_group_from_payload(tenant_id, body, existing=existing))
+    log_action(
+        "scim.group_replaced",
+        actor=_actor(request),
+        resource=f"scim/group/{saved.group_id}",
+        tenant_id=tenant_id,
+        display_name=saved.display_name,
+    )
+    return _group_to_scim(saved, request)
+
+
+@router.delete("/Groups/{group_id}", status_code=204, name="scim_delete_group")
+async def delete_group(request: Request, group_id: str) -> Response:
+    _require_scim(request)
+    tenant_id = _tenant_id(request)
+    deleted = _get_scim_store().delete_group(tenant_id, group_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Group not found")
+    log_action("scim.group_deleted", actor=_actor(request), resource=f"scim/group/{group_id}", tenant_id=tenant_id)
+    return Response(status_code=204)

--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -4,39 +4,106 @@ from __future__ import annotations
 
 import os
 
+from agent_bom.platform_invariants import normalize_tenant_id
+
 
 def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def scim_base_path() -> str:
+    """Return the configured SCIM base path, normalized for prefix checks."""
+    raw = os.environ.get("AGENT_BOM_SCIM_BASE_PATH", "").strip() or "/scim/v2"
+    path = "/" + raw.strip("/")
+    return path.rstrip("/") or "/scim/v2"
+
+
+def scim_enabled_from_env() -> bool:
+    """Return whether the dedicated SCIM bearer token is configured."""
+    return bool(os.environ.get("AGENT_BOM_SCIM_BEARER_TOKEN", "").strip())
+
+
+def scim_tenant_id_from_env() -> str:
+    """Return the tenant bound to inbound SCIM provisioning requests."""
+    raw = os.environ.get("AGENT_BOM_SCIM_TENANT_ID", "").strip() or os.environ.get("AGENT_BOM_TENANT_ID", "").strip() or "default"
+    return normalize_tenant_id(raw)
+
+
+def configured_api_replicas() -> int:
+    """Return configured API replica count for SCIM storage posture."""
+    raw = os.environ.get("AGENT_BOM_CONTROL_PLANE_REPLICAS", "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
+
+
+def scim_requires_shared_store() -> bool:
+    """Return whether SCIM state must use a shared backend."""
+    return configured_api_replicas() > 1 or _env_flag("AGENT_BOM_REQUIRE_SHARED_SCIM_STORE")
+
+
 def describe_scim_posture() -> dict[str, object]:
     """Return operator-facing SCIM configuration posture.
 
-    This is intentionally a control-plane posture surface, not a claim that
-    full SCIM provisioning is implemented end to end.
+    This intentionally reports deployment readiness without exposing token
+    material or trusting tenant information supplied by the IdP payload.
     """
 
-    token = os.environ.get("AGENT_BOM_SCIM_BEARER_TOKEN", "").strip()
-    base_path = os.environ.get("AGENT_BOM_SCIM_BASE_PATH", "").strip() or "/scim/v2"
+    configured = scim_enabled_from_env()
+    base_path = scim_base_path()
     role_attribute = os.environ.get("AGENT_BOM_SCIM_ROLE_ATTRIBUTE", "").strip() or "agent_bom_role"
     tenant_attribute = os.environ.get("AGENT_BOM_SCIM_TENANT_ATTRIBUTE", "").strip() or "tenant_id"
     external_id_attribute = os.environ.get("AGENT_BOM_SCIM_EXTERNAL_ID_ATTRIBUTE", "").strip() or "externalId"
     groups_required = _env_flag("AGENT_BOM_SCIM_REQUIRE_GROUPS")
+    if os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip():
+        storage_backend = "postgres"
+    elif os.environ.get("AGENT_BOM_DB", "").strip():
+        storage_backend = "sqlite"
+    else:
+        storage_backend = "memory"
+    replicas = configured_api_replicas()
+    shared_required = scim_requires_shared_store()
+    multi_node_ready = storage_backend == "postgres"
+    status = "disabled"
+    if configured:
+        status = "configured" if (multi_node_ready or not shared_required) else "misconfigured"
 
-    configured = bool(token)
     return {
         "supported": True,
         "configured": configured,
-        "status": "configured" if configured else "disabled",
+        "status": status,
         "base_path": base_path,
         "token_configured": configured,
+        "tenant_id": scim_tenant_id_from_env() if configured else None,
+        "tenant_id_source": "AGENT_BOM_SCIM_TENANT_ID",
+        "storage_backend": storage_backend,
+        "configured_api_replicas": replicas,
+        "shared_store_required": shared_required,
+        "multi_node_ready": multi_node_ready,
+        "lifecycle_endpoints": {
+            "users": f"{base_path}/Users",
+            "groups": f"{base_path}/Groups",
+            "service_provider_config": f"{base_path}/ServiceProviderConfig",
+        },
         "external_id_attribute": external_id_attribute,
         "role_attribute": role_attribute,
         "tenant_attribute": tenant_attribute,
         "groups_required": groups_required,
         "message": (
-            "SCIM provisioning bootstrap is configured. Control-plane posture now exposes the expected token and attribute "
-            "mapping contract, but full user and group lifecycle enforcement is still a follow-on."
+            (
+                "SCIM lifecycle provisioning is configured with Postgres-backed shared state."
+                if multi_node_ready
+                else (
+                    "SCIM lifecycle provisioning requires Postgres-backed shared state for this replica count. "
+                    "Configure AGENT_BOM_POSTGRES_URL before enabling clustered SCIM."
+                    if shared_required
+                    else "SCIM lifecycle provisioning is configured for a single-node pilot. Use Postgres-backed storage "
+                    "for clustered or EKS deployments."
+                )
+            )
             if configured
             else "SCIM provisioning is not configured. User and group lifecycle still depends on the upstream identity "
             "provider, reverse proxy, or manual API-key administration."

--- a/src/agent_bom/api/scim_store.py
+++ b/src/agent_bom/api/scim_store.py
@@ -1,0 +1,258 @@
+"""SCIM user and group stores for enterprise identity provisioning."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field, field_validator
+
+from agent_bom.platform_invariants import normalize_tenant_id, now_utc_iso
+
+
+class SCIMUser(BaseModel):
+    """Tenant-bound SCIM user record."""
+
+    tenant_id: str = "default"
+    user_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    external_id: str | None = None
+    user_name: str
+    display_name: str = ""
+    active: bool = True
+    emails: list[dict[str, Any]] = Field(default_factory=list)
+    groups: list[str] = Field(default_factory=list)
+    raw: dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=now_utc_iso)
+    updated_at: str = Field(default_factory=now_utc_iso)
+
+    @field_validator("tenant_id")
+    @classmethod
+    def _tenant(cls, value: str) -> str:
+        return normalize_tenant_id(value)
+
+
+class SCIMGroup(BaseModel):
+    """Tenant-bound SCIM group record."""
+
+    tenant_id: str = "default"
+    group_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    external_id: str | None = None
+    display_name: str
+    members: list[dict[str, Any]] = Field(default_factory=list)
+    raw: dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=now_utc_iso)
+    updated_at: str = Field(default_factory=now_utc_iso)
+
+    @field_validator("tenant_id")
+    @classmethod
+    def _tenant(cls, value: str) -> str:
+        return normalize_tenant_id(value)
+
+
+class SCIMStore(Protocol):
+    """Persistence contract for SCIM lifecycle state."""
+
+    def put_user(self, user: SCIMUser) -> SCIMUser: ...
+    def get_user(self, tenant_id: str, user_id: str) -> SCIMUser | None: ...
+    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]: ...
+    def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None: ...
+    def put_group(self, group: SCIMGroup) -> SCIMGroup: ...
+    def get_group(self, tenant_id: str, group_id: str) -> SCIMGroup | None: ...
+    def list_groups(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMGroup]: ...
+    def delete_group(self, tenant_id: str, group_id: str) -> bool: ...
+
+
+class InMemorySCIMStore:
+    """Process-local SCIM store for tests and local development."""
+
+    def __init__(self) -> None:
+        self._users: dict[tuple[str, str], SCIMUser] = {}
+        self._groups: dict[tuple[str, str], SCIMGroup] = {}
+        self._lock = threading.RLock()
+
+    def put_user(self, user: SCIMUser) -> SCIMUser:
+        user.updated_at = now_utc_iso()
+        with self._lock:
+            self._users[(user.tenant_id, user.user_id)] = user.model_copy(deep=True)
+        return user
+
+    def get_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
+        with self._lock:
+            record = self._users.get((normalize_tenant_id(tenant_id), user_id))
+            return record.model_copy(deep=True) if record else None
+
+    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]:
+        tenant = normalize_tenant_id(tenant_id)
+        with self._lock:
+            users = [u.model_copy(deep=True) for (tid, _), u in self._users.items() if tid == tenant]
+        return [u for u in users if _matches_user(u, filter_attr, filter_value)]
+
+    def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
+        with self._lock:
+            user = self._users.get((normalize_tenant_id(tenant_id), user_id))
+            if user is None:
+                return None
+            user.active = False
+            user.updated_at = now_utc_iso()
+            return user.model_copy(deep=True)
+
+    def put_group(self, group: SCIMGroup) -> SCIMGroup:
+        group.updated_at = now_utc_iso()
+        with self._lock:
+            self._groups[(group.tenant_id, group.group_id)] = group.model_copy(deep=True)
+        return group
+
+    def get_group(self, tenant_id: str, group_id: str) -> SCIMGroup | None:
+        with self._lock:
+            record = self._groups.get((normalize_tenant_id(tenant_id), group_id))
+            return record.model_copy(deep=True) if record else None
+
+    def list_groups(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMGroup]:
+        tenant = normalize_tenant_id(tenant_id)
+        with self._lock:
+            groups = [g.model_copy(deep=True) for (tid, _), g in self._groups.items() if tid == tenant]
+        return [g for g in groups if _matches_group(g, filter_attr, filter_value)]
+
+    def delete_group(self, tenant_id: str, group_id: str) -> bool:
+        with self._lock:
+            return self._groups.pop((normalize_tenant_id(tenant_id), group_id), None) is not None
+
+
+class SQLiteSCIMStore:
+    """SQLite-backed SCIM store for single-node pilots."""
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        return self._local.conn
+
+    def _init_db(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS scim_users (
+                tenant_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                external_id TEXT,
+                user_name TEXT NOT NULL,
+                active INTEGER NOT NULL,
+                updated_at TEXT NOT NULL,
+                data TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, user_id)
+            )
+        """)
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_scim_users_lookup ON scim_users(tenant_id, user_name, external_id)")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS scim_groups (
+                tenant_id TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                external_id TEXT,
+                display_name TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                data TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, group_id)
+            )
+        """)
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_scim_groups_lookup ON scim_groups(tenant_id, display_name, external_id)")
+        self._conn.commit()
+
+    def put_user(self, user: SCIMUser) -> SCIMUser:
+        user.updated_at = now_utc_iso()
+        payload = json.dumps(user.model_dump(mode="json"), sort_keys=True)
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO scim_users (tenant_id, user_id, external_id, user_name, active, updated_at, data)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (user.tenant_id, user.user_id, user.external_id, user.user_name, int(user.active), user.updated_at, payload),
+        )
+        self._conn.commit()
+        return user
+
+    def get_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
+        row = self._conn.execute(
+            "SELECT data FROM scim_users WHERE tenant_id = ? AND user_id = ?",
+            (normalize_tenant_id(tenant_id), user_id),
+        ).fetchone()
+        return SCIMUser(**json.loads(row[0])) if row else None
+
+    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]:
+        rows = self._conn.execute(
+            "SELECT data FROM scim_users WHERE tenant_id = ? ORDER BY user_name ASC, user_id ASC",
+            (normalize_tenant_id(tenant_id),),
+        ).fetchall()
+        return [user for user in (SCIMUser(**json.loads(row[0])) for row in rows) if _matches_user(user, filter_attr, filter_value)]
+
+    def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
+        user = self.get_user(tenant_id, user_id)
+        if user is None:
+            return None
+        user.active = False
+        return self.put_user(user)
+
+    def put_group(self, group: SCIMGroup) -> SCIMGroup:
+        group.updated_at = now_utc_iso()
+        payload = json.dumps(group.model_dump(mode="json"), sort_keys=True)
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO scim_groups (tenant_id, group_id, external_id, display_name, updated_at, data)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (group.tenant_id, group.group_id, group.external_id, group.display_name, group.updated_at, payload),
+        )
+        self._conn.commit()
+        return group
+
+    def get_group(self, tenant_id: str, group_id: str) -> SCIMGroup | None:
+        row = self._conn.execute(
+            "SELECT data FROM scim_groups WHERE tenant_id = ? AND group_id = ?",
+            (normalize_tenant_id(tenant_id), group_id),
+        ).fetchone()
+        return SCIMGroup(**json.loads(row[0])) if row else None
+
+    def list_groups(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMGroup]:
+        rows = self._conn.execute(
+            "SELECT data FROM scim_groups WHERE tenant_id = ? ORDER BY display_name ASC, group_id ASC",
+            (normalize_tenant_id(tenant_id),),
+        ).fetchall()
+        return [group for group in (SCIMGroup(**json.loads(row[0])) for row in rows) if _matches_group(group, filter_attr, filter_value)]
+
+    def delete_group(self, tenant_id: str, group_id: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM scim_groups WHERE tenant_id = ? AND group_id = ?",
+            (normalize_tenant_id(tenant_id), group_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+
+def _matches_user(user: SCIMUser, attr: str | None, value: str | None) -> bool:
+    if not attr:
+        return True
+    if attr == "userName":
+        return user.user_name == value
+    if attr == "externalId":
+        return user.external_id == value
+    if attr == "id":
+        return user.user_id == value
+    return False
+
+
+def _matches_group(group: SCIMGroup, attr: str | None, value: str | None) -> bool:
+    if not attr:
+        return True
+    if attr == "displayName":
+        return group.display_name == value
+    if attr == "externalId":
+        return group.external_id == value
+    if attr == "id":
+        return group.group_id == value
+    return False

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -495,14 +495,17 @@ def configure_api(
     _rate_limit_rpm = rate_limit_rpm
 
     from agent_bom.api.oidc import oidc_enabled_from_env
+    from agent_bom.api.scim import scim_enabled_from_env
 
     oidc_enabled = oidc_enabled_from_env()
+    scim_enabled = scim_enabled_from_env()
     trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
-    auth_required = bool(api_key or oidc_enabled or trusted_proxy_enabled)
+    auth_required = bool(api_key or oidc_enabled or trusted_proxy_enabled or scim_enabled)
     configure_auth_runtime(
         api_key_configured=bool(api_key),
         oidc_enabled=oidc_enabled,
         trusted_proxy_enabled=trusted_proxy_enabled,
+        scim_enabled=scim_enabled,
     )
 
     # Warn if API is exposed without authentication
@@ -550,6 +553,7 @@ from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
 from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
 from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
 from agent_bom.api.routes.schedules import router as _schedules_router  # noqa: E402
+from agent_bom.api.routes.scim import router as _scim_router  # noqa: E402
 from agent_bom.api.routes.sources import router as _sources_router  # noqa: E402
 
 app.include_router(_assets_router)
@@ -567,6 +571,7 @@ app.include_router(_privacy_router)
 app.include_router(_proxy_router)
 app.include_router(_scan_router)
 app.include_router(_schedules_router)
+app.include_router(_scim_router)
 app.include_router(_sources_router)
 
 # Re-export proxy push functions for backward compatibility

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from agent_bom.api.mcp_observation_store import MCPObservationStore
     from agent_bom.api.models import ScanJob
     from agent_bom.api.schedule_store import ScheduleStore
+    from agent_bom.api.scim_store import SCIMStore
     from agent_bom.api.source_store import SourceStore
     from agent_bom.api.tenant_quota_store import TenantQuotaStore
 
@@ -198,6 +199,7 @@ def set_schedule_store(store: ScheduleStore) -> None:
 
 # ─── Tenant quota override store (pluggable) ───────────────────────────────
 _tenant_quota_store: TenantQuotaStore | None = None
+_scim_store: SCIMStore | None = None
 
 
 def _get_tenant_quota_store() -> TenantQuotaStore:
@@ -225,6 +227,45 @@ def set_tenant_quota_store(store: TenantQuotaStore) -> None:
     """Switch the tenant quota override store backend."""
     global _tenant_quota_store
     _tenant_quota_store = store
+
+
+# ─── SCIM lifecycle store (enterprise identity) ────────────────────────────
+def _get_scim_store() -> SCIMStore:
+    """Get the active SCIM lifecycle store.
+
+    Postgres is selected for clustered self-hosted deployments. SQLite remains
+    a single-node pilot fallback and must not be used for multi-replica API
+    deployments because SCIM users/groups are identity state.
+    """
+    global _scim_store
+    if _scim_store is None:
+        with _store_lock:
+            if _scim_store is None:
+                if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+                    from agent_bom.api.postgres_scim import PostgresSCIMStore
+
+                    _scim_store = PostgresSCIMStore()
+                elif os.environ.get("AGENT_BOM_DB"):
+                    from agent_bom.api.scim import scim_enabled_from_env, scim_requires_shared_store
+                    from agent_bom.api.scim_store import SQLiteSCIMStore
+
+                    if scim_enabled_from_env() and scim_requires_shared_store():
+                        raise RuntimeError("SCIM lifecycle storage requires AGENT_BOM_POSTGRES_URL for multi-replica deployments")
+                    _scim_store = SQLiteSCIMStore(os.environ["AGENT_BOM_DB"])
+                else:
+                    from agent_bom.api.scim import scim_enabled_from_env, scim_requires_shared_store
+                    from agent_bom.api.scim_store import InMemorySCIMStore
+
+                    if scim_enabled_from_env() and scim_requires_shared_store():
+                        raise RuntimeError("SCIM lifecycle storage requires AGENT_BOM_POSTGRES_URL for multi-replica deployments")
+                    _scim_store = InMemorySCIMStore()
+    return _scim_store
+
+
+def set_scim_store(store: SCIMStore | None) -> None:
+    """Switch the SCIM lifecycle store backend."""
+    global _scim_store
+    _scim_store = store
 
 
 # ─── Source store (pluggable) ───────────────────────────────────────────────

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -344,10 +344,32 @@ def test_auth_policy_reports_scim_configuration_posture(monkeypatch: pytest.Monk
     assert body["identity_provisioning"]["scim"]["status"] == "configured"
     assert body["identity_provisioning"]["scim"]["base_path"] == "/scim/v2"
     assert body["identity_provisioning"]["scim"]["token_configured"] is True
+    assert body["identity_provisioning"]["scim"]["tenant_id"] == "default"
+    assert body["identity_provisioning"]["scim"]["storage_backend"] == "memory"
+    assert body["identity_provisioning"]["scim"]["configured_api_replicas"] == 1
+    assert body["identity_provisioning"]["scim"]["shared_store_required"] is False
+    assert body["identity_provisioning"]["scim"]["multi_node_ready"] is False
+    assert body["identity_provisioning"]["scim"]["lifecycle_endpoints"]["users"] == "/scim/v2/Users"
+    assert body["identity_provisioning"]["scim"]["lifecycle_endpoints"]["groups"] == "/scim/v2/Groups"
     assert body["identity_provisioning"]["scim"]["role_attribute"] == "roles"
     assert body["identity_provisioning"]["scim"]["tenant_attribute"] == "organization_id"
     assert body["identity_provisioning"]["scim"]["external_id_attribute"] == "employeeNumber"
     assert body["identity_provisioning"]["scim"]["groups_required"] is True
+
+
+def test_auth_policy_flags_clustered_scim_without_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "super-secret")
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "3")
+
+    client = TestClient(app)
+    body = client.get("/v1/auth/policy").json()
+
+    scim = body["identity_provisioning"]["scim"]
+    assert scim["configured"] is True
+    assert scim["status"] == "misconfigured"
+    assert scim["configured_api_replicas"] == 3
+    assert scim["shared_store_required"] is True
+    assert scim["multi_node_ready"] is False
 
 
 def test_rate_limit_runtime_reports_shared_backend(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -386,6 +408,9 @@ def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
     middleware = APIKeyMiddleware(app, api_key="static-secret")
     assert middleware._required_role("GET", "/v1/auth/policy") == "admin"
     assert middleware._required_role("GET", "/v1/auth/scim/config") == "admin"
+    assert middleware._required_role("POST", "/scim/v2/Users") == "admin"
+    assert middleware._required_scope("POST", "/scim/v2/Users") == "auth.scim:write"
+    assert middleware._required_scope("GET", "/scim/v2/Groups") == "auth.scim:read"
     assert middleware._required_role("PUT", "/v1/auth/quota") == "admin"
     assert middleware._required_role("DELETE", "/v1/auth/quota") == "admin"
     assert middleware._required_role("GET", "/v1/tenant/tenant-a/data") == "admin"

--- a/tests/test_api_scim_lifecycle.py
+++ b/tests/test_api_scim_lifecycle.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent_bom.api import server as api_server
+from agent_bom.api.scim_store import InMemorySCIMStore
+from agent_bom.api.server import app
+from agent_bom.api.stores import _get_scim_store, set_scim_store
+
+
+@pytest.fixture
+def scim_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "scim-secret")
+    monkeypatch.setenv("AGENT_BOM_SCIM_TENANT_ID", "tenant-alpha")
+    set_scim_store(InMemorySCIMStore())
+    api_server.configure_api(api_key=None)
+    return TestClient(app)
+
+
+def _headers(token: str = "scim-secret") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_scim_requires_dedicated_bearer_token(scim_client: TestClient) -> None:
+    missing = scim_client.get("/scim/v2/Users")
+    assert missing.status_code == 401
+
+    wrong = scim_client.get("/scim/v2/Users", headers=_headers("wrong"))
+    assert wrong.status_code == 401
+
+    allowed = scim_client.get("/scim/v2/Users", headers=_headers())
+    assert allowed.status_code == 200
+    assert allowed.json()["totalResults"] == 0
+
+
+def test_scim_discovery_endpoints(scim_client: TestClient) -> None:
+    service_provider = scim_client.get("/scim/v2/ServiceProviderConfig", headers=_headers())
+    assert service_provider.status_code == 200
+    assert service_provider.json()["patch"]["supported"] is True
+
+    schemas = scim_client.get("/scim/v2/Schemas", headers=_headers())
+    assert schemas.status_code == 200
+    schema_ids = {resource["id"] for resource in schemas.json()["Resources"]}
+    assert "urn:ietf:params:scim:schemas:core:2.0:User" in schema_ids
+    assert "urn:ietf:params:scim:schemas:core:2.0:Group" in schema_ids
+
+    resource_types = scim_client.get("/scim/v2/ResourceTypes", headers=_headers())
+    assert resource_types.status_code == 200
+    assert {resource["id"] for resource in resource_types.json()["Resources"]} == {"User", "Group"}
+
+
+def test_scim_user_create_list_patch_and_deactivate(scim_client: TestClient) -> None:
+    created = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={
+            "userName": "alice@example.com",
+            "externalId": "emp-123",
+            "displayName": "Alice Example",
+            "active": True,
+            "emails": [{"value": "alice@example.com", "primary": True}],
+            "tenant_id": "attacker-tenant",
+        },
+    )
+    assert created.status_code == 201
+    user = created.json()
+    user_id = user["id"]
+    assert user["userName"] == "alice@example.com"
+    assert user["active"] is True
+
+    duplicate = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "alice@example.com", "externalId": "emp-123"},
+    )
+    assert duplicate.status_code == 409
+
+    listed = scim_client.get('/scim/v2/Users?filter=userName eq "alice@example.com"', headers=_headers())
+    assert listed.status_code == 200
+    assert listed.json()["totalResults"] == 1
+    assert listed.json()["Resources"][0]["id"] == user_id
+
+    patched = scim_client.patch(
+        f"/scim/v2/Users/{user_id}",
+        headers=_headers(),
+        json={
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "replace", "path": "active", "value": False}],
+        },
+    )
+    assert patched.status_code == 200
+    assert patched.json()["active"] is False
+
+    replaced = scim_client.put(
+        f"/scim/v2/Users/{user_id}",
+        headers=_headers(),
+        json={
+            "userName": "alice.renamed@example.com",
+            "externalId": "emp-123",
+            "displayName": "Alice Renamed",
+            "active": True,
+        },
+    )
+    assert replaced.status_code == 200
+    assert replaced.json()["userName"] == "alice.renamed@example.com"
+    assert replaced.json()["active"] is True
+
+    deleted = scim_client.delete(f"/scim/v2/Users/{user_id}", headers=_headers())
+    assert deleted.status_code == 204
+
+    fetched = scim_client.get(f"/scim/v2/Users/{user_id}", headers=_headers())
+    assert fetched.status_code == 200
+    assert fetched.json()["active"] is False
+
+
+def test_scim_group_create_patch_and_delete(scim_client: TestClient) -> None:
+    user = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "bob@example.com", "externalId": "emp-456"},
+    ).json()
+    created = scim_client.post(
+        "/scim/v2/Groups",
+        headers=_headers(),
+        json={
+            "displayName": "Agent Operators",
+            "externalId": "grp-ops",
+            "members": [{"value": user["id"], "display": "bob@example.com"}],
+        },
+    )
+    assert created.status_code == 201
+    group_id = created.json()["id"]
+
+    listed = scim_client.get('/scim/v2/Groups?filter=displayName eq "Agent Operators"', headers=_headers())
+    assert listed.status_code == 200
+    assert listed.json()["totalResults"] == 1
+
+    patched = scim_client.patch(
+        f"/scim/v2/Groups/{group_id}",
+        headers=_headers(),
+        json={"Operations": [{"op": "replace", "path": "displayName", "value": "Agent Security Operators"}]},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["displayName"] == "Agent Security Operators"
+
+    replaced = scim_client.put(
+        f"/scim/v2/Groups/{group_id}",
+        headers=_headers(),
+        json={"displayName": "Identity Operators", "members": []},
+    )
+    assert replaced.status_code == 200
+    assert replaced.json()["displayName"] == "Identity Operators"
+    assert replaced.json()["members"] == []
+
+    deleted = scim_client.delete(f"/scim/v2/Groups/{group_id}", headers=_headers())
+    assert deleted.status_code == 204
+    assert scim_client.get(f"/scim/v2/Groups/{group_id}", headers=_headers()).status_code == 404
+
+
+def test_scim_store_fails_closed_without_postgres_for_multi_replica(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "scim-secret")
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+    set_scim_store(None)
+
+    with pytest.raises(RuntimeError, match="AGENT_BOM_POSTGRES_URL"):
+        _get_scim_store()


### PR DESCRIPTION
## Summary

Moves SCIM from posture-only reporting to a real enterprise provisioning surface:

- adds dedicated `/scim/v2` lifecycle endpoints for Users and Groups
- supports SCIM discovery endpoints: `ServiceProviderConfig`, `Schemas`, and `ResourceTypes`
- requires a dedicated `AGENT_BOM_SCIM_BEARER_TOKEN` for SCIM traffic; dashboard sessions and general API keys are not accepted on SCIM routes
- binds SCIM writes to `AGENT_BOM_SCIM_TENANT_ID` instead of trusting tenant fields from IdP payloads
- adds in-memory, SQLite single-node pilot, and Postgres clustered stores for SCIM users/groups
- fails closed when SCIM is enabled for multi-replica deployments without Postgres shared state
- emits audit events for user/group create, patch, replace, deactivate, and delete actions
- updates enterprise docs and auth policy posture for SCIM readiness and storage posture

## Validation

- `uv run ruff check src/agent_bom/api/scim.py src/agent_bom/api/scim_store.py src/agent_bom/api/postgres_scim.py src/agent_bom/api/routes/scim.py src/agent_bom/api/middleware.py src/agent_bom/api/server.py src/agent_bom/api/stores.py tests/test_api_scim_lifecycle.py tests/test_api_operator_policy.py`
- `uv run pytest tests/test_api_scim_lifecycle.py tests/test_api_operator_policy.py -q`
- `git diff --check origin/main...HEAD`
- pre-commit hooks during commit: ruff, ruff-format, mypy, bandit
