### PR TITLE
feat: expose secret lifecycle posture

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -33,6 +33,10 @@ controlPlane:
         value: "250"
       - name: AGENT_BOM_REQUIRE_SHARED_SCIM_STORE
         value: "1"
+      - name: AGENT_BOM_SECRET_PROVIDER
+        value: "aws_secrets_manager"
+      - name: AGENT_BOM_EXTERNAL_SECRETS_ENABLED
+        value: "1"
     autoscaling:
       enabled: true
       minReplicas: 2
@@ -102,10 +106,22 @@ controlPlane:
             remoteRef:
               key: REPLACE_ME_AUTH_SECRET_PATH
               property: REPLACE_ME_SCIM_BEARER_TOKEN_PROPERTY
+          - secretKey: AGENT_BOM_SCIM_BEARER_TOKEN_LAST_ROTATED
+            remoteRef:
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_SCIM_BEARER_TOKEN_LAST_ROTATED_PROPERTY
           - secretKey: AGENT_BOM_SCIM_TENANT_ID
             remoteRef:
               key: REPLACE_ME_AUTH_SECRET_PATH
               property: REPLACE_ME_SCIM_TENANT_ID_PROPERTY
+          - secretKey: AGENT_BOM_BROWSER_SESSION_SIGNING_KEY
+            remoteRef:
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_BROWSER_SESSION_SIGNING_KEY_PROPERTY
+          - secretKey: AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED
+            remoteRef:
+              key: REPLACE_ME_AUTH_SECRET_PATH
+              property: REPLACE_ME_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED_PROPERTY
           - secretKey: AGENT_BOM_SAML_IDP_ENTITY_ID
             remoteRef:
               key: REPLACE_ME_AUTH_SECRET_PATH

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -185,6 +185,21 @@ For horizontally scaled control-plane APIs, shared rate limiting is mandatory. `
 
 For horizontally scaled SCIM, shared identity storage is also mandatory. Set `AGENT_BOM_POSTGRES_URL` for EKS or any multi-replica control plane, and keep `AGENT_BOM_REQUIRE_SHARED_SCIM_STORE=1` enabled in production values. SQLite is acceptable only for a single-node pilot.
 
+For secret lifecycle posture, production deployments should declare the external
+secret authority and rotation metadata without exposing secret values:
+
+```bash
+export AGENT_BOM_SECRET_PROVIDER="aws_secrets_manager" # or hashicorp_vault, external_secrets, csi
+export AGENT_BOM_EXTERNAL_SECRETS_ENABLED=1
+export AGENT_BOM_AUDIT_HMAC_LAST_ROTATED="2026-04-24T00:00:00+00:00"
+export AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED="2026-04-24T00:00:00+00:00"
+export AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED="2026-04-24T00:00:00+00:00"
+export AGENT_BOM_SCIM_BEARER_TOKEN_LAST_ROTATED="2026-04-24T00:00:00+00:00"
+```
+
+Operators can verify the non-secret posture at `GET /v1/auth/secrets/lifecycle`
+or inside `GET /v1/auth/policy`.
+
 **Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, graph state, and trend history.
 
 Use the backend story this way:

--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -89,11 +89,20 @@ Recommended production posture:
   from the customer's secret manager
 - mount Kubernetes secrets through External Secrets or equivalent CSI/IRSA
   controls
-- set rotation timestamps for audit HMAC and compliance signing keys so posture
-  endpoints can expose key age
+- set `AGENT_BOM_SECRET_PROVIDER` and `AGENT_BOM_EXTERNAL_SECRETS_ENABLED=1`
+  when the deployment is backed by AWS Secrets Manager, Vault, External
+  Secrets, or an equivalent customer secret manager
+- set rotation timestamps for audit HMAC, compliance signing, SCIM bearer, and
+  browser-session signing keys so posture endpoints can expose key age
 - rotate API keys through the API rather than replacing all clients at once
 - restart API/gateway workloads after rotating mounted signing or OAuth client
   secrets
+
+`GET /v1/auth/secrets/lifecycle` and `GET /v1/auth/policy` expose a non-secret
+summary of this posture. They report configured sources, key IDs when supplied,
+rotation age, missing required secrets, and whether the deployment has declared
+an external secret-manager authority. These endpoints never return secret
+values.
 
 `agent-bom` does not replace the customer's KMS, Vault, IdP, or privileged
 access management system. The product exposes posture and supports rotation

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -347,6 +347,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("GET", "/v1/auth/debug", "viewer"),
         ("GET", "/v1/auth/me", "viewer"),
         ("GET", "/v1/auth/policy", "admin"),
+        ("GET", "/v1/auth/secrets/lifecycle", "admin"),
         ("GET", "/v1/auth/scim/config", "admin"),
         ("GET", "/scim/v2", "admin"),
         ("POST", "/scim/v2", "admin"),
@@ -398,6 +399,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
     _SCOPE_RULES: tuple[tuple[str, str, str], ...] = (
         ("GET", "/v1/auth/keys", "auth.keys:read"),
+        ("GET", "/v1/auth/secrets/lifecycle", "auth.secrets:read"),
         ("GET", "/v1/auth/scim/config", "auth.scim:read"),
         ("GET", "/scim/v2", "auth.scim:read"),
         ("POST", "/scim/v2", "auth.scim:write"),

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -401,6 +401,7 @@ async def auth_policy(request: Request) -> dict:
     from agent_bom.api.oidc import describe_oidc_posture
     from agent_bom.api.saml import describe_saml_posture
     from agent_bom.api.scim import describe_scim_posture
+    from agent_bom.api.secret_lifecycle import describe_secret_lifecycle_posture
     from agent_bom.api.tenant_quota import default_tenant_quotas, get_tenant_quota_runtime
 
     api_policy = get_api_key_policy()
@@ -438,6 +439,7 @@ async def auth_policy(request: Request) -> dict:
             "audit_hmac": describe_audit_hmac_status(),
             "compliance_signing": describe_signing_posture(),
         },
+        "secret_lifecycle": describe_secret_lifecycle_posture(),
         "tenant_quotas": defaults,
         "tenant_quota_runtime": get_tenant_quota_runtime(tenant_id),
         "identity_provisioning": {
@@ -455,6 +457,14 @@ async def auth_policy(request: Request) -> dict:
             },
         },
     }
+
+
+@router.get("/v1/auth/secrets/lifecycle", tags=["enterprise"])
+async def auth_secret_lifecycle() -> dict:
+    """Return non-secret lifecycle posture for configured control-plane secrets."""
+    from agent_bom.api.secret_lifecycle import describe_secret_lifecycle_posture
+
+    return describe_secret_lifecycle_posture()
 
 
 @router.get("/v1/auth/scim/config", tags=["enterprise"])

--- a/src/agent_bom/api/secret_lifecycle.py
+++ b/src/agent_bom/api/secret_lifecycle.py
@@ -1,0 +1,273 @@
+"""Operator-facing secret lifecycle posture for enterprise deployments."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str) -> int | None:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _rotation_posture(
+    *,
+    configured: bool,
+    subject: str,
+    last_rotated_env: str,
+    rotation_days_env: str,
+    max_age_days_env: str,
+    not_configured_status: str,
+    not_configured_message: str,
+) -> dict[str, Any]:
+    rotation_days = _env_int(rotation_days_env)
+    max_age_days = _env_int(max_age_days_env)
+    raw_last_rotated = os.environ.get(last_rotated_env, "").strip()
+
+    if not configured:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": not_configured_status,
+            "rotation_method": "secret_manager_swap_and_rollout_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": None,
+            "age_days": None,
+            "rotation_message": not_configured_message,
+        }
+
+    if not raw_last_rotated:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": "unknown_age",
+            "rotation_method": "secret_manager_swap_and_rollout_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": None,
+            "age_days": None,
+            "rotation_message": (
+                f"{subject} is configured but {last_rotated_env} is unset. Record an ISO-8601 rotation timestamp "
+                "when the secret is rotated."
+            ),
+        }
+
+    try:
+        rotated = datetime.fromisoformat(raw_last_rotated)
+    except ValueError:
+        return {
+            "rotation_tracking_supported": True,
+            "rotation_status": "unknown_age",
+            "rotation_method": "secret_manager_swap_and_rollout_restart",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "last_rotated": raw_last_rotated,
+            "age_days": None,
+            "rotation_message": (
+                f"{last_rotated_env} is set but is not a valid ISO-8601 timestamp. Use a value like '2026-04-17T00:00:00+00:00'."
+            ),
+        }
+
+    if rotated.tzinfo is None:
+        rotated = rotated.replace(tzinfo=timezone.utc)
+    age_days = max(0, int((datetime.now(timezone.utc) - rotated).total_seconds() // 86400))
+
+    if max_age_days is not None and age_days >= max_age_days:
+        status = "max_age_exceeded"
+        message = f"{subject} is {age_days} days old, exceeding the configured maximum ({max_age_days} days). Rotate it now."
+    elif rotation_days is not None and age_days >= rotation_days:
+        status = "rotation_due"
+        message = f"{subject} is {age_days} days old, past the configured rotation interval ({rotation_days} days)."
+    else:
+        status = "ok"
+        message = (
+            f"{subject} is {age_days} days old; configured rotation interval is {rotation_days} days."
+            if rotation_days is not None
+            else f"{subject} is {age_days} days old. No explicit rotation interval is configured."
+        )
+
+    return {
+        "rotation_tracking_supported": True,
+        "rotation_status": status,
+        "rotation_method": "secret_manager_swap_and_rollout_restart",
+        "rotation_days": rotation_days,
+        "max_age_days": max_age_days,
+        "last_rotated": rotated.isoformat(),
+        "age_days": age_days,
+        "rotation_message": message,
+    }
+
+
+def _env_secret_posture(
+    *,
+    name: str,
+    source_env: str,
+    subject: str,
+    required_env: str | None = None,
+    key_id_env: str | None = None,
+) -> dict[str, Any]:
+    configured = bool(os.environ.get(source_env, "").strip())
+    required = _env_enabled(required_env) if required_env else False
+    key_id = os.environ.get(key_id_env, "").strip() if key_id_env else ""
+    rotation_days_env = f"{source_env}_ROTATION_DAYS"
+    max_age_days_env = f"{source_env}_MAX_AGE_DAYS"
+    rotation = _rotation_posture(
+        configured=configured,
+        subject=subject,
+        last_rotated_env=f"{source_env}_LAST_ROTATED",
+        rotation_days_env=rotation_days_env,
+        max_age_days_env=max_age_days_env,
+        not_configured_status="missing_required" if required else "not_configured",
+        not_configured_message=(
+            f"{subject} is required by {required_env} but {source_env} is not configured."
+            if required and required_env
+            else f"{subject} is not configured."
+        ),
+    )
+    status = "configured" if configured else ("missing_required" if required else "not_configured")
+    return {
+        "name": name,
+        "status": status,
+        "configured": configured,
+        "required": required,
+        "source": source_env if configured else None,
+        "key_id_configured": bool(key_id),
+        "key_id": key_id or None,
+        **rotation,
+    }
+
+
+def _browser_session_signing_posture() -> dict[str, Any]:
+    dedicated = os.environ.get("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "").strip()
+    audit = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY", "").strip()
+    static_api = os.environ.get("AGENT_BOM_API_KEY", "").strip()
+
+    if dedicated:
+        source = "AGENT_BOM_BROWSER_SESSION_SIGNING_KEY"
+        inherited_from = None
+        configured = True
+    elif audit:
+        source = "AGENT_BOM_AUDIT_HMAC_KEY"
+        inherited_from = "audit_hmac"
+        configured = True
+    elif static_api:
+        source = "AGENT_BOM_API_KEY"
+        inherited_from = "static_api_key"
+        configured = True
+    else:
+        source = None
+        inherited_from = None
+        configured = False
+
+    rotation = _rotation_posture(
+        configured=configured,
+        subject="Browser session signing secret",
+        last_rotated_env="AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED",
+        rotation_days_env="AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_ROTATION_DAYS",
+        max_age_days_env="AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_MAX_AGE_DAYS",
+        not_configured_status="ephemeral",
+        not_configured_message=(
+            "Browser sessions use a process-ephemeral signing key. Sessions are invalidated on restart and rotation age is not stable."
+        ),
+    )
+    return {
+        "name": "browser_session_signing",
+        "status": "configured" if configured else "ephemeral",
+        "configured": configured,
+        "required": False,
+        "source": source,
+        "dedicated_key_configured": bool(dedicated),
+        "inherited_from": inherited_from,
+        **rotation,
+    }
+
+
+def _external_secret_provider_posture() -> dict[str, Any]:
+    provider = os.environ.get("AGENT_BOM_SECRET_PROVIDER", "").strip()
+    external_secrets = _env_enabled("AGENT_BOM_EXTERNAL_SECRETS_ENABLED")
+    vault_addr = os.environ.get("VAULT_ADDR", "").strip()
+    aws_region = os.environ.get("AWS_REGION", "").strip() or os.environ.get("AWS_DEFAULT_REGION", "").strip()
+    configured = bool(provider or external_secrets or vault_addr or aws_region)
+    return {
+        "status": "configured" if configured else "not_declared",
+        "configured": configured,
+        "provider": provider or ("hashicorp_vault" if vault_addr else "aws_environment" if aws_region else None),
+        "external_secrets_enabled": external_secrets,
+        "vault_addr_configured": bool(vault_addr),
+        "aws_region_configured": bool(aws_region),
+        "message": (
+            "External secret manager posture is declared. Keep secret values in KMS/Vault/External Secrets and mount only runtime env refs."
+            if configured
+            else (
+                "No external secret manager posture is declared. Production deployments should set "
+                "AGENT_BOM_SECRET_PROVIDER or use External Secrets/CSI."
+            )
+        ),
+    }
+
+
+def describe_secret_lifecycle_posture() -> dict[str, Any]:
+    """Return a consolidated, non-secret lifecycle posture surface."""
+    from agent_bom.api.audit_log import describe_audit_hmac_status
+    from agent_bom.api.compliance_signing import describe_signing_posture
+    from agent_bom.api.middleware import get_rate_limit_key_status
+
+    secrets = {
+        "audit_hmac": describe_audit_hmac_status(),
+        "compliance_signing": describe_signing_posture(),
+        "rate_limit_key": get_rate_limit_key_status(),
+        "browser_session_signing": _browser_session_signing_posture(),
+        "scim_bearer": _env_secret_posture(
+            name="scim_bearer",
+            source_env="AGENT_BOM_SCIM_BEARER_TOKEN",
+            subject="SCIM bearer token",
+            required_env="AGENT_BOM_REQUIRE_SCIM",
+            key_id_env="AGENT_BOM_SCIM_BEARER_TOKEN_ID",
+        ),
+        "api_static_key": _env_secret_posture(
+            name="api_static_key",
+            source_env="AGENT_BOM_API_KEY",
+            subject="Static API key",
+            required_env=None,
+            key_id_env="AGENT_BOM_API_KEY_ID",
+        ),
+    }
+    rotation_statuses = [
+        str(value.get("rotation_status") or value.get("status") or "unknown") for value in secrets.values() if isinstance(value, dict)
+    ]
+    blockers = [
+        name
+        for name, value in secrets.items()
+        if str(value.get("rotation_status") or value.get("status")) in {"max_age_exceeded", "missing_required"}
+    ]
+    warnings = [
+        name
+        for name, value in secrets.items()
+        if str(value.get("rotation_status") or value.get("status")) in {"unknown_age", "rotation_due", "ephemeral", "not_configured"}
+    ]
+    return {
+        "status": "blocked" if blockers else "attention_required" if warnings else "ok",
+        "rotation_statuses": rotation_statuses,
+        "blockers": blockers,
+        "warnings": warnings,
+        "external_secret_provider": _external_secret_provider_posture(),
+        "secrets": secrets,
+        "message": (
+            "One or more required secrets are missing or past max age."
+            if blockers
+            else "Secret lifecycle posture has warnings that should be closed before enterprise procurement."
+            if warnings
+            else "Secret lifecycle posture is configured and rotation timestamps are current."
+        ),
+    }

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -47,6 +47,18 @@ def _clear_rate_limit_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED", raising=False)
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_ROTATION_DAYS", raising=False)
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_MAX_AGE_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_ROTATION_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_MAX_AGE_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN_ID", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN_LAST_ROTATED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN_ROTATION_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN_MAX_AGE_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_REQUIRE_SCIM", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SECRET_PROVIDER", raising=False)
+    monkeypatch.delenv("AGENT_BOM_EXTERNAL_SECRETS_ENABLED", raising=False)
 
 
 def _reload_config() -> None:
@@ -177,6 +189,10 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
         "rotation_due",
         "max_age_exceeded",
     }
+    assert body["secret_lifecycle"]["status"] in {"ok", "attention_required", "blocked"}
+    assert body["secret_lifecycle"]["secrets"]["browser_session_signing"]["status"] in {"configured", "ephemeral"}
+    assert body["secret_lifecycle"]["secrets"]["scim_bearer"]["status"] in {"configured", "not_configured", "missing_required"}
+    assert body["secret_lifecycle"]["external_secret_provider"]["status"] in {"configured", "not_declared"}
     assert body["tenant_quotas"]["active_scan_jobs"] >= 1
     assert body["tenant_quotas"]["retained_scan_jobs"] >= 1
     assert body["tenant_quotas"]["fleet_agents"] >= 1
@@ -264,6 +280,41 @@ def test_auth_policy_reports_secret_integrity_posture(monkeypatch: pytest.Monkey
     assert signing["max_age_days"] == 180
     assert signing["last_rotated"] == compliance_rotated
     assert signing["age_days"] == 40
+
+
+def test_auth_policy_reports_secret_lifecycle_posture(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    browser_rotated = (datetime.now(timezone.utc) - timedelta(days=12)).isoformat()
+    scim_rotated = (datetime.now(timezone.utc) - timedelta(days=95)).isoformat()
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "browser-secret")
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED", browser_rotated)
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_ROTATION_DAYS", "30")
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_MAX_AGE_DAYS", "90")
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "scim-secret")
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN_ID", "scim-2026-04")
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN_LAST_ROTATED", scim_rotated)
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN_ROTATION_DAYS", "30")
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN_MAX_AGE_DAYS", "90")
+    monkeypatch.setenv("AGENT_BOM_SECRET_PROVIDER", "aws_secrets_manager")
+    monkeypatch.setenv("AGENT_BOM_EXTERNAL_SECRETS_ENABLED", "1")
+
+    client = TestClient(app)
+    body = client.get("/v1/auth/policy").json()
+    lifecycle = body["secret_lifecycle"]
+
+    assert lifecycle["status"] == "blocked"
+    assert lifecycle["external_secret_provider"]["status"] == "configured"
+    assert lifecycle["external_secret_provider"]["provider"] == "aws_secrets_manager"
+    assert lifecycle["secrets"]["browser_session_signing"]["status"] == "configured"
+    assert lifecycle["secrets"]["browser_session_signing"]["rotation_status"] == "ok"
+    assert lifecycle["secrets"]["browser_session_signing"]["age_days"] == 12
+    assert lifecycle["secrets"]["scim_bearer"]["status"] == "configured"
+    assert lifecycle["secrets"]["scim_bearer"]["key_id"] == "scim-2026-04"
+    assert lifecycle["secrets"]["scim_bearer"]["rotation_status"] == "max_age_exceeded"
+    assert "scim_bearer" in lifecycle["blockers"]
+
+    endpoint = client.get("/v1/auth/secrets/lifecycle").json()
+    assert endpoint["secrets"]["scim_bearer"]["rotation_status"] == "max_age_exceeded"
 
 
 def test_auth_quota_update_persists_tenant_override(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -407,6 +458,8 @@ def test_rate_limit_runtime_reports_single_replica_process_local_backend(monkeyp
 def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
     middleware = APIKeyMiddleware(app, api_key="static-secret")
     assert middleware._required_role("GET", "/v1/auth/policy") == "admin"
+    assert middleware._required_role("GET", "/v1/auth/secrets/lifecycle") == "admin"
+    assert middleware._required_scope("GET", "/v1/auth/secrets/lifecycle") == "auth.secrets:read"
     assert middleware._required_role("GET", "/v1/auth/scim/config") == "admin"
     assert middleware._required_role("POST", "/scim/v2/Users") == "admin"
     assert middleware._required_scope("POST", "/scim/v2/Users") == "auth.scim:write"


### PR DESCRIPTION
## Summary

Continues #1750 after the SCIM merge by making secret lifecycle posture visible without exposing secret values:

- adds `GET /v1/auth/secrets/lifecycle`
- embeds `secret_lifecycle` inside `GET /v1/auth/policy`
- reports non-secret posture for audit HMAC, compliance signing, rate-limit key, browser-session signing, SCIM bearer token, and static API key
- adds rotation timestamp support for browser-session signing and SCIM bearer token env secrets
- reports declared external secret-manager posture via `AGENT_BOM_SECRET_PROVIDER` / `AGENT_BOM_EXTERNAL_SECRETS_ENABLED`
- wires EKS production values for secret-provider posture and SCIM/browser-session rotation metadata
- updates enterprise deployment/security posture docs

## Validation

- `uv run ruff check src/agent_bom/api/secret_lifecycle.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/middleware.py tests/test_api_operator_policy.py`
- `uv run pytest tests/test_api_operator_policy.py tests/test_deploy_manifests.py -q`
- `git diff --check`
- commit hooks: YAML, ruff, ruff-format, mypy, bandit
