### PR TITLE
feat: strengthen identity readiness posture

### DIFF
--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -179,6 +179,15 @@ export AGENT_BOM_SCIM_TENANT_ID="tenant-alpha"
 
 SCIM lifecycle traffic is available under `/scim/v2/Users`, `/scim/v2/Groups`, `/scim/v2/ServiceProviderConfig`, `/scim/v2/Schemas`, and `/scim/v2/ResourceTypes`. These routes require `AGENT_BOM_SCIM_BEARER_TOKEN`; dashboard sessions and general API keys are not accepted. The tenant is always taken from `AGENT_BOM_SCIM_TENANT_ID`, so tenant fields in the IdP payload cannot steer writes into another tenant.
 
+Compatibility coverage is maintained for common IdP payload shapes:
+
+- Okta user/group lifecycle payloads with `externalId`, `emails`, `groups`, and active-state patches
+- Microsoft Entra ID SCIM replace patches that send a value object instead of a single path
+- Google Cloud Identity payloads that rely on `name.formatted` when `displayName` is absent
+
+Check `/v1/auth/policy` or `/v1/auth/scim/config` for the non-secret
+`verified_idp_templates` posture before procurement or IdP rollout reviews.
+
 For PostgreSQL-backed deployments, `agent-bom` now also pushes the authenticated tenant into the database session (`app.tenant_id`) so Postgres row-level security can enforce the same tenant boundary for fleet and schedule data. Internal scheduler work uses an explicit trusted bypass rather than silently reading across tenants.
 
 For horizontally scaled control-plane APIs, shared rate limiting is mandatory. `agent-bom` now fails closed when `AGENT_BOM_CONTROL_PLANE_REPLICAS > 1` (or `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1`) and no PostgreSQL-backed limiter is configured via `AGENT_BOM_POSTGRES_URL`.

--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -92,6 +92,27 @@ def describe_scim_posture() -> dict[str, object]:
         "role_attribute": role_attribute,
         "tenant_attribute": tenant_attribute,
         "groups_required": groups_required,
+        "verified_idp_templates": [
+            {
+                "idp": "okta",
+                "status": "contract_tested",
+                "notes": "Accepts Okta-style User and Group lifecycle payloads with externalId, emails, groups, and active patches.",
+            },
+            {
+                "idp": "microsoft_entra_id",
+                "status": "contract_tested",
+                "notes": (
+                    "Accepts Microsoft Entra ID SCIM replace patches with value objects and standard userName/displayName/email fields."
+                ),
+            },
+            {
+                "idp": "google_cloud_identity",
+                "status": "contract_tested",
+                "notes": (
+                    "Accepts Google Cloud Identity-style name.formatted fallback, externalId, active state, and group membership payloads."
+                ),
+            },
+        ],
         "message": (
             (
                 "SCIM lifecycle provisioning is configured with Postgres-backed shared state."

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -186,6 +186,20 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
 
     def _entry(quota_name: QuotaName, current: int) -> dict[str, int | bool | str | None]:
         limit = effective[quota_name]
+        utilization_pct: int | None = None
+        status = "unlimited"
+        recommended_action = "No enforced limit is configured."
+        if limit > 0:
+            utilization_pct = min(100, int(round((current / limit) * 100)))
+            if current >= limit:
+                status = "at_limit"
+                recommended_action = "Usage is at the enforced limit. Raise the tenant quota or reduce usage before new work starts."
+            elif utilization_pct >= 80:
+                status = "near_limit"
+                recommended_action = "Usage is approaching the enforced limit. Review rollout size before adding more workload."
+            else:
+                status = "ok"
+                recommended_action = "Usage is within the enforced tenant quota."
         return {
             "limit": limit,
             "default_limit": defaults[quota_name],
@@ -194,6 +208,9 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
             "remaining": None if limit <= 0 else max(limit - current, 0),
             "enforced": limit > 0,
             "source": "tenant_override" if quota_name in overrides else "global_default",
+            "utilization_pct": utilization_pct,
+            "status": status,
+            "recommended_action": recommended_action,
         }
 
     def _safe_count(fn: Callable[[], int]) -> int:

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -205,12 +205,20 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["limit"] >= 1
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["source"] == "global_default"
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["override_limit"] is None
+    assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["status"] in {"ok", "near_limit", "at_limit", "unlimited"}
+    assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["utilization_pct"] is not None
+    assert "recommended_action" in body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]
     assert body["identity_provisioning"]["oidc"]["mode"] == "disabled"
     assert body["identity_provisioning"]["saml"]["configured"] is False
     assert body["identity_provisioning"]["scim"]["status"] == "disabled"
     assert body["identity_provisioning"]["scim"]["supported"] is True
     assert body["identity_provisioning"]["scim"]["base_path"] == "/scim/v2"
     assert body["identity_provisioning"]["scim"]["token_configured"] is False
+    assert {entry["idp"] for entry in body["identity_provisioning"]["scim"]["verified_idp_templates"]} == {
+        "okta",
+        "microsoft_entra_id",
+        "google_cloud_identity",
+    }
     assert "service_keys" in body["identity_provisioning"]["session_revocation"]
 
 

--- a/tests/test_api_scim_lifecycle.py
+++ b/tests/test_api_scim_lifecycle.py
@@ -158,6 +158,109 @@ def test_scim_group_create_patch_and_delete(scim_client: TestClient) -> None:
     assert scim_client.get(f"/scim/v2/Groups/{group_id}", headers=_headers()).status_code == 404
 
 
+@pytest.mark.parametrize(
+    ("idp_name", "payload", "patch_body", "expected_created_display", "expected_patched_display"),
+    [
+        (
+            "okta",
+            {
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                "userName": "okta.user@example.com",
+                "externalId": "00u-okta-user",
+                "displayName": "Okta User",
+                "active": True,
+                "emails": [{"value": "okta.user@example.com", "type": "work", "primary": True}],
+                "groups": [{"value": "grp-okta", "$ref": "/Groups/grp-okta", "display": "Agent BOM Admins"}],
+                "tenant_id": "payload-tenant-must-not-win",
+            },
+            {"Operations": [{"op": "replace", "path": "active", "value": False}]},
+            "Okta User",
+            "Okta User",
+        ),
+        (
+            "microsoft_entra_id",
+            {
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                "userName": "entra.user@example.com",
+                "externalId": "entra-object-id",
+                "displayName": "Entra User",
+                "active": True,
+                "emails": [{"value": "entra.user@example.com", "type": "work", "primary": True}],
+            },
+            {"Operations": [{"op": "Replace", "value": {"displayName": "Entra User Renamed", "active": False}}]},
+            "Entra User",
+            "Entra User Renamed",
+        ),
+        (
+            "google_cloud_identity",
+            {
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                "userName": "google.user@example.com",
+                "externalId": "google-directory-id",
+                "name": {"formatted": "Google User"},
+                "active": True,
+                "emails": [{"value": "google.user@example.com", "type": "work", "primary": True}],
+            },
+            {"Operations": [{"op": "replace", "path": "active", "value": False}]},
+            "Google User",
+            "Google User",
+        ),
+    ],
+)
+def test_scim_user_lifecycle_accepts_common_idp_payloads(
+    scim_client: TestClient,
+    idp_name: str,
+    payload: dict,
+    patch_body: dict,
+    expected_created_display: str,
+    expected_patched_display: str,
+) -> None:
+    created = scim_client.post("/scim/v2/Users", headers=_headers(), json=payload)
+    assert created.status_code == 201, idp_name
+    user = created.json()
+    assert user["userName"] == payload["userName"]
+    assert user["displayName"] == expected_created_display
+    assert user["externalId"] == payload["externalId"]
+
+    patched = scim_client.patch(f"/scim/v2/Users/{user['id']}", headers=_headers(), json=patch_body)
+    assert patched.status_code == 200, idp_name
+    assert patched.json()["displayName"] == expected_patched_display
+    assert patched.json()["active"] is False
+
+    listed = scim_client.get(f'/scim/v2/Users?filter=externalId eq "{payload["externalId"]}"', headers=_headers())
+    assert listed.status_code == 200
+    assert listed.json()["totalResults"] == 1
+
+
+def test_scim_group_lifecycle_accepts_common_idp_members(scim_client: TestClient) -> None:
+    user = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "member@example.com", "externalId": "member-1", "displayName": "Member One"},
+    ).json()
+    created = scim_client.post(
+        "/scim/v2/Groups",
+        headers=_headers(),
+        json={
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "displayName": "Agent BOM Reviewers",
+            "externalId": "idp-group-reviewers",
+            "members": [{"value": user["id"], "display": "Member One", "$ref": f"/scim/v2/Users/{user['id']}"}],
+        },
+    )
+    assert created.status_code == 201
+    group_id = created.json()["id"]
+    assert created.json()["members"][0]["value"] == user["id"]
+
+    patched = scim_client.patch(
+        f"/scim/v2/Groups/{group_id}",
+        headers=_headers(),
+        json={"Operations": [{"op": "remove", "path": f'members[value eq "{user["id"]}"]'}]},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["members"] == []
+
+
 def test_scim_store_fails_closed_without_postgres_for_multi_replica(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "scim-secret")
     monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -110,6 +110,24 @@ function quotaInputValue(value: number | null | undefined): string {
   return value == null ? "" : String(value);
 }
 
+function quotaStatusTone(status: string): string {
+  switch (status) {
+    case "ok":
+      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-300";
+    case "near_limit":
+      return "border-amber-900/60 bg-amber-950/30 text-amber-300";
+    case "at_limit":
+      return "border-red-900/60 bg-red-950/30 text-red-300";
+    case "unlimited":
+    default:
+      return "border-zinc-800 bg-zinc-900 text-zinc-400";
+  }
+}
+
+function quotaStatusLabel(status: string): string {
+  return status.replaceAll("_", " ");
+}
+
 function formatStatusLabel(value: string): string {
   return value.replaceAll("_", " ");
 }
@@ -602,12 +620,26 @@ export function KeyLifecyclePanel({
               <div className="mt-3 grid grid-cols-2 gap-3">
                 {quotaCards.map(({ field, label, value }) => (
                   <div key={field} className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
-                    <p className="text-[11px] uppercase tracking-[0.16em] text-zinc-500">{label}</p>
-                    <p className="mt-2 text-lg font-semibold text-zinc-100">{value.limit}</p>
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-[11px] uppercase tracking-[0.16em] text-zinc-500">{label}</p>
+                      <span className={`rounded-md border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em] ${quotaStatusTone(value.status)}`}>
+                        {quotaStatusLabel(value.status)}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-lg font-semibold text-zinc-100">{value.enforced ? value.limit : "Unlimited"}</p>
                     <p className="mt-1 text-xs text-zinc-400">
                       Current {value.current}
                       {value.remaining != null ? ` · Remaining ${value.remaining}` : " · Unlimited"}
                     </p>
+                    <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-zinc-800" aria-hidden="true">
+                      <div
+                        className={`h-full rounded-full ${
+                          value.status === "at_limit" ? "bg-red-500" : value.status === "near_limit" ? "bg-amber-400" : "bg-emerald-400"
+                        }`}
+                        style={{ width: `${value.utilization_pct ?? 0}%` }}
+                      />
+                    </div>
+                    <p className="mt-2 text-xs text-zinc-500">{value.recommended_action}</p>
                     <p className="mt-1 text-[11px] uppercase tracking-[0.14em] text-zinc-500">
                       {value.source === "tenant_override" ? "Tenant override" : "Global default"}
                     </p>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -657,6 +657,9 @@ export interface AuthPolicyResponse {
         remaining: number | null;
         enforced: boolean;
         source: string;
+        utilization_pct: number | null;
+        status: "ok" | "near_limit" | "at_limit" | "unlimited" | string;
+        recommended_action: string;
       }
     >;
   };
@@ -699,6 +702,11 @@ export interface AuthPolicyResponse {
       role_attribute: string;
       tenant_attribute: string;
       groups_required: boolean;
+      verified_idp_templates?: Array<{
+        idp: string;
+        status: string;
+        notes: string;
+      }>;
       message: string;
     };
     session_revocation: {

--- a/ui/tests/key-lifecycle-panel.test.tsx
+++ b/ui/tests/key-lifecycle-panel.test.tsx
@@ -96,10 +96,10 @@ const policy: AuthPolicyResponse = {
     message: "Tenant quotas resolve from global defaults. Tenant-specific overrides can be configured when needed.",
     overrides: {},
     usage: {
-      active_scan_jobs: { limit: 10, default_limit: 10, override_limit: null, current: 2, remaining: 8, enforced: true, source: "global_default" },
-      retained_scan_jobs: { limit: 100, default_limit: 100, override_limit: null, current: 12, remaining: 88, enforced: true, source: "global_default" },
-      fleet_agents: { limit: 5000, default_limit: 5000, override_limit: null, current: 48, remaining: 4952, enforced: true, source: "global_default" },
-      schedules: { limit: 25, default_limit: 25, override_limit: null, current: 3, remaining: 22, enforced: true, source: "global_default" },
+      active_scan_jobs: { limit: 10, default_limit: 10, override_limit: null, current: 2, remaining: 8, enforced: true, source: "global_default", utilization_pct: 20, status: "ok", recommended_action: "Usage is within the enforced tenant quota." },
+      retained_scan_jobs: { limit: 100, default_limit: 100, override_limit: null, current: 12, remaining: 88, enforced: true, source: "global_default", utilization_pct: 12, status: "ok", recommended_action: "Usage is within the enforced tenant quota." },
+      fleet_agents: { limit: 5000, default_limit: 5000, override_limit: null, current: 48, remaining: 4952, enforced: true, source: "global_default", utilization_pct: 1, status: "ok", recommended_action: "Usage is within the enforced tenant quota." },
+      schedules: { limit: 25, default_limit: 25, override_limit: null, current: 3, remaining: 22, enforced: true, source: "global_default", utilization_pct: 12, status: "ok", recommended_action: "Usage is within the enforced tenant quota." },
     },
   },
   identity_provisioning: {
@@ -141,6 +141,11 @@ const policy: AuthPolicyResponse = {
       role_attribute: "agent_bom_role",
       tenant_attribute: "tenant_id",
       groups_required: false,
+      verified_idp_templates: [
+        { idp: "okta", status: "contract_tested", notes: "Okta lifecycle payloads are covered." },
+        { idp: "microsoft_entra_id", status: "contract_tested", notes: "Entra lifecycle payloads are covered." },
+        { idp: "google_cloud_identity", status: "contract_tested", notes: "Google lifecycle payloads are covered." },
+      ],
       message: "SCIM provisioning bootstrap is configured.",
     },
     session_revocation: {
@@ -189,6 +194,8 @@ describe("KeyLifecyclePanel", () => {
     expect(screen.getAllByText("Active scan jobs").length).toBeGreaterThan(0);
     expect(screen.getByText("5000")).toBeInTheDocument();
     expect(screen.getByText("Current 48 · Remaining 4952")).toBeInTheDocument();
+    expect(screen.getAllByText("ok").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Usage is within the enforced tenant quota.").length).toBeGreaterThan(0);
     expect(screen.getByText("Override management")).toBeInTheDocument();
     expect(screen.getByText("Manage overrides at /v1/auth/quota.")).toBeInTheDocument();
     expect(screen.getAllByText("Global default").length).toBeGreaterThan(0);


### PR DESCRIPTION
Summary
- adds machine-readable tenant quota utilization/status/recommended_action fields to the auth policy surface
- renders quota health in the key lifecycle UI with status badges, utilization bars, and operator guidance
- exposes SCIM verified_idp_templates for Okta, Microsoft Entra ID, and Google Cloud Identity compatibility posture
- adds SCIM lifecycle contract tests for common Okta, Entra, and Google payload/patch shapes and documents the rollout checks

Validation
- uv run ruff check src/agent_bom/api/scim.py src/agent_bom/api/tenant_quota.py tests/test_api_scim_lifecycle.py tests/test_api_operator_policy.py
- uv run pytest tests/test_api_scim_lifecycle.py tests/test_api_operator_policy.py tests/test_product_surface_contract.py -q
- cd ui && npm run lint
- cd ui && npx tsc --noEmit
- cd ui && npm run test:run -- tests/key-lifecycle-panel.test.tsx
- git diff --check