### PR TITLE
fix: harden graph identity provenance and scan scale

### DIFF
--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -301,7 +301,9 @@ controlPlane:
       - 0.0.0.0
       - --port
       - "8422"
-    env: []
+    env:
+      - name: AGENT_BOM_API_LOCAL_PATH_SCANS
+        value: "disabled"
     envFrom: []
     extraVolumes: []
     extraVolumeMounts: []

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -107,6 +107,12 @@ Rate limiting also follows an explicit fail-closed contract for scaled control p
 - multi-replica API or `AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT=1`: PostgreSQL-backed shared limiter is required
 - if shared rate limiting is required and `AGENT_BOM_POSTGRES_URL` is absent or broken, API startup now fails instead of silently falling back to process-local state
 
+API-local filesystem scans follow the same pilot-vs-control-plane split:
+
+- workstation pilot: relative paths under the API process home are allowed by default
+- EKS/shared control plane: Helm disables API-local filesystem scans by default with `AGENT_BOM_API_LOCAL_PATH_SCANS=disabled`
+- explicit single-tenant enablement: set `AGENT_BOM_API_SCAN_ROOT` to a mounted tenant workspace; the API still rejects absolute paths, traversal, symlink escapes, missing paths, and foreign-owned paths unless explicitly overridden
+
 Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`
 
 ## Storage Compatibility

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -194,6 +194,15 @@ For horizontally scaled control-plane APIs, shared rate limiting is mandatory. `
 
 For horizontally scaled SCIM, shared identity storage is also mandatory. Set `AGENT_BOM_POSTGRES_URL` for EKS or any multi-replica control plane, and keep `AGENT_BOM_REQUIRE_SHARED_SCIM_STORE=1` enabled in production values. SQLite is acceptable only for a single-node pilot.
 
+API-local filesystem scan endpoints are meant for workstation pilots. In EKS
+and other shared control planes, keep `AGENT_BOM_API_LOCAL_PATH_SCANS=disabled`
+and collect filesystem evidence through endpoint agents or mounted tenant
+workspaces. If a single-tenant deployment must enable API-local scans, set
+`AGENT_BOM_API_SCAN_ROOT` to the tenant workspace mount; paths are still
+relative-only, resolved through symlinks, confined to that root, and rejected
+when owned outside the API process unless `AGENT_BOM_API_SCAN_ALLOW_FOREIGN_OWNER=1`
+is explicitly set.
+
 For secret lifecycle posture, production deployments should declare the external
 secret authority and rotation metadata without exposing secret values:
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -24,12 +24,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse
+from werkzeug.security import safe_join
 
 from agent_bom.api.models import (
     BrowserExtensionsRequest,
@@ -54,30 +57,77 @@ from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retain
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
+_LOCAL_SCAN_DISABLE_VALUES = {"0", "false", "no", "off", "disabled"}
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
 
+def _api_local_scans_enabled() -> bool:
+    configured = os.getenv("AGENT_BOM_API_LOCAL_PATH_SCANS", os.getenv("AGENT_BOM_ENABLE_LOCAL_PATH_SCANS", "enabled"))
+    return configured.strip().lower() not in _LOCAL_SCAN_DISABLE_VALUES
+
+
+def _api_scan_root() -> Path:
+    """Return the configured API filesystem scan root.
+
+    Workstation pilots keep the historical default of ``$HOME``. Shared
+    control-plane deployments should set ``AGENT_BOM_API_SCAN_ROOT`` to a
+    tenant workspace mount, or disable these endpoints and scan via endpoint
+    agents instead.
+    """
+    configured = os.getenv("AGENT_BOM_API_SCAN_ROOT", "").strip()
+    root = Path(configured).expanduser() if configured else Path.home()
+    try:
+        resolved = root.resolve()
+    except (OSError, RuntimeError) as exc:
+        from agent_bom.security import SecurityError
+
+        raise SecurityError("Configured scan root is not available") from exc
+    if not resolved.exists() or not resolved.is_dir():
+        from agent_bom.security import SecurityError
+
+        raise SecurityError("Configured scan root is not available")
+    return resolved
+
+
+def _enforce_api_scan_path_owner(resolved: Path, root: Path) -> None:
+    """Reject paths not owned by the API process unless explicitly allowed."""
+    if os.getenv("AGENT_BOM_API_SCAN_ALLOW_FOREIGN_OWNER", "").strip().lower() in {"1", "true", "yes", "on"}:
+        return
+    if os.name == "nt":
+        return
+    from agent_bom.security import SecurityError
+
+    try:
+        uid = os.getuid()
+        root_stat = root.stat()
+        path_stat = resolved.stat()
+    except OSError as exc:
+        raise SecurityError("Path is not available") from exc
+    if root_stat.st_uid != uid or path_stat.st_uid != uid:
+        raise SecurityError("Path owner is outside the API scan boundary")
+
+
 def _sanitize_api_path(user_path: str) -> str:
     """Validate and sanitize a user-supplied path from an API request.
 
-    Interprets ``user_path`` as relative to the current user's home directory
+    Interprets ``user_path`` as relative to the configured API scan root
     (absolute paths are rejected). The resolved path is normalised, has any
-    symlinks resolved, and is verified to remain within the home directory
+    symlinks resolved, and is verified to remain within the scan root
     using ``os.path.commonpath`` before being returned.
     """
-    import os
-    from pathlib import Path
-
     from agent_bom.security import SecurityError
+
+    if not _api_local_scans_enabled():
+        raise SecurityError("Local filesystem scan endpoints are disabled")
 
     # Normalise basic whitespace
     user_path = (user_path or "").strip()
     if not user_path:
         raise SecurityError("Empty paths are not allowed")
 
-    # 1. Reject absolute paths — API callers must use paths relative to $HOME
+    # 1. Reject absolute paths — API callers must use paths relative to the scan root.
     if os.path.isabs(user_path):
         raise SecurityError(f"Absolute paths are not allowed: {user_path}")
 
@@ -86,19 +136,35 @@ def _sanitize_api_path(user_path: str) -> str:
         raise SecurityError(f"Path traversal not allowed: {user_path}")
 
     # 3. Compute fixed root and join user path under it
-    home = os.path.realpath(str(Path.home()))
-    # Normalise the user-provided relative path before joining
-    relative = os.path.normpath(user_path)
-    candidate = os.path.join(home, relative)
+    scan_root = _api_scan_root()
+    root = os.path.realpath(str(scan_root))
+    candidate = safe_join(root, user_path)
+    if candidate is None:
+        raise SecurityError("Path resolves outside configured scan root")
 
     # 4. Resolve to real absolute path (follows symlinks)
-    resolved = os.path.realpath(candidate)
+    try:
+        resolved_path = Path(candidate).resolve(strict=True)
+    except OSError as exc:
+        raise SecurityError("Path does not exist inside configured scan root") from exc
 
-    # 5. Containment check — ensure resolved path stays within $HOME
-    if os.path.commonpath([home, resolved]) != home:
-        raise SecurityError(f"Path resolves outside home directory: {user_path}")
+    # 5. Containment check — ensure resolved path stays within the configured root.
+    if os.path.commonpath([root, os.path.realpath(str(resolved_path))]) != root:
+        raise SecurityError("Path resolves outside configured scan root")
 
-    return resolved
+    _enforce_api_scan_path_owner(resolved_path, scan_root)
+
+    return str(resolved_path)
+
+
+def _api_scan_path_or_400(user_path: str) -> str:
+    from agent_bom.security import SecurityError
+
+    try:
+        return _sanitize_api_path(user_path)
+    except SecurityError as exc:
+        _logger.warning("blocked local API scan path: %s", exc)
+        raise HTTPException(status_code=400, detail="Invalid scan path") from exc
 
 
 def _dataclass_to_dict(obj: object) -> object:
@@ -562,23 +628,15 @@ async def scan_dataset_cards(request: DatasetCardsRequest) -> dict:
     Returns dataset metadata, license info, and security flags
     (unlicensed data, missing cards, unversioned data, remote sources).
     """
-    import os
-    from pathlib import Path
-
     from agent_bom.parsers.dataset_cards import scan_dataset_directory
-    from agent_bom.security import SecurityError
 
-    home = os.path.realpath(str(Path.home()))
     results = []
     safe_dirs = []
     for d in request.directories:
-        resolved = _sanitize_api_path(d)
-        if os.path.commonpath([home, resolved]) == home:
-            safe_dirs.append(resolved)
-            result = scan_dataset_directory(resolved)
-            results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
-        else:
-            raise SecurityError(f"Path escapes safe root: {d}")
+        resolved = _api_scan_path_or_400(d)
+        safe_dirs.append(resolved)
+        result = scan_dataset_directory(resolved)
+        results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
 
     return {"scan_type": "dataset-cards", "directories": safe_dirs, "results": results}
 
@@ -590,23 +648,15 @@ async def scan_training_pipelines(request: TrainingPipelinesRequest) -> dict:
     Detects MLflow runs, W&B metadata, Kubeflow pipeline definitions.
     Flags unsafe serialization (pickle), missing provenance, exposed credentials.
     """
-    import os
-    from pathlib import Path
-
     from agent_bom.parsers.training_pipeline import scan_training_directory
-    from agent_bom.security import SecurityError
 
-    home = os.path.realpath(str(Path.home()))
     results = []
     safe_dirs = []
     for d in request.directories:
-        resolved = _sanitize_api_path(d)
-        if os.path.commonpath([home, resolved]) == home:
-            safe_dirs.append(resolved)
-            result = scan_training_directory(resolved)
-            results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
-        else:
-            raise SecurityError(f"Path escapes safe root: {d}")
+        resolved = _api_scan_path_or_400(d)
+        safe_dirs.append(resolved)
+        result = scan_training_directory(resolved)
+        results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
 
     return {"scan_type": "training-pipelines", "directories": safe_dirs, "results": results}
 
@@ -664,27 +714,16 @@ async def scan_prompts(request: PromptScanRequest) -> dict:
     Detects prompt injection, jailbreak patterns, hardcoded API keys,
     shell execution instructions, and data exfiltration patterns.
     """
-    import os
-    from pathlib import Path
-
     from agent_bom.parsers.prompt_scanner import scan_prompt_files
-    from agent_bom.security import SecurityError
 
-    home = os.path.realpath(str(Path.home()))
     safe_dirs: list[Path] = []
     all_paths: list[Path] = []
     for d in request.directories:
-        resolved = _sanitize_api_path(d)
-        if os.path.commonpath([home, resolved]) == home:
-            safe_dirs.append(Path(resolved))
-        else:
-            raise SecurityError(f"Path escapes safe root: {d}")
+        resolved = _api_scan_path_or_400(d)
+        safe_dirs.append(Path(resolved))
     for f in request.files:
-        resolved = _sanitize_api_path(f)
-        if os.path.commonpath([home, resolved]) == home:
-            all_paths.append(Path(resolved))
-        else:
-            raise SecurityError(f"Path escapes safe root: {f}")
+        resolved = _api_scan_path_or_400(f)
+        all_paths.append(Path(resolved))
 
     results = []
     for safe in safe_dirs:
@@ -704,27 +743,19 @@ async def scan_model_files_endpoint(request: ModelFilesRequest) -> dict:
     Detects pickle deserialization risks (.pkl, .pt), verifies file integrity,
     and flags unsafe model formats.
     """
-    import os
-    from pathlib import Path
-
     from agent_bom.model_files import scan_model_files, scan_model_manifests, verify_model_hash
-    from agent_bom.security import SecurityError
 
-    home = os.path.realpath(str(Path.home()))
     all_files = []
     all_manifests = []
     all_warnings = []
     for d in request.directories:
-        resolved = _sanitize_api_path(d)
-        if os.path.commonpath([home, resolved]) == home:
-            files, warnings = scan_model_files(resolved)
-            manifests, manifest_warnings = scan_model_manifests(resolved)
-            all_files.extend(files)
-            all_manifests.extend(manifests)
-            all_warnings.extend(warnings)
-            all_warnings.extend(manifest_warnings)
-        else:
-            raise SecurityError(f"Path escapes safe root: {d}")
+        resolved = _api_scan_path_or_400(d)
+        files, warnings = scan_model_files(resolved)
+        manifests, manifest_warnings = scan_model_manifests(resolved)
+        all_files.extend(files)
+        all_manifests.extend(manifests)
+        all_warnings.extend(warnings)
+        all_warnings.extend(manifest_warnings)
 
     if request.verify_hashes:
         for f in all_files:

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -17,6 +17,7 @@ from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode
 from agent_bom.graph.severity import SEVERITY_RISK_SCORE
 from agent_bom.graph.types import EntityType, RelationshipType
+from agent_bom.package_utils import canonical_package_key, normalize_package_name
 
 try:
     from agent_bom.constants import is_credential_key as _is_credential_key
@@ -157,7 +158,8 @@ def build_unified_graph_from_report(
                 pkg_name = pkg_dict.get("name", "unknown")
                 pkg_version = pkg_dict.get("version", "")
                 ecosystem = pkg_dict.get("ecosystem", "")
-                pkg_id = f"pkg:{pkg_name}:{ecosystem}:{pkg_version}"
+                pkg_id = _package_node_id(pkg_dict)
+                package_evidence = _package_evidence(pkg_dict, data_source_tag)
 
                 graph.add_node(
                     UnifiedNode(
@@ -181,19 +183,23 @@ def build_unified_graph_from_report(
                     )
                 )
                 package_name_to_ids[pkg_name].append(pkg_id)
+                normalized_pkg_name = normalize_package_name(pkg_name, ecosystem)
+                if normalized_pkg_name != pkg_name:
+                    package_name_to_ids[normalized_pkg_name].append(pkg_id)
                 graph.add_edge(
                     UnifiedEdge(
                         source=srv_id,
                         target=pkg_id,
                         relationship=RelationshipType.DEPENDS_ON,
+                        evidence=package_evidence,
                     )
                 )
-                pkg_key = f"{ecosystem}:{pkg_name}:{pkg_version}"
+                pkg_key = _package_graph_key(pkg_name, pkg_version, ecosystem, pkg_dict.get("purl"))
                 pkg_key_to_servers[pkg_key].append(srv_id)
 
                 # ── Package-level vulnerabilities ──
                 for vuln_dict in pkg_dict.get("vulnerabilities", []):
-                    _add_vuln_node(graph, vuln_dict, pkg_id, data_source_tag)
+                    _add_vuln_node(graph, vuln_dict, pkg_id, data_source_tag, package_evidence)
 
             # ── Tools ──
             for tool_dict in srv_dict.get("tools", []):
@@ -285,7 +291,7 @@ def build_unified_graph_from_report(
 
         # Link package → vulnerability
         if pkg_name:
-            pkg_id = f"pkg:{pkg_name}:{ecosystem}:{pkg_version}"
+            pkg_id = _package_node_id_from_parts(pkg_name, pkg_version, ecosystem, br_dict.get("package_purl") or br_dict.get("purl"))
             if graph.has_node(pkg_id):
                 graph.add_edge(
                     UnifiedEdge(
@@ -293,6 +299,7 @@ def build_unified_graph_from_report(
                         target=vuln_node_id,
                         relationship=RelationshipType.VULNERABLE_TO,
                         weight=SEVERITY_RISK_SCORE.get(severity, 1.0),
+                        evidence=_blast_radius_package_evidence(br_dict, data_source_tag),
                     )
                 )
 
@@ -313,7 +320,7 @@ def build_unified_graph_from_report(
                     target=vuln_node_id,
                     relationship=RelationshipType.VULNERABLE_TO,
                     weight=SEVERITY_RISK_SCORE.get(severity, 1.0),
-                    evidence={"package": br_dict.get("package", "")},
+                    evidence=_blast_radius_package_evidence(br_dict, data_source_tag),
                 )
             )
 
@@ -716,6 +723,7 @@ def _add_vuln_node(
     vuln_dict: dict[str, Any],
     pkg_id: str,
     data_source: str,
+    package_evidence: dict[str, Any] | None = None,
 ) -> None:
     """Add a vulnerability node and link it to its package."""
     vuln_id_str = vuln_dict.get("id", "")
@@ -746,6 +754,7 @@ def _add_vuln_node(
             target=vuln_node_id,
             relationship=RelationshipType.VULNERABLE_TO,
             weight=SEVERITY_RISK_SCORE.get(severity, 1.0),
+            evidence=package_evidence or {"source": data_source},
         )
     )
 
@@ -780,7 +789,7 @@ def _resolve_affected_server_ids(
     """
     candidate_ids: set[str] = set()
     if pkg_name:
-        pkg_key = f"{ecosystem}:{pkg_name}:{pkg_version}"
+        pkg_key = _package_graph_key(pkg_name, pkg_version, ecosystem, br_dict.get("package_purl") or br_dict.get("purl"))
         candidate_ids.update(pkg_key_to_servers.get(pkg_key, []))
 
     server_names = {name for name in (_normalize_server_name(server) for server in br_dict.get("affected_servers", [])) if name}
@@ -798,6 +807,85 @@ def _resolve_affected_server_ids(
         candidate_ids = (candidate_ids & agent_ids) if candidate_ids else agent_ids
 
     return sorted(candidate_ids)
+
+
+def _package_graph_key(name: str, version: str, ecosystem: str, purl: str | None = None) -> str:
+    return canonical_package_key(name, version, ecosystem, purl)
+
+
+def _package_node_id(pkg_dict: dict[str, Any]) -> str:
+    return _package_node_id_from_parts(
+        str(pkg_dict.get("name", "unknown") or "unknown"),
+        str(pkg_dict.get("version", "") or ""),
+        str(pkg_dict.get("ecosystem", "") or ""),
+        pkg_dict.get("purl"),
+    )
+
+
+def _package_node_id_from_parts(name: str, version: str, ecosystem: str, purl: str | None = None) -> str:
+    return f"pkg:{_package_graph_key(name, version, ecosystem, purl)}"
+
+
+def _package_evidence(pkg_dict: dict[str, Any], data_source_tag: str) -> dict[str, Any]:
+    """Build bounded provenance evidence for package graph edges."""
+    occurrences = pkg_dict.get("occurrences", [])
+    if not isinstance(occurrences, list):
+        occurrences = []
+    normalized_occurrences: list[dict[str, Any]] = []
+    for occurrence in occurrences[:10]:
+        if not isinstance(occurrence, dict):
+            continue
+        item = {
+            key: occurrence.get(key)
+            for key in (
+                "layer_index",
+                "layer_id",
+                "layer_path",
+                "package_path",
+                "created_by",
+                "dockerfile_instruction",
+                "source_file",
+                "line",
+                "parser",
+            )
+            if occurrence.get(key) not in (None, "")
+        }
+        if item:
+            normalized_occurrences.append(item)
+
+    evidence = {
+        "source": data_source_tag,
+        "package": pkg_dict.get("name", ""),
+        "version": pkg_dict.get("version", ""),
+        "ecosystem": pkg_dict.get("ecosystem", ""),
+        "purl": pkg_dict.get("purl", ""),
+        "stable_id": pkg_dict.get("stable_id", ""),
+        "source_package": pkg_dict.get("source_package", ""),
+        "version_source": pkg_dict.get("version_source", ""),
+        "occurrence_count": pkg_dict.get("occurrence_count", len(occurrences)),
+        "occurrences": normalized_occurrences,
+    }
+    introduced = pkg_dict.get("introduced_in_layer")
+    if isinstance(introduced, dict):
+        evidence["introduced_in_layer"] = {
+            key: introduced.get(key)
+            for key in ("layer_index", "layer_id", "layer_path", "package_path", "created_by", "dockerfile_instruction")
+            if introduced.get(key) not in (None, "")
+        }
+    return {key: value for key, value in evidence.items() if value not in (None, "", [])}
+
+
+def _blast_radius_package_evidence(br_dict: dict[str, Any], data_source_tag: str) -> dict[str, Any]:
+    evidence = {
+        "source": data_source_tag,
+        "package": br_dict.get("package", ""),
+        "package_name": br_dict.get("package_name", ""),
+        "package_version": br_dict.get("package_version", ""),
+        "package_stable_id": br_dict.get("package_stable_id", ""),
+        "purl": br_dict.get("package_purl") or br_dict.get("purl", ""),
+        "reachability": br_dict.get("reachability", ""),
+    }
+    return {key: value for key, value in evidence.items() if value not in (None, "", [])}
 
 
 def _collect_compliance_tags(br_dict: dict[str, Any]) -> list[str]:

--- a/src/agent_bom/history.py
+++ b/src/agent_bom/history.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from agent_bom.models import Package
+from agent_bom.package_utils import canonical_package_key
 from agent_bom.sbom import parse_sbom_document
 
 HISTORY_DIR = Path.home() / ".agent-bom" / "history"
@@ -273,7 +274,12 @@ def _get_inventory_snapshot(report: dict) -> dict:
                 if server_id and resource_id:
                     relationships.append({"from": server_id, "to": resource_id, "type": "exposes_resource"})
             for pkg in server.get("packages", []):
-                pkg_id = pkg.get("stable_id") or f"{pkg.get('ecosystem', 'unknown')}:{pkg.get('name', '')}@{pkg.get('version', '')}"
+                pkg_id = pkg.get("stable_id") or canonical_package_key(
+                    str(pkg.get("name", "") or ""),
+                    str(pkg.get("version", "") or ""),
+                    str(pkg.get("ecosystem", "unknown") or "unknown"),
+                    str(pkg.get("purl", "") or "") or None,
+                )
                 if pkg_id and pkg_id not in seen_packages:
                     packages.append({"id": pkg_id, "name": pkg.get("name", ""), "version": pkg.get("version", "")})
                     seen_packages.add(pkg_id)

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -13,10 +13,11 @@ if TYPE_CHECKING:
 
 from agent_bom.advisory_sources import merge_advisory_sources
 from agent_bom.package_utils import (
-    host_matches_domain as _host_matches_domain,
+    canonical_package_key,
+    normalize_package_name,
 )
 from agent_bom.package_utils import (
-    normalize_package_name,
+    host_matches_domain as _host_matches_domain,
 )
 from agent_bom.package_utils import parse_debian_source_name as parse_debian_source_name  # noqa: F401
 from agent_bom.package_utils import (
@@ -357,8 +358,7 @@ class Package:
         import uuid as _uuid
 
         _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
-        purl = self.purl or f"pkg:{self.ecosystem}/{self.name}@{self.version}"
-        fingerprint = f"package:{purl.lower().strip()}"
+        fingerprint = f"package:{canonical_package_key(self.name, self.version, self.ecosystem, self.purl)}"
         return str(_uuid.uuid5(_ns, fingerprint))
 
     @property

--- a/src/agent_bom/package_utils.py
+++ b/src/agent_bom/package_utils.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 import re
 from functools import lru_cache
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 _NORMALIZE_RE = re.compile(r"[-_.]+")
+_PURL_TYPE_ALIASES = {
+    "golang": "go",
+}
 
 
 @lru_cache(maxsize=16384)
@@ -43,6 +46,77 @@ def normalize_package_name(name: str, ecosystem: str = "") -> str:
     return name.lower()
 
 
+def normalize_package_ecosystem(ecosystem: str) -> str:
+    """Normalize ecosystem aliases used by PURLs, OSV, and parsers."""
+    eco = (ecosystem or "").strip().lower()
+    return _PURL_TYPE_ALIASES.get(eco, eco)
+
+
+def _normalize_package_version(version: str, ecosystem: str) -> str:
+    """Normalize versions for identity keys without making parsing mandatory."""
+    version = (version or "").strip()
+    if not version:
+        return ""
+    try:
+        from agent_bom.version_utils import normalize_version
+
+        return normalize_version(version, normalize_package_ecosystem(ecosystem))
+    except Exception:
+        return version
+
+
+def _purl_identity(purl: str) -> tuple[str, str, str] | None:
+    """Return (ecosystem, normalized name, normalized version) from a purl."""
+    if not purl:
+        return None
+    try:
+        from packageurl import PackageURL
+
+        parsed = PackageURL.from_string(purl)
+    except Exception:
+        return None
+
+    ecosystem = normalize_package_ecosystem(parsed.type or "")
+    name_parts = [part for part in (parsed.namespace, parsed.name) if part]
+    raw_name = "/".join(unquote(part.strip()) for part in name_parts)
+    name = normalize_package_name(raw_name, ecosystem)
+    version = _normalize_package_version(parsed.version or "", ecosystem)
+    if not ecosystem or not name:
+        return None
+    return ecosystem, name, version
+
+
+def canonical_package_identity(name: str, version: str, ecosystem: str, purl: str | None = None) -> tuple[str, str, str]:
+    """Return the canonical package identity used by scan, graph, and history.
+
+    The identity intentionally mirrors scanner deduplication: ecosystem aliases
+    collapse, PyPI separators/case normalize, and versions use the same
+    ecosystem-specific normalization used for matching. A valid explicit PURL is
+    authoritative, but it is normalized before hashing or graph ID construction.
+    """
+    parsed = _purl_identity(purl or "")
+    if parsed is not None:
+        purl_ecosystem, purl_name, purl_version = parsed
+        return (
+            purl_ecosystem,
+            purl_name,
+            purl_version or _normalize_package_version(version, purl_ecosystem),
+        )
+    normalized_ecosystem = normalize_package_ecosystem(ecosystem)
+    return (
+        normalized_ecosystem,
+        normalize_package_name((name or "").strip(), normalized_ecosystem),
+        _normalize_package_version(version, normalized_ecosystem),
+    )
+
+
+def canonical_package_key(name: str, version: str, ecosystem: str, purl: str | None = None) -> str:
+    """Return a compact stable key for package maps and graph node IDs."""
+    normalized_ecosystem, normalized_name, normalized_version = canonical_package_identity(name, version, ecosystem, purl)
+    suffix = f"@{normalized_version}" if normalized_version else ""
+    return f"{normalized_ecosystem}:{normalized_name}{suffix}"
+
+
 @lru_cache(maxsize=16384)
 def parse_debian_source_name(source_field: str) -> Optional[str]:
     """Extract the Debian source package name from a ``Source:`` field."""
@@ -55,7 +129,10 @@ def parse_debian_source_name(source_field: str) -> Optional[str]:
 
 
 __all__ = [
+    "canonical_package_identity",
+    "canonical_package_key",
     "host_matches_domain",
+    "normalize_package_ecosystem",
     "normalize_package_name",
     "parse_debian_source_name",
     "reference_host_and_path",

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -42,7 +42,7 @@ from agent_bom.nist_csf import tag_blast_radius as tag_nist_csf
 from agent_bom.owasp import tag_blast_radius
 from agent_bom.owasp_agentic import tag_blast_radius as tag_owasp_agentic
 from agent_bom.owasp_mcp import tag_blast_radius as tag_owasp_mcp
-from agent_bom.package_utils import normalize_package_name
+from agent_bom.package_utils import canonical_package_identity, canonical_package_key, normalize_package_name
 from agent_bom.scanners.blast_radius import _HOP_RISK_FACTORS, expand_blast_radius_hops
 from agent_bom.scanners.osv import candidate_package_names as _candidate_package_names
 from agent_bom.scanners.osv import enrich_results_if_needed as _enrich_results_if_needed_impl
@@ -438,8 +438,7 @@ def deduplicate_packages(packages: list) -> list:
         name = getattr(pkg, "name", "") or ""
         ecosystem = getattr(pkg, "ecosystem", "") or ""
         version = getattr(pkg, "version", "") or ""
-        norm_name = normalize_package_name(name, ecosystem)
-        key = (ecosystem.lower(), norm_name, version.lower())
+        key = canonical_package_identity(name, version, ecosystem, getattr(pkg, "purl", None))
         if key not in seen:
             seen.add(key)
             result.append(pkg)
@@ -965,7 +964,7 @@ async def scan_agents(
         console.print("\n[bold blue]🛡️  Scanning for vulnerabilities...[/bold blue]\n")
 
     def _pkg_key(pkg: Package) -> str:
-        return f"{pkg.ecosystem.lower()}:{normalize_package_name(pkg.name, pkg.ecosystem)}@{pkg.version}"
+        return canonical_package_key(pkg.name, pkg.version, pkg.ecosystem, pkg.purl)
 
     # Collect all unique packages
     all_packages = []

--- a/tests/test_api_scan_types.py
+++ b/tests/test_api_scan_types.py
@@ -429,3 +429,48 @@ def test_sanitize_resolves_relative_to_home(tmp_path, monkeypatch):
 
     result = _sanitize_api_path("projects")
     assert result == os.path.realpath(str(subdir))
+
+
+def test_sanitize_respects_configured_scan_root(tmp_path, monkeypatch):
+    """_sanitize_api_path uses AGENT_BOM_API_SCAN_ROOT instead of service $HOME when set."""
+    import os
+
+    from agent_bom.api.server import _sanitize_api_path
+
+    scan_root = tmp_path / "tenant-workspace"
+    project = scan_root / "projects"
+    project.mkdir(parents=True)
+    monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(scan_root))
+
+    result = _sanitize_api_path("projects")
+
+    assert result == os.path.realpath(str(project))
+
+
+def test_sanitize_can_disable_local_path_scans(tmp_path, monkeypatch):
+    """Enterprise control planes can disable API-local filesystem scans."""
+    import pytest
+
+    from agent_bom.api.server import _sanitize_api_path
+    from agent_bom.security import SecurityError
+
+    scan_root = tmp_path / "tenant-workspace"
+    scan_root.mkdir()
+    monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(scan_root))
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "disabled")
+
+    with pytest.raises(SecurityError, match="disabled"):
+        _sanitize_api_path(".")
+
+
+def test_endpoint_returns_generic_invalid_scan_path(tmp_path, monkeypatch):
+    """Scan endpoints must not echo server filesystem details on path rejection."""
+    client, _ = _fresh_client()
+    scan_root = tmp_path / "tenant-workspace"
+    scan_root.mkdir()
+    monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(scan_root))
+
+    resp = client.post("/v1/scan/dataset-cards", json={"directories": ["missing"]})
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid scan path"

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -159,13 +159,50 @@ class TestBuildUnifiedGraphFromReport:
 
     def test_package_to_vuln_edge(self):
         g = build_unified_graph_from_report(_minimal_report())
-        pkg_id = "pkg:express:npm:4.18.0"
+        pkg_id = "pkg:npm:express@4.18.0"
         vuln_id = "vuln:CVE-2024-1234"
         assert g.has_edge(pkg_id, vuln_id)
 
     def test_server_to_package_edge(self):
         g = build_unified_graph_from_report(_minimal_report())
-        assert g.has_edge("server:claude-desktop:mcp-fs", "pkg:express:npm:4.18.0")
+        assert g.has_edge("server:claude-desktop:mcp-fs", "pkg:npm:express@4.18.0")
+
+    def test_package_edges_include_discovery_provenance(self):
+        report = _minimal_report()
+        report["agents"][0]["mcp_servers"][0]["packages"][0]["purl"] = "pkg:npm/express@4.18.0"
+        report["agents"][0]["mcp_servers"][0]["packages"][0]["occurrences"] = [
+            {
+                "layer_index": 2,
+                "layer_id": "sha256:abc",
+                "package_path": "app/package-lock.json",
+                "source_file": "package-lock.json",
+                "line": 42,
+                "parser": "npm-lock",
+            }
+        ]
+        report["agents"][0]["mcp_servers"][0]["packages"][0]["occurrence_count"] = 1
+        g = build_unified_graph_from_report(report)
+
+        edge = next(e for e in g.edges if e.source == "server:claude-desktop:mcp-fs" and e.target == "pkg:npm:express@4.18.0")
+        assert edge.evidence["source"] == "mcp-scan"
+        assert edge.evidence["purl"] == "pkg:npm/express@4.18.0"
+        assert edge.evidence["occurrences"][0]["package_path"] == "app/package-lock.json"
+        assert edge.evidence["occurrences"][0]["line"] == 42
+
+    def test_package_node_id_uses_canonical_identity(self):
+        report = _minimal_report()
+        report["agents"][0]["mcp_servers"][0]["packages"][0]["name"] = "torch_audio"
+        report["agents"][0]["mcp_servers"][0]["packages"][0]["ecosystem"] = "PyPI"
+        report["agents"][0]["mcp_servers"][0]["packages"][0]["version"] = "1.0.0"
+        report["agents"][0]["mcp_servers"][0]["packages"][0]["purl"] = "pkg:pypi/torch.audio@1.0.0"
+        report["blast_radius"][0]["package_name"] = "torch-audio"
+        report["blast_radius"][0]["package_version"] = "1.0.0"
+        report["blast_radius"][0]["ecosystem"] = "pypi"
+
+        g = build_unified_graph_from_report(report)
+
+        assert "pkg:pypi:torch-audio@1.0.0" in g.nodes
+        assert g.has_edge("pkg:pypi:torch-audio@1.0.0", "vuln:CVE-2024-1234")
 
     def test_agent_to_server_edge(self):
         g = build_unified_graph_from_report(_minimal_report())
@@ -218,7 +255,7 @@ class TestBuildUnifiedGraphFromReport:
 
     def test_dimensions_populated(self):
         g = build_unified_graph_from_report(_minimal_report())
-        pkg = g.nodes.get("pkg:express:npm:4.18.0")
+        pkg = g.nodes.get("pkg:npm:express@4.18.0")
         assert pkg is not None
         assert pkg.dimensions.ecosystem == "npm"
 
@@ -384,7 +421,7 @@ class TestSkillAuditNodes:
         assert "skill_audit:shell_access" in shell_node.compliance_tags
 
         assert g.has_edge("misconfig:skill_audit:shell_access:1", "agent:claude-desktop")
-        assert g.has_edge("misconfig:skill_audit:unknown_package:2", "pkg:express:npm:4.18.0")
+        assert g.has_edge("misconfig:skill_audit:unknown_package:2", "pkg:npm:express@4.18.0")
         assert g.has_edge("misconfig:skill_audit:unverified_server:3", "server:claude-desktop:mcp-fs")
         assert not g.has_edge("misconfig:skill_audit:unverified_server:3", "server:cursor:mcp-git")
 

--- a/tests/test_stable_ids.py
+++ b/tests/test_stable_ids.py
@@ -130,6 +130,15 @@ def test_package_stable_id_uses_purl_when_available():
     assert p_different_purl.stable_id != p_without_purl.stable_id
 
 
+def test_package_stable_id_uses_canonical_package_identity():
+    """PyPI separator/case variants must not split scan history identity."""
+    p_hyphen = Package(name="torch-audio", version="1.0.0", ecosystem="pypi")
+    p_under = Package(name="torch_audio", version="1.0.0", ecosystem="pypi")
+    p_dot = Package(name="Torch.Audio", version="1.0.0", ecosystem="PyPI", purl="pkg:pypi/Torch.Audio@1.0.0")
+
+    assert p_hyphen.stable_id == p_under.stable_id == p_dot.stable_id
+
+
 # ---------------------------------------------------------------------------
 # MCPServer stable_id
 # ---------------------------------------------------------------------------

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -26,7 +26,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { api, type JobListItem, type ScanJob } from "@/lib/api";
-import { applyDagreLayout } from "@/lib/dagre-layout";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
 import {
   lineageNodeTypes,
   type LineageNodeData,
@@ -305,19 +305,13 @@ export default function ContextPage() {
     return { rawNodes: nodes, rawEdges: edges };
   }, [graphData, selectedAgent]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useMemo(
-    () =>
-      rawNodes.length > 0
-        ? applyDagreLayout(rawNodes, rawEdges, {
-            direction: "LR",
-            nodeWidth: 200,
-            nodeHeight: 70,
-            rankSep: 140,
-            nodeSep: 25,
-          })
-        : { nodes: [] as Node[], edges: [] as Edge[] },
-    [rawNodes, rawEdges]
-  );
+  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(rawNodes, rawEdges, {
+    direction: "LR",
+    nodeWidth: 200,
+    nodeHeight: 70,
+    rankSep: 140,
+    nodeSep: 25,
+  });
 
   // Search highlighting
   const searchMatches = useMemo(

--- a/ui/app/graph/page.tsx
+++ b/ui/app/graph/page.tsx
@@ -28,7 +28,7 @@ import {
   type FilterState,
 } from "@/components/lineage-filter";
 import { lineageNodeTypes, type LineageNodeData, type LineageNodeType } from "@/components/lineage-nodes";
-import { applyDagreLayout } from "@/lib/dagre-layout";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
 import {
   EntityType,
   RelationshipType,
@@ -464,19 +464,13 @@ export default function GraphPage() {
     [flow.nodes],
   );
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useMemo(
-    () =>
-      flow.nodes.length > 0
-        ? applyDagreLayout(flow.nodes, flow.edges, {
-            direction: filters.agentName || filters.vulnOnly ? "TB" : "LR",
-            nodeWidth: filters.agentName ? 208 : 188,
-            nodeHeight: 72,
-            rankSep: filters.agentName ? 118 : 104,
-            nodeSep: filters.agentName ? 22 : 28,
-          })
-        : { nodes: [], edges: [] },
-    [flow.nodes, flow.edges, filters.agentName, filters.vulnOnly],
-  );
+  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(flow.nodes, flow.edges, {
+    direction: filters.agentName || filters.vulnOnly ? "TB" : "LR",
+    nodeWidth: filters.agentName ? 208 : 188,
+    nodeHeight: 72,
+    rankSep: filters.agentName ? 118 : 104,
+    nodeSep: filters.agentName ? 22 : 28,
+  });
 
   const connectedIds = useMemo(
     () => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null),

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -12,7 +12,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { ShieldAlert, Loader2, AlertTriangle, Search, SlidersHorizontal, Network, GitBranch } from "lucide-react";
 import { api, type JobListItem, type ScanJob } from "@/lib/api";
-import { applyDagreLayout } from "@/lib/dagre-layout";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import { MeshStats } from "@/components/mesh-stats";
@@ -294,19 +294,13 @@ export default function MeshPage() {
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [activeResult, nodeFilter, severityFilter, selectedAgents, vulnerableOnly]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useMemo(
-    () =>
-      rawNodes.length > 0
-        ? applyDagreLayout(rawNodes, rawEdges, {
-            direction: layoutMode,
-            nodeWidth: 200,
-            nodeHeight: 70,
-            rankSep: 140,
-            nodeSep: 25,
-          })
-        : { nodes: [] as Node[], edges: [] as Edge[] },
-    [rawNodes, rawEdges, layoutMode]
-  );
+  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(rawNodes, rawEdges, {
+    direction: layoutMode,
+    nodeWidth: 200,
+    nodeHeight: 70,
+    rankSep: 140,
+    nodeSep: 25,
+  });
 
   // Search highlighting
   const searchMatches = useMemo(

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -6,7 +6,7 @@ import {
   ReactFlow, Background, Controls, MiniMap, type Node, type Edge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { applyDagreLayout } from "@/lib/dagre-layout";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
 import { ArrowLeft, Loader2, AlertTriangle } from "lucide-react";
 import { api, type ScanJob } from "@/lib/api";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
@@ -38,12 +38,13 @@ export function ScanMeshView({ id }: { id: string }) {
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [job]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useMemo(
-    () => rawNodes.length > 0
-      ? applyDagreLayout(rawNodes, rawEdges, { direction: "LR", nodeWidth: 200, nodeHeight: 70, rankSep: 140, nodeSep: 25 })
-      : { nodes: [] as Node[], edges: [] as Edge[] },
-    [rawNodes, rawEdges]
-  );
+  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(rawNodes, rawEdges, {
+    direction: "LR",
+    nodeWidth: 200,
+    nodeHeight: 70,
+    rankSep: 140,
+    nodeSep: 25,
+  });
 
   const connectedIds = useMemo(() => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null), [hoveredNodeId, layoutEdges]);
 

--- a/ui/components/scan-pipeline.tsx
+++ b/ui/components/scan-pipeline.tsx
@@ -29,7 +29,7 @@ import {
   Clock,
   SkipForward,
 } from "lucide-react";
-import { applyDagreLayout } from "@/lib/dagre-layout";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
 import type { StepEvent, StepStatus } from "@/lib/api";
 import { PIPELINE_STEPS } from "@/lib/api";
 
@@ -193,7 +193,7 @@ interface ScanPipelineProps {
 }
 
 function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
-  const { nodes, edges } = useMemo(() => {
+  const { rawNodes, rawEdges } = useMemo(() => {
     const rawNodes: Node[] = PIPELINE_STEPS?.map((step) => ({
       id: step.id,
       type: "pipelineStep",
@@ -234,14 +234,16 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
       };
     });
 
-    return applyDagreLayout(rawNodes, rawEdges, {
-      direction: "LR",
-      nodeWidth: 190,
-      nodeHeight: 90,
-      rankSep: 50,
-      nodeSep: 20,
-    });
+    return { rawNodes, rawEdges };
   }, [steps]);
+
+  const { nodes, edges } = useDagreLayout(rawNodes, rawEdges, {
+    direction: "LR",
+    nodeWidth: 190,
+    nodeHeight: 90,
+    rankSep: 50,
+    nodeSep: 20,
+  });
 
   return (
     <div className={`h-[180px] ${className ?? ""}`}>

--- a/ui/lib/dagre-layout.ts
+++ b/ui/lib/dagre-layout.ts
@@ -4,7 +4,7 @@
  */
 
 import dagre from "@dagrejs/dagre";
-import { type Node, type Edge, Position } from "@xyflow/react";
+import { type Edge, type Node, type Position } from "@xyflow/react";
 
 export interface LayoutOptions {
   direction?: "LR" | "TB";
@@ -51,8 +51,8 @@ export function applyDagreLayout(
         x: pos.x - nodeWidth / 2,
         y: pos.y - nodeHeight / 2,
       },
-      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
-      targetPosition: isHorizontal ? Position.Left : Position.Top,
+      sourcePosition: (isHorizontal ? "right" : "bottom") as Position,
+      targetPosition: (isHorizontal ? "left" : "top") as Position,
     };
   });
 

--- a/ui/lib/dagre-layout.worker.ts
+++ b/ui/lib/dagre-layout.worker.ts
@@ -1,0 +1,37 @@
+import { applyDagreLayout, type LayoutOptions } from "./dagre-layout";
+
+import type { Edge, Node } from "@xyflow/react";
+
+type LayoutRequest = {
+  id: number;
+  nodes: Node[];
+  edges: Edge[];
+  options: LayoutOptions;
+};
+
+type LayoutResponse =
+  | {
+      id: number;
+      ok: true;
+      nodes: Node[];
+      edges: Edge[];
+    }
+  | {
+      id: number;
+      ok: false;
+      error: string;
+    };
+
+self.onmessage = (event: MessageEvent<LayoutRequest>) => {
+  const { id, nodes, edges, options } = event.data;
+  try {
+    const result = applyDagreLayout(nodes, edges, options);
+    self.postMessage({ id, ok: true, ...result } satisfies LayoutResponse);
+  } catch (error) {
+    self.postMessage({
+      id,
+      ok: false,
+      error: error instanceof Error ? error.message : "layout failed",
+    } satisfies LayoutResponse);
+  }
+};

--- a/ui/lib/use-dagre-layout.ts
+++ b/ui/lib/use-dagre-layout.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { type Edge, type Node } from "@xyflow/react";
+
+import { applyDagreLayout, type LayoutOptions } from "@/lib/dagre-layout";
+
+type LayoutState = {
+  nodes: Node[];
+  edges: Edge[];
+  pending: boolean;
+};
+
+type WorkerResponse =
+  | {
+      id: number;
+      ok: true;
+      nodes: Node[];
+      edges: Edge[];
+    }
+  | {
+      id: number;
+      ok: false;
+      error: string;
+    };
+
+const WORKER_NODE_THRESHOLD = 150;
+
+function optionsKey(options: LayoutOptions): string {
+  return JSON.stringify({
+    direction: options.direction ?? "LR",
+    nodeWidth: options.nodeWidth ?? 180,
+    nodeHeight: options.nodeHeight ?? 60,
+    rankSep: options.rankSep ?? 80,
+    nodeSep: options.nodeSep ?? 30,
+  });
+}
+
+export function useDagreLayout(nodes: Node[], edges: Edge[], options: LayoutOptions): LayoutState {
+  const requestId = useRef(0);
+  const [workerState, setWorkerState] = useState<LayoutState | null>(null);
+  const key = optionsKey(options);
+  const stableOptions = useMemo<LayoutOptions>(() => JSON.parse(key) as LayoutOptions, [key]);
+  const shouldUseWorker = nodes.length > WORKER_NODE_THRESHOLD;
+
+  const syncLayout = useMemo(() => {
+    if (nodes.length === 0) return { nodes: [] as Node[], edges: [] as Edge[], pending: false };
+    if (shouldUseWorker) return null;
+    return { ...applyDagreLayout(nodes, edges, stableOptions), pending: false };
+  }, [edges, nodes, shouldUseWorker, stableOptions]);
+
+  useEffect(() => {
+    if (nodes.length === 0 || !shouldUseWorker || typeof Worker === "undefined") {
+      setWorkerState(null);
+      return;
+    }
+
+    const id = requestId.current + 1;
+    requestId.current = id;
+    setWorkerState({ nodes, edges, pending: true });
+
+    const worker = new Worker(new URL("./dagre-layout.worker.ts", import.meta.url), { type: "module" });
+    worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const response = event.data;
+      if (response.id !== requestId.current) return;
+      if (response.ok) {
+        setWorkerState({ nodes: response.nodes, edges: response.edges, pending: false });
+      } else {
+        setWorkerState({ nodes, edges, pending: false });
+      }
+      worker.terminate();
+    };
+    worker.onerror = () => {
+      if (id === requestId.current) {
+        setWorkerState({ nodes, edges, pending: false });
+      }
+      worker.terminate();
+    };
+    worker.postMessage({ id, nodes, edges, options: stableOptions });
+
+    return () => {
+      worker.terminate();
+    };
+  }, [edges, nodes, shouldUseWorker, stableOptions]);
+
+  if (syncLayout) return syncLayout;
+  return workerState ?? { nodes, edges, pending: shouldUseWorker };
+}


### PR DESCRIPTION
Summary
- canonicalizes package identity across stable IDs, scanner dedup keys, graph package node IDs, and history fallback IDs
- carries bounded package discovery provenance into dependency and vulnerability graph edges
- hardens API-local filesystem scan endpoints with configurable scan root, disable switch, ownership checks, and generic client errors
- disables API-local filesystem scans by default in the Helm control-plane profile and documents the pilot vs shared-control-plane contract
- moves large ReactFlow/Dagre layouts onto a browser worker for mesh, graph, context, and scan graph surfaces while keeping small graphs synchronous

Validation
- uv run pytest tests/test_stable_ids.py tests/test_package_dedup.py tests/test_graph_builder.py tests/test_api_scan_types.py -q
- uv run pytest tests/test_graph_api.py tests/test_graph_schema.py tests/test_scan_delta.py tests/test_aibom_e2e.py -q
- uv run pytest tests/test_deploy_manifests.py tests/test_iac_helm.py tests/test_stable_ids.py tests/test_package_dedup.py tests/test_graph_builder.py tests/test_api_scan_types.py -q
- uv run ruff check src/agent_bom/package_utils.py src/agent_bom/models.py src/agent_bom/scanners/__init__.py src/agent_bom/graph/builder.py src/agent_bom/api/routes/scan.py src/agent_bom/history.py tests/test_stable_ids.py tests/test_graph_builder.py tests/test_api_scan_types.py
- cd ui && npm run lint
- cd ui && npx tsc --noEmit
- python scripts/check_release_consistency.py
- cd ui && NEXT_EXPORT=1 npm run build
- git diff --check

Closes #1812
Closes #1813
Refs #1806
