### PR TITLE
feat: add columnar CIS benchmark checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ agent-bom agents -p . --compliance-export fedramp -o evidence.zip # tamper-evide
 pip install 'agent-bom[ui]' && agent-bom serve                    # API + bundled local UI
 ```
 
-<details>
+<details open>
 <summary><b>Product views</b> — dashboard, remediation, and graph surfaces</summary>
 
 ## Product views

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -14,6 +14,7 @@
 -- Tables
 --   teams              Multi-tenant team registry
 --   scan_jobs          Async scan job lifecycle + results
+--   cis_benchmark_checks Columnar CIS benchmark check observations
 --   findings           Normalized vulnerability findings (per scan)
 --   agents             Discovered AI agents/clients (per scan)
 --   policy_results     Per-scan policy evaluation outcomes
@@ -76,6 +77,38 @@ CREATE INDEX IF NOT EXISTS idx_jobs_status  ON scan_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_jobs_created ON scan_jobs(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_jobs_team_status  ON scan_jobs(team_id, status);
 CREATE INDEX IF NOT EXISTS idx_jobs_team_created ON scan_jobs(team_id, created_at DESC);
+
+-- ── Table: CIS Benchmark Checks ──────────────────────────────────────────────
+-- Normalized cloud CIS benchmark observations extracted from scan JSON blobs.
+-- This supports indexed compliance analytics without JSONB extraction hot paths.
+
+CREATE TABLE IF NOT EXISTS cis_benchmark_checks (
+    id                    BIGSERIAL PRIMARY KEY,
+    scan_id               TEXT NOT NULL REFERENCES scan_jobs(job_id) ON DELETE CASCADE,
+    team_id               TEXT NOT NULL DEFAULT 'default' REFERENCES teams(team_id) ON DELETE CASCADE,
+    cloud                 TEXT NOT NULL,
+    check_id              TEXT NOT NULL,
+    title                 TEXT NOT NULL DEFAULT '',
+    status                TEXT NOT NULL DEFAULT 'unknown',
+    severity              TEXT NOT NULL DEFAULT 'unknown',
+    cis_section           TEXT NOT NULL DEFAULT '',
+    evidence              TEXT NOT NULL DEFAULT '',
+    resource_ids          JSONB NOT NULL DEFAULT '[]'::jsonb,
+    remediation           JSONB NOT NULL DEFAULT '{}'::jsonb,
+    fix_cli               TEXT NOT NULL DEFAULT '',
+    fix_console           TEXT NOT NULL DEFAULT '',
+    effort                TEXT NOT NULL DEFAULT '',
+    priority              INTEGER NOT NULL DEFAULT 0,
+    guardrails            TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    requires_human_review BOOLEAN NOT NULL DEFAULT FALSE,
+    measured_at           TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+);
+
+CREATE INDEX IF NOT EXISTS idx_cis_checks_scan ON cis_benchmark_checks(scan_id);
+CREATE INDEX IF NOT EXISTS idx_cis_checks_team_cloud_status_priority
+    ON cis_benchmark_checks(team_id, cloud, status, priority, measured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cis_checks_team_check
+    ON cis_benchmark_checks(team_id, cloud, check_id, measured_at DESC);
 
 -- ── Tables: Fleet Agents ──────────────────────────────────────────────────────
 
@@ -528,6 +561,9 @@ ALTER TABLE fleet_agents FORCE ROW LEVEL SECURITY;
 ALTER TABLE scan_jobs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE scan_jobs FORCE ROW LEVEL SECURITY;
 
+ALTER TABLE cis_benchmark_checks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cis_benchmark_checks FORCE ROW LEVEL SECURITY;
+
 DO $$
 BEGIN
     IF NOT EXISTS (
@@ -537,6 +573,21 @@ BEGIN
           AND policyname = 'scan_jobs_tenant_isolation'
     ) THEN
         CREATE POLICY scan_jobs_tenant_isolation ON scan_jobs
+            USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'cis_benchmark_checks'
+          AND policyname = 'cis_benchmark_checks_tenant_isolation'
+    ) THEN
+        CREATE POLICY cis_benchmark_checks_tenant_isolation ON cis_benchmark_checks
             USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
             WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
     END IF;

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -151,6 +151,7 @@ list/put plus session-scoped `app.current_tenant` for RLS.
 | Table | Source dataclass | Notes |
 |---|---|---|
 | `scan_jobs` | `ScanJob` (api/models.py) | global `job_id` PK + tenant column (`team_id` / `tenant_id`) |
+| `cis_benchmark_checks` | CIS benchmark JSON blobs normalized via `analytics_contract.build_cis_benchmark_check_rows` | indexed cloud/status/priority remediation rows for `/v1/cis/checks`; backfilled by `scripts/migrations/backfill_cis_benchmark_checks.py` |
 | `fleet_agents` | `FleetAgent` (api/fleet_store.py) | trust score + lifecycle state |
 | `api_keys` | `ApiKey` (api/auth.py) | scrypt hashes, expiry, role, tenant |
 | `exceptions` | `Exception` (api/exceptions.py) | suppression workflow |
@@ -175,6 +176,7 @@ This is not a transactional control-plane replacement.
 | `scan_metadata` | analytics_contract.scan_metadata | yes (#1501) |
 | `fleet_agents` | `FleetAgent` snapshot | yes (native) |
 | `compliance_controls` | per-control measurement | yes (#1501) |
+| `cis_benchmark_checks` | normalized cloud CIS check rows + remediation | yes |
 | `audit_events` | `AuditEntry` denormalized | yes (native) |
 
 Every `query_*` method on the analytics store accepts `tenant_id` and

--- a/scripts/migrations/backfill_cis_benchmark_checks.py
+++ b/scripts/migrations/backfill_cis_benchmark_checks.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Backfill normalized CIS benchmark check rows from scan_jobs JSONB.
+
+The migration is idempotent: each scan_id/team_id slice is deleted and rebuilt
+from the scan result blob. It is intended for existing Postgres deployments
+that already have CIS benchmark data stored in scan_jobs.data.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+from agent_bom.analytics_contract import build_cis_benchmark_check_rows
+
+
+def _connect(url: str):
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - exercised only without postgres extra
+        raise SystemExit("Install the postgres extra first: pip install 'agent-bom[postgres]'") from exc
+    return psycopg.connect(url)
+
+
+def _job_result(raw: Any) -> dict[str, Any] | None:
+    data = raw if isinstance(raw, dict) else json.loads(raw)
+    result = data.get("result")
+    return result if isinstance(result, dict) else None
+
+
+def backfill(url: str) -> int:
+    written = 0
+    with _connect(url) as conn:
+        rows = conn.execute("SELECT job_id, team_id, created_at, completed_at, data FROM scan_jobs").fetchall()
+        for job_id, team_id, created_at, completed_at, data in rows:
+            result = _job_result(data)
+            if not result:
+                continue
+            checks = build_cis_benchmark_check_rows(result, str(job_id), measured_at=completed_at or created_at)
+            conn.execute("DELETE FROM cis_benchmark_checks WHERE scan_id = %s AND team_id = %s", (job_id, team_id))
+            for check in checks:
+                conn.execute(
+                    """INSERT INTO cis_benchmark_checks (
+                           scan_id, team_id, cloud, check_id, title, status, severity, cis_section, evidence,
+                           resource_ids, remediation, fix_cli, fix_console, effort, priority, guardrails,
+                           requires_human_review, measured_at
+                       ) VALUES (
+                           %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s, %s, %s, %s, %s
+                       )""",
+                    (
+                        job_id,
+                        team_id,
+                        check["cloud"],
+                        check["check_id"],
+                        check["title"],
+                        check["status"],
+                        check["severity"],
+                        check["cis_section"],
+                        check["evidence"],
+                        json.dumps(check["resource_ids"]),
+                        json.dumps(check["remediation"], sort_keys=True),
+                        check["fix_cli"],
+                        check["fix_console"],
+                        check["effort"],
+                        int(check["priority"]),
+                        check["guardrails"],
+                        bool(check["requires_human_review"]),
+                        check["measured_at"] or completed_at or created_at,
+                    ),
+                )
+                written += 1
+        conn.commit()
+    return written
+
+
+def main() -> int:
+    url = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
+    if not url:
+        print("AGENT_BOM_POSTGRES_URL is required", file=sys.stderr)
+        return 2
+    count = backfill(url)
+    print(f"Backfilled {count} CIS benchmark check row(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/analytics_contract.py
+++ b/src/agent_bom/analytics_contract.py
@@ -27,6 +27,7 @@ class ScanAnalyticsPayload:
     posture_snapshots: dict[str, dict[str, Any]]
     fleet_snapshots: list[dict[str, Any]]
     compliance_controls: list[dict[str, Any]]
+    cis_benchmark_checks: list[dict[str, Any]]
 
 
 def build_scan_analytics_payload(
@@ -71,6 +72,7 @@ def build_scan_analytics_payload(
         posture_snapshots=posture_snapshots,
         fleet_snapshots=_build_fleet_snapshots(report),
         compliance_controls=_build_compliance_controls(report, data),
+        cis_benchmark_checks=_build_cis_benchmark_checks(report, data, final_scan_id),
     )
 
 
@@ -230,6 +232,65 @@ def _build_compliance_controls(report: AIBOMReport, data: dict[str, Any]) -> lis
                 "score": float(check.get("score", aisvs.get("overall_score", 0.0)) or 0.0),
                 "measured_at": measured_at,
                 "scan_id": report.scan_id,
+            }
+        )
+    return rows
+
+
+def build_cis_benchmark_check_rows(data: dict[str, Any], scan_id: str, *, measured_at: str | None = None) -> list[dict[str, Any]]:
+    """Normalize serialized CIS benchmark blobs into indexable analytics rows."""
+    rows: list[dict[str, Any]] = []
+    measured = measured_at or str(data.get("generated_at") or data.get("scan_timestamp") or "")
+    benchmark_sources = (
+        ("aws", data.get("cis_benchmark")),
+        ("azure", data.get("azure_cis_benchmark")),
+        ("gcp", data.get("gcp_cis_benchmark")),
+        ("snowflake", data.get("snowflake_cis_benchmark")),
+        ("databricks", data.get("databricks_cis_benchmark")),
+    )
+    for cloud, benchmark in benchmark_sources:
+        if not isinstance(benchmark, dict):
+            continue
+        rows.extend(_cis_rows_for_cloud(cloud, benchmark, scan_id, measured))
+    return rows
+
+
+def _build_cis_benchmark_checks(report: AIBOMReport, data: dict[str, Any], scan_id: str) -> list[dict[str, Any]]:
+    measured_at = report.generated_at.isoformat()
+    return build_cis_benchmark_check_rows(data, scan_id, measured_at=measured_at)
+
+
+def _cis_rows_for_cloud(cloud: str, benchmark: dict[str, Any], scan_id: str, measured_at: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for check in benchmark.get("checks", []) or []:
+        if not isinstance(check, dict):
+            continue
+        raw_remediation = check.get("remediation")
+        remediation: dict[str, Any] = dict(raw_remediation) if isinstance(raw_remediation, dict) else {}
+        priority = remediation.get("priority", check.get("priority", 0))
+        try:
+            priority_int = int(priority or 0)
+        except (TypeError, ValueError):
+            priority_int = 0
+        rows.append(
+            {
+                "scan_id": scan_id,
+                "measured_at": measured_at,
+                "cloud": cloud,
+                "check_id": str(check.get("check_id", "")),
+                "title": str(check.get("title", "")),
+                "status": str(check.get("status", "unknown")).lower() or "unknown",
+                "severity": str(check.get("severity", "unknown")).lower() or "unknown",
+                "cis_section": str(check.get("cis_section", "")),
+                "evidence": str(check.get("evidence", "")),
+                "resource_ids": [str(item) for item in check.get("resource_ids", []) or []],
+                "remediation": remediation,
+                "fix_cli": str(remediation.get("fix_cli") or ""),
+                "fix_console": str(remediation.get("fix_console") or ""),
+                "effort": str(remediation.get("effort") or ""),
+                "priority": priority_int,
+                "guardrails": [str(item) for item in remediation.get("guardrails", []) or []],
+                "requires_human_review": bool(remediation.get("requires_human_review", False)),
             }
         )
     return rows

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -17,6 +17,7 @@ Security note — SQL injection mitigation:
 
 from __future__ import annotations
 
+import json
 import logging
 import queue
 import re
@@ -96,6 +97,10 @@ class AnalyticsStore(Protocol):
         """Append a compliance control measurement."""
         ...
 
+    def record_cis_benchmark_checks(self, checks: list[dict], *, tenant_id: str = "default") -> None:
+        """Append normalized CIS benchmark check rows."""
+        ...
+
     def record_audit_event(self, event: dict) -> None:
         """Append an audit event for analytics/trending."""
         ...
@@ -134,6 +139,19 @@ class AnalyticsStore(Protocol):
 
     def query_compliance_heatmap(self, days: int = 30, *, tenant_id: str | None = None) -> list[dict]:
         """Compliance control pass/fail summary grouped by framework."""
+        ...
+
+    def query_cis_benchmark_checks(
+        self,
+        *,
+        cloud: str | None = None,
+        status: str | None = None,
+        priority: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        tenant_id: str | None = None,
+    ) -> list[dict]:
+        """List normalized CIS benchmark checks."""
         ...
 
     def record_scan_metadata(self, metadata: dict, *, tenant_id: str = "default") -> None:
@@ -178,6 +196,9 @@ class NullAnalyticsStore:
     def record_compliance_control(self, control: dict, *, tenant_id: str = "default") -> None:
         pass
 
+    def record_cis_benchmark_checks(self, checks: list[dict], *, tenant_id: str = "default") -> None:
+        pass
+
     def record_audit_event(self, event: dict) -> None:
         pass
 
@@ -209,6 +230,18 @@ class NullAnalyticsStore:
         return []
 
     def query_compliance_heatmap(self, days: int = 30, *, tenant_id: str | None = None) -> list[dict]:
+        return []
+
+    def query_cis_benchmark_checks(
+        self,
+        *,
+        cloud: str | None = None,
+        status: str | None = None,
+        priority: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        tenant_id: str | None = None,
+    ) -> list[dict]:
         return []
 
     def record_scan_metadata(self, metadata: dict, *, tenant_id: str = "default") -> None:
@@ -360,6 +393,11 @@ class ClickHouseAnalyticsStore:
             [self._compliance_row(control, tenant_id=tenant_id)],
         )
 
+    def record_cis_benchmark_checks(self, checks: list[dict], *, tenant_id: str = "default") -> None:
+        rows = [self._cis_check_row(check, tenant_id=tenant_id) for check in checks if check]
+        if rows:
+            self._client.insert_json("cis_benchmark_checks", rows)
+
     def _compliance_row(self, control: dict, *, tenant_id: str = "default") -> dict[str, Any]:
         return {
             "measured_at": control.get("measured_at"),
@@ -371,6 +409,28 @@ class ClickHouseAnalyticsStore:
             "status": control.get("status", "unknown"),
             "finding_count": int(control.get("finding_count", 0)),
             "score": float(control.get("score", 0.0)),
+        }
+
+    def _cis_check_row(self, check: dict, *, tenant_id: str = "default") -> dict[str, Any]:
+        return {
+            "measured_at": _coerce_clickhouse_timestamp(check.get("measured_at")),
+            "scan_id": check.get("scan_id", ""),
+            "tenant_id": str(check.get("tenant_id") or tenant_id or "default"),
+            "cloud": check.get("cloud", ""),
+            "check_id": check.get("check_id", ""),
+            "title": check.get("title", ""),
+            "status": check.get("status", "unknown"),
+            "severity": check.get("severity", "unknown"),
+            "cis_section": check.get("cis_section", ""),
+            "evidence": check.get("evidence", ""),
+            "resource_ids": list(check.get("resource_ids", []) or []),
+            "remediation": json.dumps(check.get("remediation", {}) or {}, sort_keys=True),
+            "fix_cli": check.get("fix_cli", ""),
+            "fix_console": check.get("fix_console", ""),
+            "effort": check.get("effort", ""),
+            "priority": int(check.get("priority", 0) or 0),
+            "guardrails": list(check.get("guardrails", []) or []),
+            "requires_human_review": int(bool(check.get("requires_human_review", False))),
         }
 
     def record_audit_event(self, event: dict) -> None:
@@ -482,6 +542,37 @@ class ClickHouseAnalyticsStore:
         )
         return self._client.query_json(query)
 
+    def query_cis_benchmark_checks(
+        self,
+        *,
+        cloud: str | None = None,
+        status: str | None = None,
+        priority: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        tenant_id: str | None = None,
+    ) -> list[dict]:
+        clauses: list[str] = []
+        if tenant_id is not None:
+            clauses.append(f"tenant_id = '{_escape(tenant_id)}'")
+        if cloud:
+            clauses.append(f"cloud = '{_escape(cloud)}'")
+        if status:
+            clauses.append(f"status = '{_escape(status)}'")
+        if priority is not None:
+            clauses.append(f"priority = {int(priority)}")
+        where = " AND ".join(clauses) if clauses else "1"
+        safe_limit = max(1, min(int(limit), 500))
+        safe_offset = max(0, int(offset))
+        query = (
+            "SELECT scan_id, measured_at, tenant_id, cloud, check_id, title, status, severity, cis_section, "
+            "evidence, resource_ids, remediation, fix_cli, fix_console, effort, priority, guardrails, "
+            "requires_human_review "  # nosec B608
+            f"FROM cis_benchmark_checks WHERE {where} "
+            f"ORDER BY measured_at DESC, priority ASC, cloud, check_id LIMIT {safe_limit} OFFSET {safe_offset}"
+        )
+        return self._client.query_json(query)
+
     def record_scan_metadata(self, metadata: dict, *, tenant_id: str = "default") -> None:
         self._client.insert_json(
             "scan_metadata",
@@ -553,6 +644,10 @@ class BufferedAnalyticsStore:
     def record_compliance_control(self, control: dict, *, tenant_id: str = "default") -> None:
         self._queue.put(("compliance", (control, tenant_id)))
 
+    def record_cis_benchmark_checks(self, checks: list[dict], *, tenant_id: str = "default") -> None:
+        if checks:
+            self._queue.put(("cis_checks", (checks, tenant_id)))
+
     def record_audit_event(self, event: dict) -> None:
         self._queue.put(("audit", (event,)))
 
@@ -592,6 +687,26 @@ class BufferedAnalyticsStore:
         self._flush_pending()
         return self._store.query_compliance_heatmap(days=days, tenant_id=tenant_id)
 
+    def query_cis_benchmark_checks(
+        self,
+        *,
+        cloud: str | None = None,
+        status: str | None = None,
+        priority: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        tenant_id: str | None = None,
+    ) -> list[dict]:
+        self._flush_pending()
+        return self._store.query_cis_benchmark_checks(
+            cloud=cloud,
+            status=status,
+            priority=priority,
+            limit=limit,
+            offset=offset,
+            tenant_id=tenant_id,
+        )
+
     def close(self) -> None:
         self._stop.set()
         self._thread.join(timeout=max(1.0, self._flush_interval * 4))
@@ -623,6 +738,7 @@ class BufferedAnalyticsStore:
         metadata_rows: list[dict[str, Any]] = []
         fleet_rows: list[dict[str, Any]] = []
         compliance_rows: list[dict[str, Any]] = []
+        cis_check_rows: list[dict[str, Any]] = []
         audit_rows: list[dict[str, Any]] = []
 
         for kind, payload in drained:
@@ -647,6 +763,9 @@ class BufferedAnalyticsStore:
             elif kind == "compliance":
                 control, tenant_id = payload
                 compliance_rows.append(self._store._compliance_row(dict(control), tenant_id=str(tenant_id)))
+            elif kind == "cis_checks":
+                checks, tenant_id = payload
+                cis_check_rows.extend(self._store._cis_check_row(dict(check), tenant_id=str(tenant_id)) for check in checks if check)
             elif kind == "audit":
                 (event,) = payload
                 audit_rows.append(self._store._audit_row(dict(event)))
@@ -664,6 +783,8 @@ class BufferedAnalyticsStore:
                 self._store._client.insert_json("fleet_agents", fleet_rows)
             if compliance_rows:
                 self._store._client.insert_json("compliance_controls", compliance_rows)
+            if cis_check_rows:
+                self._store._client.insert_json("cis_benchmark_checks", cis_check_rows)
             if audit_rows:
                 self._store._client.insert_json("audit_events", audit_rows)
         except Exception:

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -641,6 +641,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                 analytics_store.record_fleet_snapshot(fleet_snapshot)
             for control in analytics.compliance_controls:
                 analytics_store.record_compliance_control(control, tenant_id=tenant_id)
+            analytics_store.record_cis_benchmark_checks(analytics.cis_benchmark_checks, tenant_id=tenant_id)
         except Exception as analytics_exc:  # noqa: BLE001
             _logger.warning("API ClickHouse analytics persistence failed: %s", analytics_exc)
             with lock:

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -76,8 +76,37 @@ class PostgresJobStore:
                 END
                 $$;
             """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS cis_benchmark_checks (
+                    id BIGSERIAL PRIMARY KEY,
+                    scan_id TEXT NOT NULL REFERENCES scan_jobs(job_id) ON DELETE CASCADE,
+                    team_id TEXT NOT NULL DEFAULT 'default',
+                    cloud TEXT NOT NULL,
+                    check_id TEXT NOT NULL,
+                    title TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL DEFAULT 'unknown',
+                    severity TEXT NOT NULL DEFAULT 'unknown',
+                    cis_section TEXT NOT NULL DEFAULT '',
+                    evidence TEXT NOT NULL DEFAULT '',
+                    resource_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    remediation JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    fix_cli TEXT NOT NULL DEFAULT '',
+                    fix_console TEXT NOT NULL DEFAULT '',
+                    effort TEXT NOT NULL DEFAULT '',
+                    priority INTEGER NOT NULL DEFAULT 0,
+                    guardrails TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+                    requires_human_review BOOLEAN NOT NULL DEFAULT FALSE,
+                    measured_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+                )
+            """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_team_created ON scan_jobs(team_id, created_at DESC)")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cis_checks_team_cloud_status_priority "
+                "ON cis_benchmark_checks(team_id, cloud, status, priority, measured_at DESC)"
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_cis_checks_scan ON cis_benchmark_checks(scan_id)")
             _ensure_tenant_rls(conn, "scan_jobs", "team_id")
+            _ensure_tenant_rls(conn, "cis_benchmark_checks", "team_id")
             conn.commit()
 
     def put(self, job) -> None:
@@ -94,6 +123,7 @@ class PostgresJobStore:
                      data = EXCLUDED.data""",
                 (job.job_id, job.status.value, job.created_at, job.completed_at, job.tenant_id, getattr(job, "triggered_by", None), data),
             )
+            self._replace_cis_checks(conn, job)
             conn.commit()
 
     def get(self, job_id: str, tenant_id: str | None = None):
@@ -163,6 +193,63 @@ class PostgresJobStore:
                 for row in rows
             ]
 
+    def query_cis_benchmark_checks(
+        self,
+        tenant_id: str,
+        *,
+        cloud: str | None = None,
+        status: str | None = None,
+        priority: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        clauses = ["team_id = %s"]
+        params: list[object] = [tenant_id]
+        if cloud:
+            clauses.append("cloud = %s")
+            params.append(cloud)
+        if status:
+            clauses.append("status = %s")
+            params.append(status)
+        if priority is not None:
+            clauses.append("priority = %s")
+            params.append(int(priority))
+        params.extend([max(1, min(int(limit), 500)), max(0, int(offset))])
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                f"""SELECT scan_id, team_id, cloud, check_id, title, status, severity, cis_section, evidence,
+                          resource_ids, remediation, fix_cli, fix_console, effort, priority, guardrails,
+                          requires_human_review, measured_at
+                   FROM cis_benchmark_checks
+                   WHERE {" AND ".join(clauses)}
+                   ORDER BY measured_at DESC, priority ASC, cloud, check_id
+                   LIMIT %s OFFSET %s""",  # nosec B608 - clauses are fixed fragments, values are parameters.
+                params,
+            ).fetchall()
+        return [
+            {
+                "scan_id": row[0],
+                "tenant_id": row[1],
+                "cloud": row[2],
+                "check_id": row[3],
+                "title": row[4],
+                "status": row[5],
+                "severity": row[6],
+                "cis_section": row[7],
+                "evidence": row[8],
+                "resource_ids": row[9] if isinstance(row[9], list) else json.loads(row[9] or "[]"),
+                "remediation": row[10] if isinstance(row[10], dict) else json.loads(row[10] or "{}"),
+                "fix_cli": row[11],
+                "fix_console": row[12],
+                "effort": row[13],
+                "priority": row[14],
+                "guardrails": list(row[15] or []),
+                "requires_human_review": bool(row[16]),
+                "measured_at": row[17],
+            }
+            for row in rows
+        ]
+
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
@@ -174,6 +261,47 @@ class PostgresJobStore:
             )
             conn.commit()
             return cursor.rowcount
+
+    def _replace_cis_checks(self, conn, job) -> None:
+        result = getattr(job, "result", None)
+        if not isinstance(result, dict):
+            return
+        from agent_bom.analytics_contract import build_cis_benchmark_check_rows
+
+        tenant_id = str(getattr(job, "tenant_id", None) or "default")
+        measured_at = getattr(job, "completed_at", None) or getattr(job, "created_at", None)
+        rows = build_cis_benchmark_check_rows(result, str(job.job_id), measured_at=measured_at)
+        conn.execute("DELETE FROM cis_benchmark_checks WHERE scan_id = %s AND team_id = %s", (job.job_id, tenant_id))
+        for row in rows:
+            conn.execute(
+                """INSERT INTO cis_benchmark_checks (
+                       scan_id, team_id, cloud, check_id, title, status, severity, cis_section, evidence,
+                       resource_ids, remediation, fix_cli, fix_console, effort, priority, guardrails,
+                       requires_human_review, measured_at
+                   ) VALUES (
+                       %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s, %s, %s, %s, %s
+                   )""",
+                (
+                    job.job_id,
+                    tenant_id,
+                    row["cloud"],
+                    row["check_id"],
+                    row["title"],
+                    row["status"],
+                    row["severity"],
+                    row["cis_section"],
+                    row["evidence"],
+                    json.dumps(row["resource_ids"]),
+                    json.dumps(row["remediation"], sort_keys=True),
+                    row["fix_cli"],
+                    row["fix_console"],
+                    row["effort"],
+                    int(row["priority"]),
+                    row["guardrails"],
+                    bool(row["requires_human_review"]),
+                    row["measured_at"] or getattr(job, "completed_at", None) or getattr(job, "created_at", ""),
+                ),
+            )
 
 
 # ── PostgresFleetStore ─────────────────────────────────────────────────────

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from agent_bom.api.models import ComplianceReportBundle, JobStatus
-from agent_bom.api.stores import _get_fleet_store, _get_policy_store, _get_store
+from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_policy_store, _get_store
 from agent_bom.rbac import require_authenticated_permission
 
 if TYPE_CHECKING:
@@ -64,6 +64,12 @@ def _tenant_id(request: Request) -> str:
 
 def _tenant_jobs(request: Request) -> list:
     return _get_store().list_all(tenant_id=_tenant_id(request))
+
+
+def _normalize_csv_filter(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    return {item.strip().lower() for item in value.split(",") if item.strip()}
 
 
 def _result_has_runtime_signals(result: dict[str, Any]) -> bool:
@@ -376,6 +382,90 @@ async def get_compliance(request: Request) -> dict:
             "pci_dss_fail": pf,
         },
     }
+
+
+@router.get("/v1/cis/checks", tags=["compliance"])
+async def list_cis_benchmark_checks(
+    request: Request,
+    cloud: str | None = None,
+    status: str | None = None,
+    priority: int | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    """List tenant-scoped CIS benchmark checks with indexed filters where available."""
+    tenant_id = _tenant_id(request)
+    safe_limit = max(1, min(int(limit), 500))
+    safe_offset = max(0, int(offset))
+    cloud_filter = _normalize_csv_filter(cloud)
+    status_filter = _normalize_csv_filter(status)
+    if priority is not None and priority < 0:
+        raise HTTPException(status_code=400, detail="priority must be >= 0")
+
+    job_store = _get_store()
+    store_query = getattr(job_store, "query_cis_benchmark_checks", None)
+    if callable(store_query) and len(cloud_filter) <= 1 and len(status_filter) <= 1:
+        rows = store_query(
+            tenant_id,
+            cloud=next(iter(cloud_filter), None),
+            status=next(iter(status_filter), None),
+            priority=priority,
+            limit=safe_limit,
+            offset=safe_offset,
+        )
+        if rows:
+            return {"checks": [_coerce_cis_row(row) for row in rows], "count": len(rows), "source": "columnar"}
+
+    analytics_store = _get_analytics_store()
+    query_fn = getattr(analytics_store, "query_cis_benchmark_checks", None)
+    if callable(query_fn) and len(cloud_filter) <= 1 and len(status_filter) <= 1:
+        try:
+            rows = query_fn(
+                cloud=next(iter(cloud_filter), None),
+                status=next(iter(status_filter), None),
+                priority=priority,
+                limit=safe_limit,
+                offset=safe_offset,
+                tenant_id=tenant_id,
+            )
+            if rows:
+                return {"checks": [_coerce_cis_row(row) for row in rows], "count": len(rows), "source": "analytics"}
+        except Exception:
+            pass
+
+    from agent_bom.analytics_contract import build_cis_benchmark_check_rows
+
+    all_rows: list[dict[str, Any]] = []
+    for job in _tenant_jobs(request):
+        if job.status != JobStatus.DONE or not isinstance(getattr(job, "result", None), dict):
+            continue
+        all_rows.extend(
+            build_cis_benchmark_check_rows(
+                job.result,
+                str(job.result.get("scan_id") or job.job_id),
+                measured_at=getattr(job, "completed_at", None) or getattr(job, "created_at", None),
+            )
+        )
+    filtered = [
+        row
+        for row in all_rows
+        if (not cloud_filter or row["cloud"].lower() in cloud_filter)
+        and (not status_filter or row["status"].lower() in status_filter)
+        and (priority is None or int(row["priority"]) == priority)
+    ]
+    filtered.sort(key=lambda row: (str(row.get("measured_at") or ""), -int(row.get("priority") or 0)), reverse=True)
+    return {"checks": filtered[safe_offset : safe_offset + safe_limit], "count": len(filtered), "source": "scan_jobs"}
+
+
+def _coerce_cis_row(row: dict[str, Any]) -> dict[str, Any]:
+    coerced = dict(row)
+    remediation = coerced.get("remediation")
+    if isinstance(remediation, str):
+        try:
+            coerced["remediation"] = json.loads(remediation)
+        except json.JSONDecodeError:
+            coerced["remediation"] = {}
+    return coerced
 
 
 # ─── Compliance Narrative ─────────────────────────────────────────────────

--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -104,6 +104,7 @@ def run_integrations(
                     _ch_store.record_fleet_snapshot(fleet_snapshot)
                 for control in analytics.compliance_controls:
                     _ch_store.record_compliance_control(control, tenant_id=_ch_tenant_id)
+                _ch_store.record_cis_benchmark_checks(analytics.cis_benchmark_checks, tenant_id=_ch_tenant_id)
             if not quiet:
                 _finding_count = sum(len(findings) for findings in analytics.agent_findings.values()) if ctx.report else 0
                 con.print(f"  [green]✓[/green] Analytics: {_finding_count} finding(s) recorded to ClickHouse")

--- a/src/agent_bom/cloud/clickhouse.py
+++ b/src/agent_bom/cloud/clickhouse.py
@@ -252,6 +252,31 @@ CREATE TABLE IF NOT EXISTS audit_events (
 ORDER BY (event_timestamp, tenant_id, action)
 PARTITION BY toYYYYMM(event_timestamp)
 TTL event_timestamp + INTERVAL 2 YEAR""",
+    # 8. CIS benchmark check observations with remediation fields indexed
+    """\
+CREATE TABLE IF NOT EXISTS cis_benchmark_checks (
+    measured_at DateTime DEFAULT now(),
+    scan_id String,
+    tenant_id String DEFAULT 'default',
+    cloud LowCardinality(String),
+    check_id String,
+    title String,
+    status LowCardinality(String),
+    severity LowCardinality(String),
+    cis_section String,
+    evidence String,
+    resource_ids Array(String),
+    remediation String,
+    fix_cli String,
+    fix_console String,
+    effort LowCardinality(String),
+    priority UInt8,
+    guardrails Array(String),
+    requires_human_review UInt8
+) ENGINE = MergeTree()
+ORDER BY (measured_at, tenant_id, cloud, status, priority, check_id)
+PARTITION BY toYYYYMM(measured_at)
+TTL measured_at + INTERVAL 2 YEAR""",
 ]
 
 
@@ -272,4 +297,6 @@ _TABLE_MIGRATIONS: list[str] = [
     "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS session_id String DEFAULT ''",
     "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS trace_id String DEFAULT ''",
     "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS request_id String DEFAULT ''",
+    "ALTER TABLE cis_benchmark_checks ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default'",
+    "ALTER TABLE cis_benchmark_checks ADD COLUMN IF NOT EXISTS remediation String DEFAULT '{}'",
 ]

--- a/tests/test_api_pipeline_image_contract.py
+++ b/tests/test_api_pipeline_image_contract.py
@@ -56,6 +56,7 @@ def test_api_pipeline_persists_clickhouse_analytics(monkeypatch):
             self.posture_calls: list[tuple[str, dict, str]] = []
             self.fleet_calls: list[dict] = []
             self.compliance_calls: list[tuple[dict, str]] = []
+            self.cis_check_calls: list[tuple[list[dict], str]] = []
 
         def record_scan(
             self,
@@ -78,6 +79,9 @@ def test_api_pipeline_persists_clickhouse_analytics(monkeypatch):
 
         def record_compliance_control(self, control: dict, *, tenant_id: str = "default") -> None:
             self.compliance_calls.append((control, tenant_id))
+
+        def record_cis_benchmark_checks(self, checks: list[dict], *, tenant_id: str = "default") -> None:
+            self.cis_check_calls.append((checks, tenant_id))
 
     analytics = _AnalyticsStore()
 

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -269,6 +269,7 @@ class TestClickHouseAnalyticsStore:
             buffered.record_scan_metadata({"scan_id": "scan-1", "vuln_count": 4})
             buffered.record_fleet_snapshot({"agent_name": "agent-1", "trust_score": 42.0})
             buffered.record_compliance_control({"framework": "owasp-llm-top10", "control_id": "LLM01"})
+            buffered.record_cis_benchmark_checks([{"scan_id": "scan-1", "cloud": "aws", "check_id": "1.5", "priority": 1}])
             buffered.record_audit_event({"action": "auth.key_created", "actor": "system"})
             buffered.close()
 
@@ -276,7 +277,45 @@ class TestClickHouseAnalyticsStore:
         assert any(table == "scan_metadata" for table, _rows in inserted)
         assert any(table == "fleet_agents" for table, _rows in inserted)
         assert any(table == "compliance_controls" for table, _rows in inserted)
+        assert any(table == "cis_benchmark_checks" for table, _rows in inserted)
         assert any(table == "audit_events" for table, _rows in inserted)
+
+    def test_record_cis_benchmark_checks_normalizes_remediation(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        inserted = {}
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                inserted["table"] = table
+                inserted["rows"] = rows
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_cis_benchmark_checks(
+                [
+                    {
+                        "scan_id": "scan-1",
+                        "cloud": "aws",
+                        "check_id": "1.5",
+                        "status": "fail",
+                        "priority": 1,
+                        "remediation": {"fix_console": "AWS Console", "priority": 1},
+                        "requires_human_review": True,
+                    }
+                ],
+                tenant_id="tenant-alpha",
+            )
+
+        assert inserted["table"] == "cis_benchmark_checks"
+        row = inserted["rows"][0]
+        assert row["tenant_id"] == "tenant-alpha"
+        assert row["priority"] == 1
+        assert json.loads(row["remediation"])["priority"] == 1
+        assert row["requires_human_review"] == 1
 
     def test_buffered_store_flushes_before_query(self):
         from agent_bom.api.clickhouse_store import BufferedAnalyticsStore, ClickHouseAnalyticsStore
@@ -427,6 +466,30 @@ def test_build_scan_analytics_payload_splits_findings_by_agent():
     assert any(row["framework"] == "owasp-llm-top10" for row in payload.compliance_controls)
 
 
+def test_build_scan_analytics_payload_extracts_cis_checks():
+    from agent_bom.analytics_contract import build_scan_analytics_payload
+    from agent_bom.models import AIBOMReport
+
+    report = AIBOMReport(scan_id="scan-cis")
+    report.cis_benchmark_data = {
+        "checks": [
+            {
+                "check_id": "1.5",
+                "title": "Root MFA",
+                "status": "fail",
+                "severity": "high",
+                "remediation": {"priority": 1, "guardrails": ["identity"]},
+            }
+        ]
+    }
+
+    payload = build_scan_analytics_payload(report, source="api")
+
+    assert payload.cis_benchmark_checks[0]["cloud"] == "aws"
+    assert payload.cis_benchmark_checks[0]["priority"] == 1
+    assert payload.cis_benchmark_checks[0]["guardrails"] == ["identity"]
+
+
 def test_clickhouse_store_queries_fleet_and_compliance():
     from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
 
@@ -444,8 +507,11 @@ def test_clickhouse_store_queries_fleet_and_compliance():
         store = ClickHouseAnalyticsStore(url="http://localhost:8123")
         assert store.query_top_riskiest_agents(limit=5) == [{"ok": True}]
         assert store.query_compliance_heatmap(days=7) == [{"ok": True}]
+        assert store.query_cis_benchmark_checks(cloud="aws", status="fail", priority=1, tenant_id="tenant-a") == [{"ok": True}]
 
     assert "FROM fleet_agents" in queries[0]
     assert "LIMIT 5" in queries[0]
     assert "FROM compliance_controls" in queries[1]
+    assert "FROM cis_benchmark_checks" in queries[2]
+    assert "tenant_id = 'tenant-a'" in queries[2]
     assert "INTERVAL 7 DAY" in queries[1]

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -39,7 +39,7 @@ from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.routes import compliance as compliance_routes
 from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
-from agent_bom.api.stores import _get_store, set_job_store
+from agent_bom.api.stores import _get_store, set_analytics_store, set_job_store
 
 
 def _now_iso() -> str:
@@ -86,6 +86,53 @@ def _seed_jobs_with_findings(tenant_id: str = "tenant-alpha") -> list[ScanJob]:
     return [job_a]
 
 
+def _seed_job_with_cis(tenant_id: str = "tenant-alpha") -> ScanJob:
+    job = ScanJob(
+        job_id="scan-cis",
+        tenant_id=tenant_id,
+        status=JobStatus.DONE,
+        created_at=_now_iso(),
+        completed_at=_now_iso(),
+        request=ScanRequest(),
+    )
+    job.result = {
+        "scan_id": "scan-cis",
+        "cis_benchmark": {
+            "checks": [
+                {
+                    "check_id": "1.5",
+                    "title": "Ensure MFA is enabled for the root user",
+                    "status": "fail",
+                    "severity": "high",
+                    "cis_section": "1 - Identity and Access Management",
+                    "evidence": "Root user MFA is not enabled.",
+                    "resource_ids": ["root"],
+                    "remediation": {
+                        "fix_cli": "",
+                        "fix_console": "AWS Console -> IAM",
+                        "effort": "medium",
+                        "priority": 1,
+                        "guardrails": ["identity"],
+                        "requires_human_review": True,
+                    },
+                }
+            ]
+        },
+        "azure_cis_benchmark": {
+            "checks": [
+                {
+                    "check_id": "2.1",
+                    "title": "Storage account secure transfer required",
+                    "status": "pass",
+                    "severity": "medium",
+                    "remediation": {"priority": 3},
+                }
+            ]
+        },
+    }
+    return job
+
+
 def _setup_audit_log() -> InMemoryAuditLog:
     audit = InMemoryAuditLog()
     audit.append(
@@ -110,6 +157,54 @@ def _setup_audit_log() -> InMemoryAuditLog:
     )
     set_audit_log(audit)
     return audit
+
+
+def test_list_cis_checks_filters_scan_job_fallback():
+    store = InMemoryJobStore()
+    set_job_store(store)
+    store.put(_seed_job_with_cis())
+
+    class _NoAnalytics:
+        def query_cis_benchmark_checks(self, **_kwargs):
+            return []
+
+    set_analytics_store(_NoAnalytics())
+    body = asyncio.run(
+        compliance_routes.list_cis_benchmark_checks(
+            _request("tenant-alpha"),
+            cloud="aws",
+            status="fail",
+            priority=1,
+        )
+    )
+    assert body["source"] == "scan_jobs"
+    assert body["count"] == 1
+    assert body["checks"][0]["check_id"] == "1.5"
+    assert body["checks"][0]["remediation"]["priority"] == 1
+
+
+def test_list_cis_checks_prefers_columnar_store():
+    class _ColumnarStore(InMemoryJobStore):
+        def query_cis_benchmark_checks(self, tenant_id: str, **kwargs):
+            assert tenant_id == "tenant-alpha"
+            assert kwargs["cloud"] == "aws"
+            return [
+                {
+                    "scan_id": "scan-cis",
+                    "tenant_id": tenant_id,
+                    "cloud": "aws",
+                    "check_id": "1.5",
+                    "title": "Root MFA",
+                    "status": "fail",
+                    "severity": "high",
+                    "remediation": '{"priority": 1}',
+                }
+            ]
+
+    set_job_store(_ColumnarStore())
+    body = asyncio.run(compliance_routes.list_cis_benchmark_checks(_request("tenant-alpha"), cloud="aws"))
+    assert body["source"] == "columnar"
+    assert body["checks"][0]["remediation"] == {"priority": 1}
 
 
 def _patched_get_compliance_returns(payload: dict):

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 
 INIT_SQL = Path(__file__).parent.parent / "deploy" / "supabase" / "postgres" / "init.sql"
+MIGRATION = Path(__file__).parent.parent / "scripts" / "migrations" / "backfill_cis_benchmark_checks.py"
 SQL = INIT_SQL.read_text()
 
 
@@ -78,6 +79,7 @@ def test_all_expected_tables_exist():
     expected = {
         "teams",
         "scan_jobs",
+        "cis_benchmark_checks",
         "findings",
         "agents",
         "policy_results",
@@ -185,6 +187,36 @@ def test_scan_jobs_team_status_index():
 def test_scan_jobs_rls_policy_exists():
     assert "ALTER TABLE scan_jobs ENABLE ROW LEVEL SECURITY" in SQL
     assert "CREATE POLICY scan_jobs_tenant_isolation ON scan_jobs" in SQL
+
+
+def test_cis_benchmark_checks_table_is_indexed_and_tenant_scoped():
+    cols = _columns_for("cis_benchmark_checks")
+    for col in (
+        "scan_id",
+        "team_id",
+        "cloud",
+        "check_id",
+        "status",
+        "severity",
+        "cis_section",
+        "resource_ids",
+        "remediation",
+        "fix_cli",
+        "priority",
+        "guardrails",
+        "requires_human_review",
+    ):
+        assert col in cols, f"cis_benchmark_checks missing column: {col}"
+    assert "idx_cis_checks_team_cloud_status_priority" in _indexes()
+    assert "ALTER TABLE cis_benchmark_checks ENABLE ROW LEVEL SECURITY" in SQL
+    assert "CREATE POLICY cis_benchmark_checks_tenant_isolation ON cis_benchmark_checks" in SQL
+
+
+def test_cis_benchmark_backfill_migration_is_idempotent():
+    body = MIGRATION.read_text()
+    assert "build_cis_benchmark_check_rows" in body
+    assert "DELETE FROM cis_benchmark_checks WHERE scan_id = %s AND team_id = %s" in body
+    assert "INSERT INTO cis_benchmark_checks" in body
 
 
 # ── findings ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Moves #1516 materially forward by adding the normalized CIS benchmark findings path needed for fleet-scale compliance analytics:

- adds Postgres `cis_benchmark_checks` schema, indexes, tenant RLS, and automatic row replacement from completed `scan_jobs`
- adds ClickHouse `cis_benchmark_checks` analytics table plus buffered/non-buffered write and query support
- adds shared CIS row normalization in `analytics_contract` and wires API + CLI analytics emission
- adds tenant-scoped `GET /v1/cis/checks?cloud=aws&status=fail&priority=1` with columnar, analytics, and scan-job fallback paths
- adds idempotent Postgres backfill script for existing scan JSON blobs
- documents the new table in the data model
- keeps README product screenshots collapsible but displayed by default

Closes #1516
Refs #1815

## Validation

- `uv run ruff check src/agent_bom/analytics_contract.py src/agent_bom/api/clickhouse_store.py src/agent_bom/api/pipeline.py src/agent_bom/api/postgres_store.py src/agent_bom/api/routes/compliance.py src/agent_bom/cli/agents/_post.py src/agent_bom/cloud/clickhouse.py scripts/migrations/backfill_cis_benchmark_checks.py tests/test_clickhouse.py tests/test_compliance_report.py tests/test_postgres_schema.py tests/test_api_pipeline_image_contract.py`
- `uv run mypy src/agent_bom/analytics_contract.py src/agent_bom/api/clickhouse_store.py src/agent_bom/api/postgres_store.py src/agent_bom/api/routes/compliance.py scripts/migrations/backfill_cis_benchmark_checks.py`
- `uv run pytest tests/test_clickhouse.py tests/test_compliance_report.py tests/test_postgres_schema.py tests/test_api_pipeline_image_contract.py -q`
- `uv run pytest tests/test_clickhouse_tenant_isolation.py tests/test_postgres_store.py -q`
- `uv run pytest tests/test_api_tenant_isolation.py tests/test_api_hardening.py tests/test_deploy_manifests.py -q`
- `uv run pytest tests/test_clickhouse.py tests/test_compliance_report.py tests/test_postgres_schema.py tests/test_api_pipeline_image_contract.py tests/test_clickhouse_tenant_isolation.py tests/test_postgres_store.py tests/test_api_tenant_isolation.py tests/test_api_hardening.py tests/test_deploy_manifests.py -q`
- `python scripts/check_release_consistency.py`
- `git diff --check`
- `python scripts/migrations/backfill_cis_benchmark_checks.py` exits with `AGENT_BOM_POSTGRES_URL is required` when no database target is configured
