### PR TITLE
fix: harden auth session and audit evidence

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -18,6 +18,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import sqlite3
 import threading
 from collections import defaultdict
@@ -27,6 +28,13 @@ from typing import Protocol
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
+_AUDIT_DETAIL_KEY_RE = re.compile(r"[^a-zA-Z0-9_.:-]+")
+_MAX_AUDIT_DETAIL_KEYS = 64
+_MAX_AUDIT_DETAIL_KEY_LENGTH = 96
+_MAX_AUDIT_DETAIL_STRING_LENGTH = 2048
+_MAX_AUDIT_DETAIL_COLLECTION_ITEMS = 32
+_MAX_AUDIT_DETAIL_DEPTH = 4
+_MAX_AUDIT_DETAILS_JSON_BYTES = 16 * 1024
 
 
 def _env_enabled(name: str) -> bool:
@@ -213,6 +221,12 @@ class AuditEntry:
 def sign_export_payload(payload: bytes) -> str:
     """Sign an exported audit payload so downstream consumers can verify it."""
     return hmac.new(_HMAC_KEY, payload, hashlib.sha256).hexdigest()
+
+
+def verify_export_payload(payload: bytes, signature: str) -> bool:
+    """Verify a signed audit export payload without exposing key material."""
+    expected = sign_export_payload(payload)
+    return hmac.compare_digest(signature.strip(), expected)
 
 
 def describe_audit_hmac_status() -> dict[str, object]:
@@ -559,6 +573,58 @@ def _default_tenant_id(details: dict[str, object]) -> str:
     return "default"
 
 
+def _sanitize_detail_key(key: object) -> str:
+    cleaned = _AUDIT_DETAIL_KEY_RE.sub("_", str(key).strip())[:_MAX_AUDIT_DETAIL_KEY_LENGTH].strip("._:-")
+    cleaned = cleaned.strip("_")
+    return cleaned or "detail"
+
+
+def _sanitize_detail_value(value: object, *, depth: int = 0) -> object:
+    if depth >= _MAX_AUDIT_DETAIL_DEPTH:
+        return "[truncated]"
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        text = value.replace("\r", " ").replace("\n", " ").replace("\t", " ")
+        return text[:_MAX_AUDIT_DETAIL_STRING_LENGTH]
+    if isinstance(value, dict):
+        out: dict[str, object] = {}
+        for index, (raw_key, raw_value) in enumerate(value.items()):
+            if index >= _MAX_AUDIT_DETAIL_COLLECTION_ITEMS:
+                out["_truncated"] = True
+                break
+            out[_sanitize_detail_key(raw_key)] = _sanitize_detail_value(raw_value, depth=depth + 1)
+        return out
+    if isinstance(value, list | tuple | set):
+        items = list(value)
+        list_out = [_sanitize_detail_value(item, depth=depth + 1) for item in items[:_MAX_AUDIT_DETAIL_COLLECTION_ITEMS]]
+        if len(items) > _MAX_AUDIT_DETAIL_COLLECTION_ITEMS:
+            list_out.append("[truncated]")
+        return list_out
+    return str(value)[:_MAX_AUDIT_DETAIL_STRING_LENGTH]
+
+
+def sanitize_audit_details(details: dict[str, object]) -> dict[str, object]:
+    """Bound audit metadata shape and size before persistence/export."""
+    sanitized: dict[str, object] = {}
+    for index, (raw_key, raw_value) in enumerate(details.items()):
+        if index >= _MAX_AUDIT_DETAIL_KEYS:
+            sanitized["_truncated"] = True
+            break
+        sanitized[_sanitize_detail_key(raw_key)] = _sanitize_detail_value(raw_value)
+
+    encoded = json.dumps(sanitized, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8")
+    if len(encoded) <= _MAX_AUDIT_DETAILS_JSON_BYTES:
+        return sanitized
+
+    tenant_id = sanitized.get("tenant_id", "default")
+    return {
+        "tenant_id": str(tenant_id)[:_MAX_AUDIT_DETAIL_STRING_LENGTH],
+        "_truncated": True,
+        "_original_bytes": len(encoded),
+    }
+
+
 def set_audit_log(store: AuditLogStore) -> None:
     global _audit_log
     with _audit_lock:
@@ -569,6 +635,7 @@ def log_action(action: str, actor: str = "system", resource: str = "", **details
     """Convenience: append an audit entry."""
     audit_details = dict(details)
     audit_details["tenant_id"] = _default_tenant_id(audit_details)
+    audit_details = sanitize_audit_details(audit_details)
     entry = AuditEntry(action=action, actor=actor, resource=resource, details=audit_details)
     get_audit_log().append(entry)
     try:

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -336,6 +336,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             "/openapi.json",
             "/v1/auth/session",
             "/v1/auth/saml/metadata",
+            "/v1/auth/saml/relay-state",
             "/v1/auth/saml/login",
         }
         if not _DOCS_DISABLED
@@ -346,6 +347,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             "/version",
             "/v1/auth/session",
             "/v1/auth/saml/metadata",
+            "/v1/auth/saml/relay-state",
             "/v1/auth/saml/login",
         }
     )

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -6,10 +6,12 @@ Endpoints:
     GET    /v1/auth/keys                      list API keys
     DELETE /v1/auth/keys/{key_id}             revoke API key
     GET    /v1/auth/saml/metadata             generate SP metadata for IdP setup
+    POST   /v1/auth/saml/relay-state          issue one-time RelayState nonce
     POST   /v1/auth/saml/login                verify a SAML assertion and mint a short-lived API key
     GET    /v1/audit                          audit log entries
     GET    /v1/audit/integrity                verify audit HMAC integrity
     GET    /v1/audit/export                   export audit evidence packet
+    POST   /v1/audit/export/verify            verify a signed audit export packet
     POST   /v1/exceptions                     create vuln exception
     GET    /v1/exceptions                     list exceptions
     GET    /v1/exceptions/{exception_id}      get exception
@@ -32,7 +34,10 @@ import json
 import logging
 import os
 import secrets
+import threading
+import time
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from fastapi import APIRouter, Header, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -60,6 +65,80 @@ class BrowserSessionRequest(BaseModel):
         min_length=1,
         description="API key to exchange for a same-origin httpOnly browser session cookie",
     )
+
+
+class AuditExportVerifyRequest(BaseModel):
+    payload: Any = Field(..., description="Audit export payload object, JSON string, or JSONL text")
+    signature: str = Field(..., min_length=64, max_length=128, description="X-Agent-Bom-Audit-Export-Signature value")
+
+
+_AUTH_SESSION_ATTEMPTS: dict[str, list[float]] = {}
+_AUTH_SESSION_LOCK = threading.Lock()
+_SAML_RELAY_STATES: dict[str, float] = {}
+_SAML_RELAY_LOCK = threading.Lock()
+
+
+def _client_fingerprint(request: Request) -> str:
+    forwarded = (request.headers.get("x-forwarded-for") or "").split(",", 1)[0].strip()
+    host = forwarded or (request.client.host if request.client else "unknown")
+    return host[:128]
+
+
+def _auth_session_limit() -> int:
+    raw = (os.environ.get("AGENT_BOM_AUTH_SESSION_ATTEMPTS_PER_MINUTE") or "12").strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 12
+
+
+def _check_auth_session_rate_limit(request: Request) -> None:
+    now = time.monotonic()
+    window_start = now - 60
+    key = _client_fingerprint(request)
+    with _AUTH_SESSION_LOCK:
+        attempts = [ts for ts in _AUTH_SESSION_ATTEMPTS.get(key, []) if ts >= window_start]
+        if len(attempts) >= _auth_session_limit():
+            _AUTH_SESSION_ATTEMPTS[key] = attempts
+            raise HTTPException(status_code=429, detail="Too many browser session attempts")
+        attempts.append(now)
+        _AUTH_SESSION_ATTEMPTS[key] = attempts
+
+
+def _saml_relay_ttl_seconds() -> int:
+    raw = (os.environ.get("AGENT_BOM_SAML_RELAY_STATE_TTL_SECONDS") or "300").strip()
+    try:
+        return max(60, min(int(raw), 900))
+    except ValueError:
+        return 300
+
+
+def _relay_state_digest(relay_state: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(relay_state.encode("utf-8")).hexdigest()
+
+
+def _new_saml_relay_state() -> tuple[str, str]:
+    relay_state = secrets.token_urlsafe(32)
+    expires_at = time.monotonic() + _saml_relay_ttl_seconds()
+    with _SAML_RELAY_LOCK:
+        _SAML_RELAY_STATES[_relay_state_digest(relay_state)] = expires_at
+    return relay_state, (datetime.now(timezone.utc) + timedelta(seconds=_saml_relay_ttl_seconds())).isoformat()
+
+
+def _consume_saml_relay_state(relay_state: str | None) -> None:
+    if not relay_state:
+        return
+    now = time.monotonic()
+    digest = _relay_state_digest(relay_state)
+    with _SAML_RELAY_LOCK:
+        expired = [key for key, expires_at in _SAML_RELAY_STATES.items() if expires_at < now]
+        for key in expired:
+            _SAML_RELAY_STATES.pop(key, None)
+        expires_at = _SAML_RELAY_STATES.pop(digest, None)
+    if expires_at is None or expires_at < now:
+        raise HTTPException(status_code=401, detail="Invalid or expired SAML relay_state")
 
 
 def _auth_session_state(request: Request) -> dict:
@@ -201,6 +280,7 @@ async def create_browser_session(request: Request, response: Response, body: Bro
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.auth import get_key_store
 
+    _check_auth_session_rate_limit(request)
     raw_key = body.api_key.strip()
     if not raw_key:
         raise HTTPException(status_code=401, detail="Invalid API key")
@@ -639,6 +719,17 @@ async def saml_metadata() -> PlainTextResponse:
     return PlainTextResponse(content=metadata, media_type="application/samlmetadata+xml")
 
 
+@router.post("/v1/auth/saml/relay-state", tags=["enterprise"])
+async def saml_relay_state() -> dict:
+    """Issue a one-time RelayState nonce for SP-initiated SAML login."""
+    relay_state, expires_at = _new_saml_relay_state()
+    return {
+        "relay_state": relay_state,
+        "expires_at": expires_at,
+        "ttl_seconds": _saml_relay_ttl_seconds(),
+    }
+
+
 @router.post("/v1/auth/saml/login", tags=["enterprise"], status_code=201)
 async def saml_login(req: SAMLLoginRequest) -> dict:
     """Verify a SAML assertion and return a short-lived API key."""
@@ -647,6 +738,7 @@ async def saml_login(req: SAMLLoginRequest) -> dict:
     from agent_bom.api.saml import SAMLConfig, SAMLError
 
     try:
+        _consume_saml_relay_state(req.relay_state)
         cfg = SAMLConfig.from_env()
         assertion = cfg.verify_response(req.saml_response, relay_state=req.relay_state)
     except SAMLError as exc:
@@ -786,6 +878,30 @@ async def export_audit_entries(
             "X-Agent-Bom-Audit-Export-Signature": sign_export_payload(payload),
         },
     )
+
+
+@router.post("/v1/audit/export/verify", tags=["enterprise"])
+async def verify_audit_export(request: Request, body: AuditExportVerifyRequest) -> dict:
+    """Verify a signed audit export packet without returning HMAC key material."""
+    from agent_bom.api.audit_log import log_action, verify_export_payload
+
+    if isinstance(body.payload, str):
+        payload = body.payload.encode("utf-8")
+    else:
+        payload = json.dumps(body.payload, sort_keys=True).encode("utf-8")
+
+    valid = verify_export_payload(payload, body.signature)
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    actor = getattr(request.state, "api_key_name", "") or "system"
+    log_action(
+        "audit.export_verify",
+        actor=actor,
+        resource="audit/export/verify",
+        tenant_id=tenant_id,
+        valid=valid,
+        payload_bytes=len(payload),
+    )
+    return {"valid": valid, "payload_bytes": len(payload)}
 
 
 # ── Exception / Waiver Management ────────────────────────────────────────────

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -357,6 +357,43 @@ async def test_export_audit_entries_returns_signed_json(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_verify_audit_export_accepts_signed_json(monkeypatch):
+    store = InMemoryAuditLog()
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/1", details={"tenant_id": "tenant-alpha"}))
+    monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
+
+    response = await enterprise.export_audit_entries(_request("tenant-alpha", "alice-admin"))
+    payload = json.loads(response.body.decode())
+    signature = response.headers["x-agent-bom-audit-export-signature"]
+
+    verified = await enterprise.verify_audit_export(
+        _request("tenant-alpha", "alice-admin"),
+        enterprise.AuditExportVerifyRequest(payload=payload, signature=signature),
+    )
+
+    assert verified["valid"] is True
+    assert verified["payload_bytes"] > 0
+
+
+@pytest.mark.asyncio
+async def test_verify_audit_export_rejects_tampered_payload(monkeypatch):
+    store = InMemoryAuditLog()
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/1", details={"tenant_id": "tenant-alpha"}))
+    monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
+
+    response = await enterprise.export_audit_entries(_request("tenant-alpha", "alice-admin"))
+    payload = json.loads(response.body.decode())
+    payload["tenant_id"] = "tenant-beta"
+
+    verified = await enterprise.verify_audit_export(
+        _request("tenant-alpha", "alice-admin"),
+        enterprise.AuditExportVerifyRequest(payload=payload, signature=response.headers["x-agent-bom-audit-export-signature"]),
+    )
+
+    assert verified["valid"] is False
+
+
+@pytest.mark.asyncio
 async def test_export_audit_entries_supports_jsonl(monkeypatch):
     store = InMemoryAuditLog()
     store.append(AuditEntry(action="scan", actor="alice", resource="job/1", details={"tenant_id": "tenant-alpha"}))

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -4,9 +4,11 @@ import base64
 import json
 import time
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import Response
 from starlette.testclient import TestClient
 
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
@@ -39,6 +41,29 @@ def test_health_no_auth():
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_browser_session_exchange_has_targeted_rate_limit(monkeypatch):
+    from fastapi import HTTPException
+
+    from agent_bom.api.routes import enterprise
+
+    enterprise._AUTH_SESSION_ATTEMPTS.clear()
+    monkeypatch.setenv("AGENT_BOM_AUTH_SESSION_ATTEMPTS_PER_MINUTE", "2")
+    monkeypatch.setenv("AGENT_BOM_API_KEY", "valid-key")
+    request = SimpleNamespace(headers={}, client=SimpleNamespace(host="203.0.113.10"))
+
+    with pytest.raises(HTTPException) as first:
+        await enterprise.create_browser_session(request, Response(), enterprise.BrowserSessionRequest(api_key="bad-1"))
+    assert first.value.status_code == 401
+    with pytest.raises(HTTPException) as second:
+        await enterprise.create_browser_session(request, Response(), enterprise.BrowserSessionRequest(api_key="bad-2"))
+    assert second.value.status_code == 401
+    with pytest.raises(HTTPException) as error:
+        await enterprise.create_browser_session(request, Response(), enterprise.BrowserSessionRequest(api_key="valid-key"))
+
+    assert error.value.status_code == 429
 
 
 def test_trust_headers_present():

--- a/tests/test_api_saml.py
+++ b/tests/test_api_saml.py
@@ -145,6 +145,47 @@ async def test_saml_login_mints_short_lived_api_key(isolated_key_store, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_saml_login_rejects_unissued_relay_state(isolated_key_store, monkeypatch):
+    monkeypatch.setattr(
+        "agent_bom.api.saml.SAMLConfig.verify_response",
+        lambda self, saml_response, relay_state=None: None,
+    )
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.saml_login(SAMLLoginRequest(saml_response="assertion", relay_state="attacker-controlled"))
+
+    assert error.value.status_code == 401
+    assert error.value.detail == "Invalid or expired SAML relay_state"
+
+
+@pytest.mark.asyncio
+async def test_saml_relay_state_is_one_time(isolated_key_store, monkeypatch):
+    relay = await enterprise.saml_relay_state()
+
+    monkeypatch.setattr(
+        "agent_bom.api.saml.SAMLConfig.verify_response",
+        lambda self, saml_response, relay_state=None: type(
+            "Assertion",
+            (),
+            {
+                "subject": "alice@example.com",
+                "attributes": {"agent_bom_role": "admin", "tenant_id": "tenant-alpha"},
+                "role": "admin",
+                "tenant_id": "tenant-alpha",
+                "session_index": "session-1",
+            },
+        )(),
+    )
+
+    response = await enterprise.saml_login(SAMLLoginRequest(saml_response="assertion", relay_state=relay["relay_state"]))
+    assert response["tenant_id"] == "tenant-alpha"
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.saml_login(SAMLLoginRequest(saml_response="assertion", relay_state=relay["relay_state"]))
+    assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_saml_login_rejects_invalid_assertion(monkeypatch):
     def _raise_bad_saml(self, saml_response, relay_state=None):
         raise SAMLError("bad saml")

--- a/tests/test_enterprise_gaps.py
+++ b/tests/test_enterprise_gaps.py
@@ -190,6 +190,28 @@ class TestAuditLog:
         assert len(entries) == 1
         assert entries[0].details == {"packages": 42, "tenant_id": "default"}
 
+    def test_log_action_bounds_detail_schema(self):
+        from agent_bom.api.audit_log import InMemoryAuditLog, log_action, set_audit_log
+
+        store = InMemoryAuditLog()
+        set_audit_log(store)
+        log_action(
+            "scan",
+            actor="admin",
+            resource="job/test",
+            **{
+                "tenant_id": "tenant-alpha",
+                "bad key\r\n": "x" * 3000,
+                "nested": {"items": list(range(100))},
+            },
+        )
+
+        details = store.list_entries()[0].details
+        assert "bad_key" in details
+        assert len(details["bad_key"]) == 2048
+        assert details["nested"]["items"][-1] == "[truncated]"
+        assert details["tenant_id"] == "tenant-alpha"
+
     def test_audit_bounded_size(self):
         from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog
 


### PR DESCRIPTION
Summary
- add targeted /v1/auth/session brute-force throttling before API key verification
- bind SAML RelayState to one-time server-issued nonces for SP-initiated SAML login
- bound audit log detail keys, depth, collection size, and serialized size before persistence/export
- add /v1/audit/export/verify to verify signed audit evidence packets without exposing HMAC key material

Validation
- uv run ruff check src/agent_bom/api/audit_log.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/middleware.py tests/test_api_saml.py tests/test_api_enterprise_tenant.py tests/test_api_hardening.py tests/test_enterprise_gaps.py
- uv run pytest tests/test_api_saml.py tests/test_api_enterprise_tenant.py tests/test_api_hardening.py tests/test_enterprise_gaps.py -q
- uv run mypy src/agent_bom/api/audit_log.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/middleware.py
- python scripts/check_release_consistency.py
- git diff --check
- pre-commit hooks from git commit