### PR TITLE
fix: lease floating release tag updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -695,6 +695,12 @@ jobs:
           MAJOR=$(echo "${{ github.ref_name }}" | grep -oP '^v\d+')
           if [ -n "$MAJOR" ]; then
             git tag -f "$MAJOR" "${{ github.ref_name }}"
-            git push origin "$MAJOR" --force
+            REMOTE_TAG_SHA="$(git ls-remote --tags origin "refs/tags/${MAJOR}" | awk '{print $1}')"
+            if [ -n "$REMOTE_TAG_SHA" ]; then
+              git push origin "refs/tags/${MAJOR}:refs/tags/${MAJOR}" \
+                --force-with-lease="refs/tags/${MAJOR}:${REMOTE_TAG_SHA}"
+            else
+              git push origin "refs/tags/${MAJOR}:refs/tags/${MAJOR}"
+            fi
             echo "Updated floating tag $MAJOR → ${{ github.ref_name }}"
           fi

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -298,6 +298,14 @@ def test_ci_pipeline_validates_helm_profiles():
     assert any("scripts/validate_helm_profiles.py" in run for run in step_runs)
 
 
+def test_release_floating_major_tag_uses_lease():
+    """Floating release tags should fail closed if the remote tag moved."""
+    workflow = (Path(__file__).parent.parent / ".github" / "workflows" / "release.yml").read_text()
+    assert "AGENT_BOM_UPDATE_FLOATING_MAJOR_TAGS == '1'" in workflow
+    assert '--force-with-lease="refs/tags/${MAJOR}:${REMOTE_TAG_SHA}"' in workflow
+    assert 'git push origin "$MAJOR" --force' not in workflow
+
+
 def test_helm_scanner_defaults():
     """Scanner defaults are reasonable."""
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())


### PR DESCRIPTION
Summary
- Replaces the release workflow's plain forced floating-major tag update with a remote-SHA lease.
- Keeps first-time floating tag creation non-forced while failing closed if an existing remote tag moved concurrently.
- Adds a regression test that forbids the old `git push origin "$MAJOR" --force` pattern.

Validation
- `uv run ruff check tests/test_deploy_manifests.py`
- `uv run pytest tests/test_deploy_manifests.py::test_release_floating_major_tag_uses_lease -q`
- workflow YAML parse for `.github/workflows/release.yml`
- `git diff --check`