### PR TITLE
fix: harden browser auth runtime paths

### DIFF
--- a/docs/adr/006-ui-auth-model.md
+++ b/docs/adr/006-ui-auth-model.md
@@ -13,9 +13,9 @@ The packaged dashboard shipped without a defined browser authentication model. T
 The control-plane UI uses two supported browser auth modes:
 
 1. Recommended for enterprise: same-origin reverse-proxy OIDC or SSO session. The reverse proxy terminates browser auth, keeps the session cookie, and injects trusted `X-Agent-Bom-Role` and `X-Agent-Bom-Tenant-ID` headers to the backend. `AGENT_BOM_TRUST_PROXY_AUTH=1` must be enabled on the API for this mode.
-2. Fallback for local and single-user pilots: a short-lived API key entered into the dashboard and stored only in browser `sessionStorage`. The UI forwards it as `Authorization: Bearer <key>` for HTTP calls and `?token=` for the proxy WebSocket surfaces.
+2. Fallback for local and single-user pilots: a short-lived API key entered into the dashboard. The UI first exchanges it for a same-origin `httpOnly` browser session cookie. Legacy `sessionStorage` forwarding is disabled by default and must be explicitly enabled with `window.__AGENT_BOM_CONFIG__.allowSessionStorageApiKey = true` or `NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY=1`; when enabled, the UI forwards the key as `Authorization: Bearer <key>` for HTTP calls and `?token=` only for legacy proxy WebSocket surfaces.
 
-The UI always sends `credentials: "include"` so same-origin proxy sessions work without custom browser configuration. A global auth gate now blocks dashboard routes until one of the supported auth modes succeeds.
+The UI always sends `credentials: "include"` over same-origin fetch/EventSource URLs so same-origin proxy sessions work without custom browser configuration and browser credentials cannot be redirected through runtime config. A global auth gate now blocks dashboard routes until one of the supported auth modes succeeds.
 
 ## Consequences
 
@@ -23,11 +23,11 @@ The UI always sends `credentials: "include"` so same-origin proxy sessions work 
 
 - The browser auth story is explicit and consistent across backend, runtime config, and UI behavior.
 - Enterprise ingress can use OIDC without exposing raw API keys to end users.
-- Single-user pilots still have a low-friction API-key fallback without persisting secrets beyond the browser session.
+- Single-user pilots still have an explicit API-key fallback, but deployments must opt in before the browser stores the key.
 
 ### Negative
 
-- Multi-user browser access still depends on an external reverse proxy; the API itself does not mint browser cookies.
+- Multi-user browser access still depends on an external reverse proxy or the API browser-session cookie flow.
 - Proxy-auth mode trusts headers and must only be enabled behind a hardened ingress that strips spoofed client headers.
 
 ### Neutral

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -57,6 +57,7 @@ _API_CSP = "default-src 'self'"
 _DASHBOARD_CSP = (
     "default-src 'self'; "
     "script-src 'self' 'unsafe-inline'; "
+    "script-src-attr 'none'; "
     "style-src 'self' 'unsafe-inline'; "
     "img-src 'self' data: blob:; "
     "font-src 'self' data:; "

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -129,8 +129,21 @@ def test_root_uses_dashboard_friendly_csp_when_bundled(tmp_path: Path, monkeypat
     assert resp.status_code == 200
     csp = resp.headers.get("content-security-policy", "")
     assert "script-src 'self' 'unsafe-inline'" in csp
+    assert "script-src-attr 'none'" in csp
     assert "style-src 'self' 'unsafe-inline'" in csp
     assert "frame-ancestors 'none'" in csp
+
+
+def test_ui_csp_headers_do_not_allow_eval():
+    """Static and hosted UI headers should not permit eval-style script execution."""
+    root = Path(__file__).parent.parent
+    next_config = (root / "ui" / "next.config.ts").read_text(encoding="utf-8")
+    vercel_config = (root / "ui" / "vercel.json").read_text(encoding="utf-8")
+
+    assert "'unsafe-eval'" not in next_config
+    assert "'unsafe-eval'" not in vercel_config
+    assert "script-src-attr 'none'" in next_config
+    assert "script-src-attr 'none'" in vercel_config
 
 
 def test_root_allows_head_when_dashboard_is_bundled(tmp_path: Path, monkeypatch):

--- a/ui/README.md
+++ b/ui/README.md
@@ -44,9 +44,9 @@ paths to the backend service without rebuilding the UI image.
 The dashboard supports two browser auth modes:
 
 - Recommended: same-origin reverse-proxy OIDC/session auth. The proxy keeps the browser session and injects trusted `X-Agent-Bom-Role` plus `X-Agent-Bom-Tenant-ID` headers to the API. Enable `AGENT_BOM_TRUST_PROXY_AUTH=1` on the backend for this mode.
-- Fallback: a short-lived API key entered into the dashboard and stored in `sessionStorage` for the current browser tab/session only.
+- Local-only fallback: a short-lived API key entered into the dashboard. The UI first exchanges it for a same-origin `httpOnly` browser session cookie. Legacy `sessionStorage` forwarding is disabled by default and must be explicitly enabled with `window.__AGENT_BOM_CONFIG__.allowSessionStorageApiKey = true` or `NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY=1` for single-user static pilots only.
 
-All browser fetches use `credentials: "include"` so proxy-managed sessions work without custom patches.
+All browser fetches and EventSource streams use same-origin URLs plus `credentials: "include"` so proxy-managed sessions work without custom patches and runtime config cannot redirect browser credentials to a different origin.
 
 ## Frontend quality gates
 

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -6,6 +6,7 @@ import { KeyRound, Loader2, Lock, ShieldCheck } from "lucide-react";
 import { useAuthState } from "@/components/auth-provider";
 import { api } from "@/lib/api";
 import { clearSessionApiKey, getSessionApiKey, setSessionApiKey } from "@/lib/auth";
+import { allowSessionStorageApiKeyFallback } from "@/lib/runtime-config";
 
 function isAuthFailure(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -75,8 +76,14 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
                   clearSessionApiKey();
                 } catch (nextError) {
                   const message = nextError instanceof Error ? nextError.message : "Failed to create browser session";
-                  if (message.includes("404") || message.includes("405")) {
+                  if ((message.includes("404") || message.includes("405")) && allowSessionStorageApiKeyFallback()) {
                     setSessionApiKey(apiKey);
+                  } else if (message.includes("404") || message.includes("405")) {
+                    clearSessionApiKey();
+                    setFormError(
+                      "Browser session endpoint unavailable; sessionStorage API-key fallback is disabled for this deployment."
+                    );
+                    return;
                   } else {
                     clearSessionApiKey();
                     setFormError(message);
@@ -93,7 +100,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
               <p className="mb-4 text-sm leading-6 text-zinc-400">
                 Creates a same-origin
                 <code className="mx-1 rounded bg-zinc-950 px-1 py-0.5 font-mono text-zinc-200">httpOnly</code>
-                cookie when the API supports it; older static pilots fall back to session-only tab storage.
+                cookie. Legacy tab storage must be explicitly enabled by the deployment.
               </p>
               <label className="mb-3 block text-xs uppercase tracking-[0.2em] text-zinc-500">API key</label>
               <input

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1463,7 +1463,7 @@ export const api = {
 
   /** Connect to SSE stream for real-time progress */
   streamScan: (jobId: string, onMessage: (data: SSEEvent) => void, onDone: () => void) => {
-    const es = new EventSource(`${getConfiguredApiUrl()}/v1/scan/${jobId}/stream`);
+    const es = new EventSource(`${getConfiguredApiUrl()}/v1/scan/${jobId}/stream`, { withCredentials: true });
     es.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data as string);

--- a/ui/lib/auth.ts
+++ b/ui/lib/auth.ts
@@ -1,3 +1,5 @@
+import { allowSessionStorageApiKeyFallback } from "@/lib/runtime-config";
+
 const SESSION_API_KEY = "agent-bom-ui-api-key";
 const CSRF_COOKIE = "agent_bom_csrf";
 
@@ -6,7 +8,7 @@ function hasWindow(): boolean {
 }
 
 export function getSessionApiKey(): string {
-  if (!hasWindow()) return "";
+  if (!hasWindow() || !allowSessionStorageApiKeyFallback()) return "";
   try {
     return window.sessionStorage.getItem(SESSION_API_KEY)?.trim() ?? "";
   } catch {
@@ -18,7 +20,7 @@ export function setSessionApiKey(rawKey: string): void {
   if (!hasWindow()) return;
   const value = rawKey.trim();
   try {
-    if (!value) {
+    if (!value || !allowSessionStorageApiKeyFallback()) {
       window.sessionStorage.removeItem(SESSION_API_KEY);
       return;
     }

--- a/ui/lib/runtime-config.ts
+++ b/ui/lib/runtime-config.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     __AGENT_BOM_CONFIG__?: {
       apiUrl?: string;
+      allowSessionStorageApiKey?: boolean;
     };
   }
 }
@@ -39,10 +40,22 @@ export function getConfiguredApiUrl(): string {
     if (runtimeValue !== undefined) {
       return runtimeValue;
     }
+    const envValue = sameOriginRuntimeApiUrl(normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL));
+    if (envValue !== undefined) {
+      return envValue;
+    }
+    return "";
   }
   return normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL) ?? "";
 }
 
 export function getDisplayApiUrl(): string {
   return getConfiguredApiUrl() || DEFAULT_API_URL;
+}
+
+export function allowSessionStorageApiKeyFallback(): boolean {
+  if (typeof window !== "undefined" && typeof window.__AGENT_BOM_CONFIG__?.allowSessionStorageApiKey === "boolean") {
+    return window.__AGENT_BOM_CONFIG__.allowSessionStorageApiKey;
+  }
+  return process.env.NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY === "1";
 }

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -9,7 +9,7 @@ const securityHeaders = [
   {
     key: "Content-Security-Policy",
     value:
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
   },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -27,6 +27,8 @@ const originalFetch = global.fetch
 
 afterEach(() => {
   global.fetch = originalFetch
+  window.__AGENT_BOM_CONFIG__ = undefined
+  delete process.env.NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY
   clearSessionApiKey()
   vi.restoreAllMocks()
 })
@@ -58,6 +60,28 @@ describe('api.listJobs', () => {
     const oldApiUrl = process.env.NEXT_PUBLIC_API_URL
     process.env.NEXT_PUBLIC_API_URL = "https://build.example"
     window.__AGENT_BOM_CONFIG__ = { apiUrl: "https://runtime.example" }
+
+    const fetchMock = mockFetch({ jobs: [], count: 0 })
+    global.fetch = fetchMock
+
+    await api.listJobs()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/jobs",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+
+    if (oldApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = oldApiUrl
+    }
+  })
+
+  it('rejects cross-origin build-time API URLs in the browser', async () => {
+    const oldApiUrl = process.env.NEXT_PUBLIC_API_URL
+    process.env.NEXT_PUBLIC_API_URL = "https://build.example"
+    window.__AGENT_BOM_CONFIG__ = undefined
 
     const fetchMock = mockFetch({ jobs: [], count: 0 })
     global.fetch = fetchMock
@@ -113,6 +137,7 @@ describe('api.listJobs', () => {
   })
 
   it('propagates a session API key and browser credentials', async () => {
+    window.__AGENT_BOM_CONFIG__ = { allowSessionStorageApiKey: true }
     setSessionApiKey("pilot-key-123")
     const fetchMock = mockFetch({ jobs: [], count: 0 })
     global.fetch = fetchMock
@@ -124,6 +149,23 @@ describe('api.listJobs', () => {
       expect.objectContaining({
         credentials: "include",
         headers: expect.objectContaining({ Authorization: "Bearer pilot-key-123" }),
+        signal: expect.any(AbortSignal),
+      }),
+    )
+  })
+
+  it('does not propagate sessionStorage API keys unless explicitly enabled', async () => {
+    setSessionApiKey("pilot-key-123")
+    const fetchMock = mockFetch({ jobs: [], count: 0 })
+    global.fetch = fetchMock
+
+    await api.listJobs()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/jobs",
+      expect.objectContaining({
+        credentials: "include",
+        headers: {},
         signal: expect.any(AbortSignal),
       }),
     )
@@ -342,6 +384,7 @@ describe('api key lifecycle helpers', () => {
 
 describe('api.downloadScanGraph', () => {
   it('downloads graph export with session auth headers', async () => {
+    window.__AGENT_BOM_CONFIG__ = { allowSessionStorageApiKey: true }
     setSessionApiKey('pilot-key-123')
     const fetchMock = mockBlobFetch('{"nodes":[],"edges":[]}')
     global.fetch = fetchMock

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -9,6 +9,7 @@ const originalFetch = global.fetch;
 
 afterEach(() => {
   global.fetch = originalFetch;
+  window.__AGENT_BOM_CONFIG__ = undefined;
   clearSessionApiKey();
   vi.restoreAllMocks();
 });
@@ -48,6 +49,7 @@ describe("AuthGate", () => {
   });
 
   it("shows the session API key fallback when the API returns 401", async () => {
+    window.__AGENT_BOM_CONFIG__ = { allowSessionStorageApiKey: true };
     setSessionApiKey("stale-key")
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -15,7 +15,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:* https://localhost:*; font-src 'self'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'" }
       ]
     }
   ]


### PR DESCRIPTION
Summary
- Makes browser API routing fail closed to same-origin paths, including build-time `NEXT_PUBLIC_API_URL`, so fetch/EventSource credentials cannot be redirected to a different origin.
- Keeps the httpOnly browser session exchange as the default path and disables sessionStorage API-key forwarding unless the deployment explicitly opts in for a legacy single-user static pilot.
- Adds EventSource credentials parity, removes `unsafe-eval` from hosted UI CSP, adds `script-src-attr 'none'`, and documents the updated browser auth model.

Validation
- `uv run ruff check src/agent_bom/api/middleware.py tests/test_api_endpoints.py`
- `uv run pytest tests/test_api_endpoints.py::test_root_uses_dashboard_friendly_csp_when_bundled tests/test_api_endpoints.py::test_ui_csp_headers_do_not_allow_eval -q`
- `cd ui && npm ci`
- `cd ui && npm run lint`
- `cd ui && npx tsc --noEmit`
- `cd ui && npm run test:run -- tests/api.test.ts tests/auth-gate.test.tsx`
- `cd ui && NEXT_EXPORT=1 npm run build`
- `git diff --check`

Note
- This intentionally does not remove `script-src 'unsafe-inline'` yet because the packaged Next static export still emits inline bootstrap data. The remaining CSP migration is nonce/hash-based and should be handled as its own compatibility-tested PR.