### PR TITLE
fix: sanitize MCP labels in logs

### DIFF
--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import yaml  # type: ignore[import-untyped]
 from rich.console import Console
+from rich.markup import escape
 
 # Re-export parser functions for backward compatibility
 from agent_bom.discovery.config_parsers import (  # noqa: F401
@@ -29,9 +30,13 @@ from agent_bom.discovery.config_parsers import (  # noqa: F401
     parse_snowflake_connections,
 )
 from agent_bom.models import Agent, AgentStatus, AgentType, MCPServer, TransportType
-from agent_bom.security import sanitize_env_vars
+from agent_bom.security import sanitize_env_vars, sanitize_log_label
 
 console = Console(stderr=True)
+
+
+def _display_label(value: object, max_len: int = 500) -> str:
+    return escape(sanitize_log_label(value, max_len=max_len))
 
 
 def _read_text_no_symlink(path: Path, *, encoding: str = "utf-8") -> str:
@@ -410,7 +415,11 @@ def discover_global_configs(agent_types: Optional[list[AgentType]] = None) -> li
                 # Skip symlinks whose target differs from the link path's parent tree
                 raw_path = Path(os.path.expanduser(path_str)) if "*" not in path_str else rp
                 if raw_path.is_symlink() and not rp.is_relative_to(raw_path.parent):
-                    logger.warning("Skipping symlink pointing outside parent: %s -> %s", raw_path, rp)
+                    logger.warning(
+                        "Skipping symlink pointing outside parent: %s -> %s",
+                        sanitize_log_label(raw_path),
+                        sanitize_log_label(rp),
+                    )
                     continue
                 safe_paths.append(rp)
 
@@ -456,9 +465,12 @@ def discover_global_configs(agent_types: Optional[list[AgentType]] = None) -> li
                             mcp_servers=servers,
                         )
                         agents.append(agent)
-                        console.print(f"  [green]✓[/green] Found {agent_type.value} with {len(servers)} MCP server(s): {config_path}")
+                        console.print(
+                            f"  [green]✓[/green] Found {_display_label(agent_type.value)} "
+                            f"with {len(servers)} MCP server(s): {_display_label(config_path)}"
+                        )
                 except (json.JSONDecodeError, KeyError, TypeError, Exception) as e:
-                    console.print(f"  [yellow]⚠[/yellow] Error parsing {config_path}: {e}")
+                    console.print(f"  [yellow]⚠[/yellow] Error parsing {_display_label(config_path)}: {_display_label(e)}")
 
     return agents
 
@@ -489,9 +501,11 @@ def discover_project_configs(project_dir: Optional[str] = None) -> list[Agent]:
                         mcp_servers=servers,
                     )
                     agents.append(agent)
-                    console.print(f"  [green]✓[/green] Found project config with {len(servers)} MCP server(s): {config_path}")
+                    console.print(
+                        f"  [green]✓[/green] Found project config with {len(servers)} MCP server(s): {_display_label(config_path)}"
+                    )
             except (json.JSONDecodeError, KeyError, TypeError, Exception) as e:
-                console.print(f"  [yellow]⚠[/yellow] Error parsing {config_path}: {e}")
+                console.print(f"  [yellow]⚠[/yellow] Error parsing {_display_label(config_path)}: {_display_label(e)}")
 
     return agents
 
@@ -1124,7 +1138,7 @@ def discover_filesystem_mcps(root: Path) -> list[Agent]:
                 try:
                     resolved = config_path.resolve()
                     if not resolved.is_relative_to(root):
-                        logger.warning("Skipping path outside root: %s", config_path)
+                        logger.warning("Skipping path outside root: %s", sanitize_log_label(config_path))
                         continue
                 except (OSError, ValueError):
                     continue
@@ -1151,12 +1165,12 @@ def discover_filesystem_mcps(root: Path) -> list[Agent]:
                         agents.append(agent)
                         logger.info(
                             "Discovered %s with %d server(s) in filesystem: %s",
-                            agent_type.value,
+                            sanitize_log_label(agent_type.value),
                             len(servers),
-                            config_path,
+                            sanitize_log_label(config_path),
                         )
                 except Exception:
-                    logger.debug("Failed to parse %s", config_path, exc_info=True)
+                    logger.debug("Failed to parse %s", sanitize_log_label(config_path), exc_info=True)
 
     return agents
 
@@ -1199,7 +1213,8 @@ def discover_all(
     compose_agent = discover_compose_mcp_servers(project_dir)
     if compose_agent:
         console.print(
-            f"  [green]✓[/green] Found {len(compose_agent.mcp_servers)} MCP server(s) in Docker Compose: {compose_agent.config_path}"
+            f"  [green]✓[/green] Found {len(compose_agent.mcp_servers)} MCP server(s) "
+            f"in Docker Compose: {_display_label(compose_agent.config_path)}"
         )
         agents.append(compose_agent)
 
@@ -1258,7 +1273,7 @@ def discover_all(
         discovered_types = {a.agent_type for a in agents}
         installed_agents = detect_installed_agents(discovered_types)
         for ia in installed_agents:
-            console.print(f"  [dim]  {ia.name}: installed but not configured[/dim]")
+            console.print(f"  [dim]  {_display_label(ia.name)}: installed but not configured[/dim]")
         agents.extend(installed_agents)
 
     # Dynamic content-based discovery layer (opt-in)

--- a/src/agent_bom/discovery/config_parsers.py
+++ b/src/agent_bom/discovery/config_parsers.py
@@ -17,16 +17,22 @@ from typing import Optional
 import toml  # type: ignore[import-untyped]
 import yaml  # type: ignore[import-untyped]
 from rich.console import Console
+from rich.markup import escape
 
 from agent_bom.models import MCPServer, TransportType
 from agent_bom.security import (
     SecurityError,
     sanitize_env_vars,
+    sanitize_log_label,
     validate_mcp_server_config,
 )
 
 console = Console(stderr=True)
 logger = logging.getLogger(__name__)
+
+
+def _display_label(value: object, max_len: int = 500) -> str:
+    return escape(sanitize_log_label(value, max_len=max_len))
 
 
 def _string_field(value: object) -> str:
@@ -91,9 +97,9 @@ def parse_mcp_config(config_data: dict, config_path: str) -> list[MCPServer]:
         try:
             validate_mcp_server_config(server_def)
         except SecurityError as e:
-            warning_msg = f"Blocked insecure server '{name}': {e}"
+            warning_msg = f"Blocked insecure server '{sanitize_log_label(name)}': {sanitize_log_label(e)}"
             logger.warning(warning_msg)
-            console.print(f"[yellow]⚠️  {warning_msg}[/yellow]")
+            console.print(f"[yellow]⚠️  {_display_label(warning_msg)}[/yellow]")
             # Include blocked server in report for visibility — no silent skips
             blocked_server = MCPServer(
                 name=name,

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 # Allowed executables for MCP servers (security allowlist).
 # Includes package managers, runtimes, and container tools commonly used
@@ -75,6 +76,14 @@ SENSITIVE_PATTERNS = [
     r"bearer",
     r"jwt",
 ]
+
+
+def sanitize_log_label(value: object, max_len: int = 500) -> str:
+    """Return a single-line, ANSI-free label for logs and terminal output."""
+    text = ANSI_ESCAPE_RE.sub("", str(value))
+    text = text.replace("\r", " ").replace("\n", " ").replace("\t", " ")
+    text = "".join(ch for ch in text if ch >= " " and ch != "\x7f")
+    return re.sub(r" {2,}", " ", text).strip()[:max_len]
 
 
 class SecurityError(Exception):

--- a/src/agent_bom/watch.py
+++ b/src/agent_bom/watch.py
@@ -11,22 +11,19 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Protocol
 
+from agent_bom.security import sanitize_log_label
+
 logger = logging.getLogger(__name__)
-_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 
 def _log_value(value: object, max_len: int = 500) -> str:
-    text = _ANSI_RE.sub("", str(value))
-    text = text.replace("\r", " ").replace("\n", " ").replace("\t", " ")
-    text = "".join(ch for ch in text if ch >= " " and ch != "\x7f")
-    return re.sub(r" {2,}", " ", text)[:max_len]
+    return sanitize_log_label(value, max_len=max_len)
 
 
 # ─── Alert model ─────────────────────────────────────────────────────────────
@@ -62,6 +59,7 @@ class ConsoleAlertSink:
 
     def send(self, alert: Alert) -> None:
         from rich.console import Console
+        from rich.markup import escape
 
         con = Console(stderr=True)
         severity_styles = {
@@ -72,10 +70,13 @@ class ConsoleAlertSink:
             "info": "cyan",
         }
         style = severity_styles.get(alert.severity, "white")
-        con.print(f"  [{style}][{alert.severity.upper()}][/{style}] {alert.summary}")
+        summary = escape(_log_value(alert.summary))
+        con.print(f"  [{style}][{alert.severity.upper()}][/{style}] {summary}")
         if alert.details:
             for key, val in alert.details.items():
-                con.print(f"    [dim]{key}: {val}[/dim]")
+                safe_key = escape(_log_value(key, max_len=120))
+                safe_val = escape(_log_value(val))
+                con.print(f"    [dim]{safe_key}: {safe_val}[/dim]")
 
 
 class WebhookAlertSink:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -14,6 +14,7 @@ from agent_bom.security import (
     create_safe_subprocess_env,
     sanitize_env_vars,
     sanitize_error,
+    sanitize_log_label,
     validate_arguments,
     validate_command,
     validate_environment,
@@ -25,6 +26,20 @@ from agent_bom.security import (
     validate_path,
     validate_url,
 )
+
+
+def test_sanitize_log_label_strips_ansi_and_line_controls():
+    cleaned = sanitize_log_label("srv\x1b[31m-red\x1b[0m\r\nnext\tline")
+    assert cleaned == "srv-red next line"
+    assert "\x1b" not in cleaned
+    assert "\n" not in cleaned
+    assert "\r" not in cleaned
+    assert "\t" not in cleaned
+
+
+def test_sanitize_log_label_bounds_length():
+    assert sanitize_log_label("x" * 20, max_len=7) == "x" * 7
+
 
 # ---------------------------------------------------------------------------
 # validate_command


### PR DESCRIPTION
Summary
- Adds a shared `sanitize_log_label()` helper for ANSI/control-character stripping and single-line log labels.
- Reuses it in watch-mode logging and Rich console alert rendering, including markup escaping for untrusted alert summaries/details.
- Sanitizes discovery parser warnings, config paths, agent labels, and parse errors before logging or terminal display.

Validation
- `uv run ruff check src/agent_bom/security.py src/agent_bom/watch.py src/agent_bom/discovery/__init__.py src/agent_bom/discovery/config_parsers.py tests/test_security.py tests/test_watch_cov.py`
- `uv run pytest tests/test_security.py tests/test_watch_cov.py -q`
- `uv run mypy src/agent_bom/security.py src/agent_bom/watch.py src/agent_bom/discovery/__init__.py src/agent_bom/discovery/config_parsers.py`
- pre-commit hooks: yaml/json/eof/trailing whitespace/private key/case conflict/merge conflict/mixed line ending/ruff/ruff-format/mypy/bandit
- `git diff --check`