### PR TITLE
fix: verify Helm downloads in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,15 @@ jobs:
 
       - name: Install Helm
         run: |
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          set -euo pipefail
+          HELM_VERSION="3.18.6"
+          HELM_SHA256="3f43c0aa57243852dd542493a0f54f1396c0bc8ec7296bbb2c01e802010819ce"
+          HELM_ARCHIVE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          curl -fsSLo "/tmp/${HELM_ARCHIVE}" "https://get.helm.sh/${HELM_ARCHIVE}"
+          echo "${HELM_SHA256}  /tmp/${HELM_ARCHIVE}" | sha256sum -c -
+          tar -xzf "/tmp/${HELM_ARCHIVE}" -C /tmp
+          sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          helm version
 
       - name: Render shipped Helm profiles
         run: python3 scripts/validate_helm_profiles.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,8 +403,12 @@ jobs:
       - name: Install Helm
         run: |
           set -euo pipefail
-          curl -fsSL https://get.helm.sh/helm-v3.18.6-linux-amd64.tar.gz -o /tmp/helm.tar.gz
-          tar -xzf /tmp/helm.tar.gz -C /tmp
+          HELM_VERSION="3.18.6"
+          HELM_SHA256="3f43c0aa57243852dd542493a0f54f1396c0bc8ec7296bbb2c01e802010819ce"
+          HELM_ARCHIVE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          curl -fsSLo "/tmp/${HELM_ARCHIVE}" "https://get.helm.sh/${HELM_ARCHIVE}"
+          echo "${HELM_SHA256}  /tmp/${HELM_ARCHIVE}" | sha256sum -c -
+          tar -xzf "/tmp/${HELM_ARCHIVE}" -C /tmp
           sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
           helm version
 


### PR DESCRIPTION
Summary
- replaces raw Helm installer usage in CI with a pinned Helm archive download
- verifies the Helm v3.18.6 SHA-256 before extracting in CI and release packaging
- keeps release chart packaging on the same Helm version while closing the unchecked download path from the red-team list

Validation
- python workflow YAML parse for .github/workflows/ci.yml and .github/workflows/release.yml
- python scripts/check_product_surface_contract.py
- git diff --check