### PR TITLE
fix: harden gateway auth boundary

### DIFF
--- a/docs/CONTROL_MAPPING.md
+++ b/docs/CONTROL_MAPPING.md
@@ -44,7 +44,7 @@ settings in the customer environment.
 
 | Annex A control | How agent-bom supports it | Evidence |
 |---|---|---|
-| A.5.15 Access control | RBAC, OIDC tenant claims, API-key lifecycle, trusted proxy headers | `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`, `src/agent_bom/api/auth.py` |
+| A.5.15 Access control | RBAC, OIDC tenant claims, API-key lifecycle, attested trusted-proxy headers | `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`, `src/agent_bom/api/auth.py` |
 | A.5.16 Identity management | External IdP integration, SAML metadata, tenant-bound OIDC providers | `src/agent_bom/api/oidc.py`, `src/agent_bom/api/saml.py` |
 | A.5.17 Authentication information | API-key hashing, bearer-token verification, browser cookie signing, CSRF protection | `src/agent_bom/api/auth.py`, `src/agent_bom/api/browser_session.py` |
 | A.5.23 Cloud services | Self-hosted deployment guidance, customer-managed storage, cloud read-only roles | `site-docs/deployment/own-infra-eks.md`, `scripts/provision/README.md` |

--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -183,7 +183,7 @@ Horizontal scale via Helm HPA on both control plane and gateway. ClickHouse is t
 - **API keys** with enforced lifetime policy (`AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS`, `AGENT_BOM_API_KEY_MAX_TTL_SECONDS`) and zero-downtime rotation (`POST /v1/auth/keys/{key_id}/rotate`) — [`api/auth.py`](../src/agent_bom/api/auth.py), [`api/middleware.py`](../src/agent_bom/api/middleware.py).
 - **OIDC** — any IdP (Okta, Auth0, Azure AD, Google). Config in [`api/oidc.py`](../src/agent_bom/api/oidc.py).
 - **SAML** — SP metadata at [`/v1/auth/saml/metadata`](../src/agent_bom/api/saml.py). Install `pip install 'agent-bom[saml]'`.
-- **Trusted proxy headers** — RBAC via `X-Agent-Bom-Role` + `X-Agent-Bom-Tenant-ID` when an authed reverse proxy terminates client identity. [`rbac.py require_authenticated_permission`](../src/agent_bom/rbac.py).
+- **Trusted proxy headers** — RBAC via `X-Agent-Bom-Role` + `X-Agent-Bom-Tenant-ID` only when an authed reverse proxy also injects `X-Agent-Bom-Proxy-Secret` matching `AGENT_BOM_TRUST_PROXY_AUTH_SECRET`. Direct client-supplied role/tenant headers are ignored. [`rbac.py require_authenticated_permission`](../src/agent_bom/rbac.py).
 - **Gateway upstream auth** — `none`, `bearer` (env), `oauth2_client_credentials` with token cache + early refresh — [`gateway_upstreams.py UpstreamConfig.resolve_auth_headers`](../src/agent_bom/gateway_upstreams.py). Snowflake MCPs use the OAuth2 path.
 
 ### 2.11 Secrets never touch agent-bom's disk

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import hmac
 import logging
 import os
 import secrets
@@ -451,6 +452,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._api_key = api_key
         self._trusted_proxy_auth = _env_flag("AGENT_BOM_TRUST_PROXY_AUTH")
+        self._trusted_proxy_secret = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", "").strip()
         # OIDC config loaded lazily from env on first request
         self._oidc_config: OIDCConfig | None = None
         self._oidc_checked = False
@@ -659,6 +661,15 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         tenant_id = request.headers.get("x-agent-bom-tenant-id", "").strip()
         if not role_header:
             return None
+        if not self._trusted_proxy_secret:
+            _logger.error("AGENT_BOM_TRUST_PROXY_AUTH is enabled without AGENT_BOM_TRUST_PROXY_AUTH_SECRET")
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "Trusted proxy authentication is not securely configured"},
+            )
+        presented_secret = request.headers.get("x-agent-bom-proxy-secret", "").strip()
+        if not hmac.compare_digest(presented_secret, self._trusted_proxy_secret):
+            return JSONResponse(status_code=401, content={"detail": "Unauthorized — invalid trusted proxy attestation"})
         if not tenant_id:
             return JSONResponse(
                 status_code=401,
@@ -688,6 +699,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         request.state.api_key_role = proxy_role.value
         request.state.tenant_id = tenant_id
         request.state.auth_method = "proxy_header"
+        request.state.proxy_auth_attested = True
         request.state.auth_issuer = request.headers.get("x-agent-bom-auth-issuer") or None
         return await self._call_with_tenant_context(request, call_next)
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -509,11 +509,12 @@ async def auth_policy(request: Request) -> dict:
             "browser_session": "signed_http_only_cookie",
             "session_storage_fallback": "legacy_static_export_only",
             "credentials_mode": "include",
-            "trusted_proxy_headers": ["X-Agent-Bom-Role", "X-Agent-Bom-Tenant-ID"],
+            "trusted_proxy_headers": ["X-Agent-Bom-Role", "X-Agent-Bom-Tenant-ID", "X-Agent-Bom-Proxy-Secret"],
+            "trusted_proxy_secret_env": "AGENT_BOM_TRUST_PROXY_AUTH_SECRET",
             "message": (
                 "Recommended browser auth is same-origin reverse-proxy OIDC with the proxy injecting trusted "
-                "X-Agent-Bom-* headers. For single-user local or pilot access, the UI exchanges an API key for a "
-                "signed, expiring, CSRF-bound httpOnly browser session cookie."
+                "X-Agent-Bom-* headers plus X-Agent-Bom-Proxy-Secret attestation. For single-user local or pilot "
+                "access, the UI exchanges an API key for a signed, expiring, CSRF-bound httpOnly browser session cookie."
             ),
         },
         "rate_limit_runtime": rl_runtime,

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -25,7 +25,7 @@ from fastapi.responses import JSONResponse, Response
 
 from agent_bom.api.models import EvaluateRequest, JobStatus, PolicyCreate, PolicyUpdate
 from agent_bom.api.stores import _get_policy_store, _get_store
-from agent_bom.rbac import require_authenticated_permission, require_permission
+from agent_bom.rbac import require_authenticated_permission
 
 if TYPE_CHECKING:
     from agent_bom.api.policy_store import GatewayPolicy
@@ -34,7 +34,7 @@ router = APIRouter()
 
 
 def _dep(permission: str) -> Any:
-    return cast(Any, require_permission(permission))
+    return cast(Any, require_authenticated_permission(permission))
 
 
 def _policy_collection_etag(policies: list["GatewayPolicy"]) -> str:

--- a/src/agent_bom/gateway.py
+++ b/src/agent_bom/gateway.py
@@ -91,6 +91,7 @@ def evaluate_gateway_policies(
         ``(allowed, reason, policy_id)`` — if blocked, ``reason``
         explains why and ``policy_id`` identifies the blocking policy.
     """
+    first_audit_match: tuple[str, str] | None = None
     for policy in policies:
         if not policy.enabled:
             continue
@@ -102,6 +103,10 @@ def evaluate_gateway_policies(
             if policy.mode.value == "enforce":
                 return False, reason, policy.policy_id
             # audit mode — log but allow
-            return True, f"[audit] {reason}", policy.policy_id
+            if first_audit_match is None:
+                first_audit_match = (f"[audit] {reason}", policy.policy_id)
 
+    if first_audit_match is not None:
+        reason, policy_id = first_audit_match
+        return True, reason, policy_id
     return True, "", None

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -7,12 +7,15 @@ Roles:
     analyst  — Read + scan: run scans, view results, create exceptions (not approve)
     viewer   — Read-only: view results, posture, compliance (no scans or mutations)
 
-Authentication is delegated to the upstream reverse proxy (e.g., API gateway,
-OAuth2 proxy). RBAC only checks the X-Agent-Bom-Role header or API key mapping.
+Authentication is established by the API middleware (API key, OIDC, SAML,
+browser session, SCIM, or attested trusted proxy headers). RBAC consumes the
+authenticated role placed on ``request.state`` and must not trust raw client
+headers directly.
 """
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 import threading
@@ -214,9 +217,7 @@ def resolve_role(api_key: str | None = None, role_header: str | None = None) -> 
 
     Priority:
         1. API key lookup (if AGENT_BOM_API_KEYS configured)
-        2. X-Agent-Bom-Role header (trusted from reverse proxy)
-        3. Default role from AGENT_BOM_DEFAULT_ROLE env var
-        4. admin (for backward compatibility when RBAC not configured)
+        2. Default role from AGENT_BOM_DEFAULT_ROLE env var
     """
     # API key takes priority
     if api_key:
@@ -225,12 +226,8 @@ def resolve_role(api_key: str | None = None, role_header: str | None = None) -> 
         if role:
             return role
 
-    # Header from reverse proxy
     if role_header:
-        try:
-            return Role(role_header.lower())
-        except ValueError:
-            pass
+        logger.warning("Ignoring unauthenticated X-Agent-Bom-Role header outside API middleware attestation")
 
     # Default role — least privilege (viewer) unless explicitly overridden
     default = os.environ.get("AGENT_BOM_DEFAULT_ROLE", "viewer")
@@ -315,10 +312,17 @@ def require_permission(action: str) -> Callable:
     from fastapi import Depends, Header, HTTPException
 
     async def _check(
+        request: Request,
         x_api_key: str | None = Header(None, alias="X-Api-Key"),
-        x_role: str | None = Header(None, alias="X-Agent-Bom-Role"),
     ) -> Role:
-        role = resolve_role(api_key=x_api_key, role_header=x_role)
+        state_role = getattr(request.state, "api_key_role", None)
+        if state_role:
+            try:
+                role = Role(str(state_role).lower())
+            except ValueError as exc:
+                raise HTTPException(status_code=403, detail=f"Invalid authenticated role '{state_role}'") from exc
+        else:
+            role = resolve_role(api_key=x_api_key)
         if not check_permission(role, action):
             raise HTTPException(
                 status_code=403,
@@ -345,6 +349,7 @@ def require_authenticated_permission(action: str) -> Callable:
         request: Request,
         x_role: str | None = Header(None, alias="X-Agent-Bom-Role"),
         x_tenant_id: str | None = Header(None, alias="X-Agent-Bom-Tenant-ID"),
+        x_proxy_secret: str | None = Header(None, alias="X-Agent-Bom-Proxy-Secret"),
     ) -> Role:
         state_role = getattr(request.state, "api_key_role", None)
         if state_role:
@@ -356,31 +361,37 @@ def require_authenticated_permission(action: str) -> Callable:
                 request.state.tenant_id = "default"
             return _authorize(role, action)
 
-        if not x_role:
-            raise HTTPException(
-                status_code=401,
-                detail=(
-                    "Authentication required — provide an authenticated API key/token "
-                    "or trusted proxy headers (X-Agent-Bom-Role + X-Agent-Bom-Tenant-ID)"
-                ),
-            )
+        trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        proxy_secret = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", "").strip()
+        if x_role and trusted_proxy_enabled and proxy_secret and hmac.compare_digest(x_proxy_secret or "", proxy_secret):
+            try:
+                role = Role(x_role.lower())
+            except ValueError as exc:
+                raise HTTPException(status_code=403, detail=f"Invalid proxy role '{x_role}'") from exc
+            if not x_tenant_id:
+                raise HTTPException(
+                    status_code=401,
+                    detail="Authentication required — trusted proxy requests must include X-Agent-Bom-Tenant-ID",
+                )
+            request.state.api_key_role = role.value
+            request.state.tenant_id = x_tenant_id
+            request.state.api_key_name = getattr(request.state, "api_key_name", None) or "proxy-header"
+            request.state.auth_method = getattr(request.state, "auth_method", None) or "proxy_header"
+            request.state.proxy_auth_attested = True
+            return _authorize(role, action)
 
-        try:
-            role = Role(x_role.lower())
-        except ValueError as exc:
-            raise HTTPException(status_code=403, detail=f"Invalid proxy role '{x_role}'") from exc
-
-        if not x_tenant_id:
-            raise HTTPException(
-                status_code=401,
-                detail="Authentication required — trusted proxy requests must include X-Agent-Bom-Tenant-ID",
-            )
-
-        request.state.api_key_role = role.value
-        request.state.tenant_id = x_tenant_id
-        request.state.api_key_name = getattr(request.state, "api_key_name", None) or "proxy-header"
-        request.state.auth_method = getattr(request.state, "auth_method", None) or "proxy_header"
-        return _authorize(role, action)
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "Authentication required — provide an authenticated API key, browser session, "
+                "OIDC/SAML token, or attested trusted proxy identity"
+            ),
+        )
 
     return Depends(_check)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test support package."""

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -1,0 +1,25 @@
+"""Shared test helpers for attested trusted-proxy auth."""
+
+PROXY_SECRET = "test-proxy-secret"
+
+
+def proxy_headers(role: str = "viewer", tenant: str = "tenant-alpha") -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Tenant-ID": tenant,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+def enable_trusted_proxy_env() -> None:
+    import os
+
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+
+
+def disable_trusted_proxy_env() -> None:
+    import os
+
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)

--- a/tests/test_api_auth_boundary.py
+++ b/tests/test_api_auth_boundary.py
@@ -1,0 +1,61 @@
+"""Regression tests for control-plane auth boundary bypasses."""
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+PROXY_SECRET = "test-proxy-secret"
+
+
+def test_gateway_policy_create_rejects_spoofed_role_without_attestation() -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/v1/gateway/policies",
+        json={"name": "spoofed", "mode": "enforce", "rules": [{"id": "r1", "action": "block", "block_tools": ["exec"]}]},
+        headers={"X-Agent-Bom-Role": "admin", "X-Agent-Bom-Tenant-ID": "tenant-alpha"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_enterprise_read_routes_reject_spoofed_proxy_headers_without_attestation() -> None:
+    client = TestClient(app)
+    headers = {"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "tenant-alpha"}
+
+    assert client.get("/v1/posture", headers=headers).status_code == 401
+    assert client.get("/metrics", headers=headers).status_code == 401
+    assert client.get("/v1/compliance/owasp-llm/report", headers=headers).status_code == 401
+
+
+def test_attested_proxy_headers_are_accepted_when_explicitly_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/posture",
+        headers={
+            "X-Agent-Bom-Role": "viewer",
+            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+            "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_attested_proxy_headers_reject_wrong_secret(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/posture",
+        headers={
+            "X-Agent-Bom-Role": "viewer",
+            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+            "X-Agent-Bom-Proxy-Secret": "wrong",
+        },
+    )
+
+    assert response.status_code == 401

--- a/tests/test_api_compliance_auth.py
+++ b/tests/test_api_compliance_auth.py
@@ -10,22 +10,43 @@ from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import set_job_store
 
+PROXY_SECRET = "test-proxy-secret"
+
+
+def _proxy_headers(role: str = "viewer", tenant: str = "tenant-alpha") -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Tenant-ID": tenant,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+def setup_module() -> None:
+    import os
+
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+
+
+def teardown_module() -> None:
+    import os
+
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
+
 
 def test_posture_requires_authenticated_context() -> None:
     client = TestClient(app)
     resp = client.get("/v1/posture")
     assert resp.status_code == 401
-    assert "Authentication required" in resp.json()["detail"]
+    assert "Unauthorized" in resp.json()["detail"]
 
 
 def test_posture_accepts_trusted_proxy_headers() -> None:
     client = TestClient(app)
     resp = client.get(
         "/v1/posture",
-        headers={
-            "X-Agent-Bom-Role": "viewer",
-            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
-        },
+        headers=_proxy_headers(),
     )
     assert resp.status_code == 200
     assert resp.json()["grade"] == "N/A"
@@ -37,6 +58,7 @@ def test_posture_proxy_auth_requires_tenant_header() -> None:
         "/v1/posture",
         headers={
             "X-Agent-Bom-Role": "viewer",
+            "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
         },
     )
     assert resp.status_code == 401
@@ -47,17 +69,14 @@ def test_compliance_export_requires_authenticated_context() -> None:
     client = TestClient(app)
     resp = client.get("/v1/compliance")
     assert resp.status_code == 401
-    assert "Authentication required" in resp.json()["detail"]
+    assert "Unauthorized" in resp.json()["detail"]
 
 
 def test_compliance_export_accepts_trusted_proxy_headers() -> None:
     client = TestClient(app)
     resp = client.get(
         "/v1/compliance/owasp-llm/report",
-        headers={
-            "X-Agent-Bom-Role": "viewer",
-            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
-        },
+        headers=_proxy_headers(),
     )
     assert resp.status_code == 200
     body = resp.json()
@@ -103,10 +122,7 @@ def test_compliance_export_end_to_end_returns_real_evidence() -> None:
         client = TestClient(app)
         resp = client.get(
             "/v1/compliance/owasp-llm/report",
-            headers={
-                "X-Agent-Bom-Role": "viewer",
-                "X-Agent-Bom-Tenant-ID": "tenant-alpha",
-            },
+            headers=_proxy_headers(),
         )
         assert resp.status_code == 200
         body = resp.json()

--- a/tests/test_api_cross_tenant_matrix.py
+++ b/tests/test_api_cross_tenant_matrix.py
@@ -31,6 +31,15 @@ from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import set_job_store
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
 
 
 def _now() -> str:
@@ -79,12 +88,7 @@ def two_tenants_seeded():
 
 def _client_for(tenant: str) -> TestClient:
     client = TestClient(app)
-    client.headers.update(
-        {
-            "X-Agent-Bom-Role": "admin",
-            "X-Agent-Bom-Tenant-ID": tenant,
-        }
-    )
+    client.headers.update(proxy_headers(role="admin", tenant=tenant))
     return client
 
 

--- a/tests/test_api_gateway.py
+++ b/tests/test_api_gateway.py
@@ -12,7 +12,31 @@ from agent_bom.api.policy_store import (
 )
 from agent_bom.api.server import app, set_policy_store
 
-ADMIN_HEADERS = {"X-Agent-Bom-Role": "admin"}
+PROXY_SECRET = "test-proxy-secret"
+ADMIN_HEADERS = {
+    "X-Agent-Bom-Role": "admin",
+    "X-Agent-Bom-Tenant-ID": "default",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+}
+VIEWER_HEADERS = {
+    "X-Agent-Bom-Role": "viewer",
+    "X-Agent-Bom-Tenant-ID": "default",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+}
+
+
+def setup_module() -> None:
+    import os
+
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+
+
+def teardown_module() -> None:
+    import os
+
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
 
 
 def _now() -> str:
@@ -24,7 +48,9 @@ def _now() -> str:
 def _fresh_client() -> tuple[TestClient, InMemoryPolicyStore]:
     store = InMemoryPolicyStore()
     set_policy_store(store)
-    return TestClient(app), store
+    client = TestClient(app)
+    client.headers.update(ADMIN_HEADERS)
+    return client, store
 
 
 def _make_policy(
@@ -77,7 +103,7 @@ def test_list_policies_emits_etag_and_supports_not_modified():
     resp = client.get("/v1/gateway/policies?enabled=true")
     assert resp.status_code == 200
     etag = resp.headers["etag"]
-    cached = client.get("/v1/gateway/policies?enabled=true", headers={"If-None-Match": etag})
+    cached = client.get("/v1/gateway/policies?enabled=true", headers={**ADMIN_HEADERS, "If-None-Match": etag})
     assert cached.status_code == 304
     assert cached.headers["etag"] == etag
 
@@ -202,9 +228,9 @@ def test_write_routes_require_policy_write_permission():
         "mode": "enforce",
         "rules": [{"id": "r1", "action": "block", "block_tools": ["exec"]}],
     }
-    assert client.post("/v1/gateway/policies", json=payload).status_code == 403
-    assert client.put("/v1/gateway/policies/p-1", json={"name": "renamed"}).status_code == 403
-    assert client.delete("/v1/gateway/policies/p-1").status_code == 403
+    assert client.post("/v1/gateway/policies", json=payload, headers=VIEWER_HEADERS).status_code == 403
+    assert client.put("/v1/gateway/policies/p-1", json={"name": "renamed"}, headers=VIEWER_HEADERS).status_code == 403
+    assert client.delete("/v1/gateway/policies/p-1", headers=VIEWER_HEADERS).status_code == 403
 
 
 def test_list_hides_other_tenants():

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -328,6 +328,7 @@ def test_api_key_middleware_proxy_headers_authenticate_when_enabled(monkeypatch)
         )
 
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", "test-proxy-secret")
     test_app = Starlette(routes=[Route("/v1/test", dummy)])
     test_app.add_middleware(APIKeyMiddleware, api_key="")
 
@@ -337,6 +338,7 @@ def test_api_key_middleware_proxy_headers_authenticate_when_enabled(monkeypatch)
         headers={
             "X-Agent-Bom-Role": "analyst",
             "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+            "X-Agent-Bom-Proxy-Secret": "test-proxy-secret",
             "X-Agent-Bom-Subject": "alice@corp.example",
         },
     )
@@ -354,11 +356,15 @@ def test_api_key_middleware_proxy_headers_require_tenant(monkeypatch):
         return StarletteJSONResponse({"ok": True})
 
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", "test-proxy-secret")
     test_app = Starlette(routes=[Route("/v1/test", dummy)])
     test_app.add_middleware(APIKeyMiddleware, api_key="")
 
     client = TestClient(test_app)
-    resp = client.get("/v1/test", headers={"X-Agent-Bom-Role": "viewer"})
+    resp = client.get(
+        "/v1/test",
+        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Proxy-Secret": "test-proxy-secret"},
+    )
     assert resp.status_code == 401
     assert "X-Agent-Bom-Tenant-ID" in resp.json()["detail"]
 

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -24,6 +24,7 @@ from agent_bom.api.middleware import APIKeyMiddleware, get_rate_limit_key_status
 from agent_bom.api.server import app
 from agent_bom.api.stores import set_tenant_quota_store
 from agent_bom.api.tenant_quota_store import InMemoryTenantQuotaStore
+from tests.auth_helpers import PROXY_SECRET, proxy_headers
 
 # ─── Rate-limit key status ────────────────────────────────────────────────────
 
@@ -359,6 +360,7 @@ def test_auth_secret_rotation_plan_is_non_secret_and_actionable(monkeypatch: pyt
 
 def test_auth_quota_update_persists_tenant_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
     _reload_config()
     _server_mod.configure_api(api_key=None)
     original_store = _stores._tenant_quota_store
@@ -367,10 +369,7 @@ def test_auth_quota_update_persists_tenant_override(monkeypatch: pytest.MonkeyPa
         set_tenant_quota_store(quota_store)
 
         client = TestClient(app)
-        headers = {
-            "X-Agent-Bom-Role": "admin",
-            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
-        }
+        headers = proxy_headers(role="admin", tenant="tenant-alpha")
         resp = client.put(
             "/v1/auth/quota",
             headers=headers,
@@ -515,17 +514,16 @@ def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
     assert middleware._required_role("GET", "/v1/auth/debug") == "viewer"
 
 
-def test_metrics_requires_authenticated_access() -> None:
+def test_metrics_requires_authenticated_access(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
     client = TestClient(app)
     unauthenticated = client.get("/metrics")
     assert unauthenticated.status_code == 401
 
     authenticated = client.get(
         "/metrics",
-        headers={
-            "X-Agent-Bom-Role": "viewer",
-            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
-        },
+        headers=proxy_headers(role="viewer", tenant="tenant-alpha"),
     )
     assert authenticated.status_code == 200
     assert "agent_bom_" in authenticated.text
@@ -533,16 +531,14 @@ def test_metrics_requires_authenticated_access() -> None:
 
 def test_auth_debug_reports_runtime_auth_modes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
     _reload_config()
     _server_mod.configure_api(api_key=None)
 
     client = TestClient(app)
     resp = client.get(
         "/v1/auth/debug",
-        headers={
-            "X-Agent-Bom-Role": "viewer",
-            "X-Agent-Bom-Tenant-ID": "tenant-alpha",
-        },
+        headers=proxy_headers(role="viewer", tenant="tenant-alpha"),
     )
     assert resp.status_code == 200
     body = resp.json()

--- a/tests/test_api_privacy.py
+++ b/tests/test_api_privacy.py
@@ -27,6 +27,15 @@ from agent_bom.api.stores import (
     set_tenant_quota_store,
 )
 from agent_bom.api.tenant_quota_store import InMemoryTenantQuotaStore
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
 
 
 class _GraphStore:
@@ -137,13 +146,13 @@ def test_tenant_data_http_endpoint_requires_authenticated_admin(tenant_stores) -
 
     viewer = client.get(
         "/v1/tenant/tenant-a/data",
-        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "tenant-a"},
+        headers=proxy_headers(role="viewer", tenant="tenant-a"),
     )
     assert viewer.status_code == 403
 
     admin = client.get(
         "/v1/tenant/tenant-a/data",
-        headers={"X-Agent-Bom-Role": "admin", "X-Agent-Bom-Tenant-ID": "tenant-a"},
+        headers=proxy_headers(role="admin", tenant="tenant-a"),
     )
     assert admin.status_code == 200
     assert admin.json()["counts"]["jobs"] == 1

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -10,22 +10,27 @@ from agent_bom.api.server import app, configure_api
 from agent_bom.api.source_store import InMemorySourceStore
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.connectors.base import ConnectorHealthState, ConnectorStatus
+from tests.auth_helpers import PROXY_SECRET
 
 ADMIN_HEADERS = {
     "X-Agent-Bom-Role": "admin",
     "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
 }
 ANALYST_HEADERS = {
     "X-Agent-Bom-Role": "analyst",
     "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
 }
 VIEWER_HEADERS = {
     "X-Agent-Bom-Role": "viewer",
     "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
 }
 OTHER_TENANT_HEADERS = {
     "X-Agent-Bom-Role": "viewer",
     "X-Agent-Bom-Tenant-ID": "tenant-beta",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
 }
 
 
@@ -35,6 +40,7 @@ def source_client(monkeypatch: pytest.MonkeyPatch):
     old_job_store = _stores._store
 
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
     configure_api(api_key=None)
     _stores.set_source_store(InMemorySourceStore())
     _stores.set_job_store(InMemoryJobStore())

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -6,11 +6,17 @@ from starlette.testclient import TestClient
 
 from agent_bom.api.server import JobStatus, _get_store, app
 from agent_bom.api.store import InMemoryJobStore
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
-_AUTH_HEADERS = {
-    "X-Agent-Bom-Role": "viewer",
-    "X-Agent-Bom-Tenant-ID": "default",
-}
+_AUTH_HEADERS = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
 
 
 def _clear_jobs():

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -40,6 +40,15 @@ from agent_bom.api.routes import compliance as compliance_routes
 from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import _get_store, set_analytics_store, set_job_store
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
 
 
 def _now_iso() -> str:
@@ -322,10 +331,7 @@ def test_compliance_report_route_exports_real_evidence_end_to_end() -> None:
         client = TestClient(app)
         resp = client.get(
             "/v1/compliance/owasp-llm/report",
-            headers={
-                "X-Agent-Bom-Role": "viewer",
-                "X-Agent-Bom-Tenant-ID": "tenant-alpha",
-            },
+            headers=proxy_headers(tenant="tenant-alpha"),
         )
         assert resp.status_code == 200
 

--- a/tests/test_compliance_signing.py
+++ b/tests/test_compliance_signing.py
@@ -30,6 +30,15 @@ from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import set_job_store
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
 
 
 def _generate_ed25519_pem() -> tuple[str, Ed25519PublicKey]:
@@ -127,7 +136,7 @@ def test_bundle_roundtrip_verifies_with_verification_key_endpoint(monkeypatch: p
         # Pilot-team flow: fetch public key once, pin it, use it to verify bundles.
         key_resp = client.get(
             "/v1/compliance/verification-key",
-            headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "tenant-alpha"},
+            headers=proxy_headers(tenant="tenant-alpha"),
         )
         assert key_resp.status_code == 200
         key_body = key_resp.json()
@@ -140,7 +149,7 @@ def test_bundle_roundtrip_verifies_with_verification_key_endpoint(monkeypatch: p
         # Now pull a bundle and verify it with the pinned public key.
         resp = client.get(
             "/v1/compliance/owasp-llm/report",
-            headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": "tenant-alpha"},
+            headers=proxy_headers(tenant="tenant-alpha"),
         )
         assert resp.status_code == 200
         assert resp.headers["X-Agent-Bom-Compliance-Signature-Algorithm"] == "Ed25519"

--- a/tests/test_control_plane_contracts.py
+++ b/tests/test_control_plane_contracts.py
@@ -26,6 +26,15 @@ from agent_bom.api.stores import set_graph_store, set_job_store
 from agent_bom.gateway_server import GatewaySettings, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
 
 
 def _now() -> str:
@@ -34,7 +43,7 @@ def _now() -> str:
 
 def _cp_client(tenant: str) -> TestClient:
     client = TestClient(app)
-    client.headers.update({"X-Agent-Bom-Role": "admin", "X-Agent-Bom-Tenant-ID": tenant})
+    client.headers.update(proxy_headers(role="admin", tenant=tenant))
     return client
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,7 @@ from agent_bom.models import (
 )
 from agent_bom.output import export_sarif, to_cyclonedx, to_json, to_sarif, to_spdx
 from agent_bom.parsers import parse_npm_packages, parse_pip_packages
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
 # ─── Model Tests ────────────────────────────────────────────────────────────
 
@@ -3962,10 +3963,11 @@ def test_api_posture_counts_empty():
 
     tenant_id = "counts-empty"
     client = TestClient(app)
-    resp = client.get(
-        "/v1/posture/counts",
-        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": tenant_id},
-    )
+    enable_trusted_proxy_env()
+    try:
+        resp = client.get("/v1/posture/counts", headers=proxy_headers(tenant=tenant_id))
+    finally:
+        disable_trusted_proxy_env()
     assert resp.status_code == 200
     body = resp.json()
     assert "critical" in body
@@ -4023,10 +4025,11 @@ def test_api_posture_counts_with_data():
         },
     )
     _get_store().put(job)
-    resp = client.get(
-        "/v1/posture/counts",
-        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": tenant_id},
-    )
+    enable_trusted_proxy_env()
+    try:
+        resp = client.get("/v1/posture/counts", headers=proxy_headers(tenant=tenant_id))
+    finally:
+        disable_trusted_proxy_env()
     assert resp.status_code == 200
     body = resp.json()
     assert body["critical"] >= 1
@@ -4063,10 +4066,11 @@ def test_api_posture_counts_ci_cd_only_is_not_treated_as_local_runtime():
         },
     )
     _get_store().put(job)
-    resp = client.get(
-        "/v1/posture/counts",
-        headers={"X-Agent-Bom-Role": "viewer", "X-Agent-Bom-Tenant-ID": tenant_id},
-    )
+    enable_trusted_proxy_env()
+    try:
+        resp = client.get("/v1/posture/counts", headers=proxy_headers(tenant=tenant_id))
+    finally:
+        disable_trusted_proxy_env()
     assert resp.status_code == 200
     body = resp.json()
     assert body["deployment_mode"] == "local"

--- a/tests/test_enterprise_gaps.py
+++ b/tests/test_enterprise_gaps.py
@@ -67,11 +67,11 @@ class TestRBAC:
         assert resolve_role(api_key="key-xyz").value == "admin"
         configure_api_keys({})  # cleanup
 
-    def test_resolve_role_from_header(self):
+    def test_resolve_role_ignores_unauthenticated_header(self):
         from agent_bom.rbac import resolve_role
 
         assert resolve_role(role_header="viewer").value == "viewer"
-        assert resolve_role(role_header="ANALYST").value == "analyst"
+        assert resolve_role(role_header="ANALYST").value == "viewer"
 
     def test_resolve_role_default(self):
         from agent_bom.rbac import resolve_role

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -140,6 +140,25 @@ def test_multiple_policies_first_blocks():
     assert pid == "p-2"
 
 
+def test_enforce_policy_takes_precedence_over_prior_audit_match():
+    audit = _policy(
+        policy_id="audit-rm",
+        mode=PolicyMode.AUDIT,
+        rules=[GatewayRule(id="audit", action="block", block_tools=["rm"])],
+    )
+    enforce = _policy(
+        policy_id="enforce-rm",
+        mode=PolicyMode.ENFORCE,
+        rules=[GatewayRule(id="enforce", action="block", block_tools=["rm"])],
+    )
+
+    allowed, reason, pid = evaluate_gateway_policies([audit, enforce], "rm", {})
+
+    assert allowed is False
+    assert "rm" in reason
+    assert pid == "enforce-rm"
+
+
 def test_tool_name_exact_match():
     p = _policy(rules=[GatewayRule(id="r1", action="block", tool_name="write_file")])
     allowed, _, _ = evaluate_gateway_policies([p], "write_file", {})

--- a/tests/test_gateway_auth_tenant_e2e.py
+++ b/tests/test_gateway_auth_tenant_e2e.py
@@ -43,6 +43,22 @@ from agent_bom.api.stores import set_job_store
 from agent_bom.gateway_server import GatewaySettings, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 
+PROXY_SECRET = "test-proxy-secret"
+
+
+def setup_module() -> None:
+    import os
+
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+
+
+def teardown_module() -> None:
+    import os
+
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -96,7 +112,13 @@ def pilot_fleet():
 def _cp_client(tenant: str) -> TestClient:
     """TestClient for the agent-bom control-plane API authed as `tenant`."""
     c = TestClient(app)
-    c.headers.update({"X-Agent-Bom-Role": "admin", "X-Agent-Bom-Tenant-ID": tenant})
+    c.headers.update(
+        {
+            "X-Agent-Bom-Role": "admin",
+            "X-Agent-Bom-Tenant-ID": tenant,
+            "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+        }
+    )
     return c
 
 

--- a/tests/test_gateway_upstream_discovery_route.py
+++ b/tests/test_gateway_upstream_discovery_route.py
@@ -26,6 +26,15 @@ from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import set_job_store
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
 
 
 def _now() -> str:
@@ -94,12 +103,7 @@ def fleet_seeded():
 
 def _client_for(tenant: str) -> TestClient:
     c = TestClient(app)
-    c.headers.update(
-        {
-            "X-Agent-Bom-Role": "admin",
-            "X-Agent-Bom-Tenant-ID": tenant,
-        }
-    )
+    c.headers.update(proxy_headers(role="admin", tenant=tenant))
     return c
 
 


### PR DESCRIPTION
## Summary

Closes the newly reported gateway/control-plane auth boundary findings and keeps the contract consistent across API, gateway, docs, and tests:

- rejects raw client-supplied `X-Agent-Bom-Role` / `X-Agent-Bom-Tenant-ID` as authentication
- requires `AGENT_BOM_TRUST_PROXY_AUTH_SECRET` plus matching `X-Agent-Bom-Proxy-Secret` when trusted-proxy auth is enabled
- moves gateway policy routes to authenticated RBAC dependencies instead of legacy header-only permission checks
- fixes mixed audit/enforce gateway policy evaluation so enforce-mode blocks cannot be bypassed by an earlier audit match
- updates policy/debug docs and control mapping to describe attested trusted-proxy auth
- adds regression coverage for spoofed gateway CRUD, posture, metrics, compliance, and mixed policy enforcement
- updates existing tenant, compliance, source, gateway, and control-plane contract tests to use the same attested proxy contract

## Validation

- `uv run ruff check src/agent_bom/rbac.py src/agent_bom/api/middleware.py src/agent_bom/api/routes/gateway.py src/agent_bom/api/routes/enterprise.py src/agent_bom/gateway.py tests/test_enterprise_gaps.py tests/test_api_auth_boundary.py tests/test_gateway.py tests/test_api_gateway.py tests/test_api_hardening.py tests/test_api_compliance_auth.py tests/test_gateway_auth_tenant_e2e.py tests/test_api_privacy.py tests/test_control_plane_contracts.py tests/test_gateway_upstream_discovery_route.py tests/test_compliance_signing.py tests/test_compliance_report.py tests/test_compliance.py tests/test_api_sources.py tests/test_api_operator_policy.py tests/test_api_cross_tenant_matrix.py tests/test_core.py`
- `uv run pytest tests/test_enterprise_gaps.py::TestRBAC::test_resolve_role_ignores_unauthenticated_header tests/test_api_auth_boundary.py tests/test_gateway.py tests/test_api_gateway.py tests/test_api_compliance_auth.py -q`
- `uv run pytest tests/test_api_auth_boundary.py tests/test_gateway.py tests/test_api_gateway.py tests/test_api_hardening.py tests/test_api_compliance_auth.py tests/test_gateway_auth_tenant_e2e.py tests/test_api_privacy.py tests/test_control_plane_contracts.py tests/test_gateway_upstream_discovery_route.py tests/test_compliance_signing.py tests/test_compliance_report.py tests/test_compliance.py tests/test_api_sources.py tests/test_api_operator_policy.py tests/test_api_cross_tenant_matrix.py tests/test_core.py::test_api_posture_counts_empty tests/test_core.py::test_api_posture_counts_with_data tests/test_core.py::test_api_posture_counts_ci_cd_only_is_not_treated_as_local_runtime -q`
- `uv run pytest tests/ -q -m "not network"` (`8240 passed, 18 skipped, 12 deselected`)
- `git diff --check`
