### PR TITLE
fix: publish control-plane storage schema readiness

### DIFF
--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -140,6 +140,17 @@ and restore-drill cadence.
 
 See `site-docs/deployment/backup-restore.md` for the operator runbook.
 
+## Storage Schema And Upgrade Readiness
+
+The control plane exposes a non-secret storage schema manifest in
+`GET /v1/auth/policy` under `storage_schema`. SQLite and Postgres control-plane
+stores record component versions in `control_plane_schema_versions`; graph
+storage keeps its legacy `graph_schema_version` marker and is also listed in
+the manifest; ClickHouse analytics creates the same schema-version table for
+analytics readiness checks. Operators should capture this surface before and
+after rolling upgrades so schema drift is visible alongside release, Helm, and
+container version checks.
+
 ## Procurement Package
 
 A procurement packet should include:

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -27,6 +27,8 @@ from datetime import datetime, timezone
 from typing import Protocol
 from uuid import uuid4
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
 logger = logging.getLogger(__name__)
 _AUDIT_DETAIL_KEY_RE = re.compile(r"[^a-zA-Z0-9_.:-]+")
 _MAX_AUDIT_DETAIL_KEYS = 64
@@ -384,6 +386,7 @@ class SQLiteAuditLog:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "audit_log")
         self._conn.execute("""CREATE TABLE IF NOT EXISTS audit_log (
             entry_id TEXT PRIMARY KEY,
             timestamp TEXT NOT NULL,

--- a/src/agent_bom/api/exception_store.py
+++ b/src/agent_bom/api/exception_store.py
@@ -20,6 +20,8 @@ from enum import Enum
 from typing import Protocol
 from uuid import uuid4
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
 logger = logging.getLogger(__name__)
 
 
@@ -156,6 +158,7 @@ class SQLiteExceptionStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "exceptions")
         self._conn.execute("""CREATE TABLE IF NOT EXISTS exceptions (
             exception_id TEXT PRIMARY KEY,
             vuln_id TEXT NOT NULL,

--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -14,6 +14,7 @@ from typing import Protocol
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
 
 # ─── Models ──────────────────────────────────────────────────────────────────
@@ -250,6 +251,7 @@ class SQLiteFleetStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "fleet")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS fleet_agents (
                 agent_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/idempotency_store.py
+++ b/src/agent_bom/api/idempotency_store.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
 
 @dataclass
 class IdempotencyRecord:
@@ -74,6 +76,7 @@ class SQLiteIdempotencyStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "idempotency")
         self._conn.execute(
             """
             CREATE TABLE IF NOT EXISTS idempotency_keys (

--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -8,6 +8,7 @@ from typing import Protocol
 
 from pydantic import BaseModel, Field, field_validator
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
 
 
@@ -135,6 +136,7 @@ class SQLiteMCPObservationStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "mcp_observations")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS mcp_observations (
                 tenant_id TEXT NOT NULL,

--- a/src/agent_bom/api/policy_store.py
+++ b/src/agent_bom/api/policy_store.py
@@ -13,6 +13,8 @@ from typing import Protocol
 
 from pydantic import BaseModel
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
 # ── Models ────────────────────────────────────────────────────────────────────
 
 
@@ -181,6 +183,7 @@ class SQLitePolicyStore:
 
     def _init_db(self) -> None:
         c = self._conn
+        ensure_sqlite_schema_version(c, "gateway_policies")
         c.execute(
             """CREATE TABLE IF NOT EXISTS gateway_policies (
                 policy_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/postgres_access.py
+++ b/src/agent_bom/api/postgres_access.py
@@ -6,6 +6,7 @@ import json
 
 from agent_bom.api.auth import ApiKey, Role, verify_api_key
 from agent_bom.api.exception_store import ExceptionStatus, VulnException
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
 from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection, bypass_tenant_rls
 
@@ -19,6 +20,7 @@ class PostgresKeyStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "api_keys")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS api_keys (
                     key_id TEXT PRIMARY KEY,
@@ -225,6 +227,7 @@ class PostgresExceptionStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "exceptions")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS exceptions (
                     exception_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from agent_bom.api.audit_log import AuditEntry
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.baseline import TrendPoint
 
 from .postgres_common import _current_tenant, _ensure_tenant_rls, _get_pool, _tenant_connection
@@ -21,6 +22,7 @@ class PostgresAuditLog:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "audit_log")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS audit_log (
                     entry_id TEXT PRIMARY KEY,
@@ -175,6 +177,7 @@ class PostgresTrendStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "trend_history")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS trend_history (
                     id BIGSERIAL PRIMARY KEY,

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from agent_bom.api.graph_store import _escape_like_query, _node_search_text, decode_graph_cursor, encode_graph_cursor
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
 from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
 
@@ -21,6 +22,7 @@ class PostgresGraphStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "graph")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS graph_nodes (

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
 from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
 
 
@@ -17,6 +19,7 @@ class PostgresPolicyStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "gateway_policies")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS gateway_policies (
                     policy_id TEXT PRIMARY KEY,
@@ -189,6 +192,7 @@ class PostgresScheduleStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "schedules")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS scan_schedules (
                     schedule_id TEXT PRIMARY KEY,
@@ -290,6 +294,7 @@ class PostgresSourceStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "sources")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS control_plane_sources (
                     source_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/postgres_scim.py
+++ b/src/agent_bom/api/postgres_scim.py
@@ -6,6 +6,7 @@ import json
 
 from agent_bom.api.postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.scim_store import SCIMGroup, SCIMUser
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.platform_invariants import normalize_tenant_id, now_utc_iso
 
 
@@ -18,6 +19,7 @@ class PostgresSCIMStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "identity_scim")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS scim_users (
                     tenant_id TEXT NOT NULL,

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -31,6 +31,7 @@ from agent_bom.api.postgres_common import (
 from agent_bom.api.postgres_graph import PostgresGraphStore, PostgresScanCache
 from agent_bom.api.postgres_policy import PostgresPolicyStore, PostgresScheduleStore, PostgresSourceStore  # noqa: F401
 from agent_bom.api.postgres_tenant_quota import PostgresTenantQuotaStore  # noqa: F401
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
 _JOB_TTL_SECONDS = 3600
 
@@ -47,6 +48,7 @@ class PostgresJobStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "scan_jobs")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS scan_jobs (
                     job_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/postgres_tenant_quota.py
+++ b/src/agent_bom/api/postgres_tenant_quota.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Mapping
 
 from agent_bom.api.postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
 
 class PostgresTenantQuotaStore:
@@ -17,6 +18,7 @@ class PostgresTenantQuotaStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "tenant_quotas")
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS tenant_quota_overrides (
                     tenant_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -484,6 +484,7 @@ async def auth_policy(request: Request) -> dict:
     from agent_bom.api.saml import describe_saml_posture
     from agent_bom.api.scim import describe_scim_posture
     from agent_bom.api.secret_lifecycle import describe_secret_lifecycle_posture
+    from agent_bom.api.storage_schema import describe_control_plane_storage_schema
     from agent_bom.api.tenant_quota import default_tenant_quotas, get_tenant_quota_runtime
 
     api_policy = get_api_key_policy()
@@ -525,6 +526,7 @@ async def auth_policy(request: Request) -> dict:
         "secret_lifecycle": describe_secret_lifecycle_posture(),
         "tenant_quotas": defaults,
         "tenant_quota_runtime": get_tenant_quota_runtime(tenant_id),
+        "storage_schema": describe_control_plane_storage_schema(),
         "identity_provisioning": {
             "oidc": describe_oidc_posture(),
             "saml": describe_saml_posture(),

--- a/src/agent_bom/api/schedule_store.py
+++ b/src/agent_bom/api/schedule_store.py
@@ -11,6 +11,8 @@ from typing import Protocol
 
 from pydantic import BaseModel
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
 
 class ScanSchedule(BaseModel):
     """Recurring scan schedule."""
@@ -92,6 +94,7 @@ class SQLiteScheduleStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "schedules")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS schedules (
                 schedule_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/scim_store.py
+++ b/src/agent_bom/api/scim_store.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol
 
 from pydantic import BaseModel, Field, field_validator
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.platform_invariants import normalize_tenant_id, now_utc_iso
 
 
@@ -137,6 +138,7 @@ class SQLiteSCIMStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "identity_scim")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS scim_users (
                 tenant_id TEXT NOT NULL,

--- a/src/agent_bom/api/source_store.py
+++ b/src/agent_bom/api/source_store.py
@@ -7,6 +7,7 @@ import threading
 from typing import Protocol
 
 from agent_bom.api.models import SourceRecord
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 
 
 class SourceStore(Protocol):
@@ -59,6 +60,7 @@ class SQLiteSourceStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "sources")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS sources (
                 source_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -1,0 +1,124 @@
+"""Control-plane storage schema manifest and version helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+CONTROL_PLANE_SCHEMA_VERSION = 1
+CONTROL_PLANE_SCHEMA_TABLE = "control_plane_schema_versions"
+
+
+@dataclass(frozen=True)
+class StorageSchemaComponent:
+    """Operator-visible storage contract for one control-plane component."""
+
+    component: str
+    backend: str
+    tables: tuple[str, ...]
+    tenant_scoped: bool = True
+    version: int = CONTROL_PLANE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "component": self.component,
+            "backend": self.backend,
+            "tables": list(self.tables),
+            "tenant_scoped": self.tenant_scoped,
+            "version": self.version,
+        }
+
+
+CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
+    StorageSchemaComponent("scan_jobs", "sqlite/postgres", ("jobs", "scan_jobs", "cis_benchmark_checks")),
+    StorageSchemaComponent("api_keys", "postgres", ("api_keys",)),
+    StorageSchemaComponent("audit_log", "sqlite/postgres", ("audit_log",)),
+    StorageSchemaComponent("trend_history", "postgres", ("trend_history",)),
+    StorageSchemaComponent("gateway_policies", "sqlite/postgres", ("gateway_policies", "policy_audit_log")),
+    StorageSchemaComponent("fleet", "sqlite/postgres/clickhouse", ("fleet_agents",)),
+    StorageSchemaComponent("graph", "sqlite/postgres", ("graph_nodes", "graph_edges", "graph_node_search")),
+    StorageSchemaComponent("identity_scim", "sqlite/postgres", ("scim_users", "scim_groups")),
+    StorageSchemaComponent("tenant_quotas", "sqlite/postgres", ("tenant_quota_overrides",)),
+    StorageSchemaComponent("sources", "sqlite/postgres", ("sources", "control_plane_sources")),
+    StorageSchemaComponent("schedules", "sqlite/postgres", ("schedules", "scan_schedules")),
+    StorageSchemaComponent("exceptions", "sqlite/postgres", ("vuln_exceptions",)),
+    StorageSchemaComponent("idempotency", "sqlite", ("idempotency_keys",)),
+    StorageSchemaComponent("mcp_observations", "sqlite", ("mcp_observations",)),
+    StorageSchemaComponent(
+        "analytics",
+        "clickhouse",
+        ("vulnerability_scans", "runtime_events", "posture_scores", "scan_metadata", "cis_benchmark_checks"),
+    ),
+    StorageSchemaComponent("warehouse", "snowflake", ("snowflake_posture_snapshots", "snowflake_control_plane_events")),
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_sqlite_schema_version(conn: Any, component: str, version: int = CONTROL_PLANE_SCHEMA_VERSION) -> None:
+    """Record the current schema version for a SQLite control-plane component."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS control_plane_schema_versions (
+            component TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO control_plane_schema_versions (component, version, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(component) DO UPDATE SET
+            version = excluded.version,
+            updated_at = excluded.updated_at
+        """,
+        (component, int(version), _now_iso()),
+    )
+
+
+def ensure_postgres_schema_version(conn: Any, component: str, version: int = CONTROL_PLANE_SCHEMA_VERSION) -> None:
+    """Record the current schema version for a Postgres control-plane component."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS control_plane_schema_versions (
+            component TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO control_plane_schema_versions (component, version, updated_at)
+        VALUES (%s, %s, now())
+        ON CONFLICT (component) DO UPDATE SET
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at
+        """,
+        (component, int(version)),
+    )
+
+
+def describe_control_plane_storage_schema() -> dict[str, Any]:
+    """Return a non-secret schema contract for operator and release checks."""
+
+    components = [component.to_dict() for component in CONTROL_PLANE_SCHEMA_COMPONENTS]
+    return {
+        "schema_version": CONTROL_PLANE_SCHEMA_VERSION,
+        "schema_table": CONTROL_PLANE_SCHEMA_TABLE,
+        "components": components,
+        "component_count": len(components),
+        "upgrade_policy": "idempotent_bootstrap_migrations_with_explicit_component_versions",
+        "operator_message": (
+            "Each persistent control-plane backend should expose this schema table or an equivalent native "
+            "version marker before rolling upgrades. Graph keeps its legacy graph_schema_version table and is "
+            "also listed here for release-readiness checks."
+        ),
+    }

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -12,6 +12,8 @@ import threading
 from datetime import datetime, timezone
 from typing import Protocol
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
 from .server import JobStatus, ScanJob
 
 _JOB_TTL_SECONDS = 3600  # 1 hour
@@ -123,6 +125,7 @@ class SQLiteJobStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "scan_jobs")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS jobs (
                 job_id TEXT PRIMARY KEY,

--- a/src/agent_bom/api/tenant_quota_store.py
+++ b/src/agent_bom/api/tenant_quota_store.py
@@ -8,6 +8,8 @@ import threading
 from collections.abc import Mapping
 from typing import Protocol
 
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
 
 class TenantQuotaStore(Protocol):
     """Protocol for tenant quota override persistence."""
@@ -50,6 +52,7 @@ class SQLiteTenantQuotaStore:
         return self._local.conn
 
     def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "tenant_quotas")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS tenant_quota_overrides (
                 tenant_id TEXT PRIMARY KEY,

--- a/src/agent_bom/cloud/clickhouse.py
+++ b/src/agent_bom/cloud/clickhouse.py
@@ -119,6 +119,7 @@ class ClickHouseClient:
                 # error on repeat runs; log and continue so ensure_tables
                 # stays safe to call on every process start.
                 logger.debug("ClickHouse migration skipped (%s): %s", exc, migration.split("\n", 1)[0])
+        self.execute("INSERT INTO control_plane_schema_versions (component, version) VALUES ('analytics', 1)")
         logger.info("ClickHouse analytics tables ensured in database '%s'", self.database)
 
 
@@ -127,6 +128,14 @@ class ClickHouseClient:
 # ------------------------------------------------------------------
 
 _TABLE_DDL: list[str] = [
+    # 0. Control-plane schema inventory for release/upgrade readiness checks.
+    """\
+CREATE TABLE IF NOT EXISTS control_plane_schema_versions (
+    component String,
+    version UInt16,
+    updated_at DateTime DEFAULT now()
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY component""",
     # 1. Vulnerability scan results (append-only)
     """\
 CREATE TABLE IF NOT EXISTS vulnerability_scans (

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -9,6 +9,7 @@ Covers:
 from __future__ import annotations
 
 import importlib
+import sqlite3
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -22,6 +23,12 @@ from agent_bom.api import server as _server_mod
 from agent_bom.api import stores as _stores
 from agent_bom.api.middleware import APIKeyMiddleware, get_rate_limit_key_status, get_rate_limit_runtime_status
 from agent_bom.api.server import app
+from agent_bom.api.storage_schema import (
+    CONTROL_PLANE_SCHEMA_TABLE,
+    CONTROL_PLANE_SCHEMA_VERSION,
+    describe_control_plane_storage_schema,
+    ensure_sqlite_schema_version,
+)
 from agent_bom.api.stores import set_tenant_quota_store
 from agent_bom.api.tenant_quota_store import InMemoryTenantQuotaStore
 from tests.auth_helpers import PROXY_SECRET, proxy_headers
@@ -209,6 +216,12 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["status"] in {"ok", "near_limit", "at_limit", "unlimited"}
     assert body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]["utilization_pct"] is not None
     assert "recommended_action" in body["tenant_quota_runtime"]["usage"]["active_scan_jobs"]
+    assert body["storage_schema"]["schema_version"] == CONTROL_PLANE_SCHEMA_VERSION
+    assert body["storage_schema"]["schema_table"] == CONTROL_PLANE_SCHEMA_TABLE
+    assert body["storage_schema"]["component_count"] >= 10
+    assert {"scan_jobs", "audit_log", "graph", "identity_scim", "analytics"} <= {
+        component["component"] for component in body["storage_schema"]["components"]
+    }
     assert body["identity_provisioning"]["oidc"]["mode"] == "disabled"
     assert body["identity_provisioning"]["saml"]["configured"] is False
     assert body["identity_provisioning"]["scim"]["status"] == "disabled"
@@ -512,6 +525,23 @@ def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
     assert middleware._required_scope("GET", "/v1/tenant/tenant-a/data") == "privacy.data:read"
     assert middleware._required_scope("DELETE", "/v1/tenant/tenant-a/data") == "privacy.data:delete"
     assert middleware._required_role("GET", "/v1/auth/debug") == "viewer"
+
+
+def test_storage_schema_manifest_has_unique_components() -> None:
+    manifest = describe_control_plane_storage_schema()
+    components = manifest["components"]
+    names = [component["component"] for component in components]
+    assert len(names) == len(set(names))
+    assert manifest["schema_table"] == "control_plane_schema_versions"
+    assert all(component["version"] == CONTROL_PLANE_SCHEMA_VERSION for component in components)
+
+
+def test_sqlite_schema_version_helper_is_idempotent() -> None:
+    conn = sqlite3.connect(":memory:")
+    ensure_sqlite_schema_version(conn, "scan_jobs")
+    ensure_sqlite_schema_version(conn, "scan_jobs")
+    rows = conn.execute(f"SELECT component, version FROM {CONTROL_PLANE_SCHEMA_TABLE}").fetchall()
+    assert rows == [("scan_jobs", CONTROL_PLANE_SCHEMA_VERSION)]
 
 
 def test_metrics_requires_authenticated_access(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -182,8 +182,8 @@ class TestClickHouseClient:
 
         with patch("agent_bom.http_client.sync_request_with_retry", return_value=_mock_response("")) as mock_req:
             c.ensure_tables()
-            # 1 CREATE DATABASE + N CREATE TABLE + M ALTER forward-compat migrations
-            expected = 1 + len(_TABLE_DDL) + len(_TABLE_MIGRATIONS)
+            # 1 CREATE DATABASE + N CREATE TABLE + M ALTER migrations + schema-version marker
+            expected = 1 + len(_TABLE_DDL) + len(_TABLE_MIGRATIONS) + 1
             assert mock_req.call_count == expected
 
 

--- a/tests/test_clickhouse_tenant_isolation.py
+++ b/tests/test_clickhouse_tenant_isolation.py
@@ -275,12 +275,13 @@ class TestMigrationCoverage:
 
         client.execute = _fake_execute  # type: ignore[assignment]
         client.ensure_tables()
-        # Must run: CREATE DATABASE + every CREATE TABLE DDL + every migration
-        expected_calls = 1 + len(_TABLE_DDL) + len(_TABLE_MIGRATIONS)
+        # Must run: CREATE DATABASE + every CREATE TABLE DDL + every migration + schema-version marker
+        expected_calls = 1 + len(_TABLE_DDL) + len(_TABLE_MIGRATIONS) + 1
         assert len(executed) == expected_calls, (
             f"ensure_tables should execute CREATE DATABASE + {len(_TABLE_DDL)} tables + "
-            f"{len(_TABLE_MIGRATIONS)} migrations = {expected_calls} statements, "
+            f"{len(_TABLE_MIGRATIONS)} migrations + schema marker = {expected_calls} statements, "
             f"got {len(executed)}"
         )
         migrations_run = [stmt for stmt in executed if stmt.startswith("ALTER TABLE ")]
         assert set(migrations_run) == set(_TABLE_MIGRATIONS)
+        assert executed[-1] == "INSERT INTO control_plane_schema_versions (component, version) VALUES ('analytics', 1)"

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -71,6 +71,8 @@ class MockConnection:
                     table = "trend_history"
                 elif "scan_schedules" in sql:
                     table = "scan_schedules"
+                elif "control_plane_schema_versions" in sql:
+                    table = "control_plane_schema_versions"
                 elif "osv_cache" in sql:
                     table = "osv_cache"
                 if table not in self._store:
@@ -138,9 +140,23 @@ class MockConnection:
                         prefix = str(params[0]).rstrip("%")
                         rows = [r for r in rows if str(r[4]).startswith(prefix)]
                 cursor.rows = [(r[0], r[1], r[2], r[3], r[4], r[6], r[7], r[8]) for r in rows]
+            elif "distinct on (team_id)" in sql_lower and "from audit_log" in sql_lower:
+                rows = list(self._store.get("audit_log", {}).values())
+                latest: dict[str, tuple] = {}
+                for row in rows:
+                    latest[str(row[5])] = row
+                cursor.rows = [(tenant_id, row[8]) for tenant_id, row in latest.items()]
             elif "from trend_history" in sql_lower:
                 rows = list(self._store.get("trend_history", {}).values())
                 cursor.rows = [(r[0], r[2], r[3], r[4], r[5], r[6], r[7], r[8]) for r in rows]
+            elif "from scan_schedules" in sql_lower:
+                rows = list(self._store.get("scan_schedules", {}).values())
+                if params:
+                    if "schedule_id = %s" in sql_lower:
+                        rows = [r for r in rows if r[0] == params[0]]
+                    elif "tenant_id = %s" in sql_lower:
+                        rows = [r for r in rows if r[3] == params[0]]
+                cursor.rows = [(r[-1],) for r in rows]
             elif "from scan_jobs" in sql_lower and "job_id, team_id, status, created_at, completed_at, triggered_by" in sql_lower:
                 rows = list(self._store.get("scan_jobs", {}).values())
                 cursor.rows = [(r[0], r[1], r[2], r[3], r[4], (r[5] if len(r) > 6 else None)) for r in rows]


### PR DESCRIPTION
Summary
- add a control-plane storage schema manifest and schema-version helpers
- record schema component versions from SQLite/Postgres stores and ClickHouse analytics bootstrap
- expose storage_schema in /v1/auth/policy and document the upgrade-readiness check

Validation
- uv run ruff check src/agent_bom/api/storage_schema.py src/agent_bom/cloud/clickhouse.py src/agent_bom/api/postgres_store.py tests/test_api_operator_policy.py
- uv run pytest tests/test_api_operator_policy.py -q
- uv run pytest tests/test_api_operator_policy.py tests/test_api_gateway.py tests/test_gateway.py tests/test_api_hardening.py tests/test_api_compliance_auth.py tests/test_gateway_auth_tenant_e2e.py -q
- git diff --check
- pre-commit hooks: ruff, ruff-format, mypy, bandit