### PR TITLE
fix: remove browser api-key storage fallback

### DIFF
--- a/docs/adr/006-ui-auth-model.md
+++ b/docs/adr/006-ui-auth-model.md
@@ -13,7 +13,7 @@ The packaged dashboard shipped without a defined browser authentication model. T
 The control-plane UI uses two supported browser auth modes:
 
 1. Recommended for enterprise: same-origin reverse-proxy OIDC or SSO session. The reverse proxy terminates browser auth, keeps the session cookie, and injects trusted `X-Agent-Bom-Role` and `X-Agent-Bom-Tenant-ID` headers to the backend. `AGENT_BOM_TRUST_PROXY_AUTH=1` must be enabled on the API for this mode.
-2. Fallback for local and single-user pilots: a short-lived API key entered into the dashboard. The UI first exchanges it for a same-origin `httpOnly` browser session cookie. Legacy `sessionStorage` forwarding is disabled by default and must be explicitly enabled with `window.__AGENT_BOM_CONFIG__.allowSessionStorageApiKey = true` or `NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY=1`; when enabled, the UI forwards the key as `Authorization: Bearer <key>` for HTTP calls and `?token=` only for legacy proxy WebSocket surfaces.
+2. Fallback for local and single-user pilots: a short-lived API key entered into the dashboard. The UI exchanges it for a same-origin `httpOnly` browser session cookie and never stores or forwards the raw key from browser storage.
 
 The UI always sends `credentials: "include"` over same-origin fetch/EventSource URLs so same-origin proxy sessions work without custom browser configuration and browser credentials cannot be redirected through runtime config. A global auth gate now blocks dashboard routes until one of the supported auth modes succeeds.
 
@@ -23,7 +23,7 @@ The UI always sends `credentials: "include"` over same-origin fetch/EventSource 
 
 - The browser auth story is explicit and consistent across backend, runtime config, and UI behavior.
 - Enterprise ingress can use OIDC without exposing raw API keys to end users.
-- Single-user pilots still have an explicit API-key fallback, but deployments must opt in before the browser stores the key.
+- Single-user pilots still have an explicit API-key exchange without a browser-readable bearer-token cache.
 
 ### Negative
 

--- a/site-docs/architecture/auth-and-session-model.md
+++ b/site-docs/architecture/auth-and-session-model.md
@@ -68,7 +68,7 @@ These are the code-backed control-plane access modes today.
 | **Trusted reverse proxy** | enterprise same-origin ingress | reverse proxy authenticates user, injects trusted `X-Agent-Bom-*` headers | best current operator UX |
 | **OIDC bearer** | direct API/browser integration with corporate IdP | API verifies JWT issuer, audience, role, and tenant claim | secure, but more operator wiring |
 | **SAML -> short-lived API key** | SAML-only environments | SAML assertion is verified, then converted into a short-lived control-plane key | workable, but not a full browser session framework |
-| **Session-only API key fallback** | local single-user or pilot setups | browser stores an API key in `sessionStorage`, API verifies it on every request | convenience mode, not the preferred enterprise path |
+| **Browser session API-key exchange** | local single-user or pilot setups | API key is exchanged for a same-origin `httpOnly` browser session cookie | convenience mode, not the preferred enterprise path |
 
 The current UI auth helper lives in:
 
@@ -76,9 +76,9 @@ The current UI auth helper lives in:
 
 That fallback is intentionally narrow:
 
-- it uses `sessionStorage`
+- it does not store or replay raw API keys from browser storage
 - it does not make the browser a trust anchor
-- the API still verifies the key and role on every request
+- the API verifies the exchanged session and role on every request
 
 For the self-hosted data-ownership and support-sharing contract around these
 sessions, see [Customer Data and Support Boundary](../deployment/customer-data-and-support-boundary.md).

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -508,14 +508,15 @@ async def auth_policy(request: Request) -> dict:
             "recommended_mode": auth_runtime["recommended_ui_mode"],
             "configured_modes": auth_runtime["configured_modes"],
             "browser_session": "signed_http_only_cookie",
-            "session_storage_fallback": "legacy_static_export_only",
+            "session_storage_fallback": "disabled",
             "credentials_mode": "include",
             "trusted_proxy_headers": ["X-Agent-Bom-Role", "X-Agent-Bom-Tenant-ID", "X-Agent-Bom-Proxy-Secret"],
             "trusted_proxy_secret_env": "AGENT_BOM_TRUST_PROXY_AUTH_SECRET",
             "message": (
                 "Recommended browser auth is same-origin reverse-proxy OIDC with the proxy injecting trusted "
                 "X-Agent-Bom-* headers plus X-Agent-Bom-Proxy-Secret attestation. For single-user local or pilot "
-                "access, the UI exchanges an API key for a signed, expiring, CSRF-bound httpOnly browser session cookie."
+                "access, the UI exchanges an API key for a signed, expiring, CSRF-bound httpOnly browser session cookie "
+                "without storing the key in browser storage."
             ),
         },
         "rate_limit_runtime": rl_runtime,

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -173,7 +173,7 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["rate_limit_key"]["status"] in {"ok", "ephemeral", "unknown_age", "rotation_due", "max_age_exceeded"}
     assert body["ui"]["recommended_mode"] in {"no_auth", "reverse_proxy_oidc", "oidc_bearer", "session_api_key"}
     assert body["ui"]["browser_session"] == "signed_http_only_cookie"
-    assert body["ui"]["session_storage_fallback"] == "legacy_static_export_only"
+    assert body["ui"]["session_storage_fallback"] == "disabled"
     assert body["audit_hmac"]["rotation_tracking_supported"] is True
     assert body["rate_limit_runtime"]["backend"] in {"inmemory_single_process", "postgres_shared"}
     assert "shared_across_replicas" in body["rate_limit_runtime"]

--- a/ui/README.md
+++ b/ui/README.md
@@ -44,7 +44,7 @@ paths to the backend service without rebuilding the UI image.
 The dashboard supports two browser auth modes:
 
 - Recommended: same-origin reverse-proxy OIDC/session auth. The proxy keeps the browser session and injects trusted `X-Agent-Bom-Role` plus `X-Agent-Bom-Tenant-ID` headers to the API. Enable `AGENT_BOM_TRUST_PROXY_AUTH=1` on the backend for this mode.
-- Local-only fallback: a short-lived API key entered into the dashboard. The UI first exchanges it for a same-origin `httpOnly` browser session cookie. Legacy `sessionStorage` forwarding is disabled by default and must be explicitly enabled with `window.__AGENT_BOM_CONFIG__.allowSessionStorageApiKey = true` or `NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY=1` for single-user static pilots only.
+- Local-only fallback: a short-lived API key entered into the dashboard. The UI exchanges it for a same-origin `httpOnly` browser session cookie and never stores or forwards the raw key from browser storage.
 
 All browser fetches and EventSource streams use same-origin URLs plus `credentials: "include"` so proxy-managed sessions work without custom patches and runtime config cannot redirect browser credentials to a different origin.
 

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { KeyRound, Loader2, Lock, ShieldCheck } from "lucide-react";
 
 import { useAuthState } from "@/components/auth-provider";
 import { api } from "@/lib/api";
-import { clearSessionApiKey, getSessionApiKey, setSessionApiKey } from "@/lib/auth";
-import { allowSessionStorageApiKeyFallback } from "@/lib/runtime-config";
+import { clearSessionApiKey } from "@/lib/auth";
 
 function isAuthFailure(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -17,13 +16,6 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   const { session, loading, error, refresh } = useAuthState();
   const [apiKey, setApiKey] = useState("");
   const [formError, setFormError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const stored = getSessionApiKey();
-    if (stored) {
-      setApiKey(stored);
-    }
-  }, []);
 
   if (loading) {
     return (
@@ -76,13 +68,9 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
                   clearSessionApiKey();
                 } catch (nextError) {
                   const message = nextError instanceof Error ? nextError.message : "Failed to create browser session";
-                  if ((message.includes("404") || message.includes("405")) && allowSessionStorageApiKeyFallback()) {
-                    setSessionApiKey(apiKey);
-                  } else if (message.includes("404") || message.includes("405")) {
+                  if (message.includes("404") || message.includes("405")) {
                     clearSessionApiKey();
-                    setFormError(
-                      "Browser session endpoint unavailable; sessionStorage API-key fallback is disabled for this deployment."
-                    );
+                    setFormError("Browser session endpoint unavailable; update the API before using browser API-key exchange.");
                     return;
                   } else {
                     clearSessionApiKey();
@@ -95,15 +83,18 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             >
               <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-zinc-200">
                 <KeyRound className="h-4 w-4 text-amber-300" />
-                Browser session fallback
+                Browser session
               </div>
               <p className="mb-4 text-sm leading-6 text-zinc-400">
                 Creates a same-origin
                 <code className="mx-1 rounded bg-zinc-950 px-1 py-0.5 font-mono text-zinc-200">httpOnly</code>
-                cookie. Legacy tab storage must be explicitly enabled by the deployment.
+                cookie. The API key is exchanged with the control plane and is never stored in browser storage.
               </p>
-              <label className="mb-3 block text-xs uppercase tracking-[0.2em] text-zinc-500">API key</label>
+              <label htmlFor="agent-bom-browser-session-api-key" className="mb-3 block text-xs uppercase tracking-[0.2em] text-zinc-500">
+                API key
+              </label>
               <input
+                id="agent-bom-browser-session-api-key"
                 type="password"
                 value={apiKey}
                 onChange={(event) => setApiKey(event.target.value)}

--- a/ui/lib/auth.ts
+++ b/ui/lib/auth.ts
@@ -1,6 +1,3 @@
-import { allowSessionStorageApiKeyFallback } from "@/lib/runtime-config";
-
-const SESSION_API_KEY = "agent-bom-ui-api-key";
 const CSRF_COOKIE = "agent_bom_csrf";
 
 function hasWindow(): boolean {
@@ -8,35 +5,15 @@ function hasWindow(): boolean {
 }
 
 export function getSessionApiKey(): string {
-  if (!hasWindow() || !allowSessionStorageApiKeyFallback()) return "";
-  try {
-    return window.sessionStorage.getItem(SESSION_API_KEY)?.trim() ?? "";
-  } catch {
-    return "";
-  }
+  return "";
 }
 
 export function setSessionApiKey(rawKey: string): void {
-  if (!hasWindow()) return;
-  const value = rawKey.trim();
-  try {
-    if (!value || !allowSessionStorageApiKeyFallback()) {
-      window.sessionStorage.removeItem(SESSION_API_KEY);
-      return;
-    }
-    window.sessionStorage.setItem(SESSION_API_KEY, value);
-  } catch {
-    // Ignore storage failures; the user can still retry within the current render.
-  }
+  void rawKey;
 }
 
 export function clearSessionApiKey(): void {
-  if (!hasWindow()) return;
-  try {
-    window.sessionStorage.removeItem(SESSION_API_KEY);
-  } catch {
-    // Ignore storage failures; best-effort cleanup only.
-  }
+  return;
 }
 
 export function getSessionAuthHeaders(): Record<string, string> {
@@ -49,7 +26,7 @@ export function getSessionAuthHeaders(): Record<string, string> {
 }
 
 export function getSessionWebSocketToken(): string {
-  return getSessionApiKey();
+  return "";
 }
 
 export function getBrowserCsrfToken(): string {

--- a/ui/lib/runtime-config.ts
+++ b/ui/lib/runtime-config.ts
@@ -2,7 +2,6 @@ declare global {
   interface Window {
     __AGENT_BOM_CONFIG__?: {
       apiUrl?: string;
-      allowSessionStorageApiKey?: boolean;
     };
   }
 }
@@ -51,11 +50,4 @@ export function getConfiguredApiUrl(): string {
 
 export function getDisplayApiUrl(): string {
   return getConfiguredApiUrl() || DEFAULT_API_URL;
-}
-
-export function allowSessionStorageApiKeyFallback(): boolean {
-  if (typeof window !== "undefined" && typeof window.__AGENT_BOM_CONFIG__?.allowSessionStorageApiKey === "boolean") {
-    return window.__AGENT_BOM_CONFIG__.allowSessionStorageApiKey;
-  }
-  return process.env.NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY === "1";
 }

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { api } from '@/lib/api'
-import { setSessionApiKey, clearSessionApiKey } from '@/lib/auth'
+import { clearSessionApiKey, setSessionApiKey } from '@/lib/auth'
 
 // ─── Mock fetch globally ───────────────────────────────────────────────────────
 
@@ -28,7 +28,6 @@ const originalFetch = global.fetch
 afterEach(() => {
   global.fetch = originalFetch
   window.__AGENT_BOM_CONFIG__ = undefined
-  delete process.env.NEXT_PUBLIC_ALLOW_SESSION_STORAGE_API_KEY
   clearSessionApiKey()
   vi.restoreAllMocks()
 })
@@ -136,8 +135,7 @@ describe('api.listJobs', () => {
     expect(result.count).toBe(1)
   })
 
-  it('propagates a session API key and browser credentials', async () => {
-    window.__AGENT_BOM_CONFIG__ = { allowSessionStorageApiKey: true }
+  it('does not propagate browser-stored API keys and relies on same-origin credentials', async () => {
     setSessionApiKey("pilot-key-123")
     const fetchMock = mockFetch({ jobs: [], count: 0 })
     global.fetch = fetchMock
@@ -148,13 +146,14 @@ describe('api.listJobs', () => {
       "/v1/jobs",
       expect.objectContaining({
         credentials: "include",
-        headers: expect.objectContaining({ Authorization: "Bearer pilot-key-123" }),
+        headers: {},
         signal: expect.any(AbortSignal),
       }),
     )
   })
 
-  it('does not propagate sessionStorage API keys unless explicitly enabled', async () => {
+  it('ignores legacy browser token setter paths', async () => {
+    window.__AGENT_BOM_CONFIG__ = { apiUrl: "" }
     setSessionApiKey("pilot-key-123")
     const fetchMock = mockFetch({ jobs: [], count: 0 })
     global.fetch = fetchMock
@@ -383,8 +382,7 @@ describe('api key lifecycle helpers', () => {
 })
 
 describe('api.downloadScanGraph', () => {
-  it('downloads graph export with session auth headers', async () => {
-    window.__AGENT_BOM_CONFIG__ = { allowSessionStorageApiKey: true }
+  it('downloads graph export with same-origin browser credentials only', async () => {
     setSessionApiKey('pilot-key-123')
     const fetchMock = mockBlobFetch('{"nodes":[],"edges":[]}')
     global.fetch = fetchMock
@@ -396,7 +394,7 @@ describe('api.downloadScanGraph', () => {
       '/v1/scan/job-1/graph-export?format=json',
       expect.objectContaining({
         credentials: 'include',
-        headers: expect.objectContaining({ Authorization: 'Bearer pilot-key-123' }),
+        headers: {},
         signal: expect.any(AbortSignal),
       }),
     )

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 
 import { AuthGate } from "@/components/auth-gate";
 import { AuthProvider } from "@/components/auth-provider";
-import { clearSessionApiKey, setSessionApiKey } from "@/lib/auth";
+import { clearSessionApiKey } from "@/lib/auth";
 
 const originalFetch = global.fetch;
 
@@ -48,9 +48,7 @@ describe("AuthGate", () => {
     await waitFor(() => expect(screen.getByText("protected surface")).toBeInTheDocument());
   });
 
-  it("shows the session API key fallback when the API returns 401", async () => {
-    window.__AGENT_BOM_CONFIG__ = { allowSessionStorageApiKey: true };
-    setSessionApiKey("stale-key")
+  it("shows the browser session form when the API returns 401 without prefilled browser storage", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 401,
@@ -67,6 +65,6 @@ describe("AuthGate", () => {
     );
 
     await waitFor(() => expect(screen.getByText("Control-plane authentication required")).toBeInTheDocument());
-    expect(screen.getByDisplayValue("stale-key")).toBeInTheDocument();
+    expect(screen.getByLabelText("API key")).toHaveValue("");
   });
 });

--- a/ui/tests/key-lifecycle-panel.test.tsx
+++ b/ui/tests/key-lifecycle-panel.test.tsx
@@ -31,7 +31,7 @@ const policy: AuthPolicyResponse = {
     recommended_mode: "reverse_proxy_oidc",
     configured_modes: ["trusted_proxy", "api_key"],
     browser_session: "signed_http_only_cookie",
-    session_storage_fallback: "legacy_static_export_only",
+    session_storage_fallback: "disabled",
     credentials_mode: "include",
     trusted_proxy_headers: ["X-Agent-Bom-Role", "X-Agent-Bom-Tenant-ID"],
     message: "Recommended browser auth is same-origin reverse-proxy OIDC.",


### PR DESCRIPTION
Summary
- remove browser sessionStorage/API-key forwarding fallback from the UI
- keep browser API-key entry as an exchange into the same-origin httpOnly session cookie only
- update auth policy/docs/tests to report session_storage_fallback=disabled
- add label binding for the API-key auth form input

Validation
- uv run ruff check src/agent_bom/api/routes/enterprise.py tests/test_api_operator_policy.py
- uv run pytest tests/test_api_operator_policy.py -q
- cd ui && npm ci
- cd ui && npm run lint
- cd ui && npm run test:run -- tests/api.test.ts tests/auth-gate.test.tsx tests/key-lifecycle-panel.test.tsx
- cd ui && npx tsc --noEmit
- rg sessionStorage/ALLOW_SESSION_STORAGE/allowSessionStorage/legacy_static_export_only returned no matches
- git diff --check
- pre-commit hooks: ruff, ruff-format, mypy, bandit