### PR TITLE
fix: expose enrichment degraded-mode posture

### DIFF
--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -72,6 +72,16 @@ The self-hosted control plane supports:
 Browser authentication can use same-origin httpOnly cookies for the dashboard
 while keeping bearer-token support for CLI and service clients.
 
+## Vulnerability Enrichment Posture
+
+The scanner can enrich findings with OSV, NVD, EPSS, CISA KEV, and GHSA data.
+Those sources are treated as untrusted external inputs and are fetched over
+HTTPS with defensive parsing. `GET /v1/posture/enrichment` exposes a non-secret
+runtime posture for each source: latest success, latest failure, cache hits,
+configured SLO, and whether the current process sees the source as `ok`,
+`stale`, `degraded`, or `unknown`. Operators should review this surface before
+treating KEV, EPSS, or NVD-derived risk scoring as complete.
+
 ## Tenant Isolation
 
 Tenant isolation is enforced across API middleware, stores, audit export,

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1147,6 +1147,15 @@ async def get_posture_scorecard(request: Request) -> dict:
     }
 
 
+@router.get("/v1/posture/enrichment", tags=["compliance"])
+async def get_enrichment_posture() -> dict:
+    """Report runtime health for external vulnerability enrichment sources."""
+
+    from agent_bom.enrichment_posture import describe_enrichment_posture
+
+    return describe_enrichment_posture()
+
+
 @router.get("/v1/posture/counts", tags=["compliance"])
 async def get_posture_counts(request: Request) -> dict:
     """Aggregate vulnerability counts across all completed scans.

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -17,6 +17,7 @@ from rich.console import Console
 
 from agent_bom.config import ENRICHMENT_MAX_CACHE_ENTRIES as _MAX_ENRICHMENT_CACHE_ENTRIES
 from agent_bom.config import ENRICHMENT_TTL_SECONDS as _ENRICHMENT_TTL
+from agent_bom.enrichment_posture import record_enrichment_source
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Vulnerability
 
@@ -127,6 +128,7 @@ async def fetch_nvd_data(cve_id: str, client: httpx.AsyncClient, api_key: Option
         cached_at = cached.get("_cached_at", 0)
         if _now - cached_at < _nvd_max_age_secs:
             data = {k: v for k, v in cached.items() if k != "_cached_at"}
+            record_enrichment_source("nvd", "cache")
             return data if data else None
         # Stale — fall through to refetch
 
@@ -151,12 +153,16 @@ async def fetch_nvd_data(cve_id: str, client: httpx.AsyncClient, api_key: Option
                 # Store in persistent cache
                 _nvd_file_cache[cve_id] = {**result, "_cached_at": time.time()}
                 _evict_oldest(_nvd_file_cache, _MAX_ENRICHMENT_CACHE_ENTRIES)
+                record_enrichment_source("nvd", "success")
                 return result
         except (ValueError, KeyError) as e:
+            record_enrichment_source("nvd", "failure", error=f"parse error: {e}")
             console.print(f"  [dim yellow]NVD parse error for {cve_id}: {e}[/dim yellow]")
     elif response and response.status_code == 403:
+        record_enrichment_source("nvd", "failure", error="HTTP 403 rate limited")
         _logger.warning("NVD rate limited (HTTP 403) for %s — consider using NVD_API_KEY", cve_id)
     elif response and response.status_code not in (200, 404):
+        record_enrichment_source("nvd", "failure", error=f"HTTP {response.status_code}")
         _logger.warning("NVD returned HTTP %d for %s", response.status_code, cve_id)
 
     return None
@@ -192,6 +198,7 @@ async def fetch_epss_scores(cve_ids: list[str], client: httpx.AsyncClient) -> di
             cached_at = cached.get("_cached_at", 0)
             if now - cached_at < _max_age_secs:
                 scores[cve_id] = {k: v for k, v in cached.items() if k != "_cached_at"}
+                record_enrichment_source("epss", "cache")
             else:
                 uncached.append(cve_id)  # Stale — refetch
         else:
@@ -216,6 +223,7 @@ async def fetch_epss_scores(cve_ids: list[str], client: httpx.AsyncClient) -> di
         if response and response.status_code == 200:
             try:
                 data = response.json()
+                record_enrichment_source("epss", "success")
                 for item in data.get("data", []):
                     cve = item.get("cve")
                     if cve:
@@ -236,8 +244,14 @@ async def fetch_epss_scores(cve_ids: list[str], client: httpx.AsyncClient) -> di
                         scores[cve] = entry
                         _epss_file_cache[cve] = {**entry, "_cached_at": time.time()}
             except (ValueError, KeyError) as e:
+                record_enrichment_source("epss", "failure", error=f"parse error: {e}")
                 _logger.warning("EPSS parse error for batch starting at %d: %s", batch_start, e)
         else:
+            record_enrichment_source(
+                "epss",
+                "failure",
+                error=f"HTTP {response.status_code}" if response else "unreachable after retries",
+            )
             _logger.warning(
                 "EPSS API request failed for %d CVEs (batch %d–%d)",
                 len(batch),
@@ -267,6 +281,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
     if _kev_cache and _kev_cache_time:
         age = datetime.now(timezone.utc) - _kev_cache_time
         if age.total_seconds() < _KEV_CACHE_TTL_SECONDS:
+            record_enrichment_source("cisa_kev", "cache")
             return _kev_cache
 
     # Try loading from disk cache if in-memory cache is stale
@@ -277,6 +292,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
             if (time.time() - cached_at) < _KEV_CACHE_TTL_SECONDS:
                 _kev_cache = disk_data.get("data") or {}
                 _kev_cache_time = datetime.fromtimestamp(cached_at, tz=timezone.utc)
+                record_enrichment_source("cisa_kev", "cache")
                 return _kev_cache  # type: ignore[return-value]  # dict from disk cache
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             _logger.warning("Failed to load KEV disk cache: %s", exc)
@@ -302,6 +318,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
 
             _kev_cache = kev_dict
             _kev_cache_time = datetime.now(timezone.utc)
+            record_enrichment_source("cisa_kev", "success")
 
             # Persist to disk for cross-session resilience
             try:
@@ -312,6 +329,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
 
             return kev_dict
         except (ValueError, KeyError) as e:
+            record_enrichment_source("cisa_kev", "failure", error=f"parse error: {e}")
             console.print(f"  [dim yellow]CISA KEV parse error: {e}[/dim yellow]")
 
     # Fallback: serve stale disk cache if API is down
@@ -327,6 +345,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
                     len(stale_data),
                 )
                 console.print("  [dim yellow]⚠ Using stale CISA KEV cache (API unreachable)[/dim yellow]")
+                record_enrichment_source("cisa_kev", "failure", error=f"using stale cache {stale_age_hours:.0f}h old")
                 _kev_cache = stale_data
                 # Cache in memory for 1h before retrying API — prevents
                 # hitting disk on every call within this session while still
@@ -338,6 +357,7 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
         except (OSError, json.JSONDecodeError) as exc:
             _logger.warning("Failed to read stale KEV cache: %s", exc)
 
+    record_enrichment_source("cisa_kev", "failure", error="unreachable and no usable cache")
     return {}
 
 

--- a/src/agent_bom/enrichment_posture.py
+++ b/src/agent_bom/enrichment_posture.py
@@ -1,0 +1,148 @@
+"""Runtime posture for external vulnerability enrichment sources."""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+_DEFAULT_SOURCE_SLOS_SECONDS = {
+    "osv": 6 * 60 * 60,
+    "nvd": 24 * 60 * 60,
+    "epss": 24 * 60 * 60,
+    "cisa_kev": 24 * 60 * 60,
+    "ghsa": 24 * 60 * 60,
+}
+
+
+@dataclass
+class EnrichmentSourceState:
+    source: str
+    last_success_at: str | None = None
+    last_failure_at: str | None = None
+    last_cache_at: str | None = None
+    last_error: str = ""
+    success_count: int = 0
+    failure_count: int = 0
+    cache_hit_count: int = 0
+
+
+_lock = threading.RLock()
+_states: dict[str, EnrichmentSourceState] = {}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _source_slo_seconds(source: str) -> int:
+    env_name = f"AGENT_BOM_ENRICHMENT_{source.upper()}_SLO_SECONDS"
+    raw = (os.environ.get(env_name) or "").strip()
+    if raw:
+        try:
+            return max(60, int(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_SOURCE_SLOS_SECONDS.get(source, 24 * 60 * 60)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def record_enrichment_source(source: str, outcome: str, *, error: str = "") -> None:
+    """Record the latest result for an enrichment source.
+
+    ``outcome`` is one of ``success``, ``failure``, or ``cache``. Unknown
+    outcomes are treated as failures to keep operator posture conservative.
+    """
+
+    normalized = source.strip().lower().replace("-", "_")
+    if not normalized:
+        return
+    timestamp = _now_iso()
+    with _lock:
+        state = _states.setdefault(normalized, EnrichmentSourceState(source=normalized))
+        if outcome == "success":
+            state.last_success_at = timestamp
+            state.last_error = ""
+            state.success_count += 1
+        elif outcome == "cache":
+            state.last_cache_at = timestamp
+            state.cache_hit_count += 1
+        else:
+            state.last_failure_at = timestamp
+            state.last_error = str(error).replace("\r", " ").replace("\n", " ").strip()[:300]
+            state.failure_count += 1
+
+
+def reset_enrichment_posture_for_tests() -> None:
+    with _lock:
+        _states.clear()
+
+
+def describe_enrichment_posture() -> dict[str, Any]:
+    """Return non-secret enrichment source health and freshness posture."""
+
+    now = datetime.now(timezone.utc)
+    with _lock:
+        sources = {name: EnrichmentSourceState(**vars(state)) for name, state in _states.items()}
+
+    rows: list[dict[str, Any]] = []
+    for source in sorted(set(_DEFAULT_SOURCE_SLOS_SECONDS) | set(sources)):
+        state = sources.get(source, EnrichmentSourceState(source=source))
+        last_good = max(
+            [dt for dt in (_parse_iso(state.last_success_at), _parse_iso(state.last_cache_at)) if dt is not None],
+            default=None,
+        )
+        last_failure = _parse_iso(state.last_failure_at)
+        age_seconds = int((now - last_good).total_seconds()) if last_good else None
+        slo_seconds = _source_slo_seconds(source)
+        if last_failure and (last_good is None or last_failure >= last_good):
+            status = "degraded"
+            message = state.last_error or "latest enrichment attempt failed"
+        elif age_seconds is None:
+            status = "unknown"
+            message = "no enrichment source result recorded in this process"
+        elif age_seconds > slo_seconds:
+            status = "stale"
+            message = f"last successful enrichment is older than configured SLO ({slo_seconds}s)"
+        else:
+            status = "ok"
+            message = "latest enrichment source result is within SLO"
+        rows.append(
+            {
+                "source": source,
+                "status": status,
+                "last_success_at": state.last_success_at,
+                "last_failure_at": state.last_failure_at,
+                "last_cache_at": state.last_cache_at,
+                "age_seconds": age_seconds,
+                "slo_seconds": slo_seconds,
+                "success_count": state.success_count,
+                "failure_count": state.failure_count,
+                "cache_hit_count": state.cache_hit_count,
+                "message": message,
+            }
+        )
+
+    worst_order = {"degraded": 0, "stale": 1, "unknown": 2, "ok": 3}
+    worst = min(rows, key=lambda item: worst_order.get(str(item["status"]), 0)) if rows else None
+    return {
+        "status": worst["status"] if worst else "unknown",
+        "sources": rows,
+        "operator_message": (
+            "Enrichment posture is process-local runtime evidence. Pair it with cache freshness and scan warnings "
+            "when interpreting KEV, EPSS, NVD, GHSA, and OSV-derived risk scores."
+        ),
+    }

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -12,6 +12,7 @@ import logging
 
 import httpx
 
+from agent_bom.enrichment_posture import record_enrichment_source
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Package, Severity, Vulnerability
 from agent_bom.package_utils import normalize_package_name
@@ -240,89 +241,100 @@ async def check_github_advisories(
 
     total_new = 0
     semaphore = asyncio.Semaphore(5)
+    fetch_errors: list[str] = []
 
-    async with create_client(timeout=15.0) as client:
-        tasks = [_fetch_advisories_for_package(p, client, semaphore) for p in queryable]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+    try:
+        async with create_client(timeout=15.0) as client:
+            tasks = [_fetch_advisories_for_package(p, client, semaphore) for p in queryable]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        for i, result in enumerate(results):
-            if isinstance(result, BaseException):
-                logger.debug("GHSA fetch failed for %s: %s", queryable[i].name, result)
-                continue
-            if not result:
-                continue
-
-            pkg = queryable[i]
-            eco = _ECOSYSTEM_MAP.get(pkg.ecosystem.lower(), "")
-            key = f"{eco}:{pkg.name.lower()}"
-            target_pkgs = pkg_groups.get(key, [pkg])
-
-            for advisory in result:
-                ghsa_id = advisory.get("ghsa_id", "")
-                cve_id = advisory.get("cve_id") or ""
-                vuln_id = cve_id or ghsa_id
-                if not vuln_id:
+            for i, result in enumerate(results):
+                if isinstance(result, BaseException):
+                    logger.debug("GHSA fetch failed for %s: %s", queryable[i].name, result)
+                    fetch_errors.append(str(result))
+                    continue
+                if not result:
                     continue
 
-                severity, cvss_score = _parse_ghsa_severity(advisory)
-                summary = advisory.get("summary", "") or f"GitHub Advisory ({vuln_id})"
-                cwe_ids = _get_cwe_ids(advisory)
-                refs = [advisory.get("html_url", "")] if advisory.get("html_url") else []
+                pkg = queryable[i]
+                eco = _ECOSYSTEM_MAP.get(pkg.ecosystem.lower(), "")
+                key = f"{eco}:{pkg.name.lower()}"
+                target_pkgs = pkg_groups.get(key, [pkg])
 
-                for target_pkg in target_pkgs:
-                    # Verify this advisory actually affects the target package
-                    # (GitHub API does substring matching, so "express" returns
-                    # advisories for "express-session", "express-validator", etc.)
-                    # Use PEP 503 normalization so "Requests_OAuthlib" matches
-                    # the already-normalized target name "requests-oauthlib".
-                    target_eco = target_pkg.ecosystem
-                    advisory_pkg_names = {
-                        normalize_package_name(v.get("package", {}).get("name", ""), v.get("package", {}).get("ecosystem", target_eco))
-                        for v in advisory.get("vulnerabilities", [])
-                    }
-                    if normalize_package_name(target_pkg.name, target_eco) not in advisory_pkg_names:
+                for advisory in result:
+                    ghsa_id = advisory.get("ghsa_id", "")
+                    cve_id = advisory.get("cve_id") or ""
+                    vuln_id = cve_id or ghsa_id
+                    if not vuln_id:
                         continue
 
-                    existing_ids = {v.id for v in target_pkg.vulnerabilities}
-                    for v in target_pkg.vulnerabilities:
-                        existing_ids.update(v.aliases)
-                    # Skip if CVE or GHSA ID already present (including aliases)
-                    if vuln_id in existing_ids or (cve_id and cve_id in existing_ids) or (ghsa_id and ghsa_id in existing_ids):
-                        continue
+                    severity, cvss_score = _parse_ghsa_severity(advisory)
+                    summary = advisory.get("summary", "") or f"GitHub Advisory ({vuln_id})"
+                    cwe_ids = _get_cwe_ids(advisory)
+                    refs = [advisory.get("html_url", "")] if advisory.get("html_url") else []
 
-                    fixed = _extract_fixed_version(advisory, target_pkg.name, target_pkg.ecosystem)
+                    for target_pkg in target_pkgs:
+                        # Verify this advisory actually affects the target package
+                        # (GitHub API does substring matching, so "express" returns
+                        # advisories for "express-session", "express-validator", etc.)
+                        # Use PEP 503 normalization so "Requests_OAuthlib" matches
+                        # the already-normalized target name "requests-oauthlib".
+                        target_eco = target_pkg.ecosystem
+                        advisory_pkg_names = {
+                            normalize_package_name(v.get("package", {}).get("name", ""), v.get("package", {}).get("ecosystem", target_eco))
+                            for v in advisory.get("vulnerabilities", [])
+                        }
+                        if normalize_package_name(target_pkg.name, target_eco) not in advisory_pkg_names:
+                            continue
 
-                    # Skip if the installed version is already at or beyond the fix.
-                    if target_pkg.version:
-                        if fixed:
-                            # compare_versions returns True only when fix > current
-                            # (upgrade needed).  False = already patched → skip.
-                            from agent_bom.version_utils import compare_versions
+                        existing_ids = {v.id for v in target_pkg.vulnerabilities}
+                        for v in target_pkg.vulnerabilities:
+                            existing_ids.update(v.aliases)
+                        # Skip if CVE or GHSA ID already present (including aliases)
+                        if vuln_id in existing_ids or (cve_id and cve_id in existing_ids) or (ghsa_id and ghsa_id in existing_ids):
+                            continue
 
-                            if not compare_versions(target_pkg.version, fixed, target_pkg.ecosystem):
-                                continue
-                        else:
-                            # patched_versions is null in current GHSA API responses.
-                            # Use vulnerable_version_range to check whether the
-                            # installed version actually falls in the affected range.
-                            # An advisory may list MULTIPLE disjoint ranges for the same
-                            # package — version is affected if it matches ANY of them.
-                            vuln_ranges = _get_vulnerable_ranges_for_package(advisory, target_pkg.name, target_pkg.ecosystem)
-                            if vuln_ranges and not any(_installed_version_is_affected(target_pkg.version, r) for r in vuln_ranges):
-                                continue
+                        fixed = _extract_fixed_version(advisory, target_pkg.name, target_pkg.ecosystem)
 
-                    vuln = Vulnerability(
-                        id=vuln_id,
-                        summary=summary[:200],
-                        severity=severity,
-                        cvss_score=cvss_score,
-                        fixed_version=fixed,
-                        references=refs,
-                        cwe_ids=cwe_ids,
-                        advisory_sources=["ghsa"],
-                    )
-                    target_pkg.vulnerabilities.append(vuln)
-                    total_new += 1
+                        # Skip if the installed version is already at or beyond the fix.
+                        if target_pkg.version:
+                            if fixed:
+                                # compare_versions returns True only when fix > current
+                                # (upgrade needed).  False = already patched → skip.
+                                from agent_bom.version_utils import compare_versions
+
+                                if not compare_versions(target_pkg.version, fixed, target_pkg.ecosystem):
+                                    continue
+                            else:
+                                # patched_versions is null in current GHSA API responses.
+                                # Use vulnerable_version_range to check whether the
+                                # installed version actually falls in the affected range.
+                                # An advisory may list MULTIPLE disjoint ranges for the same
+                                # package — version is affected if it matches ANY of them.
+                                vuln_ranges = _get_vulnerable_ranges_for_package(advisory, target_pkg.name, target_pkg.ecosystem)
+                                if vuln_ranges and not any(_installed_version_is_affected(target_pkg.version, r) for r in vuln_ranges):
+                                    continue
+
+                        vuln = Vulnerability(
+                            id=vuln_id,
+                            summary=summary[:200],
+                            severity=severity,
+                            cvss_score=cvss_score,
+                            fixed_version=fixed,
+                            references=refs,
+                            cwe_ids=cwe_ids,
+                            advisory_sources=["ghsa"],
+                        )
+                        target_pkg.vulnerabilities.append(vuln)
+                        total_new += 1
+    except Exception as exc:
+        record_enrichment_source("ghsa", "failure", error=str(exc))
+        raise
+
+    if fetch_errors:
+        record_enrichment_source("ghsa", "failure", error=fetch_errors[0])
+    else:
+        record_enrichment_source("ghsa", "success")
 
     if total_new:
         logger.info("GHSA advisories: found %d new CVE(s)", total_new)

--- a/src/agent_bom/scanners/osv.py
+++ b/src/agent_bom/scanners/osv.py
@@ -11,6 +11,7 @@ from rich.console import Console
 
 from agent_bom.config import SCANNER_BATCH_DELAY as BATCH_DELAY_SECONDS
 from agent_bom.config import SCANNER_BATCH_SIZE as _BATCH_SIZE
+from agent_bom.enrichment_posture import record_enrichment_source
 from agent_bom.http_client import OfflineModeError, create_client, request_with_retry
 from agent_bom.models import Package
 from agent_bom.package_utils import normalize_package_name
@@ -303,6 +304,7 @@ async def query_osv_batch_impl(
     try:
         client_ctx = create_client_fn(timeout=30.0)
     except OfflineModeError:
+        record_enrichment_source("osv", "failure", error="offline mode")
         _logger.info("Offline mode: skipping OSV batch query for %d packages", len(queries))
         console.print("  [yellow]⚠[/yellow] Offline mode — CVE scanning skipped. Use local DB or remove --offline.")
         record_scan_warning("offline mode skipped remote CVE lookups")
@@ -320,6 +322,7 @@ async def query_osv_batch_impl(
                 if response and response.status_code == 200:
                     try:
                         data = response.json()
+                        record_enrichment_source("osv", "success")
                         osv_results = data.get("results", [])
                         if len(osv_results) != len(batch):
                             _logger.warning(
@@ -353,12 +356,14 @@ async def query_osv_batch_impl(
                                     existing.append(vuln)
                                     seen_ids.add(vuln.get("id"))
                     except (ValueError, KeyError) as exc:
+                        record_enrichment_source("osv", "failure", error=f"parse error: {exc}")
                         console.print(f"  [red]✗[/red] OSV response parse error: {exc}")
                         for idx in range(batch_start, min(batch_start + len(batch), len(queries))):
                             pkg_err = pkg_index.get(idx)
                             if pkg_err:
                                 lookup_errors.append((pkg_err[0].name, pkg_err[0].ecosystem, f"parse error: {exc}"))
                 elif response and response.status_code == 429:
+                    record_enrichment_source("osv", "failure", error="HTTP 429 rate limited")
                     retry_after_hdr = response.headers.get("Retry-After")
                     pipeline_wait = _PIPELINE_429_BACKOFF
                     if retry_after_hdr:
@@ -370,12 +375,14 @@ async def query_osv_batch_impl(
                     _logger.warning("OSV rate limit hit after all retries; pausing pipeline %.0fs", pipeline_wait)
                     await asyncio.sleep(pipeline_wait)
                 elif response:
+                    record_enrichment_source("osv", "failure", error=f"HTTP {response.status_code}")
                     console.print(f"  [red]✗[/red] OSV API error: HTTP {response.status_code}")
                     for idx in range(batch_start, min(batch_start + len(batch), len(queries))):
                         pkg_err = pkg_index.get(idx)
                         if pkg_err:
                             lookup_errors.append((pkg_err[0].name, pkg_err[0].ecosystem, f"HTTP {response.status_code}"))
                 else:
+                    record_enrichment_source("osv", "failure", error="unreachable after retries")
                     console.print("  [red]✗[/red] OSV API unreachable after retries")
                     for idx in range(batch_start, min(batch_start + len(batch), len(queries))):
                         pkg_err = pkg_index.get(idx)

--- a/tests/test_enrichment_posture.py
+++ b/tests/test_enrichment_posture.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+from agent_bom.enrichment_posture import (
+    describe_enrichment_posture,
+    record_enrichment_source,
+    reset_enrichment_posture_for_tests,
+)
+from tests.auth_helpers import enable_trusted_proxy_env, proxy_headers
+
+
+def test_enrichment_posture_reports_unknown_by_default() -> None:
+    reset_enrichment_posture_for_tests()
+
+    posture = describe_enrichment_posture()
+
+    assert posture["status"] == "unknown"
+    sources = {source["source"]: source for source in posture["sources"]}
+    assert {"osv", "nvd", "epss", "cisa_kev", "ghsa"} <= set(sources)
+    assert sources["osv"]["status"] == "unknown"
+
+
+def test_enrichment_posture_tracks_success_and_failure() -> None:
+    reset_enrichment_posture_for_tests()
+
+    record_enrichment_source("osv", "success")
+    record_enrichment_source("epss", "failure", error="HTTP 503\nretry later")
+    posture = describe_enrichment_posture()
+
+    sources = {source["source"]: source for source in posture["sources"]}
+    assert posture["status"] == "degraded"
+    assert sources["osv"]["status"] == "ok"
+    assert sources["epss"]["status"] == "degraded"
+    assert sources["epss"]["message"] == "HTTP 503 retry later"
+
+
+def test_enrichment_posture_endpoint() -> None:
+    reset_enrichment_posture_for_tests()
+    record_enrichment_source("cisa_kev", "cache")
+    enable_trusted_proxy_env()
+
+    client = TestClient(app)
+    resp = client.get("/v1/posture/enrichment", headers=proxy_headers(role="viewer"))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert any(source["source"] == "cisa_kev" for source in body["sources"])

--- a/tests/test_ghsa_advisory.py
+++ b/tests/test_ghsa_advisory.py
@@ -182,6 +182,27 @@ def test_advisory_filtered_by_package_name():
     assert pkg.vulnerabilities[0].fixed_version == "4.19.0"
 
 
+def test_ghsa_advisory_records_enrichment_posture():
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from agent_bom.enrichment_posture import describe_enrichment_posture, reset_enrichment_posture_for_tests
+    from agent_bom.scanners.ghsa_advisory import check_github_advisories
+
+    reset_enrichment_posture_for_tests()
+    pkg = Package(name="express", version="4.17.1", ecosystem="npm")
+
+    async def run():
+        with patch("agent_bom.scanners.ghsa_advisory._fetch_advisories_for_package", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+            return await check_github_advisories([pkg])
+
+    assert asyncio.run(run()) == 0
+    sources = {source["source"]: source for source in describe_enrichment_posture()["sources"]}
+    assert sources["ghsa"]["status"] == "ok"
+    assert sources["ghsa"]["success_count"] == 1
+
+
 def test_advisory_no_match_skipped():
     """Advisory with no matching package is completely skipped."""
     import asyncio

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1232,6 +1232,26 @@ export interface PostureResponse {
   dimensions: Record<string, { score: number; label: string; details?: string }>;
 }
 
+export interface EnrichmentSourcePosture {
+  source: string;
+  status: "ok" | "stale" | "degraded" | "unknown" | string;
+  last_success_at: string | null;
+  last_failure_at: string | null;
+  last_cache_at: string | null;
+  age_seconds: number | null;
+  slo_seconds: number;
+  success_count: number;
+  failure_count: number;
+  cache_hit_count: number;
+  message: string;
+}
+
+export interface EnrichmentPostureResponse {
+  status: "ok" | "stale" | "degraded" | "unknown" | string;
+  sources: EnrichmentSourcePosture[];
+  operator_message: string;
+}
+
 // ─── Fetch helpers ────────────────────────────────────────────────────────────
 
 const FETCH_TIMEOUT_MS = 30_000;
@@ -1485,6 +1505,9 @@ export const api = {
 
   /** Full posture grade + dimensions */
   getPosture: () => get<PostureResponse>("/v1/posture"),
+
+  /** Runtime health for external vulnerability enrichment sources */
+  getEnrichmentPosture: () => get<EnrichmentPostureResponse>("/v1/posture/enrichment"),
 
   /** Lightweight aggregate counts + scan context for nav badges */
   getPostureCounts: () => get<PostureCountsResponse>("/v1/posture/counts"),


### PR DESCRIPTION
Summary
- record process-local health for OSV, NVD, EPSS, CISA KEV, and GHSA enrichment sources
- expose authenticated GET /v1/posture/enrichment for operator SLO/degraded-mode checks
- wire OSV/NVD/EPSS/KEV success, cache-hit, and failure events into the posture model
- add UI API typing and enterprise security posture docs

Validation
- uv run ruff check src/agent_bom/enrichment_posture.py src/agent_bom/enrichment.py src/agent_bom/scanners/osv.py src/agent_bom/api/routes/compliance.py tests/test_enrichment_posture.py
- uv run pytest tests/test_enrichment_posture.py tests/test_cwe_enrichment.py -q
- cd ui && npm ci
- cd ui && npx tsc --noEmit
- git diff --check
- pre-commit hooks: ruff, ruff-format, mypy, bandit