### PR TITLE
fix: hash packaged dashboard csp scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           cd ui && npm ci && NEXT_EXPORT=1 npm run build
           cp -r out ../src/agent_bom/ui_dist
+          python ../scripts/generate_ui_csp_hashes.py ../src/agent_bom/ui_dist
 
       - name: Build package
         run: rm -rf dist/ && uv run --with build==1.4.0 python -m build

--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -153,6 +153,13 @@ domain-level commitment. Operators can also set
 `security_headers` so change windows can record whether preload is enabled and
 which CSP mode is active.
 
+Packaged self-hosted dashboard builds generate `ui_dist/csp-hashes.json` during
+`scripts/build-ui.sh` and release packaging. When that manifest is present, the
+API serves dashboard HTML with hash-based `script-src` entries instead of
+`script-src 'unsafe-inline'`. If the manifest is absent, the dashboard posture
+reports `inline_compat` so operators can see that the static export is using the
+compatibility fallback.
+
 ## Availability, Backup, And Restore
 
 The Helm chart includes an optional Postgres backup CronJob that writes custom

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -12,5 +12,6 @@ NEXT_EXPORT=1 npm run build
 echo "Copying static output to package..."
 rm -rf "$ROOT_DIR/src/agent_bom/ui_dist"
 cp -r out "$ROOT_DIR/src/agent_bom/ui_dist"
+python "$ROOT_DIR/scripts/generate_ui_csp_hashes.py" "$ROOT_DIR/src/agent_bom/ui_dist"
 
 echo "Dashboard bundled → src/agent_bom/ui_dist/"

--- a/scripts/generate_ui_csp_hashes.py
+++ b/scripts/generate_ui_csp_hashes.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Generate CSP hashes for inline blocks in the bundled dashboard export."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+class _InlineBlockParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._capture: str | None = None
+        self._parts: list[str] = []
+        self.scripts: list[str] = []
+        self.styles: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_by_name = {name.lower(): value for name, value in attrs}
+        if tag.lower() == "script" and "src" not in attrs_by_name:
+            self._capture = "script"
+            self._parts = []
+        elif tag.lower() == "style":
+            self._capture = "style"
+            self._parts = []
+
+    def handle_data(self, data: str) -> None:
+        if self._capture:
+            self._parts.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        if self._capture:
+            self._parts.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        if self._capture:
+            self._parts.append(f"&#{name};")
+
+    def handle_endtag(self, tag: str) -> None:
+        capture = self._capture
+        if capture and tag.lower() == capture:
+            value = "".join(self._parts)
+            if value.strip():
+                if capture == "script":
+                    self.scripts.append(value)
+                else:
+                    self.styles.append(value)
+            self._capture = None
+            self._parts = []
+
+
+def _hash_block(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    return "sha256-" + base64.b64encode(digest).decode("ascii")
+
+
+def generate_hash_manifest(ui_dist: Path) -> dict[str, object]:
+    script_hashes: set[str] = set()
+    style_hashes: set[str] = set()
+    html_files = sorted(ui_dist.rglob("*.html"))
+    for html_file in html_files:
+        parser = _InlineBlockParser()
+        parser.feed(html_file.read_text(encoding="utf-8"))
+        script_hashes.update(_hash_block(value) for value in parser.scripts)
+        style_hashes.update(_hash_block(value) for value in parser.styles)
+    return {
+        "version": 1,
+        "html_file_count": len(html_files),
+        "script_hashes": sorted(script_hashes),
+        "style_hashes": sorted(style_hashes),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ui_dist", type=Path, help="Path to src/agent_bom/ui_dist")
+    args = parser.parse_args()
+    ui_dist = args.ui_dist
+    if not ui_dist.is_dir():
+        raise SystemExit(f"UI dist directory not found: {ui_dist}")
+    manifest = generate_hash_manifest(ui_dist)
+    output = ui_dist / "csp-hashes.json"
+    output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Wrote {output} ({len(manifest['script_hashes'])} script hashes, {len(manifest['style_hashes'])} style hashes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/api/dashboard_csp.py
+++ b/src/agent_bom/api/dashboard_csp.py
@@ -1,0 +1,79 @@
+"""Dashboard Content-Security-Policy helpers.
+
+The packaged dashboard is a static Next.js export. App Router builds include
+inline bootstrap scripts, so release packaging generates hashes for those exact
+inline blocks and the API can serve dashboard HTML without script-src
+``'unsafe-inline'`` when the manifest is present.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_FALLBACK_REASON = "Next static export hash manifest is missing; dashboard falls back to inline script bootstrap compatibility."
+
+
+def _manifest_path() -> Path:
+    configured = os.environ.get("AGENT_BOM_DASHBOARD_CSP_HASH_MANIFEST", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path(__file__).resolve().parents[1] / "ui_dist" / "csp-hashes.json"
+
+
+def _load_manifest() -> dict[str, list[str]]:
+    path = _manifest_path()
+    if not path.is_file():
+        return {"script_hashes": [], "style_hashes": []}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"script_hashes": [], "style_hashes": []}
+    return {
+        "script_hashes": [str(value) for value in raw.get("script_hashes", []) if str(value).startswith("sha256-")],
+        "style_hashes": [str(value) for value in raw.get("style_hashes", []) if str(value).startswith("sha256-")],
+    }
+
+
+def dashboard_csp_header() -> str:
+    """Return the dashboard CSP header for the active packaged UI assets."""
+
+    manifest = _load_manifest()
+    script_hashes = manifest["script_hashes"]
+    style_hashes = manifest["style_hashes"]
+    script_src = " ".join(["'self'", *script_hashes]) if script_hashes else "'self' 'unsafe-inline'"
+    # Next/font and Tailwind still emit inline style attributes in some builds.
+    # Keep style inline compatibility until the dashboard removes those attrs.
+    style_src_values = ["'self'", "'unsafe-inline'", *style_hashes]
+    style_src = " ".join(dict.fromkeys(style_src_values))
+    return (
+        "default-src 'self'; "
+        f"script-src {script_src}; "
+        "script-src-attr 'none'; "
+        f"style-src {style_src}; "
+        "img-src 'self' data: blob:; "
+        "font-src 'self' data:; "
+        "connect-src 'self'; "
+        "object-src 'none'; "
+        "base-uri 'self'; "
+        "frame-ancestors 'none'"
+    )
+
+
+def describe_dashboard_csp_posture() -> dict[str, Any]:
+    """Return non-secret dashboard CSP posture for operator policy surfaces."""
+
+    manifest = _load_manifest()
+    script_hashes = manifest["script_hashes"]
+    header = dashboard_csp_header()
+    return {
+        "header": header,
+        "mode": "hash_manifest" if script_hashes else "inline_compat",
+        "manifest_path": str(_manifest_path()),
+        "script_hash_count": len(script_hashes),
+        "style_hash_count": len(manifest["style_hashes"]),
+        "allows_inline_script": "'unsafe-inline'" in header.partition("style-src")[0],
+        "inline_bootstrap_reason": "" if script_hashes else _FALLBACK_REASON,
+    }

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -37,6 +37,8 @@ from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp
 
+from agent_bom.api.dashboard_csp import dashboard_csp_header, describe_dashboard_csp_posture
+
 _logger = logging.getLogger(__name__)
 _RATE_LIMIT_FINGERPRINT_FALLBACK = secrets.token_bytes(32)
 _TENANT_SCOPED_AUTH_METHODS = {
@@ -55,24 +57,12 @@ _AUTH_RUNTIME_STATUS: dict[str, object] = {
     "recommended_ui_mode": "no_auth",
 }
 _API_CSP = "default-src 'self'"
-_DASHBOARD_CSP = (
-    "default-src 'self'; "
-    "script-src 'self' 'unsafe-inline'; "
-    "script-src-attr 'none'; "
-    "style-src 'self' 'unsafe-inline'; "
-    "img-src 'self' data: blob:; "
-    "font-src 'self' data:; "
-    "connect-src 'self'; "
-    "object-src 'none'; "
-    "base-uri 'self'; "
-    "frame-ancestors 'none'"
-)
 
 
 def _content_security_policy(path: str, content_type: str) -> str:
     """Return a route-aware CSP that keeps the API strict and the dashboard usable."""
     if "text/html" in content_type and not path.startswith(("/v1/", "/docs", "/redoc", "/openapi.json")):
-        return _DASHBOARD_CSP
+        return dashboard_csp_header()
     return _API_CSP
 
 
@@ -114,11 +104,7 @@ def describe_security_header_posture() -> dict[str, object]:
             "max_age_env": "AGENT_BOM_HSTS_MAX_AGE_SECONDS",
             "preload_guidance": ("Only enable preload after confirming HTTPS is permanent for the domain and every subdomain."),
         },
-        "csp": {
-            "api": _API_CSP,
-            "dashboard_allows_inline_bootstrap": "'unsafe-inline'" in _DASHBOARD_CSP,
-            "dashboard_inline_bootstrap_reason": "Next static export requires inline bootstrap until the nonce/hash migration lands.",
-        },
+        "csp": {"api": _API_CSP, "dashboard": describe_dashboard_csp_posture()},
     }
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from pathlib import Path
 
@@ -118,10 +119,11 @@ def test_root_serves_dashboard_when_bundled(tmp_path: Path, monkeypatch):
 
 
 def test_root_uses_dashboard_friendly_csp_when_bundled(tmp_path: Path, monkeypatch):
-    """Packaged dashboard HTML should allow the inline bootstrap it ships with."""
+    """Dashboard HTML keeps inline compatibility when no generated hash manifest exists."""
     index_file = tmp_path / "index.html"
     index_file.write_text("<html><body>agent-bom dashboard</body></html>", encoding="utf-8")
     monkeypatch.setattr("agent_bom.api.server._dashboard_index_file", lambda: str(index_file))
+    monkeypatch.delenv("AGENT_BOM_DASHBOARD_CSP_HASH_MANIFEST", raising=False)
 
     client, _ = _fresh_client()
     resp = client.get("/", follow_redirects=False)
@@ -132,6 +134,29 @@ def test_root_uses_dashboard_friendly_csp_when_bundled(tmp_path: Path, monkeypat
     assert "script-src-attr 'none'" in csp
     assert "style-src 'self' 'unsafe-inline'" in csp
     assert "frame-ancestors 'none'" in csp
+
+
+def test_root_uses_hash_manifest_csp_when_bundled(tmp_path: Path, monkeypatch):
+    """Packaged dashboard HTML should remove script unsafe-inline when release hashes exist."""
+    index_file = tmp_path / "index.html"
+    index_file.write_text("<html><body>agent-bom dashboard</body></html>", encoding="utf-8")
+    manifest = tmp_path / "csp-hashes.json"
+    manifest.write_text(
+        json.dumps({"script_hashes": ["sha256-abc123"], "style_hashes": ["sha256-style123"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("agent_bom.api.server._dashboard_index_file", lambda: str(index_file))
+    monkeypatch.setenv("AGENT_BOM_DASHBOARD_CSP_HASH_MANIFEST", str(manifest))
+
+    client, _ = _fresh_client()
+    resp = client.get("/", follow_redirects=False)
+
+    assert resp.status_code == 200
+    csp = resp.headers.get("content-security-policy", "")
+    script_directive = csp.split("script-src ", 1)[1].split(";", 1)[0]
+    assert script_directive == "'self' sha256-abc123"
+    assert "'unsafe-inline'" not in script_directive
+    assert "style-src 'self' 'unsafe-inline' sha256-style123" in csp
 
 
 def test_hsts_preload_is_operator_opt_in(monkeypatch):

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -181,7 +181,8 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "fail_closed" in body["rate_limit_runtime"]
     assert body["security_headers"]["hsts"]["preload"] is False
     assert body["security_headers"]["hsts"]["header"] == "max-age=31536000; includeSubDomains"
-    assert body["security_headers"]["csp"]["dashboard_allows_inline_bootstrap"] is True
+    assert body["security_headers"]["csp"]["dashboard"]["mode"] in {"inline_compat", "hash_manifest"}
+    assert "allows_inline_script" in body["security_headers"]["csp"]["dashboard"]
     assert body["secret_integrity"]["audit_hmac"]["status"] in {"configured", "ephemeral"}
     assert body["secret_integrity"]["audit_hmac"]["rotation_tracking_supported"] is True
     assert body["secret_integrity"]["audit_hmac"]["rotation_status"] in {

--- a/tests/test_ui_csp_hashes.py
+++ b/tests/test_ui_csp_hashes.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+
+from scripts.generate_ui_csp_hashes import generate_hash_manifest
+
+
+def _sha256_source(value: str) -> str:
+    return "sha256-" + base64.b64encode(hashlib.sha256(value.encode("utf-8")).digest()).decode("ascii")
+
+
+def test_generate_ui_csp_hashes_extracts_inline_scripts_and_styles(tmp_path):
+    ui_dist = tmp_path / "ui_dist"
+    ui_dist.mkdir()
+    (ui_dist / "index.html").write_text(
+        "<html><head><style>.x{color:red}</style></head>"
+        "<body><script>window.__next_f=[]</script><script src='/app.js'></script></body></html>",
+        encoding="utf-8",
+    )
+
+    manifest = generate_hash_manifest(ui_dist)
+
+    assert manifest["html_file_count"] == 1
+    assert manifest["script_hashes"] == [_sha256_source("window.__next_f=[]")]
+    assert manifest["style_hashes"] == [_sha256_source(".x{color:red}")]


### PR DESCRIPTION
Summary

- generate ui_dist/csp-hashes.json during packaged dashboard builds and release packaging
- serve packaged dashboard HTML with hash-based script-src when that manifest exists, removing script-src 'unsafe-inline' for self-hosted bundled UI assets
- keep an explicit inline_compat fallback when the manifest is absent so posture is honest instead of breaking standalone/dev modes
- expose the dashboard CSP mode/hash counts under /v1/auth/policy and document the operator-visible behavior

Validation

- uv run ruff check src/agent_bom/api/dashboard_csp.py src/agent_bom/api/middleware.py scripts/generate_ui_csp_hashes.py tests/test_api_endpoints.py tests/test_api_operator_policy.py tests/test_ui_csp_hashes.py
- uv run pytest tests/test_api_endpoints.py tests/test_api_operator_policy.py tests/test_ui_csp_hashes.py -q
- uv run mypy src/agent_bom/api/dashboard_csp.py src/agent_bom/api/middleware.py
- bash -n scripts/build-ui.sh
- workflow YAML parse for .github/workflows/release.yml
- python scripts/generate_ui_csp_hashes.py on a temp HTML export
- pre-commit run --files ...
- git diff --check

Refs #1839