### PR TITLE
docs(contracts): publish versioned evidence schemas

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,8 @@
+# agent-bom Contracts
+
+This directory contains versioned integration contracts for downstream
+dashboards, SIEM pipelines, evidence exports, and procurement review.
+
+The current stable family is [`v1`](./v1/README.md). v1 contracts are additive:
+new optional fields may be added in minor releases, but required fields and
+field meanings must not be removed or repurposed without a v2 contract.

--- a/contracts/v1/README.md
+++ b/contracts/v1/README.md
@@ -1,0 +1,25 @@
+# v1 Contracts
+
+These schemas describe the stable agent-bom payload families used across CLI,
+API, dashboard, graph, fleet, audit, and compliance evidence surfaces.
+
+Compatibility policy:
+
+- Additive optional fields are allowed in v1.
+- Required fields, enum meanings, IDs, timestamps, tenant IDs, and scan IDs are
+  compatibility anchors.
+- Removing a required field, changing field meaning, or changing ID semantics
+  requires a v2 schema.
+- Consumers should ignore unknown fields and preserve known IDs when storing or
+  transforming payloads.
+
+Published schemas:
+
+- `scan-report.schema.json` - top-level AI-BOM JSON scan output.
+- `graph-export.schema.json` - graph nodes, edges, and materialized attack
+  paths.
+- `fleet-snapshot.schema.json` - tenant/fleet agent posture rows.
+- `finding-feedback.schema.json` - tenant finding feedback and suppression
+  lifecycle records.
+- `audit-export.schema.json` - signed audit export envelope.
+- `evidence.schema.json` - procurement/compliance evidence record.

--- a/contracts/v1/audit-export.schema.json
+++ b/contracts/v1/audit-export.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.dev/contracts/v1/audit-export.schema.json",
+  "title": "agent-bom audit export v1",
+  "type": "object",
+  "required": ["tenant_id", "exported_at", "entries", "verification"],
+  "properties": {
+    "tenant_id": { "type": "string", "minLength": 1 },
+    "exported_at": { "type": "string", "format": "date-time" },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["timestamp", "action", "actor", "hmac_sha256"],
+        "properties": {
+          "timestamp": { "type": "string", "format": "date-time" },
+          "action": { "type": "string", "minLength": 1 },
+          "actor": { "type": "string" },
+          "hmac_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+          "prev_hmac_sha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "verification": {
+      "type": "object",
+      "required": ["hmac_chain_valid"],
+      "properties": {
+        "hmac_chain_valid": { "type": "boolean" },
+        "entry_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/v1/evidence.schema.json
+++ b/contracts/v1/evidence.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.dev/contracts/v1/evidence.schema.json",
+  "title": "agent-bom compliance evidence v1",
+  "type": "object",
+  "required": ["evidence_id", "framework", "control_id", "status", "collected_at", "source"],
+  "properties": {
+    "evidence_id": { "type": "string", "minLength": 1 },
+    "framework": { "type": "string", "minLength": 1 },
+    "control_id": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "enum": ["pass", "fail", "warning", "not_applicable"] },
+    "finding_count": { "type": "integer", "minimum": 0 },
+    "source": { "type": "string", "minLength": 1 },
+    "collected_at": { "type": "string", "format": "date-time" },
+    "code_paths": { "type": "array", "items": { "type": "string" } },
+    "tests": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": true
+}

--- a/contracts/v1/examples/audit-export.minimal.json
+++ b/contracts/v1/examples/audit-export.minimal.json
@@ -1,0 +1,17 @@
+{
+  "tenant_id": "tenant-demo",
+  "exported_at": "2026-04-25T00:00:00Z",
+  "entries": [
+    {
+      "timestamp": "2026-04-25T00:00:00Z",
+      "action": "scan.completed",
+      "actor": "system",
+      "hmac_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "prev_hmac_sha256": null
+    }
+  ],
+  "verification": {
+    "hmac_chain_valid": true,
+    "entry_count": 1
+  }
+}

--- a/contracts/v1/examples/evidence.minimal.json
+++ b/contracts/v1/examples/evidence.minimal.json
@@ -1,0 +1,11 @@
+{
+  "evidence_id": "evidence-demo-001",
+  "framework": "soc2-tsc",
+  "control_id": "CC6.1",
+  "status": "pass",
+  "finding_count": 0,
+  "source": "agent-bom",
+  "collected_at": "2026-04-25T00:00:00Z",
+  "code_paths": ["src/agent_bom/api/middleware.py"],
+  "tests": ["tests/test_api_compliance_auth.py"]
+}

--- a/contracts/v1/examples/finding-feedback.minimal.json
+++ b/contracts/v1/examples/finding-feedback.minimal.json
@@ -1,0 +1,9 @@
+{
+  "tenant_id": "tenant-demo",
+  "finding_id": "CVE-2026-0001:pkg:pypi/demo@1.0.0",
+  "state": "fixed_verified",
+  "actor": "security@example.com",
+  "reason": "Patched and verified in the current scan.",
+  "expires_at": null,
+  "created_at": "2026-04-25T00:00:00Z"
+}

--- a/contracts/v1/examples/fleet-snapshot.minimal.json
+++ b/contracts/v1/examples/fleet-snapshot.minimal.json
@@ -1,0 +1,12 @@
+{
+  "tenant_id": "tenant-demo",
+  "agent_name": "demo-agent",
+  "agent_type": "custom",
+  "lifecycle_state": "discovered",
+  "trust_score": 98,
+  "server_count": 1,
+  "package_count": 1,
+  "credential_count": 0,
+  "vuln_count": 0,
+  "last_seen": "2026-04-25T00:00:00Z"
+}

--- a/contracts/v1/examples/graph-export.minimal.json
+++ b/contracts/v1/examples/graph-export.minimal.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "scan_id": "scan-demo-001",
+  "tenant_id": "tenant-demo",
+  "nodes": [
+    {
+      "id": "agent:demo-agent",
+      "entity_type": "agent",
+      "label": "demo-agent",
+      "risk_score": 0
+    }
+  ],
+  "edges": [],
+  "attack_paths": []
+}

--- a/contracts/v1/examples/scan-report.minimal.json
+++ b/contracts/v1/examples/scan-report.minimal.json
@@ -1,0 +1,24 @@
+{
+  "document_type": "AI-BOM",
+  "spec_version": "1.0",
+  "scan_id": "scan-demo-001",
+  "ai_bom_version": "0.81.3",
+  "generated_at": "2026-04-25T00:00:00Z",
+  "scan_sources": ["demo"],
+  "summary": {
+    "total_agents": 1,
+    "total_mcp_servers": 1,
+    "total_packages": 1,
+    "total_vulnerabilities": 0,
+    "critical_findings": 0
+  },
+  "agents": [
+    {
+      "name": "demo-agent",
+      "stable_id": "agent:demo-agent",
+      "type": "custom",
+      "status": "configured",
+      "mcp_servers": []
+    }
+  ]
+}

--- a/contracts/v1/finding-feedback.schema.json
+++ b/contracts/v1/finding-feedback.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.dev/contracts/v1/finding-feedback.schema.json",
+  "title": "agent-bom finding feedback v1",
+  "type": "object",
+  "required": ["tenant_id", "finding_id", "state", "actor", "created_at"],
+  "properties": {
+    "tenant_id": { "type": "string", "minLength": 1 },
+    "finding_id": { "type": "string", "minLength": 1 },
+    "state": {
+      "type": "string",
+      "enum": ["false_positive", "accepted_risk", "not_applicable", "fixed_verified"]
+    },
+    "actor": { "type": "string", "minLength": 1 },
+    "reason": { "type": "string" },
+    "expires_at": { "type": ["string", "null"], "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": true
+}

--- a/contracts/v1/fleet-snapshot.schema.json
+++ b/contracts/v1/fleet-snapshot.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.dev/contracts/v1/fleet-snapshot.schema.json",
+  "title": "agent-bom fleet snapshot v1",
+  "type": "object",
+  "required": ["tenant_id", "agent_name", "agent_type", "lifecycle_state", "last_seen"],
+  "properties": {
+    "tenant_id": { "type": "string", "minLength": 1 },
+    "agent_name": { "type": "string", "minLength": 1 },
+    "agent_type": { "type": "string", "minLength": 1 },
+    "lifecycle_state": { "type": "string", "minLength": 1 },
+    "trust_score": { "type": "number", "minimum": 0, "maximum": 100 },
+    "server_count": { "type": "integer", "minimum": 0 },
+    "package_count": { "type": "integer", "minimum": 0 },
+    "credential_count": { "type": "integer", "minimum": 0 },
+    "vuln_count": { "type": "integer", "minimum": 0 },
+    "last_seen": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": true
+}

--- a/contracts/v1/graph-export.schema.json
+++ b/contracts/v1/graph-export.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.dev/contracts/v1/graph-export.schema.json",
+  "title": "agent-bom graph export v1",
+  "type": "object",
+  "required": ["schema_version", "scan_id", "tenant_id", "nodes", "edges"],
+  "properties": {
+    "schema_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" },
+    "scan_id": { "type": "string", "minLength": 1 },
+    "tenant_id": { "type": "string", "minLength": 1 },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "entity_type", "label"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "entity_type": { "type": "string", "minLength": 1 },
+          "label": { "type": "string" },
+          "risk_score": { "type": "number" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "target", "relationship"],
+        "properties": {
+          "source": { "type": "string", "minLength": 1 },
+          "target": { "type": "string", "minLength": 1 },
+          "relationship": { "type": "string", "minLength": 1 },
+          "evidence": { "type": "array" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "attack_paths": { "type": "array" }
+  },
+  "additionalProperties": true
+}

--- a/contracts/v1/scan-report.schema.json
+++ b/contracts/v1/scan-report.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.dev/contracts/v1/scan-report.schema.json",
+  "title": "agent-bom scan report v1",
+  "type": "object",
+  "required": ["document_type", "spec_version", "scan_id", "generated_at", "summary", "agents"],
+  "properties": {
+    "document_type": { "const": "AI-BOM" },
+    "spec_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" },
+    "scan_id": { "type": "string", "minLength": 1 },
+    "ai_bom_version": { "type": "string" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "scan_sources": { "type": "array", "items": { "type": "string" } },
+    "summary": {
+      "type": "object",
+      "required": ["total_agents", "total_mcp_servers", "total_packages", "total_vulnerabilities"],
+      "properties": {
+        "total_agents": { "type": "integer", "minimum": 0 },
+        "total_mcp_servers": { "type": "integer", "minimum": 0 },
+        "total_packages": { "type": "integer", "minimum": 0 },
+        "total_vulnerabilities": { "type": "integer", "minimum": 0 },
+        "critical_findings": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "stable_id", "type", "status", "mcp_servers"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "stable_id": { "type": "string", "minLength": 1 },
+          "type": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "minLength": 1 },
+          "mcp_servers": { "type": "array" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "blast_radius": { "type": "array" },
+    "inventory_snapshot": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_contract_schemas.py
+++ b/tests/test_contract_schemas.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACTS = ROOT / "contracts" / "v1"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_contract_schemas_are_valid_draft_2020_12() -> None:
+    schemas = sorted(CONTRACTS.glob("*.schema.json"))
+    assert schemas, "expected versioned contract schemas"
+    for schema_path in schemas:
+        schema = _load(schema_path)
+        jsonschema.Draft202012Validator.check_schema(schema)
+        assert schema["$id"].endswith(f"/{schema_path.name}")
+
+
+def test_contract_examples_match_their_schema() -> None:
+    examples = sorted((CONTRACTS / "examples").glob("*.minimal.json"))
+    assert examples, "expected contract example fixtures"
+    for example_path in examples:
+        schema_path = CONTRACTS / example_path.name.replace(".minimal.json", ".schema.json")
+        assert schema_path.exists(), f"missing schema for {example_path.name}"
+        jsonschema.validate(_load(example_path), _load(schema_path))


### PR DESCRIPTION
Summary

- add versioned v1 contract schemas for scan reports, graph exports, fleet snapshots, finding feedback, audit exports, and compliance evidence
- document the additive v1 compatibility policy for downstream API/dashboard/SIEM consumers
- add minimal fixtures plus a jsonschema regression test so schema drift is caught in CI

Validation

- uv run ruff check tests/test_contract_schemas.py
- uv run pytest tests/test_contract_schemas.py -q
- git diff --check
- pre-commit hooks: json, eof, whitespace, ruff, ruff-format

Closes #1831