### PR TITLE
demo: add one-shot dashboard loader

### DIFF
--- a/examples/demo-scan/README.md
+++ b/examples/demo-scan/README.md
@@ -6,6 +6,27 @@ Run a vulnerability scan against a bundled inventory of agents with known-vulner
 agent-bom scan --demo
 ```
 
+## One-shot dashboard import
+
+Start the API/dashboard, then push the bundled synthetic demo into the
+dashboard with one command:
+
+```bash
+agent-bom serve
+```
+
+In another terminal:
+
+```bash
+scripts/demo/load-dashboard-demo.sh http://127.0.0.1:8422
+```
+
+If your API requires a key, set `AGENT_BOM_API_KEY` or
+`AGENT_BOM_PUSH_API_KEY` before running the loader. The script writes the
+temporary report under the OS temp directory, pushes it to
+`/v1/results/push`, then deletes the temporary file. The bundled data is
+synthetic and uses placeholder credential names only.
+
 ## What it does
 
 The `--demo` flag loads a pre-built inventory containing two agents and three MCP servers with intentionally vulnerable dependencies (e.g. `flask==2.2.0`, `werkzeug==2.2.2`, `requests==2.28.0`). The scan runs with `--enrich` enabled so you see real CVE details, EPSS scores, and blast-radius analysis.

--- a/scripts/demo/load-dashboard-demo.sh
+++ b/scripts/demo/load-dashboard-demo.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-${AGENT_BOM_API_URL:-http://127.0.0.1:8422}}"
+BASE_URL="${BASE_URL%/}"
+PUSH_URL="${BASE_URL}/v1/results/push"
+DASHBOARD_URL="${BASE_URL}/dashboard"
+REPORT_PATH="$(mktemp "${TMPDIR:-/tmp}/agent-bom-demo-report.XXXXXX.json")"
+
+cleanup() {
+  rm -f "$REPORT_PATH"
+}
+trap cleanup EXIT
+
+args=(
+  agents
+  --demo
+  --offline
+  --no-update-db
+  --quiet
+  -f json
+  -o "$REPORT_PATH"
+  --push-url "$PUSH_URL"
+)
+
+if [[ -n "${AGENT_BOM_PUSH_API_KEY:-${AGENT_BOM_API_KEY:-}}" ]]; then
+  args+=(--push-api-key "${AGENT_BOM_PUSH_API_KEY:-${AGENT_BOM_API_KEY:-}}")
+fi
+
+agent-bom "${args[@]}"
+
+echo "Demo results pushed to ${PUSH_URL}"
+echo "Dashboard: ${DASHBOARD_URL}"

--- a/tests/test_demo_dashboard_loader.py
+++ b/tests/test_demo_dashboard_loader.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dashboard_demo_loader_is_valid_shell() -> None:
+    subprocess.run(["bash", "-n", str(ROOT / "scripts" / "demo" / "load-dashboard-demo.sh")], check=True)


### PR DESCRIPTION
Summary

- add scripts/demo/load-dashboard-demo.sh to generate the bundled synthetic demo report and push it into /v1/results/push
- document the one-command dashboard import flow and API-key environment variables
- validate the loader with a shell syntax regression test

Validation

- uv run ruff check tests/test_demo_dashboard_loader.py
- uv run pytest tests/test_demo_dashboard_loader.py -q
- git diff --check
- pre-commit hooks: eof, whitespace, ruff, ruff-format

Closes #1843