### PR TITLE
feat(registry): expose catalog freshness posture

### DIFF
--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -127,6 +127,7 @@ Every scan emits `package.is_malicious` + `package.malicious_reason` on the `Pac
 
 - **Package-level:** the MCP server's implementing package goes through the same OSV + KEV + EPSS pipeline as every other dependency ([`enrichment.py`](../src/agent_bom/enrichment.py)).
 - **Registry verification:** MCPServer.registry_verified / .registry_id ([`models.py:524`](../src/agent_bom/models.py)) — servers found in the curated MCP registry get a trust boost; unknowns don't.
+- **Registry freshness:** `agent-bom registry status --format json` reports the bundled MCP catalog's source list, server count, last sync timestamp, age, stale threshold, and airgapped posture. Treat stale registry posture as reduced confidence in registry-derived trust and refresh with `agent-bom registry sync-all` when network policy allows it.
 - **Permission profile:** [`models.py:PermissionProfile`](../src/agent_bom/models.py) classifies capabilities (`network_access`, `filesystem_write`, `shell_access`, `runs_as_root`) and scores as `critical / high / medium / low`. `critical` ≈ root + shell + network.
 - **Tool drift:** [`ToolDriftDetector`](../src/agent_bom/runtime/detectors.py) — alerts when a server advertises a tool it didn't declare in `tools/list`. Catches post-install tool injection.
 - **Trust assessment:** [`parsers/trust_assessment.py`](../src/agent_bom/parsers/trust_assessment.py) + [`parsers/skill_audit.py`](../src/agent_bom/parsers/skill_audit.py) — static analysis of MCP skill manifests.

--- a/src/agent_bom/cli/_registry.py
+++ b/src/agent_bom/cli/_registry.py
@@ -187,6 +187,46 @@ def registry_search(query, category):
     con.print(table)
 
 
+@registry.command("status")
+@click.option("--stale-after-days", type=int, default=14, show_default=True, help="Mark registry stale after this many days.")
+@click.option("--format", "-f", "fmt", type=click.Choice(["table", "json"]), default="table", help="Output format.")
+def registry_status(stale_after_days: int, fmt: str):
+    """Show MCP registry freshness and source posture."""
+    from rich.console import Console
+    from rich.table import Table
+
+    from agent_bom.registry import registry_freshness_status
+
+    status = registry_freshness_status(stale_after_days=stale_after_days)
+    payload = status.to_dict()
+    if fmt == "json":
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    con = Console()
+    color = {
+        "fresh": "green",
+        "stale": "yellow",
+        "airgapped": "cyan",
+        "airgapped_stale": "yellow",
+        "never_synced": "red",
+    }.get(status.status, "white")
+    table = Table(title="MCP Registry Freshness")
+    table.add_column("Field", style="cyan")
+    table.add_column("Value")
+    table.add_row("Status", f"[{color}]{status.status}[/{color}]")
+    table.add_row("Last synced", status.last_synced_at or "unknown")
+    table.add_row("Age", "unknown" if status.age_days is None else f"{status.age_days} day(s)")
+    table.add_row("Stale after", f"{status.stale_after_days} day(s)")
+    table.add_row("Servers", str(status.server_count))
+    table.add_row("Sources", ", ".join(status.sources) if status.sources else "unknown")
+    if status.airgapped:
+        table.add_row("Airgapped", "yes")
+    if status.error:
+        table.add_row("Error", status.error)
+    con.print(table)
+
+
 @registry.command("update")
 @click.option("--concurrency", default=5, type=int, help="Max concurrent API requests.")
 @click.option("--dry-run", is_flag=True, help="Show what would be updated without writing.")

--- a/src/agent_bom/registry.py
+++ b/src/agent_bom/registry.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -40,6 +42,37 @@ class RegistryUpdateResult:
     details: list[dict] = field(default_factory=list)
 
 
+@dataclass
+class RegistryFreshnessStatus:
+    """Operator-facing MCP registry freshness posture."""
+
+    status: str
+    last_synced_at: str | None
+    age_days: int | None
+    stale_after_days: int
+    server_count: int
+    sources: list[str]
+    airgapped: bool = False
+    error: str = ""
+
+    @property
+    def is_fresh(self) -> bool:
+        return self.status == "fresh"
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status,
+            "is_fresh": self.is_fresh,
+            "last_synced_at": self.last_synced_at,
+            "age_days": self.age_days,
+            "stale_after_days": self.stale_after_days,
+            "server_count": self.server_count,
+            "sources": self.sources,
+            "airgapped": self.airgapped,
+            "error": self.error,
+        }
+
+
 def _load_registry() -> dict:
     """Load the bundled MCP registry JSON."""
     try:
@@ -56,6 +89,76 @@ def _load_registry_full() -> dict:
     except (json.JSONDecodeError, OSError) as exc:
         logger.warning("Failed to load full MCP registry from %s: %s", _REGISTRY_PATH, exc)
         return {"servers": {}}
+
+
+def _parse_registry_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    try:
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except ValueError:
+        pass
+    try:
+        return datetime.strptime(value.strip(), "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def registry_freshness_status(
+    *,
+    stale_after_days: int = 14,
+    data: dict | None = None,
+    now: datetime | None = None,
+) -> RegistryFreshnessStatus:
+    """Return freshness posture for the bundled MCP registry.
+
+    The registry can be refreshed from several sources, but normal scans should
+    stay offline/read-only. This summarizes the local catalog's age so operators
+    can decide whether to refresh before relying on registry-derived evidence.
+    """
+    stale_after_days = max(int(stale_after_days), 0)
+    registry_data = data if data is not None else _load_registry_full()
+    servers = registry_data.get("servers", {})
+    if not isinstance(servers, dict):
+        servers = {}
+
+    raw_sources = registry_data.get("_sources", [])
+    sources = [str(source) for source in raw_sources] if isinstance(raw_sources, list) else []
+    airgapped = os.environ.get("AGENT_BOM_REGISTRY_AIRGAPPED", "").strip().lower() in {"1", "true", "yes", "on"}
+    raw_synced = registry_data.get("_last_synced_at") or registry_data.get("_updated")
+    parsed = _parse_registry_timestamp(raw_synced)
+    if parsed is None:
+        return RegistryFreshnessStatus(
+            status="airgapped" if airgapped else "never_synced",
+            last_synced_at=str(raw_synced) if raw_synced else None,
+            age_days=None,
+            stale_after_days=stale_after_days,
+            server_count=len(servers),
+            sources=sources,
+            airgapped=airgapped,
+            error="missing_or_invalid_last_synced_at",
+        )
+
+    current = now.astimezone(timezone.utc) if now is not None else datetime.now(timezone.utc)
+    age_days = max((current - parsed).days, 0)
+    status = "fresh" if age_days <= stale_after_days else "stale"
+    if airgapped and status == "stale":
+        status = "airgapped_stale"
+    return RegistryFreshnessStatus(
+        status=status,
+        last_synced_at=parsed.isoformat(),
+        age_days=age_days,
+        stale_after_days=stale_after_days,
+        server_count=len(servers),
+        sources=sources,
+        airgapped=airgapped,
+    )
 
 
 def _parse_version(version: str) -> Optional[tuple[int, ...]]:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,6 +16,7 @@ from agent_bom.registry import (
     compare_versions,
     detect_version_drift,
     list_registry,
+    registry_freshness_status,
     search_registry,
     update_registry_versions,
 )
@@ -248,6 +250,56 @@ def test_list_real_registry_filter_npm():
     assert all(e["ecosystem"] == "npm" for e in entries)
 
 
+# ── Registry freshness ─────────────────────────────────────────────────────
+
+
+def test_registry_freshness_status_fresh():
+    status = registry_freshness_status(
+        stale_after_days=14,
+        now=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        data={"_updated": "2026-04-06", "_sources": ["mcp-official"], "servers": {"a": {}}},
+    )
+
+    assert status.status == "fresh"
+    assert status.is_fresh is True
+    assert status.age_days == 4
+    assert status.server_count == 1
+    assert status.sources == ["mcp-official"]
+
+
+def test_registry_freshness_status_stale():
+    status = registry_freshness_status(
+        stale_after_days=14,
+        now=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        data={"_updated": "2026-04-06", "_sources": ["mcp-official"], "servers": {}},
+    )
+
+    assert status.status == "stale"
+    assert status.is_fresh is False
+    assert status.age_days == 19
+
+
+def test_registry_freshness_status_never_synced():
+    status = registry_freshness_status(now=datetime(2026, 4, 25, tzinfo=timezone.utc), data={"servers": {}})
+
+    assert status.status == "never_synced"
+    assert status.age_days is None
+    assert status.error == "missing_or_invalid_last_synced_at"
+
+
+def test_registry_freshness_status_airgapped_stale(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_REGISTRY_AIRGAPPED", "1")
+
+    status = registry_freshness_status(
+        stale_after_days=1,
+        now=datetime(2026, 4, 25, tzinfo=timezone.utc),
+        data={"_last_synced_at": "2026-04-01T00:00:00Z", "servers": {}},
+    )
+
+    assert status.status == "airgapped_stale"
+    assert status.airgapped is True
+
+
 # ── Update (mocked) ────────────────────────────────────────────────────────
 
 
@@ -322,6 +374,7 @@ def test_cli_registry_help():
     assert "update" in result.output
     assert "list" in result.output
     assert "search" in result.output
+    assert "status" in result.output
 
 
 def test_cli_registry_list():
@@ -369,6 +422,20 @@ def test_cli_registry_search_no_match():
     result = runner.invoke(main, ["registry", "search", "zzzzz-nonexistent-pkg"])
     assert result.exit_code == 0
     assert "No results" in result.output or "0" in result.output
+
+
+def test_cli_registry_status_json():
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["registry", "status", "-f", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["status"] in {"fresh", "stale", "airgapped_stale", "never_synced"}
+    assert data["server_count"] >= 100
+    assert "stale_after_days" in data
 
 
 # ── Dataclass construction ──────────────────────────────────────────────────


### PR DESCRIPTION
Summary

- add registry freshness posture helpers for fresh/stale/never-synced/airgapped catalog states
- expose `agent-bom registry status` with table and JSON output, including source list, server count, last sync, age, and stale threshold
- document the operator decision next to MCP registry verification in the enterprise security playbook
- add regression coverage for fresh, stale, never-synced, airgapped stale, and CLI JSON output

Validation

- uv run ruff check src/agent_bom/registry.py src/agent_bom/cli/_registry.py tests/test_registry.py
- uv run pytest tests/test_registry.py -q
- uv run agent-bom registry status -f json
- git diff --check

Closes #1862