### PR TITLE
fix(ui): install lightningcss native binding in Docker

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,6 +3,11 @@ FROM node:20-slim@sha256:d8a35d586fad3af7abb6fdb9ba972388395405f4d462da9e4a4ddcd
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci --ignore-scripts
+# Next's webpack CSS pipeline requires lightningcss' native Linux binding.
+# Some npm versions omit optional platform bindings during lockfile-driven
+# installs, so pin the Linux binding in the image rather than relying on host
+# lockfile resolution behavior.
+RUN npm install --no-save --ignore-scripts lightningcss-linux-x64-gnu@1.32.0
 
 # ── Stage 2: Build ────────────────────────────────────────────────────────────
 FROM node:20-slim@sha256:d8a35d586fad3af7abb6fdb9ba972388395405f4d462da9e4a4ddcde67b5e0fb AS builder


### PR DESCRIPTION
Summary

- install the Linux x64 GNU lightningcss native binding during the UI Docker dependency stage
- keeps host/package-lock behavior unchanged while making the Docker image build independent of npm optional-dependency omission

Validation

- git diff --check
- pre-commit hooks: whitespace, conflict, ruff/format/mypy/bandit skipped where no matching files

Could not run local `docker build` because the local Docker daemon is not running: `Cannot connect to the Docker daemon`.

Unblocks UI Validate failures like: `Cannot find module '../lightningcss.linux-x64-gnu.node'`.
