### PR TITLE
feat(enrichment): add source circuit breakers

### DIFF
--- a/src/agent_bom/enrichment_posture.py
+++ b/src/agent_bom/enrichment_posture.py
@@ -27,6 +27,9 @@ class EnrichmentSourceState:
     success_count: int = 0
     failure_count: int = 0
     cache_hit_count: int = 0
+    consecutive_failure_count: int = 0
+    circuit_opened_at: str | None = None
+    circuit_open_until: str | None = None
 
 
 _lock = threading.RLock()
@@ -46,6 +49,28 @@ def _source_slo_seconds(source: str) -> int:
         except ValueError:
             pass
     return _DEFAULT_SOURCE_SLOS_SECONDS.get(source, 24 * 60 * 60)
+
+
+def _source_failure_threshold(source: str) -> int:
+    env_name = f"AGENT_BOM_ENRICHMENT_{source.upper()}_CIRCUIT_FAILURES"
+    raw = (os.environ.get(env_name) or "").strip()
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return 3
+
+
+def _source_circuit_open_seconds(source: str) -> int:
+    env_name = f"AGENT_BOM_ENRICHMENT_{source.upper()}_CIRCUIT_OPEN_SECONDS"
+    raw = (os.environ.get(env_name) or "").strip()
+    if raw:
+        try:
+            return max(60, int(raw))
+        except ValueError:
+            pass
+    return 5 * 60
 
 
 def _parse_iso(value: str | None) -> datetime | None:
@@ -77,6 +102,9 @@ def record_enrichment_source(source: str, outcome: str, *, error: str = "") -> N
             state.last_success_at = timestamp
             state.last_error = ""
             state.success_count += 1
+            state.consecutive_failure_count = 0
+            state.circuit_opened_at = None
+            state.circuit_open_until = None
         elif outcome == "cache":
             state.last_cache_at = timestamp
             state.cache_hit_count += 1
@@ -84,6 +112,36 @@ def record_enrichment_source(source: str, outcome: str, *, error: str = "") -> N
             state.last_failure_at = timestamp
             state.last_error = str(error).replace("\r", " ").replace("\n", " ").strip()[:300]
             state.failure_count += 1
+            state.consecutive_failure_count += 1
+            if state.consecutive_failure_count >= _source_failure_threshold(normalized):
+                open_until = datetime.now(timezone.utc).timestamp() + _source_circuit_open_seconds(normalized)
+                state.circuit_opened_at = timestamp
+                state.circuit_open_until = datetime.fromtimestamp(open_until, tz=timezone.utc).isoformat()
+
+
+def enrichment_source_available(source: str) -> bool:
+    """Return False when a source circuit is open.
+
+    Callers should skip non-critical enrichment requests while this is false.
+    Cached data can still be used and should be recorded with outcome ``cache``.
+    """
+
+    normalized = source.strip().lower().replace("-", "_")
+    if not normalized:
+        return True
+    now = datetime.now(timezone.utc)
+    with _lock:
+        state = _states.get(normalized)
+        if state is None:
+            return True
+        open_until = _parse_iso(state.circuit_open_until)
+        if open_until is None:
+            return True
+        if open_until <= now:
+            state.circuit_open_until = None
+            state.circuit_opened_at = None
+            return True
+        return False
 
 
 def reset_enrichment_posture_for_tests() -> None:
@@ -108,7 +166,10 @@ def describe_enrichment_posture() -> dict[str, Any]:
         last_failure = _parse_iso(state.last_failure_at)
         age_seconds = int((now - last_good).total_seconds()) if last_good else None
         slo_seconds = _source_slo_seconds(source)
-        if last_failure and (last_good is None or last_failure >= last_good):
+        if _parse_iso(state.circuit_open_until) and not enrichment_source_available(source):
+            status = "circuit_open"
+            message = "enrichment source circuit is open after consecutive failures"
+        elif last_failure and (last_good is None or last_failure >= last_good):
             status = "degraded"
             message = state.last_error or "latest enrichment attempt failed"
         elif age_seconds is None:
@@ -132,11 +193,16 @@ def describe_enrichment_posture() -> dict[str, Any]:
                 "success_count": state.success_count,
                 "failure_count": state.failure_count,
                 "cache_hit_count": state.cache_hit_count,
+                "consecutive_failure_count": state.consecutive_failure_count,
+                "circuit_opened_at": state.circuit_opened_at,
+                "circuit_open_until": state.circuit_open_until,
+                "circuit_failure_threshold": _source_failure_threshold(source),
+                "circuit_open_seconds": _source_circuit_open_seconds(source),
                 "message": message,
             }
         )
 
-    worst_order = {"degraded": 0, "stale": 1, "unknown": 2, "ok": 3}
+    worst_order = {"circuit_open": 0, "degraded": 1, "stale": 2, "unknown": 3, "ok": 4}
     worst = min(rows, key=lambda item: worst_order.get(str(item["status"]), 0)) if rows else None
     return {
         "status": worst["status"] if worst else "unknown",

--- a/src/agent_bom/scanners/osv.py
+++ b/src/agent_bom/scanners/osv.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 from agent_bom.config import SCANNER_BATCH_DELAY as BATCH_DELAY_SECONDS
 from agent_bom.config import SCANNER_BATCH_SIZE as _BATCH_SIZE
-from agent_bom.enrichment_posture import record_enrichment_source
+from agent_bom.enrichment_posture import enrichment_source_available, record_enrichment_source
 from agent_bom.http_client import OfflineModeError, create_client, request_with_retry
 from agent_bom.models import Package
 from agent_bom.package_utils import normalize_package_name
@@ -297,6 +297,12 @@ async def query_osv_batch_impl(
         return await enrich_results_if_needed_fn(results)
     bump_scan_perf("osv_packages_queried", len(packages_to_query))
     bump_scan_perf("osv_queries_sent", len(queries))
+
+    if not enrichment_source_available("osv"):
+        _logger.warning("OSV enrichment circuit is open; skipping %d remote query item(s)", len(queries))
+        console.print("  [yellow]⚠[/yellow] OSV enrichment circuit open — using cache/local data only")
+        record_scan_warning("OSV enrichment circuit open")
+        return await enrich_results_if_needed_fn(results)
 
     lookup_errors: list[tuple[str, str, str]] = []
     batch_size = min(_BATCH_SIZE, 1000)

--- a/tests/test_enrichment_circuit_breaker.py
+++ b/tests/test_enrichment_circuit_breaker.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from rich.console import Console
+
+from agent_bom.enrichment_posture import (
+    describe_enrichment_posture,
+    enrichment_source_available,
+    record_enrichment_source,
+    reset_enrichment_posture_for_tests,
+)
+from agent_bom.models import Package
+from agent_bom.scanners.osv import query_osv_batch_impl
+
+
+def setup_function() -> None:
+    reset_enrichment_posture_for_tests()
+
+
+def test_enrichment_source_circuit_opens_after_consecutive_failures(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_ENRICHMENT_OSV_CIRCUIT_FAILURES", "2")
+    monkeypatch.setenv("AGENT_BOM_ENRICHMENT_OSV_CIRCUIT_OPEN_SECONDS", "60")
+
+    record_enrichment_source("osv", "failure", error="timeout")
+    assert enrichment_source_available("osv") is True
+
+    record_enrichment_source("osv", "failure", error="timeout")
+    assert enrichment_source_available("osv") is False
+
+    posture = describe_enrichment_posture()
+    osv = next(source for source in posture["sources"] if source["source"] == "osv")
+    assert posture["status"] == "circuit_open"
+    assert osv["status"] == "circuit_open"
+    assert osv["consecutive_failure_count"] == 2
+    assert osv["circuit_open_until"]
+
+
+def test_success_resets_circuit_state(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_ENRICHMENT_OSV_CIRCUIT_FAILURES", "1")
+
+    record_enrichment_source("osv", "failure", error="HTTP 500")
+    assert enrichment_source_available("osv") is False
+
+    record_enrichment_source("osv", "success")
+    assert enrichment_source_available("osv") is True
+
+    osv = next(source for source in describe_enrichment_posture()["sources"] if source["source"] == "osv")
+    assert osv["status"] == "ok"
+    assert osv["consecutive_failure_count"] == 0
+    assert osv["circuit_open_until"] is None
+
+
+@pytest.mark.asyncio
+async def test_osv_query_skips_remote_when_circuit_open(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_ENRICHMENT_OSV_CIRCUIT_FAILURES", "1")
+    record_enrichment_source("osv", "failure", error="timeout")
+    called = False
+    warnings: list[str] = []
+
+    async def request_with_retry(*args, **kwargs):  # noqa: ARG001
+        nonlocal called
+        called = True
+        return None
+
+    result = await query_osv_batch_impl(
+        [Package(name="requests", version="2.31.0", ecosystem="pypi")],
+        console=Console(file=None, force_terminal=False, quiet=True),
+        get_scan_cache=lambda: None,
+        get_api_semaphore=lambda: asyncio.Semaphore(1),
+        bump_scan_perf=lambda _name, _count: None,
+        enrich_results_if_needed_fn=lambda results: asyncio.sleep(0, result=results),
+        record_scan_warning=warnings.append,
+        osv_ecosystems_for_package=lambda _pkg: ["PyPI"],
+        non_osv_ecosystems=frozenset(),
+        request_with_retry_fn=request_with_retry,
+    )
+
+    assert result == {}
+    assert called is False
+    assert warnings == ["OSV enrichment circuit open"]


### PR DESCRIPTION
Summary

- add per-source enrichment circuit-breaker state to the runtime posture model
- expose circuit thresholds/open windows in `/v1/posture/enrichment` via existing posture serialization
- wire OSV batch lookups to skip remote calls while the OSV circuit is open, using cache/local data and scan warnings instead of hammering a failing source

Validation

- uv run ruff check src/agent_bom/enrichment_posture.py src/agent_bom/scanners/osv.py tests/test_enrichment_circuit_breaker.py
- uv run pytest tests/test_enrichment_circuit_breaker.py tests/test_enrichment_posture.py -q
- git diff --check

Closes #1830
