### PR TITLE
perf(graph): batch graph store writes

### DIFF
--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Iterable, Iterator, Sequence
 
 from agent_bom.api.graph_store import _escape_like_query, _node_search_text, decode_graph_cursor, encode_graph_cursor
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
@@ -14,6 +15,47 @@ from agent_bom.graph import EntityType
 from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
 
 _ALLOWED_ENTITY_TYPES = {entity_type.value for entity_type in EntityType}
+_DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
+
+
+def _graph_write_batch_size() -> int:
+    raw = os.environ.get("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", str(_DEFAULT_GRAPH_WRITE_BATCH_SIZE))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_GRAPH_WRITE_BATCH_SIZE
+
+
+def _batched_rows(rows: Iterable[Sequence[Any]], batch_size: int) -> Iterator[list[Sequence[Any]]]:
+    batch: list[Sequence[Any]] = []
+    for row in rows:
+        batch.append(row)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _execute_many_batched(conn, sql: str, rows: Iterable[Sequence[Any]], *, batch_size: int) -> int:
+    """Execute DML rows in bounded batches.
+
+    psycopg connections expose ``cursor().executemany``. Tests and light mocks
+    often only expose ``execute`` or ``executemany`` directly, so keep a small
+    compatibility fallback while preserving bounded memory behavior.
+    """
+    total = 0
+    for batch in _batched_rows(rows, batch_size):
+        if hasattr(conn, "executemany"):
+            conn.executemany(sql, batch)
+        elif hasattr(conn, "cursor"):
+            with conn.cursor() as cur:
+                cur.executemany(sql, batch)
+        else:
+            for row in batch:
+                conn.execute(sql, row)
+        total += len(batch)
+    return total
 
 
 def _assert_allowed_entity_types(entity_types: set[str] | None) -> None:
@@ -282,35 +324,13 @@ class PostgresGraphStore:
         scan = graph.scan_id or ""
         tenant = graph.tenant_id or "default"
         now = graph.created_at or datetime.now(timezone.utc).isoformat()
+        batch_size = _graph_write_batch_size()
 
         with _tenant_connection(self._pool) as conn:
-            for node in graph.nodes.values():
-                conn.execute(
-                    """
-                    INSERT INTO graph_nodes (
-                        id, entity_type, label, category_uid, class_uid, type_uid,
-                        status, risk_score, severity, severity_id,
-                        first_seen, last_seen, attributes, compliance_tags,
-                        data_sources, dimensions, scan_id, tenant_id
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (id, scan_id, tenant_id) DO UPDATE SET
-                        entity_type = EXCLUDED.entity_type,
-                        label = EXCLUDED.label,
-                        category_uid = EXCLUDED.category_uid,
-                        class_uid = EXCLUDED.class_uid,
-                        type_uid = EXCLUDED.type_uid,
-                        status = EXCLUDED.status,
-                        risk_score = EXCLUDED.risk_score,
-                        severity = EXCLUDED.severity,
-                        severity_id = EXCLUDED.severity_id,
-                        first_seen = EXCLUDED.first_seen,
-                        last_seen = EXCLUDED.last_seen,
-                        attributes = EXCLUDED.attributes,
-                        compliance_tags = EXCLUDED.compliance_tags,
-                        data_sources = EXCLUDED.data_sources,
-                        dimensions = EXCLUDED.dimensions
-                    """,
-                    (
+
+            def node_rows() -> Iterator[tuple[Any, ...]]:
+                for node in graph.nodes.values():
+                    yield (
                         node.id,
                         node.entity_type.value if hasattr(node.entity_type, "value") else node.entity_type,
                         node.label,
@@ -329,21 +349,11 @@ class PostgresGraphStore:
                         json.dumps(node.dimensions.to_dict()),
                         scan,
                         tenant,
-                    ),
-                )
-                conn.execute(
-                    """
-                    INSERT INTO graph_node_search (
-                        node_id, tenant_id, scan_id, entity_type, severity, compliance_tags, data_sources, search_text
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (node_id, scan_id, tenant_id) DO UPDATE SET
-                        entity_type = EXCLUDED.entity_type,
-                        severity = EXCLUDED.severity,
-                        compliance_tags = EXCLUDED.compliance_tags,
-                        data_sources = EXCLUDED.data_sources,
-                        search_text = EXCLUDED.search_text
-                    """,
-                    (
+                    )
+
+            def node_search_rows() -> Iterator[tuple[Any, ...]]:
+                for node in graph.nodes.values():
+                    yield (
                         node.id,
                         tenant,
                         scan,
@@ -352,28 +362,12 @@ class PostgresGraphStore:
                         " ".join(node.compliance_tags).lower(),
                         " ".join(node.data_sources).lower(),
                         _node_search_text(node),
-                    ),
-                )
+                    )
 
-            for edge in graph.edges:
-                rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else edge.relationship
-                conn.execute(
-                    """
-                    INSERT INTO graph_edges (
-                        source_id, target_id, relationship, direction, weight,
-                        traversable, first_seen, last_seen, evidence,
-                        activity_id, scan_id, tenant_id
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (source_id, target_id, relationship, scan_id, tenant_id) DO UPDATE SET
-                        direction = EXCLUDED.direction,
-                        weight = EXCLUDED.weight,
-                        traversable = EXCLUDED.traversable,
-                        first_seen = EXCLUDED.first_seen,
-                        last_seen = EXCLUDED.last_seen,
-                        evidence = EXCLUDED.evidence,
-                        activity_id = EXCLUDED.activity_id
-                    """,
-                    (
+            def edge_rows() -> Iterator[tuple[Any, ...]]:
+                for edge in graph.edges:
+                    rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else edge.relationship
+                    yield (
                         edge.source,
                         edge.target,
                         rel,
@@ -386,27 +380,11 @@ class PostgresGraphStore:
                         edge.activity_id,
                         scan,
                         tenant,
-                    ),
-                )
+                    )
 
-            for ap in graph.attack_paths:
-                conn.execute(
-                    """
-                    INSERT INTO attack_paths (
-                        source_node, target_node, hop_count, composite_risk,
-                        path_nodes, path_edges, credential_exposure, vuln_ids,
-                        scan_id, tenant_id, computed_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (source_node, target_node, scan_id, tenant_id) DO UPDATE SET
-                        hop_count = EXCLUDED.hop_count,
-                        composite_risk = EXCLUDED.composite_risk,
-                        path_nodes = EXCLUDED.path_nodes,
-                        path_edges = EXCLUDED.path_edges,
-                        credential_exposure = EXCLUDED.credential_exposure,
-                        vuln_ids = EXCLUDED.vuln_ids,
-                        computed_at = EXCLUDED.computed_at
-                    """,
-                    (
+            def attack_path_rows() -> Iterator[tuple[Any, ...]]:
+                for ap in graph.attack_paths:
+                    yield (
                         ap.source,
                         ap.target,
                         len(ap.hops),
@@ -418,22 +396,11 @@ class PostgresGraphStore:
                         scan,
                         tenant,
                         now,
-                    ),
-                )
+                    )
 
-            for ir in graph.interaction_risks:
-                conn.execute(
-                    """
-                    INSERT INTO interaction_risks (
-                        pattern, agents, risk_score, description,
-                        owasp_agentic_tag, scan_id, tenant_id
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (pattern, agents, scan_id, tenant_id) DO UPDATE SET
-                        risk_score = EXCLUDED.risk_score,
-                        description = EXCLUDED.description,
-                        owasp_agentic_tag = EXCLUDED.owasp_agentic_tag
-                    """,
-                    (
+            def interaction_risk_rows() -> Iterator[tuple[Any, ...]]:
+                for ir in graph.interaction_risks:
+                    yield (
                         ir.pattern,
                         json.dumps(sorted(ir.agents)),
                         ir.risk_score,
@@ -441,8 +408,108 @@ class PostgresGraphStore:
                         ir.owasp_agentic_tag,
                         scan,
                         tenant,
-                    ),
-                )
+                    )
+
+            _execute_many_batched(
+                conn,
+                """
+                INSERT INTO graph_nodes (
+                    id, entity_type, label, category_uid, class_uid, type_uid,
+                    status, risk_score, severity, severity_id,
+                    first_seen, last_seen, attributes, compliance_tags,
+                    data_sources, dimensions, scan_id, tenant_id
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (id, scan_id, tenant_id) DO UPDATE SET
+                    entity_type = EXCLUDED.entity_type,
+                    label = EXCLUDED.label,
+                    category_uid = EXCLUDED.category_uid,
+                    class_uid = EXCLUDED.class_uid,
+                    type_uid = EXCLUDED.type_uid,
+                    status = EXCLUDED.status,
+                    risk_score = EXCLUDED.risk_score,
+                    severity = EXCLUDED.severity,
+                    severity_id = EXCLUDED.severity_id,
+                    first_seen = EXCLUDED.first_seen,
+                    last_seen = EXCLUDED.last_seen,
+                    attributes = EXCLUDED.attributes,
+                    compliance_tags = EXCLUDED.compliance_tags,
+                    data_sources = EXCLUDED.data_sources,
+                    dimensions = EXCLUDED.dimensions
+                """,
+                node_rows(),
+                batch_size=batch_size,
+            )
+            _execute_many_batched(
+                conn,
+                """
+                INSERT INTO graph_node_search (
+                    node_id, tenant_id, scan_id, entity_type, severity, compliance_tags, data_sources, search_text
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (node_id, scan_id, tenant_id) DO UPDATE SET
+                    entity_type = EXCLUDED.entity_type,
+                    severity = EXCLUDED.severity,
+                    compliance_tags = EXCLUDED.compliance_tags,
+                    data_sources = EXCLUDED.data_sources,
+                    search_text = EXCLUDED.search_text
+                """,
+                node_search_rows(),
+                batch_size=batch_size,
+            )
+            _execute_many_batched(
+                conn,
+                """
+                INSERT INTO graph_edges (
+                    source_id, target_id, relationship, direction, weight,
+                    traversable, first_seen, last_seen, evidence,
+                    activity_id, scan_id, tenant_id
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (source_id, target_id, relationship, scan_id, tenant_id) DO UPDATE SET
+                    direction = EXCLUDED.direction,
+                    weight = EXCLUDED.weight,
+                    traversable = EXCLUDED.traversable,
+                    first_seen = EXCLUDED.first_seen,
+                    last_seen = EXCLUDED.last_seen,
+                    evidence = EXCLUDED.evidence,
+                    activity_id = EXCLUDED.activity_id
+                """,
+                edge_rows(),
+                batch_size=batch_size,
+            )
+            _execute_many_batched(
+                conn,
+                """
+                INSERT INTO attack_paths (
+                    source_node, target_node, hop_count, composite_risk,
+                    path_nodes, path_edges, credential_exposure, vuln_ids,
+                    scan_id, tenant_id, computed_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (source_node, target_node, scan_id, tenant_id) DO UPDATE SET
+                    hop_count = EXCLUDED.hop_count,
+                    composite_risk = EXCLUDED.composite_risk,
+                    path_nodes = EXCLUDED.path_nodes,
+                    path_edges = EXCLUDED.path_edges,
+                    credential_exposure = EXCLUDED.credential_exposure,
+                    vuln_ids = EXCLUDED.vuln_ids,
+                    computed_at = EXCLUDED.computed_at
+                """,
+                attack_path_rows(),
+                batch_size=batch_size,
+            )
+            _execute_many_batched(
+                conn,
+                """
+                INSERT INTO interaction_risks (
+                    pattern, agents, risk_score, description,
+                    owasp_agentic_tag, scan_id, tenant_id
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (pattern, agents, scan_id, tenant_id) DO UPDATE SET
+                    risk_score = EXCLUDED.risk_score,
+                    description = EXCLUDED.description,
+                    owasp_agentic_tag = EXCLUDED.owasp_agentic_tag
+                """,
+                interaction_risk_rows(),
+                batch_size=batch_size,
+            )
 
             stats = graph.stats()
             conn.execute(

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -14,7 +14,7 @@ import os
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, Iterable, Iterator, Sequence
 
 from agent_bom.graph import (
     SEVERITY_RANK,
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 # ═══════════════════════════════════════════════════════════════════════════
 
 _GRAPH_SCHEMA_VERSION = 2
+_DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
 
 _CREATE_TABLES = """\
 -- ── Graph nodes (one row per node per scan) ──
@@ -178,6 +179,39 @@ def _init_db(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _graph_write_batch_size() -> int:
+    raw = os.environ.get("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", str(_DEFAULT_GRAPH_WRITE_BATCH_SIZE))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_GRAPH_WRITE_BATCH_SIZE
+
+
+def _batched_rows(rows: Iterable[Sequence[Any]], batch_size: int) -> Iterator[list[Sequence[Any]]]:
+    batch: list[Sequence[Any]] = []
+    for row in rows:
+        batch.append(row)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _executemany_batched(
+    conn: sqlite3.Connection,
+    sql: str,
+    rows: Iterable[Sequence[Any]],
+    *,
+    batch_size: int,
+) -> int:
+    total = 0
+    for batch in _batched_rows(rows, batch_size):
+        conn.executemany(sql, batch)
+        total += len(batch)
+    return total
+
+
 @contextmanager
 def open_graph_db(db_path: str | Path) -> Generator[sqlite3.Connection, None, None]:
     """Open (or create) a graph database with schema initialisation."""
@@ -255,12 +289,12 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
     tenant = graph.tenant_id
     scan = graph.scan_id
     now = _now_iso()
+    batch_size = _graph_write_batch_size()
 
     # ── Nodes ──
-    node_rows = []
-    for node in graph.nodes.values():
-        node_rows.append(
-            (
+    def node_rows() -> Iterator[tuple[Any, ...]]:
+        for node in graph.nodes.values():
+            yield (
                 node.id,
                 node.entity_type.value if isinstance(node.entity_type, EntityType) else node.entity_type,
                 node.label,
@@ -280,8 +314,9 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
                 scan,
                 tenant,
             )
-        )
-    conn.executemany(
+
+    _executemany_batched(
+        conn,
         """\
         INSERT OR REPLACE INTO graph_nodes (
             id, entity_type, label, category_uid, class_uid, type_uid,
@@ -290,15 +325,15 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
             data_sources, dimensions, scan_id, tenant_id
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        node_rows,
+        node_rows(),
+        batch_size=batch_size,
     )
 
     # ── Edges ──
-    edge_rows = []
-    for edge in graph.edges:
-        rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else edge.relationship
-        edge_rows.append(
-            (
+    def edge_rows() -> Iterator[tuple[Any, ...]]:
+        for edge in graph.edges:
+            rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else edge.relationship
+            yield (
                 edge.source,
                 edge.target,
                 rel,
@@ -312,8 +347,9 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
                 scan,
                 tenant,
             )
-        )
-    conn.executemany(
+
+    _executemany_batched(
+        conn,
         """\
         INSERT OR REPLACE INTO graph_edges (
             source_id, target_id, relationship, direction, weight,
@@ -321,7 +357,8 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
             activity_id, scan_id, tenant_id
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        edge_rows,
+        edge_rows(),
+        batch_size=batch_size,
     )
 
     # ── Attack paths ──

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -83,6 +83,22 @@ def graph_db():
 class TestScanPipelineWiring:
     """Test that scan pipeline correctly produces and persists unified graphs."""
 
+    def test_sqlite_graph_write_batches_rows_without_full_buffer(self):
+        from agent_bom.db.graph_store import _executemany_batched
+
+        class FakeConnection:
+            def __init__(self) -> None:
+                self.calls: list[list[tuple[int]]] = []
+
+            def executemany(self, _sql, rows):
+                self.calls.append(list(rows))
+
+        conn = FakeConnection()
+        total = _executemany_batched(conn, "INSERT", ((idx,) for idx in range(5)), batch_size=2)
+
+        assert total == 5
+        assert [len(call) for call in conn.calls] == [2, 2, 1]
+
     def test_context_graph_to_unified_round_trip(self, graph_db):
         """Build context graph → bridge → persist → load → verify."""
         from agent_bom.context_graph import build_context_graph, find_lateral_paths, to_unified_graph

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -34,6 +34,16 @@ class MockConnection:
         self._store: dict[str, dict] = {}  # table -> {pk: data}
         self._cursors: list[MockCursor] = []
         self.executed: list[tuple[str, object]] = []
+        self.executemany_calls: list[tuple[str, list[object]]] = []
+
+    def executemany(self, sql, param_seq):
+        rows = list(param_seq)
+        self.executemany_calls.append((sql, rows))
+        cursor = MockCursor()
+        cursor.rowcount = len(rows)
+        for params in rows:
+            self.execute(sql, params)
+        return cursor
 
     def execute(self, sql, params=None):
         cursor = MockCursor()
@@ -77,8 +87,14 @@ class MockConnection:
                     table = "osv_cache"
                 elif "graph_nodes" in sql:
                     table = "graph_nodes"
+                elif "graph_edges" in sql:
+                    table = "graph_edges"
+                elif "graph_node_search" in sql:
+                    table = "graph_node_search"
                 elif "attack_paths" in sql:
                     table = "attack_paths"
+                elif "interaction_risks" in sql:
+                    table = "interaction_risks"
                 if table not in self._store:
                     self._store[table] = {}
                 self._store[table][params[0]] = params
@@ -1225,6 +1241,31 @@ def test_graph_store_nodes_by_ids_uses_node_table(mock_pool, monkeypatch):
     assert [node.id for node in nodes] == ["tool:t"]
     select_sql = "\n".join(sql for sql, _params in mock_pool._conn.executed if "FROM graph_nodes" in sql)
     assert "id IN" in select_sql
+
+
+def test_graph_store_save_graph_batches_postgres_writes(mock_pool, monkeypatch):
+    from agent_bom.api.postgres_store import PostgresGraphStore
+    from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+
+    monkeypatch.setenv("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", "2")
+    store = PostgresGraphStore(pool=mock_pool)
+    graph = UnifiedGraph(scan_id="scan-batch", tenant_id="tenant-alpha")
+    for idx in range(3):
+        graph.add_node(UnifiedNode(id=f"agent:{idx}", entity_type=EntityType.AGENT, label=f"Agent {idx}"))
+    graph.add_edge(UnifiedEdge(source="agent:0", target="agent:1", relationship=RelationshipType.DELEGATED_TO))
+    graph.add_edge(UnifiedEdge(source="agent:1", target="agent:2", relationship=RelationshipType.DELEGATED_TO))
+
+    store.save_graph(graph)
+
+    graph_node_batches = [
+        rows for sql, rows in mock_pool._conn.executemany_calls if "INSERT INTO graph_nodes" in sql and "graph_node_search" not in sql
+    ]
+    graph_search_batches = [rows for sql, rows in mock_pool._conn.executemany_calls if "INSERT INTO graph_node_search" in sql]
+    graph_edge_batches = [rows for sql, rows in mock_pool._conn.executemany_calls if "INSERT INTO graph_edges" in sql]
+
+    assert [len(batch) for batch in graph_node_batches] == [2, 1]
+    assert [len(batch) for batch in graph_search_batches] == [2, 1]
+    assert [len(batch) for batch in graph_edge_batches] == [2]
 
 
 def test_graph_store_attack_paths_for_sources_uses_materialized_table(mock_pool, monkeypatch):


### PR DESCRIPTION
Summary

- stream SQLite graph node and edge persistence through bounded executemany batches
- batch Postgres graph upserts for nodes, search rows, edges, materialized attack paths, and interaction risks
- share AGENT_BOM_GRAPH_WRITE_BATCH_SIZE across graph store write paths so large-snapshot write memory and round trips are bounded by batch/window size
- keep snapshot, attack-path, interaction-risk, tenant/RLS, and read behavior unchanged
- add regressions proving SQLite and Postgres graph persistence batch rows instead of requiring one full row list / one execute per row

Validation

- uv run ruff check src/agent_bom/api/postgres_graph.py src/agent_bom/db/graph_store.py tests/test_postgres_store.py tests/test_graph_api.py
- uv run pytest tests/test_postgres_store.py tests/test_graph_api.py tests/test_graph_schema.py -q
- git diff --check
- pre-commit hooks: ruff, ruff-format, mypy, bandit

Refs #1838
