### PR TITLE
docs(graph): record write batching architecture

### DIFF
--- a/docs/decisions/006-unified-graph-write-batching.md
+++ b/docs/decisions/006-unified-graph-write-batching.md
@@ -1,0 +1,54 @@
+# ADR-006: Unified Graph Write Batching
+
+**Status:** Accepted
+**Date:** 2026-04-25
+
+## Context
+
+Large graph snapshots can contain many nodes, search rows, edges, attack paths,
+and interaction risks. Persisting those rows one at a time is slow, but building
+full intermediate row lists before writing can make memory scale with total graph
+size. That is the wrong failure mode for fleet-scale scans.
+
+SQLite and Postgres already share the same logical persistence contract:
+`save_graph(graph)` receives a `UnifiedGraph` and writes the same graph objects
+in the same order. The batching change should preserve that contract instead of
+creating backend-specific graph save APIs.
+
+## Decision
+
+Use one operator-facing graph write batch-size setting across SQLite and
+Postgres:
+
+- `AGENT_BOM_GRAPH_WRITE_BATCH_SIZE`
+
+Each backend maps that shared setting to its own write implementation. Row
+sources are lazy iterators, and the batching helper materializes only one batch
+window at a time. That keeps graph write memory bounded by the batch size rather
+than total graph size.
+
+Batching helpers are intentionally generic. They operate on row iterables and
+SQL statements, not on graph-specific types. This keeps the pattern reusable for
+future write-heavy paths without creating separate one-off batching code.
+
+Compatibility fallbacks may write rows individually when a test or lightweight
+connection object does not expose `executemany`, but they still consume bounded
+batches. The fallback can give up round-trip efficiency; it must not give up the
+bounded-memory invariant.
+
+## Consequences
+
+- **Positive:** Operators tune one graph write batch knob instead of separate
+  SQLite and Postgres settings.
+- **Positive:** Backend implementations can differ internally while preserving
+  the shared `save_graph(graph)` contract.
+- **Positive:** Lazy row generation keeps write-path memory tied to the batch
+  window, not to graph size.
+- **Positive:** The batching primitive is reusable outside graph persistence.
+- **Trade-off:** One shared knob may not be optimal for every backend in every
+  deployment. If benchmarks prove a backend-specific need, add optional
+  backend-specific overrides while keeping `AGENT_BOM_GRAPH_WRITE_BATCH_SIZE`
+  as the default.
+- **Boundary:** This decision covers write-path batching only. Read-path
+  windowing, streaming reads, materialized drilldowns, and UI virtualization are
+  separate graph-scale concerns.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -23,6 +23,7 @@ Each ADR follows this structure:
 | 003 | [FastAPI APIRouter Pattern](003-fastapi-apirouter-pattern.md) | Accepted | 2026-03-11 |
 | 004 | [Proxy-Based Runtime Enforcement](004-proxy-runtime-enforcement.md) | Accepted | 2026-03-11 |
 | 005 | [Re-Export Pattern for Backward Compatibility](005-re-export-pattern.md) | Accepted | 2026-03-11 |
+| 006 | [Unified Graph Write Batching](006-unified-graph-write-batching.md) | Accepted | 2026-04-25 |
 
 ## Adding a New ADR
 

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -305,6 +305,28 @@ bundled k6 harness:
 These are not universal guarantees for every tenant shape. They are the
 thresholds operators should validate before calling a rollout production-ready.
 
+## Graph write batching
+
+Graph persistence uses one batch-size knob across SQLite and Postgres:
+
+```bash
+AGENT_BOM_GRAPH_WRITE_BATCH_SIZE=1000
+```
+
+Both backends persist the same logical graph objects through the same
+`save_graph(graph)` contract: nodes, search rows, edges, attack paths, and
+interaction risks. The backend implementations differ internally, but the
+operator tuning model stays consistent.
+
+The write path uses lazy row generation and bounded batches. Memory is therefore
+tied to the configured batch window instead of total graph size. Raising the
+batch size can improve write throughput, while lowering it can reduce per-batch
+memory and parameter pressure.
+
+This setting controls graph writes only. Graph read latency is governed by
+snapshot windowing, pagination, search indexes, materialized drilldowns, and UI
+virtualization.
+
 ## Publish your own benchmark numbers
 
 `agent-bom` deliberately does not claim a universal scans/day SLA. Real


### PR DESCRIPTION
Summary

- add ADR-006 documenting the unified graph write batching decision
- explain why SQLite and Postgres share AGENT_BOM_GRAPH_WRITE_BATCH_SIZE
- add operator sizing guidance that write batching bounds memory by batch window and does not cover read-path tuning

Validation

- uv run ruff check docs/decisions/README.md docs/decisions/006-unified-graph-write-batching.md site-docs/deployment/performance-and-sizing.md
- git diff --check

Refs #1838