### PR TITLE
docs(perf): scaffold scale evidence checks

### DIFF
--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -22,6 +22,15 @@ k6 run deploy/loadtest/k6-graph-api.js
 k6 run deploy/loadtest/k6-proxy-audit.js
 ```
 
+Release-quality scale evidence for 1k / 5k / 10k estate claims is tracked
+under [`docs/perf/`](perf/). Those pages carry the exact commands,
+environment fields, raw-result locations, and gaps used for enterprise
+procurement evidence. Validate the scaffold with:
+
+```bash
+python scripts/check_scale_evidence.py
+```
+
 ---
 
 ## Scanner hot paths

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,22 @@
+# Performance Evidence
+
+This directory holds release-quality performance evidence for enterprise scale
+claims. Pages here are intentionally separate from broad target-SLO guidance in
+[`docs/PERFORMANCE_BENCHMARKS.md`](../PERFORMANCE_BENCHMARKS.md): a page in
+this directory must include the command, environment, raw-result location, and
+known gaps for the specific claim it supports.
+
+Current evidence pages:
+
+- [`p95-p99-graph-query.md`](p95-p99-graph-query.md) — graph query latency at
+  1k / 5k / 10k estate sizes.
+- [`ingest-throughput.md`](ingest-throughput.md) — graph save throughput and
+  batch-size behavior.
+- [`fleet-reconciliation.md`](fleet-reconciliation.md) — fleet and Kubernetes
+  reconciliation latency.
+
+Run the structure check before publishing release numbers:
+
+```bash
+python scripts/check_scale_evidence.py
+```

--- a/docs/perf/fleet-reconciliation.md
+++ b/docs/perf/fleet-reconciliation.md
@@ -1,0 +1,56 @@
+# Fleet Reconciliation Evidence
+
+Evidence status: scaffold
+Owner issue: #1806
+
+## Claim
+
+Fleet and Kubernetes reconciliation can process repeated snapshots at 1k / 5k /
+10k host or workload scale while preserving stable identity, added/changed/
+missing/stale state, and control-plane ingest SLOs.
+
+## Scope
+
+- `agent-bom fleet reconcile-k8s`
+- control-plane fleet snapshot push
+- repeated snapshot deduplication
+- added / changed / missing / stale reconciliation output
+- graph selector/drilldown latency after fleet ingestion
+
+## Environment
+
+Record the exact environment before publishing measured numbers:
+
+- Hardware:
+- CPU:
+- Memory:
+- Kubernetes version:
+- Postgres version:
+- Dataset shape:
+- agent-bom commit:
+
+## Commands
+
+```bash
+agent-bom fleet reconcile-k8s --snapshot current.json --previous previous.json --format json
+curl -X POST "$AGENT_BOM_BASE_URL/v1/fleet/sync" \
+  -H "Authorization: Bearer $AGENT_BOM_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data @current.json
+```
+
+## Results
+
+Measured results are intentionally not filled in this scaffold PR.
+
+| Estate size | Snapshot shape | Reconcile wall time | Push p95 | Push p99 | Dedup latency | Result artifact |
+|---:|---|---:|---:|---:|---:|---|
+| 1k hosts | TBD | TBD | TBD | TBD | TBD | TBD |
+| 5k hosts | TBD | TBD | TBD | TBD | TBD | TBD |
+| 10k hosts | TBD | TBD | TBD | TBD | TBD | TBD |
+
+## Gaps
+
+- Add or document fixture generation for 1k / 5k / 10k snapshots.
+- Replace scaffold rows with measured values from a reproducible run.
+- Attach raw benchmark JSON under `docs/perf/results/`.

--- a/docs/perf/ingest-throughput.md
+++ b/docs/perf/ingest-throughput.md
@@ -1,0 +1,54 @@
+# Graph Ingest Throughput Evidence
+
+Evidence status: scaffold
+Owner issue: #1806
+
+## Claim
+
+Graph save throughput remains bounded by batch/window size rather than total
+graph size, and `AGENT_BOM_GRAPH_WRITE_BATCH_SIZE` gives operators one tuning
+knob across SQLite and Postgres write paths.
+
+## Scope
+
+- SQLite graph store writes
+- Postgres graph store writes
+- node, edge, search-row, attack-path, and interaction-risk persistence
+- batch-size sensitivity for small, default, and large batches
+
+## Environment
+
+Record the exact environment before publishing measured numbers:
+
+- Hardware:
+- CPU:
+- Memory:
+- Storage:
+- Database backend:
+- agent-bom commit:
+
+## Commands
+
+```bash
+pytest tests/benchmarks/test_graph_hot_paths.py --benchmark-only
+AGENT_BOM_GRAPH_WRITE_BATCH_SIZE=100 pytest tests/benchmarks/ --benchmark-only -k graph
+AGENT_BOM_GRAPH_WRITE_BATCH_SIZE=1000 pytest tests/benchmarks/ --benchmark-only -k graph
+AGENT_BOM_GRAPH_WRITE_BATCH_SIZE=5000 pytest tests/benchmarks/ --benchmark-only -k graph
+```
+
+## Results
+
+Measured results are intentionally not filled in this scaffold PR.
+
+| Backend | Batch size | Estate size | Nodes/sec | Edges/sec | Peak RSS | Result artifact |
+|---|---:|---:|---:|---:|---:|---|
+| SQLite | 100 | TBD | TBD | TBD | TBD | TBD |
+| SQLite | 1,000 | TBD | TBD | TBD | TBD | TBD |
+| Postgres | 1,000 | TBD | TBD | TBD | TBD | TBD |
+| Postgres | 5,000 | TBD | TBD | TBD | TBD | TBD |
+
+## Gaps
+
+- Add write-path benchmark cases for persistence, not only graph build CPU.
+- Replace scaffold rows with measured values from a reproducible run.
+- Attach raw benchmark JSON under `docs/perf/results/`.

--- a/docs/perf/p95-p99-graph-query.md
+++ b/docs/perf/p95-p99-graph-query.md
@@ -1,0 +1,66 @@
+# Graph Query p95/p99 Evidence
+
+Evidence status: scaffold
+Owner issue: #1806
+
+## Claim
+
+Graph search, selector, neighborhood, diff, and attack-path drilldown APIs stay
+within the published operator SLOs for 1k / 5k / 10k agent estates when the UI
+uses windowed selectors and bounded graph queries.
+
+## Scope
+
+- `GET /v1/graph`
+- `GET /v1/graph/search`
+- `GET /v1/graph/{node_id}`
+- `GET /v1/graph/diff`
+- materialized attack-path drilldowns
+
+## Environment
+
+Record the exact environment before publishing measured numbers:
+
+- Hardware:
+- CPU:
+- Memory:
+- Postgres version:
+- Dataset shape:
+- agent-bom commit:
+
+## Commands
+
+```bash
+export AGENT_BOM_BASE_URL=https://agent-bom.internal.example.com
+export AGENT_BOM_API_TOKEN=replace-me
+export AGENT_BOM_GRAPH_SCAN_ID=replace-me
+
+k6 run deploy/loadtest/k6-graph-api.js
+```
+
+## Results
+
+Measured results are intentionally not filled in this scaffold PR.
+
+| Estate size | Endpoint group | p95 | p99 | Target | Result artifact |
+|---:|---|---:|---:|---:|---|
+| 1k agents | graph search/selectors | TBD | TBD | TBD | TBD |
+| 5k agents | graph search/selectors | TBD | TBD | TBD | TBD |
+| 10k agents | graph search/selectors | TBD | TBD | TBD | TBD |
+
+## EXPLAIN ANALYZE
+
+Attach representative query plans for the hot Postgres graph paths:
+
+- graph node search:
+- node detail:
+- attack-path drilldown:
+- graph diff:
+
+## Gaps
+
+- Replace scaffold rows with measured values from a reproducible run.
+- Attach raw k6 output or benchmark JSON under `docs/perf/results/`.
+- Confirm whether the run includes local endpoint, Kubernetes, cloud/SaaS,
+  MCP registry, package, vulnerability, model/dataset, and exposure-path
+  objects.

--- a/scripts/check_scale_evidence.py
+++ b/scripts/check_scale_evidence.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Verify the scale-evidence documentation scaffold is release-ready.
+
+This intentionally checks structure, not performance values. The first PR for
+#1806 should make the evidence lanes hard to forget without pretending the
+numbers have already been measured.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PERF_DIR = ROOT / "docs" / "perf"
+
+REQUIRED_FILES = (
+    PERF_DIR / "p95-p99-graph-query.md",
+    PERF_DIR / "ingest-throughput.md",
+    PERF_DIR / "fleet-reconciliation.md",
+)
+
+REQUIRED_MARKERS = (
+    "Evidence status:",
+    "Owner issue: #1806",
+    "## Claim",
+    "## Scope",
+    "## Environment",
+    "## Commands",
+    "## Results",
+    "## Gaps",
+)
+
+
+def _check_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    if not path.exists():
+        return [f"missing required evidence file: {path.relative_to(ROOT)}"]
+    text = path.read_text(encoding="utf-8")
+    for marker in REQUIRED_MARKERS:
+        if marker not in text:
+            errors.append(f"{path.relative_to(ROOT)} missing marker: {marker}")
+    if "TBD" not in text and "Evidence status: measured" not in text:
+        errors.append(f"{path.relative_to(ROOT)} must either keep TBD placeholders or declare measured evidence")
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in REQUIRED_FILES:
+        errors.extend(_check_file(path))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_scale_evidence_scaffold_is_complete() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/check_scale_evidence.py"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Summary
- add `docs/perf/` evidence lanes for graph query p95/p99, graph ingest throughput, and fleet reconciliation
- add `scripts/check_scale_evidence.py` so the evidence pages cannot drift from the required command/environment/results/gaps structure
- wire a focused pytest guard around the scaffold and link it from `docs/PERFORMANCE_BENCHMARKS.md`

Why
#1806 needs public benchmark evidence after the UI and graph scale work lands. This PR creates the checked structure first without publishing placeholder measurements as real numbers; the follow-up measurement PRs can fill in reproducible results and raw artifacts.

Validation
- python scripts/check_scale_evidence.py
- uv run pytest tests/test_scale_evidence.py -q
- git diff --check

Refs #1806
