### PR TITLE
feat(scanner): expose dependency reachability evidence

### DIFF
--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -311,6 +311,8 @@ class Package:
     is_direct: bool = True  # vs transitive dependency
     parent_package: Optional[str] = None  # Name of parent package (for transitive deps)
     dependency_depth: int = 0  # 0 for direct, 1+ for transitive
+    dependency_scope: str = "runtime"  # runtime, optional, peer, extra, conditional, dev, unknown
+    reachability_evidence: str = "runtime_dependency"  # runtime_dependency, declaration_only, lockfile, unknown
     resolved_from_registry: bool = False  # True if resolved dynamically vs from lock file
     registry_version: Optional[str] = None  # Latest version from registry (for drift comparison)
     version_source: str = "detected"  # "detected" | "manifest" | "registry_fallback"
@@ -803,9 +805,12 @@ class BlastRadius:
         is_direct = self.package.is_direct
         is_high = self.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)
         has_agents = bool(self.affected_agents)
+        declaration_only = self.package.reachability_evidence == "declaration_only"
 
         if (has_creds or has_tools) and is_direct:
             return "confirmed"
+        if declaration_only and not has_creds and not has_tools:
+            return "unknown"
         if has_creds or has_tools or (is_direct and has_agents) or is_high:
             return "likely"
         if not is_direct and not has_creds and not has_tools:

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -338,6 +338,8 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                     {"name": "agent-bom:ecosystem", "value": pkg.ecosystem},
                     {"name": "agent-bom:is-direct", "value": str(pkg.is_direct).lower()},
                     {"name": "agent-bom:dependency-depth", "value": str(pkg.dependency_depth)},
+                    {"name": "agent-bom:dependency-scope", "value": pkg.dependency_scope},
+                    {"name": "agent-bom:reachability-evidence", "value": pkg.reachability_evidence},
                     {"name": "agent-bom:resolved-from-registry", "value": str(pkg.resolved_from_registry).lower()},
                     {"name": "agent-bom:version-source", "value": pkg.version_source},
                 ]

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -565,6 +565,8 @@ def to_json(report: AIBOMReport) -> dict:
                                 "is_direct": pkg.is_direct,
                                 "parent_package": pkg.parent_package,
                                 "dependency_depth": pkg.dependency_depth,
+                                "dependency_scope": pkg.dependency_scope,
+                                "reachability_evidence": pkg.reachability_evidence,
                                 "resolved_from_registry": pkg.resolved_from_registry,
                                 "version_source": pkg.version_source,
                                 "registry_version": pkg.registry_version,

--- a/src/agent_bom/transitive.py
+++ b/src/agent_bom/transitive.py
@@ -263,35 +263,66 @@ async def resolve_npm_dependencies(
         return []
 
     dependencies = []
-    dep_dict = metadata.get("dependencies", {})
+    dependency_sections = (
+        ("dependencies", "runtime", "runtime_dependency", True),
+        ("optionalDependencies", "optional", "declaration_only", False),
+        ("peerDependencies", "peer", "declaration_only", False),
+    )
 
-    for dep_name, dep_version in dep_dict.items():
-        # Clean version spec (remove ^, ~, etc.)
-        clean_version = dep_version.lstrip("^~>=<")
+    for section, dependency_scope, reachability_evidence, recurse in dependency_sections:
+        dep_dict = metadata.get(section, {}) or {}
+        for dep_name, dep_version in dep_dict.items():
+            # Clean version spec (remove ^, ~, etc.)
+            clean_version = dep_version.lstrip("^~>=<")
 
-        transitive_pkg = Package(
-            name=dep_name,
-            version=clean_version,
-            ecosystem="npm",
-            purl=f"pkg:npm/{dep_name}@{clean_version}",
-            is_direct=False,
-            parent_package=package.name,
-            dependency_depth=current_depth + 1,
-            resolved_from_registry=True,
-        )
-        dependencies.append(transitive_pkg)
+            transitive_pkg = Package(
+                name=dep_name,
+                version=clean_version,
+                ecosystem="npm",
+                purl=f"pkg:npm/{dep_name}@{clean_version}",
+                is_direct=False,
+                parent_package=package.name,
+                dependency_depth=current_depth + 1,
+                dependency_scope=dependency_scope,
+                reachability_evidence=reachability_evidence,
+                resolved_from_registry=True,
+            )
+            dependencies.append(transitive_pkg)
 
-        # Recursively resolve this package's dependencies
-        nested_deps = await resolve_npm_dependencies(
-            transitive_pkg,
-            client,
-            max_depth,
-            current_depth + 1,
-            seen,
-        )
-        dependencies.extend(nested_deps)
+            if not recurse:
+                continue
+
+            # Recursively resolve this package's runtime dependencies. Optional
+            # and peer declarations are surfaced as evidence, but not expanded
+            # as confirmed runtime paths.
+            nested_deps = await resolve_npm_dependencies(
+                transitive_pkg,
+                client,
+                max_depth,
+                current_depth + 1,
+                seen,
+            )
+            dependencies.extend(nested_deps)
 
     return dependencies
+
+
+def _split_requires_dist_marker(dep_spec: str) -> tuple[str, str]:
+    """Return the requirement body and optional PEP 508 marker."""
+    if ";" not in dep_spec:
+        return dep_spec.strip(), ""
+    requirement, marker = dep_spec.split(";", 1)
+    return requirement.strip(), marker.strip()
+
+
+def _scope_for_pypi_marker(marker: str) -> tuple[str, str]:
+    """Classify PyPI dependency markers without evaluating the local runtime."""
+    normalized = marker.lower().replace('"', "'")
+    if "extra ==" in normalized:
+        return "extra", "declaration_only"
+    if marker:
+        return "conditional", "declaration_only"
+    return "runtime", "runtime_dependency"
 
 
 async def resolve_pypi_dependencies(
@@ -329,12 +360,8 @@ async def resolve_pypi_dependencies(
 
     for dep_spec in requires_dist:
         # Parse dependency specification (e.g., "requests>=2.28.0")
-        # Skip extras and environment markers
-        if ";" in dep_spec:
-            dep_spec = dep_spec.split(";")[0].strip()
-
-        if "extra ==" in dep_spec:
-            continue  # Skip optional dependencies
+        dep_spec, marker = _split_requires_dist_marker(dep_spec)
+        dependency_scope, reachability_evidence = _scope_for_pypi_marker(marker)
 
         # Extract package name and version
         match = re.match(r"^([a-zA-Z0-9_.-]+)\s*([<>=!~]+)?\s*([a-zA-Z0-9_.*+-]+)?", dep_spec)
@@ -352,9 +379,14 @@ async def resolve_pypi_dependencies(
             is_direct=False,
             parent_package=package.name,
             dependency_depth=current_depth + 1,
+            dependency_scope=dependency_scope,
+            reachability_evidence=reachability_evidence,
             resolved_from_registry=True,
         )
         dependencies.append(transitive_pkg)
+
+        if reachability_evidence == "declaration_only":
+            continue
 
         # Recursively resolve this package's dependencies
         nested_deps = await resolve_pypi_dependencies(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -472,12 +472,35 @@ def test_json_output_includes_canonical_publish_dates(sample_report):
     assert data["blast_radius"][0]["modified_at"] == "2026-03-23T09:00:00Z"
 
 
+def test_json_output_includes_dependency_reachability_evidence(sample_report):
+    package = sample_report.agents[0].mcp_servers[0].packages[0]
+    package.dependency_scope = "peer"
+    package.reachability_evidence = "declaration_only"
+
+    data = to_json(sample_report)
+    package_json = data["agents"][0]["mcp_servers"][0]["packages"][0]
+    assert package_json["dependency_scope"] == "peer"
+    assert package_json["reachability_evidence"] == "declaration_only"
+
+
 def test_cyclonedx_output_structure(sample_report):
     data = to_cyclonedx(sample_report)
     assert data["bomFormat"] == "CycloneDX"
     assert data["specVersion"] == "1.6"
     assert len(data["components"]) > 0
     assert "vulnerabilities" in data
+
+
+def test_cyclonedx_output_includes_dependency_reachability_evidence(sample_report):
+    package = sample_report.agents[0].mcp_servers[0].packages[0]
+    package.dependency_scope = "optional"
+    package.reachability_evidence = "declaration_only"
+
+    data = to_cyclonedx(sample_report)
+    package_component = next(component for component in data["components"] if component.get("type") == "library")
+    props = {prop["name"]: prop["value"] for prop in package_component["properties"]}
+    assert props["agent-bom:dependency-scope"] == "optional"
+    assert props["agent-bom:reachability-evidence"] == "declaration_only"
 
 
 # ─── CLI Tests ───────────────────────────────────────────────────────────────

--- a/tests/test_transitive_cov.py
+++ b/tests/test_transitive_cov.py
@@ -278,6 +278,28 @@ class TestResolveNpmDependencies:
             assert result[0].name == "body-parser"
             assert result[0].is_direct is False
             assert result[0].parent_package == "express"
+            assert result[0].dependency_scope == "runtime"
+            assert result[0].reachability_evidence == "runtime_dependency"
+
+    @pytest.mark.asyncio
+    async def test_optional_and_peer_dependencies_are_declaration_evidence(self):
+        pkg = Package(name="plugin-host", version="1.0.0", ecosystem="npm")
+        mock_metadata = {
+            "dependencies": {"runtime-lib": "^1.0.0"},
+            "optionalDependencies": {"optional-lib": "^2.0.0"},
+            "peerDependencies": {"react": "^19.0.0"},
+        }
+        client = AsyncMock()
+        with patch("agent_bom.transitive.fetch_npm_metadata", return_value=mock_metadata):
+            result = await resolve_npm_dependencies(pkg, client, max_depth=1)
+
+        by_name = {p.name: p for p in result}
+        assert by_name["runtime-lib"].dependency_scope == "runtime"
+        assert by_name["runtime-lib"].reachability_evidence == "runtime_dependency"
+        assert by_name["optional-lib"].dependency_scope == "optional"
+        assert by_name["optional-lib"].reachability_evidence == "declaration_only"
+        assert by_name["react"].dependency_scope == "peer"
+        assert by_name["react"].reachability_evidence == "declaration_only"
 
     @pytest.mark.asyncio
     async def test_max_depth_stops_recursion(self):
@@ -320,7 +342,7 @@ class TestResolvePypiDependencies:
             assert "certifi" in names
 
     @pytest.mark.asyncio
-    async def test_skips_extras(self):
+    async def test_marks_extras_as_declaration_only(self):
         pkg = Package(name="requests", version="2.31.0", ecosystem="pypi")
         mock_metadata = {
             "info": {
@@ -333,8 +355,11 @@ class TestResolvePypiDependencies:
         client = AsyncMock()
         with patch("agent_bom.transitive.fetch_pypi_metadata", return_value=mock_metadata):
             result = await resolve_pypi_dependencies(pkg, client, max_depth=1)
-            names = [p.name for p in result]
-            assert "urllib3" in names
+            by_name = {p.name: p for p in result}
+            assert by_name["urllib3"].dependency_scope == "runtime"
+            assert by_name["urllib3"].reachability_evidence == "runtime_dependency"
+            assert by_name["PySocks"].dependency_scope == "extra"
+            assert by_name["PySocks"].reachability_evidence == "declaration_only"
 
     @pytest.mark.asyncio
     async def test_strips_env_markers(self):
@@ -351,6 +376,8 @@ class TestResolvePypiDependencies:
             result = await resolve_pypi_dependencies(pkg, client, max_depth=1)
             assert len(result) == 1
             assert result[0].name == "typing-extensions"
+            assert result[0].dependency_scope == "conditional"
+            assert result[0].reachability_evidence == "declaration_only"
 
     @pytest.mark.asyncio
     async def test_empty_requires_dist(self):


### PR DESCRIPTION
## Summary
- classify npm optional/peer dependencies and PyPI extras/marker-gated dependencies as declaration-only reachability evidence
- keep declaration-only dependencies visible in scan output without treating them as confirmed runtime paths
- export dependency_scope and reachability_evidence through JSON and CycloneDX properties so API, evidence, and downstream workflows stay aligned

## Why
This is a focused #1815 scanner correctness child. Optional, peer, extra, and conditional dependencies are real evidence, but they are not the same as a resolved runtime path. Surfacing that distinction reduces false confidence without hiding affected packages.

## Validation
- `uv run pytest tests/test_transitive_cov.py tests/test_transitive.py -q`
- `uv run pytest tests/test_core.py -q -k "dependency_reachability_evidence or cyclonedx_output_structure or canonical_publish_dates"`
- `uv run ruff check src/agent_bom/models.py src/agent_bom/transitive.py src/agent_bom/output/json_fmt.py src/agent_bom/output/cyclonedx_fmt.py tests/test_transitive_cov.py tests/test_core.py`
- `git diff --check`

Refs #1815
