### PR TITLE
security: add mcp container isolation runtime

### DIFF
--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -63,6 +63,31 @@ from rich.console import Console
     envvar="AGENT_BOM_PROXY_URL",
     help="SSE/HTTP MCP server URL (use instead of server_cmd for HTTP/SSE transport)",
 )
+@click.option(
+    "--isolate/--no-isolate",
+    default=False,
+    envvar="AGENT_BOM_MCP_SANDBOX",
+    help="Run the stdio MCP server through a hardened Docker/Podman container.",
+)
+@click.option(
+    "--sandbox-runtime",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_RUNTIME",
+    type=click.Choice(["auto", "docker", "podman"]),
+    help="Container runtime for --isolate (default: auto).",
+)
+@click.option(
+    "--sandbox-image",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_IMAGE",
+    help="Container image used to run non-container server commands in --isolate mode.",
+)
+@click.option(
+    "--sandbox-mount",
+    multiple=True,
+    metavar="HOST:CONTAINER[:ro|rw]",
+    help="Explicit bind mount for --isolate. Defaults to read-only.",
+)
 @click.argument("server_cmd", nargs=-1, required=False)
 def proxy_cmd(
     policy,
@@ -81,6 +106,10 @@ def proxy_cmd(
     audit_push_interval,
     response_sign_key,
     url,
+    isolate,
+    sandbox_runtime,
+    sandbox_image,
+    sandbox_mount,
     server_cmd,
 ):
     """Run an MCP server through agent-bom's security proxy.
@@ -156,6 +185,17 @@ def proxy_cmd(
         raise click.UsageError("Provide a server command (e.g. -- npx @mcp/server-filesystem /tmp) or --url for SSE/HTTP mode.")
 
     from agent_bom.proxy import run_proxy
+    from agent_bom.proxy_sandbox import sandbox_config_from_env
+
+    try:
+        sandbox_config = sandbox_config_from_env(
+            enabled=isolate,
+            runtime=sandbox_runtime,
+            image=sandbox_image,
+            mounts=tuple(sandbox_mount),
+        )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
 
     exit_code = asyncio.run(
         run_proxy(
@@ -175,6 +215,7 @@ def proxy_cmd(
             policy_refresh_seconds=policy_refresh_seconds,
             audit_push_interval=audit_push_interval,
             response_signing_key=response_sign_key,
+            sandbox_config=sandbox_config,
         )
     )
     sys.exit(exit_code)

--- a/src/agent_bom/cli/run.py
+++ b/src/agent_bom/cli/run.py
@@ -146,6 +146,31 @@ def _resolve_server_command(server: str) -> list[str]:
     is_flag=True,
     help="Suppress agent-bom startup messages.",
 )
+@click.option(
+    "--isolate/--no-isolate",
+    default=False,
+    envvar="AGENT_BOM_MCP_SANDBOX",
+    help="Run the MCP server through a hardened Docker/Podman container.",
+)
+@click.option(
+    "--sandbox-runtime",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_RUNTIME",
+    type=click.Choice(["auto", "docker", "podman"]),
+    help="Container runtime for --isolate (default: auto).",
+)
+@click.option(
+    "--sandbox-image",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_IMAGE",
+    help="Container image used to run non-container server commands in --isolate mode.",
+)
+@click.option(
+    "--sandbox-mount",
+    multiple=True,
+    metavar="HOST:CONTAINER[:ro|rw]",
+    help="Explicit bind mount for --isolate. Defaults to read-only.",
+)
 @click.pass_context
 def run_cmd(
     ctx: click.Context,
@@ -158,6 +183,10 @@ def run_cmd(
     detect_visual_leaks: bool,
     log_only: bool,
     quiet: bool,
+    isolate: bool,
+    sandbox_runtime: str | None,
+    sandbox_image: str | None,
+    sandbox_mount: tuple[str, ...],
 ) -> None:
     """Launch SERVER through agent-bom's runtime proxy.
 
@@ -187,6 +216,7 @@ def run_cmd(
     """
     from agent_bom.project_config import get_policy_path, load_project_config
     from agent_bom.proxy import run_proxy
+    from agent_bom.proxy_sandbox import sandbox_config_from_env
 
     # Auto-load .agent-bom.yaml policy if --policy not explicitly given
     if not policy:
@@ -208,6 +238,18 @@ def run_cmd(
         )
         if policy:
             click.echo(f"agent-bom: policy: {policy}", err=True)
+        if isolate:
+            click.echo("agent-bom: MCP container isolation enabled", err=True)
+
+    try:
+        sandbox_config = sandbox_config_from_env(
+            enabled=isolate,
+            runtime=sandbox_runtime,
+            image=sandbox_image,
+            mounts=sandbox_mount,
+        )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
 
     # Build env for child process — no mutation of current env needed here;
     # run_proxy spawns the subprocess itself and inherits os.environ.
@@ -221,6 +263,7 @@ def run_cmd(
             detect_visual_leaks=detect_visual_leaks,
             rate_limit_threshold=rate_limit,
             log_only=log_only,
+            sandbox_config=sandbox_config,
         )
     )
     sys.exit(exit_code)

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -39,6 +39,7 @@ from agent_bom.api.tracing import (
     parse_tracestate,
 )
 from agent_bom.async_stdin import create_async_stdin_reader, read_async_stdin_line
+from agent_bom.proxy_sandbox import SandboxConfig, build_sandboxed_command
 from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call, scan_tool_response
 from agent_bom.security import validate_arguments, validate_command
 
@@ -895,6 +896,7 @@ async def run_proxy(
     policy_refresh_seconds: int = 30,
     audit_push_interval: int = 10,
     response_signing_key: Optional[str] = None,
+    sandbox_config: SandboxConfig | None = None,
 ) -> int:
     """Main proxy loop. Spawns server subprocess, relays JSON-RPC.
 
@@ -915,6 +917,7 @@ async def run_proxy(
         metrics_token: Optional bearer token for Prometheus /metrics endpoint.
         control_plane_url: Optional control-plane URL for policy pull and audit push.
         control_plane_token: Optional bearer/API token for control-plane auth.
+        sandbox_config: Optional container isolation posture for stdio MCP servers.
 
     Returns the server process exit code.
     """
@@ -1193,10 +1196,34 @@ async def run_proxy(
     pending_calls: dict[int | str, tuple[str, float, dict[str, str]]] = {}  # id → (tool_name, start_time, trace_meta)
     pending_call_ttl = 300.0  # 5 minutes — evict orphaned entries
 
-    # Validate the server command before spawning
+    sandbox_evidence: dict[str, object] = {"enabled": False}
+    if sandbox_config and sandbox_config.enabled:
+        server_cmd, sandbox_evidence = build_sandboxed_command(server_cmd, sandbox_config)
+        logger.info(
+            "MCP server isolation enabled using %s (%s)",
+            sandbox_evidence.get("runtime"),
+            sandbox_evidence.get("mode"),
+        )
+    elif sandbox_config:
+        sandbox_evidence = sandbox_config.evidence()
+
+    # Validate the effective server command before spawning
     validate_command(server_cmd[0])
     if len(server_cmd) > 1:
         validate_arguments(list(server_cmd[1:]))
+
+    if log_file:
+        write_audit_record(
+            log_file,
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "type": "mcp_execution_posture",
+                "execution_posture": {
+                    "mode": "container_isolated" if sandbox_evidence.get("enabled") else "observation_only",
+                    "sandbox_evidence": sandbox_evidence,
+                },
+            },
+        )
 
     # Spawn the actual MCP server
     process = await asyncio.create_subprocess_exec(
@@ -1663,6 +1690,10 @@ async def run_proxy(
         # Write metrics summary + runtime alerts to audit log before closing
         summary = metrics.summary()
         summary.update(summarize_runtime_alerts(runtime_alerts))
+        summary["execution_posture"] = {
+            "mode": "container_isolated" if sandbox_evidence.get("enabled") else "observation_only",
+            "sandbox_evidence": sandbox_evidence,
+        }
         if audit_task:
             audit_task.cancel()
         if refresh_task:

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -1,0 +1,208 @@
+"""Container isolation helpers for MCP stdio proxy execution."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+SandboxRuntime = Literal["auto", "docker", "podman"]
+
+
+@dataclass(frozen=True)
+class SandboxMount:
+    """Explicit host path mount for an isolated MCP server."""
+
+    source: str
+    target: str
+    readonly: bool = True
+
+    def as_docker_mount(self) -> str:
+        mode = "readonly" if self.readonly else "rw"
+        return f"type=bind,src={self.source},dst={self.target},{mode}"
+
+
+@dataclass(frozen=True)
+class SandboxConfig:
+    """Process isolation posture for a proxied MCP server."""
+
+    enabled: bool = False
+    runtime: SandboxRuntime = "auto"
+    image: str | None = None
+    mounts: tuple[SandboxMount, ...] = field(default_factory=tuple)
+    network: str = "none"
+    read_only_rootfs: bool = True
+    drop_capabilities: bool = True
+    no_new_privileges: bool = True
+    user: str | None = None
+
+    def evidence(self) -> dict[str, object]:
+        """Return non-secret runtime evidence for audit and posture output."""
+        return {
+            "enabled": self.enabled,
+            "runtime": self.runtime,
+            "image": self.image,
+            "network": self.network,
+            "read_only_rootfs": self.read_only_rootfs,
+            "drop_capabilities": self.drop_capabilities,
+            "no_new_privileges": self.no_new_privileges,
+            "user": self.user,
+            "mounts": [
+                {
+                    "source": mount.source,
+                    "target": mount.target,
+                    "readonly": mount.readonly,
+                }
+                for mount in self.mounts
+            ],
+        }
+
+
+def parse_sandbox_mount(value: str) -> SandboxMount:
+    """Parse ``host:container[:ro|rw]`` into a mount policy."""
+    parts = value.split(":")
+    if len(parts) not in (2, 3) or not parts[0] or not parts[1]:
+        raise ValueError("sandbox mounts must use host_path:container_path[:ro|rw]")
+    mode = parts[2].lower() if len(parts) == 3 else "ro"
+    if mode not in {"ro", "rw", "readonly"}:
+        raise ValueError("sandbox mount mode must be ro or rw")
+    source = str(Path(parts[0]).expanduser().resolve())
+    return SandboxMount(source=source, target=parts[1], readonly=mode != "rw")
+
+
+def sandbox_config_from_env(
+    *,
+    enabled: bool | None = None,
+    runtime: str | None = None,
+    image: str | None = None,
+    mounts: tuple[str, ...] = (),
+    user: str | None = None,
+) -> SandboxConfig:
+    """Build sandbox config from CLI values and AGENT_BOM_MCP_SANDBOX_* env vars."""
+    if enabled is None:
+        env_enabled = os.environ.get("AGENT_BOM_MCP_SANDBOX")
+        enabled = bool(env_enabled and env_enabled.strip().lower() in {"1", "true", "yes", "on", "container"})
+    else:
+        enabled = bool(enabled)
+    requested_runtime = (runtime or os.environ.get("AGENT_BOM_MCP_SANDBOX_RUNTIME") or "auto").strip().lower()
+    if requested_runtime not in {"auto", "docker", "podman"}:
+        raise ValueError("sandbox runtime must be auto, docker, or podman")
+    requested_image = image or os.environ.get("AGENT_BOM_MCP_SANDBOX_IMAGE")
+    env_mounts = tuple(item.strip() for item in os.environ.get("AGENT_BOM_MCP_SANDBOX_MOUNTS", "").split(",") if item.strip())
+    parsed_mounts = tuple(parse_sandbox_mount(item) for item in (*mounts, *env_mounts))
+    requested_user = user or os.environ.get("AGENT_BOM_MCP_SANDBOX_USER")
+    return SandboxConfig(
+        enabled=enabled,
+        runtime=requested_runtime,  # type: ignore[arg-type]
+        image=requested_image,
+        mounts=parsed_mounts,
+        user=requested_user,
+    )
+
+
+def resolve_container_runtime(runtime: SandboxRuntime) -> str:
+    """Resolve docker/podman, preferring Docker for operator familiarity."""
+    if runtime != "auto":
+        if not shutil.which(runtime):
+            raise RuntimeError(f"MCP sandbox runtime '{runtime}' was requested but is not on PATH")
+        return runtime
+    for candidate in ("docker", "podman"):
+        if shutil.which(candidate):
+            return candidate
+    raise RuntimeError("MCP sandbox isolation requires Docker or Podman on PATH")
+
+
+def build_sandboxed_command(server_cmd: list[str], config: SandboxConfig) -> tuple[list[str], dict[str, object]]:
+    """Return the command used to run the MCP server under container isolation."""
+    if not config.enabled:
+        return server_cmd, config.evidence()
+    runtime = resolve_container_runtime(config.runtime)
+    docker_args = _sandbox_docker_args(config)
+
+    if _is_container_run(server_cmd):
+        image_index = _container_image_index(server_cmd)
+        before_image = _strip_conflicting_run_options(server_cmd[2:image_index])
+        image_and_args = server_cmd[image_index:]
+        command = [runtime, "run", *before_image, *docker_args, *image_and_args]
+        evidence = dict(config.evidence())
+        evidence.update({"runtime": runtime, "mode": "harden_existing_container"})
+        if image_and_args:
+            evidence["image"] = image_and_args[0]
+        return command, evidence
+
+    if not config.image:
+        raise RuntimeError("MCP sandbox isolation for non-container commands requires --sandbox-image or AGENT_BOM_MCP_SANDBOX_IMAGE")
+    command = [runtime, "run", *docker_args, config.image, *server_cmd]
+    evidence = dict(config.evidence())
+    evidence.update({"runtime": runtime, "mode": "wrap_command_in_image"})
+    return command, evidence
+
+
+def _sandbox_docker_args(config: SandboxConfig) -> list[str]:
+    args = ["--rm", "-i"]
+    if config.read_only_rootfs:
+        args.append("--read-only")
+    if config.no_new_privileges:
+        args.extend(["--security-opt", "no-new-privileges"])
+    if config.drop_capabilities:
+        args.extend(["--cap-drop", "ALL"])
+    if config.network:
+        args.extend(["--network", config.network])
+    if config.user:
+        args.extend(["--user", config.user])
+    for mount in config.mounts:
+        args.extend(["--mount", mount.as_docker_mount()])
+    return args
+
+
+def _is_container_run(server_cmd: list[str]) -> bool:
+    return len(server_cmd) >= 3 and Path(server_cmd[0]).name in {"docker", "podman"} and server_cmd[1] == "run"
+
+
+def _container_image_index(server_cmd: list[str]) -> int:
+    """Best-effort image index for docker/podman run commands."""
+    index = 2
+    while index < len(server_cmd):
+        item = server_cmd[index]
+        if item == "--":
+            return min(index + 1, len(server_cmd))
+        if not item.startswith("-"):
+            return index
+        # Options with a separate value.
+        if item in {"--name", "--user", "--workdir", "--network", "--env", "-e", "--mount", "-v", "--volume"}:
+            index += 2
+            continue
+        index += 1
+    return len(server_cmd)
+
+
+def _strip_conflicting_run_options(args: list[str]) -> list[str]:
+    """Remove container flags that would weaken the sandbox contract."""
+    stripped: list[str] = []
+    skip_next = False
+    options_with_values = {
+        "--network",
+        "--security-opt",
+        "--cap-add",
+        "--cap-drop",
+        "--user",
+        "--mount",
+        "-v",
+        "--volume",
+    }
+    forbidden_flags = {"--privileged", "--read-only=false"}
+    for item in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if item in forbidden_flags:
+            continue
+        if item in options_with_values:
+            skip_next = True
+            continue
+        if any(item.startswith(f"{option}=") for option in options_with_values):
+            continue
+        stripped.append(item)
+    return stripped

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -113,6 +113,7 @@ def test_run_help():
     assert "--policy" in result.output
     assert "--audit-log" in result.output
     assert "--rate-limit" in result.output
+    assert "--isolate" in result.output
 
 
 def test_run_still_works_as_hidden_command():
@@ -164,6 +165,30 @@ def test_run_passes_policy_to_run_proxy():
         mock_asyncio_run.assert_called_once()
     finally:
         os.unlink(policy_path)
+
+
+def test_run_passes_sandbox_config_to_run_proxy():
+    runner = CliRunner()
+
+    with (
+        patch("agent_bom.cli.run.asyncio.run") as mock_asyncio_run,
+        patch("agent_bom.project_config.load_project_config", return_value=None),
+    ):
+        mock_asyncio_run.side_effect = _consume_coroutine_and_return()
+        result = runner.invoke(
+            run_cmd,
+            [
+                "uvx/mcp-server-git",
+                "--quiet",
+                "--isolate",
+                "--sandbox-runtime",
+                "podman",
+                "--sandbox-image",
+                "ghcr.io/acme/mcp-sandbox:1",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_asyncio_run.assert_called_once()
 
 
 def test_run_command_not_found_handled(tmp_path):

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -86,6 +86,32 @@ def test_proxy_cmd_passes_control_plane_settings():
     assert mock_run.await_args.kwargs["audit_push_interval"] == 15
 
 
+def test_proxy_cmd_passes_sandbox_config():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.proxy.run_proxy", new_callable=AsyncMock, return_value=0) as mock_run,
+        patch("agent_bom.project_config.load_project_config", return_value=None),
+    ):
+        result = runner.invoke(
+            proxy_cmd,
+            [
+                "--isolate",
+                "--sandbox-runtime",
+                "docker",
+                "--sandbox-image",
+                "ghcr.io/acme/mcp-sandbox:1",
+                "--",
+                "npx",
+                "@mcp/server",
+            ],
+        )
+        assert result.exit_code == 0
+    config = mock_run.await_args.kwargs["sandbox_config"]
+    assert config.enabled is True
+    assert config.runtime == "docker"
+    assert config.image == "ghcr.io/acme/mcp-sandbox:1"
+
+
 # ---------------------------------------------------------------------------
 # proxy_configure_cmd
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_sandbox.py
+++ b/tests/test_proxy_sandbox.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.proxy_sandbox import (
+    SandboxConfig,
+    build_sandboxed_command,
+    parse_sandbox_mount,
+    sandbox_config_from_env,
+)
+
+
+def test_parse_sandbox_mount_defaults_to_readonly(tmp_path):
+    mount = parse_sandbox_mount(f"{tmp_path}:/workspace")
+
+    assert mount.source == str(tmp_path.resolve())
+    assert mount.target == "/workspace"
+    assert mount.readonly is True
+    assert mount.as_docker_mount().endswith(",readonly")
+
+
+def test_parse_sandbox_mount_accepts_rw(tmp_path):
+    mount = parse_sandbox_mount(f"{tmp_path}:/workspace:rw")
+
+    assert mount.readonly is False
+    assert mount.as_docker_mount().endswith(",rw")
+
+
+def test_sandbox_config_from_env_parses_operator_values(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX", "true")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_RUNTIME", "podman")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE", "ghcr.io/acme/mcp-sandbox:1")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_MOUNTS", f"{tmp_path}:/workspace")
+
+    config = sandbox_config_from_env()
+
+    assert config.enabled is True
+    assert config.runtime == "podman"
+    assert config.image == "ghcr.io/acme/mcp-sandbox:1"
+    assert config.mounts[0].target == "/workspace"
+
+
+def test_build_sandboxed_command_wraps_non_container_command(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+    config = SandboxConfig(enabled=True, runtime="auto", image="ghcr.io/acme/mcp-sandbox:1")
+
+    command, evidence = build_sandboxed_command(["npx", "--yes", "@mcp/server"], config)
+
+    assert command[:2] == ["docker", "run"]
+    assert "--read-only" in command
+    assert ["--cap-drop", "ALL"] == command[command.index("--cap-drop") : command.index("--cap-drop") + 2]
+    assert ["--network", "none"] == command[command.index("--network") : command.index("--network") + 2]
+    assert "ghcr.io/acme/mcp-sandbox:1" in command
+    assert command[-3:] == ["npx", "--yes", "@mcp/server"]
+    assert evidence["mode"] == "wrap_command_in_image"
+    assert evidence["enabled"] is True
+
+
+def test_build_sandboxed_command_hardens_existing_container_run(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "podman")
+    config = SandboxConfig(enabled=True, runtime="podman")
+
+    command, evidence = build_sandboxed_command(["docker", "run", "--rm", "-i", "ghcr.io/acme/server:1"], config)
+
+    assert command[:2] == ["podman", "run"]
+    assert "--read-only" in command
+    assert "--network" in command
+    assert "ghcr.io/acme/server:1" in command
+    assert evidence["mode"] == "harden_existing_container"
+    assert evidence["runtime"] == "podman"
+    assert evidence["image"] == "ghcr.io/acme/server:1"
+
+
+def test_build_sandboxed_command_strips_weaker_existing_container_flags(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+    config = SandboxConfig(enabled=True, runtime="docker")
+
+    command, _ = build_sandboxed_command(
+        [
+            "docker",
+            "run",
+            "--network",
+            "host",
+            "--privileged",
+            "--cap-add=SYS_ADMIN",
+            "ghcr.io/acme/server:1",
+        ],
+        config,
+    )
+
+    assert "host" not in command
+    assert "--privileged" not in command
+    assert "--cap-add=SYS_ADMIN" not in command
+    assert command[command.index("--network") + 1] == "none"
+
+
+def test_build_sandboxed_command_requires_image_for_plain_commands(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+
+    with pytest.raises(RuntimeError, match="requires --sandbox-image"):
+        build_sandboxed_command(["python", "-m", "server"], SandboxConfig(enabled=True))


### PR DESCRIPTION
## Summary
- adds a reusable MCP sandbox command builder for Docker/Podman isolation
- wires `agent-bom proxy` and hidden `agent-bom run` to `--isolate`, `--sandbox-runtime`, `--sandbox-image`, and explicit `--sandbox-mount`
- records execution posture and sandbox evidence in proxy audit output without changing MCP stdio semantics

## Why
#886/#1899 tracks the gap between observation-only proxying and enforced MCP process isolation. This PR establishes the isolated runtime path while keeping resource limits and egress tuning for the next child PR (#1900).

## Validation
- `uv run pytest tests/test_proxy_sandbox.py tests/test_cli_runtime.py tests/test_cli_run.py -q`
- `uv run ruff check src/agent_bom/proxy_sandbox.py src/agent_bom/proxy.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/run.py tests/test_proxy_sandbox.py tests/test_cli_runtime.py tests/test_cli_run.py`
- `uv run mypy src/agent_bom/proxy_sandbox.py src/agent_bom/proxy.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/run.py`
- pre-commit hooks on commit

Refs #886
Closes #1899
