### PR TITLE
security: add mcp sandbox limits

### DIFF
--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -88,6 +88,35 @@ from rich.console import Console
     metavar="HOST:CONTAINER[:ro|rw]",
     help="Explicit bind mount for --isolate. Defaults to read-only.",
 )
+@click.option("--sandbox-cpus", default=None, envvar="AGENT_BOM_MCP_SANDBOX_CPUS", help="CPU limit for isolated MCP server.")
+@click.option("--sandbox-memory", default=None, envvar="AGENT_BOM_MCP_SANDBOX_MEMORY", help="Memory limit for isolated MCP server.")
+@click.option(
+    "--sandbox-pids-limit",
+    default=None,
+    type=int,
+    envvar="AGENT_BOM_MCP_SANDBOX_PIDS_LIMIT",
+    help="Process limit for isolated MCP server.",
+)
+@click.option(
+    "--sandbox-tmpfs-size",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_TMPFS_SIZE",
+    help="Writable /tmp tmpfs size for isolated MCP server, for example 64m.",
+)
+@click.option(
+    "--sandbox-timeout-seconds",
+    default=None,
+    type=int,
+    envvar="AGENT_BOM_MCP_SANDBOX_TIMEOUT_SECONDS",
+    help="Optional max runtime before the isolated MCP server is terminated.",
+)
+@click.option(
+    "--sandbox-egress",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_EGRESS",
+    type=click.Choice(["deny", "allow-all"]),
+    help="Network egress posture for isolated MCP server.",
+)
 @click.argument("server_cmd", nargs=-1, required=False)
 def proxy_cmd(
     policy,
@@ -110,6 +139,12 @@ def proxy_cmd(
     sandbox_runtime,
     sandbox_image,
     sandbox_mount,
+    sandbox_cpus,
+    sandbox_memory,
+    sandbox_pids_limit,
+    sandbox_tmpfs_size,
+    sandbox_timeout_seconds,
+    sandbox_egress,
     server_cmd,
 ):
     """Run an MCP server through agent-bom's security proxy.
@@ -193,6 +228,12 @@ def proxy_cmd(
             runtime=sandbox_runtime,
             image=sandbox_image,
             mounts=tuple(sandbox_mount),
+            cpus=sandbox_cpus,
+            memory=sandbox_memory,
+            pids_limit=sandbox_pids_limit,
+            tmpfs_size=sandbox_tmpfs_size,
+            timeout_seconds=sandbox_timeout_seconds,
+            egress_policy=sandbox_egress,
         )
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc

--- a/src/agent_bom/cli/run.py
+++ b/src/agent_bom/cli/run.py
@@ -171,6 +171,35 @@ def _resolve_server_command(server: str) -> list[str]:
     metavar="HOST:CONTAINER[:ro|rw]",
     help="Explicit bind mount for --isolate. Defaults to read-only.",
 )
+@click.option("--sandbox-cpus", default=None, envvar="AGENT_BOM_MCP_SANDBOX_CPUS", help="CPU limit for isolated MCP server.")
+@click.option("--sandbox-memory", default=None, envvar="AGENT_BOM_MCP_SANDBOX_MEMORY", help="Memory limit for isolated MCP server.")
+@click.option(
+    "--sandbox-pids-limit",
+    default=None,
+    type=int,
+    envvar="AGENT_BOM_MCP_SANDBOX_PIDS_LIMIT",
+    help="Process limit for isolated MCP server.",
+)
+@click.option(
+    "--sandbox-tmpfs-size",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_TMPFS_SIZE",
+    help="Writable /tmp tmpfs size for isolated MCP server, for example 64m.",
+)
+@click.option(
+    "--sandbox-timeout-seconds",
+    default=None,
+    type=int,
+    envvar="AGENT_BOM_MCP_SANDBOX_TIMEOUT_SECONDS",
+    help="Optional max runtime before the isolated MCP server is terminated.",
+)
+@click.option(
+    "--sandbox-egress",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_EGRESS",
+    type=click.Choice(["deny", "allow-all"]),
+    help="Network egress posture for isolated MCP server.",
+)
 @click.pass_context
 def run_cmd(
     ctx: click.Context,
@@ -187,6 +216,12 @@ def run_cmd(
     sandbox_runtime: str | None,
     sandbox_image: str | None,
     sandbox_mount: tuple[str, ...],
+    sandbox_cpus: str | None,
+    sandbox_memory: str | None,
+    sandbox_pids_limit: int | None,
+    sandbox_tmpfs_size: str | None,
+    sandbox_timeout_seconds: int | None,
+    sandbox_egress: str | None,
 ) -> None:
     """Launch SERVER through agent-bom's runtime proxy.
 
@@ -247,6 +282,12 @@ def run_cmd(
             runtime=sandbox_runtime,
             image=sandbox_image,
             mounts=sandbox_mount,
+            cpus=sandbox_cpus,
+            memory=sandbox_memory,
+            pids_limit=sandbox_pids_limit,
+            tmpfs_size=sandbox_tmpfs_size,
+            timeout_seconds=sandbox_timeout_seconds,
+            egress_policy=sandbox_egress,
         )
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -1232,6 +1232,29 @@ async def run_proxy(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    sandbox_timeout_task = None
+    if sandbox_config and sandbox_config.enabled and sandbox_config.timeout_seconds:
+
+        async def _sandbox_timeout_watchdog() -> None:
+            await asyncio.sleep(sandbox_config.timeout_seconds or 0)
+            if process.returncode is None:
+                logger.error("MCP sandbox timeout reached after %s seconds; terminating server", sandbox_config.timeout_seconds)
+                if log_file:
+                    write_audit_record(
+                        log_file,
+                        {
+                            "ts": datetime.now(timezone.utc).isoformat(),
+                            "type": "mcp_sandbox_timeout",
+                            "timeout_seconds": sandbox_config.timeout_seconds,
+                            "execution_posture": {
+                                "mode": "container_isolated",
+                                "sandbox_evidence": sandbox_evidence,
+                            },
+                        },
+                    )
+                process.terminate()
+
+        sandbox_timeout_task = asyncio.create_task(_sandbox_timeout_watchdog())
 
     async def relay_client_to_server():
         """Read from our stdin, forward to server stdin."""
@@ -1698,6 +1721,8 @@ async def run_proxy(
             audit_task.cancel()
         if refresh_task:
             refresh_task.cancel()
+        if sandbox_timeout_task:
+            sandbox_timeout_task.cancel()
         if control_plane_url:
             await _flush_audit_buffer(summary=summary)
         if log_file:

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Literal
 
 SandboxRuntime = Literal["auto", "docker", "podman"]
+SandboxEgressPolicy = Literal["deny", "allow_all"]
 
 
 @dataclass(frozen=True)
@@ -33,6 +34,12 @@ class SandboxConfig:
     image: str | None = None
     mounts: tuple[SandboxMount, ...] = field(default_factory=tuple)
     network: str = "none"
+    egress_policy: SandboxEgressPolicy = "deny"
+    cpus: str | None = None
+    memory: str | None = None
+    pids_limit: int | None = None
+    tmpfs_size: str | None = None
+    timeout_seconds: int | None = None
     read_only_rootfs: bool = True
     drop_capabilities: bool = True
     no_new_privileges: bool = True
@@ -44,7 +51,13 @@ class SandboxConfig:
             "enabled": self.enabled,
             "runtime": self.runtime,
             "image": self.image,
-            "network": self.network,
+            "network": _effective_network(self),
+            "egress_policy": self.egress_policy,
+            "cpus": self.cpus,
+            "memory": self.memory,
+            "pids_limit": self.pids_limit,
+            "tmpfs_size": self.tmpfs_size,
+            "timeout_seconds": self.timeout_seconds,
             "read_only_rootfs": self.read_only_rootfs,
             "drop_capabilities": self.drop_capabilities,
             "no_new_privileges": self.no_new_privileges,
@@ -79,6 +92,12 @@ def sandbox_config_from_env(
     image: str | None = None,
     mounts: tuple[str, ...] = (),
     user: str | None = None,
+    egress_policy: str | None = None,
+    cpus: str | None = None,
+    memory: str | None = None,
+    pids_limit: int | None = None,
+    tmpfs_size: str | None = None,
+    timeout_seconds: int | None = None,
 ) -> SandboxConfig:
     """Build sandbox config from CLI values and AGENT_BOM_MCP_SANDBOX_* env vars."""
     if enabled is None:
@@ -89,16 +108,38 @@ def sandbox_config_from_env(
     requested_runtime = (runtime or os.environ.get("AGENT_BOM_MCP_SANDBOX_RUNTIME") or "auto").strip().lower()
     if requested_runtime not in {"auto", "docker", "podman"}:
         raise ValueError("sandbox runtime must be auto, docker, or podman")
+    requested_egress = (egress_policy or os.environ.get("AGENT_BOM_MCP_SANDBOX_EGRESS") or "deny").strip().lower().replace("-", "_")
+    if requested_egress not in {"deny", "allow_all"}:
+        raise ValueError("sandbox egress policy must be deny or allow-all")
     requested_image = image or os.environ.get("AGENT_BOM_MCP_SANDBOX_IMAGE")
     env_mounts = tuple(item.strip() for item in os.environ.get("AGENT_BOM_MCP_SANDBOX_MOUNTS", "").split(",") if item.strip())
     parsed_mounts = tuple(parse_sandbox_mount(item) for item in (*mounts, *env_mounts))
     requested_user = user or os.environ.get("AGENT_BOM_MCP_SANDBOX_USER")
+    requested_cpus = cpus or os.environ.get("AGENT_BOM_MCP_SANDBOX_CPUS")
+    requested_memory = memory or os.environ.get("AGENT_BOM_MCP_SANDBOX_MEMORY")
+    requested_tmpfs_size = tmpfs_size or os.environ.get("AGENT_BOM_MCP_SANDBOX_TMPFS_SIZE")
+    requested_pids_limit = (
+        _validate_positive_int("sandbox pids limit", pids_limit)
+        if pids_limit is not None
+        else _optional_positive_int("AGENT_BOM_MCP_SANDBOX_PIDS_LIMIT")
+    )
+    requested_timeout = (
+        _validate_positive_int("sandbox timeout seconds", timeout_seconds)
+        if timeout_seconds is not None
+        else _optional_positive_int("AGENT_BOM_MCP_SANDBOX_TIMEOUT_SECONDS")
+    )
     return SandboxConfig(
         enabled=enabled,
         runtime=requested_runtime,  # type: ignore[arg-type]
         image=requested_image,
         mounts=parsed_mounts,
         user=requested_user,
+        egress_policy=requested_egress,  # type: ignore[arg-type]
+        cpus=requested_cpus,
+        memory=requested_memory,
+        pids_limit=requested_pids_limit,
+        tmpfs_size=requested_tmpfs_size,
+        timeout_seconds=requested_timeout,
     )
 
 
@@ -148,8 +189,15 @@ def _sandbox_docker_args(config: SandboxConfig) -> list[str]:
         args.extend(["--security-opt", "no-new-privileges"])
     if config.drop_capabilities:
         args.extend(["--cap-drop", "ALL"])
-    if config.network:
-        args.extend(["--network", config.network])
+    args.extend(["--network", _effective_network(config)])
+    if config.cpus:
+        args.extend(["--cpus", config.cpus])
+    if config.memory:
+        args.extend(["--memory", config.memory])
+    if config.pids_limit is not None:
+        args.extend(["--pids-limit", str(config.pids_limit)])
+    if config.tmpfs_size:
+        args.extend(["--tmpfs", f"/tmp:size={config.tmpfs_size},mode=1777"])  # nosec B108 - container-internal tmpfs mount
     if config.user:
         args.extend(["--user", config.user])
     for mount in config.mounts:
@@ -189,6 +237,10 @@ def _strip_conflicting_run_options(args: list[str]) -> list[str]:
         "--cap-drop",
         "--user",
         "--mount",
+        "--tmpfs",
+        "--cpus",
+        "--memory",
+        "--pids-limit",
         "-v",
         "--volume",
     }
@@ -206,3 +258,26 @@ def _strip_conflicting_run_options(args: list[str]) -> list[str]:
             continue
         stripped.append(item)
     return stripped
+
+
+def _effective_network(config: SandboxConfig) -> str:
+    if config.network != "none":
+        return config.network
+    return "none" if config.egress_policy == "deny" else "bridge"
+
+
+def _optional_positive_int(env_name: str) -> int | None:
+    value = os.environ.get(env_name)
+    if not value:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{env_name} must be a positive integer") from exc
+    return _validate_positive_int(env_name, parsed)
+
+
+def _validate_positive_int(label: str, value: int) -> int:
+    if value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -114,6 +114,7 @@ def test_run_help():
     assert "--audit-log" in result.output
     assert "--rate-limit" in result.output
     assert "--isolate" in result.output
+    assert "--sandbox-memory" in result.output
 
 
 def test_run_still_works_as_hidden_command():

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -100,6 +100,18 @@ def test_proxy_cmd_passes_sandbox_config():
                 "docker",
                 "--sandbox-image",
                 "ghcr.io/acme/mcp-sandbox:1",
+                "--sandbox-cpus",
+                "0.5",
+                "--sandbox-memory",
+                "256m",
+                "--sandbox-pids-limit",
+                "64",
+                "--sandbox-tmpfs-size",
+                "32m",
+                "--sandbox-timeout-seconds",
+                "300",
+                "--sandbox-egress",
+                "allow-all",
                 "--",
                 "npx",
                 "@mcp/server",
@@ -110,6 +122,12 @@ def test_proxy_cmd_passes_sandbox_config():
     assert config.enabled is True
     assert config.runtime == "docker"
     assert config.image == "ghcr.io/acme/mcp-sandbox:1"
+    assert config.cpus == "0.5"
+    assert config.memory == "256m"
+    assert config.pids_limit == 64
+    assert config.tmpfs_size == "32m"
+    assert config.timeout_seconds == 300
+    assert config.egress_policy == "allow_all"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_sandbox.py
+++ b/tests/test_proxy_sandbox.py
@@ -40,9 +40,31 @@ def test_sandbox_config_from_env_parses_operator_values(monkeypatch, tmp_path):
     assert config.mounts[0].target == "/workspace"
 
 
+def test_sandbox_config_default_egress_is_network_none(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_EGRESS", raising=False)
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+
+    config = sandbox_config_from_env(enabled=True, image="ghcr.io/acme/mcp-sandbox:1")
+    command, evidence = build_sandboxed_command(["npx", "--yes", "@mcp/server"], config)
+
+    assert config.egress_policy == "deny"
+    assert command[command.index("--network") + 1] == "none"
+    assert evidence["egress_policy"] == "deny"
+    assert evidence["network"] == "none"
+
+
 def test_build_sandboxed_command_wraps_non_container_command(monkeypatch):
     monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
-    config = SandboxConfig(enabled=True, runtime="auto", image="ghcr.io/acme/mcp-sandbox:1")
+    config = SandboxConfig(
+        enabled=True,
+        runtime="auto",
+        image="ghcr.io/acme/mcp-sandbox:1",
+        cpus="0.5",
+        memory="256m",
+        pids_limit=64,
+        tmpfs_size="32m",
+        timeout_seconds=300,
+    )
 
     command, evidence = build_sandboxed_command(["npx", "--yes", "@mcp/server"], config)
 
@@ -50,10 +72,15 @@ def test_build_sandboxed_command_wraps_non_container_command(monkeypatch):
     assert "--read-only" in command
     assert ["--cap-drop", "ALL"] == command[command.index("--cap-drop") : command.index("--cap-drop") + 2]
     assert ["--network", "none"] == command[command.index("--network") : command.index("--network") + 2]
+    assert ["--cpus", "0.5"] == command[command.index("--cpus") : command.index("--cpus") + 2]
+    assert ["--memory", "256m"] == command[command.index("--memory") : command.index("--memory") + 2]
+    assert ["--pids-limit", "64"] == command[command.index("--pids-limit") : command.index("--pids-limit") + 2]
+    assert ["/tmp:size=32m,mode=1777"] == command[command.index("--tmpfs") + 1 : command.index("--tmpfs") + 2]
     assert "ghcr.io/acme/mcp-sandbox:1" in command
     assert command[-3:] == ["npx", "--yes", "@mcp/server"]
     assert evidence["mode"] == "wrap_command_in_image"
     assert evidence["enabled"] is True
+    assert evidence["timeout_seconds"] == 300
 
 
 def test_build_sandboxed_command_hardens_existing_container_run(monkeypatch):
@@ -83,6 +110,7 @@ def test_build_sandboxed_command_strips_weaker_existing_container_flags(monkeypa
             "host",
             "--privileged",
             "--cap-add=SYS_ADMIN",
+            "--memory=8g",
             "ghcr.io/acme/server:1",
         ],
         config,
@@ -91,7 +119,19 @@ def test_build_sandboxed_command_strips_weaker_existing_container_flags(monkeypa
     assert "host" not in command
     assert "--privileged" not in command
     assert "--cap-add=SYS_ADMIN" not in command
+    assert "--memory=8g" not in command
     assert command[command.index("--network") + 1] == "none"
+
+
+def test_allow_all_egress_uses_bridge_network(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+    config = SandboxConfig(enabled=True, runtime="docker", image="ghcr.io/acme/server:1", egress_policy="allow_all")
+
+    command, evidence = build_sandboxed_command(["npx", "@mcp/server"], config)
+
+    assert command[command.index("--network") + 1] == "bridge"
+    assert evidence["egress_policy"] == "allow_all"
+    assert evidence["network"] == "bridge"
 
 
 def test_build_sandboxed_command_requires_image_for_plain_commands(monkeypatch):


### PR DESCRIPTION
## Summary
- adds MCP sandbox CPU, memory, pids, tmpfs, timeout, and egress posture options
- maps limits to Docker/Podman flags in isolated mode and records them in sandbox evidence
- adds an optional timeout watchdog that terminates an isolated MCP server and writes audit evidence
- keeps egress enforcement honest: default deny maps to `--network none`; explicit allow-all maps to `bridge` and is visible in evidence

## Why
#1900 is the resource/egress child under #886. #1901 establishes the isolated runtime; this PR adds operator controls so untrusted MCP servers are bounded by container runtime limits rather than only by proxy message caps.

## Validation
- `uv run pytest tests/test_proxy_sandbox.py tests/test_cli_runtime.py tests/test_cli_run.py -q`
- `uv run ruff check src/agent_bom/proxy_sandbox.py src/agent_bom/proxy.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/run.py tests/test_proxy_sandbox.py tests/test_cli_runtime.py tests/test_cli_run.py`
- `uv run mypy src/agent_bom/proxy_sandbox.py src/agent_bom/proxy.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/run.py`
- pre-commit hooks on commit

Refs #886
Closes #1900
